### PR TITLE
[1083] Svelte should throw a compile time error when illegal characte…

### DIFF
--- a/src/validate/js/propValidators/computed.ts
+++ b/src/validate/js/propValidators/computed.ts
@@ -1,5 +1,6 @@
 import checkForDupes from '../utils/checkForDupes';
 import checkForComputedKeys from '../utils/checkForComputedKeys';
+import checkForValidIdentifiers from '../utils/checkForValidIdentifiers';
 import { Validator } from '../../';
 import { Node } from '../../../interfaces';
 import walkThroughTopFunctionScope from '../../../utils/walkThroughTopFunctionScope';
@@ -20,6 +21,7 @@ export default function computed(validator: Validator, prop: Node) {
 
 	checkForDupes(validator, prop.value.properties);
 	checkForComputedKeys(validator, prop.value.properties);
+  checkForValidIdentifiers(validator, prop.value.properties);
 
 	prop.value.properties.forEach((computation: Node) => {
 		if (!isFunctionExpression.has(computation.value.type)) {

--- a/src/validate/js/utils/checkForValidIdentifiers.ts
+++ b/src/validate/js/utils/checkForValidIdentifiers.ts
@@ -1,0 +1,21 @@
+import { Validator } from '../../';
+import { Node } from '../../../interfaces';
+import getName from '../../../utils/getName';
+import { parse } from 'acorn';
+
+export default function checkForValidIdentifiers(
+	validator: Validator,
+	properties: Node[]
+) {
+	properties.forEach(prop => {
+    const name = getName(prop.key);
+    const functionDefinitionString = `function ${name}() {}`;
+    try {
+      parse(functionDefinitionString);
+    } catch(exception) {
+      const invalidCharacter = functionDefinitionString[exception.pos]
+      validator.error(`Computed property name "${name}" is invalid. Character '${invalidCharacter}' at position ${exception.pos} is illegal in function identifiers`, prop.start);
+    }
+
+	});
+}

--- a/test/validator/samples/properties-computed-must-be-valid-function-names/errors.json
+++ b/test/validator/samples/properties-computed-must-be-valid-function-names/errors.json
@@ -1,0 +1,8 @@
+[{
+	"message": "Computed property name \"hours-hyphen\" is invalid. Character '-' at position 14 is illegal in function identifiers",
+	"loc": {
+		"line": 14,
+		"column": 6
+	},
+	"pos": 172
+}]

--- a/test/validator/samples/properties-computed-must-be-valid-function-names/input.html
+++ b/test/validator/samples/properties-computed-must-be-valid-function-names/input.html
@@ -1,0 +1,17 @@
+<p>
+  The hour is
+  <strong>{{hours}}</strong>
+</p>
+
+<script>
+  export default {
+    data() {
+      return {
+        time: new Date()
+      };
+    },
+    computed: {
+      "hours-hyphen": time => time.getHours()
+    }
+  };
+</script>


### PR DESCRIPTION
…rs are used in computed names

Problem  #1083 :
Computed property names are naively transformed into function identifiers so random-api becomes random-api(){} which is not allowed.

Approach:
  For each property name, construct a string that defines a function and see if parsing that string with Acorn throws an exception.
  If it does, assemble an informative error message that states which property is invalid, the first invalid character, and the location of that character within the name.

Changes to codebase:
- Added new validator test
"properties-computed-must-be-valid-function-names"
- Added new check into src/validate/js/propValidators/computed.ts,
"checkForValidIdentifiers"
  - this check was added to
  src/validate/js/utils/checkForValidIdentifiers.ts like the other
  checks in "computed.ts"

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
