### PR TITLE
use Object.create for each block child contexts

### DIFF
--- a/src/compile/nodes/EachBlock.ts
+++ b/src/compile/nodes/EachBlock.ts
@@ -91,12 +91,12 @@ export default class EachBlock extends Node {
 			this.block.getUniqueName(this.index); // this prevents name collisions (#1254)
 		}
 
-		this.contextProps = this.contexts.map(prop => `${prop.key.name}: list[i]${prop.tail}`);
+		this.contextProps = this.contexts.map(prop => `child_ctx.${prop.key.name} = list[i]${prop.tail};`);
 
 		// TODO only add these if necessary
 		this.contextProps.push(
-			`${this.each_block_value}: list`,
-			`${indexName}: i`
+			`child_ctx.${this.each_block_value} = list;`,
+			`child_ctx.${indexName} = i;`
 		);
 
 		this.compiler.target.blocks.push(this.block);
@@ -162,9 +162,9 @@ export default class EachBlock extends Node {
 
 		this.compiler.target.blocks.push(deindent`
 			function ${this.get_each_context}(ctx, list, i) {
-				return @assign(@assign({}, ctx), {
-					${this.contextProps.join(',\n')}
-				});
+				const child_ctx = Object.create(ctx);
+				${this.contextProps}
+				return child_ctx;
 			}
 		`);
 

--- a/test/js/samples/deconflict-builtins/expected-bundle.js
+++ b/test/js/samples/deconflict-builtins/expected-bundle.js
@@ -238,11 +238,11 @@ function create_each_block(component, ctx) {
 }
 
 function get_each_context(ctx, list, i) {
-	return assign(assign({}, ctx), {
-		node: list[i],
-		each_value: list,
-		node_index: i
-	});
+	const child_ctx = Object.create(ctx);
+	child_ctx.node = list[i];
+	child_ctx.each_value = list;
+	child_ctx.node_index = i;
+	return child_ctx;
 }
 
 function SvelteComponent(options) {

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -92,11 +92,11 @@ function create_each_block(component, ctx) {
 }
 
 function get_each_context(ctx, list, i) {
-	return assign(assign({}, ctx), {
-		node: list[i],
-		each_value: list,
-		node_index: i
-	});
+	const child_ctx = Object.create(ctx);
+	child_ctx.node = list[i];
+	child_ctx.each_value = list;
+	child_ctx.node_index = i;
+	return child_ctx;
 }
 
 function SvelteComponent(options) {

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -279,11 +279,11 @@ function create_each_block(component, ctx) {
 }
 
 function get_each_context(ctx, list, i) {
-	return assign(assign({}, ctx), {
-		comment: list[i],
-		each_value: list,
-		i: i
-	});
+	const child_ctx = Object.create(ctx);
+	child_ctx.comment = list[i];
+	child_ctx.each_value = list;
+	child_ctx.i = i;
+	return child_ctx;
 }
 
 function SvelteComponent(options) {

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -131,11 +131,11 @@ function create_each_block(component, ctx) {
 }
 
 function get_each_context(ctx, list, i) {
-	return assign(assign({}, ctx), {
-		comment: list[i],
-		each_value: list,
-		i: i
-	});
+	const child_ctx = Object.create(ctx);
+	child_ctx.comment = list[i];
+	child_ctx.each_value = list;
+	child_ctx.i = i;
+	return child_ctx;
 }
 
 function SvelteComponent(options) {


### PR DESCRIPTION
This results in slightly better performance and lower memory usage when creating large lists