### PR TITLE
fix simple if blocks with top-level or conditions (#532)

### DIFF
--- a/src/generators/dom/visitors/IfBlock.js
+++ b/src/generators/dom/visitors/IfBlock.js
@@ -68,7 +68,7 @@ export default function visitIfBlock ( generator, block, state, node ) {
 
 function simple ( generator, block, state, node, branch, dynamic, { name, anchor, params } ) {
 	block.builders.create.addBlock( deindent`
-		var ${name} = ${branch.condition} && ${branch.block}( ${params}, ${block.component} );
+		var ${name} = (${branch.condition}) && ${branch.block}( ${params}, ${block.component} );
 	` );
 
 	const isToplevel = !state.parentNode;

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -3,7 +3,7 @@ import { appendNode, assign, createComment, createElement, createText, detachNod
 function create_main_fragment ( state, component ) {
 	var if_block_anchor = createComment();
 
-	var if_block = state.foo && create_if_block( state, component );
+	var if_block = (state.foo) && create_if_block( state, component );
 
 	return {
 		mount: function ( target, anchor ) {

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -3,7 +3,7 @@ import { appendNode, assign, createComment, createElement, createText, detachNod
 function create_main_fragment ( state, component ) {
 	var div = createElement( 'div' );
 
-	var if_block = state.a && create_if_block( state, component );
+	var if_block = (state.a) && create_if_block( state, component );
 
 	if ( if_block ) if_block.mount( div, null );
 	var text = createText( "\n\n\t" );
@@ -13,13 +13,13 @@ function create_main_fragment ( state, component ) {
 	appendNode( createText( "this can be used as an anchor" ), p );
 	appendNode( createText( "\n\n\t" ), div );
 
-	var if_block_1 = state.b && create_if_block_1( state, component );
+	var if_block_1 = (state.b) && create_if_block_1( state, component );
 
 	if ( if_block_1 ) if_block_1.mount( div, null );
 	var text_3 = createText( "\n\n\t" );
 	appendNode( text_3, div );
 
-	var if_block_2 = state.c && create_if_block_2( state, component );
+	var if_block_2 = (state.c) && create_if_block_2( state, component );
 
 	if ( if_block_2 ) if_block_2.mount( div, null );
 	var text_4 = createText( "\n\n\t" );
@@ -29,7 +29,7 @@ function create_main_fragment ( state, component ) {
 	appendNode( createText( "so can this" ), p_1 );
 	appendNode( createText( "\n\n\t" ), div );
 
-	var if_block_3 = state.d && create_if_block_3( state, component );
+	var if_block_3 = (state.d) && create_if_block_3( state, component );
 
 	if ( if_block_3 ) if_block_3.mount( div, null );
 	var text_7 = createText( "\n\n\t" );
@@ -37,7 +37,7 @@ function create_main_fragment ( state, component ) {
 	var text_8 = createText( "\n\n" );
 	var if_block_4_anchor = createComment();
 
-	var if_block_4 = state.e && create_if_block_4( state, component );
+	var if_block_4 = (state.e) && create_if_block_4( state, component );
 
 	return {
 		mount: function ( target, anchor ) {

--- a/test/runtime/samples/if-block-or/_config.js
+++ b/test/runtime/samples/if-block-or/_config.js
@@ -1,0 +1,15 @@
+export default {
+	data: {
+		a: true,
+		b: false
+	},
+
+	html: '<p>i am visible</p>',
+
+	test ( assert, component, target ) {
+		component.set({ a: false });
+		assert.htmlEqual( target.innerHTML, '' );
+		component.set({ b: true });
+		assert.htmlEqual( target.innerHTML, '<p>i am visible</p>' );
+	}
+};

--- a/test/runtime/samples/if-block-or/main.html
+++ b/test/runtime/samples/if-block-or/main.html
@@ -1,0 +1,3 @@
+{{#if a || b}}
+	<p>i am visible</p>
+{{/if}}


### PR DESCRIPTION
Fixes #532 by always wrapping the condition in simple if blocks in parentheses.