### PR TITLE
fix determing whether an attribute should prevent innerHTML optimization

### DIFF
--- a/src/compile/nodes/Element.ts
+++ b/src/compile/nodes/Element.ts
@@ -152,8 +152,14 @@ export default class Element extends Node {
 		);
 
 		this.attributes.forEach(attr => {
-			if (attr.dependencies.size) {
+			if (
+				attr.chunks &&
+				attr.chunks.length &&
+				(attr.chunks.length > 1 || attr.chunks[0].type !== 'Text')
+			) {
 				this.parent.cannotUseInnerHTML();
+			}
+			if (attr.dependencies.size) {
 				block.addDependencies(attr.dependencies);
 
 				// special case — <option value={foo}> — see below

--- a/test/runtime/samples/attribute-dynamic-no-dependencies/_config.js
+++ b/test/runtime/samples/attribute-dynamic-no-dependencies/_config.js
@@ -1,0 +1,5 @@
+export default {
+	html: `
+		<div><div title='foo'>bar</div></div>
+	`,
+};

--- a/test/runtime/samples/attribute-dynamic-no-dependencies/main.html
+++ b/test/runtime/samples/attribute-dynamic-no-dependencies/main.html
@@ -1,0 +1,1 @@
+<div><div title={'foo'}>bar</div></div>


### PR DESCRIPTION
Fixes #1581. I'm pretty sure there aren't other cases like this to worry about. This makes it so that attributes cause their elements to opt out of `.innerHTML` whenever they contain a dynamic tag, not merely when they have something that's been determined to be a dependency. See source issue for more information in the form of a meandering monologue.