### PR TITLE
better errors for malformed event handlers 

### DIFF
--- a/test/parser/error-event-handler/error.json
+++ b/test/parser/error-event-handler/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "Expected call expression",
+	"loc": {
+		"line": 1,
+		"column": 15
+	},
+	"pos": 15
+}

--- a/test/parser/error-event-handler/input.html
+++ b/test/parser/error-event-handler/input.html
@@ -1,0 +1,1 @@
+<div on:click='foo'></div>


### PR DESCRIPTION
Ref #220. Rather than using Acorn's tokenizer to determine when an expression has ended, we read each character until we get to a quote mark (for quoted event directives) or a whitespace character (for unquoted ones), handling escaped quote marks as necessary. Then, we parse the whole lot as a program.

This avoids cryptic errors like 'unterminated string constant' and allows us to give more useful feedback.