### PR TITLE
Improve Travis CI configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "6"
-  - "stable"
+  - "node"
 env:
   global:
     - BUILD_TIMEOUT=10000

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - "6"


### PR DESCRIPTION
* Removed unnecessary `sudo` field.
  - According to [the CI docs](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments), `sudo` is `false` by default for repositories enabled in 2015 or later. [This repository was created in 2016.](https://github.com/sveltejs/svelte/commit/fc7e6e6827c3e9f2a29ec1c6ec957bab9f195841)
* Updated the Node version ID `"stable"` to `"node"`.
  - According to [the nvm docs](https://github.com/creationix/nvm/blob/26fec8035f80c82c768427c86ff2fd09693b5d68/README.markdown), `stable` is deprecated and currently just an alias for `node`.
