### PR TITLE
correctly bind one-way select value attributes (#423)

### DIFF
--- a/test/runtime/samples/select-one-way-bind-object/_config.js
+++ b/test/runtime/samples/select-one-way-bind-object/_config.js
@@ -1,0 +1,24 @@
+const items = [ {}, {} ];
+
+export default {
+	skip: true, // JSDOM quirks
+
+	'skip-ssr': true,
+
+	data: {
+		foo: items[0],
+		items
+	},
+
+	test ( assert, component, target ) {
+		const options = target.querySelectorAll( 'option' );
+
+		assert.equal( options[0].selected, true );
+		assert.equal( options[1].selected, false );
+
+		component.set( { foo: items[1] } );
+
+		assert.equal( options[0].selected, false );
+		assert.equal( options[1].selected, true );
+	}
+};

--- a/test/runtime/samples/select-one-way-bind-object/main.html
+++ b/test/runtime/samples/select-one-way-bind-object/main.html
@@ -1,0 +1,4 @@
+<select value="{{foo}}">
+	<option value='{{items[0]}}'>a</option>
+	<option value='{{items[1]}}'>b</option>
+</select>


### PR DESCRIPTION
Fixes #423. Little bit inelegant but it's an awkward special case — we need to ensure that the attribute is updated *after* child option nodes are updated.