### PR TITLE
use prepare npm script to support installing from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "precodecov": "npm run coverage",
     "lint": "eslint src test/*.js",
     "build": "node src/shared/_build.js && rollup -c",
+    "prepare": "npm run build",
     "dev": "node src/shared/_build.js && rollup -c -w",
     "pretest": "npm run build",
     "prepublishOnly": "npm run lint && npm test",


### PR DESCRIPTION
Inspired by the recent change in Rollup - Adds a `prepare` npm script so that with npm5+ you'll be able to directly install from a git branch. You can test this now with `npm install sveltejs/svelte#install-from-git`.