### PR TITLE
Expose root as a public property

### DIFF
--- a/src/generators/dom/index.ts
+++ b/src/generators/dom/index.ts
@@ -204,7 +204,7 @@ export default function dom(
 	const constructorBody = deindent`
 		${options.dev && `this._debugName = '${debugName}';`}
 		${options.dev && !generator.customElement &&
-			`if (!options || (!options.target && !options._root)) throw new Error("'target' is a required option");`}
+			`if (!options || (!options.target && !options.root)) throw new Error("'target' is a required option");`}
 		@init(this, options);
 		${generator.usesRefs && `this.refs = {};`}
 		this._state = @assign(${initialState.join(', ')});
@@ -239,13 +239,13 @@ export default function dom(
 		${templateProperties.oncreate && `var _oncreate = %oncreate.bind(this);`}
 
 		${(templateProperties.oncreate || generator.hasComponents || generator.hasComplexBindings || generator.hasIntroTransitions) && deindent`
-			if (!options._root) {
+			if (!options.root) {
 				this._oncreate = [${templateProperties.oncreate && `_oncreate`}];
 				${(generator.hasComponents || generator.hasComplexBindings) && `this._beforecreate = [];`}
 				${(generator.hasComponents || generator.hasIntroTransitions) && `this._aftercreate = [];`}
 			} ${templateProperties.oncreate && deindent`
 				else {
-					this._root._oncreate.push(_oncreate);
+					this.root._oncreate.push(_oncreate);
 				}
 			`}
 		`}

--- a/src/generators/nodes/Component.ts
+++ b/src/generators/nodes/Component.ts
@@ -68,7 +68,7 @@ export default class Component extends Node {
 
 		const name = this.var;
 
-		const componentInitProperties = [`_root: #component._root`];
+		const componentInitProperties = [`root: #component.root`];
 
 		if (this.children.length > 0) {
 			const slots = Array.from(this._slots).map(name => `${name}: @createFragment()`);
@@ -217,7 +217,7 @@ export default class Component extends Node {
 				`);
 
 				beforecreate = deindent`
-					#component._root._beforecreate.push(function() {
+					#component.root._beforecreate.push(function() {
 						var state = #component.get(), childState = ${name}.get(), newState = {};
 						if (!childState) return;
 						${setParentFromChildOnInit}

--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -527,7 +527,7 @@ export default class Element extends Node {
 				this.generator.hasComplexBindings = true;
 
 				block.builders.hydrate.addLine(
-					`if (!(${allInitialStateIsDefined})) #component._root._beforecreate.push(${handler});`
+					`if (!(${allInitialStateIsDefined})) #component.root._beforecreate.push(${handler});`
 				);
 			}
 		});
@@ -556,7 +556,7 @@ export default class Element extends Node {
 			const fn = `%transitions-${intro.name}`;
 
 			block.builders.intro.addBlock(deindent`
-				#component._root._aftercreate.push(function() {
+				#component.root._aftercreate.push(function() {
 					if (!${name}) ${name} = @wrapTransition(#component, ${this.var}, ${fn}, ${snippet}, true, null);
 					${name}.run(true, function() {
 						#component.fire("intro.end", { node: ${this.var} });
@@ -593,7 +593,7 @@ export default class Element extends Node {
 				}
 
 				block.builders.intro.addBlock(deindent`
-					#component._root._aftercreate.push(function() {
+					#component.root._aftercreate.push(function() {
 						${introName} = @wrapTransition(#component, ${this.var}, ${fn}, ${snippet}, true, null);
 						${introName}.run(true, function() {
 							#component.fire("intro.end", { node: ${this.var} });

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -67,11 +67,11 @@ export function get(key) {
 export function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 export function observe(key, callback, options) {
@@ -136,12 +136,12 @@ export function onDev(eventName, handler) {
 
 export function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 export function _set(newState) {

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -93,11 +93,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -137,12 +137,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/component-static/expected-bundle.js
+++ b/test/js/samples/component-static/expected-bundle.js
@@ -69,11 +69,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -113,12 +113,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {
@@ -174,7 +174,7 @@ var Nested = window.Nested;
 function create_main_fragment(state, component) {
 
 	var nested = new Nested({
-		_root: component._root,
+		root: component.root,
 		data: { foo: "bar" }
 	});
 
@@ -203,7 +203,7 @@ function SvelteComponent(options) {
 	init(this, options);
 	this._state = assign({}, options.data);
 
-	if (!options._root) {
+	if (!options.root) {
 		this._oncreate = [];
 		this._beforecreate = [];
 		this._aftercreate = [];

--- a/test/js/samples/component-static/expected.js
+++ b/test/js/samples/component-static/expected.js
@@ -6,7 +6,7 @@ var Nested = window.Nested;
 function create_main_fragment(state, component) {
 
 	var nested = new Nested({
-		_root: component._root,
+		root: component.root,
 		data: { foo: "bar" }
 	});
 
@@ -35,7 +35,7 @@ function SvelteComponent(options) {
 	init(this, options);
 	this._state = assign({}, options.data);
 
-	if (!options._root) {
+	if (!options.root) {
 		this._oncreate = [];
 		this._beforecreate = [];
 		this._aftercreate = [];

--- a/test/js/samples/computed-collapsed-if/expected-bundle.js
+++ b/test/js/samples/computed-collapsed-if/expected-bundle.js
@@ -69,11 +69,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -113,12 +113,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/css-media-query/expected-bundle.js
+++ b/test/js/samples/css-media-query/expected-bundle.js
@@ -89,11 +89,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -133,12 +133,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/css-shadow-dom-keyframes/expected-bundle.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected-bundle.js
@@ -81,11 +81,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -125,12 +125,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/do-use-dataset/expected-bundle.js
+++ b/test/js/samples/do-use-dataset/expected-bundle.js
@@ -85,11 +85,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -129,12 +129,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
@@ -89,11 +89,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -133,12 +133,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/dont-use-dataset-in-svg/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-svg/expected-bundle.js
@@ -89,11 +89,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -133,12 +133,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -101,11 +101,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -145,12 +145,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -81,11 +81,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -125,12 +125,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/if-block-no-update/expected-bundle.js
+++ b/test/js/samples/if-block-no-update/expected-bundle.js
@@ -85,11 +85,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -129,12 +129,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/if-block-simple/expected-bundle.js
+++ b/test/js/samples/if-block-simple/expected-bundle.js
@@ -85,11 +85,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -129,12 +129,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
@@ -85,11 +85,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -129,12 +129,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/inline-style-optimized-url/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-url/expected-bundle.js
@@ -85,11 +85,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -129,12 +129,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/inline-style-optimized/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized/expected-bundle.js
@@ -85,11 +85,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -129,12 +129,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/inline-style-unoptimized/expected-bundle.js
+++ b/test/js/samples/inline-style-unoptimized/expected-bundle.js
@@ -85,11 +85,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -129,12 +129,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/input-without-blowback-guard/expected-bundle.js
+++ b/test/js/samples/input-without-blowback-guard/expected-bundle.js
@@ -89,11 +89,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -133,12 +133,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/legacy-input-type/expected-bundle.js
+++ b/test/js/samples/legacy-input-type/expected-bundle.js
@@ -87,11 +87,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -131,12 +131,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/legacy-quote-class/expected-bundle.js
+++ b/test/js/samples/legacy-quote-class/expected-bundle.js
@@ -104,11 +104,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -148,12 +148,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/media-bindings/expected-bundle.js
+++ b/test/js/samples/media-bindings/expected-bundle.js
@@ -97,11 +97,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -141,12 +141,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {
@@ -234,15 +234,15 @@ function create_main_fragment(state, component) {
 
 		h: function hydrate() {
 			addListener(audio, "timeupdate", audio_timeupdate_handler);
-			if (!('played' in state && 'currentTime' in state)) component._root._beforecreate.push(audio_timeupdate_handler);
+			if (!('played' in state && 'currentTime' in state)) component.root._beforecreate.push(audio_timeupdate_handler);
 			addListener(audio, "durationchange", audio_durationchange_handler);
-			if (!('duration' in state)) component._root._beforecreate.push(audio_durationchange_handler);
+			if (!('duration' in state)) component.root._beforecreate.push(audio_durationchange_handler);
 			addListener(audio, "play", audio_play_pause_handler);
 			addListener(audio, "pause", audio_play_pause_handler);
 			addListener(audio, "progress", audio_progress_handler);
-			if (!('buffered' in state)) component._root._beforecreate.push(audio_progress_handler);
+			if (!('buffered' in state)) component.root._beforecreate.push(audio_progress_handler);
 			addListener(audio, "loadedmetadata", audio_loadedmetadata_handler);
-			if (!('buffered' in state && 'seekable' in state)) component._root._beforecreate.push(audio_loadedmetadata_handler);
+			if (!('buffered' in state && 'seekable' in state)) component.root._beforecreate.push(audio_loadedmetadata_handler);
 		},
 
 		m: function mount(target, anchor) {
@@ -273,7 +273,7 @@ function SvelteComponent(options) {
 	init(this, options);
 	this._state = assign({}, options.data);
 
-	if (!options._root) {
+	if (!options.root) {
 		this._oncreate = [];
 		this._beforecreate = [];
 	}

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -38,15 +38,15 @@ function create_main_fragment(state, component) {
 
 		h: function hydrate() {
 			addListener(audio, "timeupdate", audio_timeupdate_handler);
-			if (!('played' in state && 'currentTime' in state)) component._root._beforecreate.push(audio_timeupdate_handler);
+			if (!('played' in state && 'currentTime' in state)) component.root._beforecreate.push(audio_timeupdate_handler);
 			addListener(audio, "durationchange", audio_durationchange_handler);
-			if (!('duration' in state)) component._root._beforecreate.push(audio_durationchange_handler);
+			if (!('duration' in state)) component.root._beforecreate.push(audio_durationchange_handler);
 			addListener(audio, "play", audio_play_pause_handler);
 			addListener(audio, "pause", audio_play_pause_handler);
 			addListener(audio, "progress", audio_progress_handler);
-			if (!('buffered' in state)) component._root._beforecreate.push(audio_progress_handler);
+			if (!('buffered' in state)) component.root._beforecreate.push(audio_progress_handler);
 			addListener(audio, "loadedmetadata", audio_loadedmetadata_handler);
-			if (!('buffered' in state && 'seekable' in state)) component._root._beforecreate.push(audio_loadedmetadata_handler);
+			if (!('buffered' in state && 'seekable' in state)) component.root._beforecreate.push(audio_loadedmetadata_handler);
 		},
 
 		m: function mount(target, anchor) {
@@ -77,7 +77,7 @@ function SvelteComponent(options) {
 	init(this, options);
 	this._state = assign({}, options.data);
 
-	if (!options._root) {
+	if (!options.root) {
 		this._oncreate = [];
 		this._beforecreate = [];
 	}

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -83,11 +83,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -127,12 +127,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {
@@ -187,11 +187,11 @@ function create_main_fragment(state, component) {
 	var text;
 
 	var imported = new Imported({
-		_root: component._root
+		root: component.root
 	});
 
 	var nonimported = new NonImported({
-		_root: component._root
+		root: component.root
 	});
 
 	return {
@@ -226,7 +226,7 @@ function SvelteComponent(options) {
 	init(this, options);
 	this._state = assign({}, options.data);
 
-	if (!options._root) {
+	if (!options.root) {
 		this._oncreate = [];
 		this._beforecreate = [];
 		this._aftercreate = [];

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -8,11 +8,11 @@ function create_main_fragment(state, component) {
 	var text;
 
 	var imported = new Imported({
-		_root: component._root
+		root: component.root
 	});
 
 	var nonimported = new NonImported({
-		_root: component._root
+		root: component.root
 	});
 
 	return {
@@ -47,7 +47,7 @@ function SvelteComponent(options) {
 	init(this, options);
 	this._state = assign({}, options.data);
 
-	if (!options._root) {
+	if (!options.root) {
 		this._oncreate = [];
 		this._beforecreate = [];
 		this._aftercreate = [];

--- a/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected-bundle.js
@@ -69,11 +69,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -113,12 +113,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {
@@ -196,10 +196,10 @@ function SvelteComponent(options) {
 
 	var _oncreate = oncreate.bind(this);
 
-	if (!options._root) {
+	if (!options.root) {
 		this._oncreate = [_oncreate];
 	} else {
-	 	this._root._oncreate.push(_oncreate);
+	 	this.root._oncreate.push(_oncreate);
 	 }
 
 	this._fragment = create_main_fragment(this._state, this);

--- a/test/js/samples/onrender-onteardown-rewritten/expected.js
+++ b/test/js/samples/onrender-onteardown-rewritten/expected.js
@@ -28,10 +28,10 @@ function SvelteComponent(options) {
 
 	var _oncreate = oncreate.bind(this);
 
-	if (!options._root) {
+	if (!options.root) {
 		this._oncreate = [_oncreate];
 	} else {
-	 	this._root._oncreate.push(_oncreate);
+	 	this.root._oncreate.push(_oncreate);
 	 }
 
 	this._fragment = create_main_fragment(this._state, this);

--- a/test/js/samples/setup-method/expected-bundle.js
+++ b/test/js/samples/setup-method/expected-bundle.js
@@ -69,11 +69,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -113,12 +113,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -93,11 +93,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -137,12 +137,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {

--- a/test/js/samples/window-binding-scroll/expected-bundle.js
+++ b/test/js/samples/window-binding-scroll/expected-bundle.js
@@ -89,11 +89,11 @@ function get(key) {
 function init(component, options) {
 	component._observers = { pre: blankObject(), post: blankObject() };
 	component._handlers = blankObject();
-	component._root = options._root || component;
 	component._bind = options._bind;
 
 	component.options = options;
-	component.store = component._root.options.store;
+	component.root = options.root || component;
+	component.store = component.root.options.store;
 }
 
 function observe(key, callback, options) {
@@ -133,12 +133,12 @@ function on(eventName, handler) {
 
 function set(newState) {
 	this._set(assign({}, newState));
-	if (this._root._lock) return;
-	this._root._lock = true;
-	callAll(this._root._beforecreate);
-	callAll(this._root._oncreate);
-	callAll(this._root._aftercreate);
-	this._root._lock = false;
+	if (this.root._lock) return;
+	this.root._lock = true;
+	callAll(this.root._beforecreate);
+	callAll(this.root._oncreate);
+	callAll(this.root._aftercreate);
+	this.root._lock = false;
 }
 
 function _set(newState) {


### PR DESCRIPTION
Hey,

I'm opening the PR to discuss the `root` property being public (it was briefly discussed in gitter and I'll try to describe the motivation here once again).

I have an use case where I'd like to create a new instance of a component with an additional `service` property. The main motivation is easier testing with a fake service, secondary motivation is to make the chat be less dependent on a particular vendor.

```javascript
const service = new VendorService() // handles http/ws communication, the chat is not tied to a particular backend, it'll work for any as long as this service has right methods/events

new Chat({
   target: document.getElementById('foo'),
   data: { brand: 'Bar Baz' },
   service
})
```

the chat component itself looks like this:

```html
{{#if closed}}
<Bar on:click='toggle(OPEN)'>Leave a message</Bar>
{{/if}}

{{#if open}}
<Widget on:click='toggle(CLOSE)'/>
{{/if}}
```

then inside of the Widget I use the service e.g. to send a message, receive messages etc.:

```javascript
export default {
  oncreate () {
    this.service = this._root.options.service
  },
  methods () {
    send (event) {
      // set data etc.
      this.service.emit('send:message', message.text)
    }
  }
}
```

other approaches I though of or that were suggested to solve this:

a) propagate events from lowest components (e.g. form submits) and handle all of it outside of the chat component - I didn't like it because I'd need to propagate it via many layers, too much hassle, too close to redux kind of way which I find very verbose

b) check if `service` can be passed like the `store`, so that it can be automatically injected into components below - based on discussion in gitter I understood that it seems that dependency injection was discussed before and it's seen as a fragile pattern (I have the same feeling based on what I saw in other libraries, however I also think that it's not necessarily the pattern that is wrong but the excessive use, any pattern is wrong when overused)

```javascript
new Chat({
  target: document.getElementById('foo'),
  store,
  includes: { service }
})
```
then the line:

```javascript
this.service = this.root.options.service
```

is unnecessary.

c) pass it via `store` as `store.service`. A little bit weird, unexpected

d) pass it via `data`. Weird as well, unexpected

I do understand the desire to keep svelte as concise as possible so I'm open to all suggestions :) Thanks a lot.