### PR TITLE
upgrade acorn and parse as ES2018

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/mocha": "^2.2.41",
     "@types/node": "^8.0.17",
-    "acorn": "^5.1.1",
+    "acorn": "^5.4.1",
     "acorn-dynamic-import": "^2.0.2",
     "chalk": "^2.0.1",
     "codecov": "^2.2.0",

--- a/src/parse/read/directives.ts
+++ b/src/parse/read/directives.ts
@@ -31,7 +31,9 @@ function readExpression(parser: Parser, start: number, quoteMark: string|null) {
 		}
 	}
 
-	const expression = parseExpressionAt(repeat(' ', start) + str, start);
+	const expression = parseExpressionAt(repeat(' ', start) + str, start, {
+		ecmaVersion: 9,
+	});
 	parser.index = expression.end;
 
 	parser.allowWhitespace();
@@ -102,7 +104,7 @@ export function readBindingDirective(
 		}
 
 		const source = repeat(' ', a) + parser.template.slice(a, b);
-		value = parseExpressionAt(source, a);
+		value = parseExpressionAt(source, a, { ecmaVersion: 9 });
 
 		if (value.type !== 'Identifier' && value.type !== 'MemberExpression') {
 			parser.error(`Cannot bind to rvalue`, value.start);

--- a/src/parse/read/expression.ts
+++ b/src/parse/read/expression.ts
@@ -32,6 +32,7 @@ export default function readExpression(parser: Parser) {
 
 	try {
 		const node = parseExpressionAt(parser.template, parser.index, {
+			ecmaVersion: 9,
 			preserveParens: true,
 		});
 		parser.index = node.end;

--- a/src/parse/read/script.ts
+++ b/src/parse/read/script.ts
@@ -22,7 +22,7 @@ export default function readScript(parser: Parser, start: number, attributes: No
 
 	try {
 		ast = acorn.parse(source, {
-			ecmaVersion: 8,
+			ecmaVersion: 9,
 			sourceType: 'module',
 			plugins: {
 				dynamicImport: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,9 +58,13 @@ acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.1.1, acorn@^5.2.1, acorn@^5.3.0:
+acorn@^5.0.0, acorn@^5.2.1, acorn@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
+acorn@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
 acorn@~5.1.1:
   version "5.1.2"


### PR DESCRIPTION
There are a few different places where we're parsing with Acorn. I *think* it makes sense to parse as ES2018 in each place apart from `src/generators/dom/index.ts` which I think has to do with shared helpers. It might make sense to abstract this out somewhere so we don't have to remember to update as many places each year.