### PR TITLE
typecheck argument in _set when in dev mode

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -211,6 +211,14 @@ export default function dom ( parsed, source, options, names ) {
 		_set: new CodeBuilder()
 	};
 
+	if ( options.dev ) {
+		builders._set.addBlock ( deindent`
+			if ( typeof newState !== 'object' ) {
+				throw new Error( 'Component .set was called without an object of data key-values to update.' );
+			}
+		`);
+	}
+
 	builders._set.addLine( 'var oldState = this._state;' );
 	builders._set.addLine( 'this._state = Object.assign( {}, oldState, newState );' );
 


### PR DESCRIPTION
Fixes #342. I'm not *entirely* thrilled with the wording of this error message.

Putting this check in `._set` as opposed to in `.set` seemed to be the most straightforward, as there's not really a good mechanism for having different versions of the helper functions themselves in dev vs regular mode.