### PR TITLE
fix parsing of expressions wrapped in parentheses (#534)

### DIFF
--- a/src/parse/read/expression.js
+++ b/src/parse/read/expression.js
@@ -34,7 +34,7 @@ export default function readExpression ( parser ) {
 	parser.index = start;
 
 	try {
-		const node = parseExpressionAt( parser.template, parser.index );
+		const node = parseExpressionAt( parser.template, parser.index, { preserveParens: true } );
 		parser.index = node.end;
 
 		return node;

--- a/test/runtime/samples/paren-wrapped-expressions/_config.js
+++ b/test/runtime/samples/paren-wrapped-expressions/_config.js
@@ -1,0 +1,16 @@
+export default {
+	data: {
+		a: 'foo',
+		b: true,
+		c: [ 1, 2, 3 ],
+	},
+
+	html: `
+		<span>foo</span>
+		<span class="foo"></span>
+		<span>true</span>
+		<span>1</span>
+		<span>2</span>
+		<span>3</span>
+	`
+};

--- a/test/runtime/samples/paren-wrapped-expressions/main.html
+++ b/test/runtime/samples/paren-wrapped-expressions/main.html
@@ -1,0 +1,8 @@
+<span>{{ (a) }}</span>
+<span class='{{ (a) }}'></span>
+{{#if (b) }}
+	<span>true</span>
+{{/if}}
+{{#each (c) as x}}
+	<span>{{x}}</span>
+{{/each}}


### PR DESCRIPTION
Fixes #534. [Acorn's docs](https://github.com/ternjs/acorn#main-parser) do warn that the the `ParenthesizedExpressions` nodes created when the `preserveParens` option is enable are non-standard, but using this does not seem to have ill effects. Svelte is still able to walk the tree and rewrite the expressions appropriately according to the context.