### PR TITLE
upgrade prettier; use .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+useTabs: true
+singleQuote: true
+trailingComma: es5

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev": "node src/shared/_build.js && rollup -c -w",
     "pretest": "npm run build",
     "prepublishOnly": "npm run lint && npm test",
-    "prettier": "prettier --use-tabs --single-quote --trailing-comma es5 --write \"src/**/*.ts\""
+    "prettier": "prettier --write \"src/**/*.ts\""
   },
   "repository": {
     "type": "git",
@@ -59,7 +59,7 @@
     "nightmare": "^2.10.0",
     "node-resolve": "^1.3.3",
     "nyc": "^11.1.0",
-    "prettier": "^1.4.1",
+    "prettier": "^1.7.0",
     "rollup": "^0.48.2",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,8 +2310,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.4.1:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
 
 pretty-bytes@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
As of version 1.6.0, Prettier supports per-project configuration with a `.prettierrc` file. This is nice because you can now configure your editor of choice to format on save and you can have it use formatting rules specific to that project. I have my editor and a few projects set up this way, and it feels good. Configuring your editor to autoformat on save is also useful for actually maintaining the prettier'd code, because no one is going to take the time to run the npm script regularly.

One question is, for the things that have diverged from prettier's code style, whether it would be better to format them all now as part of this PR, or to format files as they are being otherwise changed.

