### PR TITLE
Normalise CSS parse errors

### DIFF
--- a/src/generators/shared/processCss.js
+++ b/src/generators/shared/processCss.js
@@ -46,7 +46,7 @@ export default function processCss ( parsed, code ) {
 	// remove comments. TODO would be nice if this was exposed in css-tree
 	let match;
 	while ( match = commentsPattern.exec( css ) ) {
-		const start = match.index;
+		const start = match.index + offset;
 		const end = start + match[0].length;
 
 		code.remove( start, end );

--- a/src/generators/shared/processCss.js
+++ b/src/generators/shared/processCss.js
@@ -1,4 +1,3 @@
-import parse from 'css-tree/lib/parser/index.js';
 import walk from 'css-tree/lib/utils/walk.js';
 
 const commentsPattern = /\/\*[\s\S]*?\*\//g;
@@ -7,16 +6,12 @@ export default function processCss ( parsed, code ) {
 	const css = parsed.css.content.styles;
 	const offset = parsed.css.content.start;
 
-	const ast = parse( css, {
-		positions: true
-	});
-
 	const attr = `[svelte-${parsed.hash}]`;
 
-	walk.rules( ast, rule => {
+	walk.rules( parsed.css.ast, rule => {
 		rule.selector.children.each( selector => {
-			const start = selector.loc.start.offset;
-			const end = selector.loc.end.offset;
+			const start = selector.start - offset;
+			const end = selector.end - offset;
 
 			const selectorString = css.slice( start, end );
 
@@ -25,7 +20,7 @@ export default function processCss ( parsed, code ) {
 			let transformed;
 
 			if ( firstToken.data.type === 'TypeSelector' ) {
-				const insert = firstToken.data.loc.end.offset;
+				const insert = firstToken.data.end - offset;
 				const head = css.slice( start, insert );
 				const tail = css.slice( insert, end );
 
@@ -41,7 +36,7 @@ export default function processCss ( parsed, code ) {
 	// remove comments. TODO would be nice if this was exposed in css-tree
 	let match;
 	while ( match = commentsPattern.exec( css ) ) {
-		const start = match.index + offset;
+		const start = match.index;
 		const end = start + match[0].length;
 
 		code.remove( start, end );

--- a/src/parse/read/style.js
+++ b/src/parse/read/style.js
@@ -27,7 +27,7 @@ export default function readStyle ( parser, start, attributes ) {
 		start,
 		end,
 		attributes,
-		ast,
+		children: JSON.parse( JSON.stringify( ast.children ) ),
 		content: {
 			start: contentStart,
 			end: contentEnd,

--- a/src/parse/read/style.js
+++ b/src/parse/read/style.js
@@ -1,7 +1,24 @@
+import parse from 'css-tree/lib/parser/index.js';
+import walk from 'css-tree/lib/utils/walk.js';
+
 export default function readStyle ( parser, start, attributes ) {
 	const contentStart = parser.index;
 	const styles = parser.readUntil( /<\/style>/ );
 	const contentEnd = parser.index;
+
+	const ast = parse( styles, {
+		positions: true,
+		offset: contentStart
+	});
+
+	// tidy up AST
+	walk.all( ast, node => {
+		if ( node.loc ) {
+			node.start = node.loc.start.offset;
+			node.end = node.loc.end.offset;
+			delete node.loc;
+		}
+	});
 
 	parser.eat( '</style>', true );
 	const end = parser.index;
@@ -10,6 +27,7 @@ export default function readStyle ( parser, start, attributes ) {
 		start,
 		end,
 		attributes,
+		ast,
 		content: {
 			start: contentStart,
 			end: contentEnd,

--- a/src/parse/read/style.js
+++ b/src/parse/read/style.js
@@ -6,10 +6,20 @@ export default function readStyle ( parser, start, attributes ) {
 	const styles = parser.readUntil( /<\/style>/ );
 	const contentEnd = parser.index;
 
-	const ast = parse( styles, {
-		positions: true,
-		offset: contentStart
-	});
+	let ast;
+
+	try {
+		ast = parse( styles, {
+			positions: true,
+			offset: contentStart
+		});
+	} catch ( err ) {
+		if ( err.name === 'CssSyntaxError' ) {
+			parser.error( err.message, err.offset );
+		} else {
+			throw err;
+		}
+	}
 
 	// tidy up AST
 	walk.all( ast, node => {

--- a/test/generator/css-space-in-attribute/_config.js
+++ b/test/generator/css-space-in-attribute/_config.js
@@ -1,4 +1,6 @@
 export default {
+	// solo: true,
+
 	test ( assert, component, target, window ) {
 		const [ control, test ] = target.querySelectorAll( 'p' );
 

--- a/test/generator/css-space-in-attribute/_config.js
+++ b/test/generator/css-space-in-attribute/_config.js
@@ -1,6 +1,4 @@
 export default {
-	// solo: true,
-
 	test ( assert, component, target, window ) {
 		const [ control, test ] = target.querySelectorAll( 'p' );
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -16,7 +16,7 @@ describe( 'parse', () => {
 			const input = fs.readFileSync( `test/parser/${dir}/input.html`, 'utf-8' ).replace( /\s+$/, '' );
 
 			try {
-				const actual = svelte.parse( input );
+				const actual = JSON.parse( JSON.stringify( svelte.parse( input ) ) );
 				const expected = require( `./parser/${dir}/output.json` );
 
 				assert.deepEqual( actual.html, expected.html );

--- a/test/parser/css/output.json
+++ b/test/parser/css/output.json
@@ -29,6 +29,65 @@
 			"start": 23,
 			"end": 48,
 			"styles": "\n\tdiv {\n\t\tcolor: red;\n\t}\n"
+		},
+		"ast": {
+			"type": "StyleSheet",
+			"start": 23,
+			"end": 48,
+			"children": [
+				{
+					"type": "Rule",
+					"start": 25,
+					"end": 47,
+					"selector": {
+						"type": "SelectorList",
+						"start": 25,
+						"end": 28,
+						"children": [
+							{
+								"type": "Selector",
+								"start": 25,
+								"end": 28,
+								"children": [
+									{
+										"type": "TypeSelector",
+										"start": 25,
+										"end": 28,
+										"name": "div"
+									}
+								]
+							}
+						]
+					},
+					"block": {
+						"type": "Block",
+						"start": 29,
+						"end": 47,
+						"children": [
+							{
+								"type": "Declaration",
+								"start": 33,
+								"end": 43,
+								"important": false,
+								"property": "color",
+								"value": {
+									"type": "Value",
+									"start": 39,
+									"end": 43,
+									"children": [
+										{
+											"type": "Identifier",
+											"start": 40,
+											"end": 43,
+											"name": "red"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			]
 		}
 	},
 	"js": null

--- a/test/parser/css/output.json
+++ b/test/parser/css/output.json
@@ -30,65 +30,60 @@
 			"end": 48,
 			"styles": "\n\tdiv {\n\t\tcolor: red;\n\t}\n"
 		},
-		"ast": {
-			"type": "StyleSheet",
-			"start": 23,
-			"end": 48,
-			"children": [
-				{
-					"type": "Rule",
+		"children": [
+			{
+				"type": "Rule",
+				"start": 25,
+				"end": 47,
+				"selector": {
+					"type": "SelectorList",
 					"start": 25,
+					"end": 28,
+					"children": [
+						{
+							"type": "Selector",
+							"start": 25,
+							"end": 28,
+							"children": [
+								{
+									"type": "TypeSelector",
+									"start": 25,
+									"end": 28,
+									"name": "div"
+								}
+							]
+						}
+					]
+				},
+				"block": {
+					"type": "Block",
+					"start": 29,
 					"end": 47,
-					"selector": {
-						"type": "SelectorList",
-						"start": 25,
-						"end": 28,
-						"children": [
-							{
-								"type": "Selector",
-								"start": 25,
-								"end": 28,
+					"children": [
+						{
+							"type": "Declaration",
+							"start": 33,
+							"end": 43,
+							"important": false,
+							"property": "color",
+							"value": {
+								"type": "Value",
+								"start": 39,
+								"end": 43,
 								"children": [
 									{
-										"type": "TypeSelector",
-										"start": 25,
-										"end": 28,
-										"name": "div"
+										"type": "Identifier",
+										"start": 40,
+										"end": 43,
+										"name": "red"
 									}
 								]
 							}
-						]
-					},
-					"block": {
-						"type": "Block",
-						"start": 29,
-						"end": 47,
-						"children": [
-							{
-								"type": "Declaration",
-								"start": 33,
-								"end": 43,
-								"important": false,
-								"property": "color",
-								"value": {
-									"type": "Value",
-									"start": 39,
-									"end": 43,
-									"children": [
-										{
-											"type": "Identifier",
-											"start": 40,
-											"end": 43,
-											"name": "red"
-										}
-									]
-								}
-							}
-						]
-					}
+						}
+					]
 				}
-			]
-		}
+			}
+		]
 	},
 	"js": null
 }

--- a/test/parser/error-css/error.json
+++ b/test/parser/error-css/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "LeftCurlyBracket is expected",
+	"loc": {
+		"line": 2,
+		"column": 16
+	},
+	"pos": 24
+}

--- a/test/parser/error-css/input.html
+++ b/test/parser/error-css/input.html
@@ -1,0 +1,3 @@
+<style>
+	this is not css
+</style>


### PR DESCRIPTION
A few tweaks to how CSS is handled — the AST is generated at parse time (necessary if we're to do any validation on it) and tidied up and turned into a POJO, because that's slightly easier to work with than the native css-tree format. Any errors that happen at parse time are normalised so that they get the same code frame etc as syntax errors elsewhere