### PR TITLE
Dont throw parse error on doctype declaration

### DIFF
--- a/src/parse/state/tag.js
+++ b/src/parse/state/tag.js
@@ -6,7 +6,7 @@ import { trimStart, trimEnd } from '../utils/trim.js';
 import { decodeCharacterReferences } from '../utils/html.js';
 import voidElementNames from '../../utils/voidElementNames.js';
 
-const validTagName = /^[a-zA-Z]{1,}:?[a-zA-Z0-9\-]*/;
+const validTagName = /^\!?[a-zA-Z]{1,}:?[a-zA-Z0-9\-]*/;
 const invalidUnquotedAttributeCharacters = /[\s"'=<>\/`]/;
 
 const specials = {

--- a/src/utils/voidElementNames.js
+++ b/src/utils/voidElementNames.js
@@ -1,1 +1,1 @@
-export default /^(?:area|base|br|col|command|doctype|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/;
+export default /^(?:area|base|br|col|command|\!doctype|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/;

--- a/test/parser/elements/input.html
+++ b/test/parser/elements/input.html
@@ -1,0 +1,1 @@
+<!doctype html>

--- a/test/parser/elements/output.json
+++ b/test/parser/elements/output.json
@@ -1,0 +1,23 @@
+{
+    "html": {
+        "start": 0,
+        "end": 15,
+        "type": "Fragment",
+        "children": [{
+            "attributes": [{
+                "end": 14,
+                "name": "html",
+                "start": 10,
+                "type": "Attribute",
+                "value": true
+            }],
+            "children": [],
+            "end": 15,
+            "name": "!doctype",
+            "start": 0,
+            "type": "Element"
+        }]
+    },
+    "css": null,
+    "js": null
+}


### PR DESCRIPTION
Hi Svelte gang. I'm trying out svelte for the first time for some server-side rendering and I ran across this bug. I want to note that this is potentially my first open-source contribution. ✊ 

I am importing `index.html` via _svelte/ssr/register_, but the compiler throws a ParseError on the `<!doctype>` tag because the regular expression for valid tag names doesn't account for the leading `!`. For the same reason, "doctype" isn't recognized as a valid void element.

It's a pretty simple bug so I hope that this explanation is sufficient.