### PR TITLE
[WIP] Fix #714

### DIFF
--- a/src/generators/dom/visitors/shared/binding/getSetter.ts
+++ b/src/generators/dom/visitors/shared/binding/getSetter.ts
@@ -29,10 +29,10 @@ export default function getSetter({
 			${computed
 				? `#component._set({ ${dependencies
 						.map((prop: string) => `${prop}: state.${prop}`)
-						.join(', ')} });`
+						.join(', ')} }, #component._protectDomUpdate);`
 				: `#component._set({ ${dependencies
 						.map((prop: string) => `${prop}: #component.get( '${prop}' )`)
-						.join(', ')} });`}
+						.join(', ')} }, #component._protectDomUpdate);`}
 		`;
 	}
 
@@ -42,11 +42,11 @@ export default function getSetter({
 			${snippet} = ${value};
 			#component._set({ ${dependencies
 				.map((prop: string) => `${prop}: state.${prop}`)
-				.join(', ')} });
+				.join(', ')} }, #component._protectDomUpdate);
 		`;
 	}
 
-	return `#component._set({ ${name}: ${value} });`;
+	return `#component._set({ ${name}: ${value} }, #component._protectDomUpdate);`;
 }
 
 function isComputed(node: Node) {

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -140,8 +140,8 @@ var template = (function () {
 
 function add_css () {
 	var style = createElement( 'style' );
-	style.id = 'svelte-2421768003-style';
-	style.textContent = "\r\n\tp[svelte-2421768003], [svelte-2421768003] p {\r\n\t\tcolor: red;\r\n\t}\r\n";
+	style.id = 'svelte-3590263702-style';
+	style.textContent = "\n\tp[svelte-3590263702], [svelte-3590263702] p {\n\t\tcolor: red;\n\t}\n";
 	appendNode( style, document.head );
 }
 
@@ -156,7 +156,7 @@ function create_main_fragment ( state, component ) {
 		},
 
 		hydrate: function ( nodes ) {
-			setAttribute( p, 'svelte-2421768003', '' );
+			setAttribute( p, 'svelte-3590263702', '' );
 		},
 
 		mount: function ( target, anchor ) {
@@ -193,7 +193,7 @@ function SvelteComponent ( options ) {
 	this._yield = options._yield;
 
 	this._torndown = false;
-	if ( !document.getElementById( 'svelte-2421768003-style' ) ) add_css();
+	if ( !document.getElementById( 'svelte-3590263702-style' ) ) add_css();
 
 	this._fragment = create_main_fragment( this._state, this );
 

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -140,8 +140,8 @@ var template = (function () {
 
 function add_css () {
 	var style = createElement( 'style' );
-	style.id = 'svelte-3590263702-style';
-	style.textContent = "\n\tp[svelte-3590263702], [svelte-3590263702] p {\n\t\tcolor: red;\n\t}\n";
+	style.id = 'svelte-2421768003-style';
+	style.textContent = "\r\n\tp[svelte-2421768003], [svelte-2421768003] p {\r\n\t\tcolor: red;\r\n\t}\r\n";
 	appendNode( style, document.head );
 }
 
@@ -156,7 +156,7 @@ function create_main_fragment ( state, component ) {
 		},
 
 		hydrate: function ( nodes ) {
-			setAttribute( p, 'svelte-3590263702', '' );
+			setAttribute( p, 'svelte-2421768003', '' );
 		},
 
 		mount: function ( target, anchor ) {
@@ -193,23 +193,28 @@ function SvelteComponent ( options ) {
 	this._yield = options._yield;
 
 	this._torndown = false;
-	if ( !document.getElementById( 'svelte-3590263702-style' ) ) add_css();
+	if ( !document.getElementById( 'svelte-2421768003-style' ) ) add_css();
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -10,8 +10,8 @@ var template = (function () {
 
 function add_css () {
 	var style = createElement( 'style' );
-	style.id = 'svelte-2421768003-style';
-	style.textContent = "\r\n\tp[svelte-2421768003], [svelte-2421768003] p {\r\n\t\tcolor: red;\r\n\t}\r\n";
+	style.id = 'svelte-3590263702-style';
+	style.textContent = "\n\tp[svelte-3590263702], [svelte-3590263702] p {\n\t\tcolor: red;\n\t}\n";
 	appendNode( style, document.head );
 }
 
@@ -26,7 +26,7 @@ function create_main_fragment ( state, component ) {
 		},
 
 		hydrate: function ( nodes ) {
-			setAttribute( p, 'svelte-2421768003', '' );
+			setAttribute( p, 'svelte-3590263702', '' );
 		},
 
 		mount: function ( target, anchor ) {
@@ -63,7 +63,7 @@ function SvelteComponent ( options ) {
 	this._yield = options._yield;
 
 	this._torndown = false;
-	if ( !document.getElementById( 'svelte-2421768003-style' ) ) add_css();
+	if ( !document.getElementById( 'svelte-3590263702-style' ) ) add_css();
 
 	this._fragment = create_main_fragment( this._state, this );
 

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -10,8 +10,8 @@ var template = (function () {
 
 function add_css () {
 	var style = createElement( 'style' );
-	style.id = 'svelte-3590263702-style';
-	style.textContent = "\n\tp[svelte-3590263702], [svelte-3590263702] p {\n\t\tcolor: red;\n\t}\n";
+	style.id = 'svelte-2421768003-style';
+	style.textContent = "\r\n\tp[svelte-2421768003], [svelte-2421768003] p {\r\n\t\tcolor: red;\r\n\t}\r\n";
 	appendNode( style, document.head );
 }
 
@@ -26,7 +26,7 @@ function create_main_fragment ( state, component ) {
 		},
 
 		hydrate: function ( nodes ) {
-			setAttribute( p, 'svelte-3590263702', '' );
+			setAttribute( p, 'svelte-2421768003', '' );
 		},
 
 		mount: function ( target, anchor ) {
@@ -63,23 +63,28 @@ function SvelteComponent ( options ) {
 	this._yield = options._yield;
 
 	this._torndown = false;
-	if ( !document.getElementById( 'svelte-3590263702-style' ) ) add_css();
+	if ( !document.getElementById( 'svelte-2421768003-style' ) ) add_css();
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/computed-collapsed-if/expected-bundle.js
+++ b/test/js/samples/computed-collapsed-if/expected-bundle.js
@@ -154,15 +154,19 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	recompute( this._state, newState, oldState, false );

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -48,15 +48,19 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	recompute( this._state, newState, oldState, false )

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -156,7 +156,7 @@ function create_main_fragment ( state, component ) {
 				each_block_iterations[i].create();
 			}
 
-			text = createText( "\r\n\r\n" );
+			text = createText( "\n\n" );
 			p = createElement( 'p' );
 			text_1 = createText( text_1_value = state.foo );
 		},
@@ -220,13 +220,13 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 			div = createElement( 'div' );
 			strong = createElement( 'strong' );
 			text = createText( text_value = i );
-			text_1 = createText( "\r\n\r\n\t\t" );
+			text_1 = createText( "\n\n\t\t" );
 			span = createElement( 'span' );
 			text_2 = createText( text_2_value = comment.author );
 			text_3 = createText( " wrote " );
 			text_4 = createText( text_4_value = state.elapsed(comment.time, state.time) );
 			text_5 = createText( " ago:" );
-			text_6 = createText( "\r\n\r\n\t\t" );
+			text_6 = createText( "\n\n\t\t" );
 			raw_before = createElement( 'noscript' );
 			raw_after = createElement( 'noscript' );
 			this.hydrate();

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -156,7 +156,7 @@ function create_main_fragment ( state, component ) {
 				each_block_iterations[i].create();
 			}
 
-			text = createText( "\n\n" );
+			text = createText( "\r\n\r\n" );
 			p = createElement( 'p' );
 			text_1 = createText( text_1_value = state.foo );
 		},
@@ -220,13 +220,13 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 			div = createElement( 'div' );
 			strong = createElement( 'strong' );
 			text = createText( text_value = i );
-			text_1 = createText( "\n\n\t\t" );
+			text_1 = createText( "\r\n\r\n\t\t" );
 			span = createElement( 'span' );
 			text_2 = createText( text_2_value = comment.author );
 			text_3 = createText( " wrote " );
 			text_4 = createText( text_4_value = state.elapsed(comment.time, state.time) );
 			text_5 = createText( " ago:" );
-			text_6 = createText( "\n\n\t\t" );
+			text_6 = createText( "\r\n\r\n\t\t" );
 			raw_before = createElement( 'noscript' );
 			raw_after = createElement( 'noscript' );
 			this.hydrate();
@@ -300,19 +300,24 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -17,7 +17,7 @@ function create_main_fragment ( state, component ) {
 				each_block_iterations[i].create();
 			}
 
-			text = createText( "\n\n" );
+			text = createText( "\r\n\r\n" );
 			p = createElement( 'p' );
 			text_1 = createText( text_1_value = state.foo );
 		},
@@ -81,13 +81,13 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 			div = createElement( 'div' );
 			strong = createElement( 'strong' );
 			text = createText( text_value = i );
-			text_1 = createText( "\n\n\t\t" );
+			text_1 = createText( "\r\n\r\n\t\t" );
 			span = createElement( 'span' );
 			text_2 = createText( text_2_value = comment.author );
 			text_3 = createText( " wrote " );
 			text_4 = createText( text_4_value = state.elapsed(comment.time, state.time) );
 			text_5 = createText( " ago:" );
-			text_6 = createText( "\n\n\t\t" );
+			text_6 = createText( "\r\n\r\n\t\t" );
 			raw_before = createElement( 'noscript' );
 			raw_after = createElement( 'noscript' );
 			this.hydrate();
@@ -161,19 +161,24 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -17,7 +17,7 @@ function create_main_fragment ( state, component ) {
 				each_block_iterations[i].create();
 			}
 
-			text = createText( "\r\n\r\n" );
+			text = createText( "\n\n" );
 			p = createElement( 'p' );
 			text_1 = createText( text_1_value = state.foo );
 		},
@@ -81,13 +81,13 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 			div = createElement( 'div' );
 			strong = createElement( 'strong' );
 			text = createText( text_value = i );
-			text_1 = createText( "\r\n\r\n\t\t" );
+			text_1 = createText( "\n\n\t\t" );
 			span = createElement( 'span' );
 			text_2 = createText( text_2_value = comment.author );
 			text_3 = createText( " wrote " );
 			text_4 = createText( text_4_value = state.elapsed(comment.time, state.time) );
 			text_5 = createText( " ago:" );
-			text_6 = createText( "\r\n\r\n\t\t" );
+			text_6 = createText( "\n\n\t\t" );
 			raw_before = createElement( 'noscript' );
 			raw_after = createElement( 'noscript' );
 			this.hydrate();

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -189,15 +189,19 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, template.methods, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -65,15 +65,19 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, template.methods, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );

--- a/test/js/samples/if-block-no-update/expected-bundle.js
+++ b/test/js/samples/if-block-no-update/expected-bundle.js
@@ -235,19 +235,24 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -105,19 +105,24 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/if-block-simple/expected-bundle.js
+++ b/test/js/samples/if-block-simple/expected-bundle.js
@@ -211,19 +211,24 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -81,19 +81,24 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -140,7 +140,7 @@ function create_main_fragment ( state, component ) {
 	return {
 		create: function () {
 			imported._fragment.create();
-			text = createText( "\n" );
+			text = createText( "\r\n" );
 			nonimported._fragment.create();
 		},
 
@@ -182,17 +182,21 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
 
 	callAll(this._oncreate);
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -140,7 +140,7 @@ function create_main_fragment ( state, component ) {
 	return {
 		create: function () {
 			imported._fragment.create();
-			text = createText( "\r\n" );
+			text = createText( "\n" );
 			nonimported._fragment.create();
 		},
 

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -24,7 +24,7 @@ function create_main_fragment ( state, component ) {
 	return {
 		create: function () {
 			imported._fragment.create();
-			text = createText( "\n" );
+			text = createText( "\r\n" );
 			nonimported._fragment.create();
 		},
 
@@ -66,17 +66,21 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
 
 	callAll(this._oncreate);
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -24,7 +24,7 @@ function create_main_fragment ( state, component ) {
 	return {
 		create: function () {
 			imported._fragment.create();
-			text = createText( "\r\n" );
+			text = createText( "\n" );
 			nonimported._fragment.create();
 		},
 

--- a/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
@@ -145,10 +145,14 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 
 	if ( options._root ) {
 		options._root._oncreate.push( template.oncreate.bind( this ) );
@@ -159,7 +163,7 @@ function SvelteComponent ( options ) {
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );

--- a/test/js/samples/onrender-onteardown-rewritten/expected.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected.js
@@ -39,10 +39,14 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 
 	if ( options._root ) {
 		options._root._oncreate.push( template.oncreate.bind( this ) );
@@ -53,7 +57,7 @@ function SvelteComponent ( options ) {
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -147,19 +147,19 @@ function create_main_fragment ( state, component ) {
 		create: function () {
 			div = createElement( 'div' );
 			if ( if_block ) if_block.create();
-			text = createText( "\n\n\t" );
+			text = createText( "\r\n\r\n\t" );
 			p = createElement( 'p' );
 			text_1 = createText( "this can be used as an anchor" );
-			text_2 = createText( "\n\n\t" );
+			text_2 = createText( "\r\n\r\n\t" );
 			if ( if_block_1 ) if_block_1.create();
-			text_3 = createText( "\n\n\t" );
+			text_3 = createText( "\r\n\r\n\t" );
 			if ( if_block_2 ) if_block_2.create();
-			text_4 = createText( "\n\n\t" );
+			text_4 = createText( "\r\n\r\n\t" );
 			p_1 = createElement( 'p' );
 			text_5 = createText( "so can this" );
-			text_6 = createText( "\n\n\t" );
+			text_6 = createText( "\r\n\r\n\t" );
 			if ( if_block_3 ) if_block_3.create();
-			text_8 = createText( "\n\n" );
+			text_8 = createText( "\r\n\r\n" );
 			if ( if_block_4 ) if_block_4.create();
 			if_block_4_anchor = createComment();
 		},
@@ -395,19 +395,24 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -147,19 +147,19 @@ function create_main_fragment ( state, component ) {
 		create: function () {
 			div = createElement( 'div' );
 			if ( if_block ) if_block.create();
-			text = createText( "\r\n\r\n\t" );
+			text = createText( "\n\n\t" );
 			p = createElement( 'p' );
 			text_1 = createText( "this can be used as an anchor" );
-			text_2 = createText( "\r\n\r\n\t" );
+			text_2 = createText( "\n\n\t" );
 			if ( if_block_1 ) if_block_1.create();
-			text_3 = createText( "\r\n\r\n\t" );
+			text_3 = createText( "\n\n\t" );
 			if ( if_block_2 ) if_block_2.create();
-			text_4 = createText( "\r\n\r\n\t" );
+			text_4 = createText( "\n\n\t" );
 			p_1 = createElement( 'p' );
 			text_5 = createText( "so can this" );
-			text_6 = createText( "\r\n\r\n\t" );
+			text_6 = createText( "\n\n\t" );
 			if ( if_block_3 ) if_block_3.create();
-			text_8 = createText( "\r\n\r\n" );
+			text_8 = createText( "\n\n" );
 			if ( if_block_4 ) if_block_4.create();
 			if_block_4_anchor = createComment();
 		},

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -17,19 +17,19 @@ function create_main_fragment ( state, component ) {
 		create: function () {
 			div = createElement( 'div' );
 			if ( if_block ) if_block.create();
-			text = createText( "\n\n\t" );
+			text = createText( "\r\n\r\n\t" );
 			p = createElement( 'p' );
 			text_1 = createText( "this can be used as an anchor" );
-			text_2 = createText( "\n\n\t" );
+			text_2 = createText( "\r\n\r\n\t" );
 			if ( if_block_1 ) if_block_1.create();
-			text_3 = createText( "\n\n\t" );
+			text_3 = createText( "\r\n\r\n\t" );
 			if ( if_block_2 ) if_block_2.create();
-			text_4 = createText( "\n\n\t" );
+			text_4 = createText( "\r\n\r\n\t" );
 			p_1 = createElement( 'p' );
 			text_5 = createText( "so can this" );
-			text_6 = createText( "\n\n\t" );
+			text_6 = createText( "\r\n\r\n\t" );
 			if ( if_block_3 ) if_block_3.create();
-			text_8 = createText( "\n\n" );
+			text_8 = createText( "\r\n\r\n" );
 			if ( if_block_4 ) if_block_4.create();
 			if_block_4_anchor = createComment();
 		},
@@ -265,19 +265,24 @@ function SvelteComponent ( options ) {
 
 	this._fragment = create_main_fragment( this._state, this );
 
+	this._protectDomUpdate = false;
 	if ( options.target ) {
 		this._fragment.create();
 		this._fragment.mount( options.target, null );
+	} else {
+		this._protectDomUpdate = true;
 	}
+	this._protectDomUpdate = false;
 }
 
 assign( SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._set = function _set ( newState ) {
+SvelteComponent.prototype._set = function _set ( newState, withoutDomUpdate ) {
 	var oldState = this._state;
 	this._state = assign( {}, oldState, newState );
 	dispatchObservers( this, this._observers.pre, newState, oldState );
-	this._fragment.update( newState, this._state );
+
+	withoutDomUpdate || this._fragment.update( newState, this._state );
 	dispatchObservers( this, this._observers.post, newState, oldState );
 };
 

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -17,19 +17,19 @@ function create_main_fragment ( state, component ) {
 		create: function () {
 			div = createElement( 'div' );
 			if ( if_block ) if_block.create();
-			text = createText( "\r\n\r\n\t" );
+			text = createText( "\n\n\t" );
 			p = createElement( 'p' );
 			text_1 = createText( "this can be used as an anchor" );
-			text_2 = createText( "\r\n\r\n\t" );
+			text_2 = createText( "\n\n\t" );
 			if ( if_block_1 ) if_block_1.create();
-			text_3 = createText( "\r\n\r\n\t" );
+			text_3 = createText( "\n\n\t" );
 			if ( if_block_2 ) if_block_2.create();
-			text_4 = createText( "\r\n\r\n\t" );
+			text_4 = createText( "\n\n\t" );
 			p_1 = createElement( 'p' );
 			text_5 = createText( "so can this" );
-			text_6 = createText( "\r\n\r\n\t" );
+			text_6 = createText( "\n\n\t" );
 			if ( if_block_3 ) if_block_3.create();
-			text_8 = createText( "\r\n\r\n" );
+			text_8 = createText( "\n\n" );
 			if ( if_block_4 ) if_block_4.create();
 			if_block_4_anchor = createComment();
 		},

--- a/test/runtime/samples/bindings-before-oncreate-change-dom/One.html
+++ b/test/runtime/samples/bindings-before-oncreate-change-dom/One.html
@@ -1,0 +1,20 @@
+<Two bind:foo/>
+<p class="{{test ? 't1' : 't2'}}"></p>
+
+<script>
+	import Two from './Two.html';
+
+	export default {
+    data() {
+      return {
+        test: false
+      };
+    },
+		components: {
+			Two
+		},
+		oncreate() {
+			this.snapshot = this.get('foo');
+		}
+	};
+</script>

--- a/test/runtime/samples/bindings-before-oncreate-change-dom/Two.html
+++ b/test/runtime/samples/bindings-before-oncreate-change-dom/Two.html
@@ -1,0 +1,15 @@
+<script>
+	export default {
+		data() {
+			return {
+				bar: 1
+			};
+		},
+
+		computed: {
+			foo(bar) {
+				return bar * 2;
+			}
+		}
+	};
+</script>

--- a/test/runtime/samples/bindings-before-oncreate-change-dom/_config.js
+++ b/test/runtime/samples/bindings-before-oncreate-change-dom/_config.js
@@ -1,0 +1,5 @@
+export default {
+	test(assert, component) {
+		assert.equal(component.refs.one.snapshot, 2);
+	}
+};

--- a/test/runtime/samples/bindings-before-oncreate-change-dom/main.html
+++ b/test/runtime/samples/bindings-before-oncreate-change-dom/main.html
@@ -1,0 +1,9 @@
+<One ref:one/>
+
+<script>
+	import One from './One.html';
+
+	export default {
+		components: { One }
+	};
+</script>


### PR DESCRIPTION
The main Idea is to avoid update dom in Binds initialization process when parent component does not have a target. If parent component does not have "target" it means DOM has not created when "Bind" call "set" for this component. Is "_set" function call "update" function for a component when we touch DOM and in this case, it can come to error.  Moreover, it makes no sense to try to update the DOM if we will create this DOM from a state on the next step.  
My approach is little hacky but it's work and this bug critical for my current project.
This PR not breaking any tests. 