### PR TITLE
Make sure parser only allows unique attribute names

### DIFF
--- a/compiler/parse/state/tag.js
+++ b/compiler/parse/state/tag.js
@@ -74,9 +74,10 @@ export default function tag ( parser ) {
 	}
 
 	const attributes = [];
+	const uniqueNames = new Map();
 
 	let attribute;
-	while ( attribute = readAttribute( parser ) ) {
+	while ( attribute = readAttribute( parser, uniqueNames ) ) {
 		attributes.push( attribute );
 		parser.allowWhitespace();
 	}
@@ -133,11 +134,17 @@ function readTagName ( parser ) {
 	return name;
 }
 
-function readAttribute ( parser ) {
+function readAttribute ( parser, uniqueNames ) {
 	const start = parser.index;
 
 	const name = parser.readUntil( /(\s|=|\/|>)/ );
 	if ( !name ) return null;
+	if ( uniqueNames.has(name) ) {
+		parser.error( 'Attributes need to be unique', start );
+		return null;
+	}
+
+	uniqueNames.set(name, true);
 
 	parser.allowWhitespace();
 

--- a/compiler/parse/state/tag.js
+++ b/compiler/parse/state/tag.js
@@ -141,7 +141,6 @@ function readAttribute ( parser, uniqueNames ) {
 	if ( !name ) return null;
 	if ( uniqueNames.has(name) ) {
 		parser.error( 'Attributes need to be unique', start );
-		return null;
 	}
 
 	uniqueNames.set(name, true);

--- a/test/parser/attribute-unique-error/error.json
+++ b/test/parser/attribute-unique-error/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "Attributes need to be unique",
+	"loc": {
+		"line": 1,
+		"column": 17
+	},
+	"pos": 17
+}

--- a/test/parser/attribute-unique-error/input.html
+++ b/test/parser/attribute-unique-error/input.html
@@ -1,0 +1,1 @@
+<div class='foo' class='bar'></div>


### PR DESCRIPTION
Like we discussed in #128 I went ahead and make the parser complain about duplicated attribute names.  