### PR TITLE
better error for attempts to use getters/setters for methods

### DIFF
--- a/src/validate/js/propValidators/methods.js
+++ b/src/validate/js/propValidators/methods.js
@@ -1,3 +1,4 @@
+import checkForAccessors from '../utils/checkForAccessors.js';
 import checkForDupes from '../utils/checkForDupes.js';
 import checkForComputedKeys from '../utils/checkForComputedKeys.js';
 import usesThisOrArguments from '../utils/usesThisOrArguments.js';
@@ -10,6 +11,7 @@ export default function methods ( validator, prop ) {
 		return;
 	}
 
+	checkForAccessors( validator, prop.value.properties, 'Methods' );
 	checkForDupes( validator, prop.value.properties );
 	checkForComputedKeys( validator, prop.value.properties );
 

--- a/src/validate/js/utils/checkForAccessors.js
+++ b/src/validate/js/utils/checkForAccessors.js
@@ -1,0 +1,7 @@
+export default function checkForAccessors ( validator, properties, label ) {
+	properties.forEach( prop => {
+		if ( prop.kind !== 'init' ) {
+			validator.error( `${label} cannot use getters and setters`, prop.start );
+		}
+	});
+}

--- a/test/validator/index.js
+++ b/test/validator/index.js
@@ -1,12 +1,13 @@
 import * as fs from 'fs';
 import assert from 'assert';
-import { svelte, exists, tryToLoadJson } from '../helpers.js';
+import { svelte, tryToLoadJson } from '../helpers.js';
 
 describe( 'validate', () => {
 	fs.readdirSync( 'test/validator/samples' ).forEach( dir => {
 		if ( dir[0] === '.' ) return;
 
-		const solo = exists( `test/validator/samples/${dir}/solo` );
+		// add .solo to a sample directory name to only run that test
+		const solo = /\.solo/.test( dir );
 
 		if ( solo && process.env.CI ) {
 			throw new Error( 'Forgot to remove `solo: true` from test' );

--- a/test/validator/samples/properties-methods-getters-setters/errors.json
+++ b/test/validator/samples/properties-methods-getters-setters/errors.json
@@ -1,0 +1,8 @@
+[{
+	"message": "Methods cannot use getters and setters",
+	"loc": {
+		"line": 4,
+		"column": 3
+	},
+	"pos": 43
+}]

--- a/test/validator/samples/properties-methods-getters-setters/input.html
+++ b/test/validator/samples/properties-methods-getters-setters/input.html
@@ -1,0 +1,9 @@
+<script>
+	export default {
+		methods: {
+			get foo () {
+
+			}
+		}
+	};
+</script>


### PR DESCRIPTION
closes #425. Only checks `methods`, but can easily be added to other properties if we see fit