### PR TITLE
Add charpeni/svelte-example into README tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is the Svelte compiler, which is primarily intended for authors of tooling 
 * [sveltify](https://github.com/tehshrike/sveltify) - Browserify transform
 * [gulp-svelte](https://github.com/shinnn/gulp-svelte) - gulp plugin
 * [metalsmith-svelte](https://github.com/shinnn/metalsmith-svelte) - Metalsmith plugin
+* [charpeni/svelte-example](https://github.com/charpeni/svelte-example) - Some Svelte examples with configured Rollup, Babel, ESLint, directives, Two-Way binding, and nested components
 * More to come!
 
 


### PR DESCRIPTION
Add [charpeni/svelte-example](https://github.com/charpeni/svelte-example) into README tools.

## Rollup plugins

- es output format
- Eslint
- Babel (presets: es2015 & stage-3)
- Svelte

## Available examples

- Hello World component with default data & Two-Way binding (input)
- Counter component with default data and on:click directive with an observer on this value
- CatList and Cat components as nested components