### PR TITLE
handle rest elements in computed properties

### DIFF
--- a/src/compile/dom/index.ts
+++ b/src/compile/dom/index.ts
@@ -67,7 +67,7 @@ export default function dom(
 	const computationDeps = new Set();
 
 	if (computations.length) {
-		computations.forEach(({ key, deps }) => {
+		computations.forEach(({ key, deps, hasRestParam }) => {
 			if (target.readonly.has(key)) {
 				// <svelte:window> bindings
 				throw new Error(
@@ -89,8 +89,10 @@ export default function dom(
 			} else {
 				// computed property depends on entire state object —
 				// these must go at the end
+				const arg = hasRestParam ? `@exclude(state, "${key}")` : `state`;
+
 				computationBuilder.addLine(
-					`if (this._differs(state.${key}, (state.${key} = %computed-${key}(state)))) changed.${key} = true;`
+					`if (this._differs(state.${key}, (state.${key} = %computed-${key}(${arg})))) changed.${key} = true;`
 				);
 			}
 		});

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -26,3 +26,9 @@ export function addLoc(element, file, line, column, char) {
 		loc: { file, line, column, char }
 	};
 }
+
+export function exclude(src, prop) {
+	const tar = {};
+	for (const k in src) k === prop || (tar[k] = src[k]);
+	return tar;
+}

--- a/src/utils/annotateWithScopes.ts
+++ b/src/utils/annotateWithScopes.ts
@@ -137,7 +137,11 @@ const extractors = {
 
 	ObjectPattern(names: string[], param: Node) {
 		param.properties.forEach((prop: Node) => {
-			extractors[prop.value.type](names, prop.value);
+			if (prop.type === 'RestElement') {
+				names.push(prop.argument.name);
+			} else {
+				extractors[prop.value.type](names, prop.value);
+			}
 		});
 	},
 

--- a/test/runtime/samples/object-rest/_config.js
+++ b/test/runtime/samples/object-rest/_config.js
@@ -1,0 +1,27 @@
+export default {
+	skip: +/v(\d+)/.exec(process.version)[1] < 8,
+
+	html: `
+		<pre>{"wanted":2}</pre>
+	`,
+
+	test(assert, component, target) {
+		component.set({
+			unwanted: 3,
+			wanted: 4
+		});
+
+ 		assert.htmlEqual(target.innerHTML, `
+			<pre>{"wanted":4}</pre>
+		`);
+
+ 		component.set({
+			unwanted: 5,
+			wanted: 6
+		});
+
+ 		assert.htmlEqual(target.innerHTML, `
+			<pre>{"wanted":6}</pre>
+		`);
+	}
+};

--- a/test/runtime/samples/object-rest/main.html
+++ b/test/runtime/samples/object-rest/main.html
@@ -1,0 +1,18 @@
+<pre>{JSON.stringify(props)}</pre>
+<script>
+	export default {
+		data: () => ({
+			unwanted: 1,
+			wanted: 2
+		}),
+
+		helpers: {
+			// prevent this being mixed in with data
+			JSON
+		},
+
+		computed: {
+			props: ({ unwanted, ...x }) => x
+		}
+	};
+</script>


### PR DESCRIPTION
Alright, let's fix #1540 once and for all. This adds support for rest elements in computed properties. It does so in a way that avoids the `props.props.props.props` thing we discovered — in a case like this...


```js
computed: {
  foo: ({ x, ...y }) => y
}
```

...`foo` will be excluded from the object passed in. This might seem slightly magical, but I think it matches people's intuitions of how this should work.