### PR TITLE
Disable Buble transforms not needed for Node 4

### DIFF
--- a/rollup/rollup.config.main.js
+++ b/rollup/rollup.config.main.js
@@ -17,7 +17,12 @@ export default {
 			include: 'src/**',
 			exclude: 'src/shared/**',
 			transforms: {
-				dangerousTaggedTemplateString: true
+				arrow: false,
+				classes: false,
+				conciseMethodProperty: false,
+				templateString: false,
+				letConst: false,
+				numericLiteral: false
 			}
 		})
 	],

--- a/rollup/rollup.config.main.js
+++ b/rollup/rollup.config.main.js
@@ -16,13 +16,8 @@ export default {
 		buble({
 			include: 'src/**',
 			exclude: 'src/shared/**',
-			transforms: {
-				arrow: false,
-				classes: false,
-				conciseMethodProperty: false,
-				templateString: false,
-				letConst: false,
-				numericLiteral: false
+			target: {
+				node: 4
 			}
 		})
 	],

--- a/rollup/rollup.config.ssr.js
+++ b/rollup/rollup.config.ssr.js
@@ -15,13 +15,8 @@ export default {
 		buble({
 			include: 'src/**',
 			exclude: 'src/shared/**',
-			transforms: {
-				arrow: false,
-				classes: false,
-				conciseMethodProperty: false,
-				templateString: false,
-				letConst: false,
-				numericLiteral: false
+			target: {
+				node: 4
 			}
 		})
 	],

--- a/rollup/rollup.config.ssr.js
+++ b/rollup/rollup.config.ssr.js
@@ -16,7 +16,12 @@ export default {
 			include: 'src/**',
 			exclude: 'src/shared/**',
 			transforms: {
-				dangerousTaggedTemplateString: true
+				arrow: false,
+				classes: false,
+				conciseMethodProperty: false,
+				templateString: false,
+				letConst: false,
+				numericLiteral: false
 			}
 		})
 	],


### PR DESCRIPTION
Many of the transforms being done by Buble aren't required for Node 4. Disabling them is nicer, and also slightly decreases the size of the bundle - down from 385KB to 375KB.