### PR TITLE
Make passing options to component optional

### DIFF
--- a/compiler/generate/index.js
+++ b/compiler/generate/index.js
@@ -433,6 +433,8 @@ export default function generate ( parsed, source, options, names ) {
 
 	topLevelStatements.push( deindent`
 		function ${constructorName} ( options ) {
+			options = options || {};
+
 			var component = this;${generator.usesRefs ? `\nthis.refs = {}` : ``}
 			var state = ${initialState};${templateProperties.computed ? `\napplyComputations( state, state, {} );` : ``}
 

--- a/test/compiler/pass-no-options/_config.js
+++ b/test/compiler/pass-no-options/_config.js
@@ -1,0 +1,7 @@
+export default {
+	html: '<h1>Just some static HTML</h1>',
+	test: function ( assert, component, target, window ) {
+		const newComp = new window.SvelteComponent();
+		assert.equal(newComp instanceof window.SvelteComponent, true);
+	}
+};

--- a/test/compiler/pass-no-options/main.html
+++ b/test/compiler/pass-no-options/main.html
@@ -1,0 +1,1 @@
+<h1>Just some static HTML</h1>

--- a/test/test.js
+++ b/test/test.js
@@ -279,6 +279,9 @@ describe( 'svelte', () => {
 
 				return env()
 					.then( window => {
+						// Put the constructor on window for testing
+						window.SvelteComponent = SvelteComponent;
+
 						const target = window.document.querySelector( 'main' );
 
 						const component = new SvelteComponent({


### PR DESCRIPTION
While working on #145 I noticed that creating a component without passing an empty options object was not possible. This PR is fixing that. 