### PR TITLE
Deconflict each-blocks contexts with reserved words

### DIFF
--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -58,7 +58,13 @@ export default class Generator {
 						// noop
 					}
 
-					else if ( contexts[ name ] ) {
+					else if ( name in contexts ) {
+						const context = contexts[ name ];
+						if ( context !== name ) {
+							// this is true for 'reserved' names like `root` and `component`
+							code.overwrite( node.start, node.start + name.length, context, true );
+						}
+
 						dependencies.push( ...contextDependencies[ name ] );
 						if ( !~usedContexts.indexOf( name ) ) usedContexts.push( name );
 					}

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -364,7 +364,7 @@ export default function dom ( parsed, source, options, names ) {
 		}
 
 		const names = [ 'get', 'fire', 'observe', 'on', 'set', '_flush', 'dispatchObservers' ].concat( Object.keys( generator.uses ) )
-			.map( name => name in generator.aliases ? `${name} as ${generator.aliases[ name ]}` : name );
+			.map( name => name in generator.aliases && name !== generator.aliases[ name ] ? `${name} as ${generator.aliases[ name ]}` : name );
 
 		builders.main.addLineAtStart(
 			`import { ${names.join( ', ' )} } from ${JSON.stringify( sharedPath )}`

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -180,7 +180,7 @@ export default function dom ( parsed, source, options, names ) {
 		contexts: {},
 		indexes: {},
 
-		params: 'root',
+		params: [ 'root' ],
 		indexNames: {},
 		listNames: {},
 

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -71,7 +71,7 @@ class DomGenerator extends Generator {
 			properties.addBlock( `update: ${this.helper( 'noop' )},` );
 		} else {
 			properties.addBlock( deindent`
-				update: function ( changed, ${fragment.params} ) {
+				update: function ( changed, ${fragment.params.join( ', ' )} ) {
 					var __tmp;
 
 					${fragment.builders.update}
@@ -90,7 +90,7 @@ class DomGenerator extends Generator {
 		}
 
 		this.renderers.push( deindent`
-			function ${fragment.name} ( ${fragment.params}, component${fragment.key ? `, key` : ''} ) {
+			function ${fragment.name} ( ${fragment.params.join( ', ' )}, component${fragment.key ? `, key` : ''} ) {
 				${fragment.builders.init}
 
 				return {

--- a/src/generators/dom/visitors/Component.js
+++ b/src/generators/dom/visitors/Component.js
@@ -62,7 +62,7 @@ export default {
 		// Component has children, put them in a separate {{yield}} block
 		if ( hasChildren ) {
 			const yieldName = generator.getUniqueName( `render${name}YieldFragment` );
-			const { params } = generator.current;
+			const params = generator.current.params.join( ', ' );
 
 			generator.generateBlock( node, yieldName );
 

--- a/src/generators/dom/visitors/IfBlock.js
+++ b/src/generators/dom/visitors/IfBlock.js
@@ -32,7 +32,7 @@ function getConditionsAndBlocks ( generator, node, _name, i = 0 ) {
 
 export default {
 	enter ( generator, node ) {
-		const { params } = generator.current;
+		const params = generator.current.params.join( ', ' );
 		const name = generator.getUniqueName( `ifBlock` );
 		const getBlock = generator.getUniqueName( `getBlock` );
 		const currentBlock = generator.getUniqueName( `currentBlock` );

--- a/src/generators/server-side-rendering/visitors/EachBlock.js
+++ b/src/generators/server-side-rendering/visitors/EachBlock.js
@@ -8,7 +8,7 @@ export default {
 		// TODO should this be the generator's job? It's duplicated between
 		// here and the equivalent DOM compiler visitor
 		const contexts = Object.assign( {}, generator.current.contexts );
-		contexts[ node.context ] = true;
+		contexts[ node.context ] = node.context;
 
 		const indexes = Object.assign( {}, generator.current.indexes );
 		if ( node.index ) indexes[ node.index ] = node.context;

--- a/test/generator/deconflict-contexts/_config.js
+++ b/test/generator/deconflict-contexts/_config.js
@@ -1,0 +1,9 @@
+export default {
+	html: `
+		<ul><li>foo</li><li>bar</li><li>baz</li></ul>
+	`,
+
+	data: {
+		components: [ 'foo', 'bar', 'baz' ]
+	}
+};

--- a/test/generator/deconflict-contexts/main.html
+++ b/test/generator/deconflict-contexts/main.html
@@ -1,0 +1,5 @@
+<ul>
+	{{#each components as component}}
+		<li>{{component}}</li>
+	{{/each}}
+</ul>


### PR DESCRIPTION
Fixes the remaining bug in #222/#251, whereby code like this...

```html
{{#each components as component}}
  <li>{{component}}</li>
{{/each}}
```

...would blow up because `component` is 'special'. It does so by renaming the context introduced by the `each` block to something safe.