### PR TITLE
better prototype assignment

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -394,7 +394,7 @@ export default function dom ( parsed, source, options ) {
 	const sharedPath = options.shared === true ? 'svelte/shared.js' : options.shared;
 
 	const prototypeBase = `${name}.prototype` + ( templateProperties.methods ? `, ${generator.alias( 'template' )}.methods` : '' );
-	const proto = sharedPath ? generator.helper( 'proto ' ) : deindent`
+	const proto = sharedPath ? `${generator.helper( 'proto' )} ` : deindent`
 		{
 			${
 				[ 'get', 'fire', 'observe', 'on', 'set', '_flush' ]

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,11 @@ import parse from './parse/index.js';
 import validate from './validate/index.js';
 import generate from './generators/dom/index.js';
 import generateSSR from './generators/server-side-rendering/index.js';
+import { assign } from './shared/index.js';
 import { version } from '../package.json';
 
 function normalizeOptions ( options ) {
-	return Object.assign( {
+	return assign( {
 		generate: 'dom',
 
 		// a filename is necessary for sourcemap generation

--- a/test/generator/index.js
+++ b/test/generator/index.js
@@ -141,8 +141,12 @@ describe( 'generate', () => {
 						component.destroy();
 						assert.equal( target.innerHTML, '' );
 					}
+
+					Object.assign = Object_assign;
 				})
 				.catch( err => {
+					Object.assign = Object_assign;
+
 					if ( config.error && !unintendedError ) {
 						config.error( assert, err );
 					}
@@ -151,9 +155,6 @@ describe( 'generate', () => {
 						if ( !config.show ) console.log( addLineNumbers( code ) ); // eslint-disable-line no-console
 						throw err;
 					}
-				})
-				.then( () => {
-					Object.assign = Object_assign;
 				});
 		});
 	}


### PR DESCRIPTION
This changes prototype assignments from this...

```js
// not shared, no custom methods
Foo.prototype.get = get;
Foo.prototype.fire = fire;
Foo.prototype.observe = observe;
Foo.prototype.on = on;
Foo.prototype.set = set;
Foo.prototype._flush = _flush;

// shared, no custom methods
Foo.prototype = assign( {}, proto );

// not shared, custom methods
Foo.prototype = template.methods; 

Foo.prototype.get = get;
Foo.prototype.fire = fire;
Foo.prototype.observe = observe;
Foo.prototype.on = on;
Foo.prototype.set = set;
Foo.prototype._flush = _flush;

// shared, custom methods
Foo.prototype = assign( {}, template.methods, proto );
```

...to this:

```js
// not shared, no custom methods
assign( Foo.prototype, {
  get: get,
  fire: fire,
  observe: observe,
  on: on,
  set: set,
  _flush: _flush
});

// shared, no custom methods
assign( Foo.prototype, proto );

// not shared, custom methods
assign( Foo.prototype, template.methods, {
  get: get,
  fire: fire,
  observe: observe,
  on: on,
  set: set,
  _flush: _flush
});

// shared, custom methods
assign( Foo.prototype, template.methods, proto );
```

This is *strictly better* (i.e. better in some ways, worse in no ways) — it's less code, it avoids reassigning the prototype, and the code that generates it is simpler