### PR TITLE
fix capitalize warning

### DIFF
--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -101,7 +101,7 @@ export default function validate(
 			throw error;
 		}
 
-		if (name && !/^[A-Z]/.test(name)) {
+		if (name && /^[a-z]/.test(name)) {
 			const message = `options.name should be capitalised`;
 			onwarn({
 				message,

--- a/test/validator/index.js
+++ b/test/validator/index.js
@@ -88,4 +88,19 @@ describe("validate", () => {
 			}
 		]);
 	});
+
+	it("does not warn if options.name begins with non-alphabetic character", () => {
+		const warnings = [];
+		svelte.compile("<div></div>", {
+			name: "_",
+			onwarn(warning) {
+				warnings.push({
+					message: warning.message,
+					pos: warning.pos,
+					loc: warning.loc
+				});
+			}
+		});
+		assert.deepEqual(warnings, []);
+	});
 });


### PR DESCRIPTION
The current 'is the component name capitalized?' check disregards the possibility of the first character being `_` or `$`. The upcoming version of Sapper has components with names like `_4xx` and `_5xx`, so this PR checks that the first character isn't `a-z` rather than checking that it *is* `A-Z`. I *think* that's a sensible fix