### PR TITLE
prevent bindings interfering with each other on the same element

### DIFF
--- a/src/generators/dom/visitors/Element/Binding.js
+++ b/src/generators/dom/visitors/Element/Binding.js
@@ -22,7 +22,7 @@ export default function visitBinding ( generator, block, state, node, attribute 
 
 	let setter = getSetter({ block, name, keypath, context: '_svelte', attribute, dependencies, value });
 	let updateElement = `${state.parentNode}.${attribute.name} = ${snippet};`;
-	const lock = block.getUniqueName( `${state.parentNode}_${attribute.name}_updating` );
+	const lock = block.alias( `${state.parentNode}_updating` );
 	let updateCondition = `!${lock}`;
 
 	// <select> special case
@@ -103,7 +103,7 @@ export default function visitBinding ( generator, block, state, node, attribute 
 			const last = block.getUniqueName( `${state.parentNode}_paused_value` );
 			block.builders.create.addLine( `var ${last} = true;` );
 
-			updateCondition += ` && ${last} !== ( ${last} = ${snippet} )`;
+			updateCondition = `${last} !== ( ${last} = ${snippet} )`;
 			updateElement = `${state.parentNode}[ ${last} ? 'pause' : 'play' ]();`;
 		}
 	}


### PR DESCRIPTION
Fixes a bug with audio bindings — when replaying an ended audio track, it should return to the start, but because each of `currentTime`, `duration` and `paused` had their own 'lock' variables, state was getting out of sync with the DOM. Fixed by sharing a lock variable between all bindings on the same element.

It *does* mean we have `var audio_updating = false` repeated once per binding. I think the solution to that would be to add a `block.addVariable` method that declares all (or most) variables in a single block at the top — this would also make the code marginally easier to read (in my opinion):


```js
// before
var p = createElement( 'p' );
var text_value = root.foo;
var text = createText( text_value );
appendNode( text, p );
var text_1 = createText( "\n" );
var p_1 = createElement( 'p' );
var text_2_value = root.bar;
var text_2 = createText( text_2_value );
appendNode( text_2, p_1 );
var text_3 = createText( "\n" );
var p_2 = createElement( 'p' );
var text_4_value = root.baz;
var text_4 = createText( text_4_value );
appendNode( text_4, p_2 );
```

```js
// after
var text_value, text_2_value, text_4_value;

var p = createElement( 'p' );
var text = createText( text_value = root.foo );
appendNode( text, p );
var text_1 = createText( "\n" );
var p_1 = createElement( 'p' );
var text_2 = createText( text_2_value = root.bar );
appendNode( text_2, p_1 );
var text_3 = createText( "\n" );
var p_2 = createElement( 'p' );
var text_4 = createText( text_4_value = root.baz );
appendNode( text_4, p_2 );
```
