### PR TITLE
Side step a blog routing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The magical disappearing UI framework.
 
-* [Read the introductory blog post](https://svelte.technology/blog/frameworks-without-the-framework/)
+* [Read the introductory blog post](https://svelte.technology/blog/frameworks-without-the-framework)
 * [Read the guide](https://svelte.technology/guide)
 * [Try it out](https://svelte.technology/repl)
 * [Chat on Gitter](https://gitter.im/sveltejs/svelte)


### PR DESCRIPTION
I'm not sure how sapper handles routing, but there seems to be an issue right now with trailing `/` characters. This PR just side steps the issue until it can be addressed. Below is a screenshot of the error when following the original link.

[Link with the trailing slash](https://svelte.technology/blog/frameworks-without-the-framework/)
[Link without the trailing slash](https://svelte.technology/blog/frameworks-without-the-framework)

![screenshot](https://user-images.githubusercontent.com/7980426/34266029-0de262da-e635-11e7-9ef2-228e66d3b4d7.png)

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
