### PR TITLE
more consistent style for generated code

### DIFF
--- a/src/generators/Generator.ts
+++ b/src/generators/Generator.ts
@@ -210,10 +210,10 @@ export default class Generator {
 						}
 
 						if (globalWhitelist.has(name)) {
-							code.prependRight(node.start, `( '${name}' in state ? state.`);
+							code.prependRight(node.start, `('${name}' in state ? state.`);
 							code.appendLeft(
 								node.object ? node.object.end : node.end,
-								` : ${name} )`
+								` : ${name})`
 							);
 						} else {
 							code.prependRight(node.start, `state.`);
@@ -337,7 +337,7 @@ export default class Generator {
 
 				if (defaultImport) {
 					statements.push(
-						`${name} = ( ${name} && ${name}.__esModule ) ? ${name}['default'] : ${name};`
+						`${name} = (${name} && ${name}.__esModule) ? ${name}['default'] : ${name};`
 					);
 				}
 			});
@@ -629,8 +629,8 @@ export default class Generator {
 			// user code gets wrapped in an IIFE
 			if (js.content.body.length) {
 				const prefix = hasDefaultExport
-					? `var ${this.alias('template')} = (function () {`
-					: `(function () {`;
+					? `var ${this.alias('template')} = (function() {`
+					: `(function() {`;
 				this.code
 					.prependRight(js.content.start, prefix)
 					.appendLeft(js.content.end, '}());');

--- a/src/generators/dom/Block.ts
+++ b/src/generators/dom/Block.ts
@@ -135,7 +135,7 @@ export default class Block {
 		this.mount(name, parentNode);
 
 		if (isToplevel) {
-			this.builders.unmount.addLine(`@detachNode( ${name} );`);
+			this.builders.unmount.addLine(`@detachNode(${name});`);
 		}
 	}
 
@@ -180,9 +180,9 @@ export default class Block {
 
 	mount(name: string, parentNode: string) {
 		if (parentNode) {
-			this.builders.mount.addLine(`@appendNode( ${name}, ${parentNode} );`);
+			this.builders.mount.addLine(`@appendNode(${name}, ${parentNode});`);
 		} else {
-			this.builders.mount.addLine(`@insertNode( ${name}, #target, anchor );`);
+			this.builders.mount.addLine(`@insertNode(${name}, #target, anchor);`);
 		}
 	}
 
@@ -225,7 +225,7 @@ export default class Block {
 			properties.addBlock(`create: @noop,`);
 		} else {
 			properties.addBlock(deindent`
-				create: function () {
+				create: function() {
 					${this.builders.create}
 					${!this.builders.hydrate.isEmpty() && `this.hydrate();`}
 				},
@@ -237,7 +237,7 @@ export default class Block {
 				properties.addBlock(`claim: @noop,`);
 			} else {
 				properties.addBlock(deindent`
-					claim: function ( nodes ) {
+					claim: function(nodes) {
 						${this.builders.claim}
 						${!this.builders.hydrate.isEmpty() && `this.hydrate();`}
 					},
@@ -247,7 +247,7 @@ export default class Block {
 
 		if (!this.builders.hydrate.isEmpty()) {
 			properties.addBlock(deindent`
-				hydrate: function ( nodes ) {
+				hydrate: function(nodes) {
 					${this.builders.hydrate}
 				},
 			`);
@@ -257,7 +257,7 @@ export default class Block {
 			properties.addBlock(`mount: @noop,`);
 		} else {
 			properties.addBlock(deindent`
-				mount: function ( #target, anchor ) {
+				mount: function(#target, anchor) {
 					${this.builders.mount}
 				},
 			`);
@@ -268,7 +268,7 @@ export default class Block {
 				properties.addBlock(`update: @noop,`);
 			} else {
 				properties.addBlock(deindent`
-					update: function ( changed, ${this.params.join(', ')} ) {
+					update: function(changed, ${this.params.join(', ')}) {
 						${this.builders.update}
 					},
 				`);
@@ -278,20 +278,20 @@ export default class Block {
 		if (this.hasIntroMethod) {
 			if (hasIntros) {
 				properties.addBlock(deindent`
-					intro: function ( #target, anchor ) {
-						if ( ${introing} ) return;
+					intro: function(#target, anchor) {
+						if (${introing}) return;
 						${introing} = true;
 						${hasOutros && `${outroing} = false;`}
 
 						${this.builders.intro}
 
-						this.mount( #target, anchor );
+						this.mount(#target, anchor);
 					},
 				`);
 			} else {
 				properties.addBlock(deindent`
-					intro: function ( #target, anchor ) {
-						this.mount( #target, anchor );
+					intro: function(#target, anchor) {
+						this.mount(#target, anchor);
 					},
 				`);
 			}
@@ -300,8 +300,8 @@ export default class Block {
 		if (this.hasOutroMethod) {
 			if (hasOutros) {
 				properties.addBlock(deindent`
-					outro: function ( ${this.alias('outrocallback')} ) {
-						if ( ${outroing} ) return;
+					outro: function(${this.alias('outrocallback')}) {
+						if (${outroing}) return;
 						${outroing} = true;
 						${hasIntros && `${introing} = false;`}
 
@@ -312,7 +312,7 @@ export default class Block {
 				`);
 			} else {
 				properties.addBlock(deindent`
-					outro: function ( outrocallback ) {
+					outro: function(outrocallback) {
 						outrocallback();
 					},
 				`);
@@ -323,7 +323,7 @@ export default class Block {
 			properties.addBlock(`unmount: @noop,`);
 		} else {
 			properties.addBlock(deindent`
-				unmount: function () {
+				unmount: function() {
 					${this.builders.unmount}
 				},
 			`);
@@ -333,16 +333,14 @@ export default class Block {
 			properties.addBlock(`destroy: @noop`);
 		} else {
 			properties.addBlock(deindent`
-				destroy: function () {
+				destroy: function() {
 					${this.builders.destroy}
 				}
 			`);
 		}
 
 		return deindent`
-			function ${this.name} ( ${this.params.join(', ')}, #component${this.key
-			? `, ${localKey}`
-			: ''} ) {
+			function ${this.name}(${this.params.join(', ')}, #component${this.key ? `, ${localKey}` : ''}) {
 				${this.variables.size > 0 &&
 					`var ${Array.from(this.variables.keys())
 						.map(key => {

--- a/src/generators/dom/index.ts
+++ b/src/generators/dom/index.ts
@@ -91,9 +91,9 @@ export default function dom(
 
 			const condition = `isInitial || ${deps.map(dep => `changed.${dep}`).join(' || ')}`;
 
-			const statement = `if ( @differs( ( state.${key} = @template.computed.${key}( ${deps
+			const statement = `if (@differs((state.${key} = @template.computed.${key}(${deps
 				.map(dep => `state.${dep}`)
-				.join(', ')} ) ), oldState.${key} ) ) changed.${key} = true;`;
+				.join(', ')})), oldState.${key})) changed.${key} = true;`;
 
 			computationBuilder.addConditional(condition, statement);
 		});
@@ -105,8 +105,8 @@ export default function dom(
 
 	if (generator.needsEncapsulateHelper) {
 		builder.addBlock(deindent`
-			function @encapsulateStyles ( node ) {
-				@setAttribute( node, '${generator.stylesheet.id}', '' );
+			function @encapsulateStyles(node) {
+				@setAttribute(node, "${generator.stylesheet.id}", "");
 			}
 		`);
 	}
@@ -118,11 +118,11 @@ export default function dom(
 
 	if (styles && generator.options.css !== false && !generator.customElement) {
 		builder.addBlock(deindent`
-			function @add_css () {
-				var style = @createElement( 'style' );
+			function @add_css() {
+				var style = @createElement("style");
 				style.id = '${generator.stylesheet.id}-style';
 				style.textContent = ${styles};
-				@appendNode( style, document.head );
+				@appendNode(style, document.head);
 			}
 		`);
 	}
@@ -149,30 +149,28 @@ export default function dom(
 
 	const constructorBody = deindent`
 		${options.dev && !generator.customElement &&
-			`if ( !options || (!options.target && !options._root) ) throw new Error( "'target' is a required option" );`}
+			`if (!options || (!options.target && !options._root)) throw new Error("'target' is a required option");`}
 		this.options = options;
 		${generator.usesRefs && `this.refs = {};`}
 		this._state = ${templateProperties.data
-			? `@assign( @template.data(), options.data )`
+			? `@assign(@template.data(), options.data)`
 			: `options.data || {}`};
 		${generator.metaBindings}
-		${computations.length && `this._recompute( {}, this._state, {}, true );`}
+		${computations.length && `this._recompute({}, this._state, {}, true);`}
 		${options.dev &&
 			Array.from(generator.expectedProperties).map(
 				prop =>
-					`if ( !( '${prop}' in this._state ) ) console.warn( "Component was created without expected data property '${prop}'" );`
+					`if (!('${prop}' in this._state)) console.warn("Component was created without expected data property '${prop}'");`
 			)}
 		${generator.bindingGroups.length &&
-			`this._bindingGroups = [ ${Array(generator.bindingGroups.length)
-				.fill('[]')
-				.join(', ')} ];`}
+			`this._bindingGroups = [${Array(generator.bindingGroups.length).fill('[]').join(', ')}];`}
 
 		this._observers = {
-			pre: Object.create( null ),
-			post: Object.create( null )
+			pre: Object.create(null),
+			post: Object.create(null)
 		};
 
-		this._handlers = Object.create( null );
+		this._handlers = Object.create(null);
 		${templateProperties.ondestroy && `this._handlers.destroy = [@template.ondestroy]`}
 
 		this._root = options._root || this;
@@ -186,13 +184,13 @@ export default function dom(
 				${css && `this.shadowRoot.innerHTML = \`<style>${options.dev ? `${css}\n/*# sourceMappingURL=${cssMap.toUrl()} */` : css}</style>\`;`}
 			` :
 			(generator.stylesheet.hasStyles && options.css !== false &&
-			`if ( !document.getElementById( '${generator.stylesheet.id}-style' ) ) @add_css();`)
+			`if (!document.getElementById("${generator.stylesheet.id}-style")) @add_css();`)
 		}
 
-		${templateProperties.oncreate && `var oncreate = @template.oncreate.bind( this );`}
+		${templateProperties.oncreate && `var oncreate = @template.oncreate.bind(this);`}
 
 		${(templateProperties.oncreate || generator.hasComponents || generator.hasComplexBindings || generator.hasIntroTransitions) && deindent`
-			if ( !options._root ) {
+			if (!options._root) {
 				this._oncreate = [${templateProperties.oncreate && `oncreate`}];
 				${(generator.hasComponents || generator.hasComplexBindings) && `this._beforecreate = [];`}
 				${(generator.hasComponents || generator.hasIntroTransitions) && `this._aftercreate = [];`}
@@ -205,22 +203,22 @@ export default function dom(
 
 		${generator.slots.size && `this.slots = {};`}
 
-		this._fragment = @create_main_fragment( this._state, this );
+		this._fragment = @create_main_fragment(this._state, this);
 
-		if ( options.target ) {
+		if (options.target) {
 			${generator.hydratable
 				? deindent`
-					var nodes = @children( options.target );
-					options.hydrate ? this._fragment.claim( nodes ) : this._fragment.create();
-					nodes.forEach( @detachNode );
+					var nodes = @children(options.target);
+					options.hydrate ? this._fragment.claim(nodes) : this._fragment.create();
+					nodes.forEach(@detachNode);
 				` :
 				deindent`
-					${options.dev && `if ( options.hydrate ) throw new Error( 'options.hydrate only works if the component was compiled with the \`hydratable: true\` option' );`}
+					${options.dev && `if (options.hydrate) throw new Error("options.hydrate only works if the component was compiled with the \`hydratable: true\` option");`}
 					this._fragment.create();
 				`}
 			${generator.customElement ?
-				`this._mount( options.target, options.anchor || null );` :
-				`this._fragment.${block.hasIntroMethod ? 'intro' : 'mount'}( options.target, options.anchor || null );`}
+				`this._mount(options.target, options.anchor || null);` :
+				`this._fragment.${block.hasIntroMethod ? 'intro' : 'mount'}(options.target, options.anchor || null);`}
 
 			${(generator.hasComponents || generator.hasComplexBindings || templateProperties.oncreate || generator.hasIntroTransitions) && deindent`
 				${generator.hasComponents && `this._lock = true;`}
@@ -263,13 +261,13 @@ export default function dom(
 						});
 					}`}
 
-				attributeChangedCallback ( attr, oldValue, newValue ) {
+				attributeChangedCallback(attr, oldValue, newValue) {
 					this.set({ [attr]: newValue });
 				}
 			}
 
-			customElements.define('${generator.tag}', ${name});
-			@assign( ${prototypeBase}, ${proto}, {
+			customElements.define("${generator.tag}", ${name});
+			@assign(${prototypeBase}, ${proto}, {
 				_mount(target, anchor) {
 					this._fragment.${block.hasIntroMethod ? 'intro' : 'mount'}(this.shadowRoot, null);
 					target.insertBefore(this, anchor);
@@ -282,32 +280,32 @@ export default function dom(
 		`);
 	} else {
 		builder.addBlock(deindent`
-			function ${name} ( options ) {
+			function ${name}(options) {
 				${constructorBody}
 			}
 
-			@assign( ${prototypeBase}, ${proto});
+			@assign(${prototypeBase}, ${proto});
 		`);
 	}
 
 	// TODO deprecate component.teardown()
 	builder.addBlock(deindent`
 		${options.dev && deindent`
-			${name}.prototype._checkReadOnly = function _checkReadOnly ( newState ) {
+			${name}.prototype._checkReadOnly = function _checkReadOnly(newState) {
 				${Array.from(generator.readonly).map(
 					prop =>
-						`if ( '${prop}' in newState && !this._updatingReadonlyProperty ) throw new Error( "Cannot set read-only property '${prop}'" );`
+						`if ('${prop}' in newState && !this._updatingReadonlyProperty) throw new Error("Cannot set read-only property '${prop}'");`
 				)}
 			};
 		`}
 
 		${computations.length ? deindent`
-			${name}.prototype._recompute = function _recompute ( changed, state, oldState, isInitial ) {
+			${name}.prototype._recompute = function _recompute(changed, state, oldState, isInitial) {
 				${computationBuilder}
 			}
 		` : (!sharedPath && `${name}.prototype._recompute = @noop;`)}
 
-		${templateProperties.setup && `@template.setup( ${name} );`}
+		${templateProperties.setup && `@template.setup(${name});`}
 	`);
 
 	const usedHelpers = new Set();
@@ -340,7 +338,7 @@ export default function dom(
 
 		else if (format === 'cjs') {
 			const SHARED = '__shared';
-			let requires = `var ${SHARED} = require( ${JSON.stringify(sharedPath)} );`;
+			let requires = `var ${SHARED} = require(${JSON.stringify(sharedPath)});`;
 			used.forEach(name => {
 				const alias = generator.alias(name);
 				requires += `\nvar ${alias} = ${SHARED}.${name};`;
@@ -390,9 +388,7 @@ export default function dom(
 				// special case
 				const global = `_svelteTransitionManager`;
 
-				result += `\n\nvar ${generator.alias(
-					'transitionManager'
-				)} = window.${global} || ( window.${global} = ${code});`;
+				result += `\n\nvar ${generator.alias('transitionManager')} = window.${global} || (window.${global} = ${code});`;
 			} else {
 				const alias = generator.alias(expression.id.name);
 				if (alias !== expression.id.name)

--- a/src/generators/dom/visitors/EachBlock.ts
+++ b/src/generators/dom/visitors/EachBlock.ts
@@ -73,16 +73,15 @@ export default function visitEachBlock(
 
 		// TODO neaten this up... will end up with an empty line in the block
 		block.builders.init.addBlock(deindent`
-			if ( !${each_block_value}.${length} ) {
-				${each_block_else} = ${node.else._block.name}( ${params}, #component );
+			if (!${each_block_value}.${length}) {
+				${each_block_else} = ${node.else._block.name}(${params}, #component);
 				${each_block_else}.create();
 			}
 		`);
 
 		block.builders.mount.addBlock(deindent`
-			if ( ${each_block_else} ) {
-				${each_block_else}.${mountOrIntro}( ${state.parentNode ||
-			'#target'}, null );
+			if (${each_block_else}) {
+				${each_block_else}.${mountOrIntro}(${state.parentNode || '#target'}, null);
 			}
 		`);
 
@@ -90,13 +89,13 @@ export default function visitEachBlock(
 
 		if (node.else._block.hasUpdateMethod) {
 			block.builders.update.addBlock(deindent`
-				if ( !${each_block_value}.${length} && ${each_block_else} ) {
+				if (!${each_block_value}.${length} && ${each_block_else}) {
 					${each_block_else}.update( changed, ${params} );
-				} else if ( !${each_block_value}.${length} ) {
-					${each_block_else} = ${node.else._block.name}( ${params}, #component );
+				} else if (!${each_block_value}.${length}) {
+					${each_block_else} = ${node.else._block.name}(${params}, #component);
 					${each_block_else}.create();
-					${each_block_else}.${mountOrIntro}( ${parentNode}, ${anchor} );
-				} else if ( ${each_block_else} ) {
+					${each_block_else}.${mountOrIntro}(${parentNode}, ${anchor});
+				} else if (${each_block_else}) {
 					${each_block_else}.unmount();
 					${each_block_else}.destroy();
 					${each_block_else} = null;
@@ -104,26 +103,26 @@ export default function visitEachBlock(
 			`);
 		} else {
 			block.builders.update.addBlock(deindent`
-				if ( ${each_block_value}.${length} ) {
-					if ( ${each_block_else} ) {
+				if (${each_block_value}.${length}) {
+					if (${each_block_else}) {
 						${each_block_else}.unmount();
 						${each_block_else}.destroy();
 						${each_block_else} = null;
 					}
-				} else if ( !${each_block_else} ) {
-					${each_block_else} = ${node.else._block.name}( ${params}, #component );
+				} else if (!${each_block_else}) {
+					${each_block_else} = ${node.else._block.name}(${params}, #component);
 					${each_block_else}.create();
-					${each_block_else}.${mountOrIntro}( ${parentNode}, ${anchor} );
+					${each_block_else}.${mountOrIntro}(${parentNode}, ${anchor});
 				}
 			`);
 		}
 
 		block.builders.unmount.addLine(
-			`if ( ${each_block_else} ) ${each_block_else}.unmount()`
+			`if (${each_block_else}) ${each_block_else}.unmount()`
 		);
 
 		block.builders.destroy.addBlock(deindent`
-			if ( ${each_block_else} ) ${each_block_else}.destroy( false );
+			if (${each_block_else}) ${each_block_else}.destroy(false);
 		`);
 	}
 
@@ -161,7 +160,7 @@ function keyed(
 	const last = block.getUniqueName(`${each_block}_last`);
 	const expected = block.getUniqueName(`${each_block}_expected`);
 
-	block.addVariable(lookup, `Object.create( null )`);
+	block.addVariable(lookup, `Object.create(null)`);
 	block.addVariable(head);
 	block.addVariable(last);
 
@@ -179,15 +178,15 @@ function keyed(
 	}
 
 	block.builders.init.addBlock(deindent`
-		for ( var #i = 0; #i < ${each_block_value}.${length}; #i += 1 ) {
+		for (var #i = 0; #i < ${each_block_value}.${length}; #i += 1) {
 			var ${key} = ${each_block_value}[#i].${node.key};
-			var ${iteration} = ${lookup}[${key}] = ${create_each_block}( ${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component, ${key} );
+			var ${iteration} = ${lookup}[${key}] = ${create_each_block}(${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component, ${key});
 
-			if ( ${last} ) ${last}.next = ${iteration};
+			if (${last}) ${last}.next = ${iteration};
 			${iteration}.last = ${last};
 			${last} = ${iteration};
 
-			if ( #i === 0 ) ${head} = ${iteration};
+			if (#i === 0) ${head} = ${iteration};
 		}
 	`);
 
@@ -196,7 +195,7 @@ function keyed(
 
 	block.builders.create.addBlock(deindent`
 		var ${iteration} = ${head};
-		while ( ${iteration} ) {
+		while (${iteration}) {
 			${iteration}.create();
 			${iteration} = ${iteration}.next;
 		}
@@ -204,16 +203,16 @@ function keyed(
 
 	block.builders.claim.addBlock(deindent`
 		var ${iteration} = ${head};
-		while ( ${iteration} ) {
-			${iteration}.claim( ${state.parentNodes} );
+		while (${iteration}) {
+			${iteration}.claim(${state.parentNodes});
 			${iteration} = ${iteration}.next;
 		}
 	`);
 
 	block.builders.mount.addBlock(deindent`
 		var ${iteration} = ${head};
-		while ( ${iteration} ) {
-			${iteration}.${mountOrIntro}( ${targetNode}, ${anchorNode} );
+		while (${iteration}) {
+			${iteration}.${mountOrIntro}(${targetNode}, ${anchorNode});
 			${iteration} = ${iteration}.next;
 		}
 	`);
@@ -225,8 +224,8 @@ function keyed(
 	if (node._block.hasOutroMethod) {
 		const fn = block.getUniqueName(`${each_block}_outro`);
 		block.builders.init.addBlock(deindent`
-			function ${fn} ( iteration ) {
-				iteration.outro( function () {
+			function ${fn}(iteration) {
+				iteration.outro(function() {
 					iteration.unmount();
 					iteration.destroy();
 					${lookup}[iteration.key] = null;
@@ -235,21 +234,21 @@ function keyed(
 		`);
 
 		destroy = deindent`
-			while ( ${expected} ) {
-				${fn}( ${expected} );
+			while (${expected}) {
+				${fn}(${expected});
 				${expected} = ${expected}.next;
 			}
 
-			for ( #i = 0; #i < discard_pile.length; #i += 1 ) {
-				if ( discard_pile[#i].discard ) {
-					${fn}( discard_pile[#i] );
+			for (#i = 0; #i < discard_pile.length; #i += 1) {
+				if (discard_pile[#i].discard) {
+					${fn}(discard_pile[#i]);
 				}
 			}
 		`;
 	} else {
 		const fn = block.getUniqueName(`${each_block}_destroy`);
 		block.builders.init.addBlock(deindent`
-			function ${fn} ( iteration ) {
+			function ${fn}(iteration) {
 				iteration.unmount();
 				iteration.destroy();
 				${lookup}[iteration.key] = null;
@@ -257,15 +256,15 @@ function keyed(
 		`);
 
 		destroy = deindent`
-			while ( ${expected} ) {
-				${fn}( ${expected} );
+			while (${expected}) {
+				${fn}(${expected});
 				${expected} = ${expected}.next;
 			}
 
-			for ( #i = 0; #i < discard_pile.length; #i += 1 ) {
+			for (#i = 0; #i < discard_pile.length; #i += 1) {
 				var ${iteration} = discard_pile[#i];
-				if ( ${iteration}.discard ) {
-					${fn}( ${iteration} );
+				if (${iteration}.discard) {
+					${fn}(${iteration});
 				}
 			}
 		`;
@@ -279,22 +278,22 @@ function keyed(
 
 		var discard_pile = [];
 
-		for ( #i = 0; #i < ${each_block_value}.${length}; #i += 1 ) {
+		for (#i = 0; #i < ${each_block_value}.${length}; #i += 1) {
 			var ${key} = ${each_block_value}[#i].${node.key};
 			var ${iteration} = ${lookup}[${key}];
 
 			${dynamic &&
-				`if ( ${iteration} ) ${iteration}.update( changed, ${params}, ${each_block_value}, ${each_block_value}[#i], #i );`}
+				`if (${iteration}) ${iteration}.update(changed, ${params}, ${each_block_value}, ${each_block_value}[#i], #i);`}
 
-			if ( ${expected} ) {
-				if ( ${key} === ${expected}.key ) {
+			if (${expected}) {
+				if (${key} === ${expected}.key) {
 					${expected} = ${expected}.next;
 				} else {
-					if ( ${iteration} ) {
+					if (${iteration}) {
 						// probably a deletion
-						while ( ${expected} && ${expected}.key !== ${key} ) {
+						while (${expected} && ${expected}.key !== ${key}) {
 							${expected}.discard = true;
-							discard_pile.push( ${expected} );
+							discard_pile.push(${expected});
 							${expected} = ${expected}.next;
 						};
 
@@ -302,12 +301,12 @@ function keyed(
 						${iteration}.discard = false;
 						${iteration}.last = ${last};
 
-						if (!${expected}) ${iteration}.mount( ${parentNode}, ${anchor} );
+						if (!${expected}) ${iteration}.mount(${parentNode}, ${anchor});
 					} else {
 						// key is being inserted
-						${iteration} = ${lookup}[${key}] = ${create_each_block}( ${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component, ${key} );
+						${iteration} = ${lookup}[${key}] = ${create_each_block}(${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component, ${key});
 						${iteration}.create();
-						${iteration}.${mountOrIntro}( ${parentNode}, ${expected}.first );
+						${iteration}.${mountOrIntro}(${parentNode}, ${expected}.first);
 
 						${expected}.last = ${iteration};
 						${iteration}.next = ${expected};
@@ -315,25 +314,24 @@ function keyed(
 				}
 			} else {
 				// we're appending from this point forward
-				if ( ${iteration} ) {
+				if (${iteration}) {
 					${iteration}.discard = false;
 					${iteration}.next = null;
-					${iteration}.mount( ${parentNode}, ${anchor} );
+					${iteration}.mount(${parentNode}, ${anchor});
 				} else {
-					${iteration} = ${lookup}[${key}] = ${create_each_block}( ${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component, ${key} );
+					${iteration} = ${lookup}[${key}] = ${create_each_block}(${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component, ${key});
 					${iteration}.create();
-					${iteration}.${mountOrIntro}( ${parentNode}, ${anchor} );
+					${iteration}.${mountOrIntro}(${parentNode}, ${anchor});
 				}
 			}
 
-			if ( ${last} ) ${last}.next = ${iteration};
+			if (${last}) ${last}.next = ${iteration};
 			${iteration}.last = ${last};
-			${node._block.hasIntroMethod &&
-				`${iteration}.intro( ${parentNode}, ${anchor} );`}
+			${node._block.hasIntroMethod && `${iteration}.intro(${parentNode}, ${anchor});`}
 			${last} = ${iteration};
 		}
 
-		if ( ${last} ) ${last}.next = null;
+		if (${last}) ${last}.next = null;
 
 		${destroy}
 
@@ -343,7 +341,7 @@ function keyed(
 	if (!state.parentNode) {
 		block.builders.unmount.addBlock(deindent`
 			var ${iteration} = ${head};
-			while ( ${iteration} ) {
+			while (${iteration}) {
 				${iteration}.unmount();
 				${iteration} = ${iteration}.next;
 			}
@@ -352,8 +350,8 @@ function keyed(
 
 	block.builders.destroy.addBlock(deindent`
 		var ${iteration} = ${head};
-		while ( ${iteration} ) {
-			${iteration}.destroy( false );
+		while (${iteration}) {
+			${iteration}.destroy(false);
 			${iteration} = ${iteration}.next;
 		}
 	`);
@@ -378,8 +376,8 @@ function unkeyed(
 	block.builders.init.addBlock(deindent`
 		var ${iterations} = [];
 
-		for ( var #i = 0; #i < ${each_block_value}.${length}; #i += 1 ) {
-			${iterations}[#i] = ${create_each_block}( ${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component );
+		for (var #i = 0; #i < ${each_block_value}.${length}; #i += 1) {
+			${iterations}[#i] = ${create_each_block}(${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component);
 		}
 	`);
 
@@ -387,20 +385,20 @@ function unkeyed(
 	const anchorNode = state.parentNode ? 'null' : 'anchor';
 
 	block.builders.create.addBlock(deindent`
-		for ( var #i = 0; #i < ${iterations}.length; #i += 1 ) {
+		for (var #i = 0; #i < ${iterations}.length; #i += 1) {
 			${iterations}[#i].create();
 		}
 	`);
 
 	block.builders.claim.addBlock(deindent`
-		for ( var #i = 0; #i < ${iterations}.length; #i += 1 ) {
-			${iterations}[#i].claim( ${state.parentNodes} );
+		for (var #i = 0; #i < ${iterations}.length; #i += 1) {
+			${iterations}[#i].claim(${state.parentNodes});
 		}
 	`);
 
 	block.builders.mount.addBlock(deindent`
-		for ( var #i = 0; #i < ${iterations}.length; #i += 1 ) {
-			${iterations}[#i].${mountOrIntro}( ${targetNode}, ${anchorNode} );
+		for (var #i = 0; #i < ${iterations}.length; #i += 1) {
+			${iterations}[#i].${mountOrIntro}(${targetNode}, ${anchorNode});
 		}
 	`);
 
@@ -421,27 +419,27 @@ function unkeyed(
 		const forLoopBody = node._block.hasUpdateMethod
 			? node._block.hasIntroMethod
 				? deindent`
-					if ( ${iterations}[#i] ) {
-						${iterations}[#i].update( changed, ${params}, ${each_block_value}, ${each_block_value}[#i], #i );
+					if (${iterations}[#i]) {
+						${iterations}[#i].update(changed, ${params}, ${each_block_value}, ${each_block_value}[#i], #i);
 					} else {
-						${iterations}[#i] = ${create_each_block}( ${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component );
+						${iterations}[#i] = ${create_each_block}(${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component);
 						${iterations}[#i].create();
 					}
-					${iterations}[#i].intro( ${parentNode}, ${anchor} );
+					${iterations}[#i].intro(${parentNode}, ${anchor});
 				`
 				: deindent`
-					if ( ${iterations}[#i] ) {
-						${iterations}[#i].update( changed, ${params}, ${each_block_value}, ${each_block_value}[#i], #i );
+					if (${iterations}[#i]) {
+						${iterations}[#i].update(changed, ${params}, ${each_block_value}, ${each_block_value}[#i], #i);
 					} else {
-						${iterations}[#i] = ${create_each_block}( ${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component );
+						${iterations}[#i] = ${create_each_block}(${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component);
 						${iterations}[#i].create();
-						${iterations}[#i].mount( ${parentNode}, ${anchor} );
+						${iterations}[#i].mount(${parentNode}, ${anchor});
 					}
 				`
 			: deindent`
-				${iterations}[#i] = ${create_each_block}( ${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component );
+				${iterations}[#i] = ${create_each_block}(${params}, ${each_block_value}, ${each_block_value}[#i], #i, #component);
 				${iterations}[#i].create();
-				${iterations}[#i].${mountOrIntro}( ${parentNode}, ${anchor} );
+				${iterations}[#i].${mountOrIntro}(${parentNode}, ${anchor});
 			`;
 
 		const start = node._block.hasUpdateMethod ? '0' : `${iterations}.length`;
@@ -449,9 +447,9 @@ function unkeyed(
 		const outro = block.getUniqueName('outro');
 		const destroy = node._block.hasOutroMethod
 			? deindent`
-				function ${outro} ( i ) {
-					if ( ${iterations}[i] ) {
-						${iterations}[i].outro( function () {
+				function ${outro}(i) {
+					if (${iterations}[i]) {
+						${iterations}[i].outro(function() {
 							${iterations}[i].unmount();
 							${iterations}[i].destroy();
 							${iterations}[i] = null;
@@ -459,10 +457,10 @@ function unkeyed(
 					}
 				}
 
-				for ( ; #i < ${iterations}.length; #i += 1 ) ${outro}( #i );
+				for (; #i < ${iterations}.length; #i += 1) ${outro}(#i);
 			`
 			: deindent`
-				for ( ; #i < ${iterations}.length; #i += 1 ) {
+				for (; #i < ${iterations}.length; #i += 1) {
 					${iterations}[#i].unmount();
 					${iterations}[#i].destroy();
 				}
@@ -472,8 +470,8 @@ function unkeyed(
 		block.builders.update.addBlock(deindent`
 			var ${each_block_value} = ${snippet};
 
-			if ( ${condition} ) {
-				for ( var #i = ${start}; #i < ${each_block_value}.${length}; #i += 1 ) {
+			if (${condition}) {
+				for (var #i = ${start}; #i < ${each_block_value}.${length}; #i += 1) {
 					${forLoopBody}
 				}
 
@@ -483,10 +481,10 @@ function unkeyed(
 	}
 
 	block.builders.unmount.addBlock(deindent`
-		for ( var #i = 0; #i < ${iterations}.length; #i += 1 ) {
+		for (var #i = 0; #i < ${iterations}.length; #i += 1) {
 			${iterations}[#i].unmount();
 		}
 	`);
 
-	block.builders.destroy.addBlock(`@destroyEach( ${iterations}, false, 0 );`);
+	block.builders.destroy.addBlock(`@destroyEach(${iterations}, false, 0);`);
 }

--- a/src/generators/dom/visitors/Element/Binding.ts
+++ b/src/generators/dom/visitors/Element/Binding.ts
@@ -67,9 +67,9 @@ export default function visitBinding(
 
 		const ifStatement = isMultipleSelect
 			? deindent`
-				${option}.selected = ~${value}.indexOf( ${option}.__value );`
+				${option}.selected = ~${value}.indexOf(${option}.__value);`
 			: deindent`
-				if ( ${option}.__value === ${value} ) {
+				if (${option}.__value === ${value}) {
 					${option}.selected = true;
 					break;
 				}`;
@@ -79,7 +79,7 @@ export default function visitBinding(
 
 		updateElement = deindent`
 			var ${value} = ${snippet};
-			for ( var #i = 0; #i < ${state.parentNode}.options.length; #i += 1 ) {
+			for (var #i = 0; #i < ${state.parentNode}.options.length; #i += 1) {
 				var ${option} = ${state.parentNode}.options[#i];
 
 				${ifStatement}
@@ -88,44 +88,44 @@ export default function visitBinding(
 
 		generator.hasComplexBindings = true;
 		block.builders.hydrate.addBlock(
-			`if ( !('${name}' in state) ) #component._root._beforecreate.push( ${handler} );`
+			`if (!('${name}' in state)) #component._root._beforecreate.push(${handler});`
 		);
 	} else if (attribute.name === 'group') {
 		// <input type='checkbox|radio' bind:group='selected'> special case
 		if (type === 'radio') {
 			setter = deindent`
-				if ( !${state.parentNode}.checked ) return;
+				if (!${state.parentNode}.checked) return;
 				${setter}
 			`;
 		}
 
 		const condition = type === 'checkbox'
-			? `~${snippet}.indexOf( ${state.parentNode}.__value )`
+			? `~${snippet}.indexOf(${state.parentNode}.__value)`
 			: `${state.parentNode}.__value === ${snippet}`;
 
 		block.builders.hydrate.addLine(
-			`#component._bindingGroups[${bindingGroup}].push( ${state.parentNode} );`
+			`#component._bindingGroups[${bindingGroup}].push(${state.parentNode});`
 		);
 
 		block.builders.destroy.addBlock(
-			`#component._bindingGroups[${bindingGroup}].splice( #component._bindingGroups[${bindingGroup}].indexOf( ${state.parentNode} ), 1 );`
+			`#component._bindingGroups[${bindingGroup}].splice(#component._bindingGroups[${bindingGroup}].indexOf(${state.parentNode}), 1);`
 		);
 
 		updateElement = `${state.parentNode}.checked = ${condition};`;
 	} else if (node.name === 'audio' || node.name === 'video') {
 		generator.hasComplexBindings = true;
-		block.builders.hydrate.addBlock(`#component._root._beforecreate.push( ${handler} );`);
+		block.builders.hydrate.addBlock(`#component._root._beforecreate.push(${handler});`);
 
 		if (attribute.name === 'currentTime') {
 			const frame = block.getUniqueName(`${state.parentNode}_animationframe`);
 			block.addVariable(frame);
 			setter = deindent`
-				cancelAnimationFrame( ${frame} );
-				if ( !${state.parentNode}.paused ) ${frame} = requestAnimationFrame( ${handler} );
+				cancelAnimationFrame(${frame});
+				if (!${state.parentNode}.paused) ${frame} = requestAnimationFrame(${handler});
 				${setter}
 			`;
 
-			updateCondition += ` && !isNaN( ${snippet} )`;
+			updateCondition += ` && !isNaN(${snippet})`;
 		} else if (attribute.name === 'duration') {
 			updateCondition = null;
 		} else if (attribute.name === 'paused') {
@@ -133,13 +133,13 @@ export default function visitBinding(
 			const last = block.getUniqueName(`${state.parentNode}_paused_value`);
 			block.addVariable(last, 'true');
 
-			updateCondition = `${last} !== ( ${last} = ${snippet} )`;
-			updateElement = `${state.parentNode}[ ${last} ? 'pause' : 'play' ]();`;
+			updateCondition = `${last} !== (${last} = ${snippet})`;
+			updateElement = `${state.parentNode}[${last} ? "pause" : "play"]();`;
 		}
 	}
 
 	block.builders.init.addBlock(deindent`
-		function ${handler} () {
+		function ${handler}() {
 			${lock} = true;
 			${setter}
 			${lock} = false;
@@ -149,21 +149,21 @@ export default function visitBinding(
 	if (node.name === 'input' && type === 'range') {
 		// need to bind to `input` and `change`, for the benefit of IE
 		block.builders.hydrate.addBlock(deindent`
-			@addListener( ${state.parentNode}, 'input', ${handler} );
-			@addListener( ${state.parentNode}, 'change', ${handler} );
+			@addListener(${state.parentNode}, "input", ${handler});
+			@addListener(${state.parentNode}, "change", ${handler});
 		`);
 
 		block.builders.destroy.addBlock(deindent`
-			@removeListener( ${state.parentNode}, 'input', ${handler} );
-			@removeListener( ${state.parentNode}, 'change', ${handler} );
+			@removeListener(${state.parentNode}, "input", ${handler});
+			@removeListener(${state.parentNode}, "change", ${handler});
 		`);
 	} else {
 		block.builders.hydrate.addLine(
-			`@addListener( ${state.parentNode}, '${eventName}', ${handler} );`
+			`@addListener(${state.parentNode}, "${eventName}", ${handler});`
 		);
 
 		block.builders.destroy.addLine(
-			`@removeListener( ${state.parentNode}, '${eventName}', ${handler} );`
+			`@removeListener(${state.parentNode}, "${eventName}", ${handler});`
 		);
 	}
 
@@ -175,7 +175,7 @@ export default function visitBinding(
 	if (updateCondition !== null) {
 		// audio/video duration is read-only, it never updates
 		block.builders.update.addBlock(deindent`
-			if ( ${updateCondition} ) {
+			if (${updateCondition}) {
 				${updateElement}
 			}
 		`);
@@ -183,10 +183,10 @@ export default function visitBinding(
 
 	if (attribute.name === 'paused') {
 		block.builders.create.addLine(
-			`@addListener( ${state.parentNode}, 'play', ${handler} );`
+			`@addListener(${state.parentNode}, "play", ${handler});`
 		);
 		block.builders.destroy.addLine(
-			`@removeListener( ${state.parentNode}, 'play', ${handler} );`
+			`@removeListener(${state.parentNode}, "play", ${handler});`
 		);
 	}
 }
@@ -221,7 +221,7 @@ function getBindingValue(
 ) {
 	// <select multiple bind:value='selected>
 	if (isMultipleSelect) {
-		return `[].map.call( ${state.parentNode}.querySelectorAll(':checked'), function ( option ) { return option.__value; })`;
+		return `[].map.call(${state.parentNode}.querySelectorAll(':checked'), function(option) { return option.__value; })`;
 	}
 
 	// <select bind:value='selected>
@@ -232,7 +232,7 @@ function getBindingValue(
 	// <input type='checkbox' bind:group='foo'>
 	if (attribute.name === 'group') {
 		if (type === 'checkbox') {
-			return `@getBindingGroupValue( #component._bindingGroups[${bindingGroup}] )`;
+			return `@getBindingGroupValue(#component._bindingGroups[${bindingGroup}])`;
 		}
 
 		return `${state.parentNode}.__value`;
@@ -240,7 +240,7 @@ function getBindingValue(
 
 	// <input type='range|number' bind:value>
 	if (type === 'range' || type === 'number') {
-		return `@toNumber( ${state.parentNode}.${attribute.name} )`;
+		return `@toNumber(${state.parentNode}.${attribute.name})`;
 	}
 
 	// everything else
@@ -286,12 +286,8 @@ function getSetter(
 			list[index]${tail} = ${value};
 
 			${computed
-				? `#component.set({ ${dependencies
-						.map((prop: string) => `${prop}: state.${prop}`)
-						.join(', ')} });`
-				: `#component.set({ ${dependencies
-						.map((prop: string) => `${prop}: #component.get( '${prop}' )`)
-						.join(', ')} });`}
+				? `#component.set({${dependencies.map((prop: string) => `${prop}: state.${prop}`).join(', ')} });`
+				: `#component.set({${dependencies.map((prop: string) => `${prop}: #component.get('${prop}')`).join(', ')} });`}
 		`;
 	}
 
@@ -299,9 +295,7 @@ function getSetter(
 		return deindent`
 			var state = #component.get();
 			${snippet} = ${value};
-			#component.set({ ${dependencies
-				.map((prop: string) => `${prop}: state.${prop}`)
-				.join(', ')} });
+			#component.set({ ${dependencies.map((prop: string) => `${prop}: state.${prop}`).join(', ')} });
 		`;
 	}
 

--- a/src/generators/dom/visitors/Element/EventHandler.ts
+++ b/src/generators/dom/visitors/Element/EventHandler.ts
@@ -71,14 +71,14 @@ export default function visitEventHandler(
 		${declarations}
 		${attribute.expression ?
 			`[✂${attribute.expression.start}-${attribute.expression.end}✂];` :
-			`${block.alias('component')}.fire('${attribute.name}', event);`}
+			`${block.alias('component')}.fire("${attribute.name}", event);`}
 	`;
 
 	if (isCustomEvent) {
 		block.addVariable(handlerName);
 
 		block.builders.hydrate.addBlock(deindent`
-			${handlerName} = @template.events.${name}.call( #component, ${state.parentNode}, function ( event ) {
+			${handlerName} = @template.events.${name}.call(#component, ${state.parentNode}, function(event) {
 				${handlerBody}
 			});
 		`);
@@ -88,7 +88,7 @@ export default function visitEventHandler(
 		`);
 	} else {
 		const handler = deindent`
-			function ${handlerName} ( event ) {
+			function ${handlerName}(event) {
 				${handlerBody}
 			}
 		`;
@@ -100,11 +100,11 @@ export default function visitEventHandler(
 		}
 
 		block.builders.hydrate.addLine(
-			`@addListener( ${state.parentNode}, '${name}', ${handlerName} );`
+			`@addListener(${state.parentNode}, "${name}", ${handlerName});`
 		);
 
 		block.builders.destroy.addLine(
-			`@removeListener( ${state.parentNode}, '${name}', ${handlerName} );`
+			`@removeListener(${state.parentNode}, "${name}", ${handlerName});`
 		);
 	}
 }

--- a/src/generators/dom/visitors/Element/Ref.ts
+++ b/src/generators/dom/visitors/Element/Ref.ts
@@ -18,7 +18,7 @@ export default function visitRef(
 	);
 
 	block.builders.destroy.addLine(deindent`
-		if ( #component.refs.${name} === ${state.parentNode} ) #component.refs.${name} = null;
+		if (#component.refs.${name} === ${state.parentNode}) #component.refs.${name} = null;
 	`);
 
 	generator.usesRefs = true; // so this component.refs object is created

--- a/src/generators/dom/visitors/Element/StyleAttribute.ts
+++ b/src/generators/dom/visitors/Element/StyleAttribute.ts
@@ -60,7 +60,7 @@ export default function visitStyleAttribute(
 
 				block.builders.update.addConditional(
 					condition,
-					`@setStyle(${node.var}, '${prop.key}', ${value});`
+					`@setStyle(${node.var}, "${prop.key}", ${value});`
 				);
 			}
 		} else {
@@ -68,7 +68,7 @@ export default function visitStyleAttribute(
 		}
 
 		block.builders.hydrate.addLine(
-			`@setStyle(${node.var}, '${prop.key}', ${value});`
+			`@setStyle(${node.var}, "${prop.key}", ${value});`
 		);
 	});
 }

--- a/src/generators/dom/visitors/Element/addTransitions.ts
+++ b/src/generators/dom/visitors/Element/addTransitions.ts
@@ -23,18 +23,18 @@ export default function addTransitions(
 		const fn = `@template.transitions.${intro.name}`;
 
 		block.builders.intro.addBlock(deindent`
-			#component._root._aftercreate.push( function () {
-				if ( !${name} ) ${name} = @wrapTransition( #component, ${node.var}, ${fn}, ${snippet}, true, null );
-				${name}.run( true, function () {
-					#component.fire( 'intro.end', { node: ${node.var} });
+			#component._root._aftercreate.push(function() {
+				if (!${name}) ${name} = @wrapTransition(#component, ${node.var}, ${fn}, ${snippet}, true, null);
+				${name}.run(true, function() {
+					#component.fire("intro.end", { node: ${node.var} });
 				});
 			});
 		`);
 
 		block.builders.outro.addBlock(deindent`
-			${name}.run( false, function () {
-				#component.fire( 'outro.end', { node: ${node.var} });
-				if ( --#outros === 0 ) #outrocallback();
+			${name}.run(false, function() {
+				#component.fire("outro.end", { node: ${node.var} });
+				if (--#outros === 0) #outrocallback();
 				${name} = null;
 			});
 		`);
@@ -52,16 +52,16 @@ export default function addTransitions(
 
 			if (outro) {
 				block.builders.intro.addBlock(deindent`
-					if ( ${introName} ) ${introName}.abort();
-					if ( ${outroName} ) ${outroName}.abort();
+					if (${introName}) ${introName}.abort();
+					if (${outroName}) ${outroName}.abort();
 				`);
 			}
 
 			block.builders.intro.addBlock(deindent`
-				#component._root._aftercreate.push( function () {
-					${introName} = @wrapTransition( #component, ${node.var}, ${fn}, ${snippet}, true, null );
-					${introName}.run( true, function () {
-						#component.fire( 'intro.end', { node: ${node.var} });
+				#component._root._aftercreate.push(function() {
+					${introName} = @wrapTransition(#component, ${node.var}, ${fn}, ${snippet}, true, null);
+					${introName}.run(true, function() {
+						#component.fire("intro.end", { node: ${node.var} });
 					});
 				});
 			`);
@@ -78,10 +78,10 @@ export default function addTransitions(
 			// TODO hide elements that have outro'd (unless they belong to a still-outroing
 			// group) prior to their removal from the DOM
 			block.builders.outro.addBlock(deindent`
-				${outroName} = @wrapTransition( #component, ${node.var}, ${fn}, ${snippet}, false, null );
-				${outroName}.run( false, function () {
-					#component.fire( 'outro.end', { node: ${node.var} });
-					if ( --#outros === 0 ) #outrocallback();
+				${outroName} = @wrapTransition(#component, ${node.var}, ${fn}, ${snippet}, false, null);
+				${outroName}.run(false, function() {
+					#component.fire("outro.end", { node: ${node.var} });
+					if (--#outros === 0) #outrocallback();
 				});
 			`);
 		}

--- a/src/generators/dom/visitors/Element/meta/Window.ts
+++ b/src/generators/dom/visitors/Element/meta/Window.ts
@@ -58,14 +58,14 @@ export default function visitWindow(
 			`;
 
 			block.builders.init.addBlock(deindent`
-				function ${handlerName} ( event ) {
+				function ${handlerName}(event) {
 					${handlerBody}
 				};
-				window.addEventListener( '${attribute.name}', ${handlerName} );
+				window.addEventListener("${attribute.name}", ${handlerName});
 			`);
 
 			block.builders.destroy.addBlock(deindent`
-				window.removeEventListener( '${attribute.name}', ${handlerName} );
+				window.removeEventListener("${attribute.name}", ${handlerName});
 			`);
 		}
 
@@ -122,14 +122,14 @@ export default function visitWindow(
 		`;
 
 		block.builders.init.addBlock(deindent`
-			function ${handlerName} ( event ) {
+			function ${handlerName}(event) {
 				${handlerBody}
 			};
-			window.addEventListener( '${event}', ${handlerName} );
+			window.addEventListener("${event}", ${handlerName});
 		`);
 
 		block.builders.destroy.addBlock(deindent`
-			window.removeEventListener( '${event}', ${handlerName} );
+			window.removeEventListener("${event}", ${handlerName});
 		`);
 	});
 
@@ -138,34 +138,33 @@ export default function visitWindow(
 		const observerCallback = block.getUniqueName(`scrollobserver`);
 
 		block.builders.init.addBlock(deindent`
-			function ${observerCallback} () {
-				if ( ${lock} ) return;
+			function ${observerCallback}() {
+				if (${lock}) return;
 				var x = ${bindings.scrollX
-					? `#component.get( '${bindings.scrollX}' )`
+					? `#component.get("${bindings.scrollX}")`
 					: `window.scrollX`};
 				var y = ${bindings.scrollY
-					? `#component.get( '${bindings.scrollY}' )`
+					? `#component.get("${bindings.scrollY}")`
 					: `window.scrollY`};
-				window.scrollTo( x, y );
+				window.scrollTo(x, y);
 			};
 		`);
 
 		if (bindings.scrollX)
 			block.builders.init.addLine(
-				`#component.observe( '${bindings.scrollX}', ${observerCallback} );`
+				`#component.observe("${bindings.scrollX}", ${observerCallback});`
 			);
 		if (bindings.scrollY)
 			block.builders.init.addLine(
-				`#component.observe( '${bindings.scrollY}', ${observerCallback} );`
+				`#component.observe("${bindings.scrollY}", ${observerCallback});`
 			);
 	} else if (bindings.scrollX || bindings.scrollY) {
 		const isX = !!bindings.scrollX;
 
 		block.builders.init.addBlock(deindent`
-			#component.observe( '${bindings.scrollX ||
-				bindings.scrollY}', function ( ${isX ? 'x' : 'y'} ) {
-				if ( ${lock} ) return;
-				window.scrollTo( ${isX ? 'x, window.scrollY' : 'window.scrollX, y'} );
+			#component.observe("${bindings.scrollX || bindings.scrollY}", function(${isX ? 'x' : 'y'}) {
+				if (${lock}) return;
+				window.scrollTo(${isX ? 'x, window.scrollY' : 'window.scrollX, y'});
 			});
 		`);
 	}
@@ -174,11 +173,11 @@ export default function visitWindow(
 	if (bindings.online) {
 		const handlerName = block.getUniqueName(`onlinestatuschanged`);
 		block.builders.init.addBlock(deindent`
-			function ${handlerName} ( event ) {
+			function ${handlerName}(event) {
 				#component.set({ ${bindings.online}: navigator.onLine });
 			};
-			window.addEventListener( 'online', ${handlerName} );
-			window.addEventListener( 'offline', ${handlerName} );
+			window.addEventListener("online", ${handlerName});
+			window.addEventListener("offline", ${handlerName});
 		`);
 
 		// add initial value
@@ -187,8 +186,8 @@ export default function visitWindow(
 		);
 
 		block.builders.destroy.addBlock(deindent`
-			window.removeEventListener( 'online', ${handlerName} );
-			window.removeEventListener( 'offline', ${handlerName} );
+			window.removeEventListener("online", ${handlerName});
+			window.removeEventListener("offline", ${handlerName});
 		`);
 	}
 }

--- a/src/generators/dom/visitors/MustacheTag.ts
+++ b/src/generators/dom/visitors/MustacheTag.ts
@@ -22,8 +22,8 @@ export default function visitMustacheTag(
 
 	block.addElement(
 		node.var,
-		`@createText( ${init} )`,
-		`@claimText( ${state.parentNodes}, ${init} )`,
+		`@createText(${init})`,
+		`@claimText(${state.parentNodes}, ${init})`,
 		state.parentNode
 	);
 }

--- a/src/generators/dom/visitors/RawMustacheTag.ts
+++ b/src/generators/dom/visitors/RawMustacheTag.ts
@@ -34,13 +34,13 @@ export default function visitRawMustacheTag(
 		insert = content => `${state.parentNode}.innerHTML = ${content};`;
 	} else if (anchorBefore === 'null') {
 		detach = `@detachBefore(${anchorAfter});`;
-		insert = content => `${anchorAfter}.insertAdjacentHTML('beforebegin', ${content});`;
+		insert = content => `${anchorAfter}.insertAdjacentHTML("beforebegin", ${content});`;
 	} else if (anchorAfter === 'null') {
 		detach = `@detachAfter(${anchorBefore});`;
-		insert = content => `${anchorBefore}.insertAdjacentHTML('afterend', ${content});`;
+		insert = content => `${anchorBefore}.insertAdjacentHTML("afterend", ${content});`;
 	} else {
 		detach = `@detachBetween(${anchorBefore}, ${anchorAfter});`;
-		insert = content => `${anchorBefore}.insertAdjacentHTML('afterend', ${content});`;
+		insert = content => `${anchorBefore}.insertAdjacentHTML("afterend", ${content});`;
 	}
 
 	const { init } = visitTag(
@@ -60,8 +60,8 @@ export default function visitRawMustacheTag(
 	if (needsAnchorBefore) {
 		block.addElement(
 			anchorBefore,
-			`@createElement( 'noscript' )`,
-			`@createElement( 'noscript' )`,
+			`@createElement('noscript')`,
+			`@createElement('noscript')`,
 			state.parentNode
 		);
 	}
@@ -69,8 +69,8 @@ export default function visitRawMustacheTag(
 	function addAnchorAfter() {
 		block.addElement(
 			anchorAfter,
-			`@createElement( 'noscript' )`,
-			`@createElement( 'noscript' )`,
+			`@createElement('noscript')`,
+			`@createElement('noscript')`,
 			state.parentNode
 		);
 	}

--- a/src/generators/dom/visitors/Text.ts
+++ b/src/generators/dom/visitors/Text.ts
@@ -14,8 +14,8 @@ export default function visitText(
 
 	block.addElement(
 		node.var,
-		`@createText( ${stringify(node.data)} )`,
-		`@claimText( ${state.parentNodes}, ${stringify(node.data)} )`,
+		`@createText(${stringify(node.data)})`,
+		`@claimText(${state.parentNodes}, ${stringify(node.data)})`,
 		state.parentNode
 	);
 }

--- a/src/generators/dom/visitors/shared/Tag.ts
+++ b/src/generators/dom/visitors/shared/Tag.ts
@@ -29,14 +29,14 @@ export default function visitTag(
 
 	if (dependencies.length || hasChangeableIndex) {
 		const changedCheck = (
-			( block.hasOutroMethod ? `#outroing || ` : '' ) +
+			(block.hasOutroMethod ? `#outroing || ` : '') +
 			dependencies.map(dependency => `changed.${dependency}`).join(' || ')
 		);
 
-		const updateCachedValue = `${value} !== ( ${value} = ${snippet} )`;
+		const updateCachedValue = `${value} !== (${value} = ${snippet})`;
 
 		const condition = shouldCache ?
-			( dependencies.length ? `( ${changedCheck} ) && ${updateCachedValue}` : updateCachedValue ) :
+			(dependencies.length ? `(${changedCheck}) && ${updateCachedValue}` : updateCachedValue) :
 			changedCheck;
 
 		block.builders.update.addConditional(

--- a/src/generators/server-side-rendering/Block.ts
+++ b/src/generators/server-side-rendering/Block.ts
@@ -21,7 +21,7 @@ export default class Block {
 	}
 
 	addBinding(binding: Node, name: string) {
-		const conditions = [`!( '${binding.name}' in state )`].concat(
+		const conditions = [`!('${binding.name}' in state)`].concat(
 			// TODO handle contextual bindings...
 			this.conditions.map(c => `(${c})`)
 		);
@@ -29,9 +29,9 @@ export default class Block {
 		const { name: prop } = getObject(binding.value);
 
 		this.generator.bindings.push(deindent`
-			if ( ${conditions.join('&&')} ) {
+			if (${conditions.join('&&')}) {
 				tmp = ${name}.data();
-				if ( '${prop}' in tmp ) {
+				if ('${prop}' in tmp) {
 					state.${binding.name} = tmp.${prop};
 					settled = false;
 				}

--- a/src/generators/server-side-rendering/index.ts
+++ b/src/generators/server-side-rendering/index.ts
@@ -105,20 +105,18 @@ export default function ssr(
 
 		${name}.filename = ${stringify(options.filename)};
 
-		${name}.data = function () {
+		${name}.data = function() {
 			return ${templateProperties.data ? `@template.data()` : `{}`};
 		};
 
-		${name}.render = function ( state, options ) {
+		${name}.render = function(state, options) {
 			${templateProperties.data
-				? `state = Object.assign( @template.data(), state || {} );`
+				? `state = Object.assign(@template.data(), state || {});`
 				: `state = state || {};`}
 
 			${computations.map(
 				({ key, deps }) =>
-					`state.${key} = @template.computed.${key}( ${deps
-						.map(dep => `state.${dep}`)
-						.join(', ')} );`
+					`state.${key} = @template.computed.${key}(${deps.map(dep => `state.${dep}`).join(', ')});`
 			)}
 
 			${generator.bindings.length &&
@@ -126,7 +124,7 @@ export default function ssr(
 				var settled = false;
 				var tmp;
 
-				while ( !settled ) {
+				while (!settled) {
 					settled = true;
 
 					${generator.bindings.join('\n\n')}
@@ -136,7 +134,7 @@ export default function ssr(
 			return \`${generator.renderCode}\`.trim();
 		};
 
-		${name}.renderCss = function () {
+		${name}.renderCss = function() {
 			var components = [];
 
 			${generator.stylesheet.hasStyles &&
@@ -152,26 +150,24 @@ export default function ssr(
 				deindent`
 				var seen = {};
 
-				function addComponent ( component ) {
+				function addComponent(component) {
 					var result = component.renderCss();
-					result.components.forEach( x => {
-						if ( seen[ x.filename ] ) return;
-						seen[ x.filename ] = true;
-						components.push( x );
+					result.components.forEach(x => {
+						if (seen[x.filename]) return;
+						seen[x.filename] = true;
+						components.push(x);
 					});
 				}
 
 				${templateProperties.components.value.properties.map(prop => {
 					const { name } = prop.key;
-					const expression =
-						generator.importedComponents.get(name) ||
-						`@template.components.${name}`;
-					return `addComponent( ${expression} );`;
+					const expression = generator.importedComponents.get(name) || `@template.components.${name}`;
+					return `addComponent(${expression});`;
 				})}
 			`}
 
 			return {
-				css: components.map( x => x.css ).join( '\\n' ),
+				css: components.map(x => x.css).join('\\n'),
 				map: null,
 				components
 			};
@@ -185,8 +181,8 @@ export default function ssr(
 			'>': '&gt;'
 		};
 
-		function __escape ( html ) {
-			return String( html ).replace( /["'&<>]/g, match => escaped[ match ] );
+		function __escape(html) {
+			return String(html).replace(/["'&<>]/g, match => escaped[match]);
 		}
 	`.replace(/(@+|#+)(\w*)/g, (match: string, sigil: string, name: string) => {
 		return sigil === '@' ? generator.alias(name) : sigil.slice(1) + name;

--- a/src/generators/server-side-rendering/visitors/EachBlock.ts
+++ b/src/generators/server-side-rendering/visitors/EachBlock.ts
@@ -10,11 +10,7 @@ export default function visitEachBlock(
 ) {
 	const { dependencies, snippet } = block.contextualise(node.expression);
 
-	const open = `\${ ${node.else
-		? `${snippet}.length ? `
-		: ''}${snippet}.map( ${node.index
-		? `( ${node.context}, ${node.index} )`
-		: node.context} => \``;
+	const open = `\${ ${node.else ? `${snippet}.length ? ` : ''}${snippet}.map(${node.index ? `(${node.context}, ${node.index})` : node.context} => \``;
 	generator.append(open);
 
 	// TODO should this be the generator's job? It's duplicated between
@@ -38,7 +34,7 @@ export default function visitEachBlock(
 		visit(generator, childBlock, child);
 	});
 
-	const close = `\` ).join( '' )`;
+	const close = `\`).join("")`;
 	generator.append(close);
 
 	if (node.else) {

--- a/src/generators/server-side-rendering/visitors/MustacheTag.ts
+++ b/src/generators/server-side-rendering/visitors/MustacheTag.ts
@@ -8,5 +8,5 @@ export default function visitMustacheTag(
 	node: Node
 ) {
 	const { snippet } = block.contextualise(node.expression);
-	generator.append('${__escape( ' + snippet + ' )}');
+	generator.append('${__escape(' + snippet + ')}');
 }

--- a/src/generators/shared/getStaticAttributeValue.ts
+++ b/src/generators/shared/getStaticAttributeValue.ts
@@ -1,4 +1,4 @@
-import { Node } from '../../../../interfaces';
+import { Node } from '../../interfaces';
 
 export default function getStaticAttributeValue(node: Node, name: string) {
 	const attribute = node.attributes.find(

--- a/src/generators/shared/utils/getGlobals.ts
+++ b/src/generators/shared/utils/getGlobals.ts
@@ -11,8 +11,7 @@ export default function getGlobals(imports: Node[], options: CompileOptions) {
 		if (!name) {
 			if (x.name.startsWith('__import')) {
 				const error = new Error(
-					`Could not determine name for imported module '${x.source
-						.value}' – use options.globals`
+					`Could not determine name for imported module '${x.source.value}' – use options.globals`
 				);
 				if (onerror) {
 					onerror(error);
@@ -21,8 +20,7 @@ export default function getGlobals(imports: Node[], options: CompileOptions) {
 				}
 			} else {
 				const warning = {
-					message: `No name was supplied for imported module '${x.source
-						.value}'. Guessing '${x.name}', but you should use options.globals`,
+					message: `No name was supplied for imported module '${x.source.value}'. Guessing '${x.name}', but you should use options.globals`,
 				};
 
 				if (onwarn) {

--- a/src/generators/shared/utils/getIntro.ts
+++ b/src/generators/shared/utils/getIntro.ts
@@ -19,23 +19,23 @@ export default function getIntro(
 
 function getAmdIntro(options: CompileOptions, imports: Node[]) {
 	const sourceString = imports.length
-		? `[ ${imports
+		? `[${imports
 				.map(declaration => `'${removeExtension(declaration.source.value)}'`)
-				.join(', ')} ], `
+				.join(', ')}], `
 		: '';
 
 	const id = options.amd && options.amd.id;
 
 	return `define(${id
-		? ` '${id}', `
-		: ''}${sourceString}function (${paramString(imports)}) { 'use strict';\n\n`;
+		? `"${id}", `
+		: ''}${sourceString}function(${paramString(imports)}) { 'use strict';\n\n`;
 }
 
 function getCjsIntro(options: CompileOptions, imports: Node[]) {
 	const requireBlock = imports
 		.map(
 			declaration =>
-				`var ${declaration.name} = require( '${declaration.source.value}' );`
+				`var ${declaration.name} = require('${declaration.source.value}');`
 		)
 		.join('\n\n');
 
@@ -51,9 +51,7 @@ function getIifeIntro(options: CompileOptions, imports: Node[]) {
 		throw new Error(`Missing required 'name' option for IIFE export`);
 	}
 
-	return `var ${options.name} = (function (${paramString(
-		imports
-	)}) { 'use strict';\n\n`;
+	return `var ${options.name} = (function(${paramString(imports)}) { 'use strict';\n\n`;
 }
 
 function getUmdIntro(options: CompileOptions, imports: Node[]) {
@@ -75,7 +73,7 @@ function getUmdIntro(options: CompileOptions, imports: Node[]) {
 
 	return (
 		deindent`
-		(function ( global, factory ) {
+		(function(global, factory) {
 			typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(${cjsDeps}) :
 			typeof define === 'function' && define.amd ? define(${amdId}${amdDeps}factory) :
 			(global.${options.name} = factory(${globalDeps}));
@@ -88,7 +86,7 @@ function getEvalIntro(options: CompileOptions, imports: Node[]) {
 }
 
 function paramString(imports: Node[]) {
-	return imports.length ? ` ${imports.map(dep => dep.name).join(', ')} ` : '';
+	return imports.map(dep => dep.name).join(', ');
 }
 
 function removeExtension(file: string) {

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -175,7 +175,7 @@ var proto = {
 	_unmount: _unmount
 };
 
-var template = (function () {
+var template = (function() {
 	return {
 		data: function () {
 			return { foo: 42 }
@@ -183,43 +183,43 @@ var template = (function () {
 	};
 }());
 
-function encapsulateStyles ( node ) {
-	setAttribute( node, 'svelte-3590263702', '' );
+function encapsulateStyles(node) {
+	setAttribute(node, "svelte-3590263702", "");
 }
 
-function add_css () {
-	var style = createElement( 'style' );
+function add_css() {
+	var style = createElement("style");
 	style.id = 'svelte-3590263702-style';
 	style.textContent = "p[svelte-3590263702],[svelte-3590263702] p{color:red}";
-	appendNode( style, document.head );
+	appendNode(style, document.head);
 }
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( state.foo );
+			text = createText(state.foo);
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
+		hydrate: function(nodes) {
 			encapsulateStyles( p );
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.foo ) {
 				text.data = state.foo;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -227,31 +227,31 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
-	this._state = assign( template.data(), options.data );
+	this._state = assign(template.data(), options.data);
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	if ( !document.getElementById( 'svelte-3590263702-style' ) ) add_css();
+	if (!document.getElementById("svelte-3590263702-style")) add_css();
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -1,6 +1,6 @@
 import { appendNode, assign, createElement, createText, detachNode, insertNode, noop, proto, setAttribute } from "svelte/shared.js";
 
-var template = (function () {
+var template = (function() {
 	return {
 		data: function () {
 			return { foo: 42 }
@@ -8,43 +8,43 @@ var template = (function () {
 	};
 }());
 
-function encapsulateStyles ( node ) {
-	setAttribute( node, 'svelte-3590263702', '' );
+function encapsulateStyles(node) {
+	setAttribute(node, "svelte-3590263702", "");
 }
 
-function add_css () {
-	var style = createElement( 'style' );
+function add_css() {
+	var style = createElement("style");
 	style.id = 'svelte-3590263702-style';
 	style.textContent = "p[svelte-3590263702],[svelte-3590263702] p{color:red}";
-	appendNode( style, document.head );
+	appendNode(style, document.head);
 }
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( state.foo );
+			text = createText(state.foo);
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
+		hydrate: function(nodes) {
 			encapsulateStyles( p );
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.foo ) {
 				text.data = state.foo;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -52,31 +52,31 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
-	this._state = assign( template.data(), options.data );
+	this._state = assign(template.data(), options.data);
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	if ( !document.getElementById( 'svelte-3590263702-style' ) ) add_css();
+	if (!document.getElementById("svelte-3590263702-style")) add_css();
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/computed-collapsed-if/expected-bundle.js
+++ b/test/js/samples/computed-collapsed-if/expected-bundle.js
@@ -151,7 +151,7 @@ var proto = {
 	_unmount: _unmount
 };
 
-var template = (function () {
+var template = (function() {
 	return {
 		computed: {
 			a: x => x * 2,
@@ -160,7 +160,7 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 
 	return {
 		create: noop,
@@ -175,36 +175,36 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
-	this._recompute( {}, this._state, {}, true );
+	this._recompute({}, this._state, {}, true);
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._recompute = function _recompute ( changed, state, oldState, isInitial ) {
+SvelteComponent.prototype._recompute = function _recompute(changed, state, oldState, isInitial) {
 	if ( isInitial || changed.x ) {
-		if ( differs( ( state.a = template.computed.a( state.x ) ), oldState.a ) ) changed.a = true;
-		if ( differs( ( state.b = template.computed.b( state.x ) ), oldState.b ) ) changed.b = true;
+		if (differs((state.a = template.computed.a(state.x)), oldState.a)) changed.a = true;
+		if (differs((state.b = template.computed.b(state.x)), oldState.b)) changed.b = true;
 	}
 };
 

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -1,6 +1,6 @@
 import { assign, differs, noop, proto } from "svelte/shared.js";
 
-var template = (function () {
+var template = (function() {
 	return {
 		computed: {
 			a: x => x * 2,
@@ -9,7 +9,7 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 
 	return {
 		create: noop,
@@ -24,36 +24,36 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
-	this._recompute( {}, this._state, {}, true );
+	this._recompute({}, this._state, {}, true);
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
-SvelteComponent.prototype._recompute = function _recompute ( changed, state, oldState, isInitial ) {
+SvelteComponent.prototype._recompute = function _recompute(changed, state, oldState, isInitial) {
 	if ( isInitial || changed.x ) {
-		if ( differs( ( state.a = template.computed.a( state.x ) ), oldState.a ) ) changed.a = true;
-		if ( differs( ( state.b = template.computed.b( state.x ) ), oldState.b ) ) changed.b = true;
+		if (differs((state.a = template.computed.a(state.x)), oldState.a)) changed.a = true;
+		if (differs((state.b = template.computed.b(state.x)), oldState.b)) changed.b = true;
 	}
 }
 

--- a/test/js/samples/css-media-query/expected-bundle.js
+++ b/test/js/samples/css-media-query/expected-bundle.js
@@ -171,37 +171,37 @@ var proto = {
 	_unmount: _unmount
 };
 
-function encapsulateStyles ( node ) {
-	setAttribute( node, 'svelte-2363328337', '' );
+function encapsulateStyles(node) {
+	setAttribute(node, "svelte-2363328337", "");
 }
 
-function add_css () {
-	var style = createElement( 'style' );
+function add_css() {
+	var style = createElement("style");
 	style.id = 'svelte-2363328337-style';
 	style.textContent = "@media(min-width: 1px){div[svelte-2363328337],[svelte-2363328337] div{color:red}}";
-	appendNode( style, document.head );
+	appendNode(style, document.head);
 }
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
+		hydrate: function(nodes) {
 			encapsulateStyles( div );
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -209,31 +209,31 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	if ( !document.getElementById( 'svelte-2363328337-style' ) ) add_css();
+	if (!document.getElementById("svelte-2363328337-style")) add_css();
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -1,36 +1,36 @@
 import { appendNode, assign, createElement, detachNode, insertNode, noop, proto, setAttribute } from "svelte/shared.js";
 
-function encapsulateStyles ( node ) {
-	setAttribute( node, 'svelte-2363328337', '' );
+function encapsulateStyles(node) {
+	setAttribute(node, "svelte-2363328337", "");
 }
 
-function add_css () {
-	var style = createElement( 'style' );
+function add_css() {
+	var style = createElement("style");
 	style.id = 'svelte-2363328337-style';
 	style.textContent = "@media(min-width: 1px){div[svelte-2363328337],[svelte-2363328337] div{color:red}}";
-	appendNode( style, document.head );
+	appendNode(style, document.head);
 }
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
+		hydrate: function(nodes) {
 			encapsulateStyles( div );
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -38,31 +38,31 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	if ( !document.getElementById( 'svelte-2363328337-style' ) ) add_css();
+	if (!document.getElementById("svelte-2363328337-style")) add_css();
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/custom-element-basic/expected-bundle.js
+++ b/test/js/samples/custom-element-basic/expected-bundle.js
@@ -171,31 +171,31 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var h1, text, text_1, text_2;
 
 	return {
-		create: function () {
+		create: function() {
 			h1 = createElement( 'h1' );
-			text = createText( "Hello " );
-			text_1 = createText( state.name );
-			text_2 = createText( "!" );
+			text = createText("Hello ");
+			text_1 = createText(state.name);
+			text_2 = createText("!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( h1, target, anchor );
-			appendNode( text, h1 );
-			appendNode( text_1, h1 );
-			appendNode( text_2, h1 );
+			appendNode(text, h1);
+			appendNode(text_1, h1);
+			appendNode(text_2, h1);
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.name ) {
 				text_1.data = state.name;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( h1 );
 		},
 
@@ -210,11 +210,11 @@ class SvelteComponent extends HTMLElement {
 		this._state = options.data || {};
 
 		this._observers = {
-			pre: Object.create( null ),
-			post: Object.create( null )
+			pre: Object.create(null),
+			post: Object.create(null)
 		};
 
-		this._handlers = Object.create( null );
+		this._handlers = Object.create(null);
 
 		this._root = options._root || this;
 		this._yield = options._yield;
@@ -222,11 +222,11 @@ class SvelteComponent extends HTMLElement {
 
 		this.attachShadow({ mode: 'open' });
 
-		this._fragment = create_main_fragment( this._state, this );
+		this._fragment = create_main_fragment(this._state, this);
 
-		if ( options.target ) {
+		if (options.target) {
 			this._fragment.create();
-			this._mount( options.target, options.anchor || null );
+			this._mount(options.target, options.anchor || null);
 		}
 	}
 
@@ -242,13 +242,13 @@ class SvelteComponent extends HTMLElement {
 		this.set({ name: value });
 	}
 
-	attributeChangedCallback ( attr, oldValue, newValue ) {
+	attributeChangedCallback(attr, oldValue, newValue) {
 		this.set({ [attr]: newValue });
 	}
 }
 
-customElements.define('custom-element', SvelteComponent);
-assign( SvelteComponent.prototype, proto , {
+customElements.define("custom-element", SvelteComponent);
+assign(SvelteComponent.prototype, proto , {
 	_mount(target, anchor) {
 		this._fragment.mount(this.shadowRoot, null);
 		target.insertBefore(this, anchor);

--- a/test/js/samples/custom-element-basic/expected.js
+++ b/test/js/samples/custom-element-basic/expected.js
@@ -1,30 +1,30 @@
 import { appendNode, assign, createElement, createText, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var h1, text, text_1, text_2;
 
 	return {
-		create: function () {
+		create: function() {
 			h1 = createElement( 'h1' );
-			text = createText( "Hello " );
-			text_1 = createText( state.name );
-			text_2 = createText( "!" );
+			text = createText("Hello ");
+			text_1 = createText(state.name);
+			text_2 = createText("!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( h1, target, anchor );
-			appendNode( text, h1 );
-			appendNode( text_1, h1 );
-			appendNode( text_2, h1 );
+			appendNode(text, h1);
+			appendNode(text_1, h1);
+			appendNode(text_2, h1);
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.name ) {
 				text_1.data = state.name;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( h1 );
 		},
 
@@ -39,11 +39,11 @@ class SvelteComponent extends HTMLElement {
 		this._state = options.data || {};
 
 		this._observers = {
-			pre: Object.create( null ),
-			post: Object.create( null )
+			pre: Object.create(null),
+			post: Object.create(null)
 		};
 
-		this._handlers = Object.create( null );
+		this._handlers = Object.create(null);
 
 		this._root = options._root || this;
 		this._yield = options._yield;
@@ -51,11 +51,11 @@ class SvelteComponent extends HTMLElement {
 
 		this.attachShadow({ mode: 'open' });
 
-		this._fragment = create_main_fragment( this._state, this );
+		this._fragment = create_main_fragment(this._state, this);
 
-		if ( options.target ) {
+		if (options.target) {
 			this._fragment.create();
-			this._mount( options.target, options.anchor || null );
+			this._mount(options.target, options.anchor || null);
 		}
 	}
 
@@ -71,13 +71,13 @@ class SvelteComponent extends HTMLElement {
 		this.set({ name: value });
 	}
 
-	attributeChangedCallback ( attr, oldValue, newValue ) {
+	attributeChangedCallback(attr, oldValue, newValue) {
 		this.set({ [attr]: newValue });
 	}
 }
 
-customElements.define('custom-element', SvelteComponent);
-assign( SvelteComponent.prototype, proto , {
+customElements.define("custom-element", SvelteComponent);
+assign(SvelteComponent.prototype, proto , {
 	_mount(target, anchor) {
 		this._fragment.mount(this.shadowRoot, null);
 		target.insertBefore(this, anchor);

--- a/test/js/samples/custom-element-slot/expected-bundle.js
+++ b/test/js/samples/custom-element-slot/expected-bundle.js
@@ -175,40 +175,40 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div, slot, p, text, text_2, slot_1, p_1, text_3;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			slot = createElement( 'slot' );
 			p = createElement( 'p' );
-			text = createText( "default fallback content" );
-			text_2 = createText( "\n\n\t" );
+			text = createText("default fallback content");
+			text_2 = createText("\n\n\t");
 			slot_1 = createElement( 'slot' );
 			p_1 = createElement( 'p' );
-			text_3 = createText( "foo fallback content" );
+			text_3 = createText("foo fallback content");
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setAttribute( slot_1, 'name', "foo" );
+		hydrate: function(nodes) {
+			setAttribute(slot_1, "name", "foo");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 			appendNode( slot, div );
 			appendNode( p, slot );
-			appendNode( text, p );
-			appendNode( text_2, div );
+			appendNode(text, p);
+			appendNode(text_2, div);
 			appendNode( slot_1, div );
 			appendNode( p_1, slot_1 );
-			appendNode( text_3, p_1 );
+			appendNode(text_3, p_1);
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -223,11 +223,11 @@ class SvelteComponent extends HTMLElement {
 		this._state = options.data || {};
 
 		this._observers = {
-			pre: Object.create( null ),
-			post: Object.create( null )
+			pre: Object.create(null),
+			post: Object.create(null)
 		};
 
-		this._handlers = Object.create( null );
+		this._handlers = Object.create(null);
 
 		this._root = options._root || this;
 		this._yield = options._yield;
@@ -238,11 +238,11 @@ class SvelteComponent extends HTMLElement {
 
 		this.slots = {};
 
-		this._fragment = create_main_fragment( this._state, this );
+		this._fragment = create_main_fragment(this._state, this);
 
-		if ( options.target ) {
+		if (options.target) {
 			this._fragment.create();
-			this._mount( options.target, options.anchor || null );
+			this._mount(options.target, options.anchor || null);
 		}
 	}
 
@@ -258,13 +258,13 @@ class SvelteComponent extends HTMLElement {
 		});
 	}
 
-	attributeChangedCallback ( attr, oldValue, newValue ) {
+	attributeChangedCallback(attr, oldValue, newValue) {
 		this.set({ [attr]: newValue });
 	}
 }
 
-customElements.define('custom-element', SvelteComponent);
-assign( SvelteComponent.prototype, proto , {
+customElements.define("custom-element", SvelteComponent);
+assign(SvelteComponent.prototype, proto , {
 	_mount(target, anchor) {
 		this._fragment.mount(this.shadowRoot, null);
 		target.insertBefore(this, anchor);

--- a/test/js/samples/custom-element-slot/expected.js
+++ b/test/js/samples/custom-element-slot/expected.js
@@ -1,39 +1,39 @@
 import { appendNode, assign, createElement, createText, detachNode, insertNode, noop, proto, setAttribute } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div, slot, p, text, text_2, slot_1, p_1, text_3;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			slot = createElement( 'slot' );
 			p = createElement( 'p' );
-			text = createText( "default fallback content" );
-			text_2 = createText( "\n\n\t" );
+			text = createText("default fallback content");
+			text_2 = createText("\n\n\t");
 			slot_1 = createElement( 'slot' );
 			p_1 = createElement( 'p' );
-			text_3 = createText( "foo fallback content" );
+			text_3 = createText("foo fallback content");
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setAttribute( slot_1, 'name', "foo" );
+		hydrate: function(nodes) {
+			setAttribute(slot_1, "name", "foo");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 			appendNode( slot, div );
 			appendNode( p, slot );
-			appendNode( text, p );
-			appendNode( text_2, div );
+			appendNode(text, p);
+			appendNode(text_2, div);
 			appendNode( slot_1, div );
 			appendNode( p_1, slot_1 );
-			appendNode( text_3, p_1 );
+			appendNode(text_3, p_1);
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -48,11 +48,11 @@ class SvelteComponent extends HTMLElement {
 		this._state = options.data || {};
 
 		this._observers = {
-			pre: Object.create( null ),
-			post: Object.create( null )
+			pre: Object.create(null),
+			post: Object.create(null)
 		};
 
-		this._handlers = Object.create( null );
+		this._handlers = Object.create(null);
 
 		this._root = options._root || this;
 		this._yield = options._yield;
@@ -63,11 +63,11 @@ class SvelteComponent extends HTMLElement {
 
 		this.slots = {};
 
-		this._fragment = create_main_fragment( this._state, this );
+		this._fragment = create_main_fragment(this._state, this);
 
-		if ( options.target ) {
+		if (options.target) {
 			this._fragment.create();
-			this._mount( options.target, options.anchor || null );
+			this._mount(options.target, options.anchor || null);
 		}
 	}
 
@@ -83,13 +83,13 @@ class SvelteComponent extends HTMLElement {
 		});
 	}
 
-	attributeChangedCallback ( attr, oldValue, newValue ) {
+	attributeChangedCallback(attr, oldValue, newValue) {
 		this.set({ [attr]: newValue });
 	}
 }
 
-customElements.define('custom-element', SvelteComponent);
-assign( SvelteComponent.prototype, proto , {
+customElements.define("custom-element", SvelteComponent);
+assign(SvelteComponent.prototype, proto , {
 	_mount(target, anchor) {
 		this._fragment.mount(this.shadowRoot, null);
 		target.insertBefore(this, anchor);

--- a/test/js/samples/custom-element-styled/expected-bundle.js
+++ b/test/js/samples/custom-element-styled/expected-bundle.js
@@ -171,31 +171,31 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var h1, text, text_1, text_2;
 
 	return {
-		create: function () {
+		create: function() {
 			h1 = createElement( 'h1' );
-			text = createText( "Hello " );
-			text_1 = createText( state.name );
-			text_2 = createText( "!" );
+			text = createText("Hello ");
+			text_1 = createText(state.name);
+			text_2 = createText("!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( h1, target, anchor );
-			appendNode( text, h1 );
-			appendNode( text_1, h1 );
-			appendNode( text_2, h1 );
+			appendNode(text, h1);
+			appendNode(text_1, h1);
+			appendNode(text_2, h1);
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.name ) {
 				text_1.data = state.name;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( h1 );
 		},
 
@@ -210,11 +210,11 @@ class SvelteComponent extends HTMLElement {
 		this._state = options.data || {};
 
 		this._observers = {
-			pre: Object.create( null ),
-			post: Object.create( null )
+			pre: Object.create(null),
+			post: Object.create(null)
 		};
 
-		this._handlers = Object.create( null );
+		this._handlers = Object.create(null);
 
 		this._root = options._root || this;
 		this._yield = options._yield;
@@ -223,11 +223,11 @@ class SvelteComponent extends HTMLElement {
 		this.attachShadow({ mode: 'open' });
 		this.shadowRoot.innerHTML = `<style>h1{color:red}</style>`;
 
-		this._fragment = create_main_fragment( this._state, this );
+		this._fragment = create_main_fragment(this._state, this);
 
-		if ( options.target ) {
+		if (options.target) {
 			this._fragment.create();
-			this._mount( options.target, options.anchor || null );
+			this._mount(options.target, options.anchor || null);
 		}
 	}
 
@@ -243,13 +243,13 @@ class SvelteComponent extends HTMLElement {
 		this.set({ name: value });
 	}
 
-	attributeChangedCallback ( attr, oldValue, newValue ) {
+	attributeChangedCallback(attr, oldValue, newValue) {
 		this.set({ [attr]: newValue });
 	}
 }
 
-customElements.define('custom-element', SvelteComponent);
-assign( SvelteComponent.prototype, proto , {
+customElements.define("custom-element", SvelteComponent);
+assign(SvelteComponent.prototype, proto , {
 	_mount(target, anchor) {
 		this._fragment.mount(this.shadowRoot, null);
 		target.insertBefore(this, anchor);

--- a/test/js/samples/custom-element-styled/expected.js
+++ b/test/js/samples/custom-element-styled/expected.js
@@ -1,30 +1,30 @@
 import { appendNode, assign, createElement, createText, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var h1, text, text_1, text_2;
 
 	return {
-		create: function () {
+		create: function() {
 			h1 = createElement( 'h1' );
-			text = createText( "Hello " );
-			text_1 = createText( state.name );
-			text_2 = createText( "!" );
+			text = createText("Hello ");
+			text_1 = createText(state.name);
+			text_2 = createText("!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( h1, target, anchor );
-			appendNode( text, h1 );
-			appendNode( text_1, h1 );
-			appendNode( text_2, h1 );
+			appendNode(text, h1);
+			appendNode(text_1, h1);
+			appendNode(text_2, h1);
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.name ) {
 				text_1.data = state.name;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( h1 );
 		},
 
@@ -39,11 +39,11 @@ class SvelteComponent extends HTMLElement {
 		this._state = options.data || {};
 
 		this._observers = {
-			pre: Object.create( null ),
-			post: Object.create( null )
+			pre: Object.create(null),
+			post: Object.create(null)
 		};
 
-		this._handlers = Object.create( null );
+		this._handlers = Object.create(null);
 
 		this._root = options._root || this;
 		this._yield = options._yield;
@@ -52,11 +52,11 @@ class SvelteComponent extends HTMLElement {
 		this.attachShadow({ mode: 'open' });
 		this.shadowRoot.innerHTML = `<style>h1{color:red}</style>`;
 
-		this._fragment = create_main_fragment( this._state, this );
+		this._fragment = create_main_fragment(this._state, this);
 
-		if ( options.target ) {
+		if (options.target) {
 			this._fragment.create();
-			this._mount( options.target, options.anchor || null );
+			this._mount(options.target, options.anchor || null);
 		}
 	}
 
@@ -72,13 +72,13 @@ class SvelteComponent extends HTMLElement {
 		this.set({ name: value });
 	}
 
-	attributeChangedCallback ( attr, oldValue, newValue ) {
+	attributeChangedCallback(attr, oldValue, newValue) {
 		this.set({ [attr]: newValue });
 	}
 }
 
-customElements.define('custom-element', SvelteComponent);
-assign( SvelteComponent.prototype, proto , {
+customElements.define("custom-element", SvelteComponent);
+assign(SvelteComponent.prototype, proto , {
 	_mount(target, anchor) {
 		this._fragment.mount(this.shadowRoot, null);
 		target.insertBefore(this, anchor);

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -184,53 +184,53 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var text, p, text_1;
 
 	var each_block_value = state.comments;
 
 	var each_block_iterations = [];
 
-	for ( var i = 0; i < each_block_value.length; i += 1 ) {
-		each_block_iterations[i] = create_each_block( state, each_block_value, each_block_value[i], i, component );
+	for (var i = 0; i < each_block_value.length; i += 1) {
+		each_block_iterations[i] = create_each_block(state, each_block_value, each_block_value[i], i, component);
 	}
 
 	return {
-		create: function () {
-			for ( var i = 0; i < each_block_iterations.length; i += 1 ) {
+		create: function() {
+			for (var i = 0; i < each_block_iterations.length; i += 1) {
 				each_block_iterations[i].create();
 			}
 
-			text = createText( "\n\n" );
+			text = createText("\n\n");
 			p = createElement( 'p' );
-			text_1 = createText( state.foo );
+			text_1 = createText(state.foo);
 		},
 
-		mount: function ( target, anchor ) {
-			for ( var i = 0; i < each_block_iterations.length; i += 1 ) {
-				each_block_iterations[i].mount( target, anchor );
+		mount: function(target, anchor) {
+			for (var i = 0; i < each_block_iterations.length; i += 1) {
+				each_block_iterations[i].mount(target, anchor);
 			}
 
-			insertNode( text, target, anchor );
+			insertNode(text, target, anchor);
 			insertNode( p, target, anchor );
-			appendNode( text_1, p );
+			appendNode(text_1, p);
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			var each_block_value = state.comments;
 
-			if ( changed.comments || changed.elapsed || changed.time ) {
-				for ( var i = 0; i < each_block_value.length; i += 1 ) {
-					if ( each_block_iterations[i] ) {
-						each_block_iterations[i].update( changed, state, each_block_value, each_block_value[i], i );
+			if (changed.comments || changed.elapsed || changed.time) {
+				for (var i = 0; i < each_block_value.length; i += 1) {
+					if (each_block_iterations[i]) {
+						each_block_iterations[i].update(changed, state, each_block_value, each_block_value[i], i);
 					} else {
-						each_block_iterations[i] = create_each_block( state, each_block_value, each_block_value[i], i, component );
+						each_block_iterations[i] = create_each_block(state, each_block_value, each_block_value[i], i, component);
 						each_block_iterations[i].create();
-						each_block_iterations[i].mount( text.parentNode, text );
+						each_block_iterations[i].mount(text.parentNode, text);
 					}
 				}
 
-				for ( ; i < each_block_iterations.length; i += 1 ) {
+				for (; i < each_block_iterations.length; i += 1) {
 					each_block_iterations[i].unmount();
 					each_block_iterations[i].destroy();
 				}
@@ -242,76 +242,76 @@ function create_main_fragment ( state, component ) {
 			}
 		},
 
-		unmount: function () {
-			for ( var i = 0; i < each_block_iterations.length; i += 1 ) {
+		unmount: function() {
+			for (var i = 0; i < each_block_iterations.length; i += 1) {
 				each_block_iterations[i].unmount();
 			}
 
-			detachNode( text );
+			detachNode(text);
 			detachNode( p );
 		},
 
-		destroy: function () {
-			destroyEach( each_block_iterations, false, 0 );
+		destroy: function() {
+			destroyEach(each_block_iterations, false, 0);
 		}
 	};
 }
 
-function create_each_block ( state, each_block_value, comment, i, component ) {
+function create_each_block(state, each_block_value, comment, i, component) {
 	var div, strong, text, text_1, span, text_2_value = comment.author, text_2, text_3, text_4_value = state.elapsed(comment.time, state.time), text_4, text_5, text_6, raw_value = comment.html, raw_before;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			strong = createElement( 'strong' );
-			text = createText( i );
-			text_1 = createText( "\n\n\t\t" );
+			text = createText(i);
+			text_1 = createText("\n\n\t\t");
 			span = createElement( 'span' );
-			text_2 = createText( text_2_value );
-			text_3 = createText( " wrote " );
-			text_4 = createText( text_4_value );
-			text_5 = createText( " ago:" );
-			text_6 = createText( "\n\n\t\t" );
-			raw_before = createElement( 'noscript' );
+			text_2 = createText(text_2_value);
+			text_3 = createText(" wrote ");
+			text_4 = createText(text_4_value);
+			text_5 = createText(" ago:");
+			text_6 = createText("\n\n\t\t");
+			raw_before = createElement('noscript');
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
+		hydrate: function(nodes) {
 			div.className = "comment";
 			span.className = "meta";
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 			appendNode( strong, div );
-			appendNode( text, strong );
-			appendNode( text_1, div );
+			appendNode(text, strong);
+			appendNode(text_1, div);
 			appendNode( span, div );
-			appendNode( text_2, span );
-			appendNode( text_3, span );
-			appendNode( text_4, span );
-			appendNode( text_5, span );
-			appendNode( text_6, div );
-			appendNode( raw_before, div );
-			raw_before.insertAdjacentHTML('afterend', raw_value);
+			appendNode(text_2, span);
+			appendNode(text_3, span);
+			appendNode(text_4, span);
+			appendNode(text_5, span);
+			appendNode(text_6, div);
+			appendNode(raw_before, div);
+			raw_before.insertAdjacentHTML("afterend", raw_value);
 		},
 
-		update: function ( changed, state, each_block_value, comment, i ) {
-			if ( ( changed.comments ) && text_2_value !== ( text_2_value = comment.author ) ) {
+		update: function(changed, state, each_block_value, comment, i) {
+			if ( (changed.comments) && text_2_value !== (text_2_value = comment.author) ) {
 				text_2.data = text_2_value;
 			}
 
-			if ( ( changed.elapsed || changed.comments || changed.time ) && text_4_value !== ( text_4_value = state.elapsed(comment.time, state.time) ) ) {
+			if ( (changed.elapsed || changed.comments || changed.time) && text_4_value !== (text_4_value = state.elapsed(comment.time, state.time)) ) {
 				text_4.data = text_4_value;
 			}
 
-			if ( ( changed.comments ) && raw_value !== ( raw_value = comment.html ) ) {
+			if ( (changed.comments) && raw_value !== (raw_value = comment.html) ) {
 				detachAfter(raw_before);
-				raw_before.insertAdjacentHTML('afterend', raw_value);
+				raw_before.insertAdjacentHTML("afterend", raw_value);
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachAfter(raw_before);
 
 			detachNode( div );
@@ -321,29 +321,29 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -1,52 +1,52 @@
 import { appendNode, assign, createElement, createText, destroyEach, detachAfter, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var text, p, text_1;
 
 	var each_block_value = state.comments;
 
 	var each_block_iterations = [];
 
-	for ( var i = 0; i < each_block_value.length; i += 1 ) {
-		each_block_iterations[i] = create_each_block( state, each_block_value, each_block_value[i], i, component );
+	for (var i = 0; i < each_block_value.length; i += 1) {
+		each_block_iterations[i] = create_each_block(state, each_block_value, each_block_value[i], i, component);
 	}
 
 	return {
-		create: function () {
-			for ( var i = 0; i < each_block_iterations.length; i += 1 ) {
+		create: function() {
+			for (var i = 0; i < each_block_iterations.length; i += 1) {
 				each_block_iterations[i].create();
 			}
 
-			text = createText( "\n\n" );
+			text = createText("\n\n");
 			p = createElement( 'p' );
-			text_1 = createText( state.foo );
+			text_1 = createText(state.foo);
 		},
 
-		mount: function ( target, anchor ) {
-			for ( var i = 0; i < each_block_iterations.length; i += 1 ) {
-				each_block_iterations[i].mount( target, anchor );
+		mount: function(target, anchor) {
+			for (var i = 0; i < each_block_iterations.length; i += 1) {
+				each_block_iterations[i].mount(target, anchor);
 			}
 
-			insertNode( text, target, anchor );
+			insertNode(text, target, anchor);
 			insertNode( p, target, anchor );
-			appendNode( text_1, p );
+			appendNode(text_1, p);
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			var each_block_value = state.comments;
 
-			if ( changed.comments || changed.elapsed || changed.time ) {
-				for ( var i = 0; i < each_block_value.length; i += 1 ) {
-					if ( each_block_iterations[i] ) {
-						each_block_iterations[i].update( changed, state, each_block_value, each_block_value[i], i );
+			if (changed.comments || changed.elapsed || changed.time) {
+				for (var i = 0; i < each_block_value.length; i += 1) {
+					if (each_block_iterations[i]) {
+						each_block_iterations[i].update(changed, state, each_block_value, each_block_value[i], i);
 					} else {
-						each_block_iterations[i] = create_each_block( state, each_block_value, each_block_value[i], i, component );
+						each_block_iterations[i] = create_each_block(state, each_block_value, each_block_value[i], i, component);
 						each_block_iterations[i].create();
-						each_block_iterations[i].mount( text.parentNode, text );
+						each_block_iterations[i].mount(text.parentNode, text);
 					}
 				}
 
-				for ( ; i < each_block_iterations.length; i += 1 ) {
+				for (; i < each_block_iterations.length; i += 1) {
 					each_block_iterations[i].unmount();
 					each_block_iterations[i].destroy();
 				}
@@ -58,76 +58,76 @@ function create_main_fragment ( state, component ) {
 			}
 		},
 
-		unmount: function () {
-			for ( var i = 0; i < each_block_iterations.length; i += 1 ) {
+		unmount: function() {
+			for (var i = 0; i < each_block_iterations.length; i += 1) {
 				each_block_iterations[i].unmount();
 			}
 
-			detachNode( text );
+			detachNode(text);
 			detachNode( p );
 		},
 
-		destroy: function () {
-			destroyEach( each_block_iterations, false, 0 );
+		destroy: function() {
+			destroyEach(each_block_iterations, false, 0);
 		}
 	};
 }
 
-function create_each_block ( state, each_block_value, comment, i, component ) {
+function create_each_block(state, each_block_value, comment, i, component) {
 	var div, strong, text, text_1, span, text_2_value = comment.author, text_2, text_3, text_4_value = state.elapsed(comment.time, state.time), text_4, text_5, text_6, raw_value = comment.html, raw_before;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			strong = createElement( 'strong' );
-			text = createText( i );
-			text_1 = createText( "\n\n\t\t" );
+			text = createText(i);
+			text_1 = createText("\n\n\t\t");
 			span = createElement( 'span' );
-			text_2 = createText( text_2_value );
-			text_3 = createText( " wrote " );
-			text_4 = createText( text_4_value );
-			text_5 = createText( " ago:" );
-			text_6 = createText( "\n\n\t\t" );
-			raw_before = createElement( 'noscript' );
+			text_2 = createText(text_2_value);
+			text_3 = createText(" wrote ");
+			text_4 = createText(text_4_value);
+			text_5 = createText(" ago:");
+			text_6 = createText("\n\n\t\t");
+			raw_before = createElement('noscript');
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
+		hydrate: function(nodes) {
 			div.className = "comment";
 			span.className = "meta";
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 			appendNode( strong, div );
-			appendNode( text, strong );
-			appendNode( text_1, div );
+			appendNode(text, strong);
+			appendNode(text_1, div);
 			appendNode( span, div );
-			appendNode( text_2, span );
-			appendNode( text_3, span );
-			appendNode( text_4, span );
-			appendNode( text_5, span );
-			appendNode( text_6, div );
-			appendNode( raw_before, div );
-			raw_before.insertAdjacentHTML('afterend', raw_value);
+			appendNode(text_2, span);
+			appendNode(text_3, span);
+			appendNode(text_4, span);
+			appendNode(text_5, span);
+			appendNode(text_6, div);
+			appendNode(raw_before, div);
+			raw_before.insertAdjacentHTML("afterend", raw_value);
 		},
 
-		update: function ( changed, state, each_block_value, comment, i ) {
-			if ( ( changed.comments ) && text_2_value !== ( text_2_value = comment.author ) ) {
+		update: function(changed, state, each_block_value, comment, i) {
+			if ( (changed.comments) && text_2_value !== (text_2_value = comment.author) ) {
 				text_2.data = text_2_value;
 			}
 
-			if ( ( changed.elapsed || changed.comments || changed.time ) && text_4_value !== ( text_4_value = state.elapsed(comment.time, state.time) ) ) {
+			if ( (changed.elapsed || changed.comments || changed.time) && text_4_value !== (text_4_value = state.elapsed(comment.time, state.time)) ) {
 				text_4.data = text_4_value;
 			}
 
-			if ( ( changed.comments ) && raw_value !== ( raw_value = comment.html ) ) {
+			if ( (changed.comments) && raw_value !== (raw_value = comment.html) ) {
 				detachAfter(raw_before);
-				raw_before.insertAdjacentHTML('afterend', raw_value);
+				raw_before.insertAdjacentHTML("afterend", raw_value);
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachAfter(raw_before);
 
 			detachNode( div );
@@ -137,29 +137,29 @@ function create_each_block ( state, each_block_value, comment, i, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -171,7 +171,7 @@ var proto = {
 	_unmount: _unmount
 };
 
-var template = (function () {
+var template = (function() {
 	return {
 		methods: {
 			foo ( bar ) {
@@ -186,63 +186,63 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var button, foo_handler, text;
 
 	return {
-		create: function () {
+		create: function() {
 			button = createElement( 'button' );
-			text = createText( "foo" );
+			text = createText("foo");
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			foo_handler = template.events.foo.call( component, button, function ( event ) {
+		hydrate: function(nodes) {
+			foo_handler = template.events.foo.call(component, button, function(event) {
 				var state = component.get();
 				component.foo( state.bar );
 			});
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( button, target, anchor );
-			appendNode( text, button );
+			appendNode(text, button);
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( button );
 		},
 
-		destroy: function () {
+		destroy: function() {
 			foo_handler.teardown();
 		}
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, template.methods, proto );
+assign(SvelteComponent.prototype, template.methods, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -1,6 +1,6 @@
 import { appendNode, assign, createElement, createText, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-var template = (function () {
+var template = (function() {
 	return {
 		methods: {
 			foo ( bar ) {
@@ -15,63 +15,63 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var button, foo_handler, text;
 
 	return {
-		create: function () {
+		create: function() {
 			button = createElement( 'button' );
-			text = createText( "foo" );
+			text = createText("foo");
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			foo_handler = template.events.foo.call( component, button, function ( event ) {
+		hydrate: function(nodes) {
+			foo_handler = template.events.foo.call(component, button, function(event) {
 				var state = component.get();
 				component.foo( state.bar );
 			});
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( button, target, anchor );
-			appendNode( text, button );
+			appendNode(text, button);
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( button );
 		},
 
-		destroy: function () {
+		destroy: function() {
 			foo_handler.teardown();
 		}
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, template.methods, proto );
+assign(SvelteComponent.prototype, template.methods, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/if-block-no-update/expected-bundle.js
+++ b/test/js/samples/if-block-no-update/expected-bundle.js
@@ -175,59 +175,59 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var if_block_anchor;
 
-	var current_block_type = select_block_type( state );
-	var if_block = current_block_type( state, component );
+	var current_block_type = select_block_type(state);
+	var if_block = current_block_type(state, component);
 
 	return {
-		create: function () {
+		create: function() {
 			if_block.create();
 			if_block_anchor = createComment();
 		},
 
-		mount: function ( target, anchor ) {
-			if_block.mount( target, anchor );
-			insertNode( if_block_anchor, target, anchor );
+		mount: function(target, anchor) {
+			if_block.mount(target, anchor);
+			insertNode(if_block_anchor, target, anchor);
 		},
 
-		update: function ( changed, state ) {
-			if ( current_block_type !== ( current_block_type = select_block_type( state ) ) ) {
+		update: function(changed, state) {
+			if (current_block_type !== (current_block_type = select_block_type(state))) {
 				if_block.unmount();
 				if_block.destroy();
-				if_block = current_block_type( state, component );
+				if_block = current_block_type(state, component);
 				if_block.create();
-				if_block.mount( if_block_anchor.parentNode, if_block_anchor );
+				if_block.mount(if_block_anchor.parentNode, if_block_anchor);
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			if_block.unmount();
-			detachNode( if_block_anchor );
+			detachNode(if_block_anchor);
 		},
 
-		destroy: function () {
+		destroy: function() {
 			if_block.destroy();
 		}
 	};
 }
 
-function create_if_block ( state, component ) {
+function create_if_block(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "foo!" );
+			text = createText("foo!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -235,21 +235,21 @@ function create_if_block ( state, component ) {
 	};
 }
 
-function create_if_block_1 ( state, component ) {
+function create_if_block_1(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "not foo!" );
+			text = createText("not foo!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -257,34 +257,34 @@ function create_if_block_1 ( state, component ) {
 	};
 }
 
-function select_block_type ( state ) {
-	if ( state.foo ) return create_if_block;
+function select_block_type(state) {
+	if (state.foo) return create_if_block;
 	return create_if_block_1;
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -1,58 +1,58 @@
 import { appendNode, assign, createComment, createElement, createText, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var if_block_anchor;
 
-	var current_block_type = select_block_type( state );
-	var if_block = current_block_type( state, component );
+	var current_block_type = select_block_type(state);
+	var if_block = current_block_type(state, component);
 
 	return {
-		create: function () {
+		create: function() {
 			if_block.create();
 			if_block_anchor = createComment();
 		},
 
-		mount: function ( target, anchor ) {
-			if_block.mount( target, anchor );
-			insertNode( if_block_anchor, target, anchor );
+		mount: function(target, anchor) {
+			if_block.mount(target, anchor);
+			insertNode(if_block_anchor, target, anchor);
 		},
 
-		update: function ( changed, state ) {
-			if ( current_block_type !== ( current_block_type = select_block_type( state ) ) ) {
+		update: function(changed, state) {
+			if (current_block_type !== (current_block_type = select_block_type(state))) {
 				if_block.unmount();
 				if_block.destroy();
-				if_block = current_block_type( state, component );
+				if_block = current_block_type(state, component);
 				if_block.create();
-				if_block.mount( if_block_anchor.parentNode, if_block_anchor );
+				if_block.mount(if_block_anchor.parentNode, if_block_anchor);
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			if_block.unmount();
-			detachNode( if_block_anchor );
+			detachNode(if_block_anchor);
 		},
 
-		destroy: function () {
+		destroy: function() {
 			if_block.destroy();
 		}
 	};
 }
 
-function create_if_block ( state, component ) {
+function create_if_block(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "foo!" );
+			text = createText("foo!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -60,21 +60,21 @@ function create_if_block ( state, component ) {
 	};
 }
 
-function create_if_block_1 ( state, component ) {
+function create_if_block_1(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "not foo!" );
+			text = createText("not foo!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -82,34 +82,34 @@ function create_if_block_1 ( state, component ) {
 	};
 }
 
-function select_block_type ( state ) {
-	if ( state.foo ) return create_if_block;
+function select_block_type(state) {
+	if (state.foo) return create_if_block;
 	return create_if_block_1;
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/if-block-simple/expected-bundle.js
+++ b/test/js/samples/if-block-simple/expected-bundle.js
@@ -175,62 +175,62 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var if_block_anchor;
 
-	var if_block = (state.foo) && create_if_block( state, component );
+	var if_block = (state.foo) && create_if_block(state, component);
 
 	return {
-		create: function () {
-			if ( if_block ) if_block.create();
+		create: function() {
+			if (if_block) if_block.create();
 			if_block_anchor = createComment();
 		},
 
-		mount: function ( target, anchor ) {
-			if ( if_block ) if_block.mount( target, anchor );
-			insertNode( if_block_anchor, target, anchor );
+		mount: function(target, anchor) {
+			if (if_block) if_block.mount(target, anchor);
+			insertNode(if_block_anchor, target, anchor);
 		},
 
-		update: function ( changed, state ) {
-			if ( state.foo ) {
-				if ( !if_block ) {
-					if_block = create_if_block( state, component );
+		update: function(changed, state) {
+			if (state.foo) {
+				if (!if_block) {
+					if_block = create_if_block(state, component);
 					if_block.create();
-					if_block.mount( if_block_anchor.parentNode, if_block_anchor );
+					if_block.mount(if_block_anchor.parentNode, if_block_anchor);
 				}
-			} else if ( if_block ) {
+			} else if (if_block) {
 				if_block.unmount();
 				if_block.destroy();
 				if_block = null;
 			}
 		},
 
-		unmount: function () {
-			if ( if_block ) if_block.unmount();
-			detachNode( if_block_anchor );
+		unmount: function() {
+			if (if_block) if_block.unmount();
+			detachNode(if_block_anchor);
 		},
 
-		destroy: function () {
-			if ( if_block ) if_block.destroy();
+		destroy: function() {
+			if (if_block) if_block.destroy();
 		}
 	};
 }
 
-function create_if_block ( state, component ) {
+function create_if_block(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "foo!" );
+			text = createText("foo!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -238,29 +238,29 @@ function create_if_block ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -1,61 +1,61 @@
 import { appendNode, assign, createComment, createElement, createText, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var if_block_anchor;
 
-	var if_block = (state.foo) && create_if_block( state, component );
+	var if_block = (state.foo) && create_if_block(state, component);
 
 	return {
-		create: function () {
-			if ( if_block ) if_block.create();
+		create: function() {
+			if (if_block) if_block.create();
 			if_block_anchor = createComment();
 		},
 
-		mount: function ( target, anchor ) {
-			if ( if_block ) if_block.mount( target, anchor );
-			insertNode( if_block_anchor, target, anchor );
+		mount: function(target, anchor) {
+			if (if_block) if_block.mount(target, anchor);
+			insertNode(if_block_anchor, target, anchor);
 		},
 
-		update: function ( changed, state ) {
-			if ( state.foo ) {
-				if ( !if_block ) {
-					if_block = create_if_block( state, component );
+		update: function(changed, state) {
+			if (state.foo) {
+				if (!if_block) {
+					if_block = create_if_block(state, component);
 					if_block.create();
-					if_block.mount( if_block_anchor.parentNode, if_block_anchor );
+					if_block.mount(if_block_anchor.parentNode, if_block_anchor);
 				}
-			} else if ( if_block ) {
+			} else if (if_block) {
 				if_block.unmount();
 				if_block.destroy();
 				if_block = null;
 			}
 		},
 
-		unmount: function () {
-			if ( if_block ) if_block.unmount();
-			detachNode( if_block_anchor );
+		unmount: function() {
+			if (if_block) if_block.unmount();
+			detachNode(if_block_anchor);
 		},
 
-		destroy: function () {
-			if ( if_block ) if_block.destroy();
+		destroy: function() {
+			if (if_block) if_block.destroy();
 		}
 	};
 }
 
-function create_if_block ( state, component ) {
+function create_if_block(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "foo!" );
+			text = createText("foo!");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -63,29 +63,29 @@ function create_if_block ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
@@ -167,35 +167,35 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setStyle(div, 'color', state.color);
-			setStyle(div, 'transform', "translate(" + state.x + "px," + state.y + "px)");
+		hydrate: function(nodes) {
+			setStyle(div, "color", state.color);
+			setStyle(div, "transform", "translate(" + state.x + "px," + state.y + "px)");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.color ) {
-				setStyle(div, 'color', state.color);
+				setStyle(div, "color", state.color);
 			}
 
 			if ( changed.x || changed.y ) {
-				setStyle(div, 'transform', "translate(" + state.x + "px," + state.y + "px)");
+				setStyle(div, "transform", "translate(" + state.x + "px," + state.y + "px)");
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -203,29 +203,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -1,34 +1,34 @@
 import { assign, createElement, detachNode, insertNode, noop, proto, setStyle } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setStyle(div, 'color', state.color);
-			setStyle(div, 'transform', "translate(" + state.x + "px," + state.y + "px)");
+		hydrate: function(nodes) {
+			setStyle(div, "color", state.color);
+			setStyle(div, "transform", "translate(" + state.x + "px," + state.y + "px)");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.color ) {
-				setStyle(div, 'color', state.color);
+				setStyle(div, "color", state.color);
 			}
 
 			if ( changed.x || changed.y ) {
-				setStyle(div, 'transform', "translate(" + state.x + "px," + state.y + "px)");
+				setStyle(div, "transform", "translate(" + state.x + "px," + state.y + "px)");
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -36,29 +36,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/inline-style-optimized-url/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-url/expected-bundle.js
@@ -167,30 +167,30 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setStyle(div, 'background', "url(data:image/png;base64," + state.data + ")");
+		hydrate: function(nodes) {
+			setStyle(div, "background", "url(data:image/png;base64," + state.data + ")");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.data ) {
-				setStyle(div, 'background', "url(data:image/png;base64," + state.data + ")");
+				setStyle(div, "background", "url(data:image/png;base64," + state.data + ")");
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -198,29 +198,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -1,29 +1,29 @@
 import { assign, createElement, detachNode, insertNode, noop, proto, setStyle } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setStyle(div, 'background', "url(data:image/png;base64," + state.data + ")");
+		hydrate: function(nodes) {
+			setStyle(div, "background", "url(data:image/png;base64," + state.data + ")");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.data ) {
-				setStyle(div, 'background', "url(data:image/png;base64," + state.data + ")");
+				setStyle(div, "background", "url(data:image/png;base64," + state.data + ")");
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -31,29 +31,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/inline-style-optimized/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized/expected-bundle.js
@@ -167,30 +167,30 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setStyle(div, 'color', state.color);
+		hydrate: function(nodes) {
+			setStyle(div, "color", state.color);
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.color ) {
-				setStyle(div, 'color', state.color);
+				setStyle(div, "color", state.color);
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -198,29 +198,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -1,29 +1,29 @@
 import { assign, createElement, detachNode, insertNode, noop, proto, setStyle } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setStyle(div, 'color', state.color);
+		hydrate: function(nodes) {
+			setStyle(div, "color", state.color);
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.color ) {
-				setStyle(div, 'color', state.color);
+				setStyle(div, "color", state.color);
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
 		},
 
@@ -31,29 +31,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/inline-style-unoptimized/expected-bundle.js
+++ b/test/js/samples/inline-style-unoptimized/expected-bundle.js
@@ -167,41 +167,41 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div, text, div_1, div_1_style_value;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
-			text = createText( "\n" );
+			text = createText("\n");
 			div_1 = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
+		hydrate: function(nodes) {
 			div.style.cssText = state.style;
-			div_1.style.cssText = div_1_style_value = "" + ( state.key ) + ": " + ( state.value );
+			div_1.style.cssText = div_1_style_value = "" + state.key + ": " + state.value;
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
-			insertNode( text, target, anchor );
+			insertNode(text, target, anchor);
 			insertNode( div_1, target, anchor );
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.style ) {
 				div.style.cssText = state.style;
 			}
 
-			if ( ( changed.key || changed.value ) && div_1_style_value !== ( div_1_style_value = "" + ( state.key ) + ": " + ( state.value ) ) ) {
+			if ( (changed.key || changed.value) && div_1_style_value !== (div_1_style_value = "" + state.key + ": " + state.value) ) {
 				div_1.style.cssText = div_1_style_value;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
-			detachNode( text );
+			detachNode(text);
 			detachNode( div_1 );
 		},
 
@@ -209,29 +209,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -1,40 +1,40 @@
 import { assign, createElement, createText, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div, text, div_1, div_1_style_value;
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
-			text = createText( "\n" );
+			text = createText("\n");
 			div_1 = createElement( 'div' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
+		hydrate: function(nodes) {
 			div.style.cssText = state.style;
-			div_1.style.cssText = div_1_style_value = "" + ( state.key ) + ": " + ( state.value );
+			div_1.style.cssText = div_1_style_value = "" + state.key + ": " + state.value;
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
-			insertNode( text, target, anchor );
+			insertNode(text, target, anchor);
 			insertNode( div_1, target, anchor );
 		},
 
-		update: function ( changed, state ) {
+		update: function(changed, state) {
 			if ( changed.style ) {
 				div.style.cssText = state.style;
 			}
 
-			if ( ( changed.key || changed.value ) && div_1_style_value !== ( div_1_style_value = "" + ( state.key ) + ": " + ( state.value ) ) ) {
+			if ( (changed.key || changed.value) && div_1_style_value !== (div_1_style_value = "" + state.key + ": " + state.value) ) {
 				div_1.style.cssText = div_1_style_value;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
-			detachNode( text );
+			detachNode(text);
 			detachNode( div_1 );
 		},
 
@@ -42,29 +42,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/legacy-input-type/expected-bundle.js
+++ b/test/js/samples/legacy-input-type/expected-bundle.js
@@ -169,26 +169,26 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var input;
 
 	return {
-		create: function () {
+		create: function() {
 			input = createElement( 'input' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setInputType( input, "search" );
+		hydrate: function(nodes) {
+			setInputType(input, "search");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( input, target, anchor );
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( input );
 		},
 
@@ -196,29 +196,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/legacy-input-type/expected.js
+++ b/test/js/samples/legacy-input-type/expected.js
@@ -1,25 +1,25 @@
 import { assign, createElement, detachNode, insertNode, noop, proto, setInputType } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var input;
 
 	return {
-		create: function () {
+		create: function() {
 			input = createElement( 'input' );
 			this.hydrate();
 		},
 
-		hydrate: function ( nodes ) {
-			setInputType( input, "search" );
+		hydrate: function(nodes) {
+			setInputType(input, "search");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( input, target, anchor );
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( input );
 		},
 
@@ -27,29 +27,29 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -165,7 +165,7 @@ var proto = {
 	_unmount: _unmount
 };
 
-var template = (function () {
+var template = (function() {
 	return {
 		components: {
 			NonImported
@@ -173,7 +173,7 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var text;
 
 	var imported = new Imported({
@@ -185,59 +185,59 @@ function create_main_fragment ( state, component ) {
 	});
 
 	return {
-		create: function () {
+		create: function() {
 			imported._fragment.create();
-			text = createText( "\n" );
+			text = createText("\n");
 			nonimported._fragment.create();
 		},
 
-		mount: function ( target, anchor ) {
-			imported._mount( target, anchor );
-			insertNode( text, target, anchor );
-			nonimported._mount( target, anchor );
+		mount: function(target, anchor) {
+			imported._mount(target, anchor);
+			insertNode(text, target, anchor);
+			nonimported._mount(target, anchor);
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			imported._unmount();
-			detachNode( text );
+			detachNode(text);
 			nonimported._unmount();
 		},
 
-		destroy: function () {
-			imported.destroy( false );
-			nonimported.destroy( false );
+		destroy: function() {
+			imported.destroy(false);
+			nonimported.destroy(false);
 		}
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	if ( !options._root ) {
+	if (!options._root) {
 		this._oncreate = [];
 		this._beforecreate = [];
 		this._aftercreate = [];
 	}
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 
 		this._lock = true;
 		callAll(this._beforecreate);
@@ -247,6 +247,6 @@ function SvelteComponent ( options ) {
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -2,7 +2,7 @@ import Imported from 'Imported.html';
 
 import { assign, callAll, createText, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-var template = (function () {
+var template = (function() {
 	return {
 		components: {
 			NonImported
@@ -10,7 +10,7 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var text;
 
 	var imported = new Imported({
@@ -22,59 +22,59 @@ function create_main_fragment ( state, component ) {
 	});
 
 	return {
-		create: function () {
+		create: function() {
 			imported._fragment.create();
-			text = createText( "\n" );
+			text = createText("\n");
 			nonimported._fragment.create();
 		},
 
-		mount: function ( target, anchor ) {
-			imported._mount( target, anchor );
-			insertNode( text, target, anchor );
-			nonimported._mount( target, anchor );
+		mount: function(target, anchor) {
+			imported._mount(target, anchor);
+			insertNode(text, target, anchor);
+			nonimported._mount(target, anchor);
 		},
 
 		update: noop,
 
-		unmount: function () {
+		unmount: function() {
 			imported._unmount();
-			detachNode( text );
+			detachNode(text);
 			nonimported._unmount();
 		},
 
-		destroy: function () {
-			imported.destroy( false );
-			nonimported.destroy( false );
+		destroy: function() {
+			imported.destroy(false);
+			nonimported.destroy(false);
 		}
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	if ( !options._root ) {
+	if (!options._root) {
 		this._oncreate = [];
 		this._beforecreate = [];
 		this._aftercreate = [];
 	}
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 
 		this._lock = true;
 		callAll(this._beforecreate);
@@ -84,6 +84,6 @@ function SvelteComponent ( options ) {
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
@@ -151,7 +151,7 @@ var proto = {
 	_unmount: _unmount
 };
 
-var template = (function () {
+var template = (function() {
 	return {
 		// this test should be removed in v2
 		oncreate () {},
@@ -159,7 +159,7 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 
 	return {
 		create: noop,
@@ -174,40 +174,40 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 	this._handlers.destroy = [template.ondestroy];
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	var oncreate = template.oncreate.bind( this );
+	var oncreate = template.oncreate.bind(this);
 
-	if ( !options._root ) {
+	if (!options._root) {
 		this._oncreate = [oncreate];
 	} else {
 	 	this._root._oncreate.push(oncreate);
 	 }
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 
 		callAll(this._oncreate);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/onrender-onteardown-rewritten/expected.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected.js
@@ -1,6 +1,6 @@
 import { assign, callAll, noop, proto } from "svelte/shared.js";
 
-var template = (function () {
+var template = (function() {
 	return {
 		// this test should be removed in v2
 		oncreate () {},
@@ -8,7 +8,7 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 
 	return {
 		create: noop,
@@ -23,40 +23,40 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 	this._handlers.destroy = [template.ondestroy]
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	var oncreate = template.oncreate.bind( this );
+	var oncreate = template.oncreate.bind(this);
 
-	if ( !options._root ) {
+	if (!options._root) {
 		this._oncreate = [oncreate];
 	} else {
 	 	this._root._oncreate.push(oncreate);
 	 }
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 
 		callAll(this._oncreate);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/setup-method/expected-bundle.js
+++ b/test/js/samples/setup-method/expected-bundle.js
@@ -151,7 +151,7 @@ var proto = {
 	_unmount: _unmount
 };
 
-var template = (function () {
+var template = (function() {
 	return {
 		methods: {
 			foo ( bar ) {
@@ -170,7 +170,7 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 
 	return {
 		create: noop,
@@ -185,31 +185,31 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, template.methods, proto );
+assign(SvelteComponent.prototype, template.methods, proto );
 
-template.setup( SvelteComponent );
+template.setup(SvelteComponent);
 
 export default SvelteComponent;

--- a/test/js/samples/setup-method/expected.js
+++ b/test/js/samples/setup-method/expected.js
@@ -1,6 +1,6 @@
 import { assign, noop, proto } from "svelte/shared.js";
 
-var template = (function () {
+var template = (function() {
 	return {
 		methods: {
 			foo ( bar ) {
@@ -19,7 +19,7 @@ var template = (function () {
 	};
 }());
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 
 	return {
 		create: noop,
@@ -34,31 +34,31 @@ function create_main_fragment ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, template.methods, proto );
+assign(SvelteComponent.prototype, template.methods, proto );
 
-template.setup( SvelteComponent );
+template.setup(SvelteComponent);
 
 export default SvelteComponent;

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -175,158 +175,158 @@ var proto = {
 	_unmount: _unmount
 };
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div, text, p, text_1, text_2, text_3, text_4, p_1, text_5, text_6, text_8, if_block_4_anchor;
 
-	var if_block = (state.a) && create_if_block( state, component );
+	var if_block = (state.a) && create_if_block(state, component);
 
-	var if_block_1 = (state.b) && create_if_block_1( state, component );
+	var if_block_1 = (state.b) && create_if_block_1(state, component);
 
-	var if_block_2 = (state.c) && create_if_block_2( state, component );
+	var if_block_2 = (state.c) && create_if_block_2(state, component);
 
-	var if_block_3 = (state.d) && create_if_block_3( state, component );
+	var if_block_3 = (state.d) && create_if_block_3(state, component);
 
-	var if_block_4 = (state.e) && create_if_block_4( state, component );
+	var if_block_4 = (state.e) && create_if_block_4(state, component);
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
-			if ( if_block ) if_block.create();
-			text = createText( "\n\n\t" );
+			if (if_block) if_block.create();
+			text = createText("\n\n\t");
 			p = createElement( 'p' );
-			text_1 = createText( "this can be used as an anchor" );
-			text_2 = createText( "\n\n\t" );
-			if ( if_block_1 ) if_block_1.create();
-			text_3 = createText( "\n\n\t" );
-			if ( if_block_2 ) if_block_2.create();
-			text_4 = createText( "\n\n\t" );
+			text_1 = createText("this can be used as an anchor");
+			text_2 = createText("\n\n\t");
+			if (if_block_1) if_block_1.create();
+			text_3 = createText("\n\n\t");
+			if (if_block_2) if_block_2.create();
+			text_4 = createText("\n\n\t");
 			p_1 = createElement( 'p' );
-			text_5 = createText( "so can this" );
-			text_6 = createText( "\n\n\t" );
-			if ( if_block_3 ) if_block_3.create();
-			text_8 = createText( "\n\n" );
-			if ( if_block_4 ) if_block_4.create();
+			text_5 = createText("so can this");
+			text_6 = createText("\n\n\t");
+			if (if_block_3) if_block_3.create();
+			text_8 = createText("\n\n");
+			if (if_block_4) if_block_4.create();
 			if_block_4_anchor = createComment();
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
-			if ( if_block ) if_block.mount( div, null );
-			appendNode( text, div );
+			if (if_block) if_block.mount(div, null);
+			appendNode(text, div);
 			appendNode( p, div );
-			appendNode( text_1, p );
-			appendNode( text_2, div );
-			if ( if_block_1 ) if_block_1.mount( div, null );
-			appendNode( text_3, div );
-			if ( if_block_2 ) if_block_2.mount( div, null );
-			appendNode( text_4, div );
+			appendNode(text_1, p);
+			appendNode(text_2, div);
+			if (if_block_1) if_block_1.mount(div, null);
+			appendNode(text_3, div);
+			if (if_block_2) if_block_2.mount(div, null);
+			appendNode(text_4, div);
 			appendNode( p_1, div );
-			appendNode( text_5, p_1 );
-			appendNode( text_6, div );
-			if ( if_block_3 ) if_block_3.mount( div, null );
-			insertNode( text_8, target, anchor );
-			if ( if_block_4 ) if_block_4.mount( target, anchor );
-			insertNode( if_block_4_anchor, target, anchor );
+			appendNode(text_5, p_1);
+			appendNode(text_6, div);
+			if (if_block_3) if_block_3.mount(div, null);
+			insertNode(text_8, target, anchor);
+			if (if_block_4) if_block_4.mount(target, anchor);
+			insertNode(if_block_4_anchor, target, anchor);
 		},
 
-		update: function ( changed, state ) {
-			if ( state.a ) {
-				if ( !if_block ) {
-					if_block = create_if_block( state, component );
+		update: function(changed, state) {
+			if (state.a) {
+				if (!if_block) {
+					if_block = create_if_block(state, component);
 					if_block.create();
-					if_block.mount( div, text );
+					if_block.mount(div, text);
 				}
-			} else if ( if_block ) {
+			} else if (if_block) {
 				if_block.unmount();
 				if_block.destroy();
 				if_block = null;
 			}
 
-			if ( state.b ) {
-				if ( !if_block_1 ) {
-					if_block_1 = create_if_block_1( state, component );
+			if (state.b) {
+				if (!if_block_1) {
+					if_block_1 = create_if_block_1(state, component);
 					if_block_1.create();
-					if_block_1.mount( div, text_3 );
+					if_block_1.mount(div, text_3);
 				}
-			} else if ( if_block_1 ) {
+			} else if (if_block_1) {
 				if_block_1.unmount();
 				if_block_1.destroy();
 				if_block_1 = null;
 			}
 
-			if ( state.c ) {
-				if ( !if_block_2 ) {
-					if_block_2 = create_if_block_2( state, component );
+			if (state.c) {
+				if (!if_block_2) {
+					if_block_2 = create_if_block_2(state, component);
 					if_block_2.create();
-					if_block_2.mount( div, text_4 );
+					if_block_2.mount(div, text_4);
 				}
-			} else if ( if_block_2 ) {
+			} else if (if_block_2) {
 				if_block_2.unmount();
 				if_block_2.destroy();
 				if_block_2 = null;
 			}
 
-			if ( state.d ) {
-				if ( !if_block_3 ) {
-					if_block_3 = create_if_block_3( state, component );
+			if (state.d) {
+				if (!if_block_3) {
+					if_block_3 = create_if_block_3(state, component);
 					if_block_3.create();
-					if_block_3.mount( div, null );
+					if_block_3.mount(div, null);
 				}
-			} else if ( if_block_3 ) {
+			} else if (if_block_3) {
 				if_block_3.unmount();
 				if_block_3.destroy();
 				if_block_3 = null;
 			}
 
-			if ( state.e ) {
-				if ( !if_block_4 ) {
-					if_block_4 = create_if_block_4( state, component );
+			if (state.e) {
+				if (!if_block_4) {
+					if_block_4 = create_if_block_4(state, component);
 					if_block_4.create();
-					if_block_4.mount( if_block_4_anchor.parentNode, if_block_4_anchor );
+					if_block_4.mount(if_block_4_anchor.parentNode, if_block_4_anchor);
 				}
-			} else if ( if_block_4 ) {
+			} else if (if_block_4) {
 				if_block_4.unmount();
 				if_block_4.destroy();
 				if_block_4 = null;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
-			if ( if_block ) if_block.unmount();
-			if ( if_block_1 ) if_block_1.unmount();
-			if ( if_block_2 ) if_block_2.unmount();
-			if ( if_block_3 ) if_block_3.unmount();
-			detachNode( text_8 );
-			if ( if_block_4 ) if_block_4.unmount();
-			detachNode( if_block_4_anchor );
+			if (if_block) if_block.unmount();
+			if (if_block_1) if_block_1.unmount();
+			if (if_block_2) if_block_2.unmount();
+			if (if_block_3) if_block_3.unmount();
+			detachNode(text_8);
+			if (if_block_4) if_block_4.unmount();
+			detachNode(if_block_4_anchor);
 		},
 
-		destroy: function () {
-			if ( if_block ) if_block.destroy();
-			if ( if_block_1 ) if_block_1.destroy();
-			if ( if_block_2 ) if_block_2.destroy();
-			if ( if_block_3 ) if_block_3.destroy();
-			if ( if_block_4 ) if_block_4.destroy();
+		destroy: function() {
+			if (if_block) if_block.destroy();
+			if (if_block_1) if_block_1.destroy();
+			if (if_block_2) if_block_2.destroy();
+			if (if_block_3) if_block_3.destroy();
+			if (if_block_4) if_block_4.destroy();
 		}
 	};
 }
 
-function create_if_block ( state, component ) {
+function create_if_block(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "a" );
+			text = createText("a");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -334,21 +334,21 @@ function create_if_block ( state, component ) {
 	};
 }
 
-function create_if_block_1 ( state, component ) {
+function create_if_block_1(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "b" );
+			text = createText("b");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -356,21 +356,21 @@ function create_if_block_1 ( state, component ) {
 	};
 }
 
-function create_if_block_2 ( state, component ) {
+function create_if_block_2(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "c" );
+			text = createText("c");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -378,21 +378,21 @@ function create_if_block_2 ( state, component ) {
 	};
 }
 
-function create_if_block_3 ( state, component ) {
+function create_if_block_3(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "d" );
+			text = createText("d");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -400,21 +400,21 @@ function create_if_block_3 ( state, component ) {
 	};
 }
 
-function create_if_block_4 ( state, component ) {
+function create_if_block_4(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "e" );
+			text = createText("e");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -422,29 +422,29 @@ function create_if_block_4 ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -1,157 +1,157 @@
 import { appendNode, assign, createComment, createElement, createText, detachNode, insertNode, noop, proto } from "svelte/shared.js";
 
-function create_main_fragment ( state, component ) {
+function create_main_fragment(state, component) {
 	var div, text, p, text_1, text_2, text_3, text_4, p_1, text_5, text_6, text_8, if_block_4_anchor;
 
-	var if_block = (state.a) && create_if_block( state, component );
+	var if_block = (state.a) && create_if_block(state, component);
 
-	var if_block_1 = (state.b) && create_if_block_1( state, component );
+	var if_block_1 = (state.b) && create_if_block_1(state, component);
 
-	var if_block_2 = (state.c) && create_if_block_2( state, component );
+	var if_block_2 = (state.c) && create_if_block_2(state, component);
 
-	var if_block_3 = (state.d) && create_if_block_3( state, component );
+	var if_block_3 = (state.d) && create_if_block_3(state, component);
 
-	var if_block_4 = (state.e) && create_if_block_4( state, component );
+	var if_block_4 = (state.e) && create_if_block_4(state, component);
 
 	return {
-		create: function () {
+		create: function() {
 			div = createElement( 'div' );
-			if ( if_block ) if_block.create();
-			text = createText( "\n\n\t" );
+			if (if_block) if_block.create();
+			text = createText("\n\n\t");
 			p = createElement( 'p' );
-			text_1 = createText( "this can be used as an anchor" );
-			text_2 = createText( "\n\n\t" );
-			if ( if_block_1 ) if_block_1.create();
-			text_3 = createText( "\n\n\t" );
-			if ( if_block_2 ) if_block_2.create();
-			text_4 = createText( "\n\n\t" );
+			text_1 = createText("this can be used as an anchor");
+			text_2 = createText("\n\n\t");
+			if (if_block_1) if_block_1.create();
+			text_3 = createText("\n\n\t");
+			if (if_block_2) if_block_2.create();
+			text_4 = createText("\n\n\t");
 			p_1 = createElement( 'p' );
-			text_5 = createText( "so can this" );
-			text_6 = createText( "\n\n\t" );
-			if ( if_block_3 ) if_block_3.create();
-			text_8 = createText( "\n\n" );
-			if ( if_block_4 ) if_block_4.create();
+			text_5 = createText("so can this");
+			text_6 = createText("\n\n\t");
+			if (if_block_3) if_block_3.create();
+			text_8 = createText("\n\n");
+			if (if_block_4) if_block_4.create();
 			if_block_4_anchor = createComment();
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( div, target, anchor );
-			if ( if_block ) if_block.mount( div, null );
-			appendNode( text, div );
+			if (if_block) if_block.mount(div, null);
+			appendNode(text, div);
 			appendNode( p, div );
-			appendNode( text_1, p );
-			appendNode( text_2, div );
-			if ( if_block_1 ) if_block_1.mount( div, null );
-			appendNode( text_3, div );
-			if ( if_block_2 ) if_block_2.mount( div, null );
-			appendNode( text_4, div );
+			appendNode(text_1, p);
+			appendNode(text_2, div);
+			if (if_block_1) if_block_1.mount(div, null);
+			appendNode(text_3, div);
+			if (if_block_2) if_block_2.mount(div, null);
+			appendNode(text_4, div);
 			appendNode( p_1, div );
-			appendNode( text_5, p_1 );
-			appendNode( text_6, div );
-			if ( if_block_3 ) if_block_3.mount( div, null );
-			insertNode( text_8, target, anchor );
-			if ( if_block_4 ) if_block_4.mount( target, anchor );
-			insertNode( if_block_4_anchor, target, anchor );
+			appendNode(text_5, p_1);
+			appendNode(text_6, div);
+			if (if_block_3) if_block_3.mount(div, null);
+			insertNode(text_8, target, anchor);
+			if (if_block_4) if_block_4.mount(target, anchor);
+			insertNode(if_block_4_anchor, target, anchor);
 		},
 
-		update: function ( changed, state ) {
-			if ( state.a ) {
-				if ( !if_block ) {
-					if_block = create_if_block( state, component );
+		update: function(changed, state) {
+			if (state.a) {
+				if (!if_block) {
+					if_block = create_if_block(state, component);
 					if_block.create();
-					if_block.mount( div, text );
+					if_block.mount(div, text);
 				}
-			} else if ( if_block ) {
+			} else if (if_block) {
 				if_block.unmount();
 				if_block.destroy();
 				if_block = null;
 			}
 
-			if ( state.b ) {
-				if ( !if_block_1 ) {
-					if_block_1 = create_if_block_1( state, component );
+			if (state.b) {
+				if (!if_block_1) {
+					if_block_1 = create_if_block_1(state, component);
 					if_block_1.create();
-					if_block_1.mount( div, text_3 );
+					if_block_1.mount(div, text_3);
 				}
-			} else if ( if_block_1 ) {
+			} else if (if_block_1) {
 				if_block_1.unmount();
 				if_block_1.destroy();
 				if_block_1 = null;
 			}
 
-			if ( state.c ) {
-				if ( !if_block_2 ) {
-					if_block_2 = create_if_block_2( state, component );
+			if (state.c) {
+				if (!if_block_2) {
+					if_block_2 = create_if_block_2(state, component);
 					if_block_2.create();
-					if_block_2.mount( div, text_4 );
+					if_block_2.mount(div, text_4);
 				}
-			} else if ( if_block_2 ) {
+			} else if (if_block_2) {
 				if_block_2.unmount();
 				if_block_2.destroy();
 				if_block_2 = null;
 			}
 
-			if ( state.d ) {
-				if ( !if_block_3 ) {
-					if_block_3 = create_if_block_3( state, component );
+			if (state.d) {
+				if (!if_block_3) {
+					if_block_3 = create_if_block_3(state, component);
 					if_block_3.create();
-					if_block_3.mount( div, null );
+					if_block_3.mount(div, null);
 				}
-			} else if ( if_block_3 ) {
+			} else if (if_block_3) {
 				if_block_3.unmount();
 				if_block_3.destroy();
 				if_block_3 = null;
 			}
 
-			if ( state.e ) {
-				if ( !if_block_4 ) {
-					if_block_4 = create_if_block_4( state, component );
+			if (state.e) {
+				if (!if_block_4) {
+					if_block_4 = create_if_block_4(state, component);
 					if_block_4.create();
-					if_block_4.mount( if_block_4_anchor.parentNode, if_block_4_anchor );
+					if_block_4.mount(if_block_4_anchor.parentNode, if_block_4_anchor);
 				}
-			} else if ( if_block_4 ) {
+			} else if (if_block_4) {
 				if_block_4.unmount();
 				if_block_4.destroy();
 				if_block_4 = null;
 			}
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( div );
-			if ( if_block ) if_block.unmount();
-			if ( if_block_1 ) if_block_1.unmount();
-			if ( if_block_2 ) if_block_2.unmount();
-			if ( if_block_3 ) if_block_3.unmount();
-			detachNode( text_8 );
-			if ( if_block_4 ) if_block_4.unmount();
-			detachNode( if_block_4_anchor );
+			if (if_block) if_block.unmount();
+			if (if_block_1) if_block_1.unmount();
+			if (if_block_2) if_block_2.unmount();
+			if (if_block_3) if_block_3.unmount();
+			detachNode(text_8);
+			if (if_block_4) if_block_4.unmount();
+			detachNode(if_block_4_anchor);
 		},
 
-		destroy: function () {
-			if ( if_block ) if_block.destroy();
-			if ( if_block_1 ) if_block_1.destroy();
-			if ( if_block_2 ) if_block_2.destroy();
-			if ( if_block_3 ) if_block_3.destroy();
-			if ( if_block_4 ) if_block_4.destroy();
+		destroy: function() {
+			if (if_block) if_block.destroy();
+			if (if_block_1) if_block_1.destroy();
+			if (if_block_2) if_block_2.destroy();
+			if (if_block_3) if_block_3.destroy();
+			if (if_block_4) if_block_4.destroy();
 		}
 	};
 }
 
-function create_if_block ( state, component ) {
+function create_if_block(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "a" );
+			text = createText("a");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -159,21 +159,21 @@ function create_if_block ( state, component ) {
 	};
 }
 
-function create_if_block_1 ( state, component ) {
+function create_if_block_1(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "b" );
+			text = createText("b");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -181,21 +181,21 @@ function create_if_block_1 ( state, component ) {
 	};
 }
 
-function create_if_block_2 ( state, component ) {
+function create_if_block_2(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "c" );
+			text = createText("c");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -203,21 +203,21 @@ function create_if_block_2 ( state, component ) {
 	};
 }
 
-function create_if_block_3 ( state, component ) {
+function create_if_block_3(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "d" );
+			text = createText("d");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -225,21 +225,21 @@ function create_if_block_3 ( state, component ) {
 	};
 }
 
-function create_if_block_4 ( state, component ) {
+function create_if_block_4(state, component) {
 	var p, text;
 
 	return {
-		create: function () {
+		create: function() {
 			p = createElement( 'p' );
-			text = createText( "e" );
+			text = createText("e");
 		},
 
-		mount: function ( target, anchor ) {
+		mount: function(target, anchor) {
 			insertNode( p, target, anchor );
-			appendNode( text, p );
+			appendNode(text, p);
 		},
 
-		unmount: function () {
+		unmount: function() {
 			detachNode( p );
 		},
 
@@ -247,29 +247,29 @@ function create_if_block_4 ( state, component ) {
 	};
 }
 
-function SvelteComponent ( options ) {
+function SvelteComponent(options) {
 	this.options = options;
 	this._state = options.data || {};
 
 	this._observers = {
-		pre: Object.create( null ),
-		post: Object.create( null )
+		pre: Object.create(null),
+		post: Object.create(null)
 	};
 
-	this._handlers = Object.create( null );
+	this._handlers = Object.create(null);
 
 	this._root = options._root || this;
 	this._yield = options._yield;
 	this._bind = options._bind;
 
-	this._fragment = create_main_fragment( this._state, this );
+	this._fragment = create_main_fragment(this._state, this);
 
-	if ( options.target ) {
+	if (options.target) {
 		this._fragment.create();
-		this._fragment.mount( options.target, options.anchor || null );
+		this._fragment.mount(options.target, options.anchor || null);
 	}
 }
 
-assign( SvelteComponent.prototype, proto );
+assign(SvelteComponent.prototype, proto );
 
 export default SvelteComponent;


### PR DESCRIPTION
This is probably fairly low on the list of priorities, but it's an itch I've been wanting to scratch for a while. Having finally given up on jQuery style (thanks to Prettier), the code the compiler generates feels at odds with the code that generates it, and was starting to become slightly inconsistent.

All this PR amounts to is removing extraneous whitespace and being consistent about using double quotes for strings. Hopefully uncontroversial so I'll merge it straight in, lest it get in the way of other stuff