### PR TITLE
pin css-tree at 1.0.0-alpha16

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "babel-register": "^6.23.0",
     "codecov": "^1.0.1",
     "console-group": "^0.3.2",
-    "css-tree": "^1.0.0-alpha16",
+    "css-tree": "1.0.0-alpha16",
     "eslint": "^3.12.2",
     "eslint-plugin-import": "^2.2.0",
     "estree-walker": "^0.3.0",


### PR DESCRIPTION
css-tree 1.0.0-alpha17 introduces some non backwards compatible changes. The path in the package to the walker changes (from `css-tree/lib/utils/walk.js` to `css-tree/lib/walker/index.js`) and its API changes. I tried to update Svelte to work with the new version, but was unable to do so quickly. So I think we should pin at this version, and then revisit this later once its API has settled down.
