### PR TITLE
failing test for bound event handler on <select> elements

### DIFF
--- a/test/runtime/samples/select-change-handler/_config.js
+++ b/test/runtime/samples/select-change-handler/_config.js
@@ -1,0 +1,22 @@
+export default {
+    data: {
+        options: [ { id: 'a' }, { id: 'b' }, { id: 'c' } ],
+        selected: 'b'
+    },
+
+    test ( assert, component, target, window ) {
+        const select = target.querySelector( 'select' );
+        assert.equal( select.value, 'b' );
+
+        const event = new window.Event( 'update' );
+
+        select.value = 'c';
+        select.dispatchEvent( event );
+
+        assert.equal( select.value, 'c' );
+        assert.equal( component.get( 'lastChangedTo' ), 'c' );
+        assert.equal( component.get( 'selected' ), 'c' );
+
+        component.destroy();
+    }
+};

--- a/test/runtime/samples/select-change-handler/main.html
+++ b/test/runtime/samples/select-change-handler/main.html
@@ -1,0 +1,15 @@
+<select bind:value="selected" on:change="updateLastChangedTo(selected)">
+    {{#each options as option}}
+    <option value="{{option.id}}">{{option.id}}</option>
+    {{/each}}
+</select>
+
+<script>
+export default {
+    methods: {
+        updateLastChangedTo(result) {
+            this.set({ lastChangedTo: result })
+        }
+    }
+}
+</script>


### PR DESCRIPTION
These two REPL issues:

* https://svelte.technology/repl?version=1.17.2&gist=eb693d0f85a05e17500fcce2a5aea647
* https://svelte.technology/repl?version=1.17.2&gist=5ec3e1ac9df113d4719fdfe3854b75da

The `on:change` event does not fire with the updated value, it fires with the previous value.