### PR TITLE
Added check that the ${each_block_value} exists

### DIFF
--- a/src/generators/dom/visitors/EachBlock.ts
+++ b/src/generators/dom/visitors/EachBlock.ts
@@ -33,7 +33,8 @@ export default function visitEachBlock(
 
 	const { snippet } = block.contextualise(node.expression);
 
-	block.builders.init.addLine(`var ${each_block_value} = ${snippet};`);
+	//Warn user if "each_block_value" is null @rich_harris
+	block.builders.init.addLine(`var ${each_block_value} = ${snippet} || [];`);
 
 	if (node.key) {
 		keyed(generator, block, state, node, snippet, vars);

--- a/src/generators/dom/visitors/EachBlock.ts
+++ b/src/generators/dom/visitors/EachBlock.ts
@@ -33,8 +33,9 @@ export default function visitEachBlock(
 
 	const { snippet } = block.contextualise(node.expression);
 
-	//Warn user if "each_block_value" is null @rich_harris
-	block.builders.init.addLine(`var ${each_block_value} = ${snippet} || [];`);
+	
+	block.builders.init.addLine(`var ${each_block_value} = ${snippet};`);
+	block.builders.init.addLine(`if(!${each_block_value}) throw new Error('Missing field or value is null ${node.expression}');`
 
 	if (node.key) {
 		keyed(generator, block, state, node, snippet, vars);

--- a/test/runtime/samples/each-block-missing-value/_config.js
+++ b/test/runtime/samples/each-block-missing-value/_config.js
@@ -1,0 +1,19 @@
+export default {
+	data: {
+		noanimals: [ 'alpaca', 'baboon', 'capybara' ]
+	},
+
+	html: `
+		<p>alpaca</p>
+		<p>baboon</p>
+		<p>capybara</p>
+	`,
+
+	test ( assert, component, target ) {
+		component.set({ noanimals: [ 'alpaca', 'baboon', 'caribou', 'dogfish' ] });
+		assert.htmlEqual( target.innerHTML, `` );
+
+		component.set({ animals: [] });
+		assert.htmlEqual( target.innerHTML, '' );
+	}
+};

--- a/test/runtime/samples/each-block-missing-value/main.html
+++ b/test/runtime/samples/each-block-missing-value/main.html
@@ -1,0 +1,3 @@
+{{#each animals as animal}}
+	<p>{{animal}}</p>
+{{/each}}


### PR DESCRIPTION
Also chaches the length of the array in a variable to avoid quering for it every time. 
Does this fix #681 ?

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
