### PR TITLE
allow dynamic each-block to have static else-block

### DIFF
--- a/src/generators/dom/visitors/EachBlock.js
+++ b/src/generators/dom/visitors/EachBlock.js
@@ -57,16 +57,28 @@ export default function visitEachBlock ( generator, block, state, node ) {
 			}
 		` );
 
-		block.builders.update.addBlock( deindent`
-			if ( !${each_block_value}.length && ${each_block_else} ) {
-				${each_block_else}.update( changed, ${params} );
-			} else if ( !${each_block_value}.length ) {
-				${each_block_else} = ${node.else._block.name}( ${params}, ${block.component} );
-				${each_block_else}.mount( ${anchor}.parentNode, ${anchor} );
-			} else if ( ${each_block_else} ) {
-				${each_block_else}.destroy( true );
-			}
-		` );
+		if ( node.else.hasUpdateMethod ) {
+			block.builders.update.addBlock( deindent`
+				if ( !${each_block_value}.length && ${each_block_else} ) {
+					${each_block_else}.update( changed, ${params} );
+				} else if ( !${each_block_value}.length ) {
+					${each_block_else} = ${node.else._block.name}( ${params}, ${block.component} );
+					${each_block_else}.mount( ${anchor}.parentNode, ${anchor} );
+				} else if ( ${each_block_else} ) {
+					${each_block_else}.destroy( true );
+				}
+			` );
+		} else {
+			block.builders.update.addBlock( deindent`
+				if ( ${each_block_value}.length ) {
+					if ( ${each_block_else} ) ${each_block_else}.destroy( true );
+				} else if ( !${each_block_else} ) {
+					${each_block_else} = ${node.else._block.name}( ${params}, ${block.component} );
+					${each_block_else}.mount( ${anchor}.parentNode, ${anchor} );
+				}
+			` );
+		}
+
 
 		block.builders.destroy.addBlock( deindent`
 			if ( ${each_block_else} ) {

--- a/src/generators/dom/visitors/EachBlock.js
+++ b/src/generators/dom/visitors/EachBlock.js
@@ -57,7 +57,7 @@ export default function visitEachBlock ( generator, block, state, node ) {
 			}
 		` );
 
-		if ( node.else.hasUpdateMethod ) {
+		if ( node.else._block.hasUpdateMethod ) {
 			block.builders.update.addBlock( deindent`
 				if ( !${each_block_value}.length && ${each_block_else} ) {
 					${each_block_else}.update( changed, ${params} );

--- a/src/generators/dom/visitors/Element/Binding.js
+++ b/src/generators/dom/visitors/Element/Binding.js
@@ -4,7 +4,7 @@ import getSetter from '../shared/binding/getSetter.js';
 import getStaticAttributeValue from './getStaticAttributeValue.js';
 
 export default function visitBinding ( generator, block, state, node, attribute ) {
-	const { name, keypath } = flattenReference( attribute.value );
+	const { name, keypath, parts } = flattenReference( attribute.value );
 	const { snippet, contexts, dependencies } = block.contextualise( attribute.value );
 
 	if ( dependencies.length > 1 ) throw new Error( 'An unexpected situation arose. Please raise an issue at https://github.com/sveltejs/svelte/issues — thanks!' );
@@ -17,7 +17,7 @@ export default function visitBinding ( generator, block, state, node, attribute 
 	const handler = block.getUniqueName( `${state.parentNode}_${eventName}_handler` );
 	const isMultipleSelect = node.name === 'select' && node.attributes.find( attr => attr.name.toLowerCase() === 'multiple' ); // TODO use getStaticAttributeValue
 	const type = getStaticAttributeValue( node, 'type' );
-	const bindingGroup = attribute.name === 'group' ? getBindingGroup( generator, keypath ) : null;
+	const bindingGroup = attribute.name === 'group' ? getBindingGroup( generator, parts.join( '.' ) ) : null;
 	const value = getBindingValue( generator, block, state, node, attribute, isMultipleSelect, bindingGroup, type );
 
 	let setter = getSetter({ block, name, keypath, context: '_svelte', attribute, dependencies, value });

--- a/test/runtime/samples/binding-input-checkbox-group-outside-each/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-group-outside-each/_config.js
@@ -1,0 +1,78 @@
+const values = [
+	{ name: 'Alpha' },
+	{ name: 'Beta' },
+	{ name: 'Gamma' }
+];
+
+export default {
+	data: {
+		values,
+		selected: [ values[1] ]
+	},
+
+	'skip-ssr': true, // values are rendered as [object Object]
+
+	html: `
+		<label>
+			<input type="checkbox"> Alpha
+		</label>
+
+		<label>
+			<input type="checkbox"> Beta
+		</label>
+
+		<label>
+			<input type="checkbox"> Gamma
+		</label>
+
+		<p>Beta</p>`,
+
+	test ( assert, component, target, window ) {
+		const inputs = target.querySelectorAll( 'input' );
+		assert.equal( inputs[0].checked, false );
+		assert.equal( inputs[1].checked, true );
+		assert.equal( inputs[2].checked, false );
+
+		const event = new window.Event( 'change' );
+
+		inputs[0].checked = true;
+		inputs[0].dispatchEvent( event );
+
+		assert.htmlEqual( target.innerHTML, `
+			<label>
+				<input type="checkbox"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox"> Gamma
+			</label>
+
+			<p>Alpha, Beta</p>
+		` );
+
+		component.set({ selected: [ values[1], values[2] ] });
+		assert.equal( inputs[0].checked, false );
+		assert.equal( inputs[1].checked, true );
+		assert.equal( inputs[2].checked, true );
+
+		assert.htmlEqual( target.innerHTML, `
+			<label>
+				<input type="checkbox"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox"> Gamma
+			</label>
+
+			<p>Beta, Gamma</p>
+		` );
+	}
+};

--- a/test/runtime/samples/binding-input-checkbox-group-outside-each/main.html
+++ b/test/runtime/samples/binding-input-checkbox-group-outside-each/main.html
@@ -1,0 +1,13 @@
+<label>
+	<input type="checkbox" value="{{values[0]}}" bind:group='selected' /> {{values[0].name}}
+</label>
+
+<label>
+	<input type="checkbox" value="{{values[1]}}" bind:group='selected' /> {{values[1].name}}
+</label>
+
+<label>
+	<input type="checkbox" value="{{values[2]}}" bind:group='selected' /> {{values[2].name}}
+</label>
+
+<p>{{selected.map( function ( value ) { return value.name; }).join( ', ' ) }}</p>

--- a/test/runtime/samples/each-block-dynamic-else-static/_config.js
+++ b/test/runtime/samples/each-block-dynamic-else-static/_config.js
@@ -1,6 +1,4 @@
 export default {
-	solo: true,
-
 	data: {
 		animals: [ 'alpaca', 'baboon', 'capybara' ]
 	},

--- a/test/runtime/samples/each-block-dynamic-else-static/_config.js
+++ b/test/runtime/samples/each-block-dynamic-else-static/_config.js
@@ -1,0 +1,29 @@
+export default {
+	solo: true,
+
+	data: {
+		animals: [ 'alpaca', 'baboon', 'capybara' ]
+	},
+
+	html: `
+		<p>alpaca</p>
+		<p>baboon</p>
+		<p>capybara</p>
+	`,
+
+	test ( assert, component, target ) {
+		component.set({ animals: [] });
+		assert.htmlEqual( target.innerHTML, `
+			<p>no animals</p>
+		` );
+
+		// trigger an 'update' of the else block, to ensure that
+		// non-existent update method is not called
+		component.set({ animals: [] });
+
+		component.set({ animals: ['wombat'] });
+		assert.htmlEqual( target.innerHTML, `
+			<p>wombat</p>
+		` );
+	}
+};

--- a/test/runtime/samples/each-block-dynamic-else-static/main.html
+++ b/test/runtime/samples/each-block-dynamic-else-static/main.html
@@ -1,0 +1,5 @@
+{{#each animals as animal}}
+	<p>{{animal}}</p>
+{{else}}
+	<p>no animals</p>
+{{/each}}


### PR DESCRIPTION
#498 was actually a twofer — if a dynamic each block has a static else block, then it's possible to create a situation where Svelte tries to update the else block (which doesn't have an `update` method). This fixes that.