### PR TITLE
Feature/render in iframe fix

### DIFF
--- a/test/generator/samples/render-in-iframe/Widget.html
+++ b/test/generator/samples/render-in-iframe/Widget.html
@@ -1,0 +1,7 @@
+<p>test</p>
+
+<style>
+	p {
+		color: red;
+	}
+</style>

--- a/test/generator/samples/render-in-iframe/_config.js
+++ b/test/generator/samples/render-in-iframe/_config.js
@@ -1,21 +1,19 @@
 export default {
 	test ( assert, component, target, window ) {
+		const testStyles = ([control, test]) => {
+			assert.equal( window.getComputedStyle( control ).color, 'blue' );
+			assert.equal( window.getComputedStyle( test ).color, 'red' );
+		};
+
 		const iframe = window.document.createElement('iframe');
 		window.document.body.appendChild(iframe);
-
 		const otherTarget = iframe.contentWindow.document.body;
 
 		new component.constructor({
 			target: otherTarget
 		});
 
-		assert.equal(
-			window.getComputedStyle(target.querySelector('h1')).color,
-			'rgb(255, 0, 0)'
-		);
-		assert.equal(
-			window.getComputedStyle(otherTarget.querySelector('h1')).color,
-			'rgb(255, 0, 0)'
-		);
+		testStyles(target.querySelectorAll( 'p' ));
+		testStyles(otherTarget.querySelectorAll( 'p' ));
 	}
 };

--- a/test/generator/samples/render-in-iframe/main.html
+++ b/test/generator/samples/render-in-iframe/main.html
@@ -1,6 +1,18 @@
-<h1>Just some static HTML</h1>
+<p>control</p>
+<div>
+	<Widget/>
+</div>
+
 <style>
-h1 {
-	color: rgb(255, 0, 0);
-}
+	p {
+		color: blue;
+	}
 </style>
+
+<script>
+	import Widget from './Widget.html';
+
+	export default {
+		components: { Widget }
+	};
+</script>


### PR DESCRIPTION
@Rich-Harris Thanks for including this!

I have updated to 1.11.2 and tested it out. Unfortunately my original test case failed to test child components (although my version did work for them) and their css was not being added to the correct document.

The problem is that when a child component is mounted, the target element is not yet part of the correct document. It was created using document.createElement, thus `target.ownerDocument` points to the original document (`window.document`). After `mount`, the target element is added to the iframe and `target.ownerDocument` is pointing to the iframe's `document`.

 I can think of three options for fixing this:
1. store the root components `options.target.ownerDocument` and reference it in the child components (my original approach)
2. create elements using the correct document (using `target.ownerDocument.createElement`)
3. call addCss **after** the elements are added to the DOM

I tried the last by adding a setTimeout around the addCss call:
```generator.current.builders.mount.addLine( `setTimeout(function(){	if ( !target.ownerDocument.__sveltecss_${parsed.hash} ) addCss( target.ownerDocument )});` );```

It works, but it's hardly ideal. First of all, it breaks all css tests due to it's async nature. Even worse, it triggers multiple style updates and reflows, since every component's css is added independently, instead of all in one go.

So I tried different stuff and finally came up with this solution: add the css after the dom is updated, using a render hook.

P.S. I am fully aware that this is a niche use case, so if the changes have an impact on the overall performance, I am ok with maintaining my own fork with this patch.