### PR TITLE
update some stray references to v1 syntax

### DIFF
--- a/src/compile/nodes/Title.ts
+++ b/src/compile/nodes/Title.ts
@@ -35,7 +35,7 @@ export default class Title extends Node {
 			// TODO some of this code is repeated in Tag.ts — would be good to
 			// DRY it out if that's possible without introducing crazy indirection
 			if (this.children.length === 1) {
-				// single {{tag}} — may be a non-string
+				// single {tag} — may be a non-string
 				const { expression } = this.children[0];
 				const { dependencies, snippet } = this.children[0].expression;
 

--- a/src/parse/state/mustache.ts
+++ b/src/parse/state/mustache.ts
@@ -37,7 +37,7 @@ export default function mustache(parser: Parser) {
 
 	parser.allowWhitespace();
 
-	// {{/if}} or {{/each}}
+	// {/if} or {/each}
 	if (parser.eat('/')) {
 		let block = parser.current();
 		let expected;
@@ -92,7 +92,7 @@ export default function mustache(parser: Parser) {
 		if (block.type !== 'IfBlock')
 			parser.error({
 				code: `invalid-elseif-placement`,
-				message: 'Cannot have an {{elseif ...}} block outside an {{#if ...}} block'
+				message: 'Cannot have an {:elseif ...} block outside an {#if ...} block'
 			});
 
 		parser.requireWhitespace();
@@ -124,7 +124,7 @@ export default function mustache(parser: Parser) {
 		if (block.type !== 'IfBlock' && block.type !== 'EachBlock') {
 			parser.error({
 				code: `invalid-else-placement`,
-				message: 'Cannot have an {{else}} block outside an {{#if ...}} or {{#each ...}} block'
+				message: 'Cannot have an {:else} block outside an {#if ...} or {#each ...} block'
 			});
 		}
 
@@ -187,7 +187,7 @@ export default function mustache(parser: Parser) {
 			parser.stack.push(catchBlock);
 		}
 	} else if (parser.eat('#')) {
-		// {{#if foo}} or {{#each foo}}
+		// {#if foo}, {#each foo} or {#await foo}
 		let type;
 
 		if (parser.eat('if')) {
@@ -244,7 +244,7 @@ export default function mustache(parser: Parser) {
 
 		parser.allowWhitespace();
 
-		// {{#each}} blocks must declare a context – {{#each list as item}}
+		// {#each} blocks must declare a context – {#each list as item}
 		if (type === 'EachBlock') {
 			parser.eat('as', true);
 			parser.requireWhitespace();
@@ -299,7 +299,7 @@ export default function mustache(parser: Parser) {
 			parser.stack.push(childBlock);
 		}
 	} else if (parser.eat('@html')) {
-		// {{{raw}}} mustache
+		// {@html content} tag
 		const expression = readExpression(parser);
 
 		parser.allowWhitespace();

--- a/src/validate/html/validateElement.ts
+++ b/src/validate/html/validateElement.ts
@@ -69,7 +69,7 @@ export default function validateElement(
 			if (child.type !== 'Text' && child.type !== 'MustacheTag') {
 				validator.error(child, {
 					code: 'illegal-structure',
-					message: `<title> can only contain text and {{tags}}`
+					message: `<title> can only contain text and {tags}`
 				});
 			}
 		});

--- a/src/validate/html/validateHead.ts
+++ b/src/validate/html/validateHead.ts
@@ -13,7 +13,7 @@ export default function validateHead(validator: Validator, node: Node, refs: Map
 	// TODO ensure only valid elements are included here
 
 	node.children.forEach(node => {
-		if (node.type !== 'Element' && node.type !== 'Title') return; // TODO handle {{#if}} and friends?
+		if (node.type !== 'Element' && node.type !== 'Title') return; // TODO handle {#if} and friends?
 		validateElement(validator, node, refs, refCallees, [], []);
 	});
 }

--- a/test/server-side-rendering/samples/styles-nested/One.html
+++ b/test/server-side-rendering/samples/styles-nested/One.html
@@ -1,7 +1,7 @@
 <div>green: {message}</div>
 
 <!-- Two styles should *not* be included -->
-<!-- <Two message='{{message}}'/> -->
+<!-- <Two {message}/> -->
 
 <style>
 	div {

--- a/test/validator/samples/title-no-children/errors.json
+++ b/test/validator/samples/title-no-children/errors.json
@@ -1,6 +1,6 @@
 [{
 	"code": "illegal-structure",
-	"message": "<title> can only contain text and {{tags}}",
+	"message": "<title> can only contain text and {tags}",
 	"start": {
 		"line": 2,
 		"column": 11,


### PR DESCRIPTION
Mostly just comments, but some error/warning messages as well. Leaves [this](https://github.com/sveltejs/svelte/blob/54799736b8b03da41b7110a321dca8a3d880ed32/src/parse/read/directives.ts#L143) one alone for now, because it's still pending what we're going to do with that leftover syntax.