### PR TITLE
provide useful feedback on encountering void element closing tag

### DIFF
--- a/src/parse/state/tag.js
+++ b/src/parse/state/tag.js
@@ -47,6 +47,10 @@ export default function tag ( parser ) {
 	parser.allowWhitespace();
 
 	if ( isClosingTag ) {
+		if ( voidElementNames.test( name ) ) {
+			parser.error( `<${name}> is a void element and cannot have children, or a closing tag`, start );
+		}
+
 		if ( !parser.eat( '>' ) ) parser.error( `Expected '>'` );
 
 		const element = parser.current();

--- a/test/parser/error-void-closing/error.json
+++ b/test/parser/error-void-closing/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "<input> is a void element and cannot have children, or a closing tag",
+	"loc": {
+		"line": 1,
+		"column": 23
+	},
+	"pos": 23
+}

--- a/test/parser/error-void-closing/input.html
+++ b/test/parser/error-void-closing/input.html
@@ -1,0 +1,1 @@
+<input>this is illegal!</input>


### PR DESCRIPTION
See #224. This handles the special case where someone tries to do something like `</input>`. It doesn't handle other unexpected closing tags, which will require a bit of extra work.