### PR TITLE
intercept parse errors with options.onerror

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,25 @@ function normalizeOptions ( options ) {
 			} else {
 				console.warn( warning.message ); // eslint-disable-line no-console
 			}
+		},
+
+		onerror: error => {
+			throw error;
 		}
 	}, options );
 }
 
 export function compile ( source, _options ) {
 	const options = normalizeOptions( _options );
-	const parsed = parse( source, options );
+
+	let parsed;
+
+	try {
+		parsed = parse( source );
+	} catch ( err ) {
+		options.onerror( err );
+		return;
+	}
 
 	const { names } = validate( parsed, source, options );
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -33,4 +33,17 @@ describe( 'parse', () => {
 			}
 		});
 	});
+
+	it( 'handles errors with options.onerror', () => {
+		let errored = false;
+
+		svelte.compile( `<h1>unclosed`, {
+			onerror ( err ) {
+				errored = true;
+				assert.equal( err.message, `Unexpected end of input` );
+			}
+		});
+
+		assert.ok( errored );
+	});
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -46,4 +46,10 @@ describe( 'parse', () => {
 
 		assert.ok( errored );
 	});
+
+	it( 'throws without options.onerror', () => {
+		assert.throws( () => {
+			svelte.compile( `<h1>unclosed` );
+		}, /Unexpected end of input/ );
+	});
 });


### PR DESCRIPTION
Fixes a minor oversight – parse errors should be intercepted by `options.onerror` the same as validator errors etc. This allows build tool plugins to use `err.loc` and `err.frame` to provide useful and nicely formatted feedback about where the error is.
