### PR TITLE
supported "muted" property as boolean on audio element

### DIFF
--- a/src/generators/dom/visitors/Element/lookup.ts
+++ b/src/generators/dom/visitors/Element/lookup.ts
@@ -128,7 +128,7 @@ const lookup = {
 	method: { appliesTo: ['form'] },
 	min: { appliesTo: ['input', 'meter'] },
 	multiple: { appliesTo: ['input', 'select'] },
-	muted: { appliesTo: ['video'] },
+	muted: { appliesTo: ['audio', 'video'] },
 	name: {
 		appliesTo: [
 			'button',


### PR DESCRIPTION
The MDN HTML attribute reference didn't include the `audio` element under the `muted` property. I updated the MDN reference and inserted `audio` here, too. Without this, `muted={{ false }}` will render the `muted` property on `audio` elements, thus muting them [(demo)](https://svelte.technology/repl?version=1.17.0&gist=9e9b34b6eb5114777db8ea056a90d88e).

I didn't see any tests for this sort of thing, so I didn't write one.

Is there a script I missed that parses the mdn page for this data? If not, would it be helpful to have one? I might be able to do that shortly.