### PR TITLE
Deconflict `template` variable (#392)

### DIFF
--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -35,6 +35,12 @@ export default class Generator {
 		this.cssId = parsed.css ? `svelte-${parsed.hash}` : '';
 		this.usesRefs = false;
 
+		// allow compiler to deconflict user's `import { get } from 'whatever'` and
+		// Svelte's builtin `import { get, ... } from 'svelte/shared.js'`;
+		this.importedNames = {};
+
+		this.aliases = {};
+
 		this._callbacks = {};
 	}
 
@@ -45,6 +51,20 @@ export default class Generator {
 				this.code.addSourcemapLocation( node.end );
 			}
 		});
+	}
+
+	alias ( name ) {
+		if ( !( name in this.aliases ) ) {
+			let alias = name;
+			let i = 1;
+			while ( alias in this.importedNames ) {
+				alias = `${name}$${i++}`;
+			}
+
+			this.aliases[ name ] = alias;
+		}
+
+		return this.aliases[ name ];
 	}
 
 	contextualise ( expression, isEventHandler ) {
@@ -58,6 +78,8 @@ export default class Generator {
 
 		let scope = annotateWithScopes( expression );
 
+		const self = this;
+
 		walk( expression, {
 			enter ( node, parent, key ) {
 				if ( node._scope ) {
@@ -70,7 +92,7 @@ export default class Generator {
 					if ( scope.has( name ) ) return;
 
 					if ( parent && parent.type === 'CallExpression' && node === parent.callee && helpers[ name ] ) {
-						code.prependRight( node.start, `template.helpers.` );
+						code.prependRight( node.start, `${self.alias( 'template' )}.helpers.` );
 					}
 
 					else if ( name === 'event' && isEventHandler ) {
@@ -249,6 +271,9 @@ export default class Generator {
 
 					imports.push( node );
 					this.code.remove( a, b );
+					node.specifiers.forEach( specifier => {
+						this.importedNames[ specifier.local.name ] = true;
+					});
 				}
 			}
 
@@ -260,21 +285,33 @@ export default class Generator {
 					// export is last property, we can just return it
 					this.code.overwrite( defaultExport.start, defaultExport.declaration.start, `return ` );
 				} else {
-					// TODO ensure `template` isn't already declared
-					this.code.overwrite( defaultExport.start, defaultExport.declaration.start, `var template = ` );
+					// we need to avoid a conflict with anything on the top-level scope of the component
+					// however, determining which things these are is tricky, so we instead just avoid conflicts with any identifiers anywhere
+					const identifiers = new Set();
+					walk( js, {
+						enter ( node ) {
+							if ( node.type === 'Identifier' ) {
+								identifiers.add( node.name );
+							}
+						}
+					});
+					let template = 'template';
+					for ( let i = 1; identifiers.has( template ); template = `template$${i++}` );
+
+					this.code.overwrite( defaultExport.start, defaultExport.declaration.start, `var ${template} = ` );
 
 					let i = defaultExport.start;
 					while ( /\s/.test( source[ i - 1 ] ) ) i--;
 
 					const indentation = source.slice( i, defaultExport.start );
-					this.code.appendLeft( finalNode.end, `\n\n${indentation}return template;` );
+					this.code.appendLeft( finalNode.end, `\n\n${indentation}return ${template};` );
 				}
 
 				defaultExport.declaration.properties.forEach( prop => {
 					templateProperties[ prop.key.name ] = prop;
 				});
 
-				this.code.prependRight( js.content.start, 'var template = (function () {' );
+				this.code.prependRight( js.content.start, `var ${this.alias( 'template' )} = (function () {` );
 			} else {
 				this.code.prependRight( js.content.start, '(function () {' );
 			}

--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -285,18 +285,9 @@ export default class Generator {
 					// export is last property, we can just return it
 					this.code.overwrite( defaultExport.start, defaultExport.declaration.start, `return ` );
 				} else {
-					// we need to avoid a conflict with anything on the top-level scope of the component
-					// however, determining which things these are is tricky, so we instead just avoid conflicts with any identifiers anywhere
-					const identifiers = new Set();
-					walk( js, {
-						enter ( node ) {
-							if ( node.type === 'Identifier' ) {
-								identifiers.add( node.name );
-							}
-						}
-					});
+					const { declarations } = annotateWithScopes( js );
 					let template = 'template';
-					for ( let i = 1; identifiers.has( template ); template = `template$${i++}` );
+					for ( let i = 1; template in declarations; template = `template$${i++}` );
 
 					this.code.overwrite( defaultExport.start, defaultExport.declaration.start, `var ${template} = ` );
 

--- a/src/generators/annotateWithScopes.js
+++ b/src/generators/annotateWithScopes.js
@@ -28,7 +28,7 @@ export default function annotateWithScopes ( expression ) {
 				node._scope = scope = new Scope( scope, true );
 			}
 
-			else if ( /Declaration/.test( node.type ) ) {
+			else if ( /(Function|Class|Variable)Declaration/.test( node.type ) ) {
 				scope.addDeclaration( node );
 			}
 		},
@@ -54,7 +54,7 @@ class Scope {
 		if ( node.kind === 'var' && !this.block && this.parent ) {
 			this.parent.addDeclaration( node );
 		} else if ( node.type === 'VariableDeclaration' ) {
-			node.declarators.forEach( declarator => {
+			node.declarations.forEach( declarator => {
 				extractNames( declarator.id ).forEach( name => {
 					this.declarations[ name ] = true;
 				});
@@ -100,4 +100,3 @@ const extractors = {
 		extractors[ param.left.type ]( names, param.left );
 	}
 };
-

--- a/src/generators/dom/visitors/Component.js
+++ b/src/generators/dom/visitors/Component.js
@@ -106,7 +106,7 @@ export default {
 			componentInitProperties.push(`data: ${name}_initialData`);
 		}
 
-		const expression = node.name === ':Self' ? generator.name : generator.importedComponents[ node.name ] || `template.components.${node.name}`;
+		const expression = node.name === ':Self' ? generator.name : generator.importedComponents[ node.name ] || `${generator.alias( 'template' )}.components.${node.name}`;
 
 		local.init.addBlockAtStart( deindent`
 			${statements.join( '\n\n' )}

--- a/src/generators/dom/visitors/attributes/addElementAttributes.js
+++ b/src/generators/dom/visitors/attributes/addElementAttributes.js
@@ -182,7 +182,7 @@ export default function addElementAttributes ( generator, node, local ) {
 
 			if ( name in generator.events ) {
 				local.init.addBlock( deindent`
-					var ${handlerName} = template.events.${name}.call( component, ${local.name}, function ( event ) {
+					var ${handlerName} = ${generator.alias( 'template' )}.events.${name}.call( component, ${local.name}, function ( event ) {
 						${handlerBody}
 					});
 				` );

--- a/src/generators/server-side-rendering/index.js
+++ b/src/generators/server-side-rendering/index.js
@@ -60,12 +60,12 @@ export default function ssr ( parsed, source, options, names ) {
 	parsed.html.children.forEach( node => generator.visit( node ) );
 
 	builders.render.addLine(
-		templateProperties.data ? `root = Object.assign( template.data(), root || {} );` : `root = root || {};`
+		templateProperties.data ? `root = Object.assign( ${generator.alias( 'template' )}.data(), root || {} );` : `root = root || {};`
 	);
 
 	computations.forEach( ({ key, deps }) => {
 		builders.render.addLine(
-			`root.${key} = template.computed.${key}( ${deps.map( dep => `root.${dep}` ).join( ', ' )} );`
+			`root.${key} = ${generator.alias( 'template' )}.computed.${key}( ${deps.map( dep => `root.${dep}` ).join( ', ' )} );`
 		);
 	});
 
@@ -118,7 +118,7 @@ export default function ssr ( parsed, source, options, names ) {
 		` );
 
 		templateProperties.components.value.properties.forEach( prop => {
-			builders.renderCss.addLine( `addComponent( template.components.${prop.key.name} );` );
+			builders.renderCss.addLine( `addComponent( ${generator.alias( 'template' )}.components.${prop.key.name} );` );
 		});
 	}
 
@@ -140,7 +140,7 @@ export default function ssr ( parsed, source, options, names ) {
 		${name}.filename = ${JSON.stringify( options.filename )};
 
 		${name}.data = function () {
-			return ${templateProperties.data ? `template.data()` : `{}`};
+			return ${templateProperties.data ? `${generator.alias( 'template' )}.data()` : `{}`};
 		};
 
 		${name}.render = function ( root, options ) {

--- a/src/generators/server-side-rendering/visitors/Component.js
+++ b/src/generators/server-side-rendering/visitors/Component.js
@@ -50,7 +50,7 @@ export default {
 			}))
 			.join( ', ' );
 
-		const expression = node.name === ':Self' ? generator.name : `template.components.${node.name}`;
+		const expression = node.name === ':Self' ? generator.name : `${generator.alias( 'template' )}.components.${node.name}`;
 
 		bindings.forEach( binding => {
 			generator.addBinding( binding, expression );

--- a/test/generator/samples/deconflict-template-1/_config.js
+++ b/test/generator/samples/deconflict-template-1/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `template`
+};

--- a/test/generator/samples/deconflict-template-1/main.html
+++ b/test/generator/samples/deconflict-template-1/main.html
@@ -1,0 +1,13 @@
+{{value}}
+
+<script>
+	import template from './module.js';
+
+	export default {
+		data() {
+			return {
+				value: template
+			};
+		}
+	};
+</script>

--- a/test/generator/samples/deconflict-template-1/module.js
+++ b/test/generator/samples/deconflict-template-1/module.js
@@ -1,0 +1,1 @@
+export default 'template';

--- a/test/generator/samples/deconflict-template-2/_config.js
+++ b/test/generator/samples/deconflict-template-2/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `template`
+};

--- a/test/generator/samples/deconflict-template-2/main.html
+++ b/test/generator/samples/deconflict-template-2/main.html
@@ -1,0 +1,15 @@
+{{value}}
+
+<script>
+	export default {
+		data() {
+			return {
+				value: template()
+			};
+		}
+	};
+
+	function template() {
+		return 'template';
+	}
+</script>


### PR DESCRIPTION
This isn't a particularly graceful solution. We simply make sure we avoid conflicts with *all* identifiers in the component's source, instead of just the ones that would actually collide with us. The code for determining the set of all identifiers lives inline in the case where we need it (when the `export default` isn't the last thing in the script), but it could be moved elsewhere if we end up needing this functionality anywhere else.