### PR TITLE
collapse consecutive if-statements with the same condition (#450)

### DIFF
--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -94,11 +94,10 @@ export default function dom ( parsed, source, options ) {
 		const differs = generator.helper( 'differs' );
 
 		computations.forEach( ({ key, deps }) => {
-			builder.addBlock( deindent`
-				if ( isInitial || ${deps.map( dep => `( '${dep}' in newState && ${differs}( state.${dep}, oldState.${dep} ) )` ).join( ' || ' )} ) {
-					state.${key} = newState.${key} = ${generator.alias( 'template' )}.computed.${key}( ${deps.map( dep => `state.${dep}` ).join( ', ' )} );
-				}
-			` );
+			const condition = `isInitial || ${deps.map( dep => `( '${dep}' in newState && ${differs}( state.${dep}, oldState.${dep} ) )` ).join( ' || ' )}`;
+			const statement = `state.${key} = newState.${key} = ${generator.alias( 'template' )}.computed.${key}( ${deps.map( dep => `state.${dep}` ).join( ', ' )} );`
+
+			builder.addConditionalLine( condition, statement );
 		});
 
 		builders.main.addBlock( deindent`

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -95,7 +95,7 @@ export default function dom ( parsed, source, options ) {
 
 		computations.forEach( ({ key, deps }) => {
 			const condition = `isInitial || ${deps.map( dep => `( '${dep}' in newState && ${differs}( state.${dep}, oldState.${dep} ) )` ).join( ' || ' )}`;
-			const statement = `state.${key} = newState.${key} = ${generator.alias( 'template' )}.computed.${key}( ${deps.map( dep => `state.${dep}` ).join( ', ' )} );`
+			const statement = `state.${key} = newState.${key} = ${generator.alias( 'template' )}.computed.${key}( ${deps.map( dep => `state.${dep}` ).join( ', ' )} );`;
 
 			builder.addConditionalLine( condition, statement );
 		});

--- a/src/utils/CodeBuilder.js
+++ b/src/utils/CodeBuilder.js
@@ -7,9 +7,31 @@ export default class CodeBuilder {
 
 		this.first = null;
 		this.last = null;
+
+		this.lastCondition = null;
+	}
+
+	addConditionalLine ( condition, line ) {
+		if ( condition === this.lastCondition ) {
+			this.result += `\n\t${line}`;
+		} else {
+			if ( this.lastCondition ) {
+				this.result += `\n}`;
+			}
+
+			this.result += `if ( ${condition} ) {\n\t${line}`;
+			this.lastCondition = condition;
+		}
+
+		this.last = BLOCK;
 	}
 
 	addLine ( line ) {
+		if ( this.lastCondition ) {
+			this.result += `\n}`;
+			this.lastCondition = null;
+		}
+
 		if ( this.last === BLOCK ) {
 			this.result += `\n\n${line}`;
 		} else if ( this.last === LINE ) {
@@ -36,6 +58,11 @@ export default class CodeBuilder {
 	}
 
 	addBlock ( block ) {
+		if ( this.lastCondition ) {
+			this.result += `\n}`;
+			this.lastCondition = null;
+		}
+
 		if ( this.result ) {
 			this.result += `\n\n${block}`;
 		} else {
@@ -62,6 +89,6 @@ export default class CodeBuilder {
 	}
 
 	toString () {
-		return this.result.trim();
+		return this.result.trim() + ( this.lastCondition ? `\n}` : `` );
 	}
 }

--- a/test/js/samples/computed-collapsed-if/input.html
+++ b/test/js/samples/computed-collapsed-if/input.html
@@ -1,0 +1,8 @@
+<script>
+	export default {
+		computed: {
+			a: x => x * 2,
+			b: x => x * 3
+		}
+	};
+</script>


### PR DESCRIPTION
Ref #450. Adds a new `addConditionalLine` method to `CodeBuilder` which collapses things like this...

```js
if ( foo ) {
  bar();
}

if ( foo ) {
  baz();
}
```

...into things like this:

```js
if ( foo ) {
  bar();
  baz();
}
```

Only used inside `recompute` for now, but could probably be used elsewhere as well.