### PR TITLE
use _set, not set, when updating child components

### DIFF
--- a/src/generators/dom/visitors/Component/Component.ts
+++ b/src/generators/dom/visitors/Component/Component.ts
@@ -212,7 +212,7 @@ export default function visitComponent(
 
 			${updates.join('\n')}
 
-			if ( Object.keys( ${name}_changes ).length ) ${name}.set( ${name}_changes );
+			if ( Object.keys( ${name}_changes ).length ) ${name}._set( ${name}_changes );
 		`);
 	}
 

--- a/test/runtime/samples/component-binding-blowback-c/Nested.html
+++ b/test/runtime/samples/component-binding-blowback-c/Nested.html
@@ -1,0 +1,18 @@
+<li>
+	{{yield}}
+</li>
+
+<script>
+	const initialValues = {
+		'id-0': 'zero',
+		'id-1': 'one',
+		'id-2': 'two',
+		'id-3': 'three'
+	};
+
+	export default {
+		oncreate() {
+			this.set({ value: initialValues[this.get('id')] });
+		}
+	};
+</script>

--- a/test/runtime/samples/component-binding-blowback-c/_config.js
+++ b/test/runtime/samples/component-binding-blowback-c/_config.js
@@ -1,0 +1,33 @@
+export default {
+	'skip-ssr': true,
+
+	data: {
+		count: 3
+	},
+
+	html: `
+		<input type='number'>
+		<ol>
+			<li>id-2: value is two</li>
+			<li>id-1: value is one</li>
+			<li>id-0: value is zero</li>
+		</ol>
+	`,
+
+	test (assert, component, target, window) {
+		const input = target.querySelector('input');
+
+		input.value = 4;
+		input.dispatchEvent(new window.Event('input'));
+
+		assert.htmlEqual(target.innerHTML, `
+			<input type='number'>
+			<ol>
+				<li>id-3: value is three</li>
+				<li>id-2: value is two</li>
+				<li>id-1: value is one</li>
+				<li>id-0: value is zero</li>
+			</ol>
+		`);
+	}
+};

--- a/test/runtime/samples/component-binding-blowback-c/main.html
+++ b/test/runtime/samples/component-binding-blowback-c/main.html
@@ -1,0 +1,34 @@
+<input type='number' bind:value='count'>
+
+<ol>
+	{{#each ids as object @id}}
+		<Nested bind:value='idToValue[object.id]' id='{{object.id}}'>
+			{{object.id}}: value is {{idToValue[object.id]}}
+		</Nested>
+	{{/each}}
+</ol>
+
+<script>
+	import Nested from './Nested.html';
+
+	export default {
+		data() {
+			return {
+				idToValue: Object.create(null)
+			};
+		},
+
+		computed: {
+			ids(count) {
+				return new Array(count)
+					.fill(null)
+					.map((_, i) => ({ id: 'id-' + i}))
+					.reverse();
+			}
+		},
+
+		components: {
+			Nested
+		}
+	};
+</script>


### PR DESCRIPTION
Fixes #721. A nice side-effect of #709 (centralising post-state-change operations in the root component) is that we can use `child._set` rather than `child.set` when updating nested components, preventing whatever binding blowback insanity was causing the array length to jump around bizarrely.