### PR TITLE
Make new optional

### DIFF
--- a/compiler/generate/index.js
+++ b/compiler/generate/index.js
@@ -433,6 +433,10 @@ export default function generate ( parsed, source, options, names ) {
 
 	topLevelStatements.push( deindent`
 		function ${constructorName} ( options ) {
+			if (!(this instanceof ${constructorName})) {
+				return new ${constructorName}( options );
+			}
+
 			var component = this;${generator.usesRefs ? `\nthis.refs = {}` : ``}
 			var state = ${initialState};${templateProperties.computed ? `\napplyComputations( state, state, {} );` : ``}
 

--- a/test/compiler/optional-new/_config.js
+++ b/test/compiler/optional-new/_config.js
@@ -1,0 +1,9 @@
+export default {
+	html: '',
+	test: function ( assert, component, target, window ) {
+		const SvelteComponent = window.SvelteComponent;
+
+		assert.equal(new SvelteComponent({}) instanceof SvelteComponent, true);
+		assert.equal(SvelteComponent({}) instanceof SvelteComponent, true);
+	}
+};

--- a/test/test.js
+++ b/test/test.js
@@ -279,6 +279,9 @@ describe( 'svelte', () => {
 
 				return env()
 					.then( window => {
+						// Put the constructor on window for testing
+						window.SvelteComponent = SvelteComponent;
+
 						const target = window.document.querySelector( 'main' );
 
 						const component = new SvelteComponent({


### PR DESCRIPTION
Like requested in #55. This is making the `new` operator optional. I had to attach the `SvelteComponent` onto the window object to be able to test this, maybe there is a better way for this? 