### PR TITLE
improve transition performance

### DIFF
--- a/src/parse/utils/hash.ts
+++ b/src/parse/utils/hash.ts
@@ -3,6 +3,6 @@ export default function hash(str: string): number {
 	let hash = 5381;
 	let i = str.length;
 
-	while (i--) hash = ((hash << 5) + hash) ^ str.charCodeAt(i);
+	while (i--) hash = ((hash << 5) - hash) ^ str.charCodeAt(i);
 	return hash >>> 0;
 }

--- a/src/parse/utils/hash.ts
+++ b/src/parse/utils/hash.ts
@@ -3,6 +3,6 @@ export default function hash(str: string): number {
 	let hash = 5381;
 	let i = str.length;
 
-	while (i--) hash = (hash * 33) ^ str.charCodeAt(i);
+	while (i--) hash = ((hash << 5) + hash) ^ str.charCodeAt(i);
 	return hash >>> 0;
 }

--- a/src/shared/transitions.js
+++ b/src/shared/transitions.js
@@ -27,7 +27,7 @@ export function hash(str) {
 	var hash = 5381;
 	var i = str.length;
 
-	while (i--) hash = ((hash << 5) + hash) ^ str.charCodeAt(i);
+	while (i--) hash = ((hash << 5) - hash) ^ str.charCodeAt(i);
 	return hash >>> 0;
 }
 

--- a/src/shared/transitions.js
+++ b/src/shared/transitions.js
@@ -27,7 +27,7 @@ export function hash(str) {
 	var hash = 5381;
 	var i = str.length;
 
-	while (i--) hash = (hash * 33) ^ str.charCodeAt(i);
+	while (i--) hash = ((hash << 5) + hash) ^ str.charCodeAt(i);
 	return hash >>> 0;
 }
 

--- a/test/css/samples/basic/expected.css
+++ b/test/css/samples/basic/expected.css
@@ -1,4 +1,4 @@
 
-	div[svelte-281576708], [svelte-281576708] div {
+	div[svelte-2278551596], [svelte-2278551596] div {
 		color: red;
 	}

--- a/test/css/samples/cascade-false-global-keyframes/_config.js
+++ b/test/css/samples/cascade-false-global-keyframes/_config.js
@@ -1,0 +1,3 @@
+export default {
+	cascade: false
+};

--- a/test/css/samples/cascade-false-global-keyframes/expected.css
+++ b/test/css/samples/cascade-false-global-keyframes/expected.css
@@ -4,10 +4,10 @@
 		100% { color: blue; }
 	}
 
-	[svelte-2486527405].animated, [svelte-2486527405] .animated {
+	.animated[svelte-90785995] {
 		animation: why 2s;
 	}
 
-	[svelte-2486527405].also-animated, [svelte-2486527405] .also-animated {
+	.also-animated[svelte-90785995] {
 		animation: not-defined-here 2s;
 	}

--- a/test/css/samples/cascade-false-keyframes/_config.js
+++ b/test/css/samples/cascade-false-keyframes/_config.js
@@ -1,0 +1,3 @@
+export default {
+	cascade: false
+};

--- a/test/css/samples/cascade-false-keyframes/expected.css
+++ b/test/css/samples/cascade-false-keyframes/expected.css
@@ -1,13 +1,13 @@
 
-	@keyframes svelte-776829126-why {
+	@keyframes svelte-1647166666-why {
 		0% { color: red; }
 		100% { color: blue; }
 	}
 
-	[svelte-776829126].animated, [svelte-776829126] .animated {
-		animation: svelte-776829126-why 2s;
+	.animated[svelte-1647166666] {
+		animation: svelte-1647166666-why 2s;
 	}
 
-	[svelte-776829126].also-animated, [svelte-776829126] .also-animated {
+	.also-animated[svelte-1647166666] {
 		animation: not-defined-here 2s;
 	}

--- a/test/css/samples/cascade-false-pseudo-element/expected.css
+++ b/test/css/samples/cascade-false-pseudo-element/expected.css
@@ -1,12 +1,12 @@
 
-	span[svelte-583610229]::after {
+	span[svelte-2146001331]::after {
 		content: 'i am a pseudo-element';
 	}
 
-	span[svelte-583610229]:first-child {
+	span[svelte-2146001331]:first-child {
 		color: red;
 	}
 
-	span[svelte-583610229]:last-child::after {
+	span[svelte-2146001331]:last-child::after {
 		color: blue;
 	}

--- a/test/css/samples/cascade-false/expected.css
+++ b/test/css/samples/cascade-false/expected.css
@@ -1,12 +1,12 @@
 
-	div[svelte-4161687011] {
+	div[svelte-781920915] {
 		color: red;
 	}
 
-	div.foo[svelte-4161687011] {
+	div.foo[svelte-781920915] {
 		color: blue;
 	}
 
-	.foo[svelte-4161687011] {
+	.foo[svelte-781920915] {
 		font-weight: bold;
 	}

--- a/test/css/samples/keyframes/expected.css
+++ b/test/css/samples/keyframes/expected.css
@@ -1,9 +1,9 @@
 
-	@keyframes svelte-4112859982-why {
+	@keyframes svelte-2931302006-why {
 		0% { color: red; }
 		100% { color: blue; }
 	}
 
-	[svelte-4112859982].animated, [svelte-4112859982] .animated {
-		animation: svelte-4112859982-why 2s;
+	[svelte-2931302006].animated, [svelte-2931302006] .animated {
+		animation: svelte-2931302006-why 2s;
 	}

--- a/test/css/samples/media-query/expected.css
+++ b/test/css/samples/media-query/expected.css
@@ -1,6 +1,6 @@
 
 	@media (min-width: 400px) {
-		[svelte-2352010302].large-screen, [svelte-2352010302] .large-screen {
+		[svelte-411199634].large-screen, [svelte-411199634] .large-screen {
 			display: block;
 		}
 	}

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -145,8 +145,8 @@ var template = (function () {
 
 function add_css () {
 	var style = createElement( 'style' );
-	style.id = "svelte-3842350206-style";
-	style.textContent = "\n\tp[svelte-3842350206], [svelte-3842350206] p {\n\t\tcolor: red;\n\t}\n";
+	style.id = "svelte-3590263702-style";
+	style.textContent = "\n\tp[svelte-3590263702], [svelte-3590263702] p {\n\t\tcolor: red;\n\t}\n";
 	appendNode( style, document.head );
 }
 
@@ -161,7 +161,7 @@ function create_main_fragment ( state, component ) {
 		},
 
 		hydrate: function ( nodes ) {
-			setAttribute( p, 'svelte-3842350206', '' );
+			setAttribute( p, 'svelte-3590263702', '' );
 		},
 
 		mount: function ( target, anchor ) {
@@ -198,7 +198,7 @@ function SvelteComponent ( options ) {
 	this._yield = options._yield;
 
 	this._torndown = false;
-	if ( !document.getElementById( "svelte-3842350206-style" ) ) add_css();
+	if ( !document.getElementById( "svelte-3590263702-style" ) ) add_css();
 
 	this._fragment = create_main_fragment( this._state, this );
 

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -10,8 +10,8 @@ var template = (function () {
 
 function add_css () {
 	var style = createElement( 'style' );
-	style.id = "svelte-3842350206-style";
-	style.textContent = "\n\tp[svelte-3842350206], [svelte-3842350206] p {\n\t\tcolor: red;\n\t}\n";
+	style.id = "svelte-3590263702-style";
+	style.textContent = "\n\tp[svelte-3590263702], [svelte-3590263702] p {\n\t\tcolor: red;\n\t}\n";
 	appendNode( style, document.head );
 }
 
@@ -26,7 +26,7 @@ function create_main_fragment ( state, component ) {
 		},
 
 		hydrate: function ( nodes ) {
-			setAttribute( p, 'svelte-3842350206', '' );
+			setAttribute( p, 'svelte-3590263702', '' );
 		},
 
 		mount: function ( target, anchor ) {
@@ -63,7 +63,7 @@ function SvelteComponent ( options ) {
 	this._yield = options._yield;
 
 	this._torndown = false;
-	if ( !document.getElementById( "svelte-3842350206-style" ) ) add_css();
+	if ( !document.getElementById( "svelte-3590263702-style" ) ) add_css();
 
 	this._fragment = create_main_fragment( this._state, this );
 

--- a/test/server-side-rendering/samples/styles-nested/_actual.css
+++ b/test/server-side-rendering/samples/styles-nested/_actual.css
@@ -1,14 +1,14 @@
 
-	div[svelte-4188175681], [svelte-4188175681] div {
+	div[svelte-1408461649], [svelte-1408461649] div {
 		color: red;
 	}
 
 
-	div[svelte-146600313], [svelte-146600313] div {
+	div[svelte-54999591], [svelte-54999591] div {
 		color: green;
 	}
 
 
-	div[svelte-1506185237], [svelte-1506185237] div {
+	div[svelte-2385185803], [svelte-2385185803] div {
 		color: blue;
 	}

--- a/test/server-side-rendering/samples/styles-nested/_actual.html
+++ b/test/server-side-rendering/samples/styles-nested/_actual.html
@@ -1,5 +1,5 @@
-<div svelte-4188175681>red</div>
-<div svelte-146600313>green: foo</div>
-<div svelte-1506185237>blue: foo</div>
-<div svelte-146600313>green: bar</div>
-<div svelte-1506185237>blue: bar</div>
+<div svelte-1408461649>red</div>
+<div svelte-54999591>green: foo</div>
+<div svelte-2385185803>blue: foo</div>
+<div svelte-54999591>green: bar</div>
+<div svelte-2385185803>blue: bar</div>

--- a/test/server-side-rendering/samples/styles-nested/_expected.css
+++ b/test/server-side-rendering/samples/styles-nested/_expected.css
@@ -1,11 +1,14 @@
-div[svelte-4188175681], [svelte-4188175681] div {
-	color: red;
-}
 
-div[svelte-146600313], [svelte-146600313] div {
-	color: green;
-}
+	div[svelte-1408461649], [svelte-1408461649] div {
+		color: red;
+	}
 
-div[svelte-1506185237], [svelte-1506185237] div {
-	color: blue;
-}
+
+	div[svelte-54999591], [svelte-54999591] div {
+		color: green;
+	}
+
+
+	div[svelte-2385185803], [svelte-2385185803] div {
+		color: blue;
+	}

--- a/test/server-side-rendering/samples/styles-nested/_expected.html
+++ b/test/server-side-rendering/samples/styles-nested/_expected.html
@@ -1,5 +1,5 @@
-<div svelte-4188175681>red</div>
-<div svelte-146600313>green: foo</div>
-<div svelte-1506185237>blue: foo</div>
-<div svelte-146600313>green: bar</div>
-<div svelte-1506185237>blue: bar</div>
+<div svelte-1408461649>red</div>
+<div svelte-54999591>green: foo</div>
+<div svelte-2385185803>blue: foo</div>
+<div svelte-54999591>green: bar</div>
+<div svelte-2385185803>blue: bar</div>

--- a/test/server-side-rendering/samples/styles/_actual.css
+++ b/test/server-side-rendering/samples/styles/_actual.css
@@ -1,4 +1,4 @@
 
-	div[svelte-281576708], [svelte-281576708] div {
+	div[svelte-2278551596], [svelte-2278551596] div {
 		color: red;
 	}

--- a/test/server-side-rendering/samples/styles/_actual.html
+++ b/test/server-side-rendering/samples/styles/_actual.html
@@ -1,1 +1,1 @@
-<div svelte-281576708>red</div>
+<div svelte-2278551596>red</div>

--- a/test/server-side-rendering/samples/styles/_expected.css
+++ b/test/server-side-rendering/samples/styles/_expected.css
@@ -1,3 +1,4 @@
-div[svelte-281576708], [svelte-281576708] div {
-	color: red;
-}
+
+	div[svelte-2278551596], [svelte-2278551596] div {
+		color: red;
+	}

--- a/test/server-side-rendering/samples/styles/_expected.html
+++ b/test/server-side-rendering/samples/styles/_expected.html
@@ -1,1 +1,1 @@
-<div svelte-281576708>red</div>
+<div svelte-2278551596>red</div>


### PR DESCRIPTION
This PR substantially improves framerate when there are lots of CSS transitions in a document with a combination of techniques:

* rather than (insanely) creating a separate `<style>` tag for each transition, we just create the one, lazily, and update it
* Identical transitions are deduped — if an element has the exact same keyframes as another one that's currently in progress, we don't create a new CSS animation for it
* We use `stylesheet.insertRule(rule, index)` rather than `style.textContent = rule`
* Animations are only removed from the `<style>` tag once there are no active transitions — i.e. when frame drops caused by updating the CSSOM are less likely to be noticed