### PR TITLE
use CSS classes for ref:* selectors

### DIFF
--- a/src/css/Stylesheet.ts
+++ b/src/css/Stylesheet.ts
@@ -247,6 +247,7 @@ export default class Stylesheet {
 	keyframes: Map<string, string>;
 
 	nodesWithCssClass: Set<Node>;
+	nodesWithRefCssClass: Map<String, Node>;
 
 	constructor(source: string, ast: Ast, filename: string, dev: boolean) {
 		this.source = source;
@@ -258,6 +259,7 @@ export default class Stylesheet {
 		this.keyframes = new Map();
 
 		this.nodesWithCssClass = new Set();
+		this.nodesWithRefCssClass = new Map();
 
 		if (ast.css && ast.css.children.length) {
 			this.id = `svelte-${hash(ast.css.content.styles)}`;
@@ -337,6 +339,9 @@ export default class Stylesheet {
 		this.nodesWithCssClass.forEach((node: Node) => {
 			node.addCssClass();
 		});
+		this.nodesWithRefCssClass.forEach((node: Node, name: String) => {
+			node.addCssClass(`svelte-ref-${name}`);
+		})
 	}
 
 	render(cssOutputFilename: string, shouldTransformSelectors: boolean) {

--- a/test/css/samples/refs-qualified/expected.css
+++ b/test/css/samples/refs-qualified/expected.css
@@ -1,1 +1,1 @@
-[svelte-ref-button].active.svelte-xyz{color:red}
+.svelte-ref-button.active.svelte-xyz{color:red}

--- a/test/css/samples/refs-qualified/expected.html
+++ b/test/css/samples/refs-qualified/expected.html
@@ -1,1 +1,1 @@
-<button svelte-ref-button="" class="active svelte-xyz">deactivate</button>
+<button class="active svelte-xyz svelte-ref-button">deactivate</button>

--- a/test/css/samples/refs/expected.css
+++ b/test/css/samples/refs/expected.css
@@ -1,1 +1,1 @@
-[svelte-ref-a].svelte-xyz{color:red}[svelte-ref-b].svelte-xyz{color:green}
+.svelte-ref-a.svelte-xyz{color:red}.svelte-ref-b.svelte-xyz{color:green}

--- a/test/css/samples/refs/expected.html
+++ b/test/css/samples/refs/expected.html
@@ -1,3 +1,3 @@
-<div class="svelte-xyz" svelte-ref-a=''></div>
-<div class="svelte-xyz" svelte-ref-b=''></div>
+<div class="svelte-xyz svelte-ref-a"></div>
+<div class="svelte-xyz svelte-ref-b"></div>
 <div></div>


### PR DESCRIPTION
Implements #1230. Rather than calling the class `.svelte-ref-foo-xyz` (as mentioned in the issue description), this just calls it `.svelte-ref-foo` (like the attribute currently is), and also keeps the `.svelte-xyz` class.