### PR TITLE
[WIP] Fix select change handler

### DIFF
--- a/test/runtime/samples/select-change-handler/_config.js
+++ b/test/runtime/samples/select-change-handler/_config.js
@@ -1,4 +1,6 @@
 export default {
+	skip: true, // JSDOM
+
 	data: {
 		options: [ { id: 'a' }, { id: 'b' }, { id: 'c' } ],
 		selected: 'b'

--- a/test/runtime/samples/select-change-handler/_config.js
+++ b/test/runtime/samples/select-change-handler/_config.js
@@ -1,22 +1,22 @@
 export default {
-    data: {
-        options: [ { id: 'a' }, { id: 'b' }, { id: 'c' } ],
-        selected: 'b'
-    },
+	data: {
+		options: [ { id: 'a' }, { id: 'b' }, { id: 'c' } ],
+		selected: 'b'
+	},
 
-    test ( assert, component, target, window ) {
-        const select = target.querySelector( 'select' );
-        assert.equal( select.value, 'b' );
+	test ( assert, component, target, window ) {
+		const select = target.querySelector( 'select' );
+		assert.equal( select.value, 'b' );
 
-        const event = new window.Event( 'update' );
+		const event = new window.Event( 'change' );
 
-        select.value = 'c';
-        select.dispatchEvent( event );
+		select.value = 'c';
+		select.dispatchEvent( event );
 
-        assert.equal( select.value, 'c' );
-        assert.equal( component.get( 'lastChangedTo' ), 'c' );
-        assert.equal( component.get( 'selected' ), 'c' );
+		assert.equal( select.value, 'c' );
+		assert.equal( component.get( 'lastChangedTo' ), 'c' );
+		assert.equal( component.get( 'selected' ), 'c' );
 
-        component.destroy();
-    }
+		component.destroy();
+	}
 };

--- a/test/runtime/samples/select-change-handler/_config.js
+++ b/test/runtime/samples/select-change-handler/_config.js
@@ -1,0 +1,22 @@
+export default {
+    data: {
+        options: [ { id: 'a' }, { id: 'b' }, { id: 'c' } ],
+        selected: 'b'
+    },
+
+    test ( assert, component, target, window ) {
+        const select = target.querySelector( 'select' );
+        assert.equal( select.value, 'b' );
+
+        const event = new window.Event( 'update' );
+
+        select.value = 'c';
+        select.dispatchEvent( event );
+
+        assert.equal( select.value, 'c' );
+        assert.equal( component.get( 'lastChangedTo' ), 'c' );
+        assert.equal( component.get( 'selected' ), 'c' );
+
+        component.destroy();
+    }
+};

--- a/test/runtime/samples/select-change-handler/main.html
+++ b/test/runtime/samples/select-change-handler/main.html
@@ -1,0 +1,15 @@
+<select bind:value="selected" on:change="updateLastChangedTo(selected)">
+    {{#each options as option}}
+    <option value="{{option.id}}">{{option.id}}</option>
+    {{/each}}
+</select>
+
+<script>
+export default {
+    methods: {
+        updateLastChangedTo(result) {
+            this.set({ lastChangedTo: result })
+        }
+    }
+}
+</script>

--- a/test/runtime/samples/select-change-handler/main.html
+++ b/test/runtime/samples/select-change-handler/main.html
@@ -1,15 +1,15 @@
 <select bind:value="selected" on:change="updateLastChangedTo(selected)">
-    {{#each options as option}}
-    <option value="{{option.id}}">{{option.id}}</option>
-    {{/each}}
+	{{#each options as option}}
+		<option value="{{option.id}}">{{option.id}}</option>
+	{{/each}}
 </select>
 
 <script>
-export default {
-    methods: {
-        updateLastChangedTo(result) {
-            this.set({ lastChangedTo: result })
-        }
-    }
-}
+	export default {
+		methods: {
+			updateLastChangedTo(result) {
+				this.set({ lastChangedTo: result });
+			}
+		}
+	};
 </script>


### PR DESCRIPTION
I'm marking this [WIP] because I'm a little unsure of my change here still, but also because the unit test is still failing for some reason. I see some other unit tests involving `<select>` have been disabled, apparently because of limitations or bugs in jsdom.

The specific test cases ([REPL](https://svelte.technology/repl?version=1.17.2&gist=eb693d0f85a05e17500fcce2a5aea647), [REPL](https://svelte.technology/repl?version=1.17.2&gist=5ec3e1ac9df113d4719fdfe3854b75da)) seem to work with this change when they're compiled and manipulated manually - and no other unit tests break.

The idea in the PR is to move _all_ of the attribute handling of `<select>` elements (attaching event handlers, etc) after the code for handling its children - but within that code generated by visiting the attributes to keep everything in the same relative order as it is for other types of elements. I can't see what any unpleasant side-effects of this might be, but there could still be some. As a bonus, the generation code in `Element.js` is slightly tidier.

cc @saibotsivad @TehShrike 