### PR TITLE
Fix: binding input radio group #399

### DIFF
--- a/src/generators/dom/visitors/attributes/addElementBinding.js
+++ b/src/generators/dom/visitors/attributes/addElementBinding.js
@@ -59,9 +59,7 @@ export default function createBinding ( generator, node, attribute, current, loc
 			setter = deindent`
 				if ( !${local.name}.checked ) return;
 				${setter}
-				component._bindingGroups[${bindingGroup}].forEach( function ( input ) {
-					input.checked = false;
-				});`;
+			`;
 		}
 
 		const condition = type === 'checkbox' ?

--- a/test/generator/samples/binding-input-radio-group/_config.js
+++ b/test/generator/samples/binding-input-radio-group/_config.js
@@ -16,15 +16,15 @@ export default {
 		<label>
 			<input type="radio"> Alpha
 		</label>
-		
+
 		<label>
 			<input type="radio"> Beta
 		</label>
-		
+
 		<label>
 			<input type="radio"> Gamma
 		</label>
-		
+
 		<p>Beta</p>`,
 
 	test ( assert, component, target, window ) {
@@ -42,17 +42,21 @@ export default {
 			<label>
 				<input type="radio"> Alpha
 			</label>
-			
+
 			<label>
 				<input type="radio"> Beta
 			</label>
-			
+
 			<label>
 				<input type="radio"> Gamma
 			</label>
-			
+
 			<p>Alpha</p>
 		` );
+
+		assert.equal( inputs[0].checked, true );
+		assert.equal( inputs[1].checked, false );
+		assert.equal( inputs[2].checked, false );
 
 		component.set({ selected: values[2] });
 		assert.equal( inputs[0].checked, false );
@@ -63,15 +67,15 @@ export default {
 			<label>
 				<input type="radio"> Alpha
 			</label>
-			
+
 			<label>
 				<input type="radio"> Beta
 			</label>
-			
+
 			<label>
 				<input type="radio"> Gamma
 			</label>
-			
+
 			<p>Gamma</p>
 		` );
 	}


### PR DESCRIPTION
I have removed the code that sets the radio input's state to unchecked. Browsers already toggle the state correctly for members of the same radiogroup.