### PR TITLE
avoid string manipulation bugs by not minifying combinators if `cascade: true`

### DIFF
--- a/src/css/Stylesheet.ts
+++ b/src/css/Stylesheet.ts
@@ -39,7 +39,7 @@ class Rule {
 					code.overwrite(c, selector.node.start, separator);
 				}
 
-				selector.minify(code);
+				if (!cascade) selector.minify(code);
 				c = selector.node.end;
 			}
 		});

--- a/test/css/samples/combinator-child/_config.js
+++ b/test/css/samples/combinator-child/_config.js
@@ -1,0 +1,3 @@
+export default {
+	cascade: false
+};

--- a/test/css/samples/combinator-child/expected.css
+++ b/test/css/samples/combinator-child/expected.css
@@ -1,0 +1,1 @@
+.test[svelte-xyz]>div[svelte-xyz]{color:#0af}

--- a/test/css/samples/combinator-child/expected.html
+++ b/test/css/samples/combinator-child/expected.html
@@ -1,0 +1,1 @@
+<div svelte-xyz="" class="test"><div svelte-xyz="">Testing...</div></div>

--- a/test/css/samples/combinator-child/input.html
+++ b/test/css/samples/combinator-child/input.html
@@ -1,0 +1,11 @@
+<div class="test">
+	<div>
+		Testing...
+	</div>
+</div>
+
+<style>
+	.test > div {
+		color: #0af;
+	}
+</style>


### PR DESCRIPTION
Fixes #743. If `options.cascade` is true (or unspecified), CSS selectors are transformed by replacing them altogether. This makes it impossible to minify selectors by removing whitespace around combinators. Easiest solution (since we're removing `cascade: true` soon enough) is just to disable combinator minification in these cases.