### PR TITLE
Improve teardown code by unifying detach branches

### DIFF
--- a/compiler/generate/index.js
+++ b/compiler/generate/index.js
@@ -27,8 +27,8 @@ export default function generate ( parsed, source, options ) {
 				` );
 			}
 			if ( isToplevel ) {
-				generator.current.teardownStatements.push( deindent`
-					if ( detach ) ${name}.parentNode.removeChild( ${name} );
+				generator.current.detachStatements.push( deindent`
+					${name}.parentNode.removeChild( ${name} );
 				` );
 			}
 		},
@@ -72,6 +72,10 @@ export default function generate ( parsed, source, options ) {
 
 						teardown: function ( detach ) {
 							${fragment.teardownStatements.join( '\n\n' )}
+
+							if ( detach ) {
+								${fragment.detachStatements.join( '\n\n' )}
+							}
 						}
 					};
 				}
@@ -255,6 +259,7 @@ export default function generate ( parsed, source, options ) {
 		initStatements: [],
 		mountStatements: [],
 		updateStatements: [],
+		detachStatements: [],
 		teardownStatements: [],
 
 		contexts: {},

--- a/compiler/generate/visitors/EachBlock.js
+++ b/compiler/generate/visitors/EachBlock.js
@@ -102,6 +102,7 @@ export default {
 
 				return `var ${contextName} = ${listName}[${indexName}];`;
 			}).join( '\n' ) ],
+			detachStatements: [],
 			teardownStatements: [],
 
 			counter: counter(),

--- a/compiler/generate/visitors/Element.js
+++ b/compiler/generate/visitors/Element.js
@@ -17,6 +17,7 @@ export default {
 			init: [],
 			mount: [],
 			update: [],
+			detach: [],
 			teardown: []
 		};
 
@@ -138,7 +139,7 @@ export default {
 
 			local.init.unshift( render );
 			if ( isToplevel ) {
-				local.teardown.push( `if ( detach ) ${name}.parentNode.removeChild( ${name} );` );
+				local.detach.push( `${name}.parentNode.removeChild( ${name} );` );
 			}
 		}
 
@@ -152,6 +153,7 @@ export default {
 		generator.current.initStatements.push( local.init.join( '\n' ) );
 		if ( local.update.length ) generator.current.updateStatements.push( local.update.join( '\n' ) );
 		if ( local.mount.length ) generator.current.mountStatements.push( local.mount.join( '\n' ) );
+		generator.current.detachStatements.push( local.detach.join( '\n' ) );
 		generator.current.teardownStatements.push( local.teardown.join( '\n' ) );
 
 		generator.push({

--- a/compiler/generate/visitors/IfBlock.js
+++ b/compiler/generate/visitors/IfBlock.js
@@ -13,6 +13,7 @@ function generateBlock ( generator, node, name ) {
 		initStatements: [],
 		mountStatements: [],
 		updateStatements: [],
+		detachStatements: [],
 		teardownStatements: [],
 
 		counter: counter()


### PR DESCRIPTION
This PR groups detach statements into a single if branch.

Note that I haven't modified the teardown template to deal with empty lists: you can end up with extra newlines and an empty if in those cases. Should that be left for minifiers or should we handle them?

Closes #99.