### PR TITLE
don't create whitespace nodes inside elements like <select>

### DIFF
--- a/src/generators/dom/visitors/Text.js
+++ b/src/generators/dom/visitors/Text.js
@@ -1,6 +1,21 @@
+// Whitespace inside one of these elements will not result in
+// a whitespace node being created in any circumstances. (This
+// list is almost certainly very incomplete)
+const elementsWithoutText = new Set([
+	'audio',
+	'datalist',
+	'dl',
+	'ol',
+	'optgroup',
+	'select',
+	'ul',
+	'video'
+]);
+
 export default function visitText ( generator, block, state, node ) {
-	if ( state.namespace && !/\S/.test( node.data ) ) {
-		return;
+	if ( !/\S/.test( node.data ) ) {
+		if ( state.namespace ) return;
+		if ( elementsWithoutText.has( state.parentNodeName) ) return;
 	}
 
 	const name = block.getUniqueName( `text` );

--- a/test/runtime/samples/select-no-whitespace/_config.js
+++ b/test/runtime/samples/select-no-whitespace/_config.js
@@ -1,0 +1,6 @@
+export default {
+	test ( assert, component, target ) {
+		const select = target.querySelector( 'select' );
+		assert.equal( select.childNodes.length, 3 );
+	}
+};

--- a/test/runtime/samples/select-no-whitespace/main.html
+++ b/test/runtime/samples/select-no-whitespace/main.html
@@ -1,0 +1,5 @@
+<select>
+	<option>a</option>
+	<option>b</option>
+	<option>c</option>
+</select>


### PR DESCRIPTION
This doesn't *close* #189 as there is more to do, but it addresses some of the low-hanging fruit — avoiding whitespace nodes inside elements that can't contain text, like `<select>` and `<ul>`