### PR TITLE
pass default onwarn and onerror handlers to user's callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ The Svelte compiler optionally takes a second argument, an object of configurati
 | `css` | `true`, `false` | Whether to include code to inject your component's styles into the DOM. | `true` |
 | `globals` | `object`, `function` | When outputting to the `'umd'`, `'iife'` or `'eval'` formats, an object or function mapping the names of imported dependencies to the names of global variables. | `{}` |
 | `legacy` | `boolean` | Ensures compatibility with very old browsers, at the cost of some extra code |
-| `onerror` | `function` | Specify a callback for when Svelte encounters an error while compiling the component. | (exception is thrown) |
-| `onwarn` | `function` | Specify a callback for when Svelte encounters a non-fatal warning while compiling the component. | (warning is logged to console) |
+| `onerror` | `function` | Specify a callback for when Svelte encounters an error while compiling the component. Passed two arguments: the error object, and another function that is Svelte's default onerror handling. | (exception is thrown) |
+| `onwarn` | `function` | Specify a callback for when Svelte encounters a non-fatal warning while compiling the component. Passed two arguments: the warning object, and another function that is Svelte's default onwarn handling. | (warning is logged to console) |
 
 ## Example/starter repos
 

--- a/src/generators/shared/utils/wrapModule.ts
+++ b/src/generators/shared/utils/wrapModule.ts
@@ -272,21 +272,13 @@ function getGlobals(dependencies: Dependency[], options: CompileOptions) {
 				const error = new Error(
 					`Could not determine name for imported module '${d.source}' – use options.globals`
 				);
-				if (onerror) {
-					onerror(error);
-				} else {
-					throw error;
-				}
+				onerror(error);
 			} else {
 				const warning = {
 					message: `No name was supplied for imported module '${d.source}'. Guessing '${d.name}', but you should use options.globals`,
 				};
 
-				if (onwarn) {
-					onwarn(warning);
-				} else {
-					console.warn(warning); // eslint-disable-line no-console
-				}
+				onwarn(warning);
 			}
 
 			name = d.name;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,26 +8,29 @@ import Stylesheet from './css/Stylesheet';
 import { Parsed, CompileOptions, Warning } from './interfaces';
 
 function normalizeOptions(options: CompileOptions): CompileOptions {
-	return assign(
-		{
-			generate: 'dom',
+	let normalizedOptions = assign({ generate: 'dom' }, options);
+	const { onwarn, onerror } = normalizedOptions;
+	normalizedOptions.onwarn = onwarn
+		? (warning: Warning) => onwarn(warning, defaultOnwarn)
+		: defaultOnwarn;
+	normalizedOptions.onerror = onerror
+		? (error: Error) => onerror(error, defaultOnerror)
+		: defaultOnerror;
+	return normalizedOptions;
+}
 
-			onwarn: (warning: Warning) => {
-				if (warning.loc) {
-					console.warn(
-						`(${warning.loc.line}:${warning.loc.column}) – ${warning.message}`
-					); // eslint-disable-line no-console
-				} else {
-					console.warn(warning.message); // eslint-disable-line no-console
-				}
-			},
+function defaultOnwarn(warning: Warning) {
+	if (warning.loc) {
+		console.warn(
+			`(${warning.loc.line}:${warning.loc.column}) – ${warning.message}`
+		); // eslint-disable-line no-console
+	} else {
+		console.warn(warning.message); // eslint-disable-line no-console
+	}
+}
 
-			onerror: (error: Error) => {
-				throw error;
-			},
-		},
-		options
-	);
+function defaultOnerror(error: Error) {
+	throw error;
 }
 
 export function compile(source: string, _options: CompileOptions) {


### PR DESCRIPTION
Part of #824. This is a bit hacky but it seemed to be the most localized change that addresses this. Basically I'm replacing `options.onwarn` and `options.onerror` with versions that take one argument (the warning/error) and call the user's original callback with two arguments (the warning/error and the default handlers). The reason for this was so that the several places where `options.onwarn` and `options.onerror` are called can all remain the same. This can be changed if that seems a bit _too_ hacky.