### PR TITLE
Make component options optional

### DIFF
--- a/src/generators/dom/index.ts
+++ b/src/generators/dom/index.ts
@@ -153,7 +153,7 @@ export default function dom(
 		function ${name} ( options ) {
 			${options.dev &&
 				`if ( !options || (!options.target && !options._root) ) throw new Error( "'target' is a required option" );`}
-			this.options = options;
+			this.options = options || {};
 			${generator.usesRefs && `this.refs = {};`}
 			this._state = ${templateProperties.data
 				? `@assign( @template.data(), options.data )`

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -217,7 +217,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = assign( template.data(), options.data );
 
 	this._observers = {

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -53,7 +53,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = assign( template.data(), options.data );
 
 	this._observers = {

--- a/test/js/samples/computed-collapsed-if/expected-bundle.js
+++ b/test/js/samples/computed-collapsed-if/expected-bundle.js
@@ -165,7 +165,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 	this._recompute( {}, this._state, {}, true );
 

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -25,7 +25,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 	this._recompute( {}, this._state, {}, true );
 

--- a/test/js/samples/css-media-query/expected-bundle.js
+++ b/test/js/samples/css-media-query/expected-bundle.js
@@ -199,7 +199,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -39,7 +39,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -313,7 +313,7 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -140,7 +140,7 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -210,7 +210,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -50,7 +50,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/if-block-no-update/expected-bundle.js
+++ b/test/js/samples/if-block-no-update/expected-bundle.js
@@ -252,7 +252,7 @@ function select_block_type ( state ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -88,7 +88,7 @@ function select_block_type ( state ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/if-block-simple/expected-bundle.js
+++ b/test/js/samples/if-block-simple/expected-bundle.js
@@ -228,7 +228,7 @@ function create_if_block ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -64,7 +64,7 @@ function create_if_block ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/legacy-input-type/expected-bundle.js
+++ b/test/js/samples/legacy-input-type/expected-bundle.js
@@ -186,7 +186,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/legacy-input-type/expected.js
+++ b/test/js/samples/legacy-input-type/expected.js
@@ -28,7 +28,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -202,7 +202,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -50,7 +50,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
@@ -164,7 +164,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/onrender-onteardown-rewritten/expected.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected.js
@@ -24,7 +24,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/setup-method/expected-bundle.js
+++ b/test/js/samples/setup-method/expected-bundle.js
@@ -175,7 +175,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/setup-method/expected.js
+++ b/test/js/samples/setup-method/expected.js
@@ -35,7 +35,7 @@ function create_main_fragment ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -412,7 +412,7 @@ function create_if_block_4 ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -248,7 +248,7 @@ function create_if_block_4 ( state, component ) {
 }
 
 function SvelteComponent ( options ) {
-	this.options = options;
+	this.options = options || {};
 	this._state = options.data || {};
 
 	this._observers = {


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
Hello! My Svelte v1.34.0 compilations were failing tests this morning. I saw that the handling of a component's `options` had changed to requiring `options`. I'm hoping to make `options` optional again. I test each component individually and set initial state in the `data()` block of a component's template, so I have no need to declare options for several of my tests.

Hear from you soon!