### PR TITLE
[WIP] failing test for #1398

### DIFF
--- a/test/css/samples/font-face/expected.css
+++ b/test/css/samples/font-face/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-y972lp{font-family:'Comic Sans Pro'}@font-face{font-family:'Comic Sans Pro';src:url("./comic-sans-pro.woff")format("woff");font-style: normal}

--- a/test/css/samples/font-face/input.html
+++ b/test/css/samples/font-face/input.html
@@ -1,0 +1,13 @@
+<h1>Hello World</h1>
+
+<style>
+	h1 {
+		font-family: 'Comic Sans Pro';
+	}
+
+	@font-face {
+		font-family: 'Comic Sans Pro';
+		src: url("./comic-sans-pro.woff") format("woff");
+		font-style: normal;
+	}
+</style>


### PR DESCRIPTION
I started working on a fix but man, CSS is a weird-ass language. One thing we need to figure out: should `font-family` be scoped? I.e. any font families declared inside a `@font-face` get the scoping treatment alongside any *uses* of the same family, like we do for `@keyframes`? Intuitively that seems like the right thing to do but I'm not certain.