### PR TITLE
also trim whitespace from elseif/else blocks

### DIFF
--- a/test/parser/if-block-else/output.json
+++ b/test/parser/if-block-else/output.json
@@ -37,12 +37,6 @@
 					"type": "ElseBlock",
 					"children": [
 						{
-							"start": 32,
-							"end": 34,
-							"type": "Text",
-							"data": "\n\t"
-						},
-						{
 							"start": 34,
 							"end": 48,
 							"type": "Element",
@@ -56,12 +50,6 @@
 									"data": "not foo"
 								}
 							]
-						},
-						{
-							"start": 48,
-							"end": 49,
-							"type": "Text",
-							"data": "\n"
 						}
 					]
 				}

--- a/test/parser/if-block-elseif/output.json
+++ b/test/parser/if-block-elseif/output.json
@@ -75,12 +75,6 @@
 							},
 							"children": [
 								{
-									"start": 60,
-									"end": 62,
-									"type": "Text",
-									"data": "\n\t"
-								},
-								{
 									"start": 62,
 									"end": 85,
 									"type": "Element",
@@ -94,12 +88,6 @@
 											"data": "x is less than 5"
 										}
 									]
-								},
-								{
-									"start": 85,
-									"end": 86,
-									"type": "Text",
-									"data": "\n"
 								}
 							]
 						}


### PR DESCRIPTION
Some else blocks were also missing `end` markers, so I added some, although I’m not 100% sure those are correct. Also noticed that the `start`/`end` markers from trimmed textnodes should maybe reflect the actual text content rather than the whole block?