### PR TITLE
Move addEventListener, removeEventListener, setAttribute into shared

### DIFF
--- a/src/generators/dom/visitors/Element.js
+++ b/src/generators/dom/visitors/Element.js
@@ -72,7 +72,8 @@ export default {
 		}
 
 		if ( generator.cssId && !generator.elementDepth ) {
-			render += `\n${name}.setAttribute( '${generator.cssId}', '' );`;
+			generator.uses.setAttribute = true;
+			render += `\nsetAttribute( ${name}, '${generator.cssId}', '' );`;
 		}
 
 		local.init.addLineAtStart( render );

--- a/src/generators/dom/visitors/attributes/binding/index.js
+++ b/src/generators/dom/visitors/attributes/binding/index.js
@@ -104,6 +104,8 @@ export default function createBinding ( generator, node, attribute, current, loc
 	} else {
 		const updateElement = `${local.name}.${attribute.name} = ${contextual ? attribute.value : `root.${attribute.value}`}`;
 
+		generator.uses.addEventListener = true;
+		generator.uses.removeEventListener = true;
 		local.init.addBlock( deindent`
 			var ${local.name}_updating = false;
 
@@ -113,7 +115,7 @@ export default function createBinding ( generator, node, attribute, current, loc
 				${local.name}_updating = false;
 			}
 
-			${local.name}.addEventListener( '${eventName}', ${handler}, false );
+			addEventListener( ${local.name}, '${eventName}', ${handler} );
 			${updateElement};
 		` );
 
@@ -122,7 +124,7 @@ export default function createBinding ( generator, node, attribute, current, loc
 		);
 
 		generator.current.builders.teardown.addLine( deindent`
-			${local.name}.removeEventListener( '${eventName}', ${handler}, false );
+			removeEventListener( ${local.name}, '${eventName}', ${handler} );
 		` );
 	}
 

--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -25,3 +25,15 @@ export function createText ( data ) {
 export function createComment ( data ) {
 	return document.createComment( data );
 }
+
+export function addEventListener ( node, event, handler ) {
+	node.addEventListener ( event, handler, false );
+}
+
+export function removeEventListener ( node, event, handler ) {
+	node.removeEventListener ( event, handler, false );
+}
+
+export function setAttribute ( node, attribute, value ) {
+	node.setAttribute ( attribute, value );
+}


### PR DESCRIPTION
It seems like there are a few more things that can be split off into shared functions to reduce code duplication. In this PR, I'm moving the `.addEventListener`, `.removeEventListener`, and `.setAttribute` calls into shared functions. This further decreases the (minified, ungzipped) code size.