### PR TITLE
Warn if svg uses the viewbox attribute

### DIFF
--- a/src/validate/html/validateElement.ts
+++ b/src/validate/html/validateElement.ts
@@ -79,6 +79,17 @@ export default function validateElement(
 		});
 	}
 
+	if (node.name === 'svg') {
+		node.attributes.forEach(attribute => {
+			if (attribute.name === 'viewbox') {
+				validator.warn(
+					`<svg> has an invalid viewbox attribute – did you mean viewBox?`,
+					node.start
+				)
+			}
+		})
+	}
+
 	let hasIntro: boolean;
 	let hasOutro: boolean;
 	let hasTransition: boolean;

--- a/test/validator/samples/svg-viewbox/input.html
+++ b/test/validator/samples/svg-viewbox/input.html
@@ -1,0 +1,6 @@
+<svg viewbox="-250 -250 500 500">
+  <line x1="0" y1="0" x2="200" y2="0" stroke="black" />
+  <line x1="0" y1="0" x2="-200" y2="0" stroke="black" />
+  <line x1="0" y1="0" x2="0" y2="200" stroke="black" />
+  <line x1="0" y1="0" x2="0" y2="-200" stroke="black" />
+</svg>

--- a/test/validator/samples/svg-viewbox/warnings.json
+++ b/test/validator/samples/svg-viewbox/warnings.json
@@ -1,0 +1,8 @@
+[{
+  "message": "<svg> has an invalid viewbox attribute – did you mean viewBox?",
+  "loc": {
+    "line": 1,
+    "column": 0
+  },
+  "pos": 0
+}]


### PR DESCRIPTION
An attempt to close https://github.com/sveltejs/svelte/issues/1062

The under the hood issue is that:

```js
node.setAttribute('viewbox', '-250 -250 500 500')
```

does not work while:

```js
node.setAttribute('viewBox', '-250 -250 500 500')
```

works correctly.

A warning seems to be the simplest solution since that is the right attribute name https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox

Thanks :)
  