### PR TITLE
[WIP] Skip some client tests for SSR

### DIFF
--- a/test/generator/onrender-fires-when-ready-nested/_config.js
+++ b/test/generator/onrender-fires-when-ready-nested/_config.js
@@ -1,3 +1,5 @@
 export default {
+	'skip-ssr': true, // uses onrender
+
 	html: `<div><p>true</p>\n<p>true</p></div>`
 };

--- a/test/generator/onrender-fires-when-ready/_config.js
+++ b/test/generator/onrender-fires-when-ready/_config.js
@@ -1,4 +1,6 @@
 export default {
+	'skip-ssr': true, // uses onrender
+
 	html: `<div><p>true</p></div>`,
 
 	test ( assert, component, target ) {

--- a/test/generator/set-in-observe/_config.js
+++ b/test/generator/set-in-observe/_config.js
@@ -1,4 +1,6 @@
 export default {
+	'skip-ssr': true, // uses onrender
+
 	html: `
 		<p>1</p>
 		<p>2</p>

--- a/test/generator/set-in-onrender/_config.js
+++ b/test/generator/set-in-onrender/_config.js
@@ -1,3 +1,5 @@
 export default {
+	'skip-ssr': true, // uses onrender
+
 	html: '<p>2</p>'
 };

--- a/test/ssr.js
+++ b/test/ssr.js
@@ -58,7 +58,7 @@ describe( 'ssr', () => {
 			throw new Error( 'Forgot to remove `solo: true` from test' );
 		}
 
-		( config.skip ? it.skip : config.solo ? it.only : it )( dir, () => {
+		( config.skip || config['skip-ssr'] ? it.skip : config.solo ? it.only : it )( dir, () => {
 			try {
 				const source = fs.readFileSync( `test/generator/${dir}/main.html`, 'utf-8' );
 				svelte.compile( source, { generate: 'ssr' });

--- a/test/ssr.js
+++ b/test/ssr.js
@@ -57,8 +57,10 @@ describe( 'ssr', () => {
 		if ( config.solo && process.env.CI ) {
 			throw new Error( 'Forgot to remove `solo: true` from test' );
 		}
+		
+		if ( config['skip-ssr'] ) return;
 
-		( config.skip || config['skip-ssr'] ? it.skip : config.solo ? it.only : it )( dir, () => {
+		( config.skip ? it.skip : config.solo ? it.only : it )( dir, () => {
 			try {
 				const source = fs.readFileSync( `test/generator/${dir}/main.html`, 'utf-8' );
 				svelte.compile( source, { generate: 'ssr' });


### PR DESCRIPTION
This adds the `skip-ssr` option for tests. This builds on top of #253 

There are a few tests that I think should pass and are issues with the SSR:
- component-binding
- component-binding-nested
- raw-mustaches
- component-yield
- svg-xmlns (waiting on #262)
- text-node-top-level