### PR TITLE
closes #531

### DIFF
--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -516,16 +516,16 @@ export default class Element extends Node {
 					});
 				`);
 
-				if (generator.options.dev) {
-					block.builders.hydrate.addBlock(deindent`
-						if (${handlerName}.teardown) {
-							console.warn("Return 'destroy()' from custom event handlers. Returning 'teardown()' has been deprecated and will be unsupported in Svelte 2");
-						}
-					`);
-				}
+
+				block.builders.hydrate.addBlock(deindent`
+					if (${handlerName}.teardown) {
+						${handlerName}.destroy = ${handlerName}.teardown;
+						${generator.options.dev && `console.warn("Return 'destroy()' from custom event handlers. Returning 'teardown()' has been deprecated and will be unsupported in Svelte 2");`}
+					}
+				`);
 
 				block.builders.destroy.addLine(deindent`
-					${handlerName}[${handlerName}.destroy ? 'destroy' : 'teardown']();
+					${handlerName}.destroy();
 				`);
 			} else {
 				const handler = deindent`

--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -517,7 +517,7 @@ export default class Element extends Node {
 				`);
 
 				block.builders.destroy.addLine(deindent`
-					${handlerName}.teardown();
+					${handlerName}[${handlerName}.destroy ? 'destroy' : 'teardown']();
 				`);
 			} else {
 				const handler = deindent`

--- a/src/generators/nodes/Element.ts
+++ b/src/generators/nodes/Element.ts
@@ -516,6 +516,14 @@ export default class Element extends Node {
 					});
 				`);
 
+				if (generator.options.dev) {
+					block.builders.hydrate.addBlock(deindent`
+						if (${handlerName}.teardown) {
+							console.warn("Return 'destroy()' from custom event handlers. Returning 'teardown()' has been deprecated and will be unsupported in Svelte 2");
+						}
+					`);
+				}
+
 				block.builders.destroy.addLine(deindent`
 					${handlerName}[${handlerName}.destroy ? 'destroy' : 'teardown']();
 				`);

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -199,6 +199,10 @@ function create_main_fragment(component, state) {
 				var state = component.get();
 				component.foo( state.bar );
 			});
+
+			if (foo_handler.teardown) {
+				foo_handler.destroy = foo_handler.teardown;
+			}
 		},
 
 		m: function mount(target, anchor) {
@@ -212,7 +216,7 @@ function create_main_fragment(component, state) {
 		},
 
 		d: function destroy$$1() {
-			foo_handler[foo_handler.destroy ? 'destroy' : 'teardown']();
+			foo_handler.destroy();
 		}
 	};
 }

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -212,7 +212,7 @@ function create_main_fragment(component, state) {
 		},
 
 		d: function destroy$$1() {
-			foo_handler.teardown();
+			foo_handler[foo_handler.destroy ? 'destroy' : 'teardown']();
 		}
 	};
 }

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -39,7 +39,7 @@ function create_main_fragment(component, state) {
 		},
 
 		d: function destroy() {
-			foo_handler.teardown();
+			foo_handler[foo_handler.destroy ? 'destroy' : 'teardown']();
 		}
 	};
 }

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -26,6 +26,10 @@ function create_main_fragment(component, state) {
 				var state = component.get();
 				component.foo( state.bar );
 			});
+
+			if (foo_handler.teardown) {
+				foo_handler.destroy = foo_handler.teardown;
+			}
 		},
 
 		m: function mount(target, anchor) {
@@ -39,7 +43,7 @@ function create_main_fragment(component, state) {
 		},
 
 		d: function destroy() {
-			foo_handler[foo_handler.destroy ? 'destroy' : 'teardown']();
+			foo_handler.destroy();
 		}
 	};
 }

--- a/test/runtime/samples/dev-warning-custom-event-destroy-not-teardown/_config.js
+++ b/test/runtime/samples/dev-warning-custom-event-destroy-not-teardown/_config.js
@@ -1,0 +1,7 @@
+export default {
+	dev: true,
+
+	warnings: [
+		`Return 'destroy()' from custom event handlers. Returning 'teardown()' has been deprecated and will be unsupported in Svelte 2`
+	]
+};

--- a/test/runtime/samples/dev-warning-custom-event-destroy-not-teardown/main.html
+++ b/test/runtime/samples/dev-warning-custom-event-destroy-not-teardown/main.html
@@ -1,0 +1,16 @@
+<button on:foo='foo()'>foo</button>
+
+<script>
+	export default {
+		methods: {
+			foo() {}
+		},
+		events: {
+			foo(node, callback) {
+				return {
+					teardown() {}
+				}
+			}
+		}
+	};
+</script>


### PR DESCRIPTION
Deprecate custom event `teardown`, and start supporting `destroy`.

This brings custom events API inline with the rest of the API.
For example `component.destroy()` and `action.destroy`