### PR TITLE
closes #1600

### DIFF
--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -220,7 +220,7 @@ export function addResizeListener(element, fn) {
 
 	return {
 		cancel: () => {
-			win.removeEventListener('resize', fn);
+			win && win.removeEventListener('resize', fn);
 			element.removeChild(object);
 		}
 	};

--- a/test/js/samples/bind-width-height/expected-bundle.js
+++ b/test/js/samples/bind-width-height/expected-bundle.js
@@ -43,7 +43,7 @@ function addResizeListener(element, fn) {
 
 	return {
 		cancel: () => {
-			win.removeEventListener('resize', fn);
+			win && win.removeEventListener('resize', fn);
 			element.removeChild(object);
 		}
 	};


### PR DESCRIPTION
This happens because `cancel` is called before the `onload` event is fired on line 208.

This PR just checks for the existence of `win` before trying to remove the listener
