### PR TITLE
fix for #1598

### DIFF
--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -66,7 +66,7 @@ export function createSvgElement(name) {
 }
 
 export function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 export function createComment() {

--- a/test/cli/samples/dev/expected/Main.js
+++ b/test/cli/samples/dev/expected/Main.js
@@ -64,7 +64,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function addLoc(element, file, line, column, char) {

--- a/test/cli/samples/globals/expected/Main.js
+++ b/test/cli/samples/globals/expected/Main.js
@@ -69,7 +69,7 @@ var Main = (function(answer) { "use strict";
 	}
 
 	function createText(data) {
-		return document.createTextNode(data);
+		return document.createTextNode(data === null ? '' : data);
 	}
 
 	function insertNode(node, target, anchor) {

--- a/test/cli/samples/store/expected/Main.js
+++ b/test/cli/samples/store/expected/Main.js
@@ -64,7 +64,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function insertNode(node, target, anchor) {

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -22,7 +22,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function blankObject() {

--- a/test/js/samples/deconflict-builtins/expected-bundle.js
+++ b/test/js/samples/deconflict-builtins/expected-bundle.js
@@ -28,7 +28,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function createComment() {

--- a/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
@@ -28,7 +28,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function blankObject() {

--- a/test/js/samples/do-use-dataset/expected-bundle.js
+++ b/test/js/samples/do-use-dataset/expected-bundle.js
@@ -18,7 +18,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function blankObject() {

--- a/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
@@ -18,7 +18,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function setAttribute(node, attribute, value) {

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -34,7 +34,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function blankObject() {

--- a/test/js/samples/each-block-keyed-animated/expected-bundle.js
+++ b/test/js/samples/each-block-keyed-animated/expected-bundle.js
@@ -22,7 +22,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function createComment() {

--- a/test/js/samples/each-block-keyed/expected-bundle.js
+++ b/test/js/samples/each-block-keyed/expected-bundle.js
@@ -22,7 +22,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function createComment() {

--- a/test/js/samples/inline-style-unoptimized/expected-bundle.js
+++ b/test/js/samples/inline-style-unoptimized/expected-bundle.js
@@ -18,7 +18,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function blankObject() {

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -16,7 +16,7 @@ function detachNode(node) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function blankObject() {

--- a/test/js/samples/svg-title/expected-bundle.js
+++ b/test/js/samples/svg-title/expected-bundle.js
@@ -22,7 +22,7 @@ function createSvgElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function blankObject() {

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -22,7 +22,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function createComment() {

--- a/test/js/samples/window-binding-scroll/expected-bundle.js
+++ b/test/js/samples/window-binding-scroll/expected-bundle.js
@@ -22,7 +22,7 @@ function createElement(name) {
 }
 
 function createText(data) {
-	return document.createTextNode(data);
+	return document.createTextNode(data === null ? '' : data);
 }
 
 function blankObject() {

--- a/test/runtime/samples/set-null-text-node/_config.js
+++ b/test/runtime/samples/set-null-text-node/_config.js
@@ -1,0 +1,22 @@
+const data = { foo: null };
+
+export default {
+	data,
+
+	html: '',
+
+	test(assert, component, target) {
+		assert.htmlEqual(target.innerHTML, 'hi there');
+
+		data.foo = 'friend';
+		component.set(data);
+
+		assert.htmlEqual(target.innerHTML, 'hi there friend');
+
+		data.foo = null;
+		component.set(data);
+
+		assert.htmlEqual(target.innerHTML, 'hi there');
+
+	}
+};

--- a/test/runtime/samples/set-null-text-node/main.html
+++ b/test/runtime/samples/set-null-text-node/main.html
@@ -1,0 +1,1 @@
+hi there {foo}


### PR DESCRIPTION
`document.createTextNode(null)` creates a text node with `'null'` in it.
`textNode.data = null` results in an empty text node.

This PR fixes that inconsistency at the `createTextNode` stage, so that updates don't cause a mismatch.

I tried with `undefined` too. But that gives consistent results regardless of whether you are creating the node or updating it (the text node contains `"undefined"`).
So I left that alone.