### PR TITLE
deconflict helpers when not using shared helpers

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -410,11 +410,13 @@ export default function dom ( parsed, source, options, names ) {
 			`import { ${names.join( ', ' )} } from ${JSON.stringify( sharedPath )}`
 		);
 	} else {
-		builders.main.addBlock( `var ${generator.aliases.dispatchObservers} = ${shared.dispatchObservers.toString()}` );
-
 		Object.keys( generator.uses ).forEach( key => {
 			const fn = shared[ key ]; // eslint-disable-line import/namespace
-			builders.main.addBlock( fn.toString() );
+			if ( key !== generator.aliases[ key ] ) {
+				builders.main.addBlock( `var ${generator.aliases[ key ]} = ${fn.toString()}}` );
+			} else {
+				builders.main.addBlock( fn.toString() );
+			}
 		});
 	}
 


### PR DESCRIPTION
This fixes #337, but also fixes the situation [here](https://svelte.technology/repl/?version=1.10.0&gist=b178c0560c9783bc983a154659553fb4). If you import things that conflict with helpers, but are not using shared helpers, these helpers will be aliased where they are used, but they will not be aliased where they are actually defined.