### PR TITLE
Collapse hydrate logic

### DIFF
--- a/src/compile/dom/Block.ts
+++ b/src/compile/dom/Block.ts
@@ -140,6 +140,8 @@ export default class Block {
 	}
 
 	toString() {
+		const { dev } = this.compiler.options;
+
 		let introing;
 		const hasIntros = !this.builders.intro.isEmpty();
 		if (hasIntros) {
@@ -184,7 +186,7 @@ export default class Block {
 			);
 
 			properties.addBlock(deindent`
-				c() {
+				${dev ? 'c: function create' : 'c'}() {
 					${this.builders.create}
 					${hydrate}
 				},
@@ -196,7 +198,7 @@ export default class Block {
 				properties.addBlock(`l: @noop,`);
 			} else {
 				properties.addBlock(deindent`
-					l(nodes) {
+					${dev ? 'l: function claim' : 'l'}(nodes) {
 						${this.builders.claim}
 						${!this.builders.hydrate.isEmpty() && `this.h();`}
 					},
@@ -206,7 +208,7 @@ export default class Block {
 
 		if (this.compiler.options.hydratable && !this.builders.hydrate.isEmpty()) {
 			properties.addBlock(deindent`
-				h() {
+				${dev ? 'h: function hydrate' : 'h'}() {
 					${this.builders.hydrate}
 				},
 			`);
@@ -216,7 +218,7 @@ export default class Block {
 			properties.addBlock(`m: @noop,`);
 		} else {
 			properties.addBlock(deindent`
-				m(#target, anchor) {
+				${dev ? 'm: function mount' : 'm'}(#target, anchor) {
 					${this.builders.mount}
 				},
 			`);
@@ -227,7 +229,7 @@ export default class Block {
 				properties.addBlock(`p: @noop,`);
 			} else {
 				properties.addBlock(deindent`
-					p(changed, ${this.maintainContext ? '_ctx' : 'ctx'}) {
+					${dev ? 'p: function update' : 'p'}(changed, ${this.maintainContext ? '_ctx' : 'ctx'}) {
 						${this.maintainContext && `ctx = _ctx;`}
 						${this.builders.update}
 					},
@@ -238,7 +240,7 @@ export default class Block {
 		if (this.hasIntroMethod) {
 			if (hasIntros) {
 				properties.addBlock(deindent`
-					i(#target, anchor) {
+					${dev ? 'i: function intro' : 'i'}(#target, anchor) {
 						if (${introing}) return;
 						${introing} = true;
 						${hasOutros && `${outroing} = false;`}
@@ -250,7 +252,7 @@ export default class Block {
 				`);
 			} else {
 				properties.addBlock(deindent`
-					i(#target, anchor) {
+					${dev ? 'i: function intro' : 'i'}(#target, anchor) {
 						this.m(#target, anchor);
 					},
 				`);
@@ -260,7 +262,7 @@ export default class Block {
 		if (this.hasOutroMethod) {
 			if (hasOutros) {
 				properties.addBlock(deindent`
-					o(#outrocallback) {
+					${dev ? 'o: function outro' : 'o'}(#outrocallback) {
 						if (${outroing}) return;
 						${outroing} = true;
 						${hasIntros && `${introing} = false;`}
@@ -281,7 +283,7 @@ export default class Block {
 			properties.addBlock(`u: @noop,`);
 		} else {
 			properties.addBlock(deindent`
-				u() {
+				${dev ? 'u: function unmount' : 'u'}() {
 					${this.builders.unmount}
 				},
 			`);
@@ -291,7 +293,7 @@ export default class Block {
 			properties.addBlock(`d: @noop`);
 		} else {
 			properties.addBlock(deindent`
-				d() {
+				${dev ? 'd: function destroy' : 'd'}() {
 					${this.builders.destroy}
 				}
 			`);

--- a/test/js/samples/action/expected-bundle.js
+++ b/test/js/samples/action/expected-bundle.js
@@ -154,28 +154,24 @@ function create_main_fragment(component, ctx) {
 	var a, link_action;
 
 	return {
-		c: function create() {
+		c() {
 			a = createElement("a");
 			a.textContent = "Test";
-			this.h();
-		},
-
-		h: function hydrate() {
 			a.href = "#";
 			link_action = link.call(component, a) || {};
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(a, target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(a);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			if (typeof link_action.destroy === 'function') link_action.destroy.call(component);
 		}
 	};

--- a/test/js/samples/action/expected.js
+++ b/test/js/samples/action/expected.js
@@ -21,28 +21,24 @@ function create_main_fragment(component, ctx) {
 	var a, link_action;
 
 	return {
-		c: function create() {
+		c() {
 			a = createElement("a");
 			a.textContent = "Test";
-			this.h();
-		},
-
-		h: function hydrate() {
 			a.href = "#";
 			link_action = link.call(component, a) || {};
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(a, target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(a);
 		},
 
-		d: function destroy() {
+		d() {
 			if (typeof link_action.destroy === 'function') link_action.destroy.call(component);
 		}
 	};

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -157,28 +157,24 @@ function create_main_fragment(component, ctx) {
 	var p, text;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			text = createText(ctx.foo);
-			this.h();
-		},
-
-		h: function hydrate() {
 			p.className = "svelte-1a7i8ec";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 			appendNode(text, p);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.foo) {
 				text.data = ctx.foo;
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -16,28 +16,24 @@ function create_main_fragment(component, ctx) {
 	var p, text;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			text = createText(ctx.foo);
-			this.h();
-		},
-
-		h: function hydrate() {
 			p.className = "svelte-1a7i8ec";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 			appendNode(text, p);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.foo) {
 				text.data = ctx.foo;
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/component-static-immutable/expected-bundle.js
+++ b/test/js/samples/component-static-immutable/expected-bundle.js
@@ -138,21 +138,21 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			nested._fragment.c();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			nested._mount(target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			nested._unmount();
 		},
 
-		d: function destroy$$1() {
+		d() {
 			nested.destroy(false);
 		}
 	};

--- a/test/js/samples/component-static-immutable/expected.js
+++ b/test/js/samples/component-static-immutable/expected.js
@@ -12,21 +12,21 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			nested._fragment.c();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			nested._mount(target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			nested._unmount();
 		},
 
-		d: function destroy() {
+		d() {
 			nested.destroy(false);
 		}
 	};

--- a/test/js/samples/component-static-immutable2/expected-bundle.js
+++ b/test/js/samples/component-static-immutable2/expected-bundle.js
@@ -138,21 +138,21 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			nested._fragment.c();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			nested._mount(target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			nested._unmount();
 		},
 
-		d: function destroy$$1() {
+		d() {
 			nested.destroy(false);
 		}
 	};

--- a/test/js/samples/component-static-immutable2/expected.js
+++ b/test/js/samples/component-static-immutable2/expected.js
@@ -12,21 +12,21 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			nested._fragment.c();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			nested._mount(target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			nested._unmount();
 		},
 
-		d: function destroy() {
+		d() {
 			nested.destroy(false);
 		}
 	};

--- a/test/js/samples/component-static/expected-bundle.js
+++ b/test/js/samples/component-static/expected-bundle.js
@@ -134,21 +134,21 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			nested._fragment.c();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			nested._mount(target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			nested._unmount();
 		},
 
-		d: function destroy$$1() {
+		d() {
 			nested.destroy(false);
 		}
 	};

--- a/test/js/samples/component-static/expected.js
+++ b/test/js/samples/component-static/expected.js
@@ -12,21 +12,21 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			nested._fragment.c();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			nested._mount(target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			nested._unmount();
 		},
 
-		d: function destroy() {
+		d() {
 			nested.destroy(false);
 		}
 	};

--- a/test/js/samples/css-media-query/expected-bundle.js
+++ b/test/js/samples/css-media-query/expected-bundle.js
@@ -150,22 +150,18 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			div.className = "svelte-1slhpfn";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -12,22 +12,18 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			div.className = "svelte-1slhpfn";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/css-shadow-dom-keyframes/expected-bundle.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected-bundle.js
@@ -139,19 +139,19 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			div.textContent = "fades in";
 			this.c = noop;
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/css-shadow-dom-keyframes/expected.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected.js
@@ -5,19 +5,19 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			div.textContent = "fades in";
 			this.c = noop;
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/deconflict-builtins/expected-bundle.js
+++ b/test/js/samples/deconflict-builtins/expected-bundle.js
@@ -165,7 +165,7 @@ function create_main_fragment(component, ctx) {
 	}
 
 	return {
-		c: function create() {
+		c() {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
@@ -173,7 +173,7 @@ function create_main_fragment(component, ctx) {
 			each_anchor = createComment();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
@@ -181,7 +181,7 @@ function create_main_fragment(component, ctx) {
 			insertNode(each_anchor, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.createElement) {
 				each_value = ctx.createElement;
 
@@ -205,7 +205,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].u();
 			}
@@ -213,7 +213,7 @@ function create_main_fragment(component, ctx) {
 			detachNode(each_anchor);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			destroyEach(each_blocks);
 		}
 	};
@@ -224,23 +224,23 @@ function create_each_block(component, ctx) {
 	var span, text_value = ctx.node, text;
 
 	return {
-		c: function create() {
+		c() {
 			span = createElement("span");
 			text = createText(text_value);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(span, target, anchor);
 			appendNode(text, span);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if ((changed.createElement) && text_value !== (text_value = ctx.node)) {
 				text.data = text_value;
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(span);
 		},
 

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -13,7 +13,7 @@ function create_main_fragment(component, ctx) {
 	}
 
 	return {
-		c: function create() {
+		c() {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
@@ -21,7 +21,7 @@ function create_main_fragment(component, ctx) {
 			each_anchor = createComment();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
@@ -29,7 +29,7 @@ function create_main_fragment(component, ctx) {
 			insertNode(each_anchor, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.createElement) {
 				each_value = ctx.createElement;
 
@@ -53,7 +53,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].u();
 			}
@@ -61,7 +61,7 @@ function create_main_fragment(component, ctx) {
 			detachNode(each_anchor);
 		},
 
-		d: function destroy() {
+		d() {
 			destroyEach(each_blocks);
 		}
 	};
@@ -72,23 +72,23 @@ function create_each_block(component, ctx) {
 	var span, text_value = ctx.node, text;
 
 	return {
-		c: function create() {
+		c() {
 			span = createElement("span");
 			text = createText(text_value);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(span, target, anchor);
 			appendNode(text, span);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if ((changed.createElement) && text_value !== (text_value = ctx.node)) {
 				text.data = text_value;
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(span);
 		},
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
@@ -169,21 +169,21 @@ function create_main_fragment(component, ctx) {
 	var p, text_value = ctx.Math.max(0, ctx.foo), text, text_1, text_2;
 
 	return {
-		c() {
+		c: function create() {
 			p = createElement("p");
 			text = createText(text_value);
 			text_1 = createText("\n\t");
 			text_2 = createText(ctx.bar);
 		},
 
-		m(target, anchor) {
+		m: function mount(target, anchor) {
 			insertNode(p, target, anchor);
 			appendNode(text, p);
 			appendNode(text_1, p);
 			appendNode(text_2, p);
 		},
 
-		p(changed, ctx) {
+		p: function update(changed, ctx) {
 			if ((changed.Math || changed.foo) && text_value !== (text_value = ctx.Math.max(0, ctx.foo))) {
 				text.data = text_value;
 			}
@@ -193,7 +193,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u() {
+		u: function unmount() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
@@ -169,21 +169,21 @@ function create_main_fragment(component, ctx) {
 	var p, text_value = ctx.Math.max(0, ctx.foo), text, text_1, text_2;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			text = createText(text_value);
 			text_1 = createText("\n\t");
 			text_2 = createText(ctx.bar);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 			appendNode(text, p);
 			appendNode(text_1, p);
 			appendNode(text_2, p);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if ((changed.Math || changed.foo) && text_value !== (text_value = ctx.Math.max(0, ctx.foo))) {
 				text.data = text_value;
 			}
@@ -193,7 +193,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -9,21 +9,21 @@ function create_main_fragment(component, ctx) {
 	var p, text_value = ctx.Math.max(0, ctx.foo), text, text_1, text_2;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			text = createText(text_value);
 			text_1 = createText("\n\t");
 			text_2 = createText(ctx.bar);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 			appendNode(text, p);
 			appendNode(text_1, p);
 			appendNode(text_2, p);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if ((changed.Math || changed.foo) && text_value !== (text_value = ctx.Math.max(0, ctx.foo))) {
 				text.data = text_value;
 			}
@@ -33,7 +33,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -9,21 +9,21 @@ function create_main_fragment(component, ctx) {
 	var p, text_value = ctx.Math.max(0, ctx.foo), text, text_1, text_2;
 
 	return {
-		c() {
+		c: function create() {
 			p = createElement("p");
 			text = createText(text_value);
 			text_1 = createText("\n\t");
 			text_2 = createText(ctx.bar);
 		},
 
-		m(target, anchor) {
+		m: function mount(target, anchor) {
 			insertNode(p, target, anchor);
 			appendNode(text, p);
 			appendNode(text_1, p);
 			appendNode(text_2, p);
 		},
 
-		p(changed, ctx) {
+		p: function update(changed, ctx) {
 			if ((changed.Math || changed.foo) && text_value !== (text_value = ctx.Math.max(0, ctx.foo))) {
 				text.data = text_value;
 			}
@@ -33,7 +33,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u() {
+		u: function unmount() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/do-use-dataset/expected-bundle.js
+++ b/test/js/samples/do-use-dataset/expected-bundle.js
@@ -143,31 +143,27 @@ function create_main_fragment(component, ctx) {
 	var div, text, div_1;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			text = createText("\n");
 			div_1 = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			div.dataset.foo = "bar";
 			div_1.dataset.foo = ctx.bar;
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			insertNode(text, target, anchor);
 			insertNode(div_1, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.bar) {
 				div_1.dataset.foo = ctx.bar;
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 			detachNode(text);
 			detachNode(div_1);

--- a/test/js/samples/do-use-dataset/expected.js
+++ b/test/js/samples/do-use-dataset/expected.js
@@ -5,31 +5,27 @@ function create_main_fragment(component, ctx) {
 	var div, text, div_1;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			text = createText("\n");
 			div_1 = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			div.dataset.foo = "bar";
 			div_1.dataset.foo = ctx.bar;
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			insertNode(text, target, anchor);
 			insertNode(div_1, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.bar) {
 				div_1.dataset.foo = ctx.bar;
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 			detachNode(text);
 			detachNode(div_1);

--- a/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
@@ -147,31 +147,27 @@ function create_main_fragment(component, ctx) {
 	var div, text, div_1;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			text = createText("\n");
 			div_1 = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setAttribute(div, "data-foo", "bar");
 			setAttribute(div_1, "data-foo", ctx.bar);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			insertNode(text, target, anchor);
 			insertNode(div_1, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.bar) {
 				setAttribute(div_1, "data-foo", ctx.bar);
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 			detachNode(text);
 			detachNode(div_1);

--- a/test/js/samples/dont-use-dataset-in-legacy/expected.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected.js
@@ -5,31 +5,27 @@ function create_main_fragment(component, ctx) {
 	var div, text, div_1;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			text = createText("\n");
 			div_1 = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setAttribute(div, "data-foo", "bar");
 			setAttribute(div_1, "data-foo", ctx.bar);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			insertNode(text, target, anchor);
 			insertNode(div_1, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.bar) {
 				setAttribute(div_1, "data-foo", ctx.bar);
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 			detachNode(text);
 			detachNode(div_1);

--- a/test/js/samples/dont-use-dataset-in-svg/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-svg/expected-bundle.js
@@ -147,31 +147,27 @@ function create_main_fragment(component, ctx) {
 	var svg, g, g_1;
 
 	return {
-		c: function create() {
+		c() {
 			svg = createSvgElement("svg");
 			g = createSvgElement("g");
 			g_1 = createSvgElement("g");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setAttribute(g, "data-foo", "bar");
 			setAttribute(g_1, "data-foo", ctx.bar);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(svg, target, anchor);
 			appendNode(g, svg);
 			appendNode(g_1, svg);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.bar) {
 				setAttribute(g_1, "data-foo", ctx.bar);
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(svg);
 		},
 

--- a/test/js/samples/dont-use-dataset-in-svg/expected.js
+++ b/test/js/samples/dont-use-dataset-in-svg/expected.js
@@ -5,31 +5,27 @@ function create_main_fragment(component, ctx) {
 	var svg, g, g_1;
 
 	return {
-		c: function create() {
+		c() {
 			svg = createSvgElement("svg");
 			g = createSvgElement("g");
 			g_1 = createSvgElement("g");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setAttribute(g, "data-foo", "bar");
 			setAttribute(g_1, "data-foo", ctx.bar);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(svg, target, anchor);
 			appendNode(g, svg);
 			appendNode(g_1, svg);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.bar) {
 				setAttribute(g_1, "data-foo", ctx.bar);
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(svg);
 		},
 

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -167,7 +167,7 @@ function create_main_fragment(component, ctx) {
 	}
 
 	return {
-		c: function create() {
+		c() {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
@@ -177,7 +177,7 @@ function create_main_fragment(component, ctx) {
 			text_1 = createText(ctx.foo);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
@@ -187,7 +187,7 @@ function create_main_fragment(component, ctx) {
 			appendNode(text_1, p);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.comments || changed.elapsed || changed.time) {
 				each_value = ctx.comments;
 
@@ -215,7 +215,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].u();
 			}
@@ -224,7 +224,7 @@ function create_main_fragment(component, ctx) {
 			detachNode(p);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			destroyEach(each_blocks);
 		}
 	};
@@ -235,7 +235,7 @@ function create_each_block(component, ctx) {
 	var div, strong, text, text_1, span, text_2_value = ctx.comment.author, text_2, text_3, text_4_value = ctx.elapsed(ctx.comment.time, ctx.time), text_4, text_5, text_6, raw_value = ctx.comment.html, raw_before;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			strong = createElement("strong");
 			text = createText(ctx.i);
@@ -247,15 +247,11 @@ function create_each_block(component, ctx) {
 			text_5 = createText(" ago:");
 			text_6 = createText("\n\n\t\t");
 			raw_before = createElement('noscript');
-			this.h();
-		},
-
-		h: function hydrate() {
 			span.className = "meta";
 			div.className = "comment";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			appendNode(strong, div);
 			appendNode(text, strong);
@@ -270,7 +266,7 @@ function create_each_block(component, ctx) {
 			raw_before.insertAdjacentHTML("afterend", raw_value);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if ((changed.comments) && text_2_value !== (text_2_value = ctx.comment.author)) {
 				text_2.data = text_2_value;
 			}
@@ -285,7 +281,7 @@ function create_each_block(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachAfter(raw_before);
 
 			detachNode(div);

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -13,7 +13,7 @@ function create_main_fragment(component, ctx) {
 	}
 
 	return {
-		c: function create() {
+		c() {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
@@ -23,7 +23,7 @@ function create_main_fragment(component, ctx) {
 			text_1 = createText(ctx.foo);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
@@ -33,7 +33,7 @@ function create_main_fragment(component, ctx) {
 			appendNode(text_1, p);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.comments || changed.elapsed || changed.time) {
 				each_value = ctx.comments;
 
@@ -61,7 +61,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			for (var i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].u();
 			}
@@ -70,7 +70,7 @@ function create_main_fragment(component, ctx) {
 			detachNode(p);
 		},
 
-		d: function destroy() {
+		d() {
 			destroyEach(each_blocks);
 		}
 	};
@@ -81,7 +81,7 @@ function create_each_block(component, ctx) {
 	var div, strong, text, text_1, span, text_2_value = ctx.comment.author, text_2, text_3, text_4_value = ctx.elapsed(ctx.comment.time, ctx.time), text_4, text_5, text_6, raw_value = ctx.comment.html, raw_before;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			strong = createElement("strong");
 			text = createText(ctx.i);
@@ -93,15 +93,11 @@ function create_each_block(component, ctx) {
 			text_5 = createText(" ago:");
 			text_6 = createText("\n\n\t\t");
 			raw_before = createElement('noscript');
-			this.h();
-		},
-
-		h: function hydrate() {
 			span.className = "meta";
 			div.className = "comment";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			appendNode(strong, div);
 			appendNode(text, strong);
@@ -116,7 +112,7 @@ function create_each_block(component, ctx) {
 			raw_before.insertAdjacentHTML("afterend", raw_value);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if ((changed.comments) && text_2_value !== (text_2_value = ctx.comment.author)) {
 				text_2.data = text_2_value;
 			}
@@ -131,7 +127,7 @@ function create_each_block(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachAfter(raw_before);
 
 			detachNode(div);

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -148,32 +148,28 @@ function create_main_fragment(component, ctx) {
 	var button, foo_handler;
 
 	return {
-		c: function create() {
+		c() {
 			button = createElement("button");
 			button.textContent = "foo";
-			this.h();
-		},
-
-		h: function hydrate() {
 			foo_handler = foo.call(component, button, function(event) {
 				component.foo( ctx.bar );
 			});
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(button, target, anchor);
 		},
 
-		p: function update(changed, _ctx) {
+		p(changed, _ctx) {
 			ctx = _ctx;
 
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(button);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			foo_handler.destroy();
 		}
 	};

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -15,32 +15,28 @@ function create_main_fragment(component, ctx) {
 	var button, foo_handler;
 
 	return {
-		c: function create() {
+		c() {
 			button = createElement("button");
 			button.textContent = "foo";
-			this.h();
-		},
-
-		h: function hydrate() {
 			foo_handler = foo.call(component, button, function(event) {
 				component.foo( ctx.bar );
 			});
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(button, target, anchor);
 		},
 
-		p: function update(changed, _ctx) {
+		p(changed, _ctx) {
 			ctx = _ctx;
 
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(button);
 		},
 
-		d: function destroy() {
+		d() {
 			foo_handler.destroy();
 		}
 	};

--- a/test/js/samples/head-no-whitespace/expected-bundle.js
+++ b/test/js/samples/head-no-whitespace/expected-bundle.js
@@ -139,27 +139,23 @@ function create_main_fragment(component, ctx) {
 	var meta, meta_1;
 
 	return {
-		c: function create() {
+		c() {
 			meta = createElement("meta");
 			meta_1 = createElement("meta");
-			this.h();
-		},
-
-		h: function hydrate() {
 			meta.name = "twitter:creator";
 			meta.content = "@sveltejs";
 			meta_1.name = "twitter:title";
 			meta_1.content = "Svelte";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			appendNode(meta, document.head);
 			appendNode(meta_1, document.head);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(meta);
 			detachNode(meta_1);
 		},

--- a/test/js/samples/head-no-whitespace/expected.js
+++ b/test/js/samples/head-no-whitespace/expected.js
@@ -5,27 +5,23 @@ function create_main_fragment(component, ctx) {
 	var meta, meta_1;
 
 	return {
-		c: function create() {
+		c() {
 			meta = createElement("meta");
 			meta_1 = createElement("meta");
-			this.h();
-		},
-
-		h: function hydrate() {
 			meta.name = "twitter:creator";
 			meta.content = "@sveltejs";
 			meta_1.name = "twitter:title";
 			meta_1.content = "Svelte";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			appendNode(meta, document.head);
 			appendNode(meta_1, document.head);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(meta);
 			detachNode(meta_1);
 		},

--- a/test/js/samples/if-block-no-update/expected-bundle.js
+++ b/test/js/samples/if-block-no-update/expected-bundle.js
@@ -151,17 +151,17 @@ function create_main_fragment(component, ctx) {
 	var if_block = current_block_type(component, ctx);
 
 	return {
-		c: function create() {
+		c() {
 			if_block.c();
 			if_block_anchor = createComment();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			if_block.m(target, anchor);
 			insertNode(if_block_anchor, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (current_block_type !== (current_block_type = select_block_type(ctx))) {
 				if_block.u();
 				if_block.d();
@@ -171,12 +171,12 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			if_block.u();
 			detachNode(if_block_anchor);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			if_block.d();
 		}
 	};
@@ -187,16 +187,16 @@ function create_if_block(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "foo!";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -209,16 +209,16 @@ function create_if_block_1(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "not foo!";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -13,17 +13,17 @@ function create_main_fragment(component, ctx) {
 	var if_block = current_block_type(component, ctx);
 
 	return {
-		c: function create() {
+		c() {
 			if_block.c();
 			if_block_anchor = createComment();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			if_block.m(target, anchor);
 			insertNode(if_block_anchor, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (current_block_type !== (current_block_type = select_block_type(ctx))) {
 				if_block.u();
 				if_block.d();
@@ -33,12 +33,12 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			if_block.u();
 			detachNode(if_block_anchor);
 		},
 
-		d: function destroy() {
+		d() {
 			if_block.d();
 		}
 	};
@@ -49,16 +49,16 @@ function create_if_block(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "foo!";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -71,16 +71,16 @@ function create_if_block_1(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "not foo!";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/if-block-simple/expected-bundle.js
+++ b/test/js/samples/if-block-simple/expected-bundle.js
@@ -145,17 +145,17 @@ function create_main_fragment(component, ctx) {
 	var if_block = (ctx.foo) && create_if_block(component, ctx);
 
 	return {
-		c: function create() {
+		c() {
 			if (if_block) if_block.c();
 			if_block_anchor = createComment();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			if (if_block) if_block.m(target, anchor);
 			insertNode(if_block_anchor, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (ctx.foo) {
 				if (!if_block) {
 					if_block = create_if_block(component, ctx);
@@ -169,12 +169,12 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			if (if_block) if_block.u();
 			detachNode(if_block_anchor);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			if (if_block) if_block.d();
 		}
 	};
@@ -185,16 +185,16 @@ function create_if_block(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "foo!";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -7,17 +7,17 @@ function create_main_fragment(component, ctx) {
 	var if_block = (ctx.foo) && create_if_block(component, ctx);
 
 	return {
-		c: function create() {
+		c() {
 			if (if_block) if_block.c();
 			if_block_anchor = createComment();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			if (if_block) if_block.m(target, anchor);
 			insertNode(if_block_anchor, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (ctx.foo) {
 				if (!if_block) {
 					if_block = create_if_block(component, ctx);
@@ -31,12 +31,12 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			if (if_block) if_block.u();
 			detachNode(if_block_anchor);
 		},
 
-		d: function destroy() {
+		d() {
 			if (if_block) if_block.d();
 		}
 	};
@@ -47,16 +47,16 @@ function create_if_block(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "foo!";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
@@ -143,21 +143,17 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setStyle(div, "color", ctx.color);
 			setStyle(div, "transform", "translate(" + ctx.x + "px," + ctx.y + "px)");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.color) {
 				setStyle(div, "color", ctx.color);
 			}
@@ -167,7 +163,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -5,21 +5,17 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setStyle(div, "color", ctx.color);
 			setStyle(div, "transform", "translate(" + ctx.x + "px," + ctx.y + "px)");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.color) {
 				setStyle(div, "color", ctx.color);
 			}
@@ -29,7 +25,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/inline-style-optimized-url/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-url/expected-bundle.js
@@ -143,26 +143,22 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setStyle(div, "background", "url(data:image/png;base64," + ctx.data + ")");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.data) {
 				setStyle(div, "background", "url(data:image/png;base64," + ctx.data + ")");
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -5,26 +5,22 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setStyle(div, "background", "url(data:image/png;base64," + ctx.data + ")");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.data) {
 				setStyle(div, "background", "url(data:image/png;base64," + ctx.data + ")");
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/inline-style-optimized/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized/expected-bundle.js
@@ -143,26 +143,22 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setStyle(div, "color", ctx.color);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.color) {
 				setStyle(div, "color", ctx.color);
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -5,26 +5,22 @@ function create_main_fragment(component, ctx) {
 	var div;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setStyle(div, "color", ctx.color);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.color) {
 				setStyle(div, "color", ctx.color);
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 		},
 

--- a/test/js/samples/inline-style-unoptimized/expected-bundle.js
+++ b/test/js/samples/inline-style-unoptimized/expected-bundle.js
@@ -143,25 +143,21 @@ function create_main_fragment(component, ctx) {
 	var div, text, div_1, div_1_style_value;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			text = createText("\n");
 			div_1 = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			div.style.cssText = ctx.style;
 			div_1.style.cssText = div_1_style_value = "" + ctx.key + ": " + ctx.value;
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			insertNode(text, target, anchor);
 			insertNode(div_1, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.style) {
 				div.style.cssText = ctx.style;
 			}
@@ -171,7 +167,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 			detachNode(text);
 			detachNode(div_1);

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -5,25 +5,21 @@ function create_main_fragment(component, ctx) {
 	var div, text, div_1, div_1_style_value;
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			text = createText("\n");
 			div_1 = createElement("div");
-			this.h();
-		},
-
-		h: function hydrate() {
 			div.style.cssText = ctx.style;
 			div_1.style.cssText = div_1_style_value = "" + ctx.key + ": " + ctx.value;
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			insertNode(text, target, anchor);
 			insertNode(div_1, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.style) {
 				div.style.cssText = ctx.style;
 			}
@@ -33,7 +29,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 			detachNode(text);
 			detachNode(div_1);

--- a/test/js/samples/input-without-blowback-guard/expected-bundle.js
+++ b/test/js/samples/input-without-blowback-guard/expected-bundle.js
@@ -155,31 +155,27 @@ function create_main_fragment(component, ctx) {
 	}
 
 	return {
-		c: function create() {
+		c() {
 			input = createElement("input");
-			this.h();
-		},
-
-		h: function hydrate() {
 			addListener(input, "change", input_change_handler);
 			setAttribute(input, "type", "checkbox");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(input, target, anchor);
 
 			input.checked = ctx.foo;
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			input.checked = ctx.foo;
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(input);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			removeListener(input, "change", input_change_handler);
 		}
 	};

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -9,31 +9,27 @@ function create_main_fragment(component, ctx) {
 	}
 
 	return {
-		c: function create() {
+		c() {
 			input = createElement("input");
-			this.h();
-		},
-
-		h: function hydrate() {
 			addListener(input, "change", input_change_handler);
 			setAttribute(input, "type", "checkbox");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(input, target, anchor);
 
 			input.checked = ctx.foo;
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			input.checked = ctx.foo;
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(input);
 		},
 
-		d: function destroy() {
+		d() {
 			removeListener(input, "change", input_change_handler);
 		}
 	};

--- a/test/js/samples/legacy-input-type/expected-bundle.js
+++ b/test/js/samples/legacy-input-type/expected-bundle.js
@@ -145,22 +145,18 @@ function create_main_fragment(component, ctx) {
 	var input;
 
 	return {
-		c: function create() {
+		c() {
 			input = createElement("input");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setInputType(input, "search");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(input, target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(input);
 		},
 

--- a/test/js/samples/legacy-input-type/expected.js
+++ b/test/js/samples/legacy-input-type/expected.js
@@ -5,22 +5,18 @@ function create_main_fragment(component, ctx) {
 	var input;
 
 	return {
-		c: function create() {
+		c() {
 			input = createElement("input");
-			this.h();
-		},
-
-		h: function hydrate() {
 			setInputType(input, "search");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(input, target, anchor);
 		},
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(input);
 		},
 

--- a/test/js/samples/media-bindings/expected-bundle.js
+++ b/test/js/samples/media-bindings/expected-bundle.js
@@ -187,12 +187,8 @@ function create_main_fragment(component, ctx) {
 	}
 
 	return {
-		c: function create() {
+		c() {
 			audio = createElement("audio");
-			this.h();
-		},
-
-		h: function hydrate() {
 			addListener(audio, "timeupdate", audio_timeupdate_handler);
 			if (!('played' in ctx && 'currentTime' in ctx)) component.root._beforecreate.push(audio_timeupdate_handler);
 			addListener(audio, "durationchange", audio_durationchange_handler);
@@ -206,23 +202,23 @@ function create_main_fragment(component, ctx) {
 			addListener(audio, "volumechange", audio_volumechange_handler);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(audio, target, anchor);
 
 			audio.volume = ctx.volume;
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (!audio_updating && !isNaN(ctx.currentTime )) audio.currentTime = ctx.currentTime ;
 			if (!audio_updating && audio_is_paused !== (audio_is_paused = ctx.paused )) audio[audio_is_paused ? "pause" : "play"]();
 			if (!audio_updating && !isNaN(ctx.volume)) audio.volume = ctx.volume;
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(audio);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			removeListener(audio, "timeupdate", audio_timeupdate_handler);
 			removeListener(audio, "durationchange", audio_durationchange_handler);
 			removeListener(audio, "play", audio_play_pause_handler);

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -37,12 +37,8 @@ function create_main_fragment(component, ctx) {
 	}
 
 	return {
-		c: function create() {
+		c() {
 			audio = createElement("audio");
-			this.h();
-		},
-
-		h: function hydrate() {
 			addListener(audio, "timeupdate", audio_timeupdate_handler);
 			if (!('played' in ctx && 'currentTime' in ctx)) component.root._beforecreate.push(audio_timeupdate_handler);
 			addListener(audio, "durationchange", audio_durationchange_handler);
@@ -56,23 +52,23 @@ function create_main_fragment(component, ctx) {
 			addListener(audio, "volumechange", audio_volumechange_handler);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(audio, target, anchor);
 
 			audio.volume = ctx.volume;
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (!audio_updating && !isNaN(ctx.currentTime )) audio.currentTime = ctx.currentTime ;
 			if (!audio_updating && audio_is_paused !== (audio_is_paused = ctx.paused )) audio[audio_is_paused ? "pause" : "play"]();
 			if (!audio_updating && !isNaN(ctx.volume)) audio.volume = ctx.volume;
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(audio);
 		},
 
-		d: function destroy() {
+		d() {
 			removeListener(audio, "timeupdate", audio_timeupdate_handler);
 			removeListener(audio, "durationchange", audio_durationchange_handler);
 			removeListener(audio, "play", audio_play_pause_handler);

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -151,13 +151,13 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			imported._fragment.c();
 			text = createText("\n");
 			nonimported._fragment.c();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			imported._mount(target, anchor);
 			insertNode(text, target, anchor);
 			nonimported._mount(target, anchor);
@@ -165,13 +165,13 @@ function create_main_fragment(component, ctx) {
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			imported._unmount();
 			detachNode(text);
 			nonimported._unmount();
 		},
 
-		d: function destroy$$1() {
+		d() {
 			imported.destroy(false);
 			nonimported.destroy(false);
 		}

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -16,13 +16,13 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			imported._fragment.c();
 			text = createText("\n");
 			nonimported._fragment.c();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			imported._mount(target, anchor);
 			insertNode(text, target, anchor);
 			nonimported._mount(target, anchor);
@@ -30,13 +30,13 @@ function create_main_fragment(component, ctx) {
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			imported._unmount();
 			detachNode(text);
 			nonimported._unmount();
 		},
 
-		d: function destroy() {
+		d() {
 			imported.destroy(false);
 			nonimported.destroy(false);
 		}

--- a/test/js/samples/svg-title/expected-bundle.js
+++ b/test/js/samples/svg-title/expected-bundle.js
@@ -147,13 +147,13 @@ function create_main_fragment(component, ctx) {
 	var svg, title, text;
 
 	return {
-		c: function create() {
+		c() {
 			svg = createSvgElement("svg");
 			title = createSvgElement("title");
 			text = createText("a title");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(svg, target, anchor);
 			appendNode(title, svg);
 			appendNode(text, title);
@@ -161,7 +161,7 @@ function create_main_fragment(component, ctx) {
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(svg);
 		},
 

--- a/test/js/samples/svg-title/expected.js
+++ b/test/js/samples/svg-title/expected.js
@@ -5,13 +5,13 @@ function create_main_fragment(component, ctx) {
 	var svg, title, text;
 
 	return {
-		c: function create() {
+		c() {
 			svg = createSvgElement("svg");
 			title = createSvgElement("title");
 			text = createText("a title");
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(svg, target, anchor);
 			appendNode(title, svg);
 			appendNode(text, title);
@@ -19,7 +19,7 @@ function create_main_fragment(component, ctx) {
 
 		p: noop,
 
-		u: function unmount() {
+		u() {
 			detachNode(svg);
 		},
 

--- a/test/js/samples/title/expected-bundle.js
+++ b/test/js/samples/title/expected-bundle.js
@@ -133,7 +133,7 @@ function create_main_fragment(component, ctx) {
 
 		m: noop,
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if ((changed.custom) && title_value !== (title_value = "a " + ctx.custom + " title")) {
 				document.title = title_value;
 			}

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -11,7 +11,7 @@ function create_main_fragment(component, ctx) {
 
 		m: noop,
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if ((changed.custom) && title_value !== (title_value = "a " + ctx.custom + " title")) {
 				document.title = title_value;
 			}

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -161,7 +161,7 @@ function create_main_fragment(component, ctx) {
 	var if_block_4 = (ctx.e) && create_if_block_4(component, ctx);
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			if (if_block) if_block.c();
 			text = createText("\n\n\t");
@@ -181,7 +181,7 @@ function create_main_fragment(component, ctx) {
 			if_block_4_anchor = createComment();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			if (if_block) if_block.m(div, null);
 			appendNode(text, div);
@@ -199,7 +199,7 @@ function create_main_fragment(component, ctx) {
 			insertNode(if_block_4_anchor, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (ctx.a) {
 				if (!if_block) {
 					if_block = create_if_block(component, ctx);
@@ -261,7 +261,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 			if (if_block) if_block.u();
 			if (if_block_1) if_block_1.u();
@@ -272,7 +272,7 @@ function create_main_fragment(component, ctx) {
 			detachNode(if_block_4_anchor);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			if (if_block) if_block.d();
 			if (if_block_1) if_block_1.d();
 			if (if_block_2) if_block_2.d();
@@ -287,16 +287,16 @@ function create_if_block(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "a";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -309,16 +309,16 @@ function create_if_block_1(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "b";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -331,16 +331,16 @@ function create_if_block_2(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "c";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -353,16 +353,16 @@ function create_if_block_3(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "d";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -375,16 +375,16 @@ function create_if_block_4(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "e";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -15,7 +15,7 @@ function create_main_fragment(component, ctx) {
 	var if_block_4 = (ctx.e) && create_if_block_4(component, ctx);
 
 	return {
-		c: function create() {
+		c() {
 			div = createElement("div");
 			if (if_block) if_block.c();
 			text = createText("\n\n\t");
@@ -35,7 +35,7 @@ function create_main_fragment(component, ctx) {
 			if_block_4_anchor = createComment();
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(div, target, anchor);
 			if (if_block) if_block.m(div, null);
 			appendNode(text, div);
@@ -53,7 +53,7 @@ function create_main_fragment(component, ctx) {
 			insertNode(if_block_4_anchor, target, anchor);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (ctx.a) {
 				if (!if_block) {
 					if_block = create_if_block(component, ctx);
@@ -115,7 +115,7 @@ function create_main_fragment(component, ctx) {
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(div);
 			if (if_block) if_block.u();
 			if (if_block_1) if_block_1.u();
@@ -126,7 +126,7 @@ function create_main_fragment(component, ctx) {
 			detachNode(if_block_4_anchor);
 		},
 
-		d: function destroy() {
+		d() {
 			if (if_block) if_block.d();
 			if (if_block_1) if_block_1.d();
 			if (if_block_2) if_block_2.d();
@@ -141,16 +141,16 @@ function create_if_block(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "a";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -163,16 +163,16 @@ function create_if_block_1(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "b";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -185,16 +185,16 @@ function create_if_block_2(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "c";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -207,16 +207,16 @@ function create_if_block_3(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "d";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
@@ -229,16 +229,16 @@ function create_if_block_4(component, ctx) {
 	var p;
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			p.textContent = "e";
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 

--- a/test/js/samples/window-binding-scroll/expected-bundle.js
+++ b/test/js/samples/window-binding-scroll/expected-bundle.js
@@ -167,29 +167,29 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			text = createText("scrolled to ");
 			text_1 = createText(ctx.y);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 			appendNode(text, p);
 			appendNode(text_1, p);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.y) {
 				text_1.data = ctx.y;
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
-		d: function destroy$$1() {
+		d() {
 			window.removeEventListener("scroll", onwindowscroll);
 		}
 	};

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -25,29 +25,29 @@ function create_main_fragment(component, ctx) {
 	});
 
 	return {
-		c: function create() {
+		c() {
 			p = createElement("p");
 			text = createText("scrolled to ");
 			text_1 = createText(ctx.y);
 		},
 
-		m: function mount(target, anchor) {
+		m(target, anchor) {
 			insertNode(p, target, anchor);
 			appendNode(text, p);
 			appendNode(text_1, p);
 		},
 
-		p: function update(changed, ctx) {
+		p(changed, ctx) {
 			if (changed.y) {
 				text_1.data = ctx.y;
 			}
 		},
 
-		u: function unmount() {
+		u() {
 			detachNode(p);
 		},
 
-		d: function destroy() {
+		d() {
 			window.removeEventListener("scroll", onwindowscroll);
 		}
 	};


### PR DESCRIPTION
There's no need to have a separate `h()` method (for adding attributes to DOM nodes etc) if we're not compiling in hydratable mode, since the only time that method is called is during `c()`. Instead, we can just merge those two methods into one, shaving off previous bytes.

This PR also gets rid of the ES5-style methods, in favour of ES6 shorthand.