### PR TITLE
Fix insertion order of if blocks and their anchors

### DIFF
--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -1,8 +1,6 @@
 import { appendNode, assign, createComment, createElement, createText, detachNode, dispatchObservers, insertNode, proto } from "svelte/shared.js";
 
 function create_main_fragment ( state, component ) {
-	var if_block_anchor = createComment();
-
 	function get_block ( state ) {
 		if ( state.foo ) return create_if_block;
 		return create_if_block_1;
@@ -11,10 +9,12 @@ function create_main_fragment ( state, component ) {
 	var current_block = get_block( state );
 	var if_block = current_block( state, component );
 
+	var if_block_anchor = createComment();
+
 	return {
 		mount: function ( target, anchor ) {
+			if_block.mount( target, anchor );
 			insertNode( if_block_anchor, target, anchor );
-			if_block.mount( target, null );
 		},
 
 		update: function ( changed, state ) {

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -1,14 +1,14 @@
 import { appendNode, assign, createComment, createElement, createText, detachNode, dispatchObservers, insertNode, proto } from "svelte/shared.js";
 
 function create_main_fragment ( state, component ) {
-	var if_block_anchor = createComment();
-
 	var if_block = (state.foo) && create_if_block( state, component );
+
+	var if_block_anchor = createComment();
 
 	return {
 		mount: function ( target, anchor ) {
+			if ( if_block ) if_block.mount( target, anchor );
 			insertNode( if_block_anchor, target, anchor );
-			if ( if_block ) if_block.mount( target, null );
 		},
 
 		update: function ( changed, state ) {

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -35,16 +35,17 @@ function create_main_fragment ( state, component ) {
 	var text_7 = createText( "\n\n\t" );
 	appendNode( text_7, div );
 	var text_8 = createText( "\n\n" );
-	var if_block_4_anchor = createComment();
 
 	var if_block_4 = (state.e) && create_if_block_4( state, component );
+
+	var if_block_4_anchor = createComment();
 
 	return {
 		mount: function ( target, anchor ) {
 			insertNode( div, target, anchor );
 			insertNode( text_8, target, anchor );
+			if ( if_block_4 ) if_block_4.mount( target, anchor );
 			insertNode( if_block_4_anchor, target, anchor );
-			if ( if_block_4 ) if_block_4.mount( target, null );
 		},
 
 		update: function ( changed, state ) {

--- a/test/runtime/samples/component-if-placement/Component.html
+++ b/test/runtime/samples/component-if-placement/Component.html
@@ -1,0 +1,3 @@
+{{#if true}}
+	<span>Component</span>
+{{/if}}

--- a/test/runtime/samples/component-if-placement/_config.js
+++ b/test/runtime/samples/component-if-placement/_config.js
@@ -1,0 +1,20 @@
+export default {
+	data: {
+		flag: true
+	},
+
+	html: `
+		<span>Before</span>
+		<span>Component</span>
+		<span>After</span>
+	`,
+
+	test ( assert, component, target ) {
+		component.set( { flag: false } );
+		assert.htmlEqual( target.innerHTML, `
+			<span>Before</span>
+			<span>Component</span>
+			<span>After</span>
+		`);
+	}
+};

--- a/test/runtime/samples/component-if-placement/main.html
+++ b/test/runtime/samples/component-if-placement/main.html
@@ -1,0 +1,14 @@
+<span>Before</span>
+{{#if flag}}
+	<Component/>
+{{else}}
+	<Component/>
+{{/if}}
+<span>After</span>
+
+<script>
+	import Component from './Component.html';
+	export default {
+		components: { Component }
+	};
+</script>


### PR DESCRIPTION
Fixes #569, but ensuring that if-block anchors are mounted *after* the if-block contents (the anchors are needed for updating — i.e. if a block is added/removed — rather than for the initial mounting)