### PR TITLE
saner escaping/unescaping of `@` and `#` sigils

### DIFF
--- a/src/generators/dom/Block.ts
+++ b/src/generators/dom/Block.ts
@@ -355,8 +355,8 @@ export default class Block {
 					${properties}
 				};
 			}
-		`.replace(/(\\\\)?#(\w*)/g, (match, escaped, name) => {
-			return escaped ? match.slice(2) : this.alias(name);
+		`.replace(/(#+)(\w*)/g, (match: string, sigil: string, name: string) => {
+			return sigil === '#' ? this.alias(name) : sigil.slice(1) + name;
 		});
 	}
 }

--- a/src/generators/dom/index.ts
+++ b/src/generators/dom/index.ts
@@ -301,13 +301,13 @@ export default function dom(
 			});
 
 			result =
-				`import { ${names.join(', ')} } from ${stringify(sharedPath, { onlyEscapeAtSymbol: true })};\n\n` +
+				`import { ${names.join(', ')} } from ${JSON.stringify(sharedPath)};\n\n` +
 				result;
 		}
 
 		else if (format === 'cjs') {
 			const SHARED = '__shared';
-			let requires = `var ${SHARED} = require( ${stringify(sharedPath, { onlyEscapeAtSymbol: true })} );`;
+			let requires = `var ${SHARED} = require( ${JSON.stringify(sharedPath)} );`;
 			used.forEach(name => {
 				const alias = generator.alias(name);
 				requires += `\nvar ${alias} = ${SHARED}.${name};`;

--- a/src/generators/dom/index.ts
+++ b/src/generators/dom/index.ts
@@ -145,12 +145,9 @@ export default function dom(
 	if (generator.stylesheet.hasStyles && options.css !== false) {
 		const { css, cssMap } = generator.stylesheet.render(options.filename);
 
-		// special case: we only want to escape '@' and not '#', because at this point all we'll be unescaping is '@'
-		const textContent = JSON.stringify((options.dev ?
+		const textContent = stringify(options.dev ?
 			`${css}\n/*# sourceMappingURL=${cssMap.toUrl()} */` :
-			css).replace(/(@+)/g, (match: string) => {
-				return match + match[0];
-			}));
+			css, { onlyEscapeAtSymbol: true });
 
 		builder.addBlock(deindent`
 			function @add_css () {
@@ -304,13 +301,13 @@ export default function dom(
 			});
 
 			result =
-				`import { ${names.join(', ')} } from ${stringify(sharedPath)};\n\n` +
+				`import { ${names.join(', ')} } from ${stringify(sharedPath, { onlyEscapeAtSymbol: true })};\n\n` +
 				result;
 		}
 
 		else if (format === 'cjs') {
 			const SHARED = '__shared';
-			let requires = `var ${SHARED} = require( ${stringify(sharedPath)} );`;
+			let requires = `var ${SHARED} = require( ${stringify(sharedPath, { onlyEscapeAtSymbol: true })} );`;
 			used.forEach(name => {
 				const alias = generator.alias(name);
 				requires += `\nvar ${alias} = ${SHARED}.${name};`;

--- a/src/generators/server-side-rendering/visitors/Component.ts
+++ b/src/generators/server-side-rendering/visitors/Component.ts
@@ -5,6 +5,7 @@ import Block from '../Block';
 import { Node } from '../../../interfaces';
 import getObject from '../../../utils/getObject';
 import getTailSnippet from '../../../utils/getTailSnippet';
+import { stringify } from '../../../utils/stringify';
 
 export default function visitComponent(
 	generator: SsrGenerator,
@@ -41,7 +42,7 @@ export default function visitComponent(
 			} else if (attribute.value.length === 1) {
 				const chunk = attribute.value[0];
 				if (chunk.type === 'Text') {
-					value = isNaN(chunk.data) ? JSON.stringify(chunk.data) : chunk.data;
+					value = isNaN(chunk.data) ? stringify(chunk.data) : chunk.data;
 				} else {
 					const { snippet } = block.contextualise(chunk.expression);
 					value = snippet;

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -1,9 +1,9 @@
-export function stringify(data: string) {
-	return JSON.stringify(escape(data));
+export function stringify(data: string, options = {}) {
+	return JSON.stringify(escape(data, options));
 }
 
-export function escape(data: string) {
-	return data.replace(/(@+|#+)/g, (match: string) => {
+export function escape(data: string, { onlyEscapeAtSymbol = false } = {}) {
+	return data.replace(onlyEscapeAtSymbol ? /(@+)/g : /(@+|#+)/g, (match: string) => {
 		return match + match[0];
 	});
 }

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -3,5 +3,7 @@ export function stringify(data: string) {
 }
 
 export function escape(data: string) {
-	return data.replace(/([^\\@#])?([@#])/g, '$1\\$2');
+	return data.replace(/(@+|#+)/g, (match: string) => {
+		return match + match[0];
+	});
 }

--- a/test/runtime/samples/component-static-at-symbol/Email.html
+++ b/test/runtime/samples/component-static-at-symbol/Email.html
@@ -1,0 +1,1 @@
+<a href='mailto:{{address}}'>email</a>

--- a/test/runtime/samples/component-static-at-symbol/_config.js
+++ b/test/runtime/samples/component-static-at-symbol/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<a href='mailto:hello@example.com'>email</a>`
+};

--- a/test/runtime/samples/component-static-at-symbol/main.html
+++ b/test/runtime/samples/component-static-at-symbol/main.html
@@ -1,0 +1,9 @@
+<Email address='hello@example.com'/>
+
+<script>
+	import Email from './Email.html';
+
+	export default {
+		components: { Email },
+	};
+</script>


### PR DESCRIPTION
I say [WIP] but this should be pretty much done.

This changes the escaping of `@` and `#` sigils to not use a prepended `\` (which gets further escaped by `JSON.stringify`, and complicates the unescaping) and instead just increases by 1 any runs of `@` or runs of `#`.

There are still a couple of gotchas:
- at the point where we're escaping injected CSS, we only want to escape `@`, because there is no further `#` unescaping that happens on that string after that point. There's probably a more elegant solution than what I have. Maybe still use `stringify` but then immediately unescape the `#` ones?
- the hash that maps characters to their HTML escaped versions in the SSR generated code contains `&#39;` as the replacement for `'`, which we have to now represent as `&##39;`. Not really a huge deal - kind of amusing more than anything.

This PR does fix the second issue I was seeing, where `@`s were being dropped from strings passed as attributes to nested components when compiled in SSR mode.

All existing tests pass, but some more tests should be written.