### PR TITLE
fix handling of shorthand event handler in dynamic components

### DIFF
--- a/src/compile/nodes/Component.ts
+++ b/src/compile/nodes/Component.ts
@@ -364,7 +364,7 @@ export default class Component extends Node {
 
 				${this.handlers.map(handler => deindent`
 					function ${handler.var}(event) {
-						${handler.snippet}
+						${handler.snippet || `#component.fire("${handler.name}", event);`}
 					}
 
 					if (${name}) ${name}.on("${handler.name}", ${handler.var});

--- a/test/runtime/samples/event-handler-shorthand-dynamic-component/Widget.html
+++ b/test/runtime/samples/event-handler-shorthand-dynamic-component/Widget.html
@@ -1,0 +1,1 @@
+<button on:click='fire("foo", { answer: 42 })'>click me</button>

--- a/test/runtime/samples/event-handler-shorthand-dynamic-component/_config.js
+++ b/test/runtime/samples/event-handler-shorthand-dynamic-component/_config.js
@@ -1,0 +1,18 @@
+export default {
+	html: `
+		<button>click me</button>
+	`,
+
+	test (assert, component, target, window) {
+		const button = target.querySelector('button');
+		const event = new window.MouseEvent('click');
+
+		let answer;
+		component.on('foo', event => {
+			answer = event.answer;
+		});
+
+		button.dispatchEvent(event);
+		assert.equal(answer, 42);
+	}
+};

--- a/test/runtime/samples/event-handler-shorthand-dynamic-component/main.html
+++ b/test/runtime/samples/event-handler-shorthand-dynamic-component/main.html
@@ -1,0 +1,9 @@
+<svelte:component this={Widget} on:foo/>
+
+<script>
+	import Widget from './Widget.html';
+
+	export default {
+		data: () => ({ Widget })
+	};
+</script>


### PR DESCRIPTION
Fixes use of `on:eventname` shorthand bubbling syntax in `<svelte:component>`.

cc @Kiho