### PR TITLE
deprecate get with string argument

### DIFF
--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -51,6 +51,11 @@ export function fire(eventName, data) {
 	}
 }
 
+export function getDev(key) {
+	if (key) console.warn("`let x = component.get('x')` is deprecated. Use `let { x } = component.get()` instead");
+	return get.call(this, key);
+}
+
 export function get(key) {
 	return key ? this._state[key] : this._state;
 }
@@ -204,7 +209,7 @@ export var proto = {
 
 export var protoDev = {
 	destroy: destroyDev,
-	get: get,
+	get: getDev,
 	fire: fire,
 	observe: observeDev,
 	on: onDev,

--- a/test/js/samples/dev-warning-missing-data-computed/_actual-bundle-v2.js
+++ b/test/js/samples/dev-warning-missing-data-computed/_actual-bundle-v2.js
@@ -66,6 +66,11 @@ function fire(eventName, data) {
 	}
 }
 
+function getDev(key) {
+	if (key) console.warn("`let x = component.get('x')` is deprecated. Use `let { x } = component.get()` instead");
+	return get.call(this, key);
+}
+
 function get(key) {
 	return key ? this._state[key] : this._state;
 }
@@ -188,7 +193,7 @@ function _unmount() {
 
 var protoDev = {
 	destroy: destroyDev,
-	get: get,
+	get: getDev,
 	fire: fire,
 	observe: observeDev,
 	on: onDev,

--- a/test/js/samples/dev-warning-missing-data-computed/expected-bundle-v2.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected-bundle-v2.js
@@ -66,6 +66,11 @@ function fire(eventName, data) {
 	}
 }
 
+function getDev(key) {
+	if (key) console.warn("`let x = component.get('x')` is deprecated. Use `let { x } = component.get()` instead");
+	return get.call(this, key);
+}
+
 function get(key) {
 	return key ? this._state[key] : this._state;
 }
@@ -188,7 +193,7 @@ function _unmount() {
 
 var protoDev = {
 	destroy: destroyDev,
-	get: get,
+	get: getDev,
 	fire: fire,
 	observe: observeDev,
 	on: onDev,

--- a/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
@@ -66,6 +66,11 @@ function fire(eventName, data) {
 	}
 }
 
+function getDev(key) {
+	if (key) console.warn("`let x = component.get('x')` is deprecated. Use `let { x } = component.get()` instead");
+	return get.call(this, key);
+}
+
 function get(key) {
 	return key ? this._state[key] : this._state;
 }
@@ -188,7 +193,7 @@ function _unmount() {
 
 var protoDev = {
 	destroy: destroyDev,
-	get: get,
+	get: getDev,
 	fire: fire,
 	observe: observeDev,
 	on: onDev,


### PR DESCRIPTION
I think it makes sense to get this warning into one of the final v1 releases, to ease migration