### PR TITLE
Make missing properties only a warning

### DIFF
--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -148,7 +148,9 @@ export default class Generator {
 		});
 
 		dependencies.forEach( name => {
-			this.expectedProperties.add( name );
+			if ( !globalWhitelist.has( name ) ) {
+				this.expectedProperties.add( name );
+			}
 		});
 
 		return {

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -218,7 +218,7 @@ export default function dom ( parsed, source, options ) {
 	if ( options.dev ) {
 		generator.expectedProperties.forEach( prop => {
 			constructorBlock.addLine(
-				`if ( !( '${prop}' in this._state ) ) throw new Error( "Component was created without expected data property '${prop}'" );`
+				`if ( !( '${prop}' in this._state ) ) console.warn( "Component was created without expected data property '${prop}'" );`
 			);
 		});
 

--- a/test/runtime/samples/dev-warning-missing-data-binding/_config.js
+++ b/test/runtime/samples/dev-warning-missing-data-binding/_config.js
@@ -1,7 +1,7 @@
 export default {
 	dev: true,
 
-	error ( assert, err ) {
-		assert.equal( err.message, `Component was created without expected data property 'value'` );
-	}
+	warnings: [
+		`Component was created without expected data property 'value'`
+	]
 };

--- a/test/runtime/samples/dev-warning-missing-data/_config.js
+++ b/test/runtime/samples/dev-warning-missing-data/_config.js
@@ -1,7 +1,8 @@
 export default {
 	dev: true,
 
-	error ( assert, err ) {
-		assert.equal( err.message, `Component was created without expected data property 'foo'` );
-	}
+	warnings: [
+		`Component was created without expected data property 'foo'`,
+		`Component was created without expected data property 'bar'`
+	]
 };

--- a/test/runtime/samples/dev-warning-missing-data/main.html
+++ b/test/runtime/samples/dev-warning-missing-data/main.html
@@ -1,1 +1,4 @@
-<p>{{foo}}</p>
+<p>
+	{{Math.max(0, foo)}}
+	{{bar}}
+</p>


### PR DESCRIPTION
Fixes #475 - makes missing properties a warning instead of a fatal error, and makes missing properties that would be whitelisted globals not even be a warning.