### PR TITLE
stop prepending CSS with spaces (fixes #140)

### DIFF
--- a/src/generate/css/process.js
+++ b/src/generate/css/process.js
@@ -1,6 +1,5 @@
-import spaces from '../../utils/spaces.js';
 import transform from './transform.js';
 
 export default function process ( parsed ) {
-	return transform( spaces( parsed.css.content.start ) + parsed.css.content.styles, parsed.hash );
+	return transform( parsed.css.content.styles, parsed.hash );
 }

--- a/test/server-side-rendering/styles-nested/_actual.css
+++ b/test/server-side-rendering/styles-nested/_actual.css
@@ -1,14 +1,14 @@
-                                                                 
+
 	div[svelte-4188175681], [svelte-4188175681] div {
 		color: red;
 	}
 
-                                                                   
+
 	div[svelte-146600313], [svelte-146600313] div {
 		color: green;
 	}
 
-                                     
+
 	div[svelte-1506185237], [svelte-1506185237] div {
 		color: blue;
 	}

--- a/test/server-side-rendering/styles/_actual.css
+++ b/test/server-side-rendering/styles/_actual.css
@@ -1,4 +1,4 @@
-                       
+
 	div[svelte-281576708], [svelte-281576708] div {
 		color: red;
 	}


### PR DESCRIPTION
Fixes the issue I mentioned in #140 where the generated CSS has spaces prepended to it which does not currently help with sourcemaps.