### PR TITLE
don't treat :foo as a directive

### DIFF
--- a/src/parse/read/directives.ts
+++ b/src/parse/read/directives.ts
@@ -1,5 +1,6 @@
 import { parseExpressionAt } from 'acorn';
 import repeat from '../../utils/repeat';
+import list from '../../utils/list';
 import { Parser } from '../index';
 
 const DIRECTIVES = {
@@ -137,8 +138,12 @@ export function readDirective(
 		}
 
 		expression = readExpression(parser, expressionStart, quoteMark);
-		if (directive.allowedExpressionTypes.indexOf(expression.type) === -1) {
-			parser.error(`Expected ${directive.allowedExpressionTypes.join(' or ')}`, expressionStart);
+		if (directive.allowedExpressionTypes) {
+			if (directive.allowedExpressionTypes.indexOf(expression.type) === -1) {
+				parser.error(`Expected ${list(directive.allowedExpressionTypes)}`, expressionStart);
+			}
+		} else {
+			parser.error(`${directiveName} directives cannot have a value`, expressionStart);
 		}
 	}
 

--- a/test/parser/samples/error-binding-rvalue/error.json
+++ b/test/parser/samples/error-binding-rvalue/error.json
@@ -1,5 +1,5 @@
 {
-	"message": "Expected Identifier or MemberExpression",
+	"message": "Can only bind to an identifier (e.g. `foo`) or a member expression (e.g. `foo.bar` or `foo[baz]`)",
 	"pos": 19,
 	"loc": {
 		"line": 1,

--- a/test/parser/samples/error-event-handler/error.json
+++ b/test/parser/samples/error-event-handler/error.json
@@ -1,5 +1,5 @@
 {
-	"message": "Expected CallExpression",
+	"message": "Expected a method call",
 	"loc": {
 		"line": 1,
 		"column": 15

--- a/test/parser/samples/error-ref-value/error.json
+++ b/test/parser/samples/error-ref-value/error.json
@@ -1,0 +1,8 @@
+{
+	"message": "ref directives cannot have a value",
+	"loc": {
+		"line": 1,
+		"column": 14
+	},
+	"pos": 14
+}

--- a/test/parser/samples/error-ref-value/input.html
+++ b/test/parser/samples/error-ref-value/input.html
@@ -1,0 +1,1 @@
+<div ref:foo='bar'></div>


### PR DESCRIPTION
small tweak to #1242 — also fixes the over-specific regex.

Also disallows `ref:foo='bar'` etc — unlike other directives, refs don't have a value