### PR TITLE
fix factory arguments for globals in UMD output

### DIFF
--- a/src/generators/shared/utils/wrapModule.ts
+++ b/src/generators/shared/utils/wrapModule.ts
@@ -206,7 +206,7 @@ function umd(
 		(function(global, factory) {
 			typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory(${cjsDeps}) :
 			typeof define === "function" && define.amd ? define(${amdId}${amdDeps}factory) :
-			(global.${options.name} = factory(${globals}));
+			(global.${options.name} = factory(${globals.join(', ')}));
 		}(this, (function (${paramString(dependencies)}) { "use strict";
 
 			${getCompatibilityStatements(dependencies)}


### PR DESCRIPTION
The arguments here were being rendered separated by newlines rather than commas. I'm guessing this stopped working (i.e., the array was no longer getting silently converted into a comma-separated string) when switching to the fancier tagged template mechanism for code generation. Switched this to manually calling `.join`, like in other parts of this file.

Thanks to @hperrin for catching this!