### PR TITLE
escape attribute values in SSR

### DIFF
--- a/src/generators/server-side-rendering/visitors/shared/stringifyAttributeValue.ts
+++ b/src/generators/server-side-rendering/visitors/shared/stringifyAttributeValue.ts
@@ -11,7 +11,7 @@ export default function stringifyAttributeValue(block: Block, chunks: Node[]) {
 
 			block.contextualise(chunk.expression);
 			const { snippet } = chunk.metadata;
-			return '${' + snippet + '}';
+			return '${__escape(' + snippet + ')}';
 		})
 		.join('');
 }

--- a/test/runtime/samples/attribute-dynamic-quotemarks/_config.js
+++ b/test/runtime/samples/attribute-dynamic-quotemarks/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<span title='"foo"'>foo</span>`
+};

--- a/test/runtime/samples/attribute-dynamic-quotemarks/main.html
+++ b/test/runtime/samples/attribute-dynamic-quotemarks/main.html
@@ -1,0 +1,1 @@
+<span title='{{"\"foo\""}}'>foo</span>


### PR DESCRIPTION
Opening this up instead of #1142. (Thanks @tav!) I'm fairly certain that all we need to escape are the same things that `__escape` already escapes. In particular, we do not need to worry about the IE behavior where attribute values can be enclosed in backticks because we are already going to be enclosing everything in double quotes - so the browser will see that first, before any potential backtick.