### PR TITLE
throw if options.name is illegal

### DIFF
--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -18,11 +18,7 @@ export default function validate ( parsed, source, { onerror, onwarn, name, file
 
 			error.toString = () => `${error.message} (${error.loc.line}:${error.loc.column})\n${error.frame}`;
 
-			if ( onerror ) {
-				onerror( error );
-			} else {
-				throw error;
-			}
+			onerror( error );
 		},
 
 		warn: ( message, pos ) => {
@@ -49,12 +45,7 @@ export default function validate ( parsed, source, { onerror, onwarn, name, file
 
 	if ( name && !/^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test( name ) ) {
 		const error = new Error( `options.name must be a valid identifier` );
-
-		if ( onerror ) {
-			onerror( error );
-		} else {
-			throw error;
-		}
+		onerror( error );
 	}
 
 	if ( parsed.js ) {

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -3,7 +3,7 @@ import validateHtml from './html/index.js';
 import { getLocator } from 'locate-character';
 import getCodeFrame from '../utils/getCodeFrame.js';
 
-export default function validate ( parsed, source, { onerror, onwarn, filename } ) {
+export default function validate ( parsed, source, { onerror, onwarn, name, filename } ) {
 	const locator = getLocator( source );
 
 	const validator = {
@@ -46,6 +46,16 @@ export default function validate ( parsed, source, { onerror, onwarn, filename }
 
 		namespace: null
 	};
+
+	if ( name && !/^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test( name ) ) {
+		const error = new Error( `options.name must be a valid identifier` );
+
+		if ( onerror ) {
+			onerror( error );
+		} else {
+			throw error;
+		}
+	}
 
 	if ( parsed.js ) {
 		validateJs( validator, parsed.js );

--- a/test/validate.js
+++ b/test/validate.js
@@ -58,4 +58,12 @@ describe( 'validate', () => {
 			}
 		});
 	});
+
+	it( 'errors if options.name is illegal', () => {
+		assert.throws( () => {
+			svelte.compile( '<div></div>', {
+				name: 'not.valid'
+			});
+		}, /options\.name must be a valid identifier/ );
+	});
 });


### PR DESCRIPTION
Ref #102. Doesn't exactly *fix* the issue – the CLI and build tool integrations will need to ensure that `options.name` is valid – but will make the resulting error a bit less mysterious.
