### PR TITLE
fix bind:online in dev mode

### DIFF
--- a/src/compile/nodes/Window.ts
+++ b/src/compile/nodes/Window.ts
@@ -200,7 +200,9 @@ export default class Window extends Node {
 			const handlerName = block.getUniqueName(`onlinestatuschanged`);
 			block.builders.init.addBlock(deindent`
 				function ${handlerName}(event) {
+					${compiler.options.dev && `component._updatingReadonlyProperty = true;`}
 					#component.set({ ${bindings.online}: navigator.onLine });
+					${compiler.options.dev && `component._updatingReadonlyProperty = false;`}
 				}
 				window.addEventListener("online", ${handlerName});
 				window.addEventListener("offline", ${handlerName});


### PR DESCRIPTION
Fixes #1502. Adds lines to set and then clear again the `_updatingReadonlyProperty` flag before and after updating the bound property.