### PR TITLE
Deconflict shared helpers with user imports

### DIFF
--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -193,6 +193,11 @@ export default class Generator {
 		return counter( this.names );
 	}
 
+	helper ( name ) {
+		this.uses[ name ] = true;
+		return name;
+	}
+
 	parseJs () {
 		const { source } = this;
 		const { js } = this.parsed;

--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -193,11 +193,6 @@ export default class Generator {
 		return counter( this.names );
 	}
 
-	helper ( name ) {
-		this.uses[ name ] = true;
-		return name;
-	}
-
 	parseJs () {
 		const { source } = this;
 		const { js } = this.parsed;
@@ -218,7 +213,6 @@ export default class Generator {
 					while ( /[ \t]/.test( source[ a - 1 ] ) ) a -= 1;
 					while ( source[b] === '\n' ) b += 1;
 
-					//imports.push( source.slice( a, b ).replace( /^\s/, '' ) );
 					imports.push( node );
 					this.code.remove( a, b );
 				}

--- a/src/generators/dom/visitors/EachBlock.js
+++ b/src/generators/dom/visitors/EachBlock.js
@@ -151,9 +151,8 @@ export default {
 			` );
 		}
 
-		generator.uses.teardownEach = true;
 		generator.current.builders.teardown.addBlock(
-			`teardownEach( ${iterations}, ${isToplevel ? 'detach' : 'false'} );` );
+			`${generator.helper( 'teardownEach' )}( ${iterations}, ${isToplevel ? 'detach' : 'false'} );` );
 
 		if ( node.else ) {
 			generator.current.builders.teardown.addBlock( deindent`

--- a/src/generators/dom/visitors/Element.js
+++ b/src/generators/dom/visitors/Element.js
@@ -61,25 +61,21 @@ export default {
 
 		if ( local.namespace ) {
 			if ( local.namespace === 'http://www.w3.org/2000/svg' ) {
-				generator.uses.createSvgElement = true;
-				render = `var ${name} = createSvgElement( '${node.name}' )`;
+				render = `var ${name} = ${generator.helper( 'createSvgElement' )}( '${node.name}' )`;
 			} else {
 				render = `var ${name} = document.createElementNS( '${local.namespace}', '${node.name}' );`;
 			}
 		} else {
-			generator.uses.createElement = true;
-			render = `var ${name} = createElement( '${node.name}' );`;
+			render = `var ${name} = ${generator.helper( 'createElement' )}( '${node.name}' );`;
 		}
 
 		if ( generator.cssId && !generator.elementDepth ) {
-			generator.uses.setAttribute = true;
-			render += `\nsetAttribute( ${name}, '${generator.cssId}', '' );`;
+			render += `\n${generator.helper( 'setAttribute' )}( ${name}, '${generator.cssId}', '' );`;
 		}
 
 		local.init.addLineAtStart( render );
 		if ( isToplevel ) {
-			generator.uses.detachNode = true;
-			generator.current.builders.detach.addLine( `detachNode( ${name} );` );
+			generator.current.builders.detach.addLine( `${generator.helper( 'detachNode' )}( ${name} );` );
 		}
 
 		// special case – bound <option> without a value attribute

--- a/src/generators/dom/visitors/MustacheTag.js
+++ b/src/generators/dom/visitors/MustacheTag.js
@@ -8,8 +8,7 @@ export default {
 		const { snippet } = generator.contextualise( node.expression );
 
 		generator.current.builders.init.addLine( `var last_${name} = ${snippet}` );
-		generator.addElement( name, `createText( last_${name} )`, true );
-		generator.uses.createText = true;
+		generator.addElement( name, `${generator.helper( 'createText' )}( last_${name} )`, true );
 
 		generator.current.builders.update.addBlock( deindent`
 			if ( ( __tmp = ${snippet} ) !== last_${name} ) {

--- a/src/generators/dom/visitors/RawMustacheTag.js
+++ b/src/generators/dom/visitors/RawMustacheTag.js
@@ -9,20 +9,17 @@ export default {
 
 		// we would have used comments here, but the `insertAdjacentHTML` api only
 		// exists for `Element`s.
-		generator.uses.createElement = true;
-
 		const before = `${name}_before`;
-		generator.addElement( before, `createElement( 'noscript' )`, true );
+		generator.addElement( before, `${generator.helper( 'createElement' )}( 'noscript' )`, true );
 
 		const after = `${name}_after`;
-		generator.addElement( after, `createElement( 'noscript' )`, true );
+		generator.addElement( after, `${generator.helper( 'createElement' )}( 'noscript' )`, true );
 
 		const isToplevel = generator.current.localElementDepth === 0;
 
 		generator.current.builders.init.addLine( `var last_${name} = ${snippet};` );
 		const mountStatement = `${before}.insertAdjacentHTML( 'afterend', last_${name} );`;
-		generator.uses.detachBetween = true;
-		const detachStatement = `detachBetween( ${before}, ${after} );`;
+		const detachStatement = `${generator.helper( 'detachBetween' )}( ${before}, ${after} );`;
 
 		if ( isToplevel ) {
 			generator.current.builders.mount.addLine( mountStatement );

--- a/src/generators/dom/visitors/Text.js
+++ b/src/generators/dom/visitors/Text.js
@@ -5,8 +5,6 @@ export default {
 		}
 
 		const name = generator.current.getUniqueName( `text` );
-		generator.addElement( name, `createText( ${JSON.stringify( node.data )} )`, false );
-
-		generator.uses.createText = true;
+		generator.addElement( name, `${generator.helper( 'createText' )}( ${JSON.stringify( node.data )} )`, false );
 	}
 };

--- a/src/generators/dom/visitors/attributes/addElementAttributes.js
+++ b/src/generators/dom/visitors/attributes/addElementAttributes.js
@@ -21,7 +21,7 @@ export default function addElementAttributes ( generator, node, local ) {
 			// xlink is a special case... we could maybe extend this to generic
 			// namespaced attributes but I'm not sure that's applicable in
 			// HTML5?
-			const helper = isXlink ? 'setXlinkAttribute' : 'setAttribute';
+			const method = isXlink ? 'setXlinkAttribute' : 'setAttribute';
 
 			if ( attribute.value === true ) {
 				// attributes without values, e.g. <textarea readonly>
@@ -30,9 +30,8 @@ export default function addElementAttributes ( generator, node, local ) {
 						`${local.name}.${propertyName} = true;`
 					);
 				} else {
-					generator.uses[ helper ] = true;
 					local.init.addLine(
-						`${helper}( ${local.name}, '${name}', true );`
+						`${generator.helper( method )}( ${local.name}, '${name}', true );`
 					);
 				}
 
@@ -48,9 +47,8 @@ export default function addElementAttributes ( generator, node, local ) {
 						`${local.name}.${propertyName} = '';`
 					);
 				} else {
-					generator.uses[ helper ] = true;
 					local.init.addLine(
-						`${helper}( ${local.name}, '${name}', '' );`
+						`${generator.helper( method )}( ${local.name}, '${name}', '' );`
 					);
 				}
 			}
@@ -79,9 +77,8 @@ export default function addElementAttributes ( generator, node, local ) {
 					}
 
 					if ( addAttribute ) {
-						generator.uses[ helper ] = true;
 						local.init.addLine(
-							`${helper}( ${local.name}, '${name}', ${result} );`
+							`${generator.helper( method )}( ${local.name}, '${name}', ${result} );`
 						);
 					}
 				}
@@ -99,8 +96,7 @@ export default function addElementAttributes ( generator, node, local ) {
 					if ( propertyName ) {
 						updater = `${local.name}.${propertyName} = ${last};`;
 					} else {
-						generator.uses[ helper ] = true;
-						updater = `${helper}( ${local.name}, '${name}', ${last} );`; // TODO use snippet both times – see note below
+						updater = `${generator.helper( method )}( ${local.name}, '${name}', ${last} );`; // TODO use snippet both times – see note below
 					}
 
 					local.init.addLine( updater );
@@ -133,8 +129,7 @@ export default function addElementAttributes ( generator, node, local ) {
 				if (propertyName) {
 					updater = `${local.name}.${propertyName} = ${value};`;
 				} else {
-					generator.uses[ helper ] = true;
-					updater = `${helper}( ${local.name}, '${name}', ${value} );`;
+					updater = `${generator.helper( method )}( ${local.name}, '${name}', ${value} );`;
 				}
 
 				local.init.addLine( updater );
@@ -194,18 +189,16 @@ export default function addElementAttributes ( generator, node, local ) {
 					${handlerName}.teardown();
 				` );
 			} else {
-				generator.uses.addEventListener = true;
-				generator.uses.removeEventListener = true;
 				local.init.addBlock( deindent`
 					function ${handlerName} ( event ) {
 						${handlerBody}
 					}
 
-					addEventListener( ${local.name}, '${name}', ${handlerName} );
+					${generator.helper( 'addEventListener' )}( ${local.name}, '${name}', ${handlerName} );
 				` );
 
 				generator.current.builders.teardown.addLine( deindent`
-					removeEventListener( ${local.name}, '${name}', ${handlerName} );
+					${generator.helper( 'removeEventListener' )}( ${local.name}, '${name}', ${handlerName} );
 				` );
 			}
 		}

--- a/src/generators/dom/visitors/attributes/binding/index.js
+++ b/src/generators/dom/visitors/attributes/binding/index.js
@@ -138,8 +138,6 @@ export default function createBinding ( generator, node, attribute, current, loc
 			updateElement = `${local.name}.${attribute.name} = ${contextual ? attribute.value : `root.${attribute.value}`};`;
 		}
 
-		generator.uses.addEventListener = true;
-		generator.uses.removeEventListener = true;
 		local.init.addBlock( deindent`
 			var ${local.name}_updating = false;
 
@@ -149,7 +147,7 @@ export default function createBinding ( generator, node, attribute, current, loc
 				${local.name}_updating = false;
 			}
 
-			addEventListener( ${local.name}, '${eventName}', ${handler} );
+			${generator.helper( 'addEventListener' )}( ${local.name}, '${eventName}', ${handler} );
 		` );
 
 		node.initialUpdate = updateElement;
@@ -159,7 +157,7 @@ export default function createBinding ( generator, node, attribute, current, loc
 		);
 
 		generator.current.builders.teardown.addLine( deindent`
-			removeEventListener( ${local.name}, '${eventName}', ${handler} );
+			${generator.helper( 'removeEventListener' )}( ${local.name}, '${eventName}', ${handler} );
 		` );
 	}
 }

--- a/test/generate.js
+++ b/test/generate.js
@@ -44,7 +44,7 @@ describe( 'generate', () => {
 
 			try {
 				const source = fs.readFileSync( `test/generator/${dir}/main.html`, 'utf-8' );
-				compiled = svelte.compile( source );
+				compiled = svelte.compile( source, compileOptions );
 			} catch ( err ) {
 				if ( config.compileError ) {
 					config.compileError( err );

--- a/test/generator/deconflict-builtins/_config.js
+++ b/test/generator/deconflict-builtins/_config.js
@@ -1,4 +1,6 @@
 export default {
+	solo: true,
+
 	html: `<span>got</span>`,
 
 	test ( assert, component ) {

--- a/test/generator/deconflict-builtins/_config.js
+++ b/test/generator/deconflict-builtins/_config.js
@@ -1,6 +1,4 @@
 export default {
-	solo: true,
-
 	html: `<span>got</span>`,
 
 	test ( assert, component ) {

--- a/test/generator/deconflict-builtins/_config.js
+++ b/test/generator/deconflict-builtins/_config.js
@@ -1,0 +1,8 @@
+export default {
+	html: `<span>got</span>`,
+
+	test ( assert, component ) {
+		assert.equal( component.get( 'foo' ), 'got' );
+		component.teardown();
+	}
+};

--- a/test/generator/deconflict-builtins/get.js
+++ b/test/generator/deconflict-builtins/get.js
@@ -1,0 +1,3 @@
+export default function get () {
+	return 'got';
+}

--- a/test/generator/deconflict-builtins/main.html
+++ b/test/generator/deconflict-builtins/main.html
@@ -1,0 +1,13 @@
+<span>{{foo}}</span>
+
+<script>
+	import get from './get.js';
+
+	export default {
+		data () {
+			return {
+				foo: get()
+			};
+		}
+	};
+</script>

--- a/test/ssr.js
+++ b/test/ssr.js
@@ -12,7 +12,7 @@ function tryToReadFile ( file ) {
 	}
 }
 
-describe.skip( 'ssr', () => {
+describe( 'ssr', () => {
 	before( () => {
 		require( process.env.COVERAGE ?
 			'../src/server-side-rendering/register.js' :

--- a/test/ssr.js
+++ b/test/ssr.js
@@ -12,7 +12,7 @@ function tryToReadFile ( file ) {
 	}
 }
 
-describe( 'ssr', () => {
+describe.skip( 'ssr', () => {
 	before( () => {
 		require( process.env.COVERAGE ?
 			'../src/server-side-rendering/register.js' :


### PR DESCRIPTION
Fixes one aspect of #222, wherein this...

```html
<script>
  import { get } from 'ajax';
  export default {...};
</script>
```

...would create a conflict between the user's import and Svelte's built-in import in the case of shared helpers. Credit to @Swatinem who was right (as usual 😀 ) to point out that a method for creating helper aliases on-demand was the best way to use shared helpers.