### PR TITLE
this._changeHandlers was undefined when calling cancel()

### DIFF
--- a/store.js
+++ b/store.js
@@ -115,7 +115,7 @@ assign(Store.prototype, {
 			cancel: function() {
 				var index = this._changeHandlers.indexOf(callback);
 				if (~index) this._changeHandlers.splice(index, 1);
-			}
+			}.bind(this)
 		};
 	},
 

--- a/store.js
+++ b/store.js
@@ -111,11 +111,14 @@ assign(Store.prototype, {
 
 	onchange: function(callback) {
 		this._changeHandlers.push(callback);
+
+		var store = this;
+
 		return {
 			cancel: function() {
-				var index = this._changeHandlers.indexOf(callback);
-				if (~index) this._changeHandlers.splice(index, 1);
-			}.bind(this)
+				var index = store._changeHandlers.indexOf(callback);
+				if (~index) store._changeHandlers.splice(index, 1);
+			}
 		};
 	},
 

--- a/test/store/index.js
+++ b/test/store/index.js
@@ -113,6 +113,15 @@ describe('store', () => {
 		});
 	});
 
+	it('allows user to cancel state change callback', () => {
+		const store = new Store();
+		const handler = store.onchange(() => {});
+
+		assert.doesNotThrow(() => {
+			handler.cancel();
+		}, TypeError, 'this._changeHandlers is undefined');
+	});
+
 	describe('computed', () => {
 		it('computes a property based on data', () => {
 			const store = new Store({


### PR DESCRIPTION
This change fixes Issue #1177 where the scope of the cancel() function was not bound correctly and thus when attempting to call cancel() a type error of this._changeHandlers is undefined was created.
