### PR TITLE
Add link to svelte-dev-store to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is the Svelte compiler, which is primarily intended for authors of tooling 
 * [svelte-hot-loader](https://github.com/ekhaled/svelte-hot-loader) – Webpack loader addon to support HMR
 * [meteor-svelte](https://github.com/klaussner/meteor-svelte) – Meteor build plugin
 * [sveltejs-brunch](https://github.com/StarpTech/sveltejs-brunch) – Brunch build plugin
+* [svelte-dev-store](https://github.com/GarethOates/svelte-dev-store) - Use Redux tools to visualise Svelte store
 * More to come!
 
 


### PR DESCRIPTION
Wondered if you could add my npm package to the README? It allows you to use the Redux Dev Tools browser extension to view the contents and state changes of a svelte store.

I know this is a bit shameless but I just though it might be useful to other people, as it has helped me recently when working with the svelte store on a new app.