### PR TITLE
set typescript target to ES6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "target": "ES6",
         "diagnostics": true,
         "noImplicitThis": true,
         "noEmitOnError": true,
@@ -7,7 +8,6 @@
         "lib": ["es5", "es6", "dom"],
         "importHelpers": true
     },
-    "target": "ES5",
     "include": [
         "src"
     ],


### PR DESCRIPTION
Two issues here - one is that the `target` option actually belongs inside `compilerOptions` in `tsconfig.json`, and so TypeScript was actually using its default target of ES3, not ES5. And then also there's not really a reason to target ES5 as far as I can tell anyway. This shaves 9% off the bundle size.