### PR TITLE
Fixing onrenderhook chain

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -268,8 +268,8 @@ export default function dom ( parsed, source, options, names ) {
 
 	if ( templateProperties.onrender ) {
 		builders.init.addBlock( deindent`
-			if ( options._root ) {
-				options._root._renderHooks.push({ fn: template.onrender, context: this });
+			if ( options._parent ) {
+				options._parent._renderHooks.push({ fn: template.onrender, context: this });
 			} else {
 				template.onrender.call( this );
 			}
@@ -291,7 +291,7 @@ export default function dom ( parsed, source, options, names ) {
 
 			this._handlers = Object.create( null );
 
-			this._root = options._root;
+			this._parent = options._parent;
 			this._yield = options._yield;
 
 			${builders.init}

--- a/src/generators/dom/visitors/Component.js
+++ b/src/generators/dom/visitors/Component.js
@@ -26,7 +26,7 @@ export default {
 
 		const componentInitProperties = [
 			`target: ${!isToplevel ? generator.current.target: 'null'}`,
-			'_root: component._root || component'
+			'_parent: component'
 		];
 
 		// Component has children, put them in a separate {{yield}} block


### PR DESCRIPTION
Fixes: #263

I've renamed `_root` to `_parent` when nesting components. `_renderHooks` should be called when components are mounted, but it isn't being emptied. So adding `_renderHooks` to a component's parent should solve this issue. 

`_root` is never being used anywhere else, and I don't think it should be needed?