### PR TITLE
xmlns should be added as an attribute for consistency

### DIFF
--- a/src/generators/dom/visitors/attributes/addElementAttributes.js
+++ b/src/generators/dom/visitors/attributes/addElementAttributes.js
@@ -78,7 +78,7 @@ export default function addElementAttributes ( generator, node, local ) {
 						addAttribute = true;
 					}
 
-					if (addAttribute) {
+					if ( addAttribute ) {
 						generator.uses[ helper ] = true;
 						local.init.addLine(
 							`${helper}( ${local.name}, '${name}', ${result} );`

--- a/src/generators/dom/visitors/attributes/addElementAttributes.js
+++ b/src/generators/dom/visitors/attributes/addElementAttributes.js
@@ -55,15 +55,21 @@ export default function addElementAttributes ( generator, node, local ) {
 					// static attributes
 					result = JSON.stringify( value.data );
 
+					let addAttribute = false;
 					if ( attribute.name === 'xmlns' ) {
 						// special case
 						// TODO this attribute must be static – enforce at compile time
 						local.namespace = value.data;
+						addAttribute = true;
 					} else if ( propertyName ) {
 						local.init.addLine(
 							`${local.name}.${propertyName} = ${result};`
 						);
 					} else {
+						addAttribute = true;
+					}
+
+					if (addAttribute) {
 						generator.uses.setAttribute = true;
 						local.init.addLine(
 							`setAttribute( ${local.name}, '${attribute.name}', ${result} );`

--- a/test/generator/svg-xmlns/_config.js
+++ b/test/generator/svg-xmlns/_config.js
@@ -6,7 +6,7 @@ export default {
 		height: 100
 	},
 
-	html: `<svg><rect x="0" y="0" width="100" height="100"></rect></svg>`,
+	html: `<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="100" height="100"></rect></svg>`,
 
 	test ( assert, component, target ) {
 		const svg = target.querySelector( 'svg' );
@@ -16,6 +16,6 @@ export default {
 		assert.equal( rect.namespaceURI, 'http://www.w3.org/2000/svg' );
 
 		component.set({ width: 150, height: 50 });
-		assert.equal( target.innerHTML, `<svg><rect x="0" y="0" width="150" height="50"></rect></svg>` );
+		assert.equal( target.innerHTML, `<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="150" height="50"></rect></svg>` );
 	}
 };


### PR DESCRIPTION
While working on #261 I found out that the client code doesn't actually set xmlns as an attribute, resulting in the outputted code to not have a namespace if converted to the string. The server handles this correctly.