### PR TITLE
allow console.* calls in event handlers

### DIFF
--- a/src/generators/dom/visitors/Element/EventHandler.ts
+++ b/src/generators/dom/visitors/Element/EventHandler.ts
@@ -1,5 +1,6 @@
 import deindent from '../../../../utils/deindent';
 import flattenReference from '../../../../utils/flattenReference';
+import validCalleeObjects from '../../../../utils/validCalleeObjects';
 import { DomGenerator } from '../../index';
 import Block from '../../Block';
 import { Node } from '../../../../interfaces';
@@ -23,7 +24,7 @@ export default function visitEventHandler(
 		generator.addSourcemapLocations(attribute.expression);
 
 		const flattened = flattenReference(attribute.expression.callee);
-		if (flattened.name !== 'event' && flattened.name !== 'this') {
+		if (!validCalleeObjects.has(flattened.name)) {
 			// allow event.stopPropagation(), this.select() etc
 			// TODO verify that it's a valid callee (i.e. built-in or declared method)
 			generator.code.prependRight(

--- a/src/utils/validCalleeObjects.ts
+++ b/src/utils/validCalleeObjects.ts
@@ -1,0 +1,3 @@
+const validCalleeObjects = new Set(['this', 'event', 'console']);
+
+export default validCalleeObjects;

--- a/src/validate/html/validateEventHandler.ts
+++ b/src/validate/html/validateEventHandler.ts
@@ -34,7 +34,7 @@ export default function validateEventHandlerCallee(
 	)
 		return;
 
-	const validCallees = ['this.*', 'event.*'].concat(
+	const validCallees = ['this.*', 'event.*', 'console.*'].concat(
 		Array.from(validBuiltins),
 		Array.from(validator.methods.keys())
 	);

--- a/src/validate/html/validateEventHandler.ts
+++ b/src/validate/html/validateEventHandler.ts
@@ -1,6 +1,7 @@
 import flattenReference from '../../utils/flattenReference';
 import list from '../utils/list';
 import { Validator } from '../index';
+import validCalleeObjects from '../../utils/validCalleeObjects';
 import { Node } from '../../interfaces';
 
 const validBuiltins = new Set(['set', 'fire', 'destroy']);
@@ -20,7 +21,7 @@ export default function validateEventHandlerCallee(
 
 	const { name } = flattenReference(callee);
 
-	if (name === 'this' || name === 'event') return;
+	if (validCalleeObjects.has(name)) return;
 
 	if (name === 'refs') {
 		refCallees.push(callee);

--- a/test/runtime/samples/event-handler-console-log/_config.js
+++ b/test/runtime/samples/event-handler-console-log/_config.js
@@ -1,0 +1,23 @@
+export default {
+	data: {
+		foo: 42
+	},
+
+	html: `
+		<button>click me</button>
+	`,
+
+	test (assert, component, target, window) {
+		const button = target.querySelector('button');
+		const event = new window.MouseEvent('click');
+
+		const messages = [];
+
+		const log = console.log;
+		console.log = msg => messages.push(msg);
+		button.dispatchEvent(event);
+		console.log = log;
+
+		assert.deepEqual(messages, [42]);
+	}
+};

--- a/test/runtime/samples/event-handler-console-log/main.html
+++ b/test/runtime/samples/event-handler-console-log/main.html
@@ -1,0 +1,1 @@
+<button on:click='console.log(foo)'>click me</button>

--- a/test/validator/samples/method-nonexistent-helper/warnings.json
+++ b/test/validator/samples/method-nonexistent-helper/warnings.json
@@ -1,5 +1,5 @@
 [{
-	"message": "'foo' is an invalid callee (should be one of this.*, event.*, set, fire, destroy or bar). 'foo' exists on 'helpers', did you put it in the wrong place?",
+	"message": "'foo' is an invalid callee (should be one of this.*, event.*, console.*, set, fire, destroy or bar). 'foo' exists on 'helpers', did you put it in the wrong place?",
 	"pos": 18,
 	"loc": {
 		"line": 1,

--- a/test/validator/samples/method-nonexistent/warnings.json
+++ b/test/validator/samples/method-nonexistent/warnings.json
@@ -1,5 +1,5 @@
 [{
-	"message": "'foo' is an invalid callee (should be one of this.*, event.*, set, fire, destroy or bar)",
+	"message": "'foo' is an invalid callee (should be one of this.*, event.*, console.*, set, fire, destroy or bar)",
 	"pos": 18,
 	"loc": {
 		"line": 1,

--- a/test/validator/samples/window-event-invalid/warnings.json
+++ b/test/validator/samples/window-event-invalid/warnings.json
@@ -1,5 +1,5 @@
 [{
-	"message": "'resize' is an invalid callee (should be one of this.*, event.*, set, fire or destroy)",
+	"message": "'resize' is an invalid callee (should be one of this.*, event.*, console.*, set, fire or destroy)",
 	"loc": {
 		"line": 1,
 		"column": 20


### PR DESCRIPTION
fixes #782. It does mean that `console` is a bit of a special case, though I personally think it's worth it as it's something I very often want when I'm debugging stuff. (If you disagree strongly, say so!)