### PR TITLE
use template.content in place of template where appropriate

### DIFF
--- a/test/runtime/samples/template/_config.js
+++ b/test/runtime/samples/template/_config.js
@@ -1,0 +1,23 @@
+export default {
+	// solo: 1,
+
+	html: `
+		<template>
+			<div>foo</div>
+		</template>
+	`,
+
+	test(assert, component, target) {
+		const template = target.querySelector('template');
+
+		assert.htmlEqual(template.innerHTML, `
+			<div>foo</div>
+		`);
+
+		const content = template.content.cloneNode(true);
+		const div = content.children[0];
+		assert.htmlEqual(div.outerHTML, `
+			<div>foo</div>
+		`);
+	}
+};

--- a/test/runtime/samples/template/main.html
+++ b/test/runtime/samples/template/main.html
@@ -1,0 +1,3 @@
+<template>
+	<div>foo</div>
+</template>


### PR DESCRIPTION
fixes #1571. Turns out that `<template>` is weird — its `innerHTML` reflects `template.content`, *not* the contents of the template itself. Seems dappy but what do I know.

Made some minor tidy-ups while I was at it.