### PR TITLE
window scroll bindings are bidirectional

### DIFF
--- a/src/generators/dom/visitors/Element/meta/Window.js
+++ b/src/generators/dom/visitors/Element/meta/Window.js
@@ -1,5 +1,6 @@
 import flattenReference from '../../../../../utils/flattenReference.js';
 import deindent from '../../../../../utils/deindent.js';
+import CodeBuilder from '../../../../../utils/CodeBuilder.js';
 
 const associatedEvents = {
 	innerWidth: 'resize',
@@ -13,6 +14,7 @@ const associatedEvents = {
 
 export default function visitWindow ( generator, block, node ) {
 	const events = {};
+	const bindings = {};
 
 	node.attributes.forEach( attribute => {
 		if ( attribute.type === 'EventHandler' ) {
@@ -51,6 +53,8 @@ export default function visitWindow ( generator, block, node ) {
 				throw new Error( `Bindings on <:Window/> must be to top-level properties, e.g. '${parts.pop()}' rather than '${keypath}'` );
 			}
 
+			bindings[ attribute.name ] = attribute.value.name;
+
 			if ( !events[ associatedEvent ] ) events[ associatedEvent ] = [];
 			events[ associatedEvent ].push( `${attribute.value.name}: this.${attribute.name}` );
 
@@ -61,16 +65,31 @@ export default function visitWindow ( generator, block, node ) {
 		}
 	});
 
+	const lock = block.getUniqueName( `window_updating` );
+
 	Object.keys( events ).forEach( event => {
 		const handlerName = block.getUniqueName( `onwindow${event}` );
-
 		const props = events[ event ].join( ',\n' );
+
+		const handlerBody = new CodeBuilder();
+		if ( event === 'scroll' ) { // TODO other bidirectional bindings...
+			block.builders.create.addLine( `var ${lock} = false;` );
+			handlerBody.addLine( `${lock} = true;` );
+		}
+
+		handlerBody.addBlock( deindent`
+			component.set({
+				${props}
+			});
+		` );
+
+		if ( event === 'scroll' ) {
+			handlerBody.addLine( `${lock} = false;` );
+		}
 
 		block.builders.create.addBlock( deindent`
 			var ${handlerName} = function ( event ) {
-				component.set({
-					${props}
-				});
+				${handlerBody}
 			};
 			window.addEventListener( '${event}', ${handlerName} );
 		` );
@@ -79,4 +98,30 @@ export default function visitWindow ( generator, block, node ) {
 			window.removeEventListener( '${event}', ${handlerName} );
 		` );
 	});
+
+	// special case... might need to abstract this out if we add more special cases
+	if ( bindings.scrollX && bindings.scrollY ) {
+		const observerCallback = block.getUniqueName( `scrollobserver` );
+
+		block.builders.create.addBlock( deindent`
+			function ${observerCallback} () {
+				if ( ${lock} ) return;
+				var x = ${bindings.scrollX ? `component.get( '${bindings.scrollX}' )` : `window.scrollX`};
+				var y = ${bindings.scrollY ? `component.get( '${bindings.scrollY}' )` : `window.scrollY`};
+				window.scrollTo( x, y );
+			};
+		` );
+
+		if ( bindings.scrollX ) block.builders.create.addLine( `component.observe( '${bindings.scrollX}', ${observerCallback} );` );
+		if ( bindings.scrollY ) block.builders.create.addLine( `component.observe( '${bindings.scrollY}', ${observerCallback} );` );
+	} else if ( bindings.scrollX || bindings.scrollY ) {
+		const isX = !!bindings.scrollX;
+
+		block.builders.create.addBlock( deindent`
+			component.observe( '${bindings.scrollX || bindings.scrollY}', function ( ${isX ? 'x' : 'y'} ) {
+				if ( ${lock} ) return;
+				window.scrollTo( ${isX ? 'x, window.scrollY' : 'window.scrollX, y' } );
+			});
+		` );
+	}
 }

--- a/test/runtime/samples/window-bind-scroll-update/_config.js
+++ b/test/runtime/samples/window-bind-scroll-update/_config.js
@@ -1,0 +1,12 @@
+export default {
+	skip: true, // JSDOM
+
+	test ( assert, component, target, window ) {
+		assert.equal( window.scrollY, 0 );
+
+		component.set({ scrollY: 100 });
+		assert.equal( window.scrollY, 100 );
+
+		component.destroy();
+	}
+};

--- a/test/runtime/samples/window-bind-scroll-update/main.html
+++ b/test/runtime/samples/window-bind-scroll-update/main.html
@@ -1,0 +1,3 @@
+<:Window bind:scrollY/>
+
+<div style='width: 100%; height: 9999px;'></div>


### PR DESCRIPTION
Ref #404. With this PR, in a situation like this...

```html
<:Window bind:scrollY='y'/>
```

...changing the value of `y` programmatically will result in the window scrolling. (The value of `y` remains constrained to the scrollable range.)

In a lot of situations this kind of bidirectional binding is unnecessary, but it would violate expectations if it didn't work this way so I think it's worth the modest overhead, which basically amounts to this:

```diff
+var window_updating = false;
  
var onwindowscroll = function ( event ) {
+  window_updating = true;
  
  component.set({
    y: this.scrollY
  });
  
+  window_updating = false;
};
window.addEventListener( 'scroll', onwindowscroll );

+component.observe( 'y', function ( y ) {
+  if ( window_updating ) return;
+  window.scrollTo( window.scrollX, y );
+});
```

Combined with an `animate` or `tween` method (#236), this would provide a very straightforward way of smoothly scrolling to a section of the page, for example.