### PR TITLE
Empty Each Blocks should have consistent behavior.

### DIFF
--- a/test/parser/samples/error-comment-unclosed/error.json
+++ b/test/parser/samples/error-comment-unclosed/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "comment was left open",
+	"loc": {
+		"line": 1,
+		"column": 0
+	},
+	"pos": 0
+}

--- a/test/parser/samples/error-comment-unclosed/input.html
+++ b/test/parser/samples/error-comment-unclosed/input.html
@@ -1,0 +1,1 @@
+<!-- an unclosed comment

--- a/test/parser/samples/error-each-blocks-empty/error.json
+++ b/test/parser/samples/error-each-blocks-empty/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "Empty block",
+	"loc": {
+		"line": 1,
+		"column": 0
+	},
+	"pos": 0
+}

--- a/test/parser/samples/error-each-blocks-empty/input.html
+++ b/test/parser/samples/error-each-blocks-empty/input.html
@@ -1,0 +1,1 @@
+{{#each foos as foo}}{{/each}}

--- a/test/parser/samples/error-each-blocks-keyed-whitespace/error.json
+++ b/test/parser/samples/error-each-blocks-keyed-whitespace/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "Empty block",
+	"loc": {
+		"line": 1,
+		"column": 0
+	},
+	"pos": 0
+}

--- a/test/parser/samples/error-each-blocks-keyed-whitespace/input.html
+++ b/test/parser/samples/error-each-blocks-keyed-whitespace/input.html
@@ -1,8 +1,11 @@
 {{#each foos as foo @id}}
 {{/each}}
-
 <script>
-	export default {
-		data: () => ({ foos: [] })
-	}
+  export default {
+    data: () => ({
+      foos: [
+        { "id": 5 }
+      ]
+    })
+  };
 </script>

--- a/test/parser/samples/error-each-blocks-keyed-whitespace/input.html
+++ b/test/parser/samples/error-each-blocks-keyed-whitespace/input.html
@@ -1,0 +1,8 @@
+{{#each foos as foo @id}}
+{{/each}}
+
+<script>
+	export default {
+		data: () => ({ foos: [] })
+	}
+</script>

--- a/test/parser/samples/error-each-blocks-whitespace/error.json
+++ b/test/parser/samples/error-each-blocks-whitespace/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "Empty block",
+	"loc": {
+		"line": 1,
+		"column": 0
+	},
+	"pos": 0
+}

--- a/test/parser/samples/error-each-blocks-whitespace/input.html
+++ b/test/parser/samples/error-each-blocks-whitespace/input.html
@@ -1,0 +1,2 @@
+{{#each foos as foo}}
+{{/each}}

--- a/test/parser/samples/error-each-blocks-whitespace/input.html
+++ b/test/parser/samples/error-each-blocks-whitespace/input.html
@@ -1,2 +1,11 @@
 {{#each foos as foo}}
 {{/each}}
+<script>
+  export default {
+    data: () => ({
+      foos: [
+        "id": 5
+      ]
+    })
+  };
+</script>


### PR DESCRIPTION
Here the `error-each-blocks-empty` behaves as expected. It throws a ParseError.
I can't get the whitespace errors to repro in the tests. They're easily seen
here: https://svelte.technology/repl?version=1.51.0&gist=b53b31b1c18ef80ff35067e02a9e7199

If you uncomment each section in sequence it demonstrates the behavior. I can't
quite figure out why my examples don't work.
