### PR TITLE
helpers

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/shared

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -268,8 +268,8 @@ export default function dom ( parsed, source, options, names ) {
 
 	if ( templateProperties.onrender ) {
 		builders.init.addBlock( deindent`
-			if ( options.root ) {
-				options.root.__renderHooks.push({ fn: template.onrender, context: this });
+			if ( options._root ) {
+				options._root.__renderHooks.push({ fn: template.onrender, context: this });
 			} else {
 				template.onrender.call( this );
 			}
@@ -298,8 +298,8 @@ export default function dom ( parsed, source, options, names ) {
 			this.set = set;
 			this.teardown = teardown;
 
-			this.root = options.root;
-			this.yield = options.yield;
+			this._root = options._root;
+			this._yield = options._yield;
 
 			${builders.init}
 		}

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -242,7 +242,7 @@ export default function dom ( parsed, source, options, names ) {
 		builders.init.addBlock( deindent`
 			this.__bindings = [];
 			this._fragment = renderMainFragment( this._state, this );
-			if ( options.target ) this._mount( options.target );
+			if ( options.target ) this._fragment.mount( options.target, null );
 			while ( this.__bindings.length ) this.__bindings.pop()();
 		` );
 
@@ -250,7 +250,7 @@ export default function dom ( parsed, source, options, names ) {
 	} else {
 		builders.init.addBlock( deindent`
 			this._fragment = renderMainFragment( this._state, this );
-			if ( options.target ) this._mount( options.target );
+			if ( options.target ) this._fragment.mount( options.target, null );
 		` );
 	}
 
@@ -297,10 +297,6 @@ export default function dom ( parsed, source, options, names ) {
 			this.on = on;
 			this.set = set;
 			this.teardown = teardown;
-
-			this._mount = function mount ( target, anchor ) {
-				this._fragment.mount( target, anchor );
-			}
 
 			this.root = options.root;
 			this.yield = options.yield;

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -291,30 +291,10 @@ export default function dom ( parsed, source, options, names ) {
 
 			this._handlers = Object.create( null );
 
-			this.get = get;
-			this.fire = fire;
-			this.observe = observe;
-			this.on = on;
-			this.set = set;
-			this.teardown = teardown;
-
 			this._root = options._root;
 			this._yield = options._yield;
 
 			${builders.init}
-		}
-
-		function set ( newState ) {
-			${builders.set}
-		}
-
-		function teardown ( detach ) {
-			this.fire( 'teardown' );${templateProperties.onteardown ? `\ntemplate.onteardown.call( this );` : ``}
-
-			this._fragment.teardown( detach !== false );
-			this._fragment = null;
-
-			this._state = {};
 		}
 	` );
 
@@ -322,10 +302,28 @@ export default function dom ( parsed, source, options, names ) {
 		builders.main.addBlock( `${name}.prototype = template.methods;` );
 	}
 
-	builders.main.addBlock( shared.fire.toString() );
-	builders.main.addBlock( shared.get.toString() );
-	builders.main.addBlock( shared.observe.toString() );
-	builders.main.addBlock( shared.on.toString() );
+	builders.main.addBlock( deindent`
+		${name}.prototype.get = ${shared.get};
+
+		${name}.prototype.fire = ${shared.fire};
+
+		${name}.prototype.observe = ${shared.observe};
+
+		${name}.prototype.on = ${shared.on};
+
+		${name}.prototype.set = function set ( newState ) {
+			${builders.set}
+		};
+
+		${name}.prototype.teardown = function teardown ( detach ) {
+			this.fire( 'teardown' );${templateProperties.onteardown ? `\ntemplate.onteardown.call( this );` : ``}
+
+			this._fragment.teardown( detach !== false );
+			this._fragment = null;
+
+			this._state = {};
+		};
+	` );
 
 	builders.main.addBlock( shared.dispatchObservers.toString() );
 

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -235,18 +235,18 @@ export default function dom ( parsed, source, options, names ) {
 	}
 
 	if ( generator.hasComponents ) {
-		builders.init.addLine( `this.__renderHooks = [];` );
+		builders.init.addLine( `this._renderHooks = [];` );
 	}
 
 	if ( generator.hasComplexBindings ) {
 		builders.init.addBlock( deindent`
-			this.__bindings = [];
+			this._bindings = [];
 			this._fragment = renderMainFragment( this._state, this );
 			if ( options.target ) this._fragment.mount( options.target, null );
-			while ( this.__bindings.length ) this.__bindings.pop()();
+			while ( this._bindings.length ) this._bindings.pop()();
 		` );
 
-		builders.set.addLine( `while ( this.__bindings.length ) this.__bindings.pop()();` );
+		builders.set.addLine( `while ( this._bindings.length ) this._bindings.pop()();` );
 	} else {
 		builders.init.addBlock( deindent`
 			this._fragment = renderMainFragment( this._state, this );
@@ -256,8 +256,8 @@ export default function dom ( parsed, source, options, names ) {
 
 	if ( generator.hasComponents ) {
 		const statement = deindent`
-			while ( this.__renderHooks.length ) {
-				var hook = this.__renderHooks.pop();
+			while ( this._renderHooks.length ) {
+				var hook = this._renderHooks.pop();
 				hook.fn.call( hook.context );
 			}
 		`;
@@ -269,7 +269,7 @@ export default function dom ( parsed, source, options, names ) {
 	if ( templateProperties.onrender ) {
 		builders.init.addBlock( deindent`
 			if ( options._root ) {
-				options._root.__renderHooks.push({ fn: template.onrender, context: this });
+				options._root._renderHooks.push({ fn: template.onrender, context: this });
 			} else {
 				template.onrender.call( this );
 			}

--- a/src/generators/dom/visitors/Component.js
+++ b/src/generators/dom/visitors/Component.js
@@ -26,7 +26,7 @@ export default {
 
 		const componentInitProperties = [
 			`target: ${!isToplevel ? generator.current.target: 'null'}`,
-			'root: component.root || component'
+			'_root: component._root || component'
 		];
 
 		// Component has children, put them in a separate {{yield}} block
@@ -43,7 +43,7 @@ export default {
 				`${name}_yieldFragment.update( changed, root );`
 			);
 
-			componentInitProperties.push(`yield: ${name}_yieldFragment`);
+			componentInitProperties.push( `_yield: ${name}_yieldFragment`);
 		}
 
 		const statements = [];

--- a/src/generators/dom/visitors/Component.js
+++ b/src/generators/dom/visitors/Component.js
@@ -83,7 +83,7 @@ export default {
 		` );
 
 		if ( isToplevel ) {
-			generator.current.builders.mount.addLine( `${name}._mount( target, anchor );` );
+			generator.current.builders.mount.addLine( `${name}._fragment.mount( target, anchor );` );
 		}
 
 		if ( local.dynamicAttributes.length ) {

--- a/src/generators/dom/visitors/Element.js
+++ b/src/generators/dom/visitors/Element.js
@@ -57,9 +57,19 @@ export default {
 			local.update.addBlock( updates );
 		}
 
-		let render = local.namespace ?
-			`var ${name} = document.createElementNS( '${local.namespace}', '${node.name}' );` :
-			`var ${name} = document.createElement( '${node.name}' );`;
+		let render;
+
+		if ( local.namespace ) {
+			if ( local.namespace === 'http://www.w3.org/2000/svg' ) {
+				generator.uses.createSvgElement = true;
+				render = `var ${name} = createSvgElement( '${node.name}' )`;
+			} else {
+				render = `var ${name} = document.createElementNS( '${local.namespace}', '${node.name}' );`;
+			}
+		} else {
+			generator.uses.createElement = true;
+			render = `var ${name} = createElement( '${node.name}' );`;
+		}
 
 		if ( generator.cssId && !generator.elementDepth ) {
 			render += `\n${name}.setAttribute( '${generator.cssId}', '' );`;
@@ -67,7 +77,8 @@ export default {
 
 		local.init.addLineAtStart( render );
 		if ( isToplevel ) {
-			generator.current.builders.detach.addLine( `${name}.parentNode.removeChild( ${name} );` );
+			generator.uses.detachNode = true;
+			generator.current.builders.detach.addLine( `detachNode( ${name} );` );
 		}
 
 		// special case – bound <option> without a value attribute

--- a/src/generators/dom/visitors/MustacheTag.js
+++ b/src/generators/dom/visitors/MustacheTag.js
@@ -7,7 +7,8 @@ export default {
 		generator.addSourcemapLocations( node.expression );
 		const { snippet } = generator.contextualise( node.expression );
 
-		generator.addElement( name, `document.createTextNode( ${snippet} )`, true );
+		generator.uses.createText = true;
+		generator.addElement( name, `createText( ${snippet} )`, true );
 
 		generator.current.builders.update.addBlock( deindent`
 			${name}.data = ${snippet};

--- a/src/generators/dom/visitors/RawMustacheTag.js
+++ b/src/generators/dom/visitors/RawMustacheTag.js
@@ -9,11 +9,13 @@ export default {
 
 		// we would have used comments here, but the `insertAdjacentHTML` api only
 		// exists for `Element`s.
+		generator.uses.createElement = true;
+
 		const before = `${name}_before`;
-		generator.addElement( before, `document.createElement( 'noscript' )`, true );
+		generator.addElement( before, `createElement( 'noscript' )`, true );
 
 		const after = `${name}_after`;
-		generator.addElement( after, `document.createElement( 'noscript' )`, true );
+		generator.addElement( after, `createElement( 'noscript' )`, true );
 
 		const isToplevel = generator.current.localElementDepth === 0;
 

--- a/src/generators/dom/visitors/Text.js
+++ b/src/generators/dom/visitors/Text.js
@@ -5,6 +5,8 @@ export default {
 		}
 
 		const name = generator.current.getUniqueName( `text` );
-		generator.addElement( name, `document.createTextNode( ${JSON.stringify( node.data )} )`, false );
+		generator.addElement( name, `createText( ${JSON.stringify( node.data )} )`, false );
+
+		generator.uses.createText = true;
 	}
 };

--- a/src/generators/dom/visitors/YieldTag.js
+++ b/src/generators/dom/visitors/YieldTag.js
@@ -4,11 +4,11 @@ export default {
 		generator.createAnchor( anchor, 'yield' );
 
 		generator.current.builders.mount.addLine(
-			`component.yield && component.yield.mount( ${generator.current.target}, ${anchor} );`
+			`component._yield && component._yield.mount( ${generator.current.target}, ${anchor} );`
 		);
 
 		generator.current.builders.teardown.addLine(
-			`component.yield && component.yield.teardown( detach );`
+			`component._yield && component._yield.teardown( detach );`
 		);
 	}
 };

--- a/src/generators/dom/visitors/attributes/binding/index.js
+++ b/src/generators/dom/visitors/attributes/binding/index.js
@@ -87,7 +87,7 @@ export default function createBinding ( generator, node, attribute, current, loc
 		local.init.addBlock( deindent`
 			var ${local.name}_updating = false;
 
-			component.__bindings.push( function () {
+			component._bindings.push( function () {
 				${local.name}.observe( '${attribute.name}', function ( value ) {
 					${local.name}_updating = true;
 					${setter}
@@ -128,6 +128,6 @@ export default function createBinding ( generator, node, attribute, current, loc
 
 	if ( node.name === 'select' ) {
 		generator.hasComplexBindings = true;
-		local.init.addLine( `component.__bindings.push( ${handler} )` );
+		local.init.addLine( `component._bindings.push( ${handler} )` );
 	}
 }

--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -1,0 +1,27 @@
+export function appendNode ( node, target ) {
+	target.appendChild( node );
+}
+
+export function insertNode ( node, target, anchor ) {
+	target.insertBefore( node, anchor );
+}
+
+export function detachNode ( node ) {
+	node.parentNode.removeChild( node );
+}
+
+export function createElement ( name ) {
+	return document.createElement( name );
+}
+
+export function createSvgElement ( name ) {
+	return document.createElementNS( 'http://www.w3.org/2000/svg', name );
+}
+
+export function createText ( data ) {
+	return document.createTextNode( data );
+}
+
+export function createComment ( data ) {
+	return document.createComment( data );
+}

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,29 +1,27 @@
+export * from './dom.js';
+export * from './methods.js';
+
 export function noop () {}
 
-export function appendNode ( node, target ) {
-	target.appendChild( node );
-}
+export function dispatchObservers ( component, group, newState, oldState ) {
+	for ( var key in group ) {
+		if ( !( key in newState ) ) continue;
 
-export function insertNode ( node, target, anchor ) {
-	target.insertBefore( node, anchor );
-}
+		var newValue = newState[ key ];
+		var oldValue = oldState[ key ];
 
-export function detachNode ( node ) {
-	node.parentNode.removeChild( node );
-}
+		if ( newValue === oldValue && typeof newValue !== 'object' ) continue;
 
-export function createElement ( name ) {
-	return document.createElement( name );
-}
+		var callbacks = group[ key ];
+		if ( !callbacks ) continue;
 
-export function createSvgElement ( name ) {
-	return document.createElementNS( 'http://www.w3.org/2000/svg', name );
-}
+		for ( var i = 0; i < callbacks.length; i += 1 ) {
+			var callback = callbacks[i];
+			if ( callback.__calling ) continue;
 
-export function createText ( data ) {
-	return document.createTextNode( data );
-}
-
-export function createComment ( data ) {
-	return document.createComment( data );
+			callback.__calling = true;
+			callback.call( component, newValue, oldValue );
+			callback.__calling = false;
+		}
+	}
 }

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,0 +1,29 @@
+export function noop () {}
+
+export function appendNode ( node, target ) {
+	target.appendChild( node );
+}
+
+export function insertNode ( node, target, anchor ) {
+	target.insertBefore( node, anchor );
+}
+
+export function detachNode ( node ) {
+	node.parentNode.removeChild( node );
+}
+
+export function createElement ( name ) {
+	return document.createElement( name );
+}
+
+export function createSvgElement ( name ) {
+	return document.createElementNS( 'http://www.w3.org/2000/svg', name );
+}
+
+export function createText ( data ) {
+	return document.createTextNode( data );
+}
+
+export function createComment ( data ) {
+	return document.createComment( data );
+}

--- a/src/shared/methods.js
+++ b/src/shared/methods.js
@@ -1,0 +1,43 @@
+export function get ( key ) {
+	return key ? this._state[ key ] : this._state;
+}
+
+export function fire ( eventName, data ) {
+	var handlers = eventName in this._handlers && this._handlers[ eventName ].slice();
+	if ( !handlers ) return;
+
+	for ( var i = 0; i < handlers.length; i += 1 ) {
+		handlers[i].call( this, data );
+	}
+}
+
+export function observe ( key, callback, options ) {
+	var group = ( options && options.defer ) ? this._observers.pre : this._observers.post;
+
+	( group[ key ] || ( group[ key ] = [] ) ).push( callback );
+
+	if ( !options || options.init !== false ) {
+		callback.__calling = true;
+		callback.call( this, this._state[ key ] );
+		callback.__calling = false;
+	}
+
+	return {
+		cancel: function () {
+			var index = group[ key ].indexOf( callback );
+			if ( ~index ) group[ key ].splice( index, 1 );
+		}
+	};
+}
+
+export function on ( eventName, handler ) {
+	var handlers = this._handlers[ eventName ] || ( this._handlers[ eventName ] = [] );
+	handlers.push( handler );
+
+	return {
+		cancel: function () {
+			var index = handlers.indexOf( handler );
+			if ( ~index ) handlers.splice( index, 1 );
+		}
+	};
+}


### PR DESCRIPTION
This PR replaces things like `document.createTextNode('foo')` with `createText('foo')`, resulting in more minifiable and (arguably?) more readable code.

While *minified* code gets smaller by a decent amount, *zipped* code only decreases in size by a tiny amount (<1% with [svelte-todomvc](https://github.com/sveltejs/svelte-todomvc)). Theoretically it would also have a negative impact on performance because of the indirection, though in practice it looks like the impact is negligible (based on [js-framework-benchmark](https://github.com/krausest/js-framework-benchmark)). So it's not totally obvious whether it's a win or not, in the simple case.

The real benefits, however, will come from being able to share functions between components. ~~I've started this PR off with simple DOM helpers, but next up are methods that don't change between components. Once that's all in place, we'll be able to create non-standalone modules that import helpers from `svelte/shared.js`.~~
