### PR TITLE
add editorconfig and flowconfig files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+
+[{package.json,.travis.yml,.eslintrc.json}]
+indent_style = space
+indent_size = 2

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,9 @@
+[ignore]
+<PROJECT_ROOT>/dist/.*
+
+[include]
+
+[libs]
+
+[options]
+strip_root=true


### PR DESCRIPTION
This does *not* mean that svelte is using flow (yet ? :-), it is only
that people using flow for code completion get some meaningful results
instead of flow complaining about a missing .flowconfig file.

The editorconfig is so that people who use spaces by default get their
editor using tabs like expected.