### PR TITLE
Fix evaluation on subsequent svg elements to use correct namespace.

### DIFF
--- a/compiler/generate/visitors/Element.js
+++ b/compiler/generate/visitors/Element.js
@@ -13,7 +13,7 @@ export default {
 
 		const local = {
 			name,
-			namespace: name === 'svg' ? 'http://www.w3.org/2000/svg' : generator.current.namespace,
+			namespace: name.substring(0,3) === 'svg' ? 'http://www.w3.org/2000/svg' : generator.current.namespace,
 			isComponent: false,
 
 			allUsedContexts: new Set(),


### PR DESCRIPTION
Fixing issue https://github.com/sveltejs/svelte/issues/130.

Fixes resolution on subsequent svg tags to use correct namespace.