### PR TITLE
Add support for intercepting more file extensions in ssr.

### DIFF
--- a/src/server-side-rendering/register.js
+++ b/src/server-side-rendering/register.js
@@ -6,12 +6,29 @@ function capitalise(name) {
 	return name[0].toUpperCase() + name.slice(1);
 }
 
-require.extensions['.html'] = function(module, filename) {
-	const { code } = compile(fs.readFileSync(filename, 'utf-8'), {
-		filename,
-		name: capitalise(path.basename(filename).replace(/\.html$/, '')),
-		generate: 'ssr'
-	});
+export default function register(options) {
+	const { extensions } = options;
+	if (extensions) {
+		_deregister('.html');
+		extensions.forEach(_register);
+	}
+}
 
-	return module._compile(code, filename);
-};
+function _deregister(extension) {
+	delete require.extensions[extension];
+}
+
+function _register(extension) {
+	require.extensions[extension] = function(module, filename) {
+		const {code} = compile(fs.readFileSync(filename, 'utf-8'), {
+			filename,
+			name: capitalise(path.basename(filename)
+				.replace(new RegExp(`${extension.replace('.', '\\.')}$`), '')),
+			generate: 'ssr',
+		});
+
+		return module._compile(code, filename);
+	};
+}
+
+_register('.html');

--- a/test/server-side-rendering/index.js
+++ b/test/server-side-rendering/index.js
@@ -21,7 +21,9 @@ function tryToReadFile(file) {
 
 describe("ssr", () => {
 	before(() => {
-		require("../../ssr/register");
+		require("../../ssr/register")({
+			extensions: ['.svelte', '.html']
+		});
 
 		return setupHtmlEqual();
 	});
@@ -41,7 +43,15 @@ describe("ssr", () => {
 		(solo ? it.only : it)(dir, () => {
 			dir = path.resolve("test/server-side-rendering/samples", dir);
 			try {
-				const component = require(`${dir}/main.html`);
+				let component;
+
+				const mainHtmlFile = `${dir}/main.html`;
+				const mainSvelteFile = `${dir}/main.svelte`;
+				if (fs.existsSync(mainHtmlFile)) {
+					component = require(mainHtmlFile);
+				} else if (fs.existsSync(mainSvelteFile)) {
+					component = require(mainSvelteFile);
+				}
 
 				const expectedHtml = tryToReadFile(`${dir}/_expected.html`);
 				const expectedCss = tryToReadFile(`${dir}/_expected.css`) || "";

--- a/test/server-side-rendering/samples/component-with-different-extension/Widget.svelte
+++ b/test/server-side-rendering/samples/component-with-different-extension/Widget.svelte
@@ -1,0 +1,1 @@
+<p>i am a widget</p>

--- a/test/server-side-rendering/samples/component-with-different-extension/_expected.html
+++ b/test/server-side-rendering/samples/component-with-different-extension/_expected.html
@@ -1,0 +1,1 @@
+<div><p>i am a widget</p></div>

--- a/test/server-side-rendering/samples/component-with-different-extension/main.svelte
+++ b/test/server-side-rendering/samples/component-with-different-extension/main.svelte
@@ -1,0 +1,11 @@
+<div>
+	<Widget/>
+</div>
+
+<script>
+	import Widget from './Widget.svelte';
+
+	export default {
+		components: { Widget }
+	};
+</script>


### PR DESCRIPTION
Provides a dual way of registering node extensions:
- The normal one the registers '.html' `require('svelte/ssr/register')`
- The extended one that registers an array of extensions and deregisters the default one `require('svelte/ssr/register')(['.html', '.svelte'])`