### PR TITLE
handle implicitly closed elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 coverage.lcov
 test/sourcemaps/*/output.js
 test/sourcemaps/*/output.js.map
+_actual.json

--- a/test/parse.js
+++ b/test/parse.js
@@ -16,7 +16,8 @@ describe( 'parse', () => {
 			const input = fs.readFileSync( `test/parser/${dir}/input.html`, 'utf-8' ).replace( /\s+$/, '' );
 
 			try {
-				const actual = JSON.parse( JSON.stringify( svelte.parse( input ) ) );
+				const actual = svelte.parse( input );
+				fs.writeFileSync( `test/parser/${dir}/_actual.json`, JSON.stringify( actual, null, '\t' ) );
 				const expected = require( `./parser/${dir}/output.json` );
 
 				assert.deepEqual( actual.html, expected.html );

--- a/test/parser/implicitly-closed-li/input.html
+++ b/test/parser/implicitly-closed-li/input.html
@@ -1,0 +1,5 @@
+<ul>
+	<li>a
+	<li>b
+	<li>c
+</ul>

--- a/test/parser/implicitly-closed-li/output.json
+++ b/test/parser/implicitly-closed-li/output.json
@@ -1,0 +1,66 @@
+{
+	"hash": 3806276940,
+	"html": {
+		"start": 0,
+		"end": 31,
+		"type": "Fragment",
+		"children": [
+			{
+				"start": 0,
+				"end": 31,
+				"type": "Element",
+				"name": "ul",
+				"attributes": [],
+				"children": [
+					{
+						"start": 6,
+						"end": 13,
+						"type": "Element",
+						"name": "li",
+						"attributes": [],
+						"children": [
+							{
+								"start": 10,
+								"end": 13,
+								"type": "Text",
+								"data": "a"
+							}
+						]
+					},
+					{
+						"start": 13,
+						"end": 20,
+						"type": "Element",
+						"name": "li",
+						"attributes": [],
+						"children": [
+							{
+								"start": 17,
+								"end": 20,
+								"type": "Text",
+								"data": "b"
+							}
+						]
+					},
+					{
+						"start": 20,
+						"end": 26,
+						"type": "Element",
+						"name": "li",
+						"attributes": [],
+						"children": [
+							{
+								"start": 24,
+								"end": 26,
+								"type": "Text",
+								"data": "c\n"
+							}
+						]
+					}
+				]
+			}
+		]
+	},
+	"css": null,
+	"js": null
+}


### PR DESCRIPTION
Starting to dig into #258 and #224 and related issues. As a starting point, Svelte needs to do a better job of handling situations like these:

```html
<!-- the <p> is never closed, but that's totally fine in HTML -->
<div><p>some text</div>

<!-- these <li> elements don't need closing tags -->
<ul>
  <li>a
  <li>b
  <li>c
</ul>
```

This PR addresses both cases, by noting which elements are forbidden from containing which other elements, and by closing all currently open elements until the one that corresponds to a particular closing tag