### PR TITLE
make mount private

### DIFF
--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -425,7 +425,7 @@ export default function generate ( parsed, source, options, names ) {
 		initStatements.push( deindent`
 			this.__bindings = [];
 			var mainFragment = renderMainFragment( state, this );
-			if ( options.target ) this.mount( options.target );
+			if ( options.target ) this._mount( options.target );
 			while ( this.__bindings.length ) this.__bindings.pop()();
 		` );
 
@@ -433,7 +433,7 @@ export default function generate ( parsed, source, options, names ) {
 	} else {
 		initStatements.push( deindent`
 			var mainFragment = renderMainFragment( state, this );
-			if ( options.target ) this.mount( options.target );
+			if ( options.target ) this._mount( options.target );
 		` );
 	}
 
@@ -515,7 +515,7 @@ export default function generate ( parsed, source, options, names ) {
 				${setStatements.join( '\n\n' )}
 			};
 
-			this.mount = function mount ( target, anchor ) {
+			this._mount = function mount ( target, anchor ) {
 				mainFragment.mount( target, anchor );
 			}
 

--- a/src/generate/visitors/Component.js
+++ b/src/generate/visitors/Component.js
@@ -80,7 +80,7 @@ export default {
 		` );
 
 		if ( isToplevel ) {
-			local.mount.unshift( `${name}.mount( target, anchor );` );
+			local.mount.unshift( `${name}._mount( target, anchor );` );
 		}
 
 		if ( local.dynamicAttributes.length ) {


### PR DESCRIPTION
See #150 – the consensus seems to be in favour of keeping `mount` out of the public API. We can always reverse the decision in future if there's a convincing need for it