### PR TITLE
Fix passing a store to nested components on server side

### DIFF
--- a/src/generators/server-side-rendering/index.ts
+++ b/src/generators/server-side-rendering/index.ts
@@ -114,7 +114,6 @@ export default function ssr(
 			}
 
 			var result = { head: '', addComponent };
-			${templateProperties.store && `options.store = %store();`}
 			var html = ${name}._render(result, state, options);
 
 			var cssCode = Array.from(components).map(c => c.css && c.css.code).filter(Boolean).join('\\n');
@@ -130,6 +129,7 @@ export default function ssr(
 		}
 
 		${name}._render = function(__result, state, options) {
+			${templateProperties.store && `options.store = %store();`}
 			__result.addComponent(${name});
 
 			state = Object.assign(${initialState.join(', ')});

--- a/test/runtime/samples/store-nested/Nested.html
+++ b/test/runtime/samples/store-nested/Nested.html
@@ -1,0 +1,13 @@
+<h1>Hello, {{$name}}!</h1>
+
+<script>
+	import { Store } from '../../../../store.js';
+
+	export default {
+		store () {
+			return new Store({
+				name: 'world'
+			});
+		},
+	};
+</script>

--- a/test/runtime/samples/store-nested/_config.js
+++ b/test/runtime/samples/store-nested/_config.js
@@ -1,0 +1,7 @@
+export default {
+	store: true, // TODO remove this in v2
+
+	html: `
+		<h1>Hello, world!</h1>
+	`,
+};

--- a/test/runtime/samples/store-nested/main.html
+++ b/test/runtime/samples/store-nested/main.html
@@ -1,0 +1,11 @@
+<Nested/>
+
+<script>
+	import Nested from './Nested.html';
+
+	export default {
+		components: {
+			Nested
+		}
+	};
+</script>


### PR DESCRIPTION
This fixes issue #1107 where supplying a store in a nested component would error with `TypeError: options.store._init is not a function` if the parent didn't have a store, or it would use the parent store, ignoring the one passed to the nested component.