### PR TITLE
allow spaces around reserved words used in tags in attributes

### DIFF
--- a/src/parse/state/tag.ts
+++ b/src/parse/state/tag.ts
@@ -439,6 +439,7 @@ function readSequence(parser: Parser, done: () => boolean) {
 				chunks.push(currentChunk);
 			}
 
+			parser.allowWhitespace();
 			const expression = readExpression(parser);
 			parser.allowWhitespace();
 			parser.eat('}', true);

--- a/test/runtime/samples/attribute-dynamic-reserved/_config.js
+++ b/test/runtime/samples/attribute-dynamic-reserved/_config.js
@@ -3,11 +3,17 @@ export default {
 		class: 'foo'
 	},
 
-	html: `<div class="foo"></div>123`,
+	html: `
+		<div class="foo"></div>123
+		<div class="foo"></div>123
+	`,
 
 	test ( assert, component, target ) {
 		component.set({ class: 'bar' });
-		assert.equal( target.innerHTML, `<div class="bar"></div>123` );
+		assert.htmlEqual( target.innerHTML, `
+			<div class="bar"></div>123
+			<div class="bar"></div>123
+		` );
 
 		component.destroy();
 	}

--- a/test/runtime/samples/attribute-dynamic-reserved/main.html
+++ b/test/runtime/samples/attribute-dynamic-reserved/main.html
@@ -1,1 +1,2 @@
 <div class='{class}'></div>{123}
+<div class='{ class }'></div>{ 123 }


### PR DESCRIPTION
Fixes #1445. We were already correctly handling this when things like `{ class }` appeared as a regular HTML tag but not when it appeared in an attribute value.