### PR TITLE
Initialize select element `value` upon creation of component.

### DIFF
--- a/src/generators/dom/visitors/Element/Binding.js
+++ b/src/generators/dom/visitors/Element/Binding.js
@@ -120,6 +120,12 @@ export default function visitBinding ( generator, block, state, node, attribute 
 		${generator.helper( 'addEventListener' )}( ${state.parentNode}, '${eventName}', ${handler} );
 	` );
 
+	if ( node.name === 'select' ) {
+		block.builders.create.addBlock( deindent`
+			${updateElement}
+		` );
+	}
+
 	if ( node.name !== 'audio' && node.name !== 'video' ) node.initialUpdate = updateElement;
 
 	if ( updateCondition !== null ) {


### PR DESCRIPTION
This PR fixes an issue where a `select` element is not set to the correct value on the initial creation of a component.

Mainly done in response to [@saibotsivad](https://gitter.im/sveltejs/svelte?at=58f679b0cfec91927250e250), but I have also experienced this behavior when writing Svelte components with `select` elements.

This snippet simply forces the select item to update after the `each_block` has been rendered, allowing `select.value` to be set.

I have not included the test that @saibotsivad created to prevent plagiarism.

/cc @saibotsivad