### PR TITLE
Fix removing last key in object when it has a trailing comma

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -206,8 +206,8 @@ export default function dom ( parsed, source, options, names ) {
 			}
 		});
 		if ( hasNonImportedComponent ) {
-			// remove the specific components which were imported, as we'll refer to them directly
-			Object.keys( generator.importedComponents ).forEach ( key => {
+			// remove the specific components that were imported, as we'll refer to them directly
+			Object.keys( generator.importedComponents ).forEach( key => {
 				removeObjectKey( generator, templateProperties.components.value, key );
 			});
 		} else {

--- a/src/utils/removeObjectKey.js
+++ b/src/utils/removeObjectKey.js
@@ -4,6 +4,6 @@ export default function removeObjectKey ( generator, node, key ) {
 	const index = properties.findIndex( property => property.key.type === 'Identifier' && property.key.name === key );
 	if ( index === -1 ) return;
 	const a = properties[ index ].start;
-	const b = index < properties.length - 1 ? properties[ index + 1 ].start : properties[ index ].end;
+	const b = index < properties.length - 1 ? properties[ index + 1 ].start : node.end - 1;
 	generator.code.remove( a, b );
 }

--- a/test/generator/samples/imported-renamed-components/main.html
+++ b/test/generator/samples/imported-renamed-components/main.html
@@ -5,6 +5,6 @@
 	import ComponentTwo from './ComponentTwo.html';
 
 	export default {
-		components: { RenamedComponentOne: ComponentOne, RenamedComponentTwo: ComponentTwo }
+		components: { RenamedComponentOne: ComponentOne, RenamedComponentTwo: ComponentTwo },
 	};
 </script>


### PR DESCRIPTION
I realized my change in #390 didn't correctly handle the case when you are removing the last key in an object and it has a trailing comma. Previously, it would leave the comma, which would lead to malformed output. Now we're removing all the way up to the end of the object node, which seems like the best way to make sure we get the comma, if present.