### PR TITLE
add outputFilename option for sourcemap generation

### DIFF
--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -168,7 +168,7 @@ export default class Generator {
 
 		return {
 			code: compiled.toString(),
-			map: compiled.generateMap({ includeContent: true })
+			map: compiled.generateMap({ includeContent: true, file: options.outputFilename })
 		};
 	}
 

--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -149,6 +149,15 @@ export default class Generator {
 
 		const { filename } = options;
 
+		// special case — the source file doesn't actually get used anywhere. we need
+		// to add an empty file to populate map.sources and map.sourcesContent
+		if ( !parts.length ) {
+			compiled.addSource({
+				filename,
+				content: new MagicString( this.source ).remove( 0, this.source.length )
+			});
+		}
+
 		parts.forEach( str => {
 			const chunk = str.replace( pattern, '' );
 			if ( chunk ) addString( chunk );

--- a/test/sourcemaps.js
+++ b/test/sourcemaps.js
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import assert from 'assert';
 import { svelte, exists } from './helpers.js';
 import { SourceMapConsumer } from 'source-map';
@@ -15,11 +16,19 @@ describe( 'sourcemaps', () => {
 		}
 
 		( solo ? it.only : it )( dir, () => {
-			const input = fs.readFileSync( `test/sourcemaps/${dir}/input.html`, 'utf-8' ).replace( /\s+$/, '' );
-			const { code, map } = svelte.compile( input );
+			const filename = path.resolve( `test/sourcemaps/${dir}/input.html` );
+			const outputFilename = path.resolve( `test/sourcemaps/${dir}/output.js` );
 
-			fs.writeFileSync( `test/sourcemaps/${dir}/output.js`, `${code}\n//# sourceMappingURL=output.js.map` );
-			fs.writeFileSync( `test/sourcemaps/${dir}/output.js.map`, JSON.stringify( map, null, '  ' ) );
+			const input = fs.readFileSync( filename, 'utf-8' ).replace( /\s+$/, '' );
+			const { code, map } = svelte.compile( input, {
+				filename,
+				outputFilename
+			});
+
+			fs.writeFileSync( outputFilename, `${code}\n//# sourceMappingURL=output.js.map` );
+			fs.writeFileSync( `${outputFilename}.map`, JSON.stringify( map, null, '  ' ) );
+
+			assert.deepEqual( map.sources, [ 'input.html' ]);
 
 			const { test } = require( `./sourcemaps/${dir}/test.js` );
 

--- a/test/sourcemaps/basic/test.js
+++ b/test/sourcemaps/basic/test.js
@@ -12,7 +12,7 @@ export function test ({ assert, smc, locateInSource, locateInGenerated }) {
 	});
 
 	assert.deepEqual( actual, {
-		source: 'SvelteComponent.html',
+		source: 'input.html',
 		name: null,
 		line: expected.line + 1,
 		column: expected.column
@@ -26,7 +26,7 @@ export function test ({ assert, smc, locateInSource, locateInGenerated }) {
 	});
 
 	assert.deepEqual( actual, {
-		source: 'SvelteComponent.html',
+		source: 'input.html',
 		name: null,
 		line: expected.line + 1,
 		column: expected.column

--- a/test/sourcemaps/script/test.js
+++ b/test/sourcemaps/script/test.js
@@ -8,7 +8,7 @@ export function test ({ assert, smc, locateInSource, locateInGenerated }) {
 	});
 
 	assert.deepEqual( actual, {
-		source: 'SvelteComponent.html',
+		source: 'input.html',
 		name: null,
 		line: expected.line + 1,
 		column: expected.column

--- a/test/sourcemaps/static-no-script/input.html
+++ b/test/sourcemaps/static-no-script/input.html
@@ -1,0 +1,1 @@
+<p>no moving parts</p>

--- a/test/sourcemaps/static-no-script/test.js
+++ b/test/sourcemaps/static-no-script/test.js
@@ -1,0 +1,9 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+export function test ({ assert, map }) {
+	assert.deepEqual( map.sources, [ 'input.html' ]);
+	assert.deepEqual( map.sourcesContent, [
+		fs.readFileSync( path.join( __dirname, 'input.html' ), 'utf-8' )
+	]);
+}


### PR DESCRIPTION
While investigating https://github.com/sveltejs/svelte/issues/293 it became apparent that Svelte needs more information to generate decent sourcemaps — namely, it needs to know where the output file is being generated so that it can populate the `sources` field correctly (or rather pass that information onto magic-string so that *it* can populate it correctly).

This mostly affects the CLI (e.g. rollup-plugin-svelte doesn't care about the sourcemap source as Rollup takes care of that sort of thing).