### PR TITLE
Improve teardown code

### DIFF
--- a/compiler/generate/index.js
+++ b/compiler/generate/index.js
@@ -57,6 +57,19 @@ export default function generate ( parsed, source, options ) {
 				fragment.initStatements.push( `${fragment.autofocus}.focus();` );
 			}
 
+			const detachStatements = fragment.detachStatements.join( '\n\n' );
+			const teardownStatements = fragment.teardownStatements.join( '\n\n' );
+
+			const detachBlock = deindent`
+				if ( detach ) {
+					${detachStatements}
+				}
+			`;
+
+			const teardownBlock = deindent`
+				${teardownStatements}${detachStatements ? `\n\n${detachBlock}` : ``}
+			`;
+
 			renderers.push( deindent`
 				function ${fragment.name} ( ${fragment.params}, component ) {
 					${fragment.initStatements.join( '\n\n' )}
@@ -71,11 +84,7 @@ export default function generate ( parsed, source, options ) {
 						},
 
 						teardown: function ( detach ) {
-							${fragment.teardownStatements.join( '\n\n' )}
-
-							if ( detach ) {
-								${fragment.detachStatements.join( '\n\n' )}
-							}
+							${teardownBlock}
 						}
 					};
 				}

--- a/compiler/generate/visitors/Component.js
+++ b/compiler/generate/visitors/Component.js
@@ -17,6 +17,7 @@ export default {
 			init: [],
 			mount: [],
 			update: [],
+			detach: [],
 			teardown: []
 		};
 
@@ -44,6 +45,7 @@ export default {
 				initStatements: [],
 				mountStatements: [],
 				updateStatements: [],
+				detachStatements: [],
 				teardownStatements: [],
 
 				counter: counter()
@@ -123,6 +125,7 @@ export default {
 		generator.current.initStatements.push( local.init.join( '\n' ) );
 		if ( local.update.length ) generator.current.updateStatements.push( local.update.join( '\n' ) );
 		if ( local.mount.length ) generator.current.mountStatements.push( local.mount.join( '\n' ) );
+		if ( local.detach.length ) generator.current.detachStatements.push( local.detach.join( '\n' ) );
 		generator.current.teardownStatements.push( local.teardown.join( '\n' ) );
 
 		generator.push({

--- a/compiler/generate/visitors/Element.js
+++ b/compiler/generate/visitors/Element.js
@@ -69,7 +69,7 @@ export default {
 
 		local.init.unshift( render );
 		if ( isToplevel ) {
-			local.teardown.push( `if ( detach ) ${name}.parentNode.removeChild( ${name} );` );
+			local.detach.push( `${name}.parentNode.removeChild( ${name} );` );
 		}
 
 		// special case – bound <option> without a value attribute
@@ -82,7 +82,7 @@ export default {
 		generator.current.initStatements.push( local.init.join( '\n' ) );
 		if ( local.update.length ) generator.current.updateStatements.push( local.update.join( '\n' ) );
 		if ( local.mount.length ) generator.current.mountStatements.push( local.mount.join( '\n' ) );
-		generator.current.detachStatements.push( local.detach.join( '\n' ) );
+		if ( local.detach.length ) generator.current.detachStatements.push( local.detach.join( '\n' ) );
 		generator.current.teardownStatements.push( local.teardown.join( '\n' ) );
 
 		generator.createMountStatement( name );


### PR DESCRIPTION
A couple of simple improvements in this PR:

Cleaned up the generated code for teardown when there are no `teardownStatements` or `detachStatements`. No more empty `if`s or extra newlines.

Fixed a regression introduced when `Component` was split from `Element`: `detachStatements` now works correctly on them, too.

Disregard yesterday's PR, I got confused!