### PR TITLE
Fixes #905 css attribute name only bug

### DIFF
--- a/src/css/Selector.ts
+++ b/src/css/Selector.ts
@@ -224,6 +224,7 @@ function attributeMatches(node: Node, name: string, expectedValue: string, opera
 	if (!attr) return false;
 	if (attr.value === true) return operator === null;
 	if (attr.value.length > 1) return true;
+	if (!expectedValue) return true;
 
 	const pattern = operators[operator](expectedValue, caseInsensitive ? 'i' : '');
 	const value = attr.value[0];

--- a/test/css/samples/attribute-selector-only-name/_config.js
+++ b/test/css/samples/attribute-selector-only-name/_config.js
@@ -1,0 +1,3 @@
+export default {
+	cascade: false
+};

--- a/test/css/samples/attribute-selector-only-name/expected.css
+++ b/test/css/samples/attribute-selector-only-name/expected.css
@@ -1,1 +1,1 @@
-[foo][svelte-xyz]{color:red}
+[foo][svelte-xyz]{color:red}[baz][svelte-xyz]{color:blue}

--- a/test/css/samples/attribute-selector-only-name/expected.css
+++ b/test/css/samples/attribute-selector-only-name/expected.css
@@ -1,0 +1,1 @@
+[foo][svelte-xyz]{color:red}

--- a/test/css/samples/attribute-selector-only-name/input.html
+++ b/test/css/samples/attribute-selector-only-name/input.html
@@ -1,0 +1,7 @@
+<div foo='bar'></div>
+
+<style>
+	[foo] {
+		color: red;
+	}
+</style>

--- a/test/css/samples/attribute-selector-only-name/input.html
+++ b/test/css/samples/attribute-selector-only-name/input.html
@@ -1,7 +1,11 @@
 <div foo='bar'></div>
+<div baz></div>
 
 <style>
 	[foo] {
 		color: red;
+	}
+	[baz] {
+		color: blue;
 	}
 </style>


### PR DESCRIPTION
#905 seems to be caused by `attributeMatches` trying to match a name-only attribute selector like `[foo]` to an html node that has that attribute and a value like `foo="bar"`. I made `attributeMatches` return true if the attribute matches and there is no `expectedValue`, since the css selector attribute has no value and there is nothing to expect, so it won't go looking for it and blow up as it was.