### PR TITLE
rename addEventListener and removeEventListener

### DIFF
--- a/src/generators/dom/visitors/Element/Binding.ts
+++ b/src/generators/dom/visitors/Element/Binding.ts
@@ -160,7 +160,7 @@ export default function visitBinding(
 		}
 
 		${generator.helper(
-			'addEventListener'
+			'addListener'
 		)}( ${state.parentNode}, '${eventName}', ${handler} );
 	`);
 
@@ -178,19 +178,19 @@ export default function visitBinding(
 
 	block.builders.destroy.addLine(deindent`
 		${generator.helper(
-			'removeEventListener'
+			'removeListener'
 		)}( ${state.parentNode}, '${eventName}', ${handler} );
 	`);
 
 	if (attribute.name === 'paused') {
 		block.builders.create.addLine(
 			`${generator.helper(
-				'addEventListener'
+				'addListener'
 			)}( ${state.parentNode}, 'play', ${handler} );`
 		);
 		block.builders.destroy.addLine(
 			`${generator.helper(
-				'removeEventListener'
+				'removeListener'
 			)}( ${state.parentNode}, 'play', ${handler} );`
 		);
 	}

--- a/src/generators/dom/visitors/Element/EventHandler.ts
+++ b/src/generators/dom/visitors/Element/EventHandler.ts
@@ -99,13 +99,13 @@ export default function visitEventHandler(
 	} else {
 		block.builders.create.addLine(deindent`
 			${generator.helper(
-				'addEventListener'
+				'addListener'
 			)}( ${state.parentNode}, '${name}', ${handlerName} );
 		`);
 
 		block.builders.destroy.addLine(deindent`
 			${generator.helper(
-				'removeEventListener'
+				'removeListener'
 			)}( ${state.parentNode}, '${name}', ${handlerName} );
 		`);
 	}

--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -39,11 +39,11 @@ export function createComment() {
 	return document.createComment('');
 }
 
-export function addEventListener(node, event, handler) {
+export function addListener(node, event, handler) {
 	node.addEventListener(event, handler, false);
 }
 
-export function removeEventListener(node, event, handler) {
+export function removeListener(node, event, handler) {
 	node.removeEventListener(event, handler, false);
 }
 


### PR DESCRIPTION
Addresses #621. This is only really disguising the real problem, which is that people are generating ESM bundles for non-ESM environments, but it's probably not Svelte's job to deal with that. And even if it was, then a cryptic error of the type seen in #621 isn't the way to go about it.