### PR TITLE
Fix delays on bidirectional transitions

### DIFF
--- a/src/generators/dom/visitors/Element/addTransitions.js
+++ b/src/generators/dom/visitors/Element/addTransitions.js
@@ -14,14 +14,14 @@ export default function addTransitions ( generator, block, state, node, intro, o
 		block.builders.intro.addBlock( deindent`
 			${block.component}._renderHooks.push( function () {
 				if ( !${name} ) ${name} = ${wrapTransition}( ${state.name}, ${fn}, ${snippet}, true, null );
-				${name}.run( ${name}.t, 1, function () {
+				${name}.run( true, function () {
 					${block.component}.fire( 'intro.end', { node: ${state.name} });
 				});
 			});
 		` );
 
 		block.builders.outro.addBlock( deindent`
-			${name}.run( ${name}.t, 0, function () {
+			${name}.run( false, function () {
 				${block.component}.fire( 'outro.end', { node: ${state.name} });
 				if ( --${block.alias( 'outros' )} === 0 ) ${block.alias( 'outrocallback' )}();
 				${name} = null;
@@ -49,7 +49,7 @@ export default function addTransitions ( generator, block, state, node, intro, o
 			block.builders.intro.addBlock( deindent`
 				${block.component}._renderHooks.push( function () {
 					${introName} = ${wrapTransition}( ${state.name}, ${fn}, ${snippet}, true, null );
-					${introName}.run( 0, 1, function () {
+					${introName}.run( true, function () {
 						${block.component}.fire( 'intro.end', { node: ${state.name} });
 					});
 				});
@@ -66,7 +66,7 @@ export default function addTransitions ( generator, block, state, node, intro, o
 			// group) prior to their removal from the DOM
 			block.builders.outro.addBlock( deindent`
 				${outroName} = ${wrapTransition}( ${state.name}, ${fn}, ${snippet}, false, null );
-				${outroName}.run( 1, 0, function () {
+				${outroName}.run( false, function () {
 					${block.component}.fire( 'outro.end', { node: ${state.name} });
 					if ( --${block.alias( 'outros' )} === 0 ) ${block.alias( 'outrocallback' )}();
 				});

--- a/src/shared/transitions.js
+++ b/src/shared/transitions.js
@@ -40,13 +40,14 @@ export function wrapTransition ( node, fn, params, intro, outgroup ) {
 	if ( intro && obj.tick ) obj.tick( 0 );
 
 	return {
-		running: false,
 		t: intro ? 0 : 1,
+		running: false,
+		program: null,
 		pending: null,
 		run: function ( intro, callback ) {
 			var program = {
-				intro: intro,
 				start: window.performance.now() + ( obj.delay || 0 ),
+				intro: intro,
 				callback: callback
 			};
 
@@ -94,8 +95,8 @@ export function wrapTransition ( node, fn, params, intro, outgroup ) {
 		abort: function () {
 			if ( obj.tick ) obj.tick( 1 );
 			if ( obj.css ) document.head.removeChild( style );
-			this.program = null;
-			this.running = !!this.pending;
+			this.program = this.pending = null;
+			this.running = false;
 		}
 	};
 }

--- a/test/runtime/samples/transition-js-delay-in-out/_config.js
+++ b/test/runtime/samples/transition-js-delay-in-out/_config.js
@@ -1,0 +1,24 @@
+export default {
+	test ( assert, component, target, window, raf ) {
+		component.set({ visible: true });
+		const div = target.querySelector( 'div' );
+		assert.equal( div.foo, 0 );
+
+		raf.tick( 50 );
+		assert.equal( div.foo, 0 );
+
+		raf.tick( 150 );
+		assert.equal( div.foo, 1 );
+
+		component.set({ visible: false });
+		assert.equal( div.bar, undefined );
+
+		raf.tick( 200 );
+		assert.equal( div.bar, 1 );
+
+		raf.tick( 300 );
+		assert.equal( div.bar, 0 );
+
+		component.destroy();
+	}
+};

--- a/test/runtime/samples/transition-js-delay-in-out/main.html
+++ b/test/runtime/samples/transition-js-delay-in-out/main.html
@@ -1,16 +1,26 @@
 {{#if visible}}
-	<div transition:foo>hello {{name}}!</div>
+	<div in:foo out:bar>delayed</div>
 {{/if}}
 
 <script>
 	export default {
 		transitions: {
 			foo: function ( node, params ) {
-				global.count += 1;
 				return {
+					delay: 50,
 					duration: 100,
 					tick: t => {
 						node.foo = t;
+					}
+				};
+			},
+
+			bar: function ( node, params ) {
+				return {
+					delay: 50,
+					duration: 100,
+					tick: t => {
+						node.bar = t;
 					}
 				};
 			}

--- a/test/runtime/samples/transition-js-delay/_config.js
+++ b/test/runtime/samples/transition-js-delay/_config.js
@@ -1,0 +1,29 @@
+export default {
+	test ( assert, component, target, window, raf ) {
+		component.set({ visible: true });
+		const div = target.querySelector( 'div' );
+		assert.equal( div.foo, 0 );
+
+		raf.tick( 50 );
+		assert.equal( div.foo, 0 );
+
+		raf.tick( 100 );
+		assert.equal( div.foo, 0.5 );
+
+		component.set({ visible: false });
+
+		raf.tick( 125 );
+		assert.equal( div.foo, 0.75 );
+
+		raf.tick( 150 );
+		assert.equal( div.foo, 1 );
+
+		raf.tick( 175 );
+		assert.equal( div.foo, 0.75 );
+
+		raf.tick( 250 );
+		assert.equal( div.foo, 0 );
+
+		component.destroy();
+	}
+};

--- a/test/runtime/samples/transition-js-delay/main.html
+++ b/test/runtime/samples/transition-js-delay/main.html
@@ -1,13 +1,13 @@
 {{#if visible}}
-	<div transition:foo>hello {{name}}!</div>
+	<div transition:foo>delayed</div>
 {{/if}}
 
 <script>
 	export default {
 		transitions: {
 			foo: function ( node, params ) {
-				global.count += 1;
 				return {
+					delay: 50,
 					duration: 100,
 					tick: t => {
 						node.foo = t;

--- a/test/runtime/samples/transition-js-dynamic-if-block-bidi/_config.js
+++ b/test/runtime/samples/transition-js-dynamic-if-block-bidi/_config.js
@@ -11,7 +11,7 @@ export default {
 		const div = target.querySelector( 'div' );
 		assert.equal( div.foo, 0 );
 
-		raf.tick( 300 );
+		raf.tick( 75 );
 		component.set({ name: 'everybody' });
 		assert.equal( div.foo, 0.75 );
 		assert.htmlEqual( div.innerHTML, 'hello everybody!' );
@@ -19,18 +19,18 @@ export default {
 		component.set({ visible: false, name: 'again' });
 		assert.htmlEqual( div.innerHTML, 'hello everybody!' );
 
-		raf.tick( 500 );
+		raf.tick( 125 );
 		assert.equal( div.foo, 0.25 );
 
 		component.set({ visible: true });
-		raf.tick( 700 );
+		raf.tick( 175 );
 		assert.equal( div.foo, 0.75 );
 		assert.htmlEqual( div.innerHTML, 'hello again!' );
 
-		raf.tick( 800 );
+		raf.tick( 200 );
 		assert.equal( div.foo, 1 );
 
-		raf.tick( 900 );
+		raf.tick( 225 );
 
 		component.destroy();
 	}


### PR DESCRIPTION
Fixes #562, by separating the transition object from the *program* (a transition could have multiple programs if it's bidirectional and flips back and forth, and a program will continue until its delayed replacement starts)