### PR TITLE
return state when using get without key

### DIFF
--- a/compiler/generate/index.js
+++ b/compiler/generate/index.js
@@ -424,7 +424,7 @@ export default function generate ( parsed, source, options ) {
 			};
 
 			this.get = function get ( key ) {
-				return state[ key ];
+				return key ? state[ key ] : state;
 			};
 
 			this.set = function set ( newState ) {

--- a/test/compiler/get-state/_config.js
+++ b/test/compiler/get-state/_config.js
@@ -1,0 +1,7 @@
+export default {
+	test ( assert, component ) {
+		assert.equal( component.get('a'), 1 );
+		assert.equal( component.get('c'), 3 );
+		assert.deepEqual( component.get(), { a: 1, b: 2, c: 3 });
+	}
+};

--- a/test/compiler/get-state/main.html
+++ b/test/compiler/get-state/main.html
@@ -1,0 +1,12 @@
+<script>
+	export default {
+		data: () => ({
+			a: 1,
+			b: 2
+		}),
+
+		computed: {
+			c: ( a, b ) => a + b,
+		}
+	};
+</script>


### PR DESCRIPTION
Return the component state when using `get()` without any arguments

References #73 
