### PR TITLE
fix assembly of initial state object

### DIFF
--- a/src/generators/dom/index.ts
+++ b/src/generators/dom/index.ts
@@ -202,7 +202,7 @@ export default function dom(
 		@init(this, options);
 		${templateProperties.store && `this.store = %store();`}
 		${generator.usesRefs && `this.refs = {};`}
-		this._state = @assign(${initialState.join(', ')});
+		this._state = ${initialState.reduce((state, piece) => `@assign(${state}, ${piece})`)};
 		${storeProps.length > 0 && `this.store._add(this, [${storeProps.map(prop => `"${prop.slice(1)}"`)}]);`}
 		${generator.metaBindings}
 		${computations.length && `this._recompute({ ${Array.from(computationDeps).map(dep => `${dep}: 1`).join(', ')} }, this._state);`}

--- a/test/runtime/samples/initial-state-assign/_config.js
+++ b/test/runtime/samples/initial-state-assign/_config.js
@@ -1,0 +1,7 @@
+export default {
+	data: { bar: 'bar' },
+	html: `
+		"foo"
+		"bar"
+	`,
+};

--- a/test/runtime/samples/initial-state-assign/main.html
+++ b/test/runtime/samples/initial-state-assign/main.html
@@ -1,0 +1,10 @@
+{{JSON.stringify(foo)}}
+{{JSON.stringify(bar)}}
+
+<script>
+	export default {
+		data() {
+			return { foo: 'foo' };
+		}
+	};
+</script>


### PR DESCRIPTION
Fixes a regression from #1282. It's _possible_ that it would be nicer to move the reduce function to some common location and use that instead of composing `@assign` manually, but for now I just wanted to address the regression.

cc @lukeed @stalkerg 