### PR TITLE
allow overwritten observe method

### DIFF
--- a/src/generators/dom/index.ts
+++ b/src/generators/dom/index.ts
@@ -138,7 +138,6 @@ export default function dom(
 		: options.shared || '';
 
 	let prototypeBase = `${name}.prototype`;
-	templateProperties.methods && (prototypeBase = `@assign(${prototypeBase}, %methods)`);
 
 	const proto = sharedPath
 		? `@proto`
@@ -343,6 +342,7 @@ export default function dom(
 			}
 
 			@assign(${prototypeBase}, ${proto});
+			${templateProperties.methods && `@assign(${prototypeBase}, %methods);`}
 		`);
 	}
 

--- a/src/validate/js/propValidators/methods.ts
+++ b/src/validate/js/propValidators/methods.ts
@@ -6,7 +6,7 @@ import getName from '../../../utils/getName';
 import { Validator } from '../../index';
 import { Node } from '../../../interfaces';
 
-const builtin = new Set(['set', 'get', 'on', 'fire', 'observe', 'destroy']);
+const builtin = new Set(['set', 'get', 'on', 'fire', 'destroy']);
 
 export default function methods(validator: Validator, prop: Node) {
 	if (prop.value.type !== 'ObjectExpression') {

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -204,6 +204,7 @@ function SvelteComponent(options) {
 	}
 }
 
-assign(assign(SvelteComponent.prototype, methods), proto);
+assign(SvelteComponent.prototype, proto);
+assign(SvelteComponent.prototype, methods);
 
 export default SvelteComponent;

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -56,5 +56,6 @@ function SvelteComponent(options) {
 	}
 }
 
-assign(assign(SvelteComponent.prototype, methods), proto);
+assign(SvelteComponent.prototype, proto);
+assign(SvelteComponent.prototype, methods);
 export default SvelteComponent;

--- a/test/js/samples/setup-method/expected-bundle.js
+++ b/test/js/samples/setup-method/expected-bundle.js
@@ -181,7 +181,8 @@ function SvelteComponent(options) {
 	}
 }
 
-assign(assign(SvelteComponent.prototype, methods), proto);
+assign(SvelteComponent.prototype, proto);
+assign(SvelteComponent.prototype, methods);
 
 setup(SvelteComponent);
 

--- a/test/js/samples/setup-method/expected.js
+++ b/test/js/samples/setup-method/expected.js
@@ -44,7 +44,8 @@ function SvelteComponent(options) {
 	}
 }
 
-assign(assign(SvelteComponent.prototype, methods), proto);
+assign(SvelteComponent.prototype, proto);
+assign(SvelteComponent.prototype, methods);
 
 setup(SvelteComponent);
 export default SvelteComponent;


### PR DESCRIPTION
Necessary to move `observe` into svelte-extras