### PR TITLE
feat: Pass filename option to preprocess hooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ function parseAttributes(str: string) {
 	return attrs;
 }
 
-async function replaceTagContents(source, type: 'script' | 'style', preprocessor: Preprocessor) {
+async function replaceTagContents(source, type: 'script' | 'style', preprocessor: Preprocessor, options: PreprocessOptions) {
 	const exp = new RegExp(`<${type}([\\S\\s]*?)>([\\S\\s]*?)<\\/${type}>`, 'ig');
 	const match = exp.exec(source);
 
@@ -59,7 +59,8 @@ async function replaceTagContents(source, type: 'script' | 'style', preprocessor
 		const content: string = match[2];
 		const processed: { code: string, map?: SourceMap | string } = await preprocessor({
 			content,
-			attributes
+			attributes,
+			options
 		});
 
 		if (processed && processed.code) {
@@ -77,16 +78,19 @@ async function replaceTagContents(source, type: 'script' | 'style', preprocessor
 export async function preprocess(source: string, options: PreprocessOptions) {
 	const { markup, style, script } = options;
 	if (!!markup) {
-		const processed: { code: string, map?: SourceMap | string } = await markup({ content: source });
+		const processed: { code: string, map?: SourceMap | string } = await markup({
+			content: source,
+			options
+		});
 		source = processed.code;
 	}
 
 	if (!!style) {
-		source = await replaceTagContents(source, 'style', style);
+		source = await replaceTagContents(source, 'style', style, options);
 	}
 
 	if (!!script) {
-		source = await replaceTagContents(source, 'script', script);
+		source = await replaceTagContents(source, 'script', script, options);
 	}
 
 	return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ async function replaceTagContents(source, type: 'script' | 'style', preprocessor
 		const processed: { code: string, map?: SourceMap | string } = await preprocessor({
 			content,
 			attributes,
-			options
+			filename : options.filename
 		});
 
 		if (processed && processed.code) {
@@ -80,7 +80,7 @@ export async function preprocess(source: string, options: PreprocessOptions) {
 	if (!!markup) {
 		const processed: { code: string, map?: SourceMap | string } = await markup({
 			content: source,
-			options
+			filename: options.filename
 		});
 		source = processed.code;
 	}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -83,7 +83,7 @@ export interface CustomElementOptions {
 }
 
 export interface PreprocessOptions {
-	markup?: (options: {content: string, options: PreprocessOptions}) => { code: string, map?: SourceMap | string };
+	markup?: (options: {content: string, filename: string}) => { code: string, map?: SourceMap | string };
 	style?: Preprocessor;
 	script?: Preprocessor;
 	filename?: string

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -83,9 +83,10 @@ export interface CustomElementOptions {
 }
 
 export interface PreprocessOptions {
-	markup?: (options: {content: string}) => { code: string, map?: SourceMap | string };
+	markup?: (options: {content: string, options: PreprocessOptions}) => { code: string, map?: SourceMap | string };
 	style?: Preprocessor;
 	script?: Preprocessor;
+	id?: string
 }
 
-export type Preprocessor = (options: {content: string, attributes: Record<string, string | boolean>}) => { code: string, map?: SourceMap | string };
+export type Preprocessor = (options: {content: string, attributes: Record<string, string | boolean>, options: PreprocessOptions}) => { code: string, map?: SourceMap | string };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -86,7 +86,7 @@ export interface PreprocessOptions {
 	markup?: (options: {content: string, options: PreprocessOptions}) => { code: string, map?: SourceMap | string };
 	style?: Preprocessor;
 	script?: Preprocessor;
-	id?: string
+	filename?: string
 }
 
-export type Preprocessor = (options: {content: string, attributes: Record<string, string | boolean>, options: PreprocessOptions}) => { code: string, map?: SourceMap | string };
+export type Preprocessor = (options: {content: string, attributes: Record<string, string | boolean>, filename?: string}) => { code: string, map?: SourceMap | string };

--- a/test/preprocess/index.js
+++ b/test/preprocess/index.js
@@ -126,6 +126,41 @@ describe('preprocess', () => {
 		});
 	});
 
+	it('provides filename to processing hooks', () => {
+		const source = `
+			<h1>Hello __MARKUP_FILENAME__!</h1>
+			<style>.red { color: __STYLE_FILENAME__; }</style>
+			<script>console.log('__SCRIPT_FILENAME__');</script>
+		`;
+
+		const expected = `
+			<h1>Hello file.html!</h1>
+			<style>.red { color: file.html; }</style>
+			<script>console.log('file.html');</script>
+		`;
+
+		return svelte.preprocess(source, {
+			filename: 'file.html',
+			markup: ({ content, filename }) => {
+				return {
+					code: content.replace('__MARKUP_FILENAME__', filename)
+				};
+			},
+			style: ({ content, filename }) => {
+				return {
+					code: content.replace('__STYLE_FILENAME__', filename)
+				};
+			},
+			script: ({ content, filename }) => {
+				return {
+					code: content.replace('__SCRIPT_FILENAME__', filename)
+				};
+			}
+		}).then(processed => {
+			assert.equal(processed.toString(), expected);
+		});
+	});
+
 	it('ignores null/undefined returned from preprocessor', () => {
 		const source = `
 			<script>


### PR DESCRIPTION
If the options object passed to `svelte.preprocess()` contains a `filename` property it'll be passed along to all the hooks so they can make file-system aware transformations.

Fixes #983