### PR TITLE
feat(a11y): add warning missing lang on html tag

### DIFF
--- a/src/validate/html/a11y.ts
+++ b/src/validate/html/a11y.ts
@@ -143,6 +143,11 @@ export default function a11y(
 		shouldHaveAttribute(['title']);
 	}
 
+	// html-has-lang
+	if (node.name === 'html') {
+		shouldHaveAttribute(['lang']);
+	}
+
 	// no-distracting-elements
 	if (node.name === 'marquee' || node.name === 'blink') {
 		validator.warn(`A11y: Avoid <${node.name}> elements`, node.start);

--- a/test/validator/samples/a11y-html-has-lang/input.html
+++ b/test/validator/samples/a11y-html-has-lang/input.html
@@ -1,5 +1,5 @@
 <html lang="en"></html>
 <html lang="en-US"></html>
-<html lang={language}></html>
+<html lang={{language}}></html>
 
 <html></html>

--- a/test/validator/samples/a11y-html-has-lang/input.html
+++ b/test/validator/samples/a11y-html-has-lang/input.html
@@ -1,0 +1,5 @@
+<html lang="en"></html>
+<html lang="en-US"></html>
+<html lang={language}></html>
+
+<html></html>

--- a/test/validator/samples/a11y-html-has-lang/warnings.json
+++ b/test/validator/samples/a11y-html-has-lang/warnings.json
@@ -1,0 +1,10 @@
+[
+		{
+			"loc": {
+				"column": 0,
+				"line": 5
+			},
+			"message": "A11y: <html> element should have a lang attribute",
+			"pos": 82
+		}
+	]


### PR DESCRIPTION
Adding warning for a11y on html tag without lang attribute. 
Refers to #820.
