### PR TITLE
Changed `create` API method to use `new Function()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export function create ( source, _options = {} ) {
 
 	let result;
 	try {
-		result = ( 1, eval )( compiled.code );
+		result = (new Function( 'return ' + compiled.code ))();
 	} catch ( err ) {
 		if ( _options.onerror ) {
 			_options.onerror( err );


### PR DESCRIPTION
As per the recommendation of @PaulBGD, I have changed the `create` API method to use `new Function` instead of an indirect eval.

All existing tests pass as expected, and real world implementation tests behave the same.