### PR TITLE
use assign helper, to avoid compatibility headaches

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -241,7 +241,7 @@ export default function dom ( parsed, source, options ) {
 	}
 
 	builders._set.addLine( 'var oldState = this._state;' );
-	builders._set.addLine( 'this._state = Object.assign( {}, oldState, newState );' );
+	builders._set.addLine( `this._state = ${generator.helper( 'assign' )}( {}, oldState, newState );` );
 
 	if ( computations.length ) {
 		const builder = new CodeBuilder();
@@ -340,7 +340,7 @@ export default function dom ( parsed, source, options ) {
 	if ( generator.usesRefs ) constructorBlock.addLine( `this.refs = {};` );
 
 	constructorBlock.addLine(
-		`this._state = ${templateProperties.data ? `Object.assign( ${generator.alias( 'template' )}.data(), options.data )` : `options.data || {}`};`
+		`this._state = ${templateProperties.data ? `${generator.helper( 'assign' )}( ${generator.alias( 'template' )}.data(), options.data )` : `options.data || {}`};`
 	);
 
 	if ( !generator.builders.metaBindings.isEmpty() ) {
@@ -393,7 +393,7 @@ export default function dom ( parsed, source, options ) {
 
 	if ( sharedPath ) {
 		const base = templateProperties.methods ? `{}, ${generator.alias( 'template' )}.methods` : `{}`;
-		builders.main.addBlock( `${name}.prototype = Object.assign( ${base}, ${generator.helper( 'proto' )} );` );
+		builders.main.addBlock( `${name}.prototype = ${generator.helper( 'assign' )}( ${base}, ${generator.helper( 'proto' )} );` );
 	} else {
 		if ( templateProperties.methods ) {
 			builders.main.addBlock( `${name}.prototype = ${generator.alias( 'template' )}.methods;` );

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -3,6 +3,15 @@ export * from './methods.js';
 
 export function noop () {}
 
+export function assign ( target ) {
+	for ( var i = 1; i < arguments.length; i += 1 ) {
+		var source = arguments[i];
+		for ( var k in source ) target[k] = source[k];
+	}
+
+	return target;
+}
+
 export function differs ( a, b ) {
 	return ( a !== b ) || ( a && ( typeof a === 'object' ) || ( typeof a === 'function' ) );
 }

--- a/test/generator/index.js
+++ b/test/generator/index.js
@@ -30,6 +30,8 @@ require.extensions[ '.html' ] = function ( module, filename ) {
 	return module._compile( code, filename );
 };
 
+const Object_assign = Object.assign;
+
 describe( 'generate', () => {
 	before( setupHtmlEqual );
 
@@ -93,6 +95,10 @@ describe( 'generate', () => {
 
 			return env()
 				.then( window => {
+					Object.assign = () => {
+						throw new Error( 'cannot use Object.assign in generated code, as it is not supported everywhere' );
+					};
+
 					global.window = window;
 
 					// Put the constructor on window for testing
@@ -145,6 +151,9 @@ describe( 'generate', () => {
 						if ( !config.show ) console.log( addLineNumbers( code ) ); // eslint-disable-line no-console
 						throw err;
 					}
+				})
+				.then( () => {
+					Object.assign = Object_assign;
 				});
 		});
 	}


### PR DESCRIPTION
This fixes #431. It adds ~100 bytes to an app (presumably less after gzip), so there's an argument against doing it, but it does mean that people stuck supporting IE11 and old Android phones don't need to do anything extra to get their Svelte apps running.

Thoughts? Should it be behind a `legacy` option, or is that unwanted complexity?