### PR TITLE
update missing options.target from dev error (#753)

### DIFF
--- a/src/generators/dom/index.ts
+++ b/src/generators/dom/index.ts
@@ -182,9 +182,7 @@ export default function dom(
 	// TODO deprecate component.teardown()
 	builder.addBlock(deindent`
 		function ${name} ( options ) {
-			options = options || {};
-			${options.dev &&
-				`if ( !options.target && !options._root ) throw new Error( "'target' is a required option" );`}
+			if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 			${generator.usesRefs && `this.refs = {};`}
 			this._state = ${templateProperties.data
 				? `@assign( @template.data(), options.data )`

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -188,7 +188,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = assign( template.data(), options.data );
 
 	this._observers = {

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -53,7 +53,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = assign( template.data(), options.data );
 
 	this._observers = {

--- a/test/js/samples/computed-collapsed-if/expected-bundle.js
+++ b/test/js/samples/computed-collapsed-if/expected-bundle.js
@@ -141,7 +141,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 	recompute( this._state, this._state, {}, true );
 

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -30,7 +30,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 	recompute( this._state, this._state, {}, true );
 

--- a/test/js/samples/css-media-query/expected-bundle.js
+++ b/test/js/samples/css-media-query/expected-bundle.js
@@ -168,7 +168,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -37,7 +37,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -288,7 +288,7 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -144,7 +144,7 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -177,7 +177,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -48,7 +48,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/if-block-no-update/expected-bundle.js
+++ b/test/js/samples/if-block-no-update/expected-bundle.js
@@ -223,7 +223,7 @@ function select_block_type ( state ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -88,7 +88,7 @@ function select_block_type ( state ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/if-block-simple/expected-bundle.js
+++ b/test/js/samples/if-block-simple/expected-bundle.js
@@ -199,7 +199,7 @@ function create_if_block ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -64,7 +64,7 @@ function create_if_block ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -169,7 +169,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -48,7 +48,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
@@ -133,7 +133,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/onrender-onteardown-rewritten/expected.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected.js
@@ -22,7 +22,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/setup-method/expected-bundle.js
+++ b/test/js/samples/setup-method/expected-bundle.js
@@ -144,7 +144,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/setup-method/expected.js
+++ b/test/js/samples/setup-method/expected.js
@@ -33,7 +33,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -383,7 +383,7 @@ function create_if_block_4 ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -248,7 +248,7 @@ function create_if_block_4 ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	options = options || {};
+	if ( !options || ( !options.target && !options._root ) ) throw new Error( "'target' is a required option" );
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/runtime/index.js
+++ b/test/runtime/index.js
@@ -215,8 +215,7 @@ describe("runtime", () => {
 	it("fails if options.target is missing in dev mode", () => {
 		const { code } = svelte.compile(`<div></div>`, {
 			format: "iife",
-			name: "SvelteComponent",
-			dev: true
+			name: "SvelteComponent"
 		});
 
 		const SvelteComponent = eval(

--- a/test/runtime/samples/pass-no-options/_config.js
+++ b/test/runtime/samples/pass-no-options/_config.js
@@ -1,8 +1,0 @@
-export default {
-	html: '<h1>Just some static HTML</h1>',
-
-	test ( assert, component, target, window ) {
-		const newComp = new window.SvelteComponent();
-		assert.equal(newComp instanceof window.SvelteComponent, true);
-	}
-};

--- a/test/runtime/samples/pass-no-options/main.html
+++ b/test/runtime/samples/pass-no-options/main.html
@@ -1,1 +1,0 @@
-<h1>Just some static HTML</h1>


### PR DESCRIPTION
Ref #753. It turns out we're already throwing an error if `options.target` is missing, but only in dev mode.

So I'm in two minds about whether to upgrade it. One the one hand, this is exactly what dev mode is for — adding these kinds of errors without bulking out generated code in production. On the other, you can end up with some fairly surprising bugs if you're not in dev mode.

Interested to hear what people think.