### PR TITLE
outro when <svelte:component> switches - 

### DIFF
--- a/src/compile/Compiler.ts
+++ b/src/compile/Compiler.ts
@@ -303,11 +303,13 @@ export default class Compiler {
 					},
 				});
 
-				if (name === 'transitionManager') {
+				if (name === 'transitionManager' || name === 'outros') {
 					// special case
-					const global = `_svelteTransitionManager`;
+					const global = name === 'outros'
+						? `_svelteOutros`
+						: `_svelteTransitionManager`;
 
-					inlineHelpers += `\n\nvar ${this.alias('transitionManager')} = window.${global} || (window.${global} = ${code});\n\n`;
+					inlineHelpers += `\n\nvar ${this.alias(name)} = window.${global} || (window.${global} = ${code});\n\n`;
 				} else if (name === 'escaped' || name === 'missingComponent') {
 					// vars are an awkward special case... would be nice to avoid this
 					const alias = this.alias(name);

--- a/src/compile/nodes/Component.ts
+++ b/src/compile/nodes/Component.ts
@@ -401,7 +401,7 @@ export default class Component extends Node {
 					if (${name}) {
 						${this.compiler.options.nestedTransitions
 						? deindent`
-						@transitionManager.groupOutros();
+						@groupOutros();
 						const old_component = ${name};
 						old_component._fragment.o(() => {
 							old_component.destroy();

--- a/src/compile/nodes/EachBlock.ts
+++ b/src/compile/nodes/EachBlock.ts
@@ -324,7 +324,7 @@ export default class EachBlock extends Node {
 		block.builders.update.addBlock(deindent`
 			const ${this.each_block_value} = ${snippet};
 
-			${this.block.hasOutros && `@transitionManager.groupOutros();`}
+			${this.block.hasOutros && `@groupOutros();`}
 			${this.block.hasAnimation && `for (let #i = 0; #i < ${blocks}.length; #i += 1) ${blocks}[#i].r();`}
 			${blocks} = @updateKeyedEach(${blocks}, #component, changed, ${get_key}, ${dynamic ? '1' : '0'}, ctx, ${this.each_block_value}, ${lookup}, ${updateMountNode}, ${destroy}, ${create_each_block}, "${mountOrIntro}", ${anchor}, ${this.get_each_context});
 			${this.block.hasAnimation && `for (let #i = 0; #i < ${blocks}.length; #i += 1) ${blocks}[#i].a();`}
@@ -449,7 +449,7 @@ export default class EachBlock extends Node {
 
 			if (this.block.hasOutros) {
 				destroy = deindent`
-					@transitionManager.groupOutros();
+					@groupOutros();
 					for (; #i < ${iterations}.length; #i += 1) ${outroBlock}(#i, 1);
 				`;
 			} else {

--- a/src/compile/nodes/IfBlock.ts
+++ b/src/compile/nodes/IfBlock.ts
@@ -301,7 +301,7 @@ export default class IfBlock extends Node {
 		const updateMountNode = this.getUpdateMountNode(anchor);
 
 		const destroyOldBlock = deindent`
-			@transitionManager.groupOutros();
+			@groupOutros();
 			${name}.o(function() {
 				${if_blocks}[${previous_block_index}].d(1);
 				${if_blocks}[${previous_block_index}] = null;
@@ -423,7 +423,7 @@ export default class IfBlock extends Node {
 		// as that will typically result in glitching
 		const exit = branch.hasOutroMethod
 			? deindent`
-				@transitionManager.groupOutros();
+				@groupOutros();
 				${name}.o(function() {
 					${name}.d(1);
 					${name} = null;

--- a/src/shared/_build.js
+++ b/src/shared/_build.js
@@ -27,7 +27,7 @@ fs.readdirSync(__dirname).forEach(file => {
 			? declaration.declarations[0].init
 			: declaration;
 
-		declarations[name] = source.slice(value.start, value.end);
+		declarations[name] = value ? source.slice(value.start, value.end) : 'null';
 	});
 });
 

--- a/src/shared/await-block.js
+++ b/src/shared/await-block.js
@@ -1,5 +1,5 @@
 import { assign, isPromise } from './utils.js';
-import { transitionManager } from './transitions.js';
+import { groupOutros } from './transitions.js';
 
 export function handlePromise(promise, info) {
 	var token = info.token = {};
@@ -16,7 +16,7 @@ export function handlePromise(promise, info) {
 			if (info.blocks) {
 				info.blocks.forEach((block, i) => {
 					if (i !== index && block) {
-						transitionManager.groupOutros();
+						groupOutros();
 						block.o(() => {
 							block.d(1);
 							info.blocks[i] = null;

--- a/src/shared/transitions.js
+++ b/src/shared/transitions.js
@@ -72,8 +72,8 @@ export function wrapTransition(component, node, fn, params, intro) {
 			}
 
 			if (!b) {
-				program.group = transitionManager.outros;
-				transitionManager.outros.remaining += 1;
+				program.group = outros;
+				outros.remaining += 1;
 			}
 
 			if (obj.delay) {
@@ -165,6 +165,16 @@ export function wrapTransition(component, node, fn, params, intro) {
 	};
 }
 
+export let outros = {
+	remaining: 0,
+	callbacks: []
+};
+
+export function groupOutros() {
+	outros.remaining = 0;
+	outros.callbacks = [];
+}
+
 export var transitionManager = {
 	running: false,
 	transitions: [],
@@ -234,13 +244,6 @@ export var transitionManager = {
 			.split(', ')
 			.filter(anim => anim && anim.indexOf(name) === -1)
 			.join(', ');
-	},
-
-	groupOutros() {
-		this.outros = {
-			remaining: 0,
-			callbacks: []
-		};
 	},
 
 	wait() {

--- a/test/js/samples/each-block-keyed-animated/expected-bundle.js
+++ b/test/js/samples/each-block-keyed-animated/expected-bundle.js
@@ -125,13 +125,6 @@ var transitionManager = {
 			.join(', ');
 	},
 
-	groupOutros() {
-		this.outros = {
-			remaining: 0,
-			callbacks: []
-		};
-	},
-
 	wait() {
 		if (!transitionManager.promise) {
 			transitionManager.promise = Promise.resolve();

--- a/test/runtime/samples/transition-js-dynamic-component/A.html
+++ b/test/runtime/samples/transition-js-dynamic-component/A.html
@@ -1,0 +1,16 @@
+<div transition:a>a</div>
+
+<script>
+	export default {
+		transitions: {
+			a(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.a = t;
+					}
+				};
+			}
+		}
+	};
+</script>

--- a/test/runtime/samples/transition-js-dynamic-component/B.html
+++ b/test/runtime/samples/transition-js-dynamic-component/B.html
@@ -1,0 +1,16 @@
+<div transition:b>b</div>
+
+<script>
+	export default {
+		transitions: {
+			b(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.b = t;
+					}
+				};
+			}
+		}
+	};
+</script>

--- a/test/runtime/samples/transition-js-dynamic-component/_config.js
+++ b/test/runtime/samples/transition-js-dynamic-component/_config.js
@@ -1,0 +1,37 @@
+export default {
+	nestedTransitions: true,
+	skipIntroByDefault: true,
+
+	data: {
+		x: true,
+	},
+
+	html: `
+		<div>a</div>
+	`,
+
+	test (assert, component, target, window, raf) {
+		component.set({ x: false });
+
+		assert.htmlEqual(target.innerHTML, `
+			<div>a</div>
+			<div>b</div>
+		`);
+
+		const [a, b] = target.querySelectorAll('div');
+
+		raf.tick(25);
+
+		assert.equal(a.a, 0.75);
+		assert.equal(b.b, 0.25);
+
+		raf.tick(100);
+
+		assert.equal(a.a, 0);
+		assert.equal(b.b, 1);
+
+		assert.htmlEqual(target.innerHTML, `
+			<div>b</div>
+		`);
+	}
+};

--- a/test/runtime/samples/transition-js-dynamic-component/main.html
+++ b/test/runtime/samples/transition-js-dynamic-component/main.html
@@ -1,0 +1,12 @@
+<svelte:component this="{x ? A : B}"/>
+
+<script>
+	import A from './A.html';
+	import B from './B.html';
+
+	export default {
+		data() {
+			return { A, B };
+		}
+	};
+</script>


### PR DESCRIPTION
ref #1568. This doesn't add the `switch` directive (that can wait), but it causes components to outro if `nestedTransitions` is true (as it will by default in v3).

~~Adding `transitionManager.groupOutros` does cause the whole of `transitionManager` to be included regardless of whether the component has outros, which is a longer-standing issue that needs resolving.~~