### PR TITLE
SSR: more sigil and template string escaping fixes

### DIFF
--- a/src/generators/server-side-rendering/visitors/Component.ts
+++ b/src/generators/server-side-rendering/visitors/Component.ts
@@ -6,7 +6,7 @@ import { AppendTarget } from '../interfaces';
 import { Node } from '../../../interfaces';
 import getObject from '../../../utils/getObject';
 import getTailSnippet from '../../../utils/getTailSnippet';
-import { stringify } from '../../../utils/stringify';
+import { escape, stringify } from '../../../utils/stringify';
 
 export default function visitComponent(
 	generator: SsrGenerator,
@@ -14,7 +14,7 @@ export default function visitComponent(
 	node: Node
 ) {
 	function stringifyAttribute(chunk: Node) {
-		if (chunk.type === 'Text') return chunk.data;
+		if (chunk.type === 'Text') return escape(chunk.data);
 		if (chunk.type === 'MustacheTag') {
 			block.contextualise(chunk.expression);
 			const { snippet } = chunk.metadata;

--- a/src/generators/server-side-rendering/visitors/Component.ts
+++ b/src/generators/server-side-rendering/visitors/Component.ts
@@ -6,7 +6,7 @@ import { AppendTarget } from '../interfaces';
 import { Node } from '../../../interfaces';
 import getObject from '../../../utils/getObject';
 import getTailSnippet from '../../../utils/getTailSnippet';
-import { escape, stringify } from '../../../utils/stringify';
+import { escape, escapeTemplate, stringify } from '../../../utils/stringify';
 
 export default function visitComponent(
 	generator: SsrGenerator,
@@ -14,7 +14,9 @@ export default function visitComponent(
 	node: Node
 ) {
 	function stringifyAttribute(chunk: Node) {
-		if (chunk.type === 'Text') return escape(chunk.data);
+		if (chunk.type === 'Text') {
+			return escapeTemplate(escape(chunk.data));
+		}
 		if (chunk.type === 'MustacheTag') {
 			block.contextualise(chunk.expression);
 			const { snippet } = chunk.metadata;

--- a/src/generators/server-side-rendering/visitors/Text.ts
+++ b/src/generators/server-side-rendering/visitors/Text.ts
@@ -1,6 +1,6 @@
 import { SsrGenerator } from '../index';
 import Block from '../Block';
-import { escape, escapeHTML } from '../../../utils/stringify';
+import { escape, escapeHTML, escapeTemplate } from '../../../utils/stringify';
 import { Node } from '../../../interfaces';
 
 export default function visitText(
@@ -8,5 +8,5 @@ export default function visitText(
 	block: Block,
 	node: Node
 ) {
-	generator.append(escapeHTML(escape(node.data).replace(/(\${|`|\\)/g, '\\$1')));
+	generator.append(escapeTemplate(escapeHTML(escape(node.data))));
 }

--- a/src/generators/server-side-rendering/visitors/shared/stringifyAttributeValue.ts
+++ b/src/generators/server-side-rendering/visitors/shared/stringifyAttributeValue.ts
@@ -1,12 +1,12 @@
 import Block from '../../Block';
-import { escape } from '../../../../utils/stringify';
+import { escape, escapeTemplate } from '../../../../utils/stringify';
 import { Node } from '../../../../interfaces';
 
 export default function stringifyAttributeValue(block: Block, chunks: Node[]) {
 	return chunks
 		.map((chunk: Node) => {
 			if (chunk.type === 'Text') {
-				return escape(chunk.data).replace(/"/g, '&quot;');
+				return escapeTemplate(escape(chunk.data).replace(/"/g, '&quot;'));
 			}
 
 			block.contextualise(chunk.expression);

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -17,3 +17,7 @@ const escaped = {
 export function escapeHTML(html) {
 	return String(html).replace(/[&<>]/g, match => escaped[match]);
 }
+
+export function escapeTemplate(str) {
+	return str.replace(/(\${|`|\\)/g, '\\$1');
+}

--- a/test/runtime/samples/escape-template-literals/Widget.html
+++ b/test/runtime/samples/escape-template-literals/Widget.html
@@ -1,0 +1,1 @@
+<div>{{value}}</div>

--- a/test/runtime/samples/escape-template-literals/_config.js
+++ b/test/runtime/samples/escape-template-literals/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: '<code>`${foo}\\n`</code>'
+	html: '<code>`${foo}\\n`</code>\n<div title="`${foo}\\n`">foo</div>\n<div>`${foo}\\n`</div>',
 };

--- a/test/runtime/samples/escape-template-literals/main.html
+++ b/test/runtime/samples/escape-template-literals/main.html
@@ -1,1 +1,8 @@
 <code>`${foo}\n`</code>
+<div title="`${foo}\n`">foo</div>
+<Widget value="`${foo}\n`"/>
+
+<script>
+	import Widget from './Widget.html';
+	export default { components: { Widget } };
+</script>

--- a/test/runtime/samples/sigil-component-attribute/Widget.html
+++ b/test/runtime/samples/sigil-component-attribute/Widget.html
@@ -1,0 +1,1 @@
+<div>{{value}}</div>

--- a/test/runtime/samples/sigil-component-attribute/_config.js
+++ b/test/runtime/samples/sigil-component-attribute/_config.js
@@ -1,0 +1,4 @@
+export default {
+	data: { foo: 'foo' },
+	html: `<div>foo @ foo # foo</div>`,
+};

--- a/test/runtime/samples/sigil-component-attribute/main.html
+++ b/test/runtime/samples/sigil-component-attribute/main.html
@@ -1,0 +1,6 @@
+<Widget value='foo @ {{foo}} # foo'/>
+
+<script>
+	import Widget from './Widget.html';
+	export default { components: { Widget } };
+</script>


### PR DESCRIPTION
In SSR mode, sigils aren't being correctly escaped in the static text portion of component attribute values if they also contain a dynamic portion.