### PR TITLE
Update css-tree [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chalk": "^2.0.1",
     "codecov": "^2.2.0",
     "console-group": "^0.3.2",
-    "css-tree": "1.0.0-alpha16",
+    "css-tree": "1.0.0-alpha22",
     "eslint": "^4.3.0",
     "eslint-plugin-html": "^3.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/src/css/Selector.ts
+++ b/src/css/Selector.ts
@@ -160,7 +160,7 @@ function applySelector(blocks: Block[], node: Node, stack: Node[], toEncapsulate
 		}
 
 		else if (selector.type === 'AttributeSelector') {
-			if (!attributeMatches(node, selector.name.name, selector.value && unquote(selector.value), selector.operator, selector.flags)) return false;
+			if (!attributeMatches(node, selector.name.name, selector.value && unquote(selector.value), selector.matcher, selector.flags)) return false;
 		}
 
 		else if (selector.type === 'TypeSelector') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,10 +557,11 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
-css-tree@1.0.0-alpha16:
-  version "1.0.0-alpha16"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha16.tgz#6cb2cdff6947259dfdaf790626333a862de948b0"
+css-tree@1.0.0-alpha22:
+  version "1.0.0-alpha22"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha22.tgz#338a006e331c7b4f9dab7b6af539ece56ff78af2"
   dependencies:
+    mdn-data "^1.0.0"
     source-map "^0.5.3"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
@@ -1690,6 +1691,10 @@ md5-hex@^1.2.0:
 md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+
+mdn-data@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.0.0.tgz#a69d9da76847b4d5834c1465ea25c0653a1fbf66"
 
 mem@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
https://github.com/csstree/csstree/issues/47

This has apparently been addressed, and it looks like we can now import just the parser. (It looks like at some point between then and now we stopped using css-tree's walker and started using `estree-walker` for walking the AST?) This upgrade does increase the bundle size, but not as dramatically as alpha16 -> alpha17 would have.

I had to make one other change for a renamed property in order to get the tests to pass, but css-tree's changelog should be looked at more thoroughly.