### PR TITLE
Resolved embedded Svelte library breaking HTML document

### DIFF
--- a/src/parse/read/script.js
+++ b/src/parse/read/script.js
@@ -17,7 +17,7 @@ export default function readScript ( parser, start, attributes ) {
 			break;
 		}
 
-		if ( parser.eat( '</script>' ) ) {
+		if ( parser.eat( '<\/script>' ) ) {
 			break;
 		}
 	}


### PR DESCRIPTION
This resolves issue #344.

When the Svelte library is included inline in an HTML document, this line closes the HTML script block unexpectedly.

This prevents that from happening, and also prevents (most) minifiers from converting it back to `'</script>'`, which is why `'</scr' + 'ipt>'` was not used.