### PR TITLE
WIP: separate create from mount

### DIFF
--- a/test/compiler/each-block-random-permute/_config.js
+++ b/test/compiler/each-block-random-permute/_config.js
@@ -1,0 +1,33 @@
+const VALUES = Array.from( 'abcdefghijklmnopqrstuvwxyz' );
+
+function permute () {
+	const values = VALUES.slice();
+	const number = Math.floor(Math.random() * VALUES.length);
+	const permuted = [];
+	for (let i = 0; i < number; i++) {
+		permuted.push( ...values.splice( Math.floor( Math.random() * ( number - i ) ), 1 ) );
+	}
+
+	return {
+		data: permuted,
+		expected: permuted.length ? `(${permuted.join(')(')})` : ''
+	};
+}
+
+let step = permute();
+
+export default {
+	data: {
+		values: step.data
+	},
+
+	html: step.expected,
+
+	test ( assert, component, target ) {
+		for (let i = 0; i < 100; i++) {
+			step = permute();
+			component.set({ values: step.data });
+			assert.htmlEqual( target.innerHTML, step.expected );
+		}
+	}
+};

--- a/test/compiler/each-block-random-permute/main.html
+++ b/test/compiler/each-block-random-permute/main.html
@@ -1,0 +1,3 @@
+{{#each values as value}}
+	({{value}})
+{{/each}}


### PR DESCRIPTION
This is a first step towards keyed iteration, see #81, #77, #33 

The changes got a bit more invasive than I had hoped, but the tests do pass so thats a plus :-)
The `EachBlock` changes currently take the index as key, which is pretty useless for now, but pending some bikeshedding on actual keyed `{{#each}}` syntax, this should be good to go.