### PR TITLE
add each_value to contextProps

### DIFF
--- a/src/generators/nodes/EachBlock.ts
+++ b/src/generators/nodes/EachBlock.ts
@@ -75,6 +75,7 @@ export default class EachBlock extends Node {
 		}
 
 		this.contextProps = [
+			`${this.block.listName}: ${this.block.listName}`,
 			`${this.context}: ${this.block.listName}[#i]`,
 			`${this.block.indexName}: #i`
 		];

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -212,6 +212,7 @@ function create_main_fragment(component, state) {
 
 	for (var i = 0; i < comments.length; i += 1) {
 		each_blocks[i] = create_each_block(component, assign({}, state, {
+			comments: comments,
 			comment: comments[i],
 			i: i
 		}));
@@ -244,6 +245,7 @@ function create_main_fragment(component, state) {
 			if (changed.comments || changed.elapsed || changed.time) {
 				for (var i = 0; i < comments.length; i += 1) {
 					var each_context = assign({}, state, {
+						comments: comments,
 						comment: comments[i],
 						i: i
 					});

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -10,6 +10,7 @@ function create_main_fragment(component, state) {
 
 	for (var i = 0; i < comments.length; i += 1) {
 		each_blocks[i] = create_each_block(component, assign({}, state, {
+			comments: comments,
 			comment: comments[i],
 			i: i
 		}));
@@ -42,6 +43,7 @@ function create_main_fragment(component, state) {
 			if (changed.comments || changed.elapsed || changed.time) {
 				for (var i = 0; i < comments.length; i += 1) {
 					var each_context = assign({}, state, {
+						comments: comments,
 						comment: comments[i],
 						i: i
 					});

--- a/test/runtime/samples/each-block-array-literal/_config.js
+++ b/test/runtime/samples/each-block-array-literal/_config.js
@@ -1,17 +1,19 @@
 export default {
 	html: `
-		<button>racoon</button><button>eagle</button>
+		<button>racoon</button>
+		<button>eagle</button>
 	`,
 
-	test ( assert, component, target ) {
-		assert.htmlEqual( target.innerHTML, `
-			<button>racoon</button><button>eagle</button>
+	test(assert, component, target) {
+		assert.htmlEqual(target.innerHTML,`
+			<button>racoon</button>
+			<button>eagle</button>
 		`);
 
-		const button = target.querySelector( 'button' );
-		const event = new window.MouseEvent( 'click' );
+		const button = target.querySelector('button');
+		const event = new window.MouseEvent('click');
 
-		button.dispatchEvent( event );
-		assert.equal( component.get( 'clicked' ), 'racoon' );
+		button.dispatchEvent(event);
+		assert.equal(component.get('clicked'), 'racoon');
 	},
 };

--- a/test/runtime/samples/each-block-array-literal/main.html
+++ b/test/runtime/samples/each-block-array-literal/main.html
@@ -1,5 +1,5 @@
 {{#each ['racoon', 'eagle'] as animal}}
-  <button on:click="set({clicked: animal})">{{animal}}</button>
+	<button on:click="set({clicked: animal})">{{animal}}</button>
 {{/each}}
 
 <script>


### PR DESCRIPTION
This fixes #1206. A neater solution would determine that the click handler only needed the `animal` value and didn't need to get it in a convoluted way, so we could just pass that around instead of the array and the index. (See also #1187.) But the priority is obviously to fix the bug