### PR TITLE
deconflict computed properties with arguments to _recompute

### DIFF
--- a/src/generators/Generator.ts
+++ b/src/generators/Generator.ts
@@ -485,7 +485,7 @@ export default class Generator {
 					`);
 				};
 
-				const addDeclaration = (key: string, node: Node, disambiguator?: string) => {
+				const addDeclaration = (key: string, node: Node, disambiguator?: string, conflicts?: Record<string, boolean>) => {
 					const qualified = disambiguator ? `${disambiguator}-${key}` : key;
 
 					if (node.type === 'Identifier' && node.name === key) {
@@ -493,7 +493,10 @@ export default class Generator {
 						return;
 					}
 
-					let name = this.getUniqueName(key);
+					let deconflicted = key;
+					if (conflicts) while (deconflicted in conflicts) deconflicted += '_'
+
+					let name = this.getUniqueName(deconflicted);
 					this.templateVars.set(qualified, name);
 
 					// deindent
@@ -548,7 +551,11 @@ export default class Generator {
 						computations.push({ key, deps });
 
 						const prop = templateProperties.computed.value.properties.find((prop: Node) => getName(prop.key) === key);
-						addDeclaration(key, prop.value, 'computed');
+
+						addDeclaration(key, prop.value, 'computed', {
+							state: true,
+							changed: true
+						});
 					};
 
 					templateProperties.computed.value.properties.forEach((prop: Node) =>

--- a/src/generators/nodes/Text.ts
+++ b/src/generators/nodes/Text.ts
@@ -1,7 +1,6 @@
 import { stringify } from '../../utils/stringify';
 import Node from './shared/Node';
 import Block from '../dom/Block';
-import { State } from '../dom/interfaces';
 
 // Whitespace inside one of these elements will not result in
 // a whitespace node being created in any circumstances. (This

--- a/test/runtime/samples/computed-values-deconflicted/_config.js
+++ b/test/runtime/samples/computed-values-deconflicted/_config.js
@@ -1,6 +1,4 @@
 export default {
-	solo: true,
-
 	html: '<span>waiting</span>',
 
 	test(assert, component, target) {

--- a/test/runtime/samples/computed-values-deconflicted/_config.js
+++ b/test/runtime/samples/computed-values-deconflicted/_config.js
@@ -1,0 +1,12 @@
+export default {
+	solo: true,
+
+	html: '<span>waiting</span>',
+
+	test(assert, component, target) {
+		component.set({ x: 'ready' });
+		assert.htmlEqual(target.innerHTML, `
+			<span>ready</span>
+		`);
+	}
+};

--- a/test/runtime/samples/computed-values-deconflicted/main.html
+++ b/test/runtime/samples/computed-values-deconflicted/main.html
@@ -1,0 +1,14 @@
+<span>{{state}}</span>
+
+<script>
+	export default {
+		data() {
+			return {
+				x: 'waiting'
+			};
+		},
+		computed: {
+			state: x => x
+		}
+	};
+</script>


### PR DESCRIPTION
This fixes #1012, but you'll have to take my word for it — because the tests manipulate names to ensure that we're not accidentally hardcoding stuff, the regression doesn't actually show up when you're testing. I suppose if we wanted to be super-rigorous we could test both ways, but I'm lazy. This'll do for now