### PR TITLE
Remove querySelector and querySelectorAll from shared/dom.js

### DIFF
--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -169,15 +169,15 @@ export function selectOptions(select, value) {
 }
 
 export function selectValue(select) {
-  var selectedOption = select.options[select.selectedIndex >= 0 ? select.selectedIndex : 0];
-  return selectedOption && selectedOption.__value;
+	var selectedOption = select.options[select.selectedIndex >= 0 ? select.selectedIndex : 0];
+	return selectedOption && selectedOption.__value;
 }
 
 export function selectMultipleValue(select) {
-  var values = [];
+	var values = [];
 	for (var i = 0; i < select.options.length; i += 1) {
 		var option = select.options[i];
-    option.selected && values.push(option.__value);
-  }
-  return values;
+		option.selected && values.push(option.__value);
+	}
+	return values;
 }

--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -169,12 +169,15 @@ export function selectOptions(select, value) {
 }
 
 export function selectValue(select) {
-	var selectedOption = select.querySelector(':checked') || select.options[0];
-	return selectedOption && selectedOption.__value;
+  var selectedOption = select.options[select.selectedIndex >= 0 ? select.selectedIndex : 0];
+  return selectedOption && selectedOption.__value;
 }
 
 export function selectMultipleValue(select) {
-	return [].map.call(select.querySelectorAll(':checked'), function(option) {
-		return option.__value;
-	});
+  var values = [];
+	for (var i = 0; i < select.options.length; i += 1) {
+		var option = select.options[i];
+    option.selected && values.push(option.__value);
+  }
+  return values;
 }


### PR DESCRIPTION
Hello,

I noticed when exploring examples using HTMLSelectElements that querySelector and querySelectorAll was used to find the options checked. I'm working on a DOM implementation that doesn't currently support these APIs and made changes locally to continue along.

First, this change uses `selectedIndex` when only a single value is allowed in a HTMLSelectElement. `selectedIndex` has been present since DOM level 1 and should provide a reasonable replacement. (https://www.w3.org/TR/REC-DOM-Level-1/level-one-html.html#ID-94282980)

Secondly, when multiple values are possible, this change moves to iterating over the options and creating an array of values for selected options.

Am slightly unfamiliar with the structure of the project, and wasn't sure where to add tests regarding the performance of these implementations. Happy to do so or make other changes if helpful.

Total change adds 23 bytes to uncompressed (but minified) output of an application leveraging both functions.