### PR TITLE
Properly escape sharedPath in generated import statements

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -343,7 +343,7 @@ export default function dom ( parsed, source, options, names ) {
 
 		const names = [ 'get', 'fire', 'observe', 'on', 'dispatchObservers' ].concat( Object.keys( generator.uses ) );
 		builders.main.addLineAtStart(
-			`import { ${names.join( ', ' )} } from '${sharedPath}'`
+			`import { ${names.join( ', ' )} } from ${JSON.stringify( sharedPath )}`
 		);
 	} else {
 		builders.main.addBlock( shared.dispatchObservers.toString() );


### PR DESCRIPTION
If the `sharedPath` contains any special characters, the generated `import` statement is not correctly escaping them. This PR fixes that.

As an added bonus, unit tests pass on Windows again. Previously, the unit tests which used `shared` were generating

```javascript
import { things } from 'C:\some\path\svelte\shared.js'
```

which is the same as `'C:somepathsvelteshared.js'`, which reify rightfully balked at.