### PR TITLE
disallow `import root` during validation

### DIFF
--- a/src/validate/js/index.js
+++ b/src/validate/js/index.js
@@ -63,5 +63,13 @@ export default function validateJs ( validator, js ) {
 
 			validator.defaultExport = node;
 		}
+
+		if ( node.type === 'ImportDeclaration' ) {
+			node.specifiers.forEach( specifier => {
+				if ( specifier.local.name === 'root' ) {
+					validator.error( `Imported identifiers cannot have a name of 'root' due to technical limitations`, specifier.start );
+				}
+			});
+		}
 	});
 }

--- a/test/validator/samples/import-root/errors.json
+++ b/test/validator/samples/import-root/errors.json
@@ -1,0 +1,8 @@
+[{
+	"message": "Imported identifiers cannot have a name of 'root' due to technical limitations",
+	"pos": 17,
+	"loc": {
+		"line": 2,
+		"column": 8
+	}
+}]

--- a/test/validator/samples/import-root/input.html
+++ b/test/validator/samples/import-root/input.html
@@ -1,0 +1,3 @@
+<script>
+	import root from 'foo';
+</script>


### PR DESCRIPTION
That the root context is called `root` is ingrained pretty deeply, and it seems difficult to deconflict this with an import of `root`. So for now it's probably best to simply disallow this entirely during validation.