### PR TITLE
Only do special reserved name handling when tag is all lowercase letters

### DIFF
--- a/src/parse/read/expression.js
+++ b/src/parse/read/expression.js
@@ -4,7 +4,7 @@ export default function readExpression ( parser ) {
 	const start = parser.index;
 
 	const name = parser.readUntil( /\s*}}/ );
-	if ( name && /^\w+$/.test( name ) ) {
+	if ( name && /^[a-z]+$/.test( name ) ) {
 		return {
 			type: 'Identifier',
 			start,

--- a/test/generator/samples/attribute-dynamic-reserved/_config.js
+++ b/test/generator/samples/attribute-dynamic-reserved/_config.js
@@ -3,12 +3,12 @@ export default {
 		class: 'foo'
 	},
 
-	html: `<div class="foo"></div>`,
+	html: `<div class="foo"></div>123`,
 
 	test ( assert, component, target ) {
 		component.set({ class: 'bar' });
-		assert.equal( target.innerHTML, `<div class="bar"></div>` );
-		
+		assert.equal( target.innerHTML, `<div class="bar"></div>123` );
+
 		component.destroy();
 	}
 };

--- a/test/generator/samples/attribute-dynamic-reserved/main.html
+++ b/test/generator/samples/attribute-dynamic-reserved/main.html
@@ -1,1 +1,1 @@
-<div class='{{class}}'></div>
+<div class='{{class}}'></div>{{123}}


### PR DESCRIPTION
The changes in #385 caused undesirable behavior with tags like `{{123}}`. Since `123` matches `/^\w+$/`, this is now turned into `root.123`.

This PR restricts the special handling only to tags made up of all lowercase letters, which will cover all the cases where the tag is a reserved word. Other cases will continue to be parsed by Acorn.