### PR TITLE
make void element test case insensitive

### DIFF
--- a/src/utils/voidElementNames.js
+++ b/src/utils/voidElementNames.js
@@ -1,1 +1,1 @@
-export default /^(?:area|base|br|col|command|\!doctype|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/;
+export default /^(?:area|base|br|col|command|\!doctype|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/i;


### PR DESCRIPTION
Fixes #336, but also fixes other issues where writing a void element in anything but lowercase would throw an error.
