### PR TITLE
generate more idiomatic code when removing object properties

### DIFF
--- a/src/utils/removeObjectKey.js
+++ b/src/utils/removeObjectKey.js
@@ -1,9 +1,33 @@
 export default function removeObjectKey ( generator, node, key ) {
 	if ( node.type !== 'ObjectExpression' ) return;
-	const properties = node.properties;
-	const index = properties.findIndex( property => property.key.type === 'Identifier' && property.key.name === key );
-	if ( index === -1 ) return;
-	const a = properties[ index ].start;
-	const b = index < properties.length - 1 ? properties[ index + 1 ].start : node.end - 1;
-	generator.code.remove( a, b );
+
+	let i = node.properties.length;
+	while ( i-- ) {
+		const property = node.properties[i];
+		if ( property.key.type === 'Identifier' && property.key.name === key ) {
+			let a;
+			let b;
+
+			if ( node.properties.length === 1 ) {
+				// remove everything, leave {}
+				a = node.start + 1;
+				b = node.end - 1;
+			} else if ( i === 0 ) {
+				// remove everything before second property, including comments
+				a = node.start + 1;
+				while ( /\s/.test( generator.code.original[a] ) ) a += 1;
+
+				b = node.properties[i].end;
+				while ( /[\s,]/.test( generator.code.original[b] ) ) b += 1;
+			} else {
+				// remove the end of the previous property to the end of this one
+				a = node.properties[ i - 1 ].end;
+				b = property.end;
+			}
+
+			generator.code.remove( a, b );
+			node.properties.splice( i, 1 );
+			return;
+		}
+	}
 }

--- a/test/generator/samples/attribute-partial-number/main.html
+++ b/test/generator/samples/attribute-partial-number/main.html
@@ -1,11 +1,11 @@
 <Component value="10px"/>
 
 <script>
-    import Component from './Component.html';
+	import Component from './Component.html';
 
-    export default {
-        components: {
-            Component
-        }
-    };
+	export default {
+		components: {
+			Component
+		}
+	};
 </script>


### PR DESCRIPTION
#442 (part two) — Svelte now removes properties from objects the same way a human would. Probably overkill but quite satisfying... will probably make sense to abstract this into a general purpose node removal function that can be used for eliminating `import` declarations and default exports with no remaining purpose.