### PR TITLE
remove transition styles in Firefox

### DIFF
--- a/src/shared/transitions.js
+++ b/src/shared/transitions.js
@@ -199,7 +199,7 @@ export var transitionManager = {
 		node.style.animation = node.style.animation
 			.split(', ')
 			.filter(function(anim) {
-				return anim.slice(0, name.length) !== name;
+				return !/__svelte/.test(anim);
 			})
 			.join(', ');
 	}


### PR DESCRIPTION
Styles are stringified differently between browsers; this fix should be reliable. I can't think of a good way to test it, though, so we might have to just let this one through.