### PR TITLE
Revert "Fix for #1553"

### DIFF
--- a/src/compile/nodes/EventHandler.ts
+++ b/src/compile/nodes/EventHandler.ts
@@ -67,12 +67,12 @@ export default class EventHandler extends Node {
 				compiler.code.overwrite(
 					this.insertionPoint,
 					this.insertionPoint + 1,
-					`return ${component}.store.`
+					`${component}.store.`
 				);
 			} else {
 				compiler.code.prependRight(
 					this.insertionPoint,
-					`return ${component}.`
+					`${component}.`
 				);
 			}
 		}

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -146,7 +146,7 @@ function create_main_fragment(component, ctx) {
 			button = createElement("button");
 			button.textContent = "foo";
 			foo_handler = foo.call(component, button, function(event) {
-				return component.foo( ctx.bar );
+				component.foo( ctx.bar );
 			});
 		},
 

--- a/test/js/samples/event-handlers-custom/expected.js
+++ b/test/js/samples/event-handlers-custom/expected.js
@@ -19,7 +19,7 @@ function create_main_fragment(component, ctx) {
 			button = createElement("button");
 			button.textContent = "foo";
 			foo_handler = foo.call(component, button, function(event) {
-				return component.foo( ctx.bar );
+				component.foo( ctx.bar );
 			});
 		},
 


### PR DESCRIPTION
Reverts  sveltejs/svelte#1557. After thinking this through a bit more, it feels like a design mistake — the motivating use case is to allow custom event definitions to have app-specific side-effects, which isn't what they're for (an event is just 'this thing happened', and anything that happens in *response* to that event should happen in the handler). Instead, we should return once more to #779.