### PR TITLE
don't transform bidi transitions twice

### DIFF
--- a/src/generators/dom/visitors/Element/addTransitions.ts
+++ b/src/generators/dom/visitors/Element/addTransitions.ts
@@ -15,10 +15,9 @@ export default function addTransitions(
 
 	if (!intro && !outro) return;
 
-	if (intro) block.contextualise(intro.expression); // TODO remove all these
-	if (outro) block.contextualise(outro.expression);
-
 	if (intro === outro) {
+		block.contextualise(intro.expression); // TODO remove all these
+
 		const name = block.getUniqueName(`${node.var}_transition`);
 		const snippet = intro.expression
 			? intro.metadata.snippet
@@ -49,6 +48,8 @@ export default function addTransitions(
 		const outroName = outro && block.getUniqueName(`${node.var}_outro`);
 
 		if (intro) {
+			block.contextualise(intro.expression);
+
 			block.addVariable(introName);
 			const snippet = intro.expression
 				? intro.metadata.snippet
@@ -74,6 +75,8 @@ export default function addTransitions(
 		}
 
 		if (outro) {
+			block.contextualise(outro.expression);
+
 			block.addVariable(outroName);
 			const snippet = outro.expression
 				? outro.metadata.snippet

--- a/test/runtime/samples/transition-js-parameterised-with-state/_config.js
+++ b/test/runtime/samples/transition-js-parameterised-with-state/_config.js
@@ -1,0 +1,21 @@
+export default {
+	data: {
+		duration: 200
+	},
+
+	test(assert, component, target, window, raf) {
+		component.set({ visible: true });
+		const div = target.querySelector('div');
+		assert.equal(div.foo, 0);
+
+		raf.tick(50);
+		assert.equal(div.foo, 100);
+
+		raf.tick(100);
+		assert.equal(div.foo, 200);
+
+		raf.tick(101);
+
+		component.destroy();
+	},
+};

--- a/test/runtime/samples/transition-js-parameterised-with-state/main.html
+++ b/test/runtime/samples/transition-js-parameterised-with-state/main.html
@@ -1,0 +1,18 @@
+{{#if visible}}
+	<div transition:foo='{k: duration}'>fades in</div>
+{{/if}}
+
+<script>
+	export default {
+		transitions: {
+			foo(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.foo = t * params.k;
+					}
+				};
+			}
+		}
+	};
+</script>


### PR DESCRIPTION
fixes the regression in #962 that would fail on bidirectional transitions that referenced state