### PR TITLE
Properly override toString in CompileError

### DIFF
--- a/src/utils/CompileError.ts
+++ b/src/utils/CompileError.ts
@@ -24,7 +24,7 @@ export default class CompileError extends Error {
 		this.frame = getCodeFrame(template, line, column);
 	}
 
-	toString() {
+	public toString = () => {
 		return `${this.message} (${this.loc.line}:${this.loc.column})\n${this
 			.frame}`;
 	}

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -40,6 +40,7 @@ describe('parse', () => {
 					assert.equal(err.message, expected.message);
 					assert.deepEqual(err.loc, expected.loc);
 					assert.equal(err.pos, expected.pos);
+					assert.equal(err.toString().split('\n')[0], `${expected.message} (${expected.loc.line}:${expected.loc.column})`);
 				} catch (err2) {
 					const e = err2.code === 'MODULE_NOT_FOUND' ? err : err2;
 					throw e;


### PR DESCRIPTION
This bug actually breaks most of the test cases in svelte-loader, when svelte's version is updated to the current one.
