### PR TITLE
evaluate each block key in child scope

### DIFF
--- a/src/compile/nodes/EachBlock.ts
+++ b/src/compile/nodes/EachBlock.ts
@@ -40,15 +40,15 @@ export default class EachBlock extends Node {
 			this.scope.add(context.key.name, this.expression.dependencies);
 		});
 
+		this.key = info.key
+			? new Expression(compiler, this, this.scope, info.key)
+			: null;
+
 		if (this.index) {
 			// index can only change if this is a keyed each block
 			const dependencies = this.key ? this.expression.dependencies : [];
 			this.scope.add(this.index, dependencies);
 		}
-
-		this.key = info.key
-			? new Expression(compiler, this, this.scope, info.key)
-			: null;
 
 		this.children = mapChildren(compiler, this, this.scope, info.children);
 

--- a/src/compile/nodes/EachBlock.ts
+++ b/src/compile/nodes/EachBlock.ts
@@ -31,10 +31,6 @@ export default class EachBlock extends Node {
 		this.context = info.context.name || 'each'; // TODO this is used to facilitate binding; currently fails with destructuring
 		this.index = info.index;
 
-		this.key = info.key
-			? new Expression(compiler, this, scope, info.key)
-			: null;
-
 		this.scope = scope.child();
 
 		this.contexts = [];
@@ -49,6 +45,10 @@ export default class EachBlock extends Node {
 			const dependencies = this.key ? this.expression.dependencies : [];
 			this.scope.add(this.index, dependencies);
 		}
+
+		this.key = info.key
+			? new Expression(compiler, this, this.scope, info.key)
+			: null;
 
 		this.children = mapChildren(compiler, this, this.scope, info.children);
 

--- a/test/runtime/samples/dev-warning-missing-data-each/_config.js
+++ b/test/runtime/samples/dev-warning-missing-data-each/_config.js
@@ -1,0 +1,22 @@
+export default {
+	dev: true,
+
+	data: {
+		letters: [
+			{
+				id: 1,
+				char: 'a',
+			},
+			{
+				id: 2,
+				char: 'b',
+			},
+			{
+				id: 3,
+				char: 'c',
+			},
+		],
+	},
+
+	warnings: [],
+};

--- a/test/runtime/samples/dev-warning-missing-data-each/main.html
+++ b/test/runtime/samples/dev-warning-missing-data-each/main.html
@@ -1,0 +1,3 @@
+{#each letters as letter (letter.id)}
+  <div>{letter.char}</div>
+{/each}


### PR DESCRIPTION
fixes #1397