### PR TITLE
Allow xlink:href attribute

### DIFF
--- a/src/validate/html/a11y.ts
+++ b/src/validate/html/a11y.ts
@@ -106,14 +106,21 @@ export default function a11y(
 		}
 	}
 
+	function shouldHaveValidHref (attribute) {
+		const href = attributeMap.get(attribute);
+		const value = getStaticAttributeValue(node, attribute);
+		if (value === '' || value === '#') {
+			validator.warn(`A11y: '${value}' is not a valid ${attribute} attribute`, href.start);
+		}
+	}
+
 	if (node.name === 'a') {
-		// anchor-is-valid
-		const href = attributeMap.get('href');
 		if (attributeMap.has('href')) {
-			const value = getStaticAttributeValue(node, 'href');
-			if (value === '' || value === '#') {
-				validator.warn(`A11y: '${value}' is not a valid href attribute`, href.start);
-			}
+			// anchor-is-valid
+			shouldHaveValidHref('href')
+		} else if (attributeMap.has('xlink:href')) {
+			// anchor-in-svg-is-valid
+			shouldHaveValidHref('xlink:href')
 		} else {
 			validator.warn(`A11y: <a> element should have an href attribute`, node.start);
 		}

--- a/test/validator/samples/a11y-anchor-in-svg-is-valid/input.html
+++ b/test/validator/samples/a11y-anchor-in-svg-is-valid/input.html
@@ -1,0 +1,3 @@
+<svg><text><a>not actually a link</a></text></svg>
+<svg><text><a xlink:href=''>not actually a link</a></text></svg>
+<svg><text><a xlink:href='#'>not actually a link</a></text></svg>

--- a/test/validator/samples/a11y-anchor-in-svg-is-valid/warnings.json
+++ b/test/validator/samples/a11y-anchor-in-svg-is-valid/warnings.json
@@ -1,0 +1,26 @@
+[
+  {
+    "message": "A11y: <a> element should have an href attribute",
+    "loc": {
+      "line": 1,
+      "column": 11
+    },
+    "pos": 11
+  },
+  {
+    "message": "A11y: '' is not a valid xlink:href attribute",
+    "loc": {
+      "line": 2,
+      "column": 14
+    },
+    "pos": 65
+  },
+  {
+    "message": "A11y: '#' is not a valid xlink:href attribute",
+    "loc": {
+      "line": 3,
+      "column": 14
+    },
+    "pos": 130
+  }
+]


### PR DESCRIPTION
An attempt to close https://github.com/sveltejs/svelte/issues/1008

I thought of checking whether given node is inside of an svg but that wouldn't be too good performance-wise.

I'm wondering if this should be used together with the `legacy` flag due to: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href#Browser_compatibility

I'm open to suggestions as usual :) thanks