### PR TITLE
Refactor directive parsing for code reuse

### DIFF
--- a/test/parser/samples/error-binding-mustaches/error.json
+++ b/test/parser/samples/error-binding-mustaches/error.json
@@ -1,5 +1,5 @@
 {
-	"message": "bound values should not be wrapped — use 'foo', not '{{foo}}'",
+	"message": "directive values should not be wrapped — use 'foo', not '{{foo}}'",
 	"loc": {
 		"line": 1,
 		"column": 19

--- a/test/parser/samples/error-binding-rvalue/error.json
+++ b/test/parser/samples/error-binding-rvalue/error.json
@@ -1,5 +1,5 @@
 {
-	"message": "Cannot bind to rvalue",
+	"message": "Expected Identifier or MemberExpression",
 	"pos": 19,
 	"loc": {
 		"line": 1,

--- a/test/parser/samples/error-event-handler/error.json
+++ b/test/parser/samples/error-event-handler/error.json
@@ -1,5 +1,5 @@
 {
-	"message": "Expected call expression",
+	"message": "Expected CallExpression",
 	"loc": {
 		"line": 1,
 		"column": 15


### PR DESCRIPTION
This removes the copy-pasta for directive parsing and removes the need for special if-else cases for each directive. Future directives (if any) will benefit from this cleanup as well.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
