### PR TITLE
Sync state with view if <select> binding does not have initial value

### DIFF
--- a/src/generators/dom/visitors/Element/Binding.ts
+++ b/src/generators/dom/visitors/Element/Binding.ts
@@ -89,6 +89,11 @@ export default function visitBinding(
 				${ifStatement}
 			}
 		`;
+
+		generator.hasComplexBindings = true;
+		block.builders.create.addBlock(
+			`if ( !('${name}' in state) ) ${block.component}._bindings.push( ${handler} );`
+		);
 	} else if (attribute.name === 'group') {
 		// <input type='checkbox|radio' bind:group='selected'> special case
 		if (type === 'radio') {

--- a/test/runtime/samples/binding-select-initial-value-undefined/_config.js
+++ b/test/runtime/samples/binding-select-initial-value-undefined/_config.js
@@ -1,0 +1,26 @@
+export default {
+	solo: true,
+	show: true,
+
+	html: `
+		<p>selected: a</p>
+
+		<select>
+			<option>a</option>
+			<option>b</option>
+			<option>c</option>
+		</select>
+
+		<p>selected: a</p>
+	`,
+
+	test ( assert, component, target ) {
+		const select = target.querySelector( 'select' );
+		const options = [ ...target.querySelectorAll( 'option' ) ];
+
+		assert.equal( select.value, 'a' );
+		assert.ok( options[0].selected );
+
+		component.destroy();
+	}
+};

--- a/test/runtime/samples/binding-select-initial-value-undefined/_config.js
+++ b/test/runtime/samples/binding-select-initial-value-undefined/_config.js
@@ -1,6 +1,5 @@
 export default {
-	solo: true,
-	show: true,
+	'skip-ssr': true, // TODO would be nice to fix this in SSR as well
 
 	html: `
 		<p>selected: a</p>

--- a/test/runtime/samples/binding-select-initial-value-undefined/main.html
+++ b/test/runtime/samples/binding-select-initial-value-undefined/main.html
@@ -1,0 +1,9 @@
+<p>selected: {{selected}}</p>
+
+<select bind:value='selected'>
+	<option>a</option>
+	<option>b</option>
+	<option>c</option>
+</select>
+
+<p>selected: {{selected}}</p>


### PR DESCRIPTION
Fixes first bug in #639