### PR TITLE
process code in @supports queries with cascade: false

### DIFF
--- a/src/css/Stylesheet.ts
+++ b/src/css/Stylesheet.ts
@@ -163,7 +163,7 @@ class Atrule {
 	}
 
 	apply(node: Element, stack: Element[]) {
-		if (this.node.name === 'media') {
+		if (this.node.name === 'media' || this.node.name === 'supports') {
 			this.children.forEach(child => {
 				child.apply(node, stack);
 			});
@@ -199,6 +199,14 @@ class Atrule {
 			if (this.node.expression.start - c > 1) code.overwrite(c, this.node.expression.start, ' ');
 			c = this.node.expression.end;
 			if (this.node.block.start - c > 0) code.remove(c, this.node.block.start);
+		} else if (this.node.name === 'supports') {
+			let c = this.node.start + 9;
+			if (this.node.expression.start - c > 1) code.overwrite(c, this.node.expression.start, ' ');
+			this.node.expression.children.forEach((query: Node) => {
+				// TODO minify queries
+				c = query.end;
+			});
+			code.remove(c, this.node.block.start);
 		}
 
 		// TODO other atrules

--- a/test/css/samples/supports-query/_config.js
+++ b/test/css/samples/supports-query/_config.js
@@ -1,0 +1,3 @@
+export default {
+	cascade: false
+};

--- a/test/css/samples/supports-query/expected.css
+++ b/test/css/samples/supports-query/expected.css
@@ -1,0 +1,1 @@
+@supports (display: grid){.maybe-grid[svelte-xyz]{display:grid}}

--- a/test/css/samples/supports-query/input.html
+++ b/test/css/samples/supports-query/input.html
@@ -1,0 +1,9 @@
+<div class='maybe-grid'>something with a nice layout</div>
+
+<style>
+	@supports (display: grid) {
+		.maybe-grid {
+			display: grid;
+		}
+	}
+</style>


### PR DESCRIPTION
with the `cascade: false` option, CSS in `@supports` blocks was getting removed

```html
<div class='maybe-grid'>something with a nice layout</div>

<style>
  @supports (display: grid) {
    .maybe-grid {
      display: grid;
    }
  }
</style>
```

You would expect to get the code within the block e.g.

```css
@supports (display: grid) {.maybe-grid[svelte-xyz]{display:grid}}
```

but you would get 

```css
@supports (display: grid) {}
```

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->