### PR TITLE
Add end position to warnings and errors

### DIFF
--- a/src/css/Selector.ts
+++ b/src/css/Selector.ts
@@ -102,7 +102,7 @@ export default class Selector {
 			while (i-- > 1) {
 				const selector = block.selectors[i];
 				if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
-					validator.error(`:global(...) must be the first element in a compound selector`, { start: selector.start, end: selector.end });
+					validator.error(`:global(...) must be the first element in a compound selector`, selector);
 				}
 			}
 		});
@@ -120,8 +120,7 @@ export default class Selector {
 
 		for (let i = start; i < end; i += 1) {
 			if (this.blocks[i].global) {
-				const selector = this.blocks[i].selectors[0];
-				validator.error(`:global(...) can be at the start or end of a selector sequence, but not in the middle`, { start: selector.start, end: selector.end });
+				validator.error(`:global(...) can be at the start or end of a selector sequence, but not in the middle`, this.blocks[i].selectors[0]);
 			}
 		}
 	}

--- a/src/css/Selector.ts
+++ b/src/css/Selector.ts
@@ -102,7 +102,7 @@ export default class Selector {
 			while (i-- > 1) {
 				const selector = block.selectors[i];
 				if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
-					validator.error(`:global(...) must be the first element in a compound selector`, selector.start);
+					validator.error(`:global(...) must be the first element in a compound selector`, { start: selector.start, end: selector.end });
 				}
 			}
 		});
@@ -120,7 +120,8 @@ export default class Selector {
 
 		for (let i = start; i < end; i += 1) {
 			if (this.blocks[i].global) {
-				validator.error(`:global(...) can be at the start or end of a selector sequence, but not in the middle`, this.blocks[i].selectors[0].start);
+				const selector = this.blocks[i].selectors[0];
+				validator.error(`:global(...) can be at the start or end of a selector sequence, but not in the middle`, { start: selector.start, end: selector.end });
 			}
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,4 +146,4 @@ export function create(source: string, _options: CompileOptions = {}) {
 	}
 }
 
-export { parse, validate, version as VERSION };
+export { parse, validate, Stylesheet, version as VERSION };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,6 +29,7 @@ export interface Parsed {
 
 export interface Warning {
 	loc?: { line: number; column: number; pos?: number };
+	end?: { line: number; column: number; };
 	pos?: number;
 	message: string;
 	filename?: string;

--- a/src/utils/CompileError.ts
+++ b/src/utils/CompileError.ts
@@ -4,24 +4,28 @@ import getCodeFrame from '../utils/getCodeFrame';
 export default class CompileError extends Error {
 	frame: string;
 	loc: { line: number; column: number };
+	end: { line: number; column: number };
 	pos: number;
 	filename: string;
 
 	constructor(
 		message: string,
 		template: string,
-		index: number,
-		filename: string
+		startPos: number,
+		filename: string,
+		endPos: number = startPos
 	) {
 		super(message);
 
-		const { line, column } = locate(template, index);
+		const start = locate(template, startPos);
+		const end = locate(template, endPos);
 
-		this.loc = { line: line + 1, column };
-		this.pos = index;
+		this.loc = { line: start.line + 1, column: start.column };
+		this.end = { line: end.line + 1, column: end.column };
+		this.pos = startPos;
 		this.filename = filename;
 
-		this.frame = getCodeFrame(template, line, column);
+		this.frame = getCodeFrame(template, start.line, start.column);
 	}
 
 	public toString = () => {

--- a/src/validate/html/a11y.ts
+++ b/src/validate/html/a11y.ts
@@ -33,7 +33,7 @@ export default function a11y(
 		if (name.startsWith('aria-')) {
 			if (invisibleElements.has(node.name)) {
 				// aria-unsupported-elements
-				validator.warn(`A11y: <${node.name}> should not have aria-* attributes`, attribute.start);
+				validator.warn(`A11y: <${node.name}> should not have aria-* attributes`, { start: attribute.start, end: attribute.end });
 			}
 
 			const type = name.slice(5);
@@ -42,7 +42,7 @@ export default function a11y(
 				let message = `A11y: Unknown aria attribute 'aria-${type}'`;
 				if (match) message += ` (did you mean '${match}'?)`;
 
-				validator.warn(message, attribute.start);
+				validator.warn(message, { start: attribute.start, end: attribute.end });
 			}
 		}
 
@@ -50,7 +50,7 @@ export default function a11y(
 		if (name === 'role') {
 			if (invisibleElements.has(node.name)) {
 				// aria-unsupported-elements
-				validator.warn(`A11y: <${node.name}> should not have role attribute`, attribute.start);
+				validator.warn(`A11y: <${node.name}> should not have role attribute`, { start: attribute.start, end: attribute.end });
 			}
 
 			const value = getStaticAttributeValue(node, 'role');
@@ -59,30 +59,30 @@ export default function a11y(
 				let message = `A11y: Unknown role '${value}'`;
 				if (match) message += ` (did you mean '${match}'?)`;
 
-				validator.warn(message, attribute.start);
+				validator.warn(message, { start: attribute.start, end: attribute.end });
 			}
 		}
 
 		// no-access-key
 		if (name === 'accesskey') {
-			validator.warn(`A11y: Avoid using accesskey`, attribute.start);
+			validator.warn(`A11y: Avoid using accesskey`, { start: attribute.start, end: attribute.end });
 		}
 
 		// no-autofocus
 		if (name === 'autofocus') {
-			validator.warn(`A11y: Avoid using autofocus`, attribute.start);
+			validator.warn(`A11y: Avoid using autofocus`, { start: attribute.start, end: attribute.end });
 		}
 
 		// scope
 		if (name === 'scope' && node.name !== 'th') {
-			validator.warn(`A11y: The scope attribute should only be used with <th> elements`, attribute.start);
+			validator.warn(`A11y: The scope attribute should only be used with <th> elements`, { start: attribute.start, end: attribute.end });
 		}
 
 		// tabindex-no-positive
 		if (name === 'tabindex') {
 			const value = getStaticAttributeValue(node, 'tabindex');
 			if (!isNaN(value) && +value > 0) {
-				validator.warn(`A11y: avoid tabindex values above zero`, attribute.start);
+				validator.warn(`A11y: avoid tabindex values above zero`, { start: attribute.start, end: attribute.end });
 			}
 		}
 
@@ -96,13 +96,13 @@ export default function a11y(
 				attributes.slice(0, -1).join(', ') + ` or ${attributes[attributes.length - 1]}` :
 				attributes[0];
 
-			validator.warn(`A11y: <${name}> element should have ${article} ${sequence} attribute`, node.start);
+			validator.warn(`A11y: <${name}> element should have ${article} ${sequence} attribute`, { start: node.start, end: node.end });
 		}
 	}
 
 	function shouldHaveContent() {
 		if (node.children.length === 0) {
-			validator.warn(`A11y: <${node.name}> element should have child content`, node.start);
+			validator.warn(`A11y: <${node.name}> element should have child content`, { start: node.start, end: node.end });
 		}
 	}
 
@@ -110,7 +110,7 @@ export default function a11y(
 		const href = attributeMap.get(attribute);
 		const value = getStaticAttributeValue(node, attribute);
 		if (value === '' || value === '#') {
-			validator.warn(`A11y: '${value}' is not a valid ${attribute} attribute`, href.start);
+			validator.warn(`A11y: '${value}' is not a valid ${attribute} attribute`, { start: href.start, end: href.end });
 		}
 	}
 
@@ -122,7 +122,7 @@ export default function a11y(
 			// anchor-in-svg-is-valid
 			shouldHaveValidHref('xlink:href')
 		} else {
-			validator.warn(`A11y: <a> element should have an href attribute`, node.start);
+			validator.warn(`A11y: <a> element should have an href attribute`, { start: node.start, end: node.end });
 		}
 
 		// anchor-has-content
@@ -141,7 +141,8 @@ export default function a11y(
 		shouldHaveContent();
 
 		if (attributeMap.has('aria-hidden')) {
-			validator.warn(`A11y: <${node.name}> element should not be hidden`, attributeMap.get('aria-hidden').start);
+			const attr = attributeMap.get('aria-hidden');
+			validator.warn(`A11y: <${node.name}> element should not be hidden`, { start: attr.start, end: attr.end });
 		}
 	}
 
@@ -157,14 +158,14 @@ export default function a11y(
 
 	// no-distracting-elements
 	if (node.name === 'marquee' || node.name === 'blink') {
-		validator.warn(`A11y: Avoid <${node.name}> elements`, node.start);
+		validator.warn(`A11y: Avoid <${node.name}> elements`, { start: node.start, end: node.end });
 	}
 
 	if (node.name === 'figcaption') {
 		const parent = elementStack[elementStack.length - 1];
 		if (parent) {
 			if (parent.name !== 'figure') {
-				validator.warn(`A11y: <figcaption> must be an immediate child of <figure>`, node.start);
+				validator.warn(`A11y: <figcaption> must be an immediate child of <figure>`, { start: node.start, end: node.end });
 			} else {
 				const children = parent.children.filter(node => {
 					if (node.type === 'Comment') return false;
@@ -175,7 +176,7 @@ export default function a11y(
 				const index = children.indexOf(node);
 
 				if (index !== 0 && index !== children.length - 1) {
-					validator.warn(`A11y: <figcaption> must be first or last child of <figure>`, node.start);
+					validator.warn(`A11y: <figcaption> must be first or last child of <figure>`, { start: node.start, end: node.end });
 				}
 			}
 		}

--- a/src/validate/html/a11y.ts
+++ b/src/validate/html/a11y.ts
@@ -33,7 +33,7 @@ export default function a11y(
 		if (name.startsWith('aria-')) {
 			if (invisibleElements.has(node.name)) {
 				// aria-unsupported-elements
-				validator.warn(`A11y: <${node.name}> should not have aria-* attributes`, { start: attribute.start, end: attribute.end });
+				validator.warn(`A11y: <${node.name}> should not have aria-* attributes`, attribute);
 			}
 
 			const type = name.slice(5);
@@ -42,7 +42,7 @@ export default function a11y(
 				let message = `A11y: Unknown aria attribute 'aria-${type}'`;
 				if (match) message += ` (did you mean '${match}'?)`;
 
-				validator.warn(message, { start: attribute.start, end: attribute.end });
+				validator.warn(message, attribute);
 			}
 		}
 
@@ -50,7 +50,7 @@ export default function a11y(
 		if (name === 'role') {
 			if (invisibleElements.has(node.name)) {
 				// aria-unsupported-elements
-				validator.warn(`A11y: <${node.name}> should not have role attribute`, { start: attribute.start, end: attribute.end });
+				validator.warn(`A11y: <${node.name}> should not have role attribute`, attribute);
 			}
 
 			const value = getStaticAttributeValue(node, 'role');
@@ -59,30 +59,30 @@ export default function a11y(
 				let message = `A11y: Unknown role '${value}'`;
 				if (match) message += ` (did you mean '${match}'?)`;
 
-				validator.warn(message, { start: attribute.start, end: attribute.end });
+				validator.warn(message, attribute);
 			}
 		}
 
 		// no-access-key
 		if (name === 'accesskey') {
-			validator.warn(`A11y: Avoid using accesskey`, { start: attribute.start, end: attribute.end });
+			validator.warn(`A11y: Avoid using accesskey`, attribute);
 		}
 
 		// no-autofocus
 		if (name === 'autofocus') {
-			validator.warn(`A11y: Avoid using autofocus`, { start: attribute.start, end: attribute.end });
+			validator.warn(`A11y: Avoid using autofocus`, attribute);
 		}
 
 		// scope
 		if (name === 'scope' && node.name !== 'th') {
-			validator.warn(`A11y: The scope attribute should only be used with <th> elements`, { start: attribute.start, end: attribute.end });
+			validator.warn(`A11y: The scope attribute should only be used with <th> elements`, attribute);
 		}
 
 		// tabindex-no-positive
 		if (name === 'tabindex') {
 			const value = getStaticAttributeValue(node, 'tabindex');
 			if (!isNaN(value) && +value > 0) {
-				validator.warn(`A11y: avoid tabindex values above zero`, { start: attribute.start, end: attribute.end });
+				validator.warn(`A11y: avoid tabindex values above zero`, attribute);
 			}
 		}
 
@@ -96,13 +96,13 @@ export default function a11y(
 				attributes.slice(0, -1).join(', ') + ` or ${attributes[attributes.length - 1]}` :
 				attributes[0];
 
-			validator.warn(`A11y: <${name}> element should have ${article} ${sequence} attribute`, { start: node.start, end: node.end });
+			validator.warn(`A11y: <${name}> element should have ${article} ${sequence} attribute`, node);
 		}
 	}
 
 	function shouldHaveContent() {
 		if (node.children.length === 0) {
-			validator.warn(`A11y: <${node.name}> element should have child content`, { start: node.start, end: node.end });
+			validator.warn(`A11y: <${node.name}> element should have child content`, node);
 		}
 	}
 
@@ -110,7 +110,7 @@ export default function a11y(
 		const href = attributeMap.get(attribute);
 		const value = getStaticAttributeValue(node, attribute);
 		if (value === '' || value === '#') {
-			validator.warn(`A11y: '${value}' is not a valid ${attribute} attribute`, { start: href.start, end: href.end });
+			validator.warn(`A11y: '${value}' is not a valid ${attribute} attribute`, href);
 		}
 	}
 
@@ -122,7 +122,7 @@ export default function a11y(
 			// anchor-in-svg-is-valid
 			shouldHaveValidHref('xlink:href')
 		} else {
-			validator.warn(`A11y: <a> element should have an href attribute`, { start: node.start, end: node.end });
+			validator.warn(`A11y: <a> element should have an href attribute`, node);
 		}
 
 		// anchor-has-content
@@ -141,8 +141,7 @@ export default function a11y(
 		shouldHaveContent();
 
 		if (attributeMap.has('aria-hidden')) {
-			const attr = attributeMap.get('aria-hidden');
-			validator.warn(`A11y: <${node.name}> element should not be hidden`, { start: attr.start, end: attr.end });
+			validator.warn(`A11y: <${node.name}> element should not be hidden`, attributeMap.get('aria-hidden'));
 		}
 	}
 
@@ -158,14 +157,14 @@ export default function a11y(
 
 	// no-distracting-elements
 	if (node.name === 'marquee' || node.name === 'blink') {
-		validator.warn(`A11y: Avoid <${node.name}> elements`, { start: node.start, end: node.end });
+		validator.warn(`A11y: Avoid <${node.name}> elements`, node);
 	}
 
 	if (node.name === 'figcaption') {
 		const parent = elementStack[elementStack.length - 1];
 		if (parent) {
 			if (parent.name !== 'figure') {
-				validator.warn(`A11y: <figcaption> must be an immediate child of <figure>`, { start: node.start, end: node.end });
+				validator.warn(`A11y: <figcaption> must be an immediate child of <figure>`, node);
 			} else {
 				const children = parent.children.filter(node => {
 					if (node.type === 'Comment') return false;
@@ -176,7 +175,7 @@ export default function a11y(
 				const index = children.indexOf(node);
 
 				if (index !== 0 && index !== children.length - 1) {
-					validator.warn(`A11y: <figcaption> must be first or last child of <figure>`, { start: node.start, end: node.end });
+					validator.warn(`A11y: <figcaption> must be first or last child of <figure>`, node);
 				}
 			}
 		}

--- a/src/validate/html/index.ts
+++ b/src/validate/html/index.ts
@@ -103,7 +103,7 @@ export default function validateHtml(validator: Validator, html: Node) {
 			let message = `'refs.${ref}' does not exist`;
 			if (match) message += ` (did you mean 'refs.${match}'?)`;
 
-			validator.error(message, callee.start);
+			validator.error(message, { start: callee.start, end: callee.end });
 		}
 	});
 }

--- a/src/validate/html/index.ts
+++ b/src/validate/html/index.ts
@@ -67,7 +67,7 @@ export default function validateHtml(validator: Validator, html: Node) {
 		}
 
 		if (validator.options.dev && isEmptyBlock(node)) {
-			validator.warn('Empty block', { start: node.start, end: node.end });
+			validator.warn('Empty block', node);
 		}
 
 		if (node.children) {
@@ -103,7 +103,7 @@ export default function validateHtml(validator: Validator, html: Node) {
 			let message = `'refs.${ref}' does not exist`;
 			if (match) message += ` (did you mean 'refs.${match}'?)`;
 
-			validator.error(message, { start: callee.start, end: callee.end });
+			validator.error(message, callee);
 		}
 	});
 }

--- a/src/validate/html/index.ts
+++ b/src/validate/html/index.ts
@@ -52,7 +52,7 @@ export default function validateHtml(validator: Validator, html: Node) {
 
 		else if (node.type === 'EachBlock') {
 			if (validator.helpers.has(node.context)) {
-				let c = node.expression.end;
+				let c: number = node.expression.end;
 
 				// find start of context
 				while (/\s/.test(validator.source[c])) c += 1;
@@ -61,13 +61,13 @@ export default function validateHtml(validator: Validator, html: Node) {
 
 				validator.warn(
 					`Context clashes with a helper. Rename one or the other to eliminate any ambiguity`,
-					c
+					{ start: c, end: c + node.context.length }
 				);
 			}
 		}
 
 		if (validator.options.dev && isEmptyBlock(node)) {
-			validator.warn('Empty block', node.start);
+			validator.warn('Empty block', { start: node.start, end: node.end });
 		}
 
 		if (node.children) {

--- a/src/validate/html/validateElement.ts
+++ b/src/validate/html/validateElement.ts
@@ -34,12 +34,12 @@ export default function validateElement(
 		const nameAttribute = node.attributes.find((attribute: Node) => attribute.name === 'name');
 		if (nameAttribute) {
 			if (nameAttribute.value.length !== 1 || nameAttribute.value[0].type !== 'Text') {
-				validator.error(`<slot> name cannot be dynamic`, nameAttribute.start);
+				validator.error(`<slot> name cannot be dynamic`, { start: nameAttribute.start, end: nameAttribute.end });
 			}
 
 			const slotName = nameAttribute.value[0].data;
 			if (slotName === 'default') {
-				validator.error(`default is a reserved word — it cannot be used as a slot name`, nameAttribute.start);
+				validator.error(`default is a reserved word — it cannot be used as a slot name`, { start: nameAttribute.start, end: nameAttribute.end });
 			}
 
 			// TODO should duplicate slots be disallowed? Feels like it's more likely to be a
@@ -61,9 +61,10 @@ export default function validateElement(
 
 	if (node.name === 'title') {
 		if (node.attributes.length > 0) {
+			const attr = node.attributes[0];
 			validator.error(
 				`<title> cannot have attributes`,
-				node.attributes[0].start
+				{ start: attr.start, end: attr.end }
 			);
 		}
 
@@ -71,7 +72,7 @@ export default function validateElement(
 			if (child.type !== 'Text' && child.type !== 'MustacheTag') {
 				validator.error(
 					`<title> can only contain text and {{tags}}`,
-					child.start
+					{ start: child.start, end: child.end }
 				);
 			}
 		});
@@ -98,7 +99,7 @@ export default function validateElement(
 				) {
 					validator.error(
 						`'value' is not a valid binding on <${node.name}> elements`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				}
 
@@ -107,21 +108,21 @@ export default function validateElement(
 				if (node.name !== 'input') {
 					validator.error(
 						`'${name}' is not a valid binding on <${node.name}> elements`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				}
 
 				if (checkTypeAttribute(validator, node) !== 'checkbox') {
 					validator.error(
 						`'${name}' binding can only be used with <input type="checkbox">`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				}
 			} else if (name === 'group') {
 				if (node.name !== 'input') {
 					validator.error(
 						`'group' is not a valid binding on <${node.name}> elements`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				}
 
@@ -130,7 +131,7 @@ export default function validateElement(
 				if (type !== 'checkbox' && type !== 'radio') {
 					validator.error(
 						`'checked' binding can only be used with <input type="checkbox"> or <input type="radio">`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				}
 			} else if (
@@ -145,13 +146,13 @@ export default function validateElement(
 				if (node.name !== 'audio' && node.name !== 'video') {
 					validator.error(
 						`'${name}' binding can only be used with <audio> or <video>`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				}
 			} else {
 				validator.error(
 					`'${attribute.name}' is not a valid binding`,
-					attribute.start
+					{ start: attribute.start, end: attribute.end }
 				);
 			}
 		} else if (attribute.type === 'EventHandler') {
@@ -159,7 +160,7 @@ export default function validateElement(
 			validateEventHandler(validator, attribute, refCallees);
 		} else if (attribute.type === 'Transition') {
 			if (isComponent) {
-				validator.error(`Transitions can only be applied to DOM elements, not components`, attribute.start);
+				validator.error(`Transitions can only be applied to DOM elements, not components`, { start: attribute.start, end: attribute.end });
 			}
 
 			validator.used.transitions.add(attribute.name);
@@ -170,13 +171,13 @@ export default function validateElement(
 				if (bidi)
 					validator.error(
 						`An element can only have one 'transition' directive`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				validator.error(
 					`An element cannot have both a 'transition' directive and an '${attribute.intro
 						? 'in'
 						: 'out'}' directive`,
-					attribute.start
+					{ start: attribute.start, end: attribute.end }
 				);
 			}
 
@@ -186,11 +187,11 @@ export default function validateElement(
 						`An element cannot have both an '${hasIntro
 							? 'in'
 							: 'out'}' directive and a 'transition' directive`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				validator.error(
 					`An element can only have one '${hasIntro ? 'in' : 'out'}' directive`,
-					attribute.start
+					{ start: attribute.start, end: attribute.end }
 				);
 			}
 
@@ -201,7 +202,7 @@ export default function validateElement(
 			if (!validator.transitions.has(attribute.name)) {
 				validator.error(
 					`Missing transition '${attribute.name}'`,
-					attribute.start
+					{ start: attribute.start, end: attribute.end }
 				);
 			}
 		} else if (attribute.type === 'Attribute') {
@@ -209,7 +210,7 @@ export default function validateElement(
 				if (node.children.length) {
 					validator.error(
 						`A <textarea> can have either a value attribute or (equivalently) child content, but not both`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				}
 			}
@@ -228,13 +229,13 @@ function checkTypeAttribute(validator: Validator, node: Node) {
 	if (!attribute) return null;
 
 	if (attribute.value === true) {
-		validator.error(`'type' attribute must be specified`, attribute.start);
+		validator.error(`'type' attribute must be specified`, { start: attribute.start, end: attribute.end });
 	}
 
 	if (isDynamic(attribute)) {
 		validator.error(
 			`'type' attribute cannot be dynamic if input uses two-way binding`,
-			attribute.start
+			{ start: attribute.start, end: attribute.end }
 		);
 	}
 
@@ -245,7 +246,7 @@ function checkSlotAttribute(validator: Validator, node: Node, attribute: Node, s
 	if (isDynamic(attribute)) {
 		validator.error(
 			`slot attribute cannot have a dynamic value`,
-			attribute.start
+			{ start: attribute.start, end: attribute.end }
 		);
 	}
 
@@ -260,11 +261,11 @@ function checkSlotAttribute(validator: Validator, node: Node, attribute: Node, s
 
 		if (parent.type === 'IfBlock' || parent.type === 'EachBlock') {
 			const message = `Cannot place slotted elements inside an ${parent.type === 'IfBlock' ? 'if' : 'each'}-block`;
-			validator.error(message, attribute.start);
+			validator.error(message, { start: attribute.start, end: attribute.end });
 		}
 	}
 
-	validator.error(`Element with a slot='...' attribute must be a descendant of a component or custom element`, attribute.start);
+	validator.error(`Element with a slot='...' attribute must be a descendant of a component or custom element`, { start: attribute.start, end: attribute.end });
 }
 
 function isDynamic(attribute: Node) {

--- a/src/validate/html/validateElement.ts
+++ b/src/validate/html/validateElement.ts
@@ -20,13 +20,13 @@ export default function validateElement(
 
 	if (!isComponent && /^[A-Z]/.test(node.name[0])) {
 		// TODO upgrade to validator.error in v2
-		validator.warn(`${node.name} component is not defined`, node.start);
+		validator.warn(`${node.name} component is not defined`, { start: node.start, end: node.end });
 	}
 
 	if (elementStack.length === 0 && validator.namespace !== namespaces.svg && svg.test(node.name)) {
 		validator.warn(
 			`<${node.name}> is an SVG element – did you forget to add { namespace: 'svg' } ?`,
-			node.start
+			{ start: node.start, end: node.end }
 		);
 	}
 

--- a/src/validate/html/validateEventHandler.ts
+++ b/src/validate/html/validateEventHandler.ts
@@ -13,10 +13,10 @@ export default function validateEventHandlerCallee(
 ) {
 	if (!attribute.expression) return;
 
-	const { callee, start, type } = attribute.expression;
+	const { callee, type } = attribute.expression;
 
 	if (type !== 'CallExpression') {
-		validator.error(`Expected a call expression`, start);
+		validator.error(`Expected a call expression`, { start: attribute.expression.start, end: attribute.expression.end });
 	}
 
 	const { name } = flattenReference(callee);

--- a/src/validate/html/validateEventHandler.ts
+++ b/src/validate/html/validateEventHandler.ts
@@ -16,7 +16,7 @@ export default function validateEventHandlerCallee(
 	const { callee, type } = attribute.expression;
 
 	if (type !== 'CallExpression') {
-		validator.error(`Expected a call expression`, { start: attribute.expression.start, end: attribute.expression.end });
+		validator.error(`Expected a call expression`, attribute.expression);
 	}
 
 	const { name } = flattenReference(callee);
@@ -32,7 +32,7 @@ export default function validateEventHandlerCallee(
 		if (!validator.options.store) {
 			validator.warn(
 				'compile with `store: true` in order to call store methods',
-				{ start: attribute.expression.start, end: attribute.expression.end }
+				attribute.expression
 			);
 		}
 		return;
@@ -59,5 +59,5 @@ export default function validateEventHandlerCallee(
 		message += `. '${callee.name}' exists on 'helpers', did you put it in the wrong place?`;
 	}
 
-	validator.warn(message, { start: attribute.expression.start, end: attribute.expression.end });
+	validator.warn(message, attribute.expression);
 }

--- a/src/validate/html/validateEventHandler.ts
+++ b/src/validate/html/validateEventHandler.ts
@@ -30,7 +30,10 @@ export default function validateEventHandlerCallee(
 
 	if (name === 'store' && attribute.expression.callee.type === 'MemberExpression') {
 		if (!validator.options.store) {
-			validator.warn('compile with `store: true` in order to call store methods', attribute.expression.start);
+			validator.warn(
+				'compile with `store: true` in order to call store methods',
+				{ start: attribute.expression.start, end: attribute.expression.end }
+			);
 		}
 		return;
 	}
@@ -56,5 +59,5 @@ export default function validateEventHandlerCallee(
 		message += `. '${callee.name}' exists on 'helpers', did you put it in the wrong place?`;
 	}
 
-	validator.warn(message, start);
+	validator.warn(message, { start: attribute.expression.start, end: attribute.expression.end });
 }

--- a/src/validate/html/validateHead.ts
+++ b/src/validate/html/validateHead.ts
@@ -4,7 +4,7 @@ import { Node } from '../../interfaces';
 
 export default function validateHead(validator: Validator, node: Node, refs: Map<string, Node[]>, refCallees: Node[]) {
 	if (node.attributes.length) {
-		validator.error(`<:Head> should not have any attributes or directives`, node.start);
+		validator.error(`<:Head> should not have any attributes or directives`, { start: node.start, end: node.end });
 	}
 
 	// TODO ensure only valid elements are included here

--- a/src/validate/html/validateHead.ts
+++ b/src/validate/html/validateHead.ts
@@ -4,7 +4,7 @@ import { Node } from '../../interfaces';
 
 export default function validateHead(validator: Validator, node: Node, refs: Map<string, Node[]>, refCallees: Node[]) {
 	if (node.attributes.length) {
-		validator.error(`<:Head> should not have any attributes or directives`, { start: node.start, end: node.end });
+		validator.error(`<:Head> should not have any attributes or directives`, node);
 	}
 
 	// TODO ensure only valid elements are included here

--- a/src/validate/html/validateWindow.ts
+++ b/src/validate/html/validateWindow.ts
@@ -25,7 +25,7 @@ export default function validateWindow(validator: Validator, node: Node, refs: M
 					`Bindings on <:Window/> must be to top-level properties, e.g. '${parts[
 						parts.length - 1
 					]}' rather than '${parts.join('.')}'`,
-					attribute.value.start
+					{ start: attribute.value.start, end: attribute.value.end }
 				);
 			}
 
@@ -41,12 +41,12 @@ export default function validateWindow(validator: Validator, node: Node, refs: M
 				if (match) {
 					validator.error(
 						`${message} (did you mean '${match}'?)`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				} else {
 					validator.error(
 						`${message} — valid bindings are ${list(validBindings)}`,
-						attribute.start
+						{ start: attribute.start, end: attribute.end }
 					);
 				}
 			}

--- a/src/validate/html/validateWindow.ts
+++ b/src/validate/html/validateWindow.ts
@@ -25,7 +25,7 @@ export default function validateWindow(validator: Validator, node: Node, refs: M
 					`Bindings on <:Window/> must be to top-level properties, e.g. '${parts[
 						parts.length - 1
 					]}' rather than '${parts.join('.')}'`,
-					{ start: attribute.value.start, end: attribute.value.end }
+					attribute.value
 				);
 			}
 
@@ -41,12 +41,12 @@ export default function validateWindow(validator: Validator, node: Node, refs: M
 				if (match) {
 					validator.error(
 						`${message} (did you mean '${match}'?)`,
-						{ start: attribute.start, end: attribute.end }
+						attribute
 					);
 				} else {
 					validator.error(
 						`${message} — valid bindings are ${list(validBindings)}`,
-						{ start: attribute.start, end: attribute.end }
+						attribute
 					);
 				}
 			}

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -150,7 +150,7 @@ export default function validate(
 						if (!validator.used[category].has(name)) {
 							validator.warn(
 								`The '${name}' ${categories[category]} is unused`,
-								{ start: prop.start, end: prop.end }
+								prop
 							);
 						}
 					});

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -10,10 +10,10 @@ class ValidationError extends CompileError {
 	constructor(
 		message: string,
 		template: string,
-		index: number,
-		filename: string
+		pos: { start: number, end: number },
+		filename: string,
 	) {
-		super(message, template, index, filename);
+		super(message, template, pos.start, filename, pos.end);
 		this.name = 'ValidationError';
 	}
 }
@@ -66,7 +66,7 @@ export class Validator {
 		};
 	}
 
-	error(message: string, pos: number) {
+	error(message: string, pos: { start: number, end: number }) {
 		throw new ValidationError(message, this.source, pos, this.filename);
 	}
 

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -70,19 +70,21 @@ export class Validator {
 		throw new ValidationError(message, this.source, pos, this.filename);
 	}
 
-	warn(message: string, pos: number) {
+	warn(message: string, pos: { start: number, end: number }) {
 		if (!this.locator) this.locator = getLocator(this.source);
-		const { line, column } = this.locator(pos);
+		const start = this.locator(pos.start);
+		const end = this.locator(pos.end);
 
-		const frame = getCodeFrame(this.source, line, column);
+		const frame = getCodeFrame(this.source, start.line, start.column);
 
 		this.onwarn({
 			message,
 			frame,
-			loc: { line: line + 1, column },
-			pos,
+			loc: { line: start.line + 1, column: start.column },
+			end: { line: end.line + 1, column: end.column },
+			pos: pos.start,
 			filename: this.filename,
-			toString: () => `${message} (${line + 1}:${column})\n${frame}`,
+			toString: () => `${message} (${start.line + 1}:${start.column})\n${frame}`,
 		});
 	}
 }
@@ -148,7 +150,7 @@ export default function validate(
 						if (!validator.used[category].has(name)) {
 							validator.warn(
 								`The '${name}' ${categories[category]} is unused`,
-								prop.start
+								{ start: prop.start, end: prop.end }
 							);
 						}
 					});

--- a/src/validate/js/index.ts
+++ b/src/validate/js/index.ts
@@ -13,14 +13,14 @@ export default function validateJs(validator: Validator, js: Node) {
 	js.content.body.forEach((node: Node) => {
 		// check there are no named exports
 		if (node.type === 'ExportNamedDeclaration') {
-			validator.error(`A component can only have a default export`, node.start);
+			validator.error(`A component can only have a default export`, { start: node.start, end: node.start });
 		}
 
 		if (node.type === 'ExportDefaultDeclaration') {
 			if (node.declaration.type !== 'ObjectExpression') {
 				return validator.error(
 					`Default export must be an object literal`,
-					node.declaration.start
+					{ start: node.declaration.start, end: node.declaration.end }
 				);
 			}
 
@@ -35,16 +35,18 @@ export default function validateJs(validator: Validator, js: Node) {
 
 			// Remove these checks in version 2
 			if (props.has('oncreate') && props.has('onrender')) {
+				const onrender = props.get('onrender');
 				validator.error(
 					'Cannot have both oncreate and onrender',
-					props.get('onrender').start
+					{ start: onrender.start, end: onrender.end }
 				);
 			}
 
 			if (props.has('ondestroy') && props.has('onteardown')) {
+				const onteardown = props.get('onteardown');
 				validator.error(
 					'Cannot have both ondestroy and onteardown',
-					props.get('onteardown').start
+					{ start: onteardown.start, end: onteardown.end }
 				);
 			}
 
@@ -60,17 +62,17 @@ export default function validateJs(validator: Validator, js: Node) {
 					if (match) {
 						validator.error(
 							`Unexpected property '${name}' (did you mean '${match}'?)`,
-							prop.start
+							{ start: prop.start, end: prop.end }
 						);
 					} else if (/FunctionExpression/.test(prop.value.type)) {
 						validator.error(
 							`Unexpected property '${name}' (did you mean to include it in 'methods'?)`,
-							prop.start
+							{ start: prop.start, end: prop.end }
 						);
 					} else {
 						validator.error(
 							`Unexpected property '${name}'`,
-							prop.start
+							{ start: prop.start, end: prop.end }
 						);
 					}
 				}

--- a/src/validate/js/index.ts
+++ b/src/validate/js/index.ts
@@ -13,14 +13,14 @@ export default function validateJs(validator: Validator, js: Node) {
 	js.content.body.forEach((node: Node) => {
 		// check there are no named exports
 		if (node.type === 'ExportNamedDeclaration') {
-			validator.error(`A component can only have a default export`, { start: node.start, end: node.start });
+			validator.error(`A component can only have a default export`, node);
 		}
 
 		if (node.type === 'ExportDefaultDeclaration') {
 			if (node.declaration.type !== 'ObjectExpression') {
 				return validator.error(
 					`Default export must be an object literal`,
-					{ start: node.declaration.start, end: node.declaration.end }
+					node.declaration
 				);
 			}
 
@@ -35,18 +35,16 @@ export default function validateJs(validator: Validator, js: Node) {
 
 			// Remove these checks in version 2
 			if (props.has('oncreate') && props.has('onrender')) {
-				const onrender = props.get('onrender');
 				validator.error(
 					'Cannot have both oncreate and onrender',
-					{ start: onrender.start, end: onrender.end }
+					props.get('onrender')
 				);
 			}
 
 			if (props.has('ondestroy') && props.has('onteardown')) {
-				const onteardown = props.get('onteardown');
 				validator.error(
 					'Cannot have both ondestroy and onteardown',
-					{ start: onteardown.start, end: onteardown.end }
+					props.get('onteardown')
 				);
 			}
 
@@ -62,17 +60,17 @@ export default function validateJs(validator: Validator, js: Node) {
 					if (match) {
 						validator.error(
 							`Unexpected property '${name}' (did you mean '${match}'?)`,
-							{ start: prop.start, end: prop.end }
+							prop
 						);
 					} else if (/FunctionExpression/.test(prop.value.type)) {
 						validator.error(
 							`Unexpected property '${name}' (did you mean to include it in 'methods'?)`,
-							{ start: prop.start, end: prop.end }
+							prop
 						);
 					} else {
 						validator.error(
 							`Unexpected property '${name}'`,
-							{ start: prop.start, end: prop.end }
+							prop
 						);
 					}
 				}

--- a/src/validate/js/propValidators/components.ts
+++ b/src/validate/js/propValidators/components.ts
@@ -26,7 +26,7 @@ export default function components(validator: Validator, prop: Node) {
 		}
 
 		if (!/^[A-Z]/.test(name)) {
-			validator.warn(`Component names should be capitalised`, component.start);
+			validator.warn(`Component names should be capitalised`, { start: component.start, end: component.end });
 		}
 	});
 }

--- a/src/validate/js/propValidators/components.ts
+++ b/src/validate/js/propValidators/components.ts
@@ -8,7 +8,7 @@ export default function components(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'components' property must be an object literal`,
-			{ start: prop.start, end: prop.end }
+			prop
 		);
 	}
 
@@ -21,12 +21,12 @@ export default function components(validator: Validator, prop: Node) {
 		if (name === 'state') {
 			validator.error(
 				`Component constructors cannot be called 'state' due to technical limitations`,
-				{ start: component.start, end: component.end }
+				component
 			);
 		}
 
 		if (!/^[A-Z]/.test(name)) {
-			validator.warn(`Component names should be capitalised`, { start: component.start, end: component.end });
+			validator.warn(`Component names should be capitalised`, component);
 		}
 	});
 }

--- a/src/validate/js/propValidators/components.ts
+++ b/src/validate/js/propValidators/components.ts
@@ -8,7 +8,7 @@ export default function components(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'components' property must be an object literal`,
-			prop.start
+			{ start: prop.start, end: prop.end }
 		);
 	}
 
@@ -21,7 +21,7 @@ export default function components(validator: Validator, prop: Node) {
 		if (name === 'state') {
 			validator.error(
 				`Component constructors cannot be called 'state' due to technical limitations`,
-				component.start
+				{ start: component.start, end: component.end }
 			);
 		}
 

--- a/src/validate/js/propValidators/computed.ts
+++ b/src/validate/js/propValidators/computed.ts
@@ -17,7 +17,7 @@ export default function computed(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'computed' property must be an object literal`,
-			{ start: prop.start, end: prop.end }
+			prop
 		);
 	}
 
@@ -31,21 +31,21 @@ export default function computed(validator: Validator, prop: Node) {
 			const suggestion = name.replace(/[^_$a-z0-9]/ig, '_').replace(/^\d/, '_$&');
 			validator.error(
 				`Computed property name '${name}' is invalid — must be a valid identifier such as ${suggestion}`,
-				{ start: computation.start, end: computation.end }
+				computation
 			);
 		}
 
 		if (reservedNames.has(name)) {
 			validator.error(
 				`Computed property name '${name}' is invalid — cannot be a JavaScript reserved word`,
-				{ start: computation.start, end: computation.end }
+				computation
 			);
 		}
 
 		if (!isFunctionExpression.has(computation.value.type)) {
 			validator.error(
 				`Computed properties can be function expressions or arrow function expressions`,
-				{ start: computation.value.start, end: computation.value.end }
+				computation.value
 			);
 		}
 
@@ -55,14 +55,14 @@ export default function computed(validator: Validator, prop: Node) {
 			if (isThisGetCallExpression(node) && !node.callee.property.computed) {
 				validator.error(
 					`Cannot use this.get(...) — values must be passed into the function as arguments`,
-					{ start: node.start, end: node.end }
+					node
 				);
 			}
 
 			if (node.type === 'ThisExpression') {
 				validator.error(
 					`Computed properties should be pure functions — they do not have access to the component instance and cannot use 'this'. Did you mean to put this in 'methods'?`,
-					{ start: node.start, end: node.end }
+					node
 				);
 			}
 		});
@@ -70,7 +70,7 @@ export default function computed(validator: Validator, prop: Node) {
 		if (params.length === 0) {
 			validator.error(
 				`A computed value must depend on at least one property`,
-				{ start: computation.value.start, end: computation.value.end }
+				computation.value
 			);
 		}
 
@@ -83,7 +83,7 @@ export default function computed(validator: Validator, prop: Node) {
 			if (!valid) {
 				validator.error(
 					`Computed properties cannot use destructuring in function parameters`,
-					{ start: param.start, end: param.end }
+					param
 				);
 			}
 		});

--- a/src/validate/js/propValidators/computed.ts
+++ b/src/validate/js/propValidators/computed.ts
@@ -17,7 +17,7 @@ export default function computed(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'computed' property must be an object literal`,
-			prop.start
+			{ start: prop.start, end: prop.end }
 		);
 	}
 
@@ -31,21 +31,21 @@ export default function computed(validator: Validator, prop: Node) {
 			const suggestion = name.replace(/[^_$a-z0-9]/ig, '_').replace(/^\d/, '_$&');
 			validator.error(
 				`Computed property name '${name}' is invalid — must be a valid identifier such as ${suggestion}`,
-				computation.start
+				{ start: computation.start, end: computation.end }
 			);
 		}
 
 		if (reservedNames.has(name)) {
 			validator.error(
 				`Computed property name '${name}' is invalid — cannot be a JavaScript reserved word`,
-				computation.start
+				{ start: computation.start, end: computation.end }
 			);
 		}
 
 		if (!isFunctionExpression.has(computation.value.type)) {
 			validator.error(
 				`Computed properties can be function expressions or arrow function expressions`,
-				computation.value.start
+				{ start: computation.value.start, end: computation.value.end }
 			);
 		}
 
@@ -55,14 +55,14 @@ export default function computed(validator: Validator, prop: Node) {
 			if (isThisGetCallExpression(node) && !node.callee.property.computed) {
 				validator.error(
 					`Cannot use this.get(...) — values must be passed into the function as arguments`,
-					node.start
+					{ start: node.start, end: node.end }
 				);
 			}
 
 			if (node.type === 'ThisExpression') {
 				validator.error(
 					`Computed properties should be pure functions — they do not have access to the component instance and cannot use 'this'. Did you mean to put this in 'methods'?`,
-					node.start
+					{ start: node.start, end: node.end }
 				);
 			}
 		});
@@ -70,7 +70,7 @@ export default function computed(validator: Validator, prop: Node) {
 		if (params.length === 0) {
 			validator.error(
 				`A computed value must depend on at least one property`,
-				computation.value.start
+				{ start: computation.value.start, end: computation.value.end }
 			);
 		}
 
@@ -83,7 +83,7 @@ export default function computed(validator: Validator, prop: Node) {
 			if (!valid) {
 				validator.error(
 					`Computed properties cannot use destructuring in function parameters`,
-					param.start
+					{ start: param.start, end: param.end }
 				);
 			}
 		});

--- a/src/validate/js/propValidators/data.ts
+++ b/src/validate/js/propValidators/data.ts
@@ -7,6 +7,6 @@ export default function data(validator: Validator, prop: Node) {
 	while (prop.type === 'ParenthesizedExpression') prop = prop.expression;
 
 	if (disallowed.has(prop.value.type)) {
-		validator.error(`'data' must be a function`, { start: prop.value.start, end: prop.value.end });
+		validator.error(`'data' must be a function`, prop.value);
 	}
 }

--- a/src/validate/js/propValidators/data.ts
+++ b/src/validate/js/propValidators/data.ts
@@ -7,6 +7,6 @@ export default function data(validator: Validator, prop: Node) {
 	while (prop.type === 'ParenthesizedExpression') prop = prop.expression;
 
 	if (disallowed.has(prop.value.type)) {
-		validator.error(`'data' must be a function`, prop.value.start);
+		validator.error(`'data' must be a function`, { start: prop.value.start, end: prop.value.end });
 	}
 }

--- a/src/validate/js/propValidators/events.ts
+++ b/src/validate/js/propValidators/events.ts
@@ -7,7 +7,7 @@ export default function events(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'events' property must be an object literal`,
-			prop.start
+			{ start: prop.start, end: prop.end }
 		);
 	}
 

--- a/src/validate/js/propValidators/events.ts
+++ b/src/validate/js/propValidators/events.ts
@@ -7,7 +7,7 @@ export default function events(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'events' property must be an object literal`,
-			{ start: prop.start, end: prop.end }
+			prop
 		);
 	}
 

--- a/src/validate/js/propValidators/helpers.ts
+++ b/src/validate/js/propValidators/helpers.ts
@@ -43,7 +43,7 @@ export default function helpers(validator: Validator, prop: Node) {
 		if (prop.value.params.length === 0 && !usesArguments) {
 			validator.warn(
 				`Helpers should be pure functions, with at least one argument`,
-				prop.start
+				{ start: prop.start, end: prop.end }
 			);
 		}
 	});

--- a/src/validate/js/propValidators/helpers.ts
+++ b/src/validate/js/propValidators/helpers.ts
@@ -10,7 +10,7 @@ export default function helpers(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'helpers' property must be an object literal`,
-			prop.start
+			{ start: prop.start, end: prop.end }
 		);
 	}
 
@@ -26,14 +26,14 @@ export default function helpers(validator: Validator, prop: Node) {
 			if (isThisGetCallExpression(node) && !node.callee.property.computed) {
 				validator.error(
 					`Cannot use this.get(...) — values must be passed into the helper function as arguments`,
-					node.start
+					{ start: node.start, end: node.end }
 				);
 			}
 
 			if (node.type === 'ThisExpression') {
 				validator.error(
 					`Helpers should be pure functions — they do not have access to the component instance and cannot use 'this'. Did you mean to put this in 'methods'?`,
-					node.start
+					{ start: node.start, end: node.end }
 				);
 			} else if (node.type === 'Identifier' && node.name === 'arguments') {
 				usesArguments = true;

--- a/src/validate/js/propValidators/helpers.ts
+++ b/src/validate/js/propValidators/helpers.ts
@@ -10,7 +10,7 @@ export default function helpers(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'helpers' property must be an object literal`,
-			{ start: prop.start, end: prop.end }
+			prop
 		);
 	}
 
@@ -26,14 +26,14 @@ export default function helpers(validator: Validator, prop: Node) {
 			if (isThisGetCallExpression(node) && !node.callee.property.computed) {
 				validator.error(
 					`Cannot use this.get(...) — values must be passed into the helper function as arguments`,
-					{ start: node.start, end: node.end }
+					node
 				);
 			}
 
 			if (node.type === 'ThisExpression') {
 				validator.error(
 					`Helpers should be pure functions — they do not have access to the component instance and cannot use 'this'. Did you mean to put this in 'methods'?`,
-					{ start: node.start, end: node.end }
+					node
 				);
 			} else if (node.type === 'Identifier' && node.name === 'arguments') {
 				usesArguments = true;
@@ -43,7 +43,7 @@ export default function helpers(validator: Validator, prop: Node) {
 		if (prop.value.params.length === 0 && !usesArguments) {
 			validator.warn(
 				`Helpers should be pure functions, with at least one argument`,
-				{ start: prop.start, end: prop.end }
+				prop
 			);
 		}
 	});

--- a/src/validate/js/propValidators/immutable.ts
+++ b/src/validate/js/propValidators/immutable.ts
@@ -5,7 +5,7 @@ export default function immutable(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'Literal' || typeof prop.value.value !== 'boolean') {
 		validator.error(
 			`'immutable' must be a boolean literal`,
-			{ start: prop.value.start, end: prop.value.end }
+			prop.value
 		);
 	}
 }

--- a/src/validate/js/propValidators/immutable.ts
+++ b/src/validate/js/propValidators/immutable.ts
@@ -5,7 +5,7 @@ export default function immutable(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'Literal' || typeof prop.value.value !== 'boolean') {
 		validator.error(
 			`'immutable' must be a boolean literal`,
-			prop.value.start
+			{ start: prop.value.start, end: prop.value.end }
 		);
 	}
 }

--- a/src/validate/js/propValidators/methods.ts
+++ b/src/validate/js/propValidators/methods.ts
@@ -12,7 +12,7 @@ export default function methods(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'methods' property must be an object literal`,
-			prop.start
+			{ start: prop.start, end: prop.end }
 		);
 	}
 
@@ -26,7 +26,7 @@ export default function methods(validator: Validator, prop: Node) {
 		if (builtin.has(name)) {
 			validator.error(
 				`Cannot overwrite built-in method '${name}'`,
-				prop.start
+				{ start: prop.start, end: prop.end }
 			);
 		}
 
@@ -35,7 +35,7 @@ export default function methods(validator: Validator, prop: Node) {
 				validator.error(
 					`Method '${prop.key
 						.name}' should be a function expression, not an arrow function expression`,
-					prop.start
+					{ start: prop.start, end: prop.end }
 				);
 			}
 		}

--- a/src/validate/js/propValidators/methods.ts
+++ b/src/validate/js/propValidators/methods.ts
@@ -12,7 +12,7 @@ export default function methods(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'methods' property must be an object literal`,
-			{ start: prop.start, end: prop.end }
+			prop
 		);
 	}
 
@@ -26,7 +26,7 @@ export default function methods(validator: Validator, prop: Node) {
 		if (builtin.has(name)) {
 			validator.error(
 				`Cannot overwrite built-in method '${name}'`,
-				{ start: prop.start, end: prop.end }
+				prop
 			);
 		}
 
@@ -35,7 +35,7 @@ export default function methods(validator: Validator, prop: Node) {
 				validator.error(
 					`Method '${prop.key
 						.name}' should be a function expression, not an arrow function expression`,
-					{ start: prop.start, end: prop.end }
+					prop
 				);
 			}
 		}

--- a/src/validate/js/propValidators/namespace.ts
+++ b/src/validate/js/propValidators/namespace.ts
@@ -11,7 +11,7 @@ export default function namespace(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'Literal' || typeof ns !== 'string') {
 		validator.error(
 			`The 'namespace' property must be a string literal representing a valid namespace`,
-			{ start: prop.start, end: prop.end }
+			prop
 		);
 	}
 
@@ -20,10 +20,10 @@ export default function namespace(validator: Validator, prop: Node) {
 		if (match) {
 			validator.error(
 				`Invalid namespace '${ns}' (did you mean '${match}'?)`,
-				{ start: prop.start, end: prop.end }
+				prop
 			);
 		} else {
-			validator.error(`Invalid namespace '${ns}'`, { start: prop.start, end: prop.end });
+			validator.error(`Invalid namespace '${ns}'`, prop);
 		}
 	}
 }

--- a/src/validate/js/propValidators/namespace.ts
+++ b/src/validate/js/propValidators/namespace.ts
@@ -11,7 +11,7 @@ export default function namespace(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'Literal' || typeof ns !== 'string') {
 		validator.error(
 			`The 'namespace' property must be a string literal representing a valid namespace`,
-			prop.start
+			{ start: prop.start, end: prop.end }
 		);
 	}
 
@@ -20,10 +20,10 @@ export default function namespace(validator: Validator, prop: Node) {
 		if (match) {
 			validator.error(
 				`Invalid namespace '${ns}' (did you mean '${match}'?)`,
-				prop.start
+				{ start: prop.start, end: prop.end }
 			);
 		} else {
-			validator.error(`Invalid namespace '${ns}'`, prop.start);
+			validator.error(`Invalid namespace '${ns}'`, { start: prop.start, end: prop.end });
 		}
 	}
 }

--- a/src/validate/js/propValidators/oncreate.ts
+++ b/src/validate/js/propValidators/oncreate.ts
@@ -7,7 +7,7 @@ export default function oncreate(validator: Validator, prop: Node) {
 		if (usesThisOrArguments(prop.value.body)) {
 			validator.error(
 				`'oncreate' should be a function expression, not an arrow function expression`,
-				prop.start
+				{ start: prop.start, end: prop.end }
 			);
 		}
 	}

--- a/src/validate/js/propValidators/oncreate.ts
+++ b/src/validate/js/propValidators/oncreate.ts
@@ -7,7 +7,7 @@ export default function oncreate(validator: Validator, prop: Node) {
 		if (usesThisOrArguments(prop.value.body)) {
 			validator.error(
 				`'oncreate' should be a function expression, not an arrow function expression`,
-				{ start: prop.start, end: prop.end }
+				prop
 			);
 		}
 	}

--- a/src/validate/js/propValidators/ondestroy.ts
+++ b/src/validate/js/propValidators/ondestroy.ts
@@ -7,7 +7,7 @@ export default function ondestroy(validator: Validator, prop: Node) {
 		if (usesThisOrArguments(prop.value.body)) {
 			validator.error(
 				`'ondestroy' should be a function expression, not an arrow function expression`,
-				{ start: prop.start, end: prop.end }
+				prop
 			);
 		}
 	}

--- a/src/validate/js/propValidators/ondestroy.ts
+++ b/src/validate/js/propValidators/ondestroy.ts
@@ -7,7 +7,7 @@ export default function ondestroy(validator: Validator, prop: Node) {
 		if (usesThisOrArguments(prop.value.body)) {
 			validator.error(
 				`'ondestroy' should be a function expression, not an arrow function expression`,
-				prop.start
+				{ start: prop.start, end: prop.end }
 			);
 		}
 	}

--- a/src/validate/js/propValidators/onrender.ts
+++ b/src/validate/js/propValidators/onrender.ts
@@ -5,7 +5,7 @@ import { Node } from '../../../interfaces';
 export default function onrender(validator: Validator, prop: Node) {
 	validator.warn(
 		`'onrender' has been deprecated in favour of 'oncreate', and will cause an error in Svelte 2.x`,
-		prop.start
+		{ start: prop.start, end: prop.end }
 	);
 	oncreate(validator, prop);
 }

--- a/src/validate/js/propValidators/onrender.ts
+++ b/src/validate/js/propValidators/onrender.ts
@@ -5,7 +5,7 @@ import { Node } from '../../../interfaces';
 export default function onrender(validator: Validator, prop: Node) {
 	validator.warn(
 		`'onrender' has been deprecated in favour of 'oncreate', and will cause an error in Svelte 2.x`,
-		{ start: prop.start, end: prop.end }
+		prop
 	);
 	oncreate(validator, prop);
 }

--- a/src/validate/js/propValidators/onteardown.ts
+++ b/src/validate/js/propValidators/onteardown.ts
@@ -5,7 +5,7 @@ import { Node } from '../../../interfaces';
 export default function onteardown(validator: Validator, prop: Node) {
 	validator.warn(
 		`'onteardown' has been deprecated in favour of 'ondestroy', and will cause an error in Svelte 2.x`,
-		prop.start
+		{ start: prop.start, end: prop.end }
 	);
 	ondestroy(validator, prop);
 }

--- a/src/validate/js/propValidators/onteardown.ts
+++ b/src/validate/js/propValidators/onteardown.ts
@@ -5,7 +5,7 @@ import { Node } from '../../../interfaces';
 export default function onteardown(validator: Validator, prop: Node) {
 	validator.warn(
 		`'onteardown' has been deprecated in favour of 'ondestroy', and will cause an error in Svelte 2.x`,
-		{ start: prop.start, end: prop.end }
+		prop
 	);
 	ondestroy(validator, prop);
 }

--- a/src/validate/js/propValidators/props.ts
+++ b/src/validate/js/propValidators/props.ts
@@ -5,7 +5,7 @@ export default function props(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ArrayExpression') {
 		validator.error(
 			`'props' must be an array expression, if specified`,
-			prop.value.start
+			{ start: prop.value.start, end: prop.value.end }
 		);
 	}
 
@@ -13,7 +13,7 @@ export default function props(validator: Validator, prop: Node) {
 		if (element.type !== 'Literal' || typeof element.value !== 'string') {
 			validator.error(
 				`'props' must be an array of string literals`,
-				element.start
+				{ start: element.start, end: element.end }
 			);
 		}
 	});

--- a/src/validate/js/propValidators/props.ts
+++ b/src/validate/js/propValidators/props.ts
@@ -5,7 +5,7 @@ export default function props(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ArrayExpression') {
 		validator.error(
 			`'props' must be an array expression, if specified`,
-			{ start: prop.value.start, end: prop.value.end }
+			prop.value
 		);
 	}
 
@@ -13,7 +13,7 @@ export default function props(validator: Validator, prop: Node) {
 		if (element.type !== 'Literal' || typeof element.value !== 'string') {
 			validator.error(
 				`'props' must be an array of string literals`,
-				{ start: element.start, end: element.end }
+				element
 			);
 		}
 	});

--- a/src/validate/js/propValidators/setup.ts
+++ b/src/validate/js/propValidators/setup.ts
@@ -7,6 +7,6 @@ export default function setup(validator: Validator, prop: Node) {
 	while (prop.type === 'ParenthesizedExpression') prop = prop.expression;
 
 	if (disallowed.has(prop.value.type)) {
-		validator.error(`'setup' must be a function`, { start: prop.value.start, end: prop.value.end });
+		validator.error(`'setup' must be a function`, prop.value);
 	}
 }

--- a/src/validate/js/propValidators/setup.ts
+++ b/src/validate/js/propValidators/setup.ts
@@ -7,6 +7,6 @@ export default function setup(validator: Validator, prop: Node) {
 	while (prop.type === 'ParenthesizedExpression') prop = prop.expression;
 
 	if (disallowed.has(prop.value.type)) {
-		validator.error(`'setup' must be a function`, prop.value.start);
+		validator.error(`'setup' must be a function`, { start: prop.value.start, end: prop.value.end });
 	}
 }

--- a/src/validate/js/propValidators/tag.ts
+++ b/src/validate/js/propValidators/tag.ts
@@ -5,7 +5,7 @@ export default function tag(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'Literal' || typeof prop.value.value !== 'string') {
 		validator.error(
 			`'tag' must be a string literal`,
-			{ start: prop.value.start, end: prop.value.end }
+			prop.value
 		);
 	}
 
@@ -13,7 +13,7 @@ export default function tag(validator: Validator, prop: Node) {
 	if (!/^[a-zA-Z][a-zA-Z0-9]*-[a-zA-Z0-9-]+$/.test(tag)) {
 		validator.error(
 			`tag name must be two or more words joined by the '-' character`,
-			{ start: prop.value.start, end: prop.value.end }
+			prop.value
 		);
 	}
 }

--- a/src/validate/js/propValidators/tag.ts
+++ b/src/validate/js/propValidators/tag.ts
@@ -5,7 +5,7 @@ export default function tag(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'Literal' || typeof prop.value.value !== 'string') {
 		validator.error(
 			`'tag' must be a string literal`,
-			prop.value.start
+			{ start: prop.value.start, end: prop.value.end }
 		);
 	}
 
@@ -13,7 +13,7 @@ export default function tag(validator: Validator, prop: Node) {
 	if (!/^[a-zA-Z][a-zA-Z0-9]*-[a-zA-Z0-9-]+$/.test(tag)) {
 		validator.error(
 			`tag name must be two or more words joined by the '-' character`,
-			prop.value.start
+			{ start: prop.value.start, end: prop.value.end }
 		);
 	}
 }

--- a/src/validate/js/propValidators/transitions.ts
+++ b/src/validate/js/propValidators/transitions.ts
@@ -7,7 +7,7 @@ export default function transitions(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'transitions' property must be an object literal`,
-			{ start: prop.start, end: prop.end }
+			prop
 		);
 	}
 

--- a/src/validate/js/propValidators/transitions.ts
+++ b/src/validate/js/propValidators/transitions.ts
@@ -7,7 +7,7 @@ export default function transitions(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {
 		validator.error(
 			`The 'transitions' property must be an object literal`,
-			prop.start
+			{ start: prop.start, end: prop.end }
 		);
 	}
 

--- a/src/validate/js/utils/checkForAccessors.ts
+++ b/src/validate/js/utils/checkForAccessors.ts
@@ -8,7 +8,7 @@ export default function checkForAccessors(
 ) {
 	properties.forEach(prop => {
 		if (prop.kind !== 'init') {
-			validator.error(`${label} cannot use getters and setters`, prop.start);
+			validator.error(`${label} cannot use getters and setters`, { start: prop.start, end: prop.end });
 		}
 	});
 }

--- a/src/validate/js/utils/checkForAccessors.ts
+++ b/src/validate/js/utils/checkForAccessors.ts
@@ -8,7 +8,7 @@ export default function checkForAccessors(
 ) {
 	properties.forEach(prop => {
 		if (prop.kind !== 'init') {
-			validator.error(`${label} cannot use getters and setters`, { start: prop.start, end: prop.end });
+			validator.error(`${label} cannot use getters and setters`, prop);
 		}
 	});
 }

--- a/src/validate/js/utils/checkForComputedKeys.ts
+++ b/src/validate/js/utils/checkForComputedKeys.ts
@@ -7,7 +7,7 @@ export default function checkForComputedKeys(
 ) {
 	properties.forEach(prop => {
 		if (prop.key.computed) {
-			validator.error(`Cannot use computed keys`, { start: prop.start, end: prop.end });
+			validator.error(`Cannot use computed keys`, prop);
 		}
 	});
 }

--- a/src/validate/js/utils/checkForComputedKeys.ts
+++ b/src/validate/js/utils/checkForComputedKeys.ts
@@ -7,7 +7,7 @@ export default function checkForComputedKeys(
 ) {
 	properties.forEach(prop => {
 		if (prop.key.computed) {
-			validator.error(`Cannot use computed keys`, prop.start);
+			validator.error(`Cannot use computed keys`, { start: prop.start, end: prop.end });
 		}
 	});
 }

--- a/src/validate/js/utils/checkForDupes.ts
+++ b/src/validate/js/utils/checkForDupes.ts
@@ -12,7 +12,7 @@ export default function checkForDupes(
 		const name = getName(prop.key);
 
 		if (seen.has(name)) {
-			validator.error(`Duplicate property '${name}'`, prop.start);
+			validator.error(`Duplicate property '${name}'`, { start: prop.start, end: prop.end });
 		}
 
 		seen.add(name);

--- a/src/validate/js/utils/checkForDupes.ts
+++ b/src/validate/js/utils/checkForDupes.ts
@@ -12,7 +12,7 @@ export default function checkForDupes(
 		const name = getName(prop.key);
 
 		if (seen.has(name)) {
-			validator.error(`Duplicate property '${name}'`, { start: prop.start, end: prop.end });
+			validator.error(`Duplicate property '${name}'`, prop);
 		}
 
 		seen.add(name);

--- a/test/validator/index.js
+++ b/test/validator/index.js
@@ -56,6 +56,7 @@ describe("validate", () => {
 
 				assert.equal(error.message, expected.message);
 				assert.deepEqual(error.loc, expected.loc);
+				assert.deepEqual(error.end, expected.end);
 				assert.equal(error.pos, expected.pos);
 			}
 		});

--- a/test/validator/index.js
+++ b/test/validator/index.js
@@ -31,7 +31,8 @@ describe("validate", () => {
 						warnings.push({
 							message: warning.message,
 							pos: warning.pos,
-							loc: warning.loc
+							loc: warning.loc,
+							end: warning.end,
 						});
 					},
 					dev: config.dev

--- a/test/validator/samples/a11y-alt-text/warnings.json
+++ b/test/validator/samples/a11y-alt-text/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 0
 		},
+		"end": {
+			"line": 1,
+			"column": 19
+		},
 		"pos": 0
 	},
 
@@ -13,6 +17,10 @@
 		"loc": {
 			"line": 4,
 			"column": 1
+		},
+		"end": {
+			"line": 4,
+			"column": 7
 		},
 		"pos": 28
 	},
@@ -23,6 +31,10 @@
 			"line": 7,
 			"column": 0
 		},
+		"end": {
+			"line": 7,
+			"column": 17
+		},
 		"pos": 43
 	},
 
@@ -31,6 +43,10 @@
 		"loc": {
 			"line": 9,
 			"column": 0
+		},
+		"end": {
+			"line": 9,
+			"column": 20
 		},
 		"pos": 62
 	}

--- a/test/validator/samples/a11y-anchor-has-content/warnings.json
+++ b/test/validator/samples/a11y-anchor-has-content/warnings.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 0
 	},
+	"end": {
+		"line": 1,
+		"column": 19
+	},
 	"pos": 0
 }]

--- a/test/validator/samples/a11y-anchor-in-svg-is-valid/warnings.json
+++ b/test/validator/samples/a11y-anchor-in-svg-is-valid/warnings.json
@@ -5,6 +5,10 @@
       "line": 1,
       "column": 11
     },
+		"end": {
+			"line": 1,
+			"column": 37
+		},
     "pos": 11
   },
   {
@@ -13,6 +17,10 @@
       "line": 2,
       "column": 14
     },
+		"end": {
+			"line": 2,
+			"column": 27
+		},
     "pos": 65
   },
   {
@@ -21,6 +29,10 @@
       "line": 3,
       "column": 14
     },
+		"end": {
+			"line": 3,
+			"column": 28
+		},
     "pos": 130
   }
 ]

--- a/test/validator/samples/a11y-anchor-is-valid/warnings.json
+++ b/test/validator/samples/a11y-anchor-is-valid/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 0
 		},
+		"end": {
+			"line": 1,
+			"column": 26
+		},
 		"pos": 0
 	},
 	{
@@ -13,6 +17,10 @@
 			"line": 2,
 			"column": 3
 		},
+		"end": {
+			"line": 2,
+			"column": 10
+		},
 		"pos": 30
 	},
 	{
@@ -20,6 +28,10 @@
 		"loc": {
 			"line": 3,
 			"column": 3
+		},
+		"end": {
+			"line": 3,
+			"column": 11
 		},
 		"pos": 53
 	}

--- a/test/validator/samples/a11y-aria-props/warnings.json
+++ b/test/validator/samples/a11y-aria-props/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 20
 		},
+		"end": {
+			"line": 1,
+			"column": 40
+		},
 		"pos": 20
 	},
 
@@ -13,6 +17,10 @@
 		"loc": {
 			"column": 0,
 			"line": 1
+		},
+		"end": {
+			"line": 1,
+			"column": 41
 		},
 		"pos": 0
 	}

--- a/test/validator/samples/a11y-aria-role/warnings.json
+++ b/test/validator/samples/a11y-aria-role/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 5
 		},
+		"end": {
+			"line": 1,
+			"column": 20
+		},
 		"pos": 5
 	}
 ]

--- a/test/validator/samples/a11y-aria-unsupported-element/warnings.json
+++ b/test/validator/samples/a11y-aria-unsupported-element/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 6
 		},
+		"end": {
+			"line": 1,
+			"column": 25
+		},
 		"pos": 6
 	},
 
@@ -13,6 +17,10 @@
 		"loc": {
 			"line": 2,
 			"column": 6
+		},
+		"end": {
+			"line": 2,
+			"column": 20
 		},
 		"pos": 33
 	}

--- a/test/validator/samples/a11y-figcaption-wrong-place/warnings.json
+++ b/test/validator/samples/a11y-figcaption-wrong-place/warnings.json
@@ -5,6 +5,10 @@
 			"line": 4,
 			"column": 1
 		},
+		"end": {
+			"line": 6,
+			"column": 14
+		},
 		"pos": 57
 	},
 	{
@@ -12,6 +16,10 @@
 		"loc": {
 			"line": 15,
 			"column": 2
+		},
+		"end": {
+			"line": 17,
+			"column": 15
 		},
 		"pos": 252
 	}

--- a/test/validator/samples/a11y-heading-has-content/warnings.json
+++ b/test/validator/samples/a11y-heading-has-content/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 0
 		},
+		"end": {
+			"line": 1,
+			"column": 9
+		},
 		"pos": 0
 	},
 
@@ -13,6 +17,10 @@
 		"loc": {
 			"line": 2,
 			"column": 4
+		},
+		"end": {
+			"line": 2,
+			"column": 15
 		},
 		"pos": 14
 	}

--- a/test/validator/samples/a11y-html-has-lang/warnings.json
+++ b/test/validator/samples/a11y-html-has-lang/warnings.json
@@ -4,6 +4,10 @@
 			"column": 0,
 			"line": 5
 		},
+		"end": {
+			"line": 5,
+			"column": 13
+		},
 		"message": "A11y: <html> element should have a lang attribute",
 		"pos": 84
 	}

--- a/test/validator/samples/a11y-iframe-has-title/warnings.json
+++ b/test/validator/samples/a11y-iframe-has-title/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 0
 		},
+		"end": {
+			"line": 1,
+			"column": 31
+		},
 		"pos": 0
 	}
 ]

--- a/test/validator/samples/a11y-no-access-key/warnings.json
+++ b/test/validator/samples/a11y-no-access-key/warnings.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 5
 	},
+	"end": {
+		"line": 1,
+		"column": 18
+	},
 	"pos": 5
 }]

--- a/test/validator/samples/a11y-no-autofocus/warnings.json
+++ b/test/validator/samples/a11y-no-autofocus/warnings.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 5
 	},
+	"end": {
+		"line": 1,
+		"column": 14
+	},
 	"pos": 5
 }]

--- a/test/validator/samples/a11y-no-distracting-elements/warnings.json
+++ b/test/validator/samples/a11y-no-distracting-elements/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 0
 		},
+		"end": {
+			"line": 1,
+			"column": 10
+		},
 		"pos": 0
 	},
 
@@ -13,6 +17,10 @@
 		"loc": {
 			"line": 2,
 			"column": 0
+		},
+		"end": {
+			"line": 2,
+			"column": 8
 		},
 		"pos": 11
 	}

--- a/test/validator/samples/a11y-not-on-components/warnings.json
+++ b/test/validator/samples/a11y-not-on-components/warnings.json
@@ -5,6 +5,10 @@
 			"column": 8,
 			"line": 2
 		},
+		"end": {
+			"line": 2,
+			"column": 17
+		},
 		"pos": 29
 	}
 ]

--- a/test/validator/samples/a11y-scope/warnings.json
+++ b/test/validator/samples/a11y-scope/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 5
 		},
+		"end": {
+			"line": 1,
+			"column": 10
+		},
 		"pos": 5
 	}
 ]

--- a/test/validator/samples/a11y-tabindex-no-positive/warnings.json
+++ b/test/validator/samples/a11y-tabindex-no-positive/warnings.json
@@ -5,6 +5,10 @@
 			"line": 3,
 			"column": 5
 		},
+		"end": {
+			"line": 3,
+			"column": 17
+		},
 		"pos": 46
 	}
 ]

--- a/test/validator/samples/binding-input-checked/errors.json
+++ b/test/validator/samples/binding-input-checked/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 7
 	},
+	"end": {
+		"line": 1,
+		"column": 25
+	},
 	"pos": 7
 }]

--- a/test/validator/samples/binding-input-type-boolean/errors.json
+++ b/test/validator/samples/binding-input-type-boolean/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 24
 	},
+	"end": {
+		"line": 1,
+		"column": 28
+	},
 	"pos": 24
 }]

--- a/test/validator/samples/binding-input-type-dynamic/errors.json
+++ b/test/validator/samples/binding-input-type-dynamic/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 24
 	},
+	"end": {
+		"line": 1,
+		"column": 44
+	},
 	"pos": 24
 }]

--- a/test/validator/samples/binding-invalid-on-element/errors.json
+++ b/test/validator/samples/binding-invalid-on-element/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 1,
 		"column": 5
+	},
+	"end": {
+		"line": 1,
+		"column": 15
 	}
 }]

--- a/test/validator/samples/binding-invalid/errors.json
+++ b/test/validator/samples/binding-invalid/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 1,
 		"column": 5
+	},
+	"end": {
+		"line": 1,
+		"column": 18
 	}
 }]

--- a/test/validator/samples/component-cannot-be-called-state/errors.json
+++ b/test/validator/samples/component-cannot-be-called-state/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 6,
 		"column": 3
+	},
+	"end": {
+		"line": 6,
+		"column": 8
 	}
 }]

--- a/test/validator/samples/component-slot-default-reserved/errors.json
+++ b/test/validator/samples/component-slot-default-reserved/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 6
 	},
+	"end": {
+		"line": 1,
+		"column": 20
+	},
 	"pos": 6
 }]

--- a/test/validator/samples/component-slot-dynamic-attribute/errors.json
+++ b/test/validator/samples/component-slot-dynamic-attribute/errors.json
@@ -4,5 +4,9 @@
 		"line": 2,
 		"column": 9
 	},
+	"end": {
+		"line": 2,
+		"column": 23
+	},
 	"pos": 18
 }]

--- a/test/validator/samples/component-slot-dynamic/errors.json
+++ b/test/validator/samples/component-slot-dynamic/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 6
 	},
+	"end": {
+		"line": 1,
+		"column": 20
+	},
 	"pos": 6
 }]

--- a/test/validator/samples/component-slot-each-block/errors.json
+++ b/test/validator/samples/component-slot-each-block/errors.json
@@ -4,5 +4,9 @@
 		"line": 2,
 		"column": 1
 	},
+	"end": {
+		"line": 2,
+		"column": 1
+	},
 	"pos": 27
 }]

--- a/test/validator/samples/component-slotted-each-block/errors.json
+++ b/test/validator/samples/component-slotted-each-block/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 7
 	},
+	"end": {
+		"line": 3,
+		"column": 17
+	},
 	"pos": 43
 }]

--- a/test/validator/samples/component-slotted-if-block/errors.json
+++ b/test/validator/samples/component-slotted-if-block/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 7
 	},
+	"end": {
+		"line": 3,
+		"column": 17
+	},
 	"pos": 31
 }]

--- a/test/validator/samples/computed-purity-check-no-this/errors.json
+++ b/test/validator/samples/computed-purity-check-no-this/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 7,
 		"column": 4
+	},
+	"end": {
+		"line": 7,
+		"column": 8
 	}
 }]

--- a/test/validator/samples/computed-purity-check-this-get/errors.json
+++ b/test/validator/samples/computed-purity-check-this-get/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 7,
 		"column": 11
+	},
+	"end": {
+		"line": 7,
+		"column": 28
 	}
 }]

--- a/test/validator/samples/css-invalid-global-placement/errors.json
+++ b/test/validator/samples/css-invalid-global-placement/errors.json
@@ -4,5 +4,9 @@
 		"line": 2,
 		"column": 6
 	},
+	"end": {
+		"line": 2,
+		"column": 19
+	},
 	"pos": 14
 }]

--- a/test/validator/samples/css-invalid-global/errors.json
+++ b/test/validator/samples/css-invalid-global/errors.json
@@ -4,5 +4,9 @@
 		"line": 2,
 		"column": 5
 	},
+	"end": {
+		"line": 2,
+		"column": 18
+	},
 	"pos": 13
 }]

--- a/test/validator/samples/each-block-invalid-context-destructured/errors.json
+++ b/test/validator/samples/each-block-invalid-context-destructured/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 18
 	},
+	"end": {
+		"line": 1,
+		"column": 18
+	},
 	"pos": 18
 }]

--- a/test/validator/samples/each-block-invalid-context/errors.json
+++ b/test/validator/samples/each-block-invalid-context/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 17
 	},
+	"end": {
+		"line": 1,
+		"column": 17
+	},
 	"pos": 17
 }]

--- a/test/validator/samples/empty-block-dev/warnings.json
+++ b/test/validator/samples/empty-block-dev/warnings.json
@@ -5,6 +5,10 @@
 			"line": 1,
 			"column": 0
 		},
+		"end": {
+			"line": 3,
+			"column": 9
+		},
 		"pos": 0
 	},
 	{
@@ -12,6 +16,10 @@
 		"loc": {
 			"line": 5,
 			"column": 0
+		},
+		"end": {
+			"line": 5,
+			"column": 34
 		},
 		"pos": 38
 	}

--- a/test/validator/samples/event-handler-ref-invalid/errors.json
+++ b/test/validator/samples/event-handler-ref-invalid/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 2,
 		"column": 18
+	},
+	"end": {
+		"line": 2,
+		"column": 35
 	}
 }]

--- a/test/validator/samples/export-default-duplicated/errors.json
+++ b/test/validator/samples/export-default-duplicated/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 3,
 		"column": 8
+	},
+	"end": {
+		"line": 3,
+		"column": 8
 	}
 }]

--- a/test/validator/samples/export-default-must-be-object/errors.json
+++ b/test/validator/samples/export-default-must-be-object/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 2,
 		"column": 16
+	},
+	"end": {
+		"line": 2,
+		"column": 22
 	}
 }]

--- a/test/validator/samples/helper-clash-context/warnings.json
+++ b/test/validator/samples/helper-clash-context/warnings.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 18
 	},
+	"end": {
+		"line": 1,
+		"column": 23
+	},
 	"pos": 18
 }]

--- a/test/validator/samples/helper-purity-check-needs-arguments/warnings.json
+++ b/test/validator/samples/helper-purity-check-needs-arguments/warnings.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 6,
 		"column": 3
+	},
+	"end": {
+		"line": 8,
+		"column": 4
 	}
 }]

--- a/test/validator/samples/helper-purity-check-no-this/errors.json
+++ b/test/validator/samples/helper-purity-check-no-this/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 7,
 		"column": 4
+	},
+	"end": {
+		"line": 7,
+		"column": 8
 	}
 }]

--- a/test/validator/samples/helper-purity-check-this-get/errors.json
+++ b/test/validator/samples/helper-purity-check-this-get/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 7,
 		"column": 11
+	},
+	"end": {
+		"line": 7,
+		"column": 28
 	}
 }]

--- a/test/validator/samples/method-arrow-this/errors.json
+++ b/test/validator/samples/method-arrow-this/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 6,
 		"column": 3
+	},
+	"end": {
+		"line": 8,
+		"column": 4
 	}
 }]

--- a/test/validator/samples/method-nonexistent-helper/warnings.json
+++ b/test/validator/samples/method-nonexistent-helper/warnings.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 1,
 		"column": 18
+	},
+	"end": {
+		"line": 1,
+		"column": 23
 	}
 }]

--- a/test/validator/samples/method-nonexistent/warnings.json
+++ b/test/validator/samples/method-nonexistent/warnings.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 1,
 		"column": 18
+	},
+	"end": {
+		"line": 1,
+		"column": 23
 	}
 }]

--- a/test/validator/samples/missing-component/warnings.json
+++ b/test/validator/samples/missing-component/warnings.json
@@ -4,5 +4,9 @@
 		"line": 2,
 		"column": 1
 	},
+	"end": {
+		"line": 2,
+		"column": 10
+	},
 	"pos": 7
 }]

--- a/test/validator/samples/named-export/errors.json
+++ b/test/validator/samples/named-export/errors.json
@@ -7,6 +7,6 @@
 	},
 	"end": {
 		"line": 2,
-		"column": 1
+		"column": 21
 	}
 }]

--- a/test/validator/samples/named-export/errors.json
+++ b/test/validator/samples/named-export/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 2,
 		"column": 1
+	},
+	"end": {
+		"line": 2,
+		"column": 1
 	}
 }]

--- a/test/validator/samples/namespace-invalid-unguessable/errors.json
+++ b/test/validator/samples/namespace-invalid-unguessable/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 3,
 		"column": 2
+	},
+	"end": {
+		"line": 3,
+		"column": 18
 	}
 }]

--- a/test/validator/samples/namespace-invalid/errors.json
+++ b/test/validator/samples/namespace-invalid/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 3,
 		"column": 2
+	},
+	"end": {
+		"line": 3,
+		"column": 41
 	}
 }]

--- a/test/validator/samples/namespace-non-literal/errors.json
+++ b/test/validator/samples/namespace-non-literal/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 5,
 		"column": 2
+	},
+	"end": {
+		"line": 5,
+		"column": 11
 	}
 }]

--- a/test/validator/samples/non-object-literal-components/errors.json
+++ b/test/validator/samples/non-object-literal-components/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 2
 	},
+	"end": {
+		"line": 3,
+		"column": 37
+	},
 	"pos": 29
 }]

--- a/test/validator/samples/non-object-literal-events/errors.json
+++ b/test/validator/samples/non-object-literal-events/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 2
 	},
+	"end": {
+		"line": 3,
+		"column": 33
+	},
 	"pos": 29
 }]

--- a/test/validator/samples/non-object-literal-helpers/errors.json
+++ b/test/validator/samples/non-object-literal-helpers/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 2
 	},
+	"end": {
+		"line": 3,
+		"column": 34
+	},
 	"pos": 29
 }]

--- a/test/validator/samples/non-object-literal-methods/errors.json
+++ b/test/validator/samples/non-object-literal-methods/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 2
 	},
+	"end": {
+		"line": 3,
+		"column": 34
+	},
 	"pos": 29
 }]

--- a/test/validator/samples/non-object-literal-transitions/errors.json
+++ b/test/validator/samples/non-object-literal-transitions/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 2
 	},
+	"end": {
+		"line": 3,
+		"column": 38
+	},
 	"pos": 29
 }]

--- a/test/validator/samples/oncreate-arrow-this/errors.json
+++ b/test/validator/samples/oncreate-arrow-this/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 3,
 		"column": 2
+	},
+	"end": {
+		"line": 5,
+		"column": 3
 	}
 }]

--- a/test/validator/samples/ondestroy-arrow-this/errors.json
+++ b/test/validator/samples/ondestroy-arrow-this/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 3,
 		"column": 2
+	},
+	"end": {
+		"line": 5,
+		"column": 3
 	}
 }]

--- a/test/validator/samples/properties-components-should-be-capitalised/warnings.json
+++ b/test/validator/samples/properties-components-should-be-capitalised/warnings.json
@@ -4,5 +4,9 @@
 		"line": 6,
 		"column": 3
 	},
+	"end": {
+		"line": 6,
+		"column": 6
+	},
 	"pos": 59
 }]

--- a/test/validator/samples/properties-computed-cannot-be-reserved/errors.json
+++ b/test/validator/samples/properties-computed-cannot-be-reserved/errors.json
@@ -5,5 +5,9 @@
 		"line": 9,
 		"column": 3
 	},
+	"end": {
+		"line": 9,
+		"column": 18
+	},
 	"pos": 87
 }]

--- a/test/validator/samples/properties-computed-must-be-an-object/errors.json
+++ b/test/validator/samples/properties-computed-must-be-an-object/errors.json
@@ -4,5 +4,9 @@
 		"line": 5,
 		"column": 2
 	},
+	"end": {
+		"line": 5,
+		"column": 23
+	},
 	"pos": 42
 }]

--- a/test/validator/samples/properties-computed-must-be-functions/errors.json
+++ b/test/validator/samples/properties-computed-must-be-functions/errors.json
@@ -4,5 +4,9 @@
 		"line": 6,
 		"column": 8
 	},
+	"end": {
+		"line": 6,
+		"column": 20
+	},
 	"pos": 62
 }]

--- a/test/validator/samples/properties-computed-must-be-valid-function-names/errors.json
+++ b/test/validator/samples/properties-computed-must-be-valid-function-names/errors.json
@@ -4,5 +4,9 @@
 		"line": 9,
 		"column": 3
 	},
+	"end": {
+		"line": 9,
+		"column": 28
+	},
 	"pos": 87
 }]

--- a/test/validator/samples/properties-computed-no-destructuring/errors.json
+++ b/test/validator/samples/properties-computed-no-destructuring/errors.json
@@ -4,5 +4,9 @@
 		"line": 6,
 		"column": 8
 	},
+	"end": {
+		"line": 6,
+		"column": 16
+	},
 	"pos": 62
 }]

--- a/test/validator/samples/properties-computed-values-needs-arguments/errors.json
+++ b/test/validator/samples/properties-computed-values-needs-arguments/errors.json
@@ -4,5 +4,9 @@
 	"loc": {
 		"line": 4,
 		"column": 8
+	},
+	"end": {
+		"line": 4,
+		"column": 16
 	}
 }]

--- a/test/validator/samples/properties-data-must-be-function/errors.json
+++ b/test/validator/samples/properties-data-must-be-function/errors.json
@@ -4,5 +4,9 @@
 		"line": 5,
 		"column": 8
 	},
+	"end": {
+		"line": 7,
+		"column": 3
+	},
 	"pos": 48
 }]

--- a/test/validator/samples/properties-duplicated/errors.json
+++ b/test/validator/samples/properties-duplicated/errors.json
@@ -4,5 +4,9 @@
 		"line": 9,
 		"column": 2
 	},
+	"end": {
+		"line": 11,
+		"column": 3
+	},
 	"pos": 74
 }]

--- a/test/validator/samples/properties-methods-getters-setters/errors.json
+++ b/test/validator/samples/properties-methods-getters-setters/errors.json
@@ -4,5 +4,9 @@
 		"line": 4,
 		"column": 3
 	},
+	"end": {
+		"line": 6,
+		"column": 4
+	},
 	"pos": 43
 }]

--- a/test/validator/samples/properties-unexpected-b/errors.json
+++ b/test/validator/samples/properties-unexpected-b/errors.json
@@ -4,5 +4,9 @@
 		"line": 5,
 		"column": 2
 	},
+	"end": {
+		"line": 7,
+		"column": 3
+	},
 	"pos": 42
 }]

--- a/test/validator/samples/properties-unexpected/errors.json
+++ b/test/validator/samples/properties-unexpected/errors.json
@@ -4,5 +4,9 @@
 		"line": 5,
 		"column": 2
 	},
+	"end": {
+		"line": 9,
+		"column": 3
+	},
 	"pos": 42
 }]

--- a/test/validator/samples/slot-attribute-invalid/errors.json
+++ b/test/validator/samples/slot-attribute-invalid/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 5
 	},
+	"end": {
+		"line": 1,
+		"column": 15
+	},
 	"pos": 5
 }]

--- a/test/validator/samples/store-unexpected/warnings.json
+++ b/test/validator/samples/store-unexpected/warnings.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 18
 	},
+	"end": {
+		"line": 1,
+		"column": 29
+	},
 	"pos": 18
 }]

--- a/test/validator/samples/svg-child-component-undeclared-namespace/warnings.json
+++ b/test/validator/samples/svg-child-component-undeclared-namespace/warnings.json
@@ -4,6 +4,10 @@
 		"line": 1,
 		"column": 0
 	},
+	"end": {
+		"line": 1,
+		"column": 65
+	},
 	"pos": 0
 },
 {
@@ -11,6 +15,10 @@
 	"loc": {
 		"column": 1,
 		"line": 5
+	},
+	"end": {
+		"line": 5,
+		"column": 66
 	},
 	"pos": 90
 },
@@ -20,6 +28,10 @@
 		"column": 2,
 		"line": 10
 	},
+	"end": {
+		"line": 10,
+		"column": 67
+	},
 	"pos": 191
 },
 {
@@ -28,6 +40,10 @@
 		"column": 2,
 		"line": 20
 	},
+	"end": {
+		"line": 20,
+		"column": 67
+	},
 	"pos": 333
 },
 {
@@ -35,6 +51,10 @@
 	"loc": {
 		"column": 2,
 		"line": 26
+	},
+	"end": {
+		"line": 26,
+		"column": 67
 	},
 	"pos": 445
 }]

--- a/test/validator/samples/tag-invalid/errors.json
+++ b/test/validator/samples/tag-invalid/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 7
 	},
+	"end": {
+		"line": 3,
+		"column": 16
+	},
 	"pos": 34
 }]

--- a/test/validator/samples/tag-non-string/errors.json
+++ b/test/validator/samples/tag-non-string/errors.json
@@ -4,5 +4,9 @@
 		"line": 3,
 		"column": 7
 	},
+	"end": {
+		"line": 3,
+		"column": 9
+	},
 	"pos": 34
 }]

--- a/test/validator/samples/textarea-value-children/errors.json
+++ b/test/validator/samples/textarea-value-children/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 10
 	},
+	"end": {
+		"line": 1,
+		"column": 25
+	},
 	"pos": 10
 }]

--- a/test/validator/samples/title-no-attributes/errors.json
+++ b/test/validator/samples/title-no-attributes/errors.json
@@ -4,5 +4,9 @@
 		"line": 2,
 		"column": 8
 	},
+	"end": {
+		"line": 2,
+		"column": 25
+	},
 	"pos": 16
 }]

--- a/test/validator/samples/title-no-children/errors.json
+++ b/test/validator/samples/title-no-children/errors.json
@@ -4,5 +4,9 @@
 		"line": 2,
 		"column": 11
 	},
+	"end": {
+		"line": 2,
+		"column": 35
+	},
 	"pos": 19
 }]

--- a/test/validator/samples/transition-duplicate-in-transition/errors.json
+++ b/test/validator/samples/transition-duplicate-in-transition/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 12
 	},
+	"end": {
+		"line": 1,
+		"column": 26
+	},
 	"pos": 12
 }]

--- a/test/validator/samples/transition-duplicate-in/errors.json
+++ b/test/validator/samples/transition-duplicate-in/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 12
 	},
+	"end": {
+		"line": 1,
+		"column": 18
+	},
 	"pos": 12
 }]

--- a/test/validator/samples/transition-duplicate-out-transition/errors.json
+++ b/test/validator/samples/transition-duplicate-out-transition/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 13
 	},
+	"end": {
+		"line": 1,
+		"column": 27
+	},
 	"pos": 13
 }]

--- a/test/validator/samples/transition-duplicate-out/errors.json
+++ b/test/validator/samples/transition-duplicate-out/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 13
 	},
+	"end": {
+		"line": 1,
+		"column": 20
+	},
 	"pos": 13
 }]

--- a/test/validator/samples/transition-duplicate-transition-in/errors.json
+++ b/test/validator/samples/transition-duplicate-transition-in/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 20
 	},
+	"end": {
+		"line": 1,
+		"column": 26
+	},
 	"pos": 20
 }]

--- a/test/validator/samples/transition-duplicate-transition-out/errors.json
+++ b/test/validator/samples/transition-duplicate-transition-out/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 20
 	},
+	"end": {
+		"line": 1,
+		"column": 27
+	},
 	"pos": 20
 }]

--- a/test/validator/samples/transition-duplicate-transition/errors.json
+++ b/test/validator/samples/transition-duplicate-transition/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 20
 	},
+	"end": {
+		"line": 1,
+		"column": 34
+	},
 	"pos": 20
 }]

--- a/test/validator/samples/transition-missing/errors.json
+++ b/test/validator/samples/transition-missing/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 5
 	},
+	"end": {
+		"line": 1,
+		"column": 11
+	},
 	"pos": 5
 }]

--- a/test/validator/samples/transition-on-component/errors.json
+++ b/test/validator/samples/transition-on-component/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 8
 	},
+	"end": {
+		"line": 1,
+		"column": 14
+	},
 	"pos": 8
 }]

--- a/test/validator/samples/unused-components/warnings.json
+++ b/test/validator/samples/unused-components/warnings.json
@@ -5,6 +5,10 @@
 			"line": 7,
 			"column": 3
 		},
+		"end": {
+			"line": 7,
+			"column": 6
+		},
 		"pos": 109
 	},
 	{
@@ -12,6 +16,10 @@
 		"loc": {
 			"line": 8,
 			"column": 3
+		},
+		"end": {
+			"line": 8,
+			"column": 6
 		},
 		"pos": 117
 	}

--- a/test/validator/samples/unused-event/warnings.json
+++ b/test/validator/samples/unused-event/warnings.json
@@ -4,5 +4,9 @@
 		"line": 4,
 		"column": 3
 	},
+	"end": {
+		"line": 6,
+		"column": 4
+	},
 	"pos": 42
 }]

--- a/test/validator/samples/unused-transition/warnings.json
+++ b/test/validator/samples/unused-transition/warnings.json
@@ -4,5 +4,9 @@
 		"line": 4,
 		"column": 3
 	},
+	"end": {
+		"line": 6,
+		"column": 4
+	},
 	"pos": 47
 }]

--- a/test/validator/samples/window-binding-invalid-innerwidth/errors.json
+++ b/test/validator/samples/window-binding-invalid-innerwidth/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 9
 	},
+	"end": {
+		"line": 1,
+		"column": 28
+	},
 	"pos": 9
 }]

--- a/test/validator/samples/window-binding-invalid-value/errors.json
+++ b/test/validator/samples/window-binding-invalid-value/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 26
 	},
+	"end": {
+		"line": 1,
+		"column": 37
+	},
 	"pos": 26
 }]

--- a/test/validator/samples/window-binding-invalid-width/errors.json
+++ b/test/validator/samples/window-binding-invalid-width/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 9
 	},
+	"end": {
+		"line": 1,
+		"column": 23
+	},
 	"pos": 9
 }]

--- a/test/validator/samples/window-binding-invalid/errors.json
+++ b/test/validator/samples/window-binding-invalid/errors.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 9
 	},
+	"end": {
+		"line": 1,
+		"column": 26
+	},
 	"pos": 9
 }]

--- a/test/validator/samples/window-event-invalid/warnings.json
+++ b/test/validator/samples/window-event-invalid/warnings.json
@@ -4,5 +4,9 @@
 		"line": 1,
 		"column": 20
 	},
+	"end": {
+		"line": 1,
+		"column": 28
+	},
 	"pos": 20
 }]


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->

Been working on a language server for svelte for better editor support and for that, the end position is needed to nicely display where the errors/warnings are.

I left the start as `loc` to avoid breaking anyone

Sneak peek
![](https://files.unwritten.fun/9a5a1ed98c.gif)

#1235 