### PR TITLE
add cascade option, to prevent components inheriting styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "glob": "^7.1.1",
     "jsdom": "^9.9.1",
     "locate-character": "^2.0.0",
-    "magic-string": "^0.19.0",
+    "magic-string": "^0.21.1",
     "mocha": "^3.2.0",
     "node-resolve": "^1.3.3",
     "nyc": "^10.0.0",

--- a/src/generators/Generator.ts
+++ b/src/generators/Generator.ts
@@ -29,8 +29,11 @@ export default class Generator {
 	transitions: Set<string>;
 	importedComponents: Map<string, string>;
 
+	code: MagicString;
+
 	bindingGroups: string[];
 	expectedProperties: Set<string>;
+	cascade: boolean;
 	css: string;
 	cssId: string;
 	usesRefs: boolean;
@@ -59,7 +62,8 @@ export default class Generator {
 		this.expectedProperties = new Set();
 
 		this.code = new MagicString( source );
-		this.css = parsed.css ? processCss( parsed, this.code ) : null;
+		this.cascade = options.cascade !== false; // TODO remove this option in v2
+		this.css = parsed.css ? processCss( parsed, this.code, this.cascade ) : null;
 		this.cssId = parsed.css ? `svelte-${parsed.hash}` : '';
 		this.usesRefs = false;
 

--- a/src/generators/dom/visitors/Element/Element.ts
+++ b/src/generators/dom/visitors/Element/Element.ts
@@ -46,7 +46,7 @@ export default function visitElement ( generator: DomGenerator, block: Block, st
 	block.mount( name, state.parentNode );
 
 	// add CSS encapsulation attribute
-	if ( generator.cssId && state.isTopLevel ) {
+	if ( generator.cssId && ( !generator.cascade || state.isTopLevel ) ) {
 		block.builders.create.addLine( `${generator.helper( 'setAttribute' )}( ${name}, '${generator.cssId}', '' );` );
 	}
 

--- a/src/generators/server-side-rendering/index.ts
+++ b/src/generators/server-side-rendering/index.ts
@@ -13,6 +13,7 @@ export class SsrGenerator extends Generator {
 		super( parsed, source, name, options );
 		this.bindings = [];
 		this.renderCode = '';
+		this.elementDepth = 0;
 	}
 
 	append ( code: string ) {

--- a/src/generators/server-side-rendering/visitors/Element.ts
+++ b/src/generators/server-side-rendering/visitors/Element.ts
@@ -50,7 +50,7 @@ export default function visitElement ( generator: SsrGenerator, block: Block, no
 		}
 	});
 
-	if ( generator.cssId && !generator.elementDepth ) {
+	if ( generator.cssId && ( !generator.cascade || generator.elementDepth === 0 ) ) {
 		openingTag += ` ${generator.cssId}`;
 	}
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -40,6 +40,7 @@ export interface CompileOptions {
 
 	dev?: boolean;
 	shared?: boolean | string;
+	cascade?: boolean;
 
 	onerror?: (error: Error) => void
 	onwarn?: (warning: Warning) => void

--- a/test/css/index.js
+++ b/test/css/index.js
@@ -1,6 +1,15 @@
 import assert from 'assert';
 import * as fs from 'fs';
-import { svelte, exists } from '../helpers.js';
+import { svelte } from '../helpers.js';
+
+function tryRequire ( file ) {
+	try {
+		return require( file ).default;
+	} catch ( err ) {
+		if ( err.code !== 'MODULE_NOT_FOUND' ) throw err;
+		return null;
+	}
+}
 
 describe( 'css', () => {
 	fs.readdirSync( 'test/css/samples' ).forEach( dir => {
@@ -14,9 +23,10 @@ describe( 'css', () => {
 		}
 
 		( solo ? it.only : it )( dir, () => {
+			const config = tryRequire( `./samples/${dir}/_config.js` ) || {};
 			const input = fs.readFileSync( `test/css/samples/${dir}/input.html`, 'utf-8' ).replace( /\s+$/, '' );
 
-			const actual = svelte.compile( input ).css;
+			const actual = svelte.compile( input, config ).css;
 			fs.writeFileSync( `test/css/samples/${dir}/_actual.css`, actual );
 			const expected = fs.readFileSync( `test/css/samples/${dir}/expected.css`, 'utf-8' );
 

--- a/test/css/samples/cascade-false-global-keyframes/expected.css
+++ b/test/css/samples/cascade-false-global-keyframes/expected.css
@@ -1,0 +1,13 @@
+
+	@keyframes why {
+		0% { color: red; }
+		100% { color: blue; }
+	}
+
+	[svelte-2486527405].animated, [svelte-2486527405] .animated {
+		animation: why 2s;
+	}
+
+	[svelte-2486527405].also-animated, [svelte-2486527405] .also-animated {
+		animation: not-defined-here 2s;
+	}

--- a/test/css/samples/cascade-false-global-keyframes/input.html
+++ b/test/css/samples/cascade-false-global-keyframes/input.html
@@ -1,0 +1,17 @@
+<div class='animated'>animated</div>
+<div class='also-animated'>also animated</div>
+
+<style>
+	@keyframes -global-why {
+		0% { color: red; }
+		100% { color: blue; }
+	}
+
+	.animated {
+		animation: why 2s;
+	}
+
+	.also-animated {
+		animation: not-defined-here 2s;
+	}
+</style>

--- a/test/css/samples/cascade-false-global/_config.js
+++ b/test/css/samples/cascade-false-global/_config.js
@@ -1,0 +1,3 @@
+export default {
+	cascade: false
+};

--- a/test/css/samples/cascade-false-global/expected.css
+++ b/test/css/samples/cascade-false-global/expected.css
@@ -1,0 +1,12 @@
+
+	div {
+		color: red;
+	}
+
+	div.foo {
+		color: blue;
+	}
+
+	.foo {
+		font-weight: bold;
+	}

--- a/test/css/samples/cascade-false-global/input.html
+++ b/test/css/samples/cascade-false-global/input.html
@@ -1,0 +1,16 @@
+<div>red</div>
+<div class='foo'>bold/blue</div>
+
+<style>
+	:global(div) {
+		color: red;
+	}
+
+	:global(div.foo) {
+		color: blue;
+	}
+
+	:global(.foo) {
+		font-weight: bold;
+	}
+</style>

--- a/test/css/samples/cascade-false-keyframes/expected.css
+++ b/test/css/samples/cascade-false-keyframes/expected.css
@@ -1,0 +1,13 @@
+
+	@keyframes svelte-776829126-why {
+		0% { color: red; }
+		100% { color: blue; }
+	}
+
+	[svelte-776829126].animated, [svelte-776829126] .animated {
+		animation: svelte-776829126-why 2s;
+	}
+
+	[svelte-776829126].also-animated, [svelte-776829126] .also-animated {
+		animation: not-defined-here 2s;
+	}

--- a/test/css/samples/cascade-false-keyframes/input.html
+++ b/test/css/samples/cascade-false-keyframes/input.html
@@ -1,0 +1,17 @@
+<div class='animated'>animated</div>
+<div class='also-animated'>also animated</div>
+
+<style>
+	@keyframes why {
+		0% { color: red; }
+		100% { color: blue; }
+	}
+
+	.animated {
+		animation: why 2s;
+	}
+
+	.also-animated {
+		animation: not-defined-here 2s;
+	}
+</style>

--- a/test/css/samples/cascade-false/_config.js
+++ b/test/css/samples/cascade-false/_config.js
@@ -1,0 +1,3 @@
+export default {
+	cascade: false
+};

--- a/test/css/samples/cascade-false/expected.css
+++ b/test/css/samples/cascade-false/expected.css
@@ -1,0 +1,12 @@
+
+	div[svelte-4161687011] {
+		color: red;
+	}
+
+	div.foo[svelte-4161687011] {
+		color: blue;
+	}
+
+	.foo[svelte-4161687011] {
+		font-weight: bold;
+	}

--- a/test/css/samples/cascade-false/input.html
+++ b/test/css/samples/cascade-false/input.html
@@ -1,0 +1,16 @@
+<div>red</div>
+<div class='foo'>bold/blue</div>
+
+<style>
+	div {
+		color: red;
+	}
+
+	div.foo {
+		color: blue;
+	}
+
+	.foo {
+		font-weight: bold;
+	}
+</style>


### PR DESCRIPTION
Addresses #583 by adding a `cascade` option. If `cascade` is false, and a component has a `<style>` attribute, *all* elements get the `svelte-123xyz` attribute (not just the component's top-level elements), and selectors are transformed in such a way that they only apply to the component's own elements, *not* to child components.

This seems to be more in line with the wider community's expectations of how CSS scoping should work, and makes it easier to do certain forms of analysis such as identifying redundant selectors, and omitting the `svelte-123xyz` attribute on nodes that won't benefit from it. I'm therefore proposing that we remove the option in v2 and *never* cascade styles, unless selectors have been wrapped with the `:global(...)` escape hatch (which is the convention used by css-modules and styled-jsx).

Keyframes are a little tricky — this...

```css
@keyframes :global(my-animation) {...}
```

...isn't valid CSS, so it causes problems with syntax highlighting and linting in editors, and with parsing during compilation. For that reason, this PR **does not** use `:global(...)` for animation names as css-modules does. Instead, animation names can be marked as global with the `-global-` prefix (which is simply removed during transformation):

```css
@keyframes -global-my-animation {...}
```

What does everyone think?