### PR TITLE
Fixed empty component 'computed' from throwing error.

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -302,7 +302,7 @@ export default function dom ( parsed, source, options ) {
 		constructorBlock.addBlock( generator.builders.metaBindings );
 	}
 
-	if ( templateProperties.computed ) {
+	if ( computations.length ) {
 		constructorBlock.addLine(
 			`${generator.alias( 'recompute' )}( this._state, this._state, {}, true );`
 		);

--- a/test/generator/samples/computed-empty/_config.js
+++ b/test/generator/samples/computed-empty/_config.js
@@ -1,0 +1,8 @@
+export default {
+	html: '<div>empty</div>',
+	test ( assert, component, target ) {
+		assert.equal( component.get( 'created' ), true );
+		assert.equal( target.innerHTML, '<div>empty</div>' );
+		component.destroy();
+	}
+};

--- a/test/generator/samples/computed-empty/main.html
+++ b/test/generator/samples/computed-empty/main.html
@@ -1,0 +1,14 @@
+<div>empty</div>
+<script>
+	export default {
+		data () {
+			return {};
+		},
+
+		computed: {},
+
+		oncreate () {
+			this.set({ created: true });
+		}
+	};
+</script>


### PR DESCRIPTION
Fixes #452.

Referencing `computations.length` instead of `templateProperties.computed` prevents the generator from adding in invalid code when an empty object is passed as the `computed` value.

I've added a (passing) test that ensures that the component instantiates while having an empty `computed` object.