### PR TITLE
prevent cyclical store computations, and computation duplication

### DIFF
--- a/store.js
+++ b/store.js
@@ -53,7 +53,7 @@ assign(Store.prototype, {
 
 		function visit(key) {
 			if (cycles[key]) {
-				throw new Error(`Cyclical dependency detected — a computed property cannot indirectly depend on itself`);
+				throw new Error('Cyclical dependency detected');
 			}
 
 			if (visited[key]) return;

--- a/store.js
+++ b/store.js
@@ -48,19 +48,30 @@ assign(Store.prototype, {
 	_sortComputedProperties: function() {
 		var computed = this._computed;
 		var sorted = this._sortedComputedProperties = [];
+		var cycles;
 		var visited = blankObject();
 
 		function visit(key) {
+			if (cycles[key]) {
+				throw new Error(`Cyclical dependency detected — a computed property cannot indirectly depend on itself`);
+			}
+
 			if (visited[key]) return;
+			visited[key] = true;
+
 			var c = computed[key];
 
 			if (c) {
+				cycles[key] = true;
 				c.deps.forEach(visit);
 				sorted.push(c);
 			}
 		}
 
-		for (var key in this._computed) visit(key);
+		for (var key in this._computed) {
+			cycles = blankObject();
+			visit(key);
+		}
 	},
 
 	compute: function(key, deps, fn) {

--- a/test/store/index.js
+++ b/test/store/index.js
@@ -1,7 +1,27 @@
+import fs from 'fs';
 import assert from 'assert';
+import MagicString from 'magic-string';
+import { parse } from 'acorn';
 import { Store } from '../../store.js';
 
 describe('store', () => {
+	it('is written in ES5', () => {
+		const source = fs.readFileSync('store.js', 'utf-8');
+
+		const ast = parse(source, {
+			sourceType: 'module'
+		});
+
+		const magicString = new MagicString(source);
+		ast.body.forEach(node => {
+			if (/^(Im|Ex)port/.test(node.type)) magicString.remove(node.start, node.end);
+		});
+
+		parse(magicString.toString(), {
+			ecmaVersion: 5
+		});
+	});
+
 	describe('get', () => {
 		it('gets a specific key', () => {
 			const store = new Store({

--- a/test/store/index.js
+++ b/test/store/index.js
@@ -184,7 +184,7 @@ describe('store', () => {
 			assert.throws(() => {
 				store.compute('a', ['b'], b => b + 1);
 				store.compute('b', ['a'], a => a + 1);
-			}, /Cyclical dependency detected — a computed property cannot indirectly depend on itself/);
+			}, /Cyclical dependency detected/);
 		});
 	});
 });


### PR DESCRIPTION
Something @adamhaile spotted yesterday (thanks for the eagle eye!) — when `Store` re-sorts its computed properties, it doesn't bother to mark which ones it's already seen, so in a situation like this...

```js
store.compute('b', ['a'], a => a * 2);
store.compute('c', ['b'], b => b * 3);
store.compute('d', ['b'], b => b * 4);
```

...where both `c` and `d` depend on a computed value, it would end up thinking it had as many as 5 things to recompute on each state change, rather than a maximum of 3.

I also added some cyclical dependency detection, so that this...

```js
store.compute('a', ['b'], b => b + 1);
store.compute('b', ['a'], a => a + 1);
```

...results in a helpful 'Cyclical dependency detected — a computed property cannot indirectly depend on itself' error, rather than a stack overflow.