### PR TITLE
Remove ES2015 let from css block

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -255,7 +255,7 @@ export default function dom ( parsed, source, options, names ) {
 
 	if ( parsed.css && options.css !== false ) {
 		builders.main.addBlock( deindent`
-			let addedCss = false;
+			var addedCss = false;
 			function addCss () {
 				var style = ${generator.helper( 'createElement' )}( 'style' );
 				style.textContent = ${JSON.stringify( processCss( parsed, generator.code ) )};


### PR DESCRIPTION
A `let` has snuck by the in the generated code for adding css:

Input:

```html
<h1>Hello {{name}}!</h1>

<style>
  h1 {
    color: red;
  }
</style>
```
Output:

```js
let addedCss = false;
function addCss () {
	var style = createElement( 'style' );
	style.textContent = "\n  h1[svelte-895830737], [svelte-895830737] h1 {\n    color: red;\n  }\n";
	appendNode( style, document.head );

	addedCss = true;
}

function renderMainFragment ( root, component ) {
// ...
```

It is sneaking by the ES5 syntax check in the tests (introduced in #82) because the css block is appended before the starting point of the check, `renderMainFragment`. I played with possible ways of updating the check, but I couldn't find a non-hacky approach since there are few types of blocks that may appear (at least `applyComputations` and `addCss`).

Thanks so much for your work on this framework, it's great! 
