### PR TITLE
Escape HTML attribute values in SSR

### DIFF
--- a/src/generators/server-side-rendering/index.ts
+++ b/src/generators/server-side-rendering/index.ts
@@ -206,7 +206,7 @@ export default function ssr(
 
 		${
 			// TODO this is a bit hacky
-			/__escape/.test(generator.renderCode) && deindent`
+			/__escape\(/.test(generator.renderCode) && deindent`
 				var escaped = {
 					'"': '&quot;',
 					"'": '&##39;',
@@ -218,6 +218,93 @@ export default function ssr(
 				function __escape(html) {
 					return String(html).replace(/["'&<>]/g, match => escaped[match]);
 				}
+			`
+		}
+
+		${
+			// TODO this is a bit hacky
+			/__escapeAttr\(/.test(generator.renderCode) && deindent`
+				const __escapeWhitelist = new Set([
+					32,
+					45,
+					48,
+					49,
+					50,
+					51,
+					52,
+					53,
+					54,
+					55,
+					56,
+					57,
+					65,
+					66,
+					67,
+					68,
+					69,
+					70,
+					71,
+					72,
+					73,
+					74,
+					75,
+					76,
+					77,
+					78,
+					79,
+					80,
+					81,
+					82,
+					83,
+					84,
+					85,
+					86,
+					87,
+					88,
+					89,
+					90,
+					95,
+					97,
+					98,
+					99,
+					100,
+					101,
+					102,
+					103,
+					104,
+					105,
+					106,
+					107,
+					108,
+					109,
+					110,
+					111,
+					112,
+					113,
+					114,
+					115,
+					116,
+					117,
+					118,
+					119,
+					120,
+					121,
+					122,
+				])
+
+				function __escapeAttr(s) {
+					const escaped = []
+					for (var i = 0; i < s.length; i++) {
+						const cp = s.codePointAt(i)
+						if (__escapeWhitelist.has(cp)) {
+							escaped.push(s.charAt(i))
+						} else {
+							escaped.push('&#' + s.codePointAt(i) + ';')
+						}
+					}
+					return escaped.join('')
+				}
+
 			`
 		}
 

--- a/src/generators/server-side-rendering/visitors/shared/stringifyAttributeValue.ts
+++ b/src/generators/server-side-rendering/visitors/shared/stringifyAttributeValue.ts
@@ -11,7 +11,7 @@ export default function stringifyAttributeValue(block: Block, chunks: Node[]) {
 
 			block.contextualise(chunk.expression);
 			const { snippet } = chunk.metadata;
-			return '${' + snippet + '}';
+			return '${__escapeAttr(' + snippet + ')}';
 		})
 		.join('');
 }


### PR DESCRIPTION
When generating code for SSR, the output of `{{tag expressions}}` isn't currently properly escaped within HTML attributes — leading to both security issues and unexpected behaviour when the content includes special characters.

From briefly looking at the source, it looks like the issue is with this line in [`stringifyAttributeValue`](https://github.com/sveltejs/svelte/blob/56e9343294d4a83806ab4640c6f4df968a258353/src/generators/server-side-rendering/visitors/shared/stringifyAttributeValue.ts#L14):

```typescript
return '${' + snippet + '}';
```

Which should perhaps be replaced within something like:

```typescript
return '${__escapeAttr(' + snippet + ')}';
```

Where the `__escapeAttr` function replaces anything except the "safe" subset of the printable ASCII characters with the equivalent `&#NN;` HTML character reference.

This pull request implements the above, limiting the above to the "safe" characters of `a-z`, `A-Z`, `0-9`, `-`, ` `, and `_`.

Let me know if you'd like me to make any further changes, or if you'd rather reimplement it in a better way yourselves.

Thank you!