### PR TITLE
throw error in dev mode for missing bound properties (#249)

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -319,7 +319,7 @@ export default function dom ( parsed, source, options, names ) {
 	if ( options.dev ) {
 		Object.keys( generator.expectedProperties ).forEach( prop => {
 			stateBlock.addLine(
-				`if ( !( '${prop}' in this._state ) ) throw new Error( "Component was created without expected data property 'foo'" );`
+				`if ( !( '${prop}' in this._state ) ) throw new Error( "Component was created without expected data property '${prop}'" );`
 			);
 		});
 	}

--- a/test/generator/dev-warning-missing-data-binding/_config.js
+++ b/test/generator/dev-warning-missing-data-binding/_config.js
@@ -1,0 +1,7 @@
+export default {
+	dev: true,
+
+	error ( assert, err ) {
+		assert.equal( err.message, `Component was created without expected data property 'value'` );
+	}
+};

--- a/test/generator/dev-warning-missing-data-binding/main.html
+++ b/test/generator/dev-warning-missing-data-binding/main.html
@@ -1,0 +1,1 @@
+<input bind:value>


### PR DESCRIPTION
Ref #249. If a template has a binding...

```html
<input bind:value>
```

...and the component is initialised without a value for `value`, an error will be thrown in dev mode.

(Also fixes my *ahem* [deliberate mistake](https://github.com/sveltejs/svelte/pull/320/files#diff-63b1c2c951c4dda845ff23351e808431R309) in the last PR)