### PR TITLE
throw if default export is not an object literal

### DIFF
--- a/src/validate/js/index.js
+++ b/src/validate/js/index.js
@@ -16,10 +16,6 @@ export default function validateJs ( validator, js ) {
 		}
 
 		if ( node.type === 'ExportDefaultDeclaration' ) {
-			if ( validator.defaultExport ) {
-				return validator.error( `Duplicate default export`, node.start );
-			}
-
 			if ( node.declaration.type !== 'ObjectExpression' ) {
 				return validator.error( `Default export must be an object literal`, node.declaration.start );
 			}

--- a/test/validate.js
+++ b/test/validate.js
@@ -46,9 +46,9 @@ describe( 'validate', () => {
 				if ( err.name !== 'ParseError' ) throw err;
 
 				try {
-					const expected = require( `./validator/${dir}/error.json` );
+					const expected = require( `./validator/${dir}/errors.json` )[0];
 
-					assert.equal( err.shortMessage, expected.message );
+					assert.equal( err.message, expected.message );
 					assert.deepEqual( err.loc, expected.loc );
 					assert.equal( err.pos, expected.pos );
 				} catch ( err2 ) {

--- a/test/validator/export-default-duplicated/errors.json
+++ b/test/validator/export-default-duplicated/errors.json
@@ -1,0 +1,8 @@
+[{
+	"message": "Duplicate export 'default'",
+	"pos": 37,
+	"loc": {
+		"line": 3,
+		"column": 8
+	}
+}]

--- a/test/validator/export-default-duplicated/input.html
+++ b/test/validator/export-default-duplicated/input.html
@@ -1,0 +1,4 @@
+<script>
+	export default {};
+	export default {};
+</script>

--- a/test/validator/export-default-must-be-object/errors.json
+++ b/test/validator/export-default-must-be-object/errors.json
@@ -1,0 +1,8 @@
+[{
+	"message": "Default export must be an object literal",
+	"pos": 25,
+	"loc": {
+		"line": 2,
+		"column": 16
+	}
+}]

--- a/test/validator/export-default-must-be-object/input.html
+++ b/test/validator/export-default-must-be-object/input.html
@@ -1,0 +1,3 @@
+<script>
+	export default potato;
+</script>


### PR DESCRIPTION
This prevents confusing errors of the sort encountered in #188 

