### PR TITLE
allow options.* as event handler callee

### DIFF
--- a/src/validate/html/validateEventHandler.ts
+++ b/src/validate/html/validateEventHandler.ts
@@ -21,7 +21,7 @@ export default function validateEventHandlerCallee(
 
 	const { name } = flattenReference(callee);
 
-	if (validCalleeObjects.has(name)) return;
+	if (validCalleeObjects.has(name) || name === 'options') return;
 
 	if (name === 'refs') {
 		refCallees.push(callee);
@@ -34,7 +34,7 @@ export default function validateEventHandlerCallee(
 	)
 		return;
 
-	const validCallees = ['this.*', 'event.*', 'console.*'].concat(
+	const validCallees = ['this.*', 'event.*', 'options.*', 'console.*'].concat(
 		Array.from(validBuiltins),
 		Array.from(validator.methods.keys())
 	);

--- a/test/validator/samples/method-nonexistent-helper/warnings.json
+++ b/test/validator/samples/method-nonexistent-helper/warnings.json
@@ -1,5 +1,5 @@
 [{
-	"message": "'foo' is an invalid callee (should be one of this.*, event.*, console.*, set, fire, destroy or bar). 'foo' exists on 'helpers', did you put it in the wrong place?",
+	"message": "'foo' is an invalid callee (should be one of this.*, event.*, options.*, console.*, set, fire, destroy or bar). 'foo' exists on 'helpers', did you put it in the wrong place?",
 	"pos": 18,
 	"loc": {
 		"line": 1,

--- a/test/validator/samples/method-nonexistent/warnings.json
+++ b/test/validator/samples/method-nonexistent/warnings.json
@@ -1,5 +1,5 @@
 [{
-	"message": "'foo' is an invalid callee (should be one of this.*, event.*, console.*, set, fire, destroy or bar)",
+	"message": "'foo' is an invalid callee (should be one of this.*, event.*, options.*, console.*, set, fire, destroy or bar)",
 	"pos": 18,
 	"loc": {
 		"line": 1,

--- a/test/validator/samples/window-event-invalid/warnings.json
+++ b/test/validator/samples/window-event-invalid/warnings.json
@@ -1,5 +1,5 @@
 [{
-	"message": "'resize' is an invalid callee (should be one of this.*, event.*, console.*, set, fire or destroy)",
+	"message": "'resize' is an invalid callee (should be one of this.*, event.*, options.*, console.*, set, fire or destroy)",
 	"loc": {
 		"line": 1,
 		"column": 20


### PR DESCRIPTION
[Gitter convo](https://gitter.im/sveltejs/svelte?at=59e751445c40c1ba79b72499).

This is a little hacky, as the handling of `options.*` is different than other things that are already in there. It's not like `set`/`fire`/`destroy`, as we're calling `options.something()`, not just `options()` - and it's not like `this`/`event`/`console`, as those variables already exist in scope, and for `options` we need to output `component.options.whatever()`.