### PR TITLE
Prevent unclosed <script> causing infinite loop

### DIFF
--- a/src/parse/read/script.js
+++ b/src/parse/read/script.js
@@ -7,6 +7,8 @@ export default function readScript ( parser, start, attributes ) {
 	const scriptStart = parser.index;
 	const scriptEnd = parser.template.indexOf( scriptClosingTag, scriptStart );
 
+	if ( scriptEnd === -1 ) parser.error( `<script> must have a closing tag` );
+
 	const source = spaces( scriptStart ) + parser.template.slice( scriptStart, scriptEnd );
 	parser.index = scriptEnd + scriptClosingTag.length;
 

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -1,15 +1,16 @@
 import assert from 'assert';
 import * as fs from 'fs';
-import { svelte, exists } from '../helpers.js';
+import { svelte } from '../helpers.js';
 
 describe( 'parse', () => {
 	fs.readdirSync( 'test/parser/samples' ).forEach( dir => {
 		if ( dir[0] === '.' ) return;
 
-		const solo = exists( `test/parser/samples/${dir}/solo` );
+		// add .solo to a sample directory name to only run that test
+		const solo = /\.solo$/.test( dir );
 
 		if ( solo && process.env.CI ) {
-			throw new Error( 'Forgot to remove `solo: true` from test' );
+			throw new Error( `Forgot to remove '.solo' from test parser/samples/${dir}` );
 		}
 
 		( solo ? it.only : it )( dir, () => {

--- a/test/parser/samples/error-script-unclosed/error.json
+++ b/test/parser/samples/error-script-unclosed/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "<script> must have a closing tag",
+	"loc": {
+		"line": 3,
+		"column": 8
+	},
+	"pos": 34
+}

--- a/test/parser/samples/error-script-unclosed/input.html
+++ b/test/parser/samples/error-script-unclosed/input.html
@@ -1,0 +1,3 @@
+<h1>Hello {{name}}!</h1>
+
+<script>


### PR DESCRIPTION
Sometimes in the REPL you'll start writing a `<script>` tag, and before you get a chance to close it the compiler goes haywire. This PR prevents that