### PR TITLE
correctly handle when helper functions have been internally renamed (#538)

### DIFF
--- a/src/generators/dom/sharedNames.js
+++ b/src/generators/dom/sharedNames.js
@@ -1,0 +1,12 @@
+import * as shared from '../../shared/index.js';
+
+export const nameMap = new Map();
+export const sharedMap = new Map();
+
+Object.keys(shared).forEach( key => {
+	const value = shared[ key ]; // eslint-disable-line import/namespace
+	if ( typeof value === 'function' ) {
+		nameMap.set( value.name, key );
+	}
+	sharedMap.set( key, value.toString() );
+});


### PR DESCRIPTION
Fixes #538 - admittedly a picky thing, but it was bound to be a problem sometime, and is currently stopping us from upgrading to Acorn 5.