### PR TITLE
Improve performance by checking that the data changes

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -167,7 +167,7 @@ export default function dom ( parsed, source, options, names ) {
 		getUniqueName: generator.getUniqueNameMaker()
 	});
 
-	parsed.html.children.forEach( node => generator.visit( node ) );
+	parsed.html.children.forEach( node => generator.visit(node) );
 
 	generator.addRenderer( generator.pop() );
 

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -167,7 +167,7 @@ export default function dom ( parsed, source, options, names ) {
 		getUniqueName: generator.getUniqueNameMaker()
 	});
 
-	parsed.html.children.forEach( node => generator.visit(node) );
+	parsed.html.children.forEach( node => generator.visit( node ) );
 
 	generator.addRenderer( generator.pop() );
 

--- a/src/generators/dom/visitors/MustacheTag.js
+++ b/src/generators/dom/visitors/MustacheTag.js
@@ -9,9 +9,12 @@ export default {
 
 		generator.uses.createText = true;
 		generator.addElement( name, `createText( ${snippet} )`, true );
+		generator.current.builders.init.addLine(`var last_${name} = ${snippet}`);
 
 		generator.current.builders.update.addBlock( deindent`
-			${name}.data = ${snippet};
+			if (${snippet} !== last_${name}) {
+				${name}.data = last_${name} = ${snippet};
+			}
 		` );
 	}
 };


### PR DESCRIPTION
Basically, anything that touches the DOM is slow. Because if that, this PR checks if any data changes before touching the DOM. 

You can see the performance by comparing the dbmonster built with this PR to the normal one: https://svelte-dbmonster-perf.surge.sh/dist/index.html

Here are some screenshots from my late 2012 i5 macbook pro:

![screen shot 2017-02-05 at 8 06 03 pm](https://cloud.githubusercontent.com/assets/3516420/22632419/a1ab4768-ebde-11e6-83e3-436c755340eb.png)
![screen shot 2017-02-05 at 8 06 14 pm](https://cloud.githubusercontent.com/assets/3516420/22632418/a1aa7536-ebde-11e6-8500-e6cfd16aed82.png)

The dbmonster based off this PR will jump up to 600fps, but the regular dbmonster doesn't go past 60fps. I'm not sure why the dbmonster based off this PR has such sudden fps jumps (although it doesn't drop below 60 for me.)
