### PR TITLE
compile time error on slotted content inside if/each blocks. closes #849

### DIFF
--- a/src/validate/html/index.ts
+++ b/src/validate/html/index.ts
@@ -11,6 +11,7 @@ const meta = new Map([[':Window', validateWindow]]);
 export default function validateHtml(validator: Validator, html: Node) {
 	const refs = new Map();
 	const refCallees: Node[] = [];
+	const stack: Node[] = [];
 	const elementStack: Node[] = [];
 
 	function visit(node: Node) {
@@ -21,7 +22,7 @@ export default function validateHtml(validator: Validator, html: Node) {
 				return meta.get(node.name)(validator, node, refs, refCallees);
 			}
 
-			validateElement(validator, node, refs, refCallees, elementStack);
+			validateElement(validator, node, refs, refCallees, stack, elementStack);
 		} else if (node.type === 'EachBlock') {
 			if (validator.helpers.has(node.context)) {
 				let c = node.expression.end;
@@ -40,7 +41,9 @@ export default function validateHtml(validator: Validator, html: Node) {
 
 		if (node.children) {
 			if (node.type === 'Element') elementStack.push(node);
+			stack.push(node);
 			node.children.forEach(visit);
+			stack.pop();
 			if (node.type === 'Element') elementStack.pop();
 		}
 

--- a/test/validator/samples/component-slotted-each-block/errors.json
+++ b/test/validator/samples/component-slotted-each-block/errors.json
@@ -1,0 +1,8 @@
+[{
+	"message": "Cannot place slotted elements inside an each-block",
+	"loc": {
+		"line": 3,
+		"column": 7
+	},
+	"pos": 43
+}]

--- a/test/validator/samples/component-slotted-each-block/input.html
+++ b/test/validator/samples/component-slotted-each-block/input.html
@@ -1,0 +1,15 @@
+<Nested>
+	{{#each things as thing}}
+		<div slot='foo'>{{thing}}</div>
+	{{/each}}
+</Nested>
+
+<script>
+	import Nested from './Nested.html';
+
+	export default {
+		components: {
+			Nested
+		}
+	};
+</script>

--- a/test/validator/samples/component-slotted-if-block/errors.json
+++ b/test/validator/samples/component-slotted-if-block/errors.json
@@ -1,0 +1,8 @@
+[{
+	"message": "Cannot place slotted elements inside an if-block",
+	"loc": {
+		"line": 3,
+		"column": 7
+	},
+	"pos": 31
+}]

--- a/test/validator/samples/component-slotted-if-block/input.html
+++ b/test/validator/samples/component-slotted-if-block/input.html
@@ -1,0 +1,15 @@
+<Nested>
+	{{#if thing}}
+		<div slot='foo'>{{thing}}</div>
+	{{/if}}
+</Nested>
+
+<script>
+	import Nested from './Nested.html';
+
+	export default {
+		components: {
+			Nested
+		}
+	};
+</script>


### PR DESCRIPTION
This closes #849. It doesn't *fix* it, it just causes a validation error to be thrown if `slot='foo'` is encountered inside an if or each block.

Maybe we could actually make that work in future, but going through it in my head just now it seemed like it would be rather complex. As @mrkishi says, it's relatively easy to work around.