### PR TITLE
always flush render hooks, even if initiator is a nested component

### DIFF
--- a/src/generators/dom/visitors/attributes/binding/index.js
+++ b/src/generators/dom/visitors/attributes/binding/index.js
@@ -64,7 +64,7 @@ export default function createBinding ( generator, node, attribute, current, loc
 			var index = this.__svelte.${indexName};
 			list[index]${parts.slice( 1 ).map( part => `.${part}` ).join( '' )} = ${value};
 
-			component.set({ ${prop}: component.get( '${prop}' ) });
+			component._set({ ${prop}: component.get( '${prop}' ) });
 		`;
 	} else if ( deep ) {
 		setter = deindent`
@@ -98,7 +98,7 @@ export default function createBinding ( generator, node, attribute, current, loc
 
 		local.update.addBlock( deindent`
 			if ( !${local.name}_updating && '${parts[0]}' in changed ) {
-				${local.name}.set({ ${attribute.name}: ${contextual ? attribute.value : `root.${attribute.value}`} });
+				${local.name}._set({ ${attribute.name}: ${contextual ? attribute.value : `root.${attribute.value}`} });
 			}
 		` );
 	} else {

--- a/src/shared/methods.js
+++ b/src/shared/methods.js
@@ -41,3 +41,17 @@ export function on ( eventName, handler ) {
 		}
 	};
 }
+
+export function set ( newState ) {
+	this._set( newState );
+	( this._root || this )._flush();
+}
+
+export function _flush () {
+	if ( !this._renderHooks ) return;
+
+	while ( this._renderHooks.length ) {
+		var hook = this._renderHooks.pop();
+		hook.fn.call( hook.context );
+	}
+}

--- a/test/generator/onrender-chain/Item.html
+++ b/test/generator/onrender-chain/Item.html
@@ -1,0 +1,16 @@
+<span>{{foo}}</span>
+
+<script>
+	export default {
+		data () {
+			return {
+				foo: 'XX'
+			};
+		},
+		onrender () {
+			this.observe( 'item', item => {
+				this.set({ foo: item });
+			});
+		}
+	};
+</script>

--- a/test/generator/onrender-chain/List.html
+++ b/test/generator/onrender-chain/List.html
@@ -1,0 +1,25 @@
+{{#each items as item}}
+	<Item item={{item}} />
+{{/each}}
+
+<script>
+	import Item from './Item.html';
+
+	export default {
+		data () {
+			return {
+				items: [ 3, 2, 1 ]
+			};
+		},
+		methods: {
+			update () {
+				this.set({
+					items: [ 1, 2, 3, 4, 5 ]
+				});
+			}
+		},
+		components: {
+			Item
+		}
+	};
+</script>

--- a/test/generator/onrender-chain/_config.js
+++ b/test/generator/onrender-chain/_config.js
@@ -1,0 +1,15 @@
+export default {
+	html: `
+		<span>3</span><span>2</span><span>1</span>
+	`,
+
+	test ( assert, component, target ) {
+		component.refs.list.update();
+
+		assert.htmlEqual( target.innerHTML, `
+			<span>1</span><span>2</span><span>3</span><span>4</span><span>5</span>
+		` );
+
+		component.teardown();
+	}
+};

--- a/test/generator/onrender-chain/main.html
+++ b/test/generator/onrender-chain/main.html
@@ -1,0 +1,11 @@
+<List ref:list/>
+
+<script>
+	import List from './List.html';
+
+	export default {
+		components: {
+			List
+		}
+	};
+</script>


### PR DESCRIPTION
Fixes #263. It does so by separating the public `set` method from the component-specific `_set` — `component.set(...)` calls `component._set(...)`, but then *flushes* the queue of `onrender` hooks (stored at the root instance) that were waiting until the component was in the DOM.