### PR TITLE
Rework handling of non-root <script> and <style>

### DIFF
--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -232,7 +232,7 @@ export default class Element extends Node {
 				);
 			} else {
 				block.builders.create.addLine(
-					`${name}.innerHTML = ${stringify(this.children.map(toHTML).join(''))};`
+					`${name}.innerHTML = ${stringify(this.children.map(node => toHTML(node, false)).join(''))};`
 				);
 			}
 		} else {
@@ -414,8 +414,10 @@ export default class Element extends Node {
 			);
 		}
 
-		function toHTML(node: Element | Text) {
-			if (node.type === 'Text') return escapeHTML(node.data);
+		function toHTML(node: Element | Text, dontEscapeText: Boolean) {
+			if (node.type === 'Text') {
+				return dontEscapeText ? node.data : escapeHTML(node.data);
+			}
 
 			let open = `<${node.name}`;
 
@@ -433,11 +435,9 @@ export default class Element extends Node {
 
 			if (isVoidElementName(node.name)) return open + '>';
 
-			if (node.name === 'script' || node.name === 'style') {
-				return `${open}>${node.data}</${node.name}>`;
-			}
+			const shouldNotEscapeText = node.name === 'script' || node.name === 'style';
 
-			return `${open}>${node.children.map(toHTML).join('')}</${node.name}>`;
+			return `${open}>${node.children.map(node => toHTML(node, shouldNotEscapeText)).join('')}</${node.name}>`;
 		}
 	}
 

--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -232,7 +232,7 @@ export default class Element extends Node {
 				);
 			} else {
 				block.builders.create.addLine(
-					`${name}.innerHTML = ${stringify(this.children.map(node => toHTML(node, false)).join(''))};`
+					`${name}.innerHTML = ${stringify(this.children.map(toHTML).join(''))};`
 				);
 			}
 		} else {
@@ -414,9 +414,13 @@ export default class Element extends Node {
 			);
 		}
 
-		function toHTML(node: Element | Text, dontEscapeText: Boolean) {
+		function toHTML(node: Element | Text) {
 			if (node.type === 'Text') {
-				return dontEscapeText ? node.data : escapeHTML(node.data);
+				return node.parent &&
+					node.parent.type === 'Element' &&
+					(node.parent.name === 'script' || node.parent.name === 'style')
+					? node.data
+					: escapeHTML(node.data);
 			}
 
 			let open = `<${node.name}`;
@@ -435,9 +439,7 @@ export default class Element extends Node {
 
 			if (isVoidElementName(node.name)) return open + '>';
 
-			const shouldNotEscapeText = node.name === 'script' || node.name === 'style';
-
-			return `${open}>${node.children.map(node => toHTML(node, shouldNotEscapeText)).join('')}</${node.name}>`;
+			return `${open}>${node.children.map(toHTML).join('')}</${node.name}>`;
 		}
 	}
 

--- a/src/generators/server-side-rendering/visitors/Element.ts
+++ b/src/generators/server-side-rendering/visitors/Element.ts
@@ -68,8 +68,6 @@ export default function visitElement(
 
 	if (node.name === 'textarea' && textareaContents !== undefined) {
 		generator.append(textareaContents);
-	} else if (node.name === 'script' || node.name === 'style') {
-		generator.append(escape(node.data));
 	} else {
 		node.children.forEach((child: Node) => {
 			visit(generator, block, child);

--- a/src/generators/server-side-rendering/visitors/Text.ts
+++ b/src/generators/server-side-rendering/visitors/Text.ts
@@ -8,5 +8,14 @@ export default function visitText(
 	block: Block,
 	node: Node
 ) {
-	generator.append(escapeHTML(escape(node.data).replace(/(\${|`|\\)/g, '\\$1')));
+	let text = escape(node.data).replace(/(\${|`|\\)/g, '\\$1');
+	if (
+		!node.parent ||
+		node.parent.type !== 'Element' ||
+		(node.parent.name !== 'script' && node.parent.name !== 'style')
+	) {
+		// unless this Text node is inside a <script> or <style> element, escape &,<,>
+		text = escapeHTML(text);
+	}
+	generator.append(text);
 }

--- a/src/parse/state/tag.ts
+++ b/src/parse/state/tag.ts
@@ -224,10 +224,22 @@ export default function tag(parser: Parser) {
 		);
 		parser.read(/<\/textarea>/);
 		element.end = parser.index;
-	} else if (name === 'script' || name === 'style') {
+	} else if (name === 'script') {
 		// special case
-		element.data = parser.readUntil(new RegExp(`</${name}>`));
-		parser.eat(`</${name}>`, true);
+		const start = parser.index;
+		const data = parser.readUntil(/<\/script>/);
+		const end = parser.index;
+		element.children.push({ start, end, type: 'Text', data });
+		parser.eat('</script>', true);
+		element.end = parser.index;
+	} else if (name === 'style') {
+		// special case
+		element.children = readSequence(
+			parser,
+			() =>
+				parser.template.slice(parser.index, parser.index + 8) === '</style>'
+		);
+		parser.read(/<\/style>/);
 		element.end = parser.index;
 	} else {
 		parser.stack.push(element);

--- a/test/runtime/samples/non-root-style-interpolation/_config.js
+++ b/test/runtime/samples/non-root-style-interpolation/_config.js
@@ -18,6 +18,27 @@ export default {
 			<div>
 				<style>
 					div > div {
+						color: blue;
+					}
+				</style>
+				foo
+			</div>
+		</div>
+
+		<div>
+			<style>
+			/* something with < and > */
+				div {
+					color: red;
+				}
+			</style>
+			foo
+		</div>
+
+		<div>
+			<div>
+				<style>
+					div > div {
 						color: red;
 					}
 				</style>

--- a/test/runtime/samples/non-root-style-interpolation/_config.js
+++ b/test/runtime/samples/non-root-style-interpolation/_config.js
@@ -1,0 +1,28 @@
+export default {
+	data: {
+		color: 'red',
+	},
+
+	html: `
+		<div>
+			<style>
+			/* something with < and > */
+				div {
+					color: blue;
+				}
+			</style>
+			foo
+		</div>
+
+		<div>
+			<div>
+				<style>
+					div > div {
+						color: red;
+					}
+				</style>
+				foo
+			</div>
+		</div>
+	`,
+};

--- a/test/runtime/samples/non-root-style-interpolation/main.html
+++ b/test/runtime/samples/non-root-style-interpolation/main.html
@@ -12,6 +12,27 @@
 	<div>
 		<style>
 			div > div {
+				color: blue;
+			}
+		</style>
+		foo
+	</div>
+</div>
+
+<div>
+	<style>
+	/* something with < and > */
+		div {
+			color: {{color}};
+		}
+	</style>
+	foo
+</div>
+
+<div>
+	<div>
+		<style>
+			div > div {
 				color: {{color}};
 			}
 		</style>

--- a/test/runtime/samples/non-root-style-interpolation/main.html
+++ b/test/runtime/samples/non-root-style-interpolation/main.html
@@ -1,0 +1,20 @@
+<div>
+	<style>
+	/* something with < and > */
+		div {
+			color: blue;
+		}
+	</style>
+	foo
+</div>
+
+<div>
+	<div>
+		<style>
+			div > div {
+				color: {{color}};
+			}
+		</style>
+		foo
+	</div>
+</div>

--- a/test/runtime/samples/script-style-non-top-level/_config.js
+++ b/test/runtime/samples/script-style-non-top-level/_config.js
@@ -1,0 +1,8 @@
+export default {
+	html: `
+		<div>
+			<style>div { color: red; }</style>
+			<script>alert('<>');</script>
+		</div>
+	`
+};

--- a/test/runtime/samples/script-style-non-top-level/main.html
+++ b/test/runtime/samples/script-style-non-top-level/main.html
@@ -1,0 +1,4 @@
+<div>
+	<style>div { color: red; }</style>
+	<script>alert('<>');</script>
+</div>


### PR DESCRIPTION
In practical terms, this fixes hydration of non-root <script> and <style>, and also fixes tag interpolation in non-root <style> (#1147). This supersedes other previous PRs I'd opened.

This switches non-root <script> and <style> back to being parsed as regular elements containing one child Text node (in the case of <script>) and one or more Text or Tag nodes (in the case of <style>). There are also some other changes to make sure we don't escape HTML special characters in DOM or SSR mode for the Text nodes inside non-root <script> and <style> elements.