### PR TITLE
allow {:then}/{:catch} to have no bound identifier

### DIFF
--- a/src/parse/state/mustache.ts
+++ b/src/parse/state/mustache.ts
@@ -147,11 +147,12 @@ export default function mustache(parser: Parser) {
 			parser.stack.pop();
 			const awaitBlock = parser.current();
 
-			parser.requireWhitespace();
-			awaitBlock.value = parser.readIdentifier();
-
-			parser.allowWhitespace();
-			parser.eat('}', true);
+			if (!parser.eat('}')) {
+				parser.requireWhitespace();
+				awaitBlock.value = parser.readIdentifier();
+				parser.allowWhitespace();
+				parser.eat('}', true);
+			}
 
 			const thenBlock: Node = {
 				start,
@@ -170,11 +171,12 @@ export default function mustache(parser: Parser) {
 			parser.stack.pop();
 			const awaitBlock = parser.current();
 
-			parser.requireWhitespace();
-			awaitBlock.error = parser.readIdentifier();
-
-			parser.allowWhitespace();
-			parser.eat('}', true);
+			if (!parser.eat('}')) {
+				parser.requireWhitespace();
+				awaitBlock.error = parser.readIdentifier();
+				parser.allowWhitespace();
+				parser.eat('}', true);
+			}
 
 			const catchBlock: Node = {
 				start,

--- a/test/runtime/samples/await-then-catch-no-values/_config.js
+++ b/test/runtime/samples/await-then-catch-no-values/_config.js
@@ -1,0 +1,41 @@
+let fulfil;
+
+let thePromise = new Promise(f => {
+	fulfil = f;
+});
+
+export default {
+	data: {
+		thePromise
+	},
+
+	html: `waiting`,
+
+	test(assert, component, target) {
+		fulfil(9000);
+
+		return thePromise
+			.then(() => {
+				assert.htmlEqual(target.innerHTML, `resolved`);
+
+				let reject;
+
+				thePromise = new Promise((f, r) => {
+					reject = r;
+				});
+
+				component.set({
+					thePromise
+				});
+
+				assert.htmlEqual(target.innerHTML, `waiting`);
+
+				reject(new Error('something broke'));
+
+				return thePromise.catch(() => {});
+			})
+			.then(() => {
+				assert.htmlEqual(target.innerHTML, `rejected`);
+			});
+	}
+};

--- a/test/runtime/samples/await-then-catch-no-values/main.html
+++ b/test/runtime/samples/await-then-catch-no-values/main.html
@@ -1,0 +1,7 @@
+{#await thePromise}
+	waiting
+{:then}
+	resolved
+{:catch}
+	rejected
+{/await}


### PR DESCRIPTION
#1507. The compiler seems to behave fine when then or catch blocks have no bound identifier for the resolution/rejection value, so update the parser to not require them.