### PR TITLE
Deferred transitions

### DIFF
--- a/src/compile/dom/index.ts
+++ b/src/compile/dom/index.ts
@@ -228,7 +228,7 @@ export default function dom(
 			this._fragment.c();
 			this._fragment.${block.hasIntroMethod ? 'i' : 'm'}(this.shadowRoot, null);
 
-			if (options.target) this._mount(options.target, options.anchor, ${options.skipIntroByDefault ? `options.intro` : 'true'});
+			if (options.target) this._mount(options.target, options.anchor);
 		` : deindent`
 			if (options.target) {
 				${compiler.options.hydratable
@@ -241,7 +241,7 @@ export default function dom(
 						${options.dev && `if (options.hydrate) throw new Error("options.hydrate only works if the component was compiled with the \`hydratable: true\` option");`}
 						this._fragment.c();
 					`}
-				this._mount(options.target, options.anchor, ${options.skipIntroByDefault ? `options.intro` : 'true'});
+				this._mount(options.target, options.anchor);
 
 				${(compiler.hasComponents || target.hasComplexBindings || hasInitHooks || target.hasIntroTransitions) && deindent`
 					${compiler.hasComponents && `this._lock = true;`}

--- a/src/compile/nodes/Component.ts
+++ b/src/compile/nodes/Component.ts
@@ -387,7 +387,7 @@ export default class Component extends Node {
 
 			block.builders.mount.addBlock(deindent`
 				if (${name}) {
-					${name}._mount(${parentNode || '#target'}, ${parentNode ? 'null' : 'anchor'}, ${compiler.options.skipIntroByDefault ? '#component._intro' : 'true'});
+					${name}._mount(${parentNode || '#target'}, ${parentNode ? 'null' : 'anchor'});
 					${this.ref && `#component.refs.${this.ref} = ${name};`}
 				}
 			`);
@@ -409,7 +409,7 @@ export default class Component extends Node {
 						${name}._fragment.c();
 
 						${this.children.map(child => child.remount(name))}
-						${name}._mount(${updateMountNode}, ${anchor}, true);
+						${name}._mount(${updateMountNode}, ${anchor});
 
 						${this.handlers.map(handler => deindent`
 							${name}.on("${handler.name}", ${handler.var});
@@ -468,7 +468,7 @@ export default class Component extends Node {
 			}
 
 			block.builders.mount.addLine(
-				`${name}._mount(${parentNode || '#target'}, ${parentNode ? 'null' : 'anchor'}, ${compiler.options.skipIntroByDefault ? '#component._intro' : 'true'});`
+				`${name}._mount(${parentNode || '#target'}, ${parentNode ? 'null' : 'anchor'});`
 			);
 
 			if (updates.length) {
@@ -493,7 +493,7 @@ export default class Component extends Node {
 	}
 
 	remount(name: string) {
-		return `${this.var}._mount(${name}._slotted.default, null, false);`;
+		return `${this.var}._mount(${name}._slotted.default, null);`;
 	}
 
 	ssr() {

--- a/src/compile/nodes/Element.ts
+++ b/src/compile/nodes/Element.ts
@@ -699,7 +699,7 @@ export default class Element extends Node {
 
 			const fn = `%transitions-${intro.name}`;
 
-			block.builders.intro.addBlock(deindent`
+			block.builders.intro.addConditional(`#component._intro`, deindent`
 				if (${name}) ${name}.invalidate();
 
 				#component.root._aftercreate.push(() => {
@@ -709,6 +709,7 @@ export default class Element extends Node {
 			`);
 
 			block.builders.outro.addBlock(deindent`
+				if (!${name}) ${name} = @wrapTransition(#component, ${this.var}, ${fn}, ${snippet}, false);
 				${name}.run(0, () => {
 					#outrocallback();
 					${name} = null;
@@ -733,7 +734,7 @@ export default class Element extends Node {
 					`);
 				}
 
-				block.builders.intro.addBlock(deindent`
+				block.builders.intro.addConditional(`#component._intro`, deindent`
 					#component.root._aftercreate.push(() => {
 						${introName} = @wrapTransition(#component, ${this.var}, ${fn}, ${snippet}, true);
 						${introName}.run(1);

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -128,8 +128,8 @@ export function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-export function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+export function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 export var PENDING = {};

--- a/test/cli/samples/basic/expected/Main.js
+++ b/test/cli/samples/basic/expected/Main.js
@@ -32,7 +32,7 @@ function Main(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 
@@ -150,8 +150,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/custom-element/expected/Main.js
+++ b/test/cli/samples/custom-element/expected/Main.js
@@ -38,7 +38,7 @@ class Main extends HTMLElement {
 		this._fragment.c();
 		this._fragment.m(this.shadowRoot, null);
 
-		if (options.target) this._mount(options.target, options.anchor, true);
+		if (options.target) this._mount(options.target, options.anchor);
 	}
 
 	static get observedAttributes() {
@@ -171,8 +171,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dev/expected/Main.js
+++ b/test/cli/samples/dev/expected/Main.js
@@ -35,7 +35,7 @@ function Main(options) {
 	if (options.target) {
 		if (options.hydrate) throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 
@@ -154,8 +154,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir-sourcemap/expected/Main.js
+++ b/test/cli/samples/dir-sourcemap/expected/Main.js
@@ -15,7 +15,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			widget._mount(target, anchor, true);
+			widget._mount(target, anchor);
 		},
 
 		p: noop,
@@ -41,7 +41,7 @@ function Main(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);
@@ -157,8 +157,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir-sourcemap/expected/Widget.js
+++ b/test/cli/samples/dir-sourcemap/expected/Widget.js
@@ -32,7 +32,7 @@ function Widget(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 
@@ -150,8 +150,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir-subdir/expected/Main.js
+++ b/test/cli/samples/dir-subdir/expected/Main.js
@@ -15,7 +15,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			widget._mount(target, anchor, true);
+			widget._mount(target, anchor);
 		},
 
 		p: noop,
@@ -41,7 +41,7 @@ function Main(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);
@@ -157,8 +157,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir-subdir/expected/widget/Widget.js
+++ b/test/cli/samples/dir-subdir/expected/widget/Widget.js
@@ -32,7 +32,7 @@ function Widget(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 
@@ -150,8 +150,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir/expected/Main.js
+++ b/test/cli/samples/dir/expected/Main.js
@@ -15,7 +15,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			widget._mount(target, anchor, true);
+			widget._mount(target, anchor);
 		},
 
 		p: noop,
@@ -41,7 +41,7 @@ function Main(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);
@@ -157,8 +157,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir/expected/Widget.js
+++ b/test/cli/samples/dir/expected/Widget.js
@@ -32,7 +32,7 @@ function Widget(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 
@@ -150,8 +150,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/globals/expected/Main.js
+++ b/test/cli/samples/globals/expected/Main.js
@@ -47,7 +47,7 @@ var Main = (function(answer) { "use strict";
 
 		if (options.target) {
 			this._fragment.c();
-			this._mount(options.target, options.anchor, true);
+			this._mount(options.target, options.anchor);
 		}
 	}
 
@@ -171,8 +171,8 @@ var Main = (function(answer) { "use strict";
 		}
 	}
 
-	function _mount(target, anchor, intro) {
-		this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+	function _mount(target, anchor) {
+		this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 	}
 
 	function _differs(a, b) {

--- a/test/cli/samples/sourcemap-inline/expected/Main.js
+++ b/test/cli/samples/sourcemap-inline/expected/Main.js
@@ -32,7 +32,7 @@ function Main(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 
@@ -150,8 +150,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/sourcemap/expected/Main.js
+++ b/test/cli/samples/sourcemap/expected/Main.js
@@ -32,7 +32,7 @@ function Main(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 
@@ -150,8 +150,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/store/expected/Main.js
+++ b/test/cli/samples/store/expected/Main.js
@@ -42,7 +42,7 @@ function Main(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 
@@ -170,8 +170,8 @@ function _set(newState) {
 	}
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 function _differs(a, b) {

--- a/test/js/samples/action/expected-bundle.js
+++ b/test/js/samples/action/expected-bundle.js
@@ -111,8 +111,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -180,7 +180,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/action/expected.js
+++ b/test/js/samples/action/expected.js
@@ -53,7 +53,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/bind-width-height/expected-bundle.js
+++ b/test/js/samples/bind-width-height/expected-bundle.js
@@ -143,8 +143,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -206,7 +206,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		callAll(this._beforecreate);
 	}

--- a/test/js/samples/bind-width-height/expected.js
+++ b/test/js/samples/bind-width-height/expected.js
@@ -46,7 +46,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		callAll(this._beforecreate);
 	}

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -119,8 +119,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -187,7 +187,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -52,7 +52,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/component-static-array/expected-bundle.js
+++ b/test/js/samples/component-static-array/expected-bundle.js
@@ -99,8 +99,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -133,7 +133,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			nested._mount(target, anchor, true);
+			nested._mount(target, anchor);
 		},
 
 		p: noop,
@@ -159,7 +159,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/component-static-array/expected.js
+++ b/test/js/samples/component-static-array/expected.js
@@ -17,7 +17,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			nested._mount(target, anchor, true);
+			nested._mount(target, anchor);
 		},
 
 		p: noop,
@@ -43,7 +43,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/component-static-immutable/expected-bundle.js
+++ b/test/js/samples/component-static-immutable/expected-bundle.js
@@ -103,8 +103,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -137,7 +137,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			nested._mount(target, anchor, true);
+			nested._mount(target, anchor);
 		},
 
 		p: noop,
@@ -163,7 +163,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/component-static-immutable/expected.js
+++ b/test/js/samples/component-static-immutable/expected.js
@@ -17,7 +17,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			nested._mount(target, anchor, true);
+			nested._mount(target, anchor);
 		},
 
 		p: noop,
@@ -43,7 +43,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/component-static-immutable2/expected-bundle.js
+++ b/test/js/samples/component-static-immutable2/expected-bundle.js
@@ -103,8 +103,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -137,7 +137,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			nested._mount(target, anchor, true);
+			nested._mount(target, anchor);
 		},
 
 		p: noop,
@@ -163,7 +163,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/component-static-immutable2/expected.js
+++ b/test/js/samples/component-static-immutable2/expected.js
@@ -17,7 +17,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			nested._mount(target, anchor, true);
+			nested._mount(target, anchor);
 		},
 
 		p: noop,
@@ -43,7 +43,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/component-static/expected-bundle.js
+++ b/test/js/samples/component-static/expected-bundle.js
@@ -99,8 +99,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -133,7 +133,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			nested._mount(target, anchor, true);
+			nested._mount(target, anchor);
 		},
 
 		p: noop,
@@ -159,7 +159,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/component-static/expected.js
+++ b/test/js/samples/component-static/expected.js
@@ -17,7 +17,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			nested._mount(target, anchor, true);
+			nested._mount(target, anchor);
 		},
 
 		p: noop,
@@ -43,7 +43,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/computed-collapsed-if/expected-bundle.js
+++ b/test/js/samples/computed-collapsed-if/expected-bundle.js
@@ -99,8 +99,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -148,7 +148,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -32,7 +32,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/css-media-query/expected-bundle.js
+++ b/test/js/samples/css-media-query/expected-bundle.js
@@ -115,8 +115,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -174,7 +174,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -42,7 +42,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/css-shadow-dom-keyframes/expected-bundle.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected-bundle.js
@@ -111,8 +111,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -168,7 +168,7 @@ class SvelteComponent extends HTMLElement {
 		this._fragment.c();
 		this._fragment.m(this.shadowRoot, null);
 
-		if (options.target) this._mount(options.target, options.anchor, true);
+		if (options.target) this._mount(options.target, options.anchor);
 	}
 
 	static get observedAttributes() {

--- a/test/js/samples/css-shadow-dom-keyframes/expected.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected.js
@@ -40,7 +40,7 @@ class SvelteComponent extends HTMLElement {
 		this._fragment.c();
 		this._fragment.m(this.shadowRoot, null);
 
-		if (options.target) this._mount(options.target, options.anchor, true);
+		if (options.target) this._mount(options.target, options.anchor);
 	}
 
 	static get observedAttributes() {

--- a/test/js/samples/deconflict-builtins/expected-bundle.js
+++ b/test/js/samples/deconflict-builtins/expected-bundle.js
@@ -129,8 +129,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -254,7 +254,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -108,7 +108,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/deconflict-globals/expected-bundle.js
+++ b/test/js/samples/deconflict-globals/expected-bundle.js
@@ -104,8 +104,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -162,7 +162,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		callAll(this._oncreate);
 	}

--- a/test/js/samples/deconflict-globals/expected.js
+++ b/test/js/samples/deconflict-globals/expected.js
@@ -42,7 +42,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		callAll(this._oncreate);
 	}

--- a/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var protoDev = {
@@ -209,7 +209,7 @@ function SvelteComponent(options) {
 	if (options.target) {
 		if (options.hydrate) throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -55,7 +55,7 @@ function SvelteComponent(options) {
 	if (options.target) {
 		if (options.hydrate) throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/do-use-dataset/expected-bundle.js
+++ b/test/js/samples/do-use-dataset/expected-bundle.js
@@ -115,8 +115,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -176,7 +176,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/do-use-dataset/expected.js
+++ b/test/js/samples/do-use-dataset/expected.js
@@ -44,7 +44,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
@@ -119,8 +119,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -180,7 +180,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/dont-use-dataset-in-legacy/expected.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected.js
@@ -44,7 +44,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/dont-use-dataset-in-svg/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-svg/expected-bundle.js
@@ -119,8 +119,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -178,7 +178,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/dont-use-dataset-in-svg/expected.js
+++ b/test/js/samples/dont-use-dataset-in-svg/expected.js
@@ -42,7 +42,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -131,8 +131,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -295,7 +295,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -147,7 +147,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -111,8 +111,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -178,7 +178,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -51,7 +51,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/head-no-whitespace/expected-bundle.js
+++ b/test/js/samples/head-no-whitespace/expected-bundle.js
@@ -111,8 +111,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -165,7 +165,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/head-no-whitespace/expected.js
+++ b/test/js/samples/head-no-whitespace/expected.js
@@ -37,7 +37,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/if-block-no-update/expected-bundle.js
+++ b/test/js/samples/if-block-no-update/expected-bundle.js
@@ -115,8 +115,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -226,7 +226,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -94,7 +94,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/if-block-simple/expected-bundle.js
+++ b/test/js/samples/if-block-simple/expected-bundle.js
@@ -115,8 +115,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -202,7 +202,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -70,7 +70,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
@@ -115,8 +115,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -174,7 +174,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -42,7 +42,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized-url/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-url/expected-bundle.js
@@ -115,8 +115,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -169,7 +169,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -37,7 +37,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized/expected-bundle.js
@@ -115,8 +115,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -169,7 +169,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -37,7 +37,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/inline-style-unoptimized/expected-bundle.js
+++ b/test/js/samples/inline-style-unoptimized/expected-bundle.js
@@ -115,8 +115,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -180,7 +180,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -48,7 +48,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/input-range/expected-bundle.js
+++ b/test/js/samples/input-range/expected-bundle.js
@@ -127,8 +127,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -190,7 +190,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -46,7 +46,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/input-without-blowback-guard/expected-bundle.js
+++ b/test/js/samples/input-without-blowback-guard/expected-bundle.js
@@ -123,8 +123,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -184,7 +184,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -44,7 +44,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/legacy-input-type/expected-bundle.js
+++ b/test/js/samples/legacy-input-type/expected-bundle.js
@@ -117,8 +117,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -167,7 +167,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/legacy-input-type/expected.js
+++ b/test/js/samples/legacy-input-type/expected.js
@@ -33,7 +33,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/media-bindings/expected-bundle.js
+++ b/test/js/samples/media-bindings/expected-bundle.js
@@ -127,8 +127,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -238,7 +238,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		callAll(this._beforecreate);
 	}

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -94,7 +94,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		callAll(this._beforecreate);
 	}

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -113,8 +113,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -152,9 +152,9 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			imported._mount(target, anchor, true);
+			imported._mount(target, anchor);
 			insertNode(text, target, anchor);
-			nonimported._mount(target, anchor, true);
+			nonimported._mount(target, anchor);
 		},
 
 		p: noop,
@@ -185,7 +185,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -23,9 +23,9 @@ function create_main_fragment(component, ctx) {
 		},
 
 		m(target, anchor) {
-			imported._mount(target, anchor, true);
+			imported._mount(target, anchor);
 			insertNode(text, target, anchor);
-			nonimported._mount(target, anchor, true);
+			nonimported._mount(target, anchor);
 		},
 
 		p: noop,
@@ -56,7 +56,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 
 		this._lock = true;
 		callAll(this._beforecreate);

--- a/test/js/samples/setup-method/expected-bundle.js
+++ b/test/js/samples/setup-method/expected-bundle.js
@@ -99,8 +99,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -155,7 +155,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/setup-method/expected.js
+++ b/test/js/samples/setup-method/expected.js
@@ -39,7 +39,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/svg-title/expected-bundle.js
+++ b/test/js/samples/svg-title/expected-bundle.js
@@ -119,8 +119,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -172,7 +172,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/svg-title/expected.js
+++ b/test/js/samples/svg-title/expected.js
@@ -36,7 +36,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/title/expected-bundle.js
+++ b/test/js/samples/title/expected-bundle.js
@@ -99,8 +99,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -146,7 +146,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -30,7 +30,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -123,8 +123,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -390,7 +390,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -250,7 +250,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/window-binding-scroll/expected-bundle.js
+++ b/test/js/samples/window-binding-scroll/expected-bundle.js
@@ -119,8 +119,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor, intro) {
-	this._fragment[intro && this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
 }
 
 var proto = {
@@ -199,7 +199,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -63,7 +63,7 @@ function SvelteComponent(options) {
 
 	if (options.target) {
 		this._fragment.c();
-		this._mount(options.target, options.anchor, true);
+		this._mount(options.target, options.anchor);
 	}
 }
 

--- a/test/runtime/samples/transition-js-deferred/_config.js
+++ b/test/runtime/samples/transition-js-deferred/_config.js
@@ -1,0 +1,15 @@
+export default {
+	skipIntroByDefault: true,
+
+	test(assert, component, target, window, raf) {
+		component.set({ visible: true });
+
+		return Promise.resolve().then(() => {
+			const div = target.querySelector('div');
+			assert.equal(div.foo, 0);
+
+			raf.tick(50);
+			assert.equal(div.foo, 0.5);
+		});
+	},
+};

--- a/test/runtime/samples/transition-js-deferred/main.html
+++ b/test/runtime/samples/transition-js-deferred/main.html
@@ -1,0 +1,20 @@
+{#if visible}
+	<div transition:foo></div>
+{/if}
+
+<script>
+	export default {
+		transitions: {
+			foo(node, params) {
+				return () => {
+					return {
+						duration: 100,
+						tick: t => {
+							node.foo = t;
+						}
+					};
+				};
+			}
+		}
+	};
+</script>


### PR DESCRIPTION
This implements another part of #1431. Transitions can now return a function, which says 'come back to me in a moment'. This allows coordination between transitions, without worrying about order, which in turn facilitates this sort of thing:

![redrover2](https://user-images.githubusercontent.com/1162160/39962331-c6bf2e9c-5619-11e8-9fc6-e6bd2c33add0.gif)

In this GIF, a pair of transitions (which happen to be called `send` and `receive`) essentially 'talk' to each other by sharing measurements — if a node with key 'c' outros and another with the same key intros, they can each generate a CSS animation that makes it look as though a single node is morphing, all while using custom transform behaviour for spinning and scaling.

There's an awkward gap left by the outroing node, if it's not the one at the bottom — that will be fixed with the final part of #1431.