### PR TITLE
Only update dynamic subtrees

### DIFF
--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -63,6 +63,8 @@ export default class Generator {
 	}
 
 	contextualise ( block, expression, context, isEventHandler ) {
+		if ( expression._contextualised ) return expression._contextualised;
+
 		this.addSourcemapLocations( expression );
 
 		const usedContexts = [];
@@ -153,12 +155,13 @@ export default class Generator {
 			}
 		});
 
-		return {
+		expression._contextualised = {
 			dependencies,
 			contexts: usedContexts,
-			snippet: `[✂${expression.start}-${expression.end}✂]`,
-			string: this.code.slice( expression.start, expression.end )
+			snippet: `[✂${expression.start}-${expression.end}✂]`
 		};
+
+		return expression._contextualised;
 	}
 
 	generate ( result, options, { name, format } ) {

--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -63,8 +63,6 @@ export default class Generator {
 	}
 
 	contextualise ( block, expression, context, isEventHandler ) {
-		if ( expression._contextualised ) return expression._contextualised;
-
 		this.addSourcemapLocations( expression );
 
 		const usedContexts = [];
@@ -155,13 +153,11 @@ export default class Generator {
 			}
 		});
 
-		expression._contextualised = {
+		return {
 			dependencies,
 			contexts: usedContexts,
 			snippet: `[✂${expression.start}-${expression.end}✂]`
 		};
-
-		return expression._contextualised;
 	}
 
 	findDependencies ( block, expression, isEventHandler ) {

--- a/src/generators/Generator.js
+++ b/src/generators/Generator.js
@@ -151,13 +151,11 @@ export default class Generator {
 		};
 	}
 
-	findDependencies ( block, expression, isEventHandler ) {
+	findDependencies ( contextDependencies, expression ) {
 		if ( expression._dependencies ) return expression._dependencies;
 
-		const dependencies = [];
-		const { contextDependencies, contexts } = block;
-
 		let scope = annotateWithScopes( expression );
+		const dependencies = [];
 
 		walk( expression, {
 			enter ( node, parent ) {
@@ -170,9 +168,7 @@ export default class Generator {
 					const { name } = flattenReference( node );
 					if ( scope.has( name ) ) return;
 
-					if ( name === 'event' && isEventHandler ) {
-						// noop
-					} else if ( contexts.has( name ) ) {
+					if ( contextDependencies.has( name ) ) {
 						dependencies.push( ...contextDependencies.get( name ) );
 					} else {
 						dependencies.push( name );

--- a/src/generators/dom/Block.js
+++ b/src/generators/dom/Block.js
@@ -2,34 +2,23 @@ import CodeBuilder from '../../utils/CodeBuilder.js';
 import deindent from '../../utils/deindent.js';
 
 export default class Block {
-	constructor ({
-		generator,
-		name,
-		key,
-		expression,
-		context,
-		contextDependencies,
-		dependencies,
-		contexts,
-		indexes,
-		params,
-		indexNames,
-		listNames
-	}) {
-		this.generator = generator;
-		this.name = name;
-		this.key = key;
-		this.expression = expression;
-		this.context = context;
+	constructor ( options ) {
+		this.generator = options.generator;
+		this.name = options.name;
+		this.key = options.key;
+		this.expression = options.expression;
+		this.context = options.context;
 
-		this.contexts = contexts;
-		this.indexes = indexes;
-		this.contextDependencies = contextDependencies;
-		this.dependencies = dependencies;
+		this.contexts = options.contexts;
+		this.indexes = options.indexes;
+		this.contextDependencies = options.contextDependencies;
+		this.dependencies = new Set();
 
-		this.params = params;
-		this.indexNames = indexNames;
-		this.listNames = listNames;
+		this.params = options.params;
+		this.indexNames = options.indexNames;
+		this.listNames = options.listNames;
+
+		this.listName = options.listName;
 
 		this.builders = {
 			create: new CodeBuilder(),
@@ -40,11 +29,17 @@ export default class Block {
 			destroy: new CodeBuilder()
 		};
 
-		this.getUniqueName = generator.getUniqueNameMaker( params );
+		this.getUniqueName = this.generator.getUniqueNameMaker( options.params );
 
 		// unique names
 		this.component = this.getUniqueName( 'component' );
 		this.target = this.getUniqueName( 'target' );
+	}
+
+	addDependencies ( dependencies ) {
+		dependencies.forEach( dependency => {
+			this.dependencies.add( dependency );
+		});
 	}
 
 	addElement ( name, renderStatement, parentNode, needsIdentifier = false ) {

--- a/src/generators/dom/Block.js
+++ b/src/generators/dom/Block.js
@@ -30,6 +30,7 @@ export default class Block {
 
 		// unique names
 		this.component = this.getUniqueName( 'component' );
+		this.target = this.getUniqueName( 'target' );
 	}
 
 	addElement ( name, renderStatement, parentNode, needsIdentifier = false ) {
@@ -66,7 +67,7 @@ export default class Block {
 		if ( parentNode ) {
 			this.builders.create.addLine( `${this.generator.helper( 'appendNode' )}( ${name}, ${parentNode} );` );
 		} else {
-			this.builders.mount.addLine( `${this.generator.helper( 'insertNode' )}( ${name}, target, anchor );` );
+			this.builders.mount.addLine( `${this.generator.helper( 'insertNode' )}( ${name}, ${this.target}, anchor );` );
 		}
 	}
 
@@ -99,7 +100,7 @@ export default class Block {
 			properties.addBlock( `mount: ${this.generator.helper( 'noop' )},` );
 		} else {
 			properties.addBlock( deindent`
-				mount: function ( target, anchor ) {
+				mount: function ( ${this.target}, anchor ) {
 					${this.builders.mount}
 				},
 			` );

--- a/src/generators/dom/Block.js
+++ b/src/generators/dom/Block.js
@@ -154,9 +154,4 @@ export default class Block {
 			}
 		`;
 	}
-
-	tmp () {
-		if ( !this._tmp ) this._tmp = this.getUniqueName( 'tmp' );
-		return this._tmp;
-	}
 }

--- a/src/generators/dom/Block.js
+++ b/src/generators/dom/Block.js
@@ -74,8 +74,8 @@ export default class Block {
 		this.addElement( name, renderStatement, parentNode, true );
 	}
 
-	findDependencies ( expression, isEventHandler ) {
-		return this.generator.findDependencies( this, expression, isEventHandler );
+	findDependencies ( expression ) {
+		return this.generator.findDependencies( this.contextDependencies, expression );
 	}
 
 	mount ( name, parentNode ) {

--- a/src/generators/dom/Block.js
+++ b/src/generators/dom/Block.js
@@ -34,6 +34,8 @@ export default class Block {
 		// unique names
 		this.component = this.getUniqueName( 'component' );
 		this.target = this.getUniqueName( 'target' );
+
+		this.hasUpdateMethod = false; // determined later
 	}
 
 	addDependencies ( dependencies ) {
@@ -70,6 +72,10 @@ export default class Block {
 	createAnchor ( name, parentNode ) {
 		const renderStatement = `${this.generator.helper( 'createComment' )}()`;
 		this.addElement( name, renderStatement, parentNode, true );
+	}
+
+	findDependencies ( expression, isEventHandler ) {
+		return this.generator.findDependencies( this, expression, isEventHandler );
 	}
 
 	mount ( name, parentNode ) {
@@ -115,15 +121,17 @@ export default class Block {
 			` );
 		}
 
-		if ( this.builders.update.isEmpty() ) {
-			properties.addBlock( `update: ${this.generator.helper( 'noop' )},` );
-		} else {
-			if ( this._tmp ) this.builders.update.addBlockAtStart( `var ${this._tmp};` );
-			properties.addBlock( deindent`
-				update: function ( changed, ${this.params.join( ', ' )} ) {
-					${this.builders.update}
-				},
-			` );
+		if ( this.hasUpdateMethod ) {
+			if ( this.builders.update.isEmpty() ) {
+				properties.addBlock( `update: ${this.generator.helper( 'noop' )},` );
+			} else {
+				if ( this._tmp ) this.builders.update.addBlockAtStart( `var ${this._tmp};` );
+				properties.addBlock( deindent`
+					update: function ( changed, ${this.params.join( ', ' )} ) {
+						${this.builders.update}
+					},
+				` );
+			}
 		}
 
 		if ( this.builders.destroy.isEmpty() ) {

--- a/src/generators/dom/Block.js
+++ b/src/generators/dom/Block.js
@@ -2,7 +2,20 @@ import CodeBuilder from '../../utils/CodeBuilder.js';
 import deindent from '../../utils/deindent.js';
 
 export default class Block {
-	constructor ({ generator, name, key, expression, context, contextDependencies, contexts, indexes, params, indexNames, listNames }) {
+	constructor ({
+		generator,
+		name,
+		key,
+		expression,
+		context,
+		contextDependencies,
+		dependencies,
+		contexts,
+		indexes,
+		params,
+		indexNames,
+		listNames
+	}) {
 		this.generator = generator;
 		this.name = name;
 		this.key = key;
@@ -12,6 +25,7 @@ export default class Block {
 		this.contexts = contexts;
 		this.indexes = indexes;
 		this.contextDependencies = contextDependencies;
+		this.dependencies = dependencies;
 
 		this.params = params;
 		this.indexNames = indexNames;

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -24,10 +24,6 @@ class DomGenerator extends Generator {
 		};
 	}
 
-	addBlock ( block ) {
-		this.blocks.push( block );
-	}
-
 	helper ( name ) {
 		if ( this.options.dev && `${name}Dev` in shared ) {
 			name = `${name}Dev`;
@@ -59,8 +55,6 @@ export default function dom ( parsed, source, options ) {
 		visit( generator, block, state, node );
 	});
 
-	generator.addBlock( block );
-
 	const builders = {
 		main: new CodeBuilder(),
 		init: new CodeBuilder(),
@@ -68,7 +62,7 @@ export default function dom ( parsed, source, options ) {
 	};
 
 	if ( options.dev ) {
-		builders._set.addBlock ( deindent`
+		builders._set.addBlock( deindent`
 			if ( typeof newState !== 'object' ) {
 				throw new Error( 'Component .set was called without an object of data key-values to update.' );
 			}
@@ -137,8 +131,9 @@ export default function dom ( parsed, source, options ) {
 		` );
 	}
 
-	let i = generator.blocks.length;
-	while ( i-- ) builders.main.addBlock( generator.blocks[i].render() );
+	generator.blocks.forEach( block => {
+		builders.main.addBlock( block.render() );
+	});
 
 	builders.init.addLine( `this._torndown = false;` );
 

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -107,12 +107,9 @@ export default function dom ( parsed, source, options ) {
 		builders._set.addLine( `${generator.alias( 'recompute' )}( this._state, newState, oldState, false )` );
 	}
 
-	// TODO is the `if` necessary?
-	builders._set.addBlock( deindent`
-		${generator.helper( 'dispatchObservers' )}( this, this._observers.pre, newState, oldState );
-		if ( this._fragment ) this._fragment.update( newState, this._state );
-		${generator.helper( 'dispatchObservers' )}( this, this._observers.post, newState, oldState );
-	` );
+	builders._set.addLine( `${generator.helper( 'dispatchObservers' )}( this, this._observers.pre, newState, oldState );` );
+	if ( block.hasUpdateMethod ) builders._set.addLine( `if ( this._fragment ) this._fragment.update( newState, this._state );` ); // TODO is the condition necessary?
+	builders._set.addLine( `${generator.helper( 'dispatchObservers' )}( this, this._observers.post, newState, oldState );` );
 
 	if ( hasJs ) {
 		builders.main.addBlock( `[✂${parsed.js.content.start}-${parsed.js.content.end}✂]` );

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -7,7 +7,7 @@ import deindent from '../../utils/deindent.js';
 import CodeBuilder from '../../utils/CodeBuilder.js';
 import visit from './visit.js';
 import Generator from '../Generator.js';
-import Block from './Block.js';
+import preprocess from './preprocess.js';
 import * as shared from '../../shared/index.js';
 
 class DomGenerator extends Generator {
@@ -47,37 +47,13 @@ export default function dom ( parsed, source, options ) {
 
 	const { computations, hasJs, templateProperties, namespace } = generator.parseJs();
 
-	const getUniqueName = generator.getUniqueNameMaker( [ 'root' ] );
-	const component = getUniqueName( 'component' );
-
-	const mainBlock = new Block({
-		generator,
-		name: generator.alias( 'create_main_fragment' ),
-		key: null,
-
-		component,
-
-		contexts: new Map(),
-		indexes: new Map(),
-
-		params: [ 'root' ],
-		indexNames: new Map(),
-		listNames: new Map(),
-
-		getUniqueName
-	});
-
-	const state = {
-		namespace,
-		parentNode: null,
-		isTopLevel: true
-	};
+	const { block, state } = preprocess( generator, parsed.html.children, namespace );
 
 	parsed.html.children.forEach( node => {
-		visit( generator, mainBlock, state, node );
+		visit( generator, block, state, node );
 	});
 
-	generator.addBlock( mainBlock );
+	generator.addBlock( block );
 
 	const builders = {
 		main: new CodeBuilder(),

--- a/src/generators/dom/index.js
+++ b/src/generators/dom/index.js
@@ -47,7 +47,13 @@ export default function dom ( parsed, source, options ) {
 
 	const { computations, hasJs, templateProperties, namespace } = generator.parseJs();
 
-	const { block, state } = preprocess( generator, parsed.html.children, namespace );
+	const block = preprocess( generator, parsed.html.children );
+
+	const state = {
+		namespace,
+		parentNode: null,
+		isTopLevel: true
+	};
 
 	parsed.html.children.forEach( node => {
 		visit( generator, block, state, node );

--- a/src/generators/dom/preprocess.js
+++ b/src/generators/dom/preprocess.js
@@ -111,7 +111,7 @@ function preprocessChildren ( generator, block, children ) {
 	});
 }
 
-export default function preprocess ( generator, children, namespace ) {
+export default function preprocess ( generator, children ) {
 	const block = new Block({
 		generator,
 		name: generator.alias( 'create_main_fragment' ),
@@ -127,13 +127,7 @@ export default function preprocess ( generator, children, namespace ) {
 		dependencies: new Set()
 	});
 
-	const state = {
-		namespace,
-		parentNode: null,
-		isTopLevel: true
-	};
-
 	preprocessChildren( generator, block, children );
 
-	return { block, state };
+	return block;
 }

--- a/src/generators/dom/preprocess.js
+++ b/src/generators/dom/preprocess.js
@@ -1,0 +1,118 @@
+import Block from './Block.js';
+
+function isElseIf ( node ) {
+	return node && node.children.length === 1 && node.children[0].type === 'IfBlock';
+}
+
+const preprocessors = {
+	MustacheTag: ( generator, block, node ) => {
+		const { dependencies } = block.contextualise( node.expression );
+		dependencies.forEach( dependency => {
+			block.dependencies.add( dependency );
+		});
+	},
+
+	IfBlock: ( generator, block, node ) => {
+		function attachBlocks ( node ) {
+			const { dependencies } = block.contextualise( node.expression );
+
+			node._block = block.child({
+				name: generator.getUniqueName( `create_if_block` )
+			});
+
+			preprocessChildren( generator, node._block, node.children );
+
+			if ( isElseIf( node.else ) ) {
+				attachBlocks( node.else );
+			} else if ( node.else ) {
+				node.else._block = block.child({
+					name: generator.getUniqueName( `create_if_block` )
+				});
+
+				preprocessChildren( generator, node.else._block, node.else.children );
+			}
+		}
+
+		attachBlocks ( node );
+	},
+
+	EachBlock: ( generator, block, node ) => {
+		const { dependencies } = block.contextualise( node.expression );
+
+		const indexNames = new Map( block.indexNames );
+		const indexName = node.index || block.getUniqueName( `${node.context}_index` );
+		indexNames.set( node.context, indexName );
+
+		const listNames = new Map( block.listNames );
+		const listName = block.getUniqueName( `each_block_value` );
+		listNames.set( node.context, listName );
+
+		const context = generator.getUniqueName( node.context );
+		const contexts = new Map( block.contexts );
+		contexts.set( node.context, context );
+
+		const indexes = new Map( block.indexes );
+		if ( node.index ) indexes.set( indexName, node.context );
+
+		const contextDependencies = new Map( block.contextDependencies );
+		contextDependencies.set( node.context, dependencies );
+
+		node._block = block.child({
+			name: generator.getUniqueName( 'create_each_block' ),
+			expression: node.expression,
+			context: node.context,
+			key: node.key,
+
+			contextDependencies,
+			contexts,
+			indexes,
+
+			indexNames,
+			listNames,
+			params: block.params.concat( listName, context, indexName )
+		});
+
+		preprocessChildren( generator, node._block, node.children );
+	},
+
+	Element: ( generator, block, node ) => {
+		// TODO attributes and bindings (and refs?)...
+		preprocessChildren( generator, block, node.children );
+	}
+};
+
+preprocessors.RawMustacheTag = preprocessors.MustacheTag;
+
+function preprocessChildren ( generator, block, children ) {
+	children.forEach( child => {
+		const preprocess = preprocessors[ child.type ];
+		if ( preprocess ) preprocess( generator, block, child );
+	});
+}
+
+export default function preprocess ( generator, children, namespace ) {
+	const block = new Block({
+		generator,
+		name: generator.alias( 'create_main_fragment' ),
+		key: null,
+
+		contexts: new Map(),
+		indexes: new Map(),
+
+		params: [ 'root' ],
+		indexNames: new Map(),
+		listNames: new Map(),
+
+		dependencies: new Set()
+	});
+
+	const state = {
+		namespace,
+		parentNode: null,
+		isTopLevel: true
+	};
+
+	preprocessChildren( generator, block, children );
+
+	return { block, state };
+}

--- a/src/generators/dom/preprocess.js
+++ b/src/generators/dom/preprocess.js
@@ -19,6 +19,7 @@ const preprocessors = {
 				name: generator.getUniqueName( `create_if_block` )
 			});
 
+			generator.blocks.push( node._block );
 			preprocessChildren( generator, node._block, node.children );
 			block.addDependencies( node._block.dependencies );
 
@@ -29,6 +30,7 @@ const preprocessors = {
 					name: generator.getUniqueName( `create_if_block` )
 				});
 
+				generator.blocks.push( node.else._block );
 				preprocessChildren( generator, node.else._block, node.else.children );
 				block.addDependencies( node.else._block.dependencies );
 			}
@@ -77,6 +79,7 @@ const preprocessors = {
 			params: block.params.concat( listName, context, indexName )
 		});
 
+		generator.blocks.push( node._block );
 		preprocessChildren( generator, node._block, node.children );
 		block.addDependencies( node._block.dependencies );
 
@@ -85,6 +88,7 @@ const preprocessors = {
 				name: generator.getUniqueName( `${node._block.name}_else` )
 			});
 
+			generator.blocks.push( node.else._block );
 			preprocessChildren( generator, node.else._block, node.else.children );
 		}
 	},
@@ -115,6 +119,7 @@ const preprocessors = {
 				name: generator.getUniqueName( `create_${name}_yield_fragment` )
 			});
 
+			generator.blocks.push( node._block );
 			preprocessChildren( generator, node._block, node.children );
 		}
 
@@ -149,6 +154,7 @@ export default function preprocess ( generator, children ) {
 		dependencies: new Set()
 	});
 
+	generator.blocks.push( block );
 	preprocessChildren( generator, block, children );
 
 	return block;

--- a/src/generators/dom/preprocess.js
+++ b/src/generators/dom/preprocess.js
@@ -79,6 +79,14 @@ const preprocessors = {
 
 		preprocessChildren( generator, node._block, node.children );
 		block.addDependencies( node._block.dependencies );
+
+		if ( node.else ) {
+			node.else._block = block.child({
+				name: generator.getUniqueName( `${node._block.name}_else` )
+			});
+
+			preprocessChildren( generator, node.else._block, node.else.children );
+		}
 	},
 
 	Element: ( generator, block, node ) => {

--- a/src/generators/dom/preprocess.js
+++ b/src/generators/dom/preprocess.js
@@ -82,7 +82,22 @@ const preprocessors = {
 	},
 
 	Element: ( generator, block, node ) => {
-		// TODO attributes and bindings (and refs?)...
+		node.attributes.forEach( attribute => {
+			if ( attribute.type === 'Attribute' && attribute.value !== true ) {
+				attribute.value.forEach( chunk => {
+					if ( chunk.type !== 'Text' ) {
+						const { dependencies } = block.contextualise( chunk.expression );
+						block.addDependencies( dependencies );
+					}
+				});
+			}
+
+			else if ( attribute.type === 'Binding' ) {
+				const { dependencies } = block.contextualise( attribute.value );
+				block.addDependencies( dependencies );
+			}
+		});
+
 		preprocessChildren( generator, block, node.children );
 	}
 };

--- a/src/generators/dom/preprocess.js
+++ b/src/generators/dom/preprocess.js
@@ -106,7 +106,21 @@ const preprocessors = {
 			}
 		});
 
-		preprocessChildren( generator, block, node.children );
+		const isComponent = generator.components.has( node.name ) || node.name === ':Self';
+
+		if ( isComponent ) {
+			const name = block.getUniqueName( ( node.name === ':Self' ? generator.name : node.name ).toLowerCase() );
+
+			node._block = block.child({
+				name: generator.getUniqueName( `create_${name}_yield_fragment` )
+			});
+
+			preprocessChildren( generator, node._block, node.children );
+		}
+
+		else {
+			preprocessChildren( generator, block, node.children );
+		}
 	}
 };
 

--- a/src/generators/dom/preprocess.js
+++ b/src/generators/dom/preprocess.js
@@ -127,14 +127,6 @@ const preprocessors = {
 				const dependencies = block.findDependencies( attribute.value );
 				block.addDependencies( dependencies );
 			}
-
-			// else if ( attribute.type === 'EventHandler' ) {
-			// 	// TODO is this necessary?
-			// 	attribute.expression.arguments.forEach( arg => {
-			// 		const dependencies = block.findDependencies( arg );
-			// 		block.addDependencies( dependencies );
-			// 	});
-			// }
 		});
 
 		const isComponent = generator.components.has( node.name ) || node.name === ':Self';
@@ -175,6 +167,7 @@ export default function preprocess ( generator, children ) {
 
 		contexts: new Map(),
 		indexes: new Map(),
+		contextDependencies: new Map(),
 
 		params: [ 'root' ],
 		indexNames: new Map(),

--- a/src/generators/dom/visitors/Component/Attribute.js
+++ b/src/generators/dom/visitors/Component/Attribute.js
@@ -28,12 +28,12 @@ export default function visitAttribute ( generator, block, state, node, attribut
 
 		else {
 			// simple dynamic attributes
-			const { dependencies, string } = generator.contextualise( block, value.expression );
+			const { dependencies, snippet } = block.contextualise( value.expression );
 
 			// TODO only update attributes that have changed
 			local.dynamicAttributes.push({
 				name: attribute.name,
-				value: string,
+				value: snippet,
 				dependencies
 			});
 		}
@@ -48,12 +48,12 @@ export default function visitAttribute ( generator, block, state, node, attribut
 				if ( chunk.type === 'Text' ) {
 					return JSON.stringify( chunk.data );
 				} else {
-					const { dependencies, string } = generator.contextualise( block, chunk.expression );
+					const { dependencies, snippet } = block.contextualise( chunk.expression );
 					dependencies.forEach( dependency => {
 						if ( !~allDependencies.indexOf( dependency ) ) allDependencies.push( dependency );
 					});
 
-					return `( ${string} )`;
+					return `( ${snippet} )`;
 				}
 			}).join( ' + ' )
 		);

--- a/src/generators/dom/visitors/Component/Binding.js
+++ b/src/generators/dom/visitors/Component/Binding.js
@@ -4,7 +4,7 @@ import getSetter from '../shared/binding/getSetter.js';
 
 export default function visitBinding ( generator, block, state, node, attribute, local ) {
 	const { name, keypath } = flattenReference( attribute.value );
-	const { snippet, contexts, dependencies } = generator.contextualise( block, attribute.value );
+	const { snippet, contexts, dependencies } = block.contextualise( attribute.value );
 
 	if ( dependencies.length > 1 ) throw new Error( 'An unexpected situation arose. Please raise an issue at https://github.com/sveltejs/svelte/issues — thanks!' );
 

--- a/src/generators/dom/visitors/Component/Component.js
+++ b/src/generators/dom/visitors/Component/Component.js
@@ -6,10 +6,6 @@ import visitEventHandler from './EventHandler.js';
 import visitBinding from './Binding.js';
 import visitRef from './Ref.js';
 
-function capDown ( name ) {
-	return `${name[0].toLowerCase()}${name.slice( 1 )}`;
-}
-
 function stringifyProps ( props ) {
 	if ( !props.length ) return '{}';
 
@@ -38,7 +34,7 @@ const visitors = {
 
 export default function visitComponent ( generator, block, state, node ) {
 	const hasChildren = node.children.length > 0;
-	const name = block.getUniqueName( capDown( node.name === ':Self' ? generator.name : node.name ) );
+	const name = block.getUniqueName( ( node.name === ':Self' ? generator.name : node.name ).toLowerCase() );
 
 	const childState = Object.assign( {}, state, {
 		parentNode: null
@@ -105,9 +101,7 @@ export default function visitComponent ( generator, block, state, node ) {
 	if ( hasChildren ) {
 		const params = block.params.join( ', ' );
 
-		const childBlock = block.child({
-			name: generator.getUniqueName( `create_${name}_yield_fragment` ) // TODO should getUniqueName happen inside Fragment? probably
-		});
+		const childBlock = node._block;
 
 		node.children.forEach( child => {
 			visit( generator, childBlock, childState, child );

--- a/src/generators/dom/visitors/Component/Component.js
+++ b/src/generators/dom/visitors/Component/Component.js
@@ -162,7 +162,7 @@ export default function visitComponent ( generator, block, state, node ) {
 	` );
 
 	if ( isToplevel ) {
-		block.builders.mount.addLine( `${name}._fragment.mount( target, anchor );` );
+		block.builders.mount.addLine( `${name}._fragment.mount( ${block.target}, anchor );` );
 	}
 
 	if ( local.dynamicAttributes.length ) {

--- a/src/generators/dom/visitors/Component/Component.js
+++ b/src/generators/dom/visitors/Component/Component.js
@@ -118,8 +118,6 @@ export default function visitComponent ( generator, block, state, node ) {
 		);
 
 		componentInitProperties.push( `_yield: ${yieldFragment}`);
-
-		generator.addBlock( childBlock );
 	}
 
 	const statements = [];

--- a/src/generators/dom/visitors/Component/EventHandler.js
+++ b/src/generators/dom/visitors/Component/EventHandler.js
@@ -7,7 +7,7 @@ export default function visitEventHandler ( generator, block, state, node, attri
 
 	const usedContexts = [];
 	attribute.expression.arguments.forEach( arg => {
-		const { contexts } = generator.contextualise( block, arg, null, true );
+		const { contexts } = block.contextualise( arg, null, true );
 
 		contexts.forEach( context => {
 			if ( !~usedContexts.indexOf( context ) ) usedContexts.push( context );
@@ -31,5 +31,5 @@ export default function visitEventHandler ( generator, block, state, node, attri
 		${local.name}.on( '${attribute.name}', function ( event ) {
 			${handlerBody}
 		});
-	` );	
+	` );
 }

--- a/src/generators/dom/visitors/EachBlock.js
+++ b/src/generators/dom/visitors/EachBlock.js
@@ -187,7 +187,7 @@ function unkeyed ( generator, block, state, node, snippet, { create_each_block, 
 		}
 	` );
 
-	const { dependencies } = block.contextualise( node.expression );
+	const dependencies = block.findDependencies( node.expression );
 	const allDependencies = new Set( block.dependencies );
 	dependencies.forEach( dependency => {
 		allDependencies.add( dependency );

--- a/src/generators/dom/visitors/EachBlock.js
+++ b/src/generators/dom/visitors/EachBlock.js
@@ -75,25 +75,23 @@ export default function visitEachBlock ( generator, block, state, node ) {
 		` );
 	}
 
-	const childBlock = node._block;
-
 	const childState = Object.assign( {}, state, {
 		parentNode: null,
 		inEachBlock: true
 	});
 
 	node.children.forEach( child => {
-		visit( generator, childBlock, childState, child );
+		visit( generator, node._block, childState, child );
 	});
 
-	generator.addBlock( childBlock );
-
 	if ( node.else ) {
+		const childState = Object.assign( {}, state, {
+			parentNode: null
+		});
+
 		node.else.children.forEach( child => {
 			visit( generator, node.else._block, childState, child );
 		});
-
-		generator.addBlock( node.else._block );
 	}
 }
 

--- a/src/generators/dom/visitors/EachBlock.js
+++ b/src/generators/dom/visitors/EachBlock.js
@@ -5,7 +5,7 @@ import visit from '../visit.js';
 export default function visitEachBlock ( generator, block, state, node ) {
 	const each_block = generator.getUniqueName( `each_block` );
 	const each_block_else = generator.getUniqueName( `${each_block}_else` );
-	const create_each_block = generator.getUniqueName( `create_each_block` );
+	const create_each_block = node._block.name;
 	const create_each_block_else = generator.getUniqueName( `${create_each_block}_else` );
 	const listName = block.getUniqueName( `${each_block}_value` );
 	const iterations = block.getUniqueName( `${each_block}_iterations` );
@@ -15,7 +15,7 @@ export default function visitEachBlock ( generator, block, state, node ) {
 
 	const vars = { each_block, create_each_block, listName, iterations, i, params, anchor };
 
-	const { dependencies, snippet } = generator.contextualise( block, node.expression );
+	const { dependencies, snippet } = block.contextualise( node.expression );
 
 	block.createAnchor( anchor, state.parentNode );
 	block.builders.create.addLine( `var ${listName} = ${snippet};` );
@@ -75,37 +75,38 @@ export default function visitEachBlock ( generator, block, state, node ) {
 		` );
 	}
 
-	const indexNames = new Map( block.indexNames );
-	const indexName = node.index || block.getUniqueName( `${node.context}_index` );
-	indexNames.set( node.context, indexName );
+	// const indexNames = new Map( block.indexNames );
+	// const indexName = node.index || block.getUniqueName( `${node.context}_index` );
+	// indexNames.set( node.context, indexName );
 
-	const listNames = new Map( block.listNames );
-	listNames.set( node.context, listName );
+	// const listNames = new Map( block.listNames );
+	// listNames.set( node.context, listName );
 
-	const context = generator.getUniqueName( node.context );
-	const contexts = new Map( block.contexts );
-	contexts.set( node.context, context );
+	// const context = generator.getUniqueName( node.context );
+	// const contexts = new Map( block.contexts );
+	// contexts.set( node.context, context );
 
-	const indexes = new Map( block.indexes );
-	if ( node.index ) indexes.set( indexName, node.context );
+	// const indexes = new Map( block.indexes );
+	// if ( node.index ) indexes.set( indexName, node.context );
 
-	const contextDependencies = new Map( block.contextDependencies );
-	contextDependencies.set( node.context, dependencies );
+	// const contextDependencies = new Map( block.contextDependencies );
+	// contextDependencies.set( node.context, dependencies );
 
-	const childBlock = block.child({
-		name: vars.create_each_block,
-		expression: node.expression,
-		context: node.context,
-		key: node.key,
+	// const childBlock = block.child({
+	// 	name: vars.create_each_block,
+	// 	expression: node.expression,
+	// 	context: node.context,
+	// 	key: node.key,
 
-		contextDependencies,
-		contexts,
-		indexes,
+	// 	contextDependencies,
+	// 	contexts,
+	// 	indexes,
 
-		indexNames,
-		listNames,
-		params: block.params.concat( listName, context, indexName )
-	});
+	// 	indexNames,
+	// 	listNames,
+	// 	params: block.params.concat( listName, context, indexName )
+	// });
+	const childBlock = node._block;
 
 	const childState = Object.assign( {}, state, {
 		parentNode: null,

--- a/src/generators/dom/visitors/Element/Attribute.js
+++ b/src/generators/dom/visitors/Element/Attribute.js
@@ -81,8 +81,7 @@ export default function visitAttribute ( generator, block, state, node, attribut
 
 		block.builders.create.addLine( updater );
 		block.builders.update.addBlock( deindent`
-			if ( ( ${block.tmp()} = ${value} ) !== ${last} ) {
-				${last} = ${block.tmp()};
+			if ( ${last} !== ( ${last} = ${value} ) ) {
 				${updater}
 			}
 		` );

--- a/src/generators/dom/visitors/Element/Attribute.js
+++ b/src/generators/dom/visitors/Element/Attribute.js
@@ -43,7 +43,7 @@ export default function visitAttribute ( generator, block, state, node, attribut
 			);
 		}
 
-		const last = `last_${state.parentNode}_${name.replace( /[^a-zA-Z_$]/g, '_')}`;
+		const last = block.getUniqueName( `${state.parentNode}_${name.replace( /[^a-zA-Z_$]/g, '_')}_value` );
 		block.builders.create.addLine( `var ${last} = ${value};` );
 
 		const isSelectValueAttribute = name === 'value' && state.parentNodeName === 'select';

--- a/src/generators/dom/visitors/Element/Attribute.js
+++ b/src/generators/dom/visitors/Element/Attribute.js
@@ -27,7 +27,7 @@ export default function visitAttribute ( generator, block, state, node, attribut
 
 		if ( attribute.value.length === 1 ) {
 			// single {{tag}} — may be a non-string
-			const { snippet } = generator.contextualise( block, attribute.value[0].expression );
+			const { snippet } = block.contextualise( attribute.value[0].expression );
 			value = snippet;
 		} else {
 			// '{{foo}} {{bar}}' — treat as string concatenation
@@ -36,7 +36,7 @@ export default function visitAttribute ( generator, block, state, node, attribut
 					if ( chunk.type === 'Text' ) {
 						return JSON.stringify( chunk.data );
 					} else {
-						const { snippet } = generator.contextualise( block, chunk.expression );
+						const { snippet } = block.contextualise( chunk.expression );
 						return `( ${snippet} )`;
 					}
 				}).join( ' + ' )

--- a/src/generators/dom/visitors/Element/Binding.js
+++ b/src/generators/dom/visitors/Element/Binding.js
@@ -5,7 +5,7 @@ import getStaticAttributeValue from './getStaticAttributeValue.js';
 
 export default function visitBinding ( generator, block, state, node, attribute ) {
 	const { name, keypath } = flattenReference( attribute.value );
-	const { snippet, contexts, dependencies } = generator.contextualise( block, attribute.value );
+	const { snippet, contexts, dependencies } = block.contextualise( attribute.value );
 
 	if ( dependencies.length > 1 ) throw new Error( 'An unexpected situation arose. Please raise an issue at https://github.com/sveltejs/svelte/issues — thanks!' );
 

--- a/src/generators/dom/visitors/Element/EventHandler.js
+++ b/src/generators/dom/visitors/Element/EventHandler.js
@@ -75,7 +75,7 @@ export default function visitEventHandler ( generator, block, state, node, attri
 		`;
 
 	if ( shouldHoist ) {
-		generator.addBlock({
+		generator.blocks.push({
 			render: () => handler
 		});
 	} else {

--- a/src/generators/dom/visitors/IfBlock.js
+++ b/src/generators/dom/visitors/IfBlock.js
@@ -5,39 +5,34 @@ function isElseIf ( node ) {
 	return node && node.children.length === 1 && node.children[0].type === 'IfBlock';
 }
 
-function getConditionsAndBlocks ( generator, block, state, node, _name, i = 0 ) {
-	const name = generator.getUniqueName( `${_name}_${i}` );
-
+function getConditionsAndBlocks ( generator, block, state, node ) {
 	const conditionsAndBlocks = [{
 		condition: block.contextualise( node.expression ).snippet,
-		block: name
+		block: node._block.name
 	}];
 
-	generateBlock( generator, block, state, node, name );
+	generateBlock( generator, block, state, node );
 
 	if ( isElseIf( node.else ) ) {
 		conditionsAndBlocks.push(
-			...getConditionsAndBlocks( generator, block, state, node.else.children[0], _name, i + 1 )
+			...getConditionsAndBlocks( generator, block, state, node.else.children[0] )
 		);
 	} else {
-		const name = generator.getUniqueName( `${_name}_${i + 1}` );
 		conditionsAndBlocks.push({
 			condition: null,
-			block: node.else ? name : null,
+			block: node.else ? node.else._block.name : null,
 		});
 
 		if ( node.else ) {
-			generateBlock( generator, block, state, node.else, name );
+			generateBlock( generator, block, state, node.else );
 		}
 	}
 
 	return conditionsAndBlocks;
 }
 
-function generateBlock ( generator, block, state, node, name ) {
-	const childBlock = block.child({
-		name
-	});
+function generateBlock ( generator, block, state, node ) {
+	const childBlock = node._block;
 
 	const childState = Object.assign( {}, state, {
 		parentNode: null

--- a/src/generators/dom/visitors/IfBlock.js
+++ b/src/generators/dom/visitors/IfBlock.js
@@ -11,7 +11,7 @@ function getConditionsAndBlocks ( generator, block, state, node ) {
 		block: node._block.name
 	}];
 
-	generateBlock( generator, block, state, node );
+	visitChildren( generator, block, state, node );
 
 	if ( isElseIf( node.else ) ) {
 		conditionsAndBlocks.push(
@@ -24,25 +24,21 @@ function getConditionsAndBlocks ( generator, block, state, node ) {
 		});
 
 		if ( node.else ) {
-			generateBlock( generator, block, state, node.else );
+			visitChildren( generator, block, state, node.else );
 		}
 	}
 
 	return conditionsAndBlocks;
 }
 
-function generateBlock ( generator, block, state, node ) {
-	const childBlock = node._block;
-
+function visitChildren ( generator, block, state, node ) {
 	const childState = Object.assign( {}, state, {
 		parentNode: null
 	});
 
-	node.children.forEach( node => {
-		visit( generator, childBlock, childState, node );
+	node.children.forEach( child => {
+		visit( generator, node._block, childState, child );
 	});
-
-	generator.addBlock( childBlock );
 }
 
 export default function visitIfBlock ( generator, block, state, node ) {

--- a/src/generators/dom/visitors/IfBlock.js
+++ b/src/generators/dom/visitors/IfBlock.js
@@ -47,8 +47,7 @@ export default function visitIfBlock ( generator, block, state, node ) {
 	const params = block.params.join( ', ' );
 	const name = generator.getUniqueName( `if_block` );
 	const getBlock = block.getUniqueName( `get_block` );
-	const currentBlock = block.getUniqueName( `current_block` );
-	const _currentBlock = block.getUniqueName( `_current_block` );
+	const current_block = block.getUniqueName( `current_block` );
 
 	const branches = getBranches( generator, block, state, node, generator.getUniqueName( `create_if_block` ) );
 	const dynamic = branches.some( branch => branch.dynamic );
@@ -63,8 +62,8 @@ export default function visitIfBlock ( generator, block, state, node ) {
 			} ).join( '\n' )}
 		}
 
-		var ${currentBlock} = ${getBlock}( ${params} );
-		var ${name} = ${currentBlock} && ${currentBlock}( ${params}, ${block.component} );
+		var ${current_block} = ${getBlock}( ${params} );
+		var ${name} = ${current_block} && ${current_block}( ${params}, ${block.component} );
 	` );
 
 	const isToplevel = !state.parentNode;
@@ -75,26 +74,21 @@ export default function visitIfBlock ( generator, block, state, node ) {
 		block.builders.create.addLine( `if ( ${name} ) ${name}.mount( ${state.parentNode}, ${anchor} );` );
 	}
 
-	block.builders.update.addBlock( deindent`
-		var ${_currentBlock} = ${currentBlock};
-		${currentBlock} = ${getBlock}( ${params} );
-	` );
-
 	if ( dynamic ) {
 		block.builders.update.addBlock( deindent`
-			if ( ${_currentBlock} === ${currentBlock} && ${name} ) {
+			if ( ${current_block} === ( ${current_block} = ${getBlock}( ${params} ) ) && ${name} ) {
 				${name}.update( changed, ${params} );
 			} else {
 				if ( ${name} ) ${name}.destroy( true );
-				${name} = ${currentBlock} && ${currentBlock}( ${params}, ${block.component} );
+				${name} = ${current_block} && ${current_block}( ${params}, ${block.component} );
 				if ( ${name} ) ${name}.mount( ${anchor}.parentNode, ${anchor} );
 			}
 		` );
 	} else {
 		block.builders.update.addBlock( deindent`
-			if ( ${_currentBlock} !== ${currentBlock} ) {
+			if ( ${current_block} !== ( ${current_block} = ${getBlock}( ${params} ) ) ) {
 				if ( ${name} ) ${name}.destroy( true );
-				${name} = ${currentBlock} && ${currentBlock}( ${params}, ${block.component} );
+				${name} = ${current_block} && ${current_block}( ${params}, ${block.component} );
 				if ( ${name} ) ${name}.mount( ${anchor}.parentNode, ${anchor} );
 			}
 		` );

--- a/src/generators/dom/visitors/MustacheTag.js
+++ b/src/generators/dom/visitors/MustacheTag.js
@@ -2,15 +2,16 @@ import deindent from '../../../utils/deindent.js';
 
 export default function visitMustacheTag ( generator, block, state, node ) {
 	const name = block.getUniqueName( 'text' );
+	const value = block.getUniqueName( `${name}_value` );
 
 	const { snippet } = block.contextualise( node.expression );
 
-	block.builders.create.addLine( `var last_${name} = ${snippet};` );
-	block.addElement( name, `${generator.helper( 'createText' )}( last_${name} )`, state.parentNode, true );
+	block.builders.create.addLine( `var ${value} = ${snippet};` );
+	block.addElement( name, `${generator.helper( 'createText' )}( ${value} )`, state.parentNode, true );
 
 	block.builders.update.addBlock( deindent`
-		if ( last_${name} !== ( last_${name} = ${snippet} ) ) {
-			${name}.data = last_${name};
+		if ( ${value} !== ( ${value} = ${snippet} ) ) {
+			${name}.data = ${value};
 		}
 	` );
 }

--- a/src/generators/dom/visitors/MustacheTag.js
+++ b/src/generators/dom/visitors/MustacheTag.js
@@ -9,8 +9,8 @@ export default function visitMustacheTag ( generator, block, state, node ) {
 	block.addElement( name, `${generator.helper( 'createText' )}( last_${name} )`, state.parentNode, true );
 
 	block.builders.update.addBlock( deindent`
-		if ( ( ${block.tmp()} = ${snippet} ) !== last_${name} ) {
-			${name}.data = last_${name} = ${block.tmp()};
+		if ( last_${name} !== ( last_${name} = ${snippet} ) ) {
+			${name}.data = last_${name};
 		}
 	` );
 }

--- a/src/generators/dom/visitors/MustacheTag.js
+++ b/src/generators/dom/visitors/MustacheTag.js
@@ -3,7 +3,7 @@ import deindent from '../../../utils/deindent.js';
 export default function visitMustacheTag ( generator, block, state, node ) {
 	const name = block.getUniqueName( 'text' );
 
-	const { snippet } = generator.contextualise( block, node.expression );
+	const { snippet } = block.contextualise( node.expression );
 
 	block.builders.create.addLine( `var last_${name} = ${snippet};` );
 	block.addElement( name, `${generator.helper( 'createText' )}( last_${name} )`, state.parentNode, true );

--- a/src/generators/dom/visitors/RawMustacheTag.js
+++ b/src/generators/dom/visitors/RawMustacheTag.js
@@ -3,7 +3,7 @@ import deindent from '../../../utils/deindent.js';
 export default function visitRawMustacheTag ( generator, block, state, node ) {
 	const name = block.getUniqueName( 'raw' );
 
-	const { snippet } = generator.contextualise( block, node.expression );
+	const { snippet } = block.contextualise( node.expression );
 
 	// we would have used comments here, but the `insertAdjacentHTML` api only
 	// exists for `Element`s.

--- a/src/generators/dom/visitors/RawMustacheTag.js
+++ b/src/generators/dom/visitors/RawMustacheTag.js
@@ -2,21 +2,21 @@ import deindent from '../../../utils/deindent.js';
 
 export default function visitRawMustacheTag ( generator, block, state, node ) {
 	const name = block.getUniqueName( 'raw' );
+	const value = block.getUniqueName( `${name}_value` );
+	const before = block.getUniqueName( `${name}_before` );
+	const after = block.getUniqueName( `${name}_after` );
 
 	const { snippet } = block.contextualise( node.expression );
 
 	// we would have used comments here, but the `insertAdjacentHTML` api only
 	// exists for `Element`s.
-	const before = `${name}_before`;
 	block.addElement( before, `${generator.helper( 'createElement' )}( 'noscript' )`, state.parentNode, true );
-
-	const after = `${name}_after`;
 	block.addElement( after, `${generator.helper( 'createElement' )}( 'noscript' )`, state.parentNode, true );
 
 	const isToplevel = !state.parentNode;
 
-	block.builders.create.addLine( `var last_${name} = ${snippet};` );
-	const mountStatement = `${before}.insertAdjacentHTML( 'afterend', last_${name} );`;
+	block.builders.create.addLine( `var ${value} = ${snippet};` );
+	const mountStatement = `${before}.insertAdjacentHTML( 'afterend', ${value} );`;
 	const detachStatement = `${generator.helper( 'detachBetween' )}( ${before}, ${after} );`;
 
 	if ( isToplevel ) {
@@ -26,7 +26,7 @@ export default function visitRawMustacheTag ( generator, block, state, node ) {
 	}
 
 	block.builders.update.addBlock( deindent`
-		if ( last_${name} !== ( last_${name} = ${snippet} ) ) {
+		if ( ${value} !== ( ${value} = ${snippet} ) ) {
 			${detachStatement}
 			${mountStatement}
 		}

--- a/src/generators/dom/visitors/RawMustacheTag.js
+++ b/src/generators/dom/visitors/RawMustacheTag.js
@@ -26,8 +26,7 @@ export default function visitRawMustacheTag ( generator, block, state, node ) {
 	}
 
 	block.builders.update.addBlock( deindent`
-		if ( ( ${block.tmp()} = ${snippet} ) !== last_${name} ) {
-			last_${name} = ${block.tmp()};
+		if ( last_${name} !== ( last_${name} = ${snippet} ) ) {
 			${detachStatement}
 			${mountStatement}
 		}

--- a/src/generators/dom/visitors/YieldTag.js
+++ b/src/generators/dom/visitors/YieldTag.js
@@ -3,7 +3,7 @@ export default function visitYieldTag ( generator, block, state ) {
 	block.createAnchor( anchor, state.parentNode );
 
 	block.builders.mount.addLine(
-		`${block.component}._yield && ${block.component}._yield.mount( ${state.parentNode || 'target'}, ${anchor} );`
+		`${block.component}._yield && ${block.component}._yield.mount( ${state.parentNode || block.target}, ${anchor} );`
 	);
 
 	block.builders.destroy.addLine(

--- a/src/generators/server-side-rendering/Block.js
+++ b/src/generators/server-side-rendering/Block.js
@@ -27,4 +27,8 @@ export default class Block {
 	child ( options ) {
 		return new Block( Object.assign( {}, this, options, { parent: this } ) );
 	}
+
+	contextualise ( expression, context, isEventHandler ) {
+		return this.generator.contextualise( this, expression, context, isEventHandler );
+	}
 }

--- a/src/generators/server-side-rendering/visitors/Component.js
+++ b/src/generators/server-side-rendering/visitors/Component.js
@@ -5,7 +5,7 @@ export default function visitComponent ( generator, block, node ) {
 	function stringify ( chunk ) {
 		if ( chunk.type === 'Text' ) return chunk.data;
 		if ( chunk.type === 'MustacheTag' ) {
-			const { snippet } = generator.contextualise( block, chunk.expression );
+			const { snippet } = block.contextualise( chunk.expression );
 			return '${__escape( ' + snippet + ')}';
 		}
 	}
@@ -34,7 +34,7 @@ export default function visitComponent ( generator, block, node ) {
 				if ( chunk.type === 'Text' ) {
 					value = isNaN( chunk.data ) ? JSON.stringify( chunk.data ) : chunk.data;
 				} else {
-					const { snippet } = generator.contextualise( block, chunk.expression );
+					const { snippet } = block.contextualise( chunk.expression );
 					value = snippet;
 				}
 			} else {

--- a/src/generators/server-side-rendering/visitors/EachBlock.js
+++ b/src/generators/server-side-rendering/visitors/EachBlock.js
@@ -1,7 +1,7 @@
 import visit from '../visit.js';
 
 export default function visitEachBlock ( generator, block, node ) {
-	const { dependencies, snippet } = generator.contextualise( block, node.expression );
+	const { dependencies, snippet } = block.contextualise( node.expression );
 
 	const open = `\${ ${snippet}.map( ${ node.index ? `( ${node.context}, ${node.index} )` : node.context} => \``;
 	generator.append( open );

--- a/src/generators/server-side-rendering/visitors/Element.js
+++ b/src/generators/server-side-rendering/visitors/Element.js
@@ -30,7 +30,7 @@ export default function visitElement ( generator, block, node ) {
 					return chunk.data;
 				}
 
-				const { snippet } = generator.contextualise( block, chunk.expression );
+				const { snippet } = block.contextualise( chunk.expression );
 				return '${' + snippet + '}';
 			}).join( '' ) + `"`;
 		}

--- a/src/generators/server-side-rendering/visitors/IfBlock.js
+++ b/src/generators/server-side-rendering/visitors/IfBlock.js
@@ -1,7 +1,7 @@
 import visit from '../visit.js';
 
 export default function visitIfBlock ( generator, block, node ) {
-	const { snippet } = generator.contextualise( block, node.expression );
+	const { snippet } = block.contextualise( node.expression );
 
 	generator.append( '${ ' + snippet + ' ? `' );
 

--- a/src/generators/server-side-rendering/visitors/MustacheTag.js
+++ b/src/generators/server-side-rendering/visitors/MustacheTag.js
@@ -1,4 +1,4 @@
 export default function visitMustacheTag ( generator, block, node ) {
-	const { snippet } = generator.contextualise( block, node.expression );
+	const { snippet } = block.contextualise( node.expression );
 	generator.append( '${__escape( ' + snippet + ' )}' );
 }

--- a/src/generators/server-side-rendering/visitors/RawMustacheTag.js
+++ b/src/generators/server-side-rendering/visitors/RawMustacheTag.js
@@ -1,4 +1,4 @@
 export default function visitRawMustacheTag ( generator, block, node ) {
-	const { snippet } = generator.contextualise( block, node.expression );
+	const { snippet } = block.contextualise( node.expression );
 	generator.append( '${' + snippet + '}' );
 }

--- a/test/js/index.js
+++ b/test/js/index.js
@@ -18,9 +18,16 @@ describe( 'js', () => {
 			dir = path.resolve( 'test/js/samples', dir );
 			const input = fs.readFileSync( `${dir}/input.html`, 'utf-8' ).replace( /\s+$/, '' );
 
-			const actual = svelte.compile( input, {
-				shared: true
-			}).code;
+			let actual;
+
+			try {
+				actual = svelte.compile( input, {
+					shared: true
+				}).code;
+			} catch ( err ) {
+				console.log( err.frame );
+				throw err;
+			}
 
 			fs.writeFileSync( `${dir}/_actual.js`, actual );
 			const expected = fs.readFileSync( `${dir}/expected.js`, 'utf-8' );

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -17,13 +17,11 @@ var template = (function () {
 }());
 
 function create_main_fragment ( root, component ) {
-	
+
 
 	return {
 		mount: noop,
-		
-		update: noop,
-		
+
 		destroy: noop
 	};
 }
@@ -32,19 +30,19 @@ function SvelteComponent ( options ) {
 	options = options || {};
 	this._state = options.data || {};
 	recompute( this._state, this._state, {}, true );
-	
+
 	this._observers = {
 		pre: Object.create( null ),
 		post: Object.create( null )
 	};
-	
+
 	this._handlers = Object.create( null );
-	
+
 	this._root = options._root;
 	this._yield = options._yield;
-	
+
 	this._torndown = false;
-	
+
 	this._fragment = create_main_fragment( this._state, this );
 	if ( options.target ) this._fragment.mount( options.target, null );
 }
@@ -55,9 +53,7 @@ SvelteComponent.prototype._set = function _set ( newState ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	recompute( this._state, newState, oldState, false )
-	
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	if ( this._fragment ) this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -14,14 +14,14 @@ function create_main_fragment ( root, component ) {
 			insertNode( each_block_anchor, target, anchor );
 
 			for ( var i = 0; i < each_block_iterations.length; i += 1 ) {
-				each_block_iterations[i].mount( each_block_anchor.parentNode, each_block_anchor );
+				each_block_iterations[i].mount( target, each_block_anchor );
 			}
 		},
 
 		update: function ( changed, root ) {
-			if ( 'comments' in changed || 'time' in changed ) {
-				var each_block_value = root.comments;
+			var each_block_value = root.comments;
 
+			if ( 'comments' in changed || 'elapsed' in changed || 'time' in changed ) {
 				for ( var i = 0; i < each_block_value.length; i += 1 ) {
 					if ( !each_block_iterations[i] ) {
 						each_block_iterations[i] = create_each_block( root, each_block_value, each_block_value[i], i, component );

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -1,0 +1,146 @@
+import { appendNode, assign, createComment, createElement, createText, destroyEach, detachBetween, detachNode, dispatchObservers, insertNode, proto } from "svelte/shared.js";
+
+function create_main_fragment ( root, component ) {
+	var each_block_anchor = createComment();
+	var each_block_value = root.comments;
+	var each_block_iterations = [];
+
+	for ( var i = 0; i < each_block_value.length; i += 1 ) {
+		each_block_iterations[i] = create_each_block( root, each_block_value, each_block_value[i], i, component );
+	}
+
+	return {
+		mount: function ( target, anchor ) {
+			insertNode( each_block_anchor, target, anchor );
+
+			for ( var i = 0; i < each_block_iterations.length; i += 1 ) {
+				each_block_iterations[i].mount( each_block_anchor.parentNode, each_block_anchor );
+			}
+		},
+
+		update: function ( changed, root ) {
+			if ( 'comments' in changed || 'time' in changed ) {
+				var each_block_value = root.comments;
+
+				for ( var i = 0; i < each_block_value.length; i += 1 ) {
+					if ( !each_block_iterations[i] ) {
+						each_block_iterations[i] = create_each_block( root, each_block_value, each_block_value[i], i, component );
+						each_block_iterations[i].mount( each_block_anchor.parentNode, each_block_anchor );
+					} else {
+						each_block_iterations[i].update( changed, root, each_block_value, each_block_value[i], i );
+					}
+				}
+
+				destroyEach( each_block_iterations, true, each_block_value.length );
+
+				each_block_iterations.length = each_block_value.length;
+			}
+		},
+
+		destroy: function ( detach ) {
+			destroyEach( each_block_iterations, detach, 0 );
+
+			if ( detach ) {
+				detachNode( each_block_anchor );
+			}
+		}
+	};
+}
+
+function create_each_block ( root, each_block_value, comment, comment_index, component ) {
+	var div = createElement( 'div' );
+	div.className = "comment";
+	var span = createElement( 'span' );
+	appendNode( span, div );
+	span.className = "meta";
+	var last_text = comment.author;
+	var text = createText( last_text );
+	appendNode( text, span );
+	appendNode( createText( " wrote " ), span );
+	var last_text_2 = root.elapsed(comment.time, root.time);
+	var text_2 = createText( last_text_2 );
+	appendNode( text_2, span );
+	appendNode( createText( " ago:" ), span );
+	appendNode( createText( "\n\n\t\t" ), div );
+	var raw_before = createElement( 'noscript' );
+	appendNode( raw_before, div );
+	var raw_after = createElement( 'noscript' );
+	appendNode( raw_after, div );
+	var last_raw = comment.html;
+	raw_before.insertAdjacentHTML( 'afterend', last_raw );
+
+	return {
+		mount: function ( target, anchor ) {
+			insertNode( div, target, anchor );
+		},
+
+		update: function ( changed, root, each_block_value, comment, comment_index ) {
+			var tmp;
+
+			if ( ( tmp = comment.author ) !== last_text ) {
+				text.data = last_text = tmp;
+			}
+
+			if ( ( tmp = root.elapsed(comment.time, root.time) ) !== last_text_2 ) {
+				text_2.data = last_text_2 = tmp;
+			}
+
+			if ( ( tmp = comment.html ) !== last_raw ) {
+				last_raw = tmp;
+				detachBetween( raw_before, raw_after );
+				raw_before.insertAdjacentHTML( 'afterend', last_raw );
+			}
+		},
+
+		destroy: function ( detach ) {
+			if ( detach ) {
+				detachBetween( raw_before, raw_after );
+
+				detachNode( div );
+			}
+		}
+	};
+}
+
+function SvelteComponent ( options ) {
+	options = options || {};
+	this._state = options.data || {};
+
+	this._observers = {
+		pre: Object.create( null ),
+		post: Object.create( null )
+	};
+
+	this._handlers = Object.create( null );
+
+	this._root = options._root;
+	this._yield = options._yield;
+
+	this._torndown = false;
+
+	this._fragment = create_main_fragment( this._state, this );
+	if ( options.target ) this._fragment.mount( options.target, null );
+}
+
+assign( SvelteComponent.prototype, proto );
+
+SvelteComponent.prototype._set = function _set ( newState ) {
+	var oldState = this._state;
+	this._state = assign( {}, oldState, newState );
+
+	dispatchObservers( this, this._observers.pre, newState, oldState );
+	if ( this._fragment ) this._fragment.update( newState, this._state );
+	dispatchObservers( this, this._observers.post, newState, oldState );
+};
+
+SvelteComponent.prototype.teardown = SvelteComponent.prototype.destroy = function destroy ( detach ) {
+	this.fire( 'destroy' );
+
+	this._fragment.destroy( detach !== false );
+	this._fragment = null;
+
+	this._state = {};
+	this._torndown = true;
+};
+
+export default SvelteComponent;

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -53,12 +53,12 @@ function create_each_block ( root, each_block_value, comment, comment_index, com
 	var span = createElement( 'span' );
 	appendNode( span, div );
 	span.className = "meta";
-	var last_text = comment.author;
-	var text = createText( last_text );
+	var text_value = comment.author;
+	var text = createText( text_value );
 	appendNode( text, span );
 	appendNode( createText( " wrote " ), span );
-	var last_text_2 = root.elapsed(comment.time, root.time);
-	var text_2 = createText( last_text_2 );
+	var text_2_value = root.elapsed(comment.time, root.time);
+	var text_2 = createText( text_2_value );
 	appendNode( text_2, span );
 	appendNode( createText( " ago:" ), span );
 	appendNode( createText( "\n\n\t\t" ), div );
@@ -66,8 +66,8 @@ function create_each_block ( root, each_block_value, comment, comment_index, com
 	appendNode( raw_before, div );
 	var raw_after = createElement( 'noscript' );
 	appendNode( raw_after, div );
-	var last_raw = comment.html;
-	raw_before.insertAdjacentHTML( 'afterend', last_raw );
+	var raw_value = comment.html;
+	raw_before.insertAdjacentHTML( 'afterend', raw_value );
 
 	return {
 		mount: function ( target, anchor ) {
@@ -75,17 +75,17 @@ function create_each_block ( root, each_block_value, comment, comment_index, com
 		},
 
 		update: function ( changed, root, each_block_value, comment, comment_index ) {
-			if ( last_text !== ( last_text = comment.author ) ) {
-				text.data = last_text;
+			if ( text_value !== ( text_value = comment.author ) ) {
+				text.data = text_value;
 			}
 
-			if ( last_text_2 !== ( last_text_2 = root.elapsed(comment.time, root.time) ) ) {
-				text_2.data = last_text_2;
+			if ( text_2_value !== ( text_2_value = root.elapsed(comment.time, root.time) ) ) {
+				text_2.data = text_2_value;
 			}
 
-			if ( last_raw !== ( last_raw = comment.html ) ) {
+			if ( raw_value !== ( raw_value = comment.html ) ) {
 				detachBetween( raw_before, raw_after );
-				raw_before.insertAdjacentHTML( 'afterend', last_raw );
+				raw_before.insertAdjacentHTML( 'afterend', raw_value );
 			}
 		},
 

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -75,18 +75,15 @@ function create_each_block ( root, each_block_value, comment, comment_index, com
 		},
 
 		update: function ( changed, root, each_block_value, comment, comment_index ) {
-			var tmp;
-
-			if ( ( tmp = comment.author ) !== last_text ) {
-				text.data = last_text = tmp;
+			if ( last_text !== ( last_text = comment.author ) ) {
+				text.data = last_text;
 			}
 
-			if ( ( tmp = root.elapsed(comment.time, root.time) ) !== last_text_2 ) {
-				text_2.data = last_text_2 = tmp;
+			if ( last_text_2 !== ( last_text_2 = root.elapsed(comment.time, root.time) ) ) {
+				text_2.data = last_text_2;
 			}
 
-			if ( ( tmp = comment.html ) !== last_raw ) {
-				last_raw = tmp;
+			if ( last_raw !== ( last_raw = comment.html ) ) {
 				detachBetween( raw_before, raw_after );
 				raw_before.insertAdjacentHTML( 'afterend', last_raw );
 			}

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -23,11 +23,11 @@ function create_main_fragment ( root, component ) {
 
 			if ( 'comments' in changed || 'elapsed' in changed || 'time' in changed ) {
 				for ( var i = 0; i < each_block_value.length; i += 1 ) {
-					if ( !each_block_iterations[i] ) {
+					if ( each_block_iterations[i] ) {
+						each_block_iterations[i].update( changed, root, each_block_value, each_block_value[i], i );
+					} else {
 						each_block_iterations[i] = create_each_block( root, each_block_value, each_block_value[i], i, component );
 						each_block_iterations[i].mount( each_block_anchor.parentNode, each_block_anchor );
-					} else {
-						each_block_iterations[i].update( changed, root, each_block_value, each_block_value[i], i );
 					}
 				}
 
@@ -127,7 +127,6 @@ assign( SvelteComponent.prototype, proto );
 SvelteComponent.prototype._set = function _set ( newState ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
-
 	dispatchObservers( this, this._observers.pre, newState, oldState );
 	if ( this._fragment ) this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );

--- a/test/js/samples/each-block-changed-check/input.html
+++ b/test/js/samples/each-block-changed-check/input.html
@@ -1,0 +1,9 @@
+{{#each comments as comment}}
+	<div class='comment'>
+		<span class='meta'>
+			{{comment.author}} wrote {{elapsed(comment.time, time)}} ago:
+		</span>
+
+		{{{comment.html}}}
+	</div>
+{{/each}}

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -1,4 +1,4 @@
-import { appendNode, assign, createElement, createText, detachNode, dispatchObservers, insertNode, noop, proto } from "svelte/shared.js";
+import { appendNode, assign, createElement, createText, detachNode, dispatchObservers, insertNode, proto } from "svelte/shared.js";
 
 var template = (function () {
 	return {
@@ -29,8 +29,6 @@ function create_main_fragment ( root, component ) {
 		mount: function ( target, anchor ) {
 			insertNode( button, target, anchor );
 		},
-
-		update: noop,
 
 		destroy: function ( detach ) {
 			foo_handler.teardown();
@@ -67,9 +65,7 @@ assign( SvelteComponent.prototype, template.methods, proto );
 SvelteComponent.prototype._set = function _set ( newState ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
-
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	if ( this._fragment ) this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -1,0 +1,115 @@
+import { appendNode, assign, createComment, createElement, createText, detachNode, dispatchObservers, insertNode, proto } from "svelte/shared.js";
+
+function create_main_fragment ( root, component ) {
+	var if_block_anchor = createComment();
+
+	function get_block ( root ) {
+		if ( root.foo ) return create_if_block;
+		return create_if_block_1;
+	}
+
+	var current_block = get_block( root );
+	var if_block = current_block && current_block( root, component );
+
+	return {
+		mount: function ( target, anchor ) {
+			insertNode( if_block_anchor, target, anchor );
+			if ( if_block ) if_block.mount( target, if_block_anchor );
+		},
+
+		update: function ( changed, root ) {
+			var _current_block = current_block;
+			current_block = get_block( root );
+
+			if ( _current_block !== current_block ) {
+				if ( if_block ) if_block.destroy( true );
+				if_block = current_block && current_block( root, component );
+				if ( if_block ) if_block.mount( if_block_anchor.parentNode, if_block_anchor );
+			}
+		},
+
+		destroy: function ( detach ) {
+			if ( if_block ) if_block.destroy( detach );
+
+			if ( detach ) {
+				detachNode( if_block_anchor );
+			}
+		}
+	};
+}
+
+function create_if_block ( root, component ) {
+	var p = createElement( 'p' );
+	appendNode( createText( "foo!" ), p );
+
+	return {
+		mount: function ( target, anchor ) {
+			insertNode( p, target, anchor );
+		},
+
+		destroy: function ( detach ) {
+			if ( detach ) {
+				detachNode( p );
+			}
+		}
+	};
+}
+
+function create_if_block_1 ( root, component ) {
+	var p = createElement( 'p' );
+	appendNode( createText( "not foo!" ), p );
+
+	return {
+		mount: function ( target, anchor ) {
+			insertNode( p, target, anchor );
+		},
+
+		destroy: function ( detach ) {
+			if ( detach ) {
+				detachNode( p );
+			}
+		}
+	};
+}
+
+function SvelteComponent ( options ) {
+	options = options || {};
+	this._state = options.data || {};
+
+	this._observers = {
+		pre: Object.create( null ),
+		post: Object.create( null )
+	};
+
+	this._handlers = Object.create( null );
+
+	this._root = options._root;
+	this._yield = options._yield;
+
+	this._torndown = false;
+
+	this._fragment = create_main_fragment( this._state, this );
+	if ( options.target ) this._fragment.mount( options.target, null );
+}
+
+assign( SvelteComponent.prototype, proto );
+
+SvelteComponent.prototype._set = function _set ( newState ) {
+	var oldState = this._state;
+	this._state = assign( {}, oldState, newState );
+	dispatchObservers( this, this._observers.pre, newState, oldState );
+	if ( this._fragment ) this._fragment.update( newState, this._state );
+	dispatchObservers( this, this._observers.post, newState, oldState );
+};
+
+SvelteComponent.prototype.teardown = SvelteComponent.prototype.destroy = function destroy ( detach ) {
+	this.fire( 'destroy' );
+
+	this._fragment.destroy( detach !== false );
+	this._fragment = null;
+
+	this._state = {};
+	this._torndown = true;
+};
+
+export default SvelteComponent;

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -18,10 +18,7 @@ function create_main_fragment ( root, component ) {
 		},
 
 		update: function ( changed, root ) {
-			var _current_block = current_block;
-			current_block = get_block( root );
-
-			if ( _current_block !== current_block ) {
+			if ( current_block !== ( current_block = get_block( root ) ) ) {
 				if ( if_block ) if_block.destroy( true );
 				if_block = current_block && current_block( root, component );
 				if ( if_block ) if_block.mount( if_block_anchor.parentNode, if_block_anchor );

--- a/test/js/samples/if-block-no-update/input.html
+++ b/test/js/samples/if-block-no-update/input.html
@@ -1,0 +1,5 @@
+{{#if foo}}
+	<p>foo!</p>
+{{else}}
+	<p>not foo!</p>
+{{/if}}

--- a/test/runtime/samples/component-yield-parent/_config.js
+++ b/test/runtime/samples/component-yield-parent/_config.js
@@ -1,9 +1,15 @@
 export default {
-	html: '<div><p>Hello</p></div>',
+	html: `
+		<div><p>Hello</p></div>
+	`,
+
 	test ( assert, component, target ) {
 		assert.equal( component.get( 'data' ), 'Hello' );
-		component.set({data: 'World'});
+
+		component.set({ data: 'World' });
 		assert.equal( component.get( 'data' ), 'World' );
-		assert.equal( target.innerHTML, '<div><p>World<!----></p></div>' );
+		assert.htmlEqual( target.innerHTML, `
+			<div><p>World</p></div>
+		` );
 	}
 };


### PR DESCRIPTION
This builds on top of #489. Blocks representing subtrees that only have static content don't get `update` methods — less code, and less work.