### PR TITLE
Add resolution for electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
       "src/**/__test__.js",
       "src/shared/**"
     ]
+  },
+  "resolutions": {
+    "electron": "1.6.15"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,13 +10,13 @@
   version "6.0.85"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.85.tgz#ec02bfe54a61044f2be44f13b389c6a0e8ee05ae"
 
+"@types/node@^7.0.18":
+  version "7.0.44"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.44.tgz#20422b3dada536f35bf318ac3e24b8c48200803d"
+
 "@types/node@^8.0.17":
   version "8.0.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.19.tgz#e46e2b0243de7d03f15b26b45c59ebb84f657a4e"
-
-"@types/node@^8.0.24":
-  version "8.0.28"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.28.tgz#86206716f8d9251cf41692e384264cbd7058ad60"
 
 abab@^1.0.3:
   version "1.0.3"
@@ -753,11 +753,11 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
-electron@^1.4.4:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.0.tgz#896f429b1e664f496f62b9cc7ee6a67a71375f31"
+electron@1.6.15, electron@^1.4.4:
+  version "1.6.15"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.15.tgz#c34ec54486b7f49a66db58c6f24a0928414faea7"
   dependencies:
-    "@types/node" "^8.0.24"
+    "@types/node" "^7.0.18"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 
@@ -2309,9 +2309,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.4.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
+prettier@^1.7.0:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
 pretty-bytes@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
This is a pretty superficial and potentially controversial change and will likely not affect many people, so I certainly don't blame anyone if it's not merged.

Currently by default `yarn install` will fail on Linux because the resolved electron version doesn't install for one reason or another. I haven't really looked into the reason why admittedly. Electron is a dependency of some dependency, so this is definitely an upstream issue that should likely be fixed elsewhere, but it's slightly annoying in the meantime.

```
$ yarn
yarn install v1.2.1
[1/4] Resolving packages...
[2/4] Fetching packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/electron/-/electron-1.8.0.tgz: Request failed \"404 Not Found\"".
```

I notice that svelte's package manager of choice seems to be yarn, so that means the `resolutions` field is available exactly to fix this issue. This change adds `electron` to that field in package.json, causing installations to work out of the box on Linux.

It does however slightly increase cognitive load and make upkeep slightly harder, and can be confusing to people who are unfamiliar with yarn.
