### PR TITLE
Make buffered/played/seekable attributes of media element bindable

### DIFF
--- a/src/validate/html/validateElement.ts
+++ b/src/validate/html/validateElement.ts
@@ -99,7 +99,10 @@ export default function validateElement(validator: Validator, node: Node, refs: 
 			} else if (
 				name === 'currentTime' ||
 				name === 'duration' ||
-				name === 'paused'
+				name === 'paused' ||
+				name === 'buffered' ||
+				name === 'seekable' ||
+				name === 'played'
 			) {
 				if (node.name !== 'audio' && node.name !== 'video') {
 					validator.error(


### PR DESCRIPTION
I need this for a little side project of mine.

It's hard to add tests as these three IDL attributes are readonly (the spec for testing the existing `currentTime` and `duration` attributes is skipped for that same reason), but happy to provide a REPL/gist example once it's merged.