### PR TITLE
Apply CSS scoping classes directly to AST (WIP)

### DIFF
--- a/src/css/Selector.ts
+++ b/src/css/Selector.ts
@@ -1,16 +1,19 @@
 import MagicString from 'magic-string';
+import Stylesheet from './Stylesheet';
 import { gatherPossibleValues, UNKNOWN } from './gatherPossibleValues';
 import { Validator } from '../validate/index';
 import { Node } from '../interfaces';
 
 export default class Selector {
 	node: Node;
+	stylesheet: Stylesheet;
 	blocks: Block[];
 	localBlocks: Block[];
 	used: boolean;
 
-	constructor(node: Node) {
+	constructor(node: Node, stylesheet: Stylesheet) {
 		this.node = node;
+		this.stylesheet = stylesheet;
 
 		this.blocks = groupSelectors(node);
 
@@ -31,7 +34,7 @@ export default class Selector {
 
 		if (toEncapsulate.length > 0) {
 			toEncapsulate.filter((_, i) => i === 0 || i === toEncapsulate.length - 1).forEach(({ node, block }) => {
-				node.addCssClass();
+				this.stylesheet.nodesWithCssClass.add(node);
 				block.shouldEncapsulate = true;
 			});
 

--- a/src/css/Selector.ts
+++ b/src/css/Selector.ts
@@ -31,7 +31,7 @@ export default class Selector {
 
 		if (toEncapsulate.length > 0) {
 			toEncapsulate.filter((_, i) => i === 0 || i === toEncapsulate.length - 1).forEach(({ node, block }) => {
-				node._needsCssAttribute = true;
+				node.addCssClass();
 				block.shouldEncapsulate = true;
 			});
 

--- a/src/css/Stylesheet.ts
+++ b/src/css/Stylesheet.ts
@@ -353,7 +353,7 @@ export default class Stylesheet {
 		}
 
 		if (this.cascade) {
-			if (stack.length === 0) node._needsCssAttribute = true;
+			if (stack.length === 0) node.addCssClass();
 			return;
 		}
 

--- a/src/generators/Generator.ts
+++ b/src/generators/Generator.ts
@@ -179,6 +179,7 @@ export default class Generator {
 		}
 
 		this.walkTemplate();
+		this.stylesheet.reify();
 	}
 
 	addSourcemapLocations(node: Node) {

--- a/src/generators/Generator.ts
+++ b/src/generators/Generator.ts
@@ -179,7 +179,7 @@ export default class Generator {
 		}
 
 		this.walkTemplate();
-		this.stylesheet.reify();
+		if (!this.customElement) this.stylesheet.reify();
 	}
 
 	addSourcemapLocations(node: Node) {

--- a/src/generators/nodes/Attribute.ts
+++ b/src/generators/nodes/Attribute.ts
@@ -141,10 +141,6 @@ export default class Attribute {
 				shouldCache = true;
 			}
 
-			if (node._needsCssAttribute && name === 'class') {
-				value = `(${value}) + " ${this.generator.stylesheet.id}"`;
-			}
-
 			const isSelectValueAttribute =
 				name === 'value' && node.name === 'select';
 
@@ -227,21 +223,10 @@ export default class Attribute {
 				);
 			}
 		} else {
-			const isScopedClassAttribute = (
-				name === 'class' &&
-				this.parent._needsCssAttribute &&
-				!this.generator.customElement
-			);
-
-			const value = isScopedClassAttribute && this.value !== true
-				? this.value.length === 0
-					? `'${this.generator.stylesheet.id}'`
-					: stringify(this.value[0].data.concat(` ${this.generator.stylesheet.id}`))
-				: this.value === true
-					? 'true'
-					: this.value.length === 0
-						? `''`
-						: stringify(this.value[0].data);
+		const value =
+			this.value === true
+				? 'true'
+				: this.value.length === 0 ? `''` : stringify(this.value[0].data);
 
 			const statement = (
 				isLegacyInputType

--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -438,8 +438,8 @@ export default class Element extends Node {
 			}
 
 			node.attributes.forEach((attr: Node) => {
-				const value = node._needsCssAttribute && attr.name === 'class'
-					? attr.value.concat({ type: 'Text', data: ` ${generator.stylesheet.id}` })
+				const value = (node._needsCssAttribute && attr.name === 'class')
+					? [{ type: 'Text', data: `${attr.value[0].data} ${generator.stylesheet.id}` }]
 					: attr.value;
 
 				open += ` ${fixAttributeCasing(attr.name)}${stringifyAttributeValue(value)}`

--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -142,8 +142,6 @@ export default class Element extends Node {
 			this.name.replace(/[^a-zA-Z0-9_$]/g, '_')
 		);
 
-		this.generator.stylesheet.apply(this);
-
 		if (this.children.length) {
 			if (this.name === 'pre' || this.name === 'textarea') stripWhitespace = false;
 			this.initChildren(block, stripWhitespace, nextSibling);
@@ -671,8 +669,6 @@ export default class Element extends Node {
 	}
 
 	addCssClass() {
-		if (this._addedCssClass || this.generator.customElement) return;
-		this._addedCssClass = true;
 		const classAttribute = this.attributes.find(a => a.name === 'class');
 		if (classAttribute && classAttribute.value !== true) {
 			if (classAttribute.value.length === 1 && classAttribute.value[0].type === 'Text') {

--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -212,22 +212,11 @@ export default class Element extends Node {
 			block.builders.unmount.addLine(`@detachNode(${name});`);
 		}
 
-		// add CSS encapsulation attribute
-		if (this._needsCssAttribute && !this.generator.customElement) {
-			if (!this.attributes.find(a => a.type === 'Attribute' && a.name === 'class')) {
-				block.builders.hydrate.addLine(
-					this.namespace
-						? `@setAttribute(${name}, "class", "${this.generator.stylesheet.id}");`
-						: `${name}.className = "${this.generator.stylesheet.id}";`
-				);
-			}
-
-			// TODO move this into a class as well?
-			if (this._cssRefAttribute) {
-				block.builders.hydrate.addLine(
-					`@setAttribute(${name}, "svelte-ref-${this._cssRefAttribute}", "");`
-				)
-			}
+		// TODO move this into a class as well?
+		if (this._cssRefAttribute) {
+			block.builders.hydrate.addLine(
+				`@setAttribute(${name}, "svelte-ref-${this._cssRefAttribute}", "");`
+			)
 		}
 
 		// insert static children with textContent or innerHTML
@@ -438,16 +427,8 @@ export default class Element extends Node {
 			}
 
 			node.attributes.forEach((attr: Node) => {
-				const value = (node._needsCssAttribute && attr.name === 'class')
-					? [{ type: 'Text', data: `${attr.value[0].data} ${generator.stylesheet.id}` }]
-					: attr.value;
-
-				open += ` ${fixAttributeCasing(attr.name)}${stringifyAttributeValue(value)}`
+				open += ` ${fixAttributeCasing(attr.name)}${stringifyAttributeValue(attr.value)}`
 			});
-
-			if (node._needsCssAttribute && !node.attributes.find(a => a.name === 'class')) {
-				open += ` class="${generator.stylesheet.id}"`;
-			}
 
 			if (isVoidElementName(node.name)) return open + '>';
 
@@ -687,6 +668,30 @@ export default class Element extends Node {
 		}
 
 		return `@appendNode(${this.var}, ${name}._slotted${this.generator.legacy ? `["default"]` : `.default`});`;
+	}
+
+	addCssClass() {
+		if (this._addedCssClass || this.generator.customElement) return;
+		this._addedCssClass = true;
+		const classAttribute = this.attributes.find(a => a.name === 'class');
+		if (classAttribute && classAttribute.value !== true) {
+			if (classAttribute.value.length === 1 && classAttribute.value[0].type === 'Text') {
+				classAttribute.value[0].data += ` ${this.generator.stylesheet.id}`;
+			} else {
+				(<Node[]>classAttribute.value).push(
+					new Node({ type: 'Text', data: ` ${this.generator.stylesheet.id}` })
+				);
+			}
+		} else {
+			this.attributes.push(
+				new Attribute({
+					generator: this.generator,
+					name: 'class',
+					value: [new Node({ type: 'Text', data: `${this.generator.stylesheet.id}` })],
+					parent: this,
+				})
+			);
+		}
 	}
 }
 

--- a/src/generators/server-side-rendering/visitors/Element.ts
+++ b/src/generators/server-side-rendering/visitors/Element.ts
@@ -50,25 +50,12 @@ export default function visitElement(
 			block.contextualise(attribute.value[0].expression);
 			openingTag += '${' + attribute.value[0].metadata.snippet + ' ? " ' + attribute.name + '" : "" }';
 		} else {
-			const value = attribute.name === 'class' && node._needsCssAttribute
-				? attribute.value.concat({
-					type: 'Text',
-					data: ` ${generator.stylesheet.id}`
-				})
-				: attribute.value;
-
-			openingTag += ` ${attribute.name}="${stringifyAttributeValue(block, value)}"`;
+			openingTag += ` ${attribute.name}="${stringifyAttributeValue(block, attribute.value)}"`;
 		}
 	});
 
-	if (node._needsCssAttribute && !node.attributes.find(a => a.type === 'Attribute' && a.name === 'class')) {
-		openingTag += ` class="${generator.stylesheet.id}"`;
-	}
-
-	if (node._needsCssAttribute) {
-		if (node._cssRefAttribute) {
-			openingTag += ` svelte-ref-${node._cssRefAttribute}`;
-		}
+	if (node._cssRefAttribute) {
+		openingTag += ` svelte-ref-${node._cssRefAttribute}`;
 	}
 
 	openingTag += '>';

--- a/test/css/samples/cascade-false-nested/_config.js
+++ b/test/css/samples/cascade-false-nested/_config.js
@@ -1,0 +1,7 @@
+export default {
+	cascade: false,
+
+	data: {
+		dynamic: 'x'
+	}
+};

--- a/test/css/samples/cascade-false-nested/expected.css
+++ b/test/css/samples/cascade-false-nested/expected.css
@@ -1,0 +1,1 @@
+.foo.svelte-xyz{color:red}.bar.svelte-xyz{font-style:italic}

--- a/test/css/samples/cascade-false-nested/expected.html
+++ b/test/css/samples/cascade-false-nested/expected.html
@@ -1,0 +1,2 @@
+<span class="foo svelte-xyz"><span class="bar svelte-xyz">text</span></span>
+<span class="foo svelte-xyz"><span class="bar svelte-xyz">x</span></span>

--- a/test/css/samples/cascade-false-nested/input.html
+++ b/test/css/samples/cascade-false-nested/input.html
@@ -1,0 +1,16 @@
+<span class='foo'>
+	<span class='bar'>text</span>
+</span>
+
+<span class='foo'>
+	<span class='bar'>{{dynamic}}</span>
+</span>
+
+<style>
+	.foo {
+		color: red;
+	}
+	.bar {
+		font-style: italic;
+	}
+</style>


### PR DESCRIPTION
(Based on the #1223 branch to also get its unit test.)

A couple of issues still remain here:

- This breaks the `unused-selector-ternary` test because `attributeMatches` bails when `attr.value.length > 1`, which it now is, because there's the ternary part and the `svelte-xyz` class part. Not sure how to best handle this. Would it be practical to make the AST modifications after all the `Selector#apply` stuff?
- The `Element#addCssClass` logic could use some more thought. I'm not sure how to handle when the class attribute's `value` is `true` (this would mean that there is a bare `class` attribute, what the heck do we do with that?); and TypeScript is also still complaining about `classAttribute.value.length`, not sure whether it needs appeasing there or what.