### PR TITLE
Better handling of textareas

### DIFF
--- a/src/generators/dom/visitors/Element/Element.ts
+++ b/src/generators/dom/visitors/Element/Element.ts
@@ -107,6 +107,20 @@ export default function visitElement ( generator: DomGenerator, block: Block, st
 	}
 
 	if ( node.name !== 'select' ) {
+		if ( node.name === 'textarea' ) {
+			// this is an egregious hack, but it's the easiest way to get <textarea>
+			// children treated the same way as a value attribute
+			if ( node.children.length > 0 ) {
+				node.attributes.push({
+					type: 'Attribute',
+					name: 'value',
+					value: node.children
+				});
+
+				node.children = [];
+			}
+		}
+
 		// <select> value attributes are an annoying special case — it must be handled
 		// *after* its children have been updated
 		visitAttributesAndAddProps();

--- a/src/generators/dom/visitors/Element/lookup.ts
+++ b/src/generators/dom/visitors/Element/lookup.ts
@@ -109,7 +109,7 @@ const lookup = {
 	title: {},
 	type: { appliesTo: [ 'button', 'input', 'command', 'embed', 'object', 'script', 'source', 'style', 'menu' ] },
 	usemap: { propertyName: 'useMap', appliesTo: [ 'img', 'input', 'object' ] },
-	value: { appliesTo: [ 'button', 'option', 'input', 'li', 'meter', 'progress', 'param', 'select' ] },
+	value: { appliesTo: [ 'button', 'option', 'input', 'li', 'meter', 'progress', 'param', 'select', 'textarea' ] },
 	width: { appliesTo: [ 'canvas', 'embed', 'iframe', 'img', 'input', 'object', 'video' ] },
 	wrap: { appliesTo: [ 'textarea' ] }
 };

--- a/src/generators/server-side-rendering/visitors/Element.ts
+++ b/src/generators/server-side-rendering/visitors/Element.ts
@@ -10,6 +10,17 @@ const meta = {
 	':Window': visitWindow
 };
 
+function stringifyAttributeValue ( block: Block, chunks: Node[] ) {
+	return chunks.map( ( chunk: Node ) => {
+		if ( chunk.type === 'Text' ) {
+			return chunk.data;
+		}
+
+		const { snippet } = block.contextualise( chunk.expression );
+		return '${' + snippet + '}';
+	}).join( '' )
+}
+
 export default function visitElement ( generator: SsrGenerator, block: Block, node: Node ) {
 	if ( node.name in meta ) {
 		return meta[ node.name ]( generator, block, node );
@@ -21,24 +32,22 @@ export default function visitElement ( generator: SsrGenerator, block: Block, no
 	}
 
 	let openingTag = `<${node.name}`;
+	let textareaContents; // awkward special case
 
 	node.attributes.forEach( ( attribute: Node ) => {
 		if ( attribute.type !== 'Attribute' ) return;
 
-		let str = ` ${attribute.name}`;
+		if ( attribute.name === 'value' && node.name === 'textarea' ) {
+			textareaContents = stringifyAttributeValue( block, attribute.value );
+		} else {
+			let str = ` ${attribute.name}`;
 
-		if ( attribute.value !== true ) {
-			str += `="` + attribute.value.map( ( chunk: Node ) => {
-				if ( chunk.type === 'Text' ) {
-					return chunk.data;
-				}
+			if ( attribute.value !== true ) {
+				str += `="${stringifyAttributeValue( block, attribute.value )}"`;
+			}
 
-				const { snippet } = block.contextualise( chunk.expression );
-				return '${' + snippet + '}';
-			}).join( '' ) + `"`;
+			openingTag += str;
 		}
-
-		openingTag += str;
 	});
 
 	if ( generator.cssId && !generator.elementDepth ) {
@@ -49,13 +58,17 @@ export default function visitElement ( generator: SsrGenerator, block: Block, no
 
 	generator.append( openingTag );
 
-	generator.elementDepth += 1;
+	if ( node.name === 'textarea' && textareaContents !== undefined ) {
+		generator.append( textareaContents );
+	} else {
+		generator.elementDepth += 1;
 
-	node.children.forEach( ( child: Node ) => {
-		visit( generator, block, child );
-	});
+		node.children.forEach( ( child: Node ) => {
+			visit( generator, block, child );
+		});
 
-	generator.elementDepth -= 1;
+		generator.elementDepth -= 1;
+	}
 
 	if ( !isVoidElementName( node.name ) ) {
 		generator.append( `</${node.name}>` );

--- a/src/validate/html/validateElement.ts
+++ b/src/validate/html/validateElement.ts
@@ -77,6 +77,14 @@ export default function validateElement ( validator: Validator, node: Node ) {
 				validator.error( `Missing transition '${attribute.name}'`, attribute.start );
 			}
 		}
+
+		else if ( attribute.type === 'Attribute' ) {
+			if ( attribute.name === 'value' && node.name === 'textarea' ) {
+				if ( node.children.length ) {
+					validator.error( `A <textarea> can have either a value attribute or (equivalently) child content, but not both`, attribute.start );
+				}
+			}
+		}
 	});
 }
 

--- a/test/parser/samples/textarea-children/input.html
+++ b/test/parser/samples/textarea-children/input.html
@@ -1,0 +1,3 @@
+<textarea>
+	<p>not actually an element. {{foo}}</p>
+</textarea>

--- a/test/parser/samples/textarea-children/output.json
+++ b/test/parser/samples/textarea-children/output.json
@@ -1,0 +1,44 @@
+{
+	"hash": 3618147195,
+	"html": {
+		"start": 0,
+		"end": 63,
+		"type": "Fragment",
+		"children": [
+			{
+				"start": 0,
+				"end": 63,
+				"type": "Element",
+				"name": "textarea",
+				"attributes": [],
+				"children": [
+					{
+						"start": 10,
+						"end": 40,
+						"type": "Text",
+						"data": "\n\t<p>not actually an element. "
+					},
+					{
+						"start": 40,
+						"end": 47,
+						"type": "MustacheTag",
+						"expression": {
+							"type": "Identifier",
+							"start": 42,
+							"end": 45,
+							"name": "foo"
+						}
+					},
+					{
+						"start": 47,
+						"end": 52,
+						"type": "Text",
+						"data": "</p>\n"
+					}
+				]
+			}
+		]
+	},
+	"css": null,
+	"js": null
+}

--- a/test/runtime/samples/textarea-children/_config.js
+++ b/test/runtime/samples/textarea-children/_config.js
@@ -1,0 +1,17 @@
+export default {
+	'skip-ssr': true, // SSR behaviour is awkwardly different
+
+	data: {
+		foo: 42
+	},
+
+	html: `<textarea></textarea>`,
+
+	test ( assert, component, target ) {
+		const textarea = target.querySelector( 'textarea' );
+		assert.strictEqual( textarea.value, `\n\t<p>not actually an element. 42</p>\n` );
+
+		component.set({ foo: 43 });
+		assert.strictEqual( textarea.value, `\n\t<p>not actually an element. 43</p>\n` );
+	}
+};

--- a/test/runtime/samples/textarea-children/main.html
+++ b/test/runtime/samples/textarea-children/main.html
@@ -1,0 +1,3 @@
+<textarea>
+	<p>not actually an element. {{foo}}</p>
+</textarea>

--- a/test/runtime/samples/textarea-value/_config.js
+++ b/test/runtime/samples/textarea-value/_config.js
@@ -1,0 +1,17 @@
+export default {
+	'skip-ssr': true, // SSR behaviour is awkwardly different
+
+	data: {
+		foo: 42
+	},
+
+	html: `<textarea></textarea>`,
+
+	test ( assert, component, target ) {
+		const textarea = target.querySelector( 'textarea' );
+		assert.strictEqual( textarea.value, '42' );
+
+		component.set({ foo: 43 });
+		assert.strictEqual( textarea.value, '43' );
+	}
+};

--- a/test/runtime/samples/textarea-value/main.html
+++ b/test/runtime/samples/textarea-value/main.html
@@ -1,0 +1,1 @@
+<textarea value='{{foo}}'/>

--- a/test/server-side-rendering/samples/textarea-children/_expected.html
+++ b/test/server-side-rendering/samples/textarea-children/_expected.html
@@ -1,0 +1,3 @@
+<textarea>
+	<p>not actually an element. 42</p>
+</textarea>

--- a/test/server-side-rendering/samples/textarea-children/main.html
+++ b/test/server-side-rendering/samples/textarea-children/main.html
@@ -1,0 +1,11 @@
+<textarea>
+	<p>not actually an element. {{foo}}</p>
+</textarea>
+
+<script>
+	export default {
+		data () {
+			return { foo: 42 };
+		}
+	};
+</script>

--- a/test/server-side-rendering/samples/textarea-value/_expected.html
+++ b/test/server-side-rendering/samples/textarea-value/_expected.html
@@ -1,0 +1,1 @@
+<textarea>42</textarea>

--- a/test/server-side-rendering/samples/textarea-value/main.html
+++ b/test/server-side-rendering/samples/textarea-value/main.html
@@ -1,0 +1,9 @@
+<textarea value='{{foo}}'/>
+
+<script>
+	export default {
+		data () {
+			return { foo: 42 };
+		}
+	};
+</script>

--- a/test/validator/samples/textarea-value-children/errors.json
+++ b/test/validator/samples/textarea-value-children/errors.json
@@ -1,0 +1,8 @@
+[{
+	"message": "A <textarea> can have either a value attribute or (equivalently) child content, but not both",
+	"loc": {
+		"line": 1,
+		"column": 10
+	},
+	"pos": 10
+}]

--- a/test/validator/samples/textarea-value-children/input.html
+++ b/test/validator/samples/textarea-value-children/input.html
@@ -1,0 +1,3 @@
+<textarea value='{{foo}}'>
+	some illegal text
+</textarea>


### PR DESCRIPTION
This primarily fixes #582, but also address some other behaviour around textareas:

## `value` and children are treated equivalently

```html
<!-- these are the same, as far as Svelte is concerned -->
<textarea value='{{foo}}'/>
<textarea>{{foo}}</textarea>
```

A textarea with both a value attribute *and* children will fail validation.

## textareas cannot have child elements or if/each blocks

As a corollary to the above:

```html
<!-- these are the same -->
<textarea>
  <p>surprise! this isn't an element</p>
</textarea>

<textarea value="\n\t<p>surprise! this isn't an element</p>\n"/>
```

## SSR

Before (incorrect):

```html
<textarea value="42"></textarea>
```

After:

```html
<textarea>42</textarea>
```