### PR TITLE
handle multiline comments in CSS

### DIFF
--- a/src/generators/shared/css/transform.js
+++ b/src/generators/shared/css/transform.js
@@ -1,6 +1,6 @@
 // largely borrowed from Ractive – https://github.com/ractivejs/ractive/blob/2ec648aaf5296bb88c21812e947e0e42fcc456e3/src/Ractive/config/custom/css/transform.js
 const selectorsPattern = /(?:^|\})?\s*([^\{\}]+)\s*\{/g;
-const commentsPattern = /\/\*.*?\*\//g;
+const commentsPattern = /\/\*[\s\S]*?\*\//g;
 const selectorUnitPattern = /((?:(?:\[[^\]+]\])|(?:[^\s\+\>~:]))+)((?:::?[^\s\+\>\~\(:]+(?:\([^\)]+\))?)*\s*[\s\+\>\~]?)\s*/g;
 const excludePattern = /^(?:@|\d+%)/;
 

--- a/test/generator/css-comments/_config.js
+++ b/test/generator/css-comments/_config.js
@@ -1,0 +1,7 @@
+// JSDOM makes this test pass when it should fail. weird
+export default {
+	test ( assert, component, target, window ) {
+		const p = target.querySelector( 'p' );
+		assert.equal( window.getComputedStyle( p ).color, 'red' );
+	}
+};

--- a/test/generator/css-comments/main.html
+++ b/test/generator/css-comments/main.html
@@ -1,0 +1,11 @@
+<p>red</p>
+
+<style>
+	/*
+		div {}
+	*/
+
+	p {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
Fixes #252, and insodoing reveals another odd way in which JSDOM behaves differently from browsers. We'll have to get round to submitting issues at some point, as these test cases are probably quite valuable, and I *really* can't be bothered to test with a headless browser