### PR TITLE
use props when passing data to custom elements (#875)

### DIFF
--- a/src/compile/nodes/Attribute.ts
+++ b/src/compile/nodes/Attribute.ts
@@ -130,9 +130,11 @@ export default class Attribute extends Node {
 		// xlink is a special case... we could maybe extend this to generic
 		// namespaced attributes but I'm not sure that's applicable in
 		// HTML5?
-		const method = name.slice(0, 6) === 'xlink:'
-			? '@setXlinkAttribute'
-			: '@setAttribute';
+		const method = /-/.test(node.name)
+			? '@setCustomElementData'
+			: name.slice(0, 6) === 'xlink:'
+				? '@setXlinkAttribute'
+				: '@setAttribute';
 
 		const isLegacyInputType = this.compiler.options.legacy && name === 'type' && this.parent.name === 'input';
 

--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -96,6 +96,16 @@ export function setAttributes(node, attributes) {
 	}
 }
 
+export function setCustomElementData(node, prop, value) {
+	if (prop in node) {
+		node[prop] = value;
+	} else if (value) {
+		setAttribute(node, prop, value);
+	} else {
+		removeAttribute(node, prop);
+	}
+}
+
 export function removeAttribute(node, attribute) {
 	node.removeAttribute(attribute);
 }

--- a/test/custom-elements/samples/props/main.html
+++ b/test/custom-elements/samples/props/main.html
@@ -1,0 +1,15 @@
+<my-widget class="foo" {items}/>
+
+<script>
+	import './my-widget.html';
+
+	export default {
+		tag: 'custom-element',
+
+		data() {
+			return {
+				items: ['a', 'b', 'c']
+			};
+		}
+	};
+</script>

--- a/test/custom-elements/samples/props/my-widget.html
+++ b/test/custom-elements/samples/props/my-widget.html
@@ -1,9 +1,14 @@
-<p>{(items || []).length} items</p>
-<p>{(items || []).join(', ')}</p>
-<p>{JSON.stringify(items)}</p>
+<p>{items.length} items</p>
+<p>{items.join(', ')}</p>
 
 <script>
 	export default {
-		tag: 'my-widget'
+		tag: 'my-widget',
+
+		data() {
+			return {
+				items: []
+			};
+		}
 	};
 </script>

--- a/test/custom-elements/samples/props/my-widget.html
+++ b/test/custom-elements/samples/props/my-widget.html
@@ -1,0 +1,9 @@
+<p>{(items || []).length} items</p>
+<p>{(items || []).join(', ')}</p>
+<p>{JSON.stringify(items)}</p>
+
+<script>
+	export default {
+		tag: 'my-widget'
+	};
+</script>

--- a/test/custom-elements/samples/props/test.js
+++ b/test/custom-elements/samples/props/test.js
@@ -1,0 +1,23 @@
+import * as assert from 'assert';
+import CustomElement from './main.html';
+
+export default function (target) {
+	new CustomElement({
+		target
+	});
+
+	assert.equal(target.innerHTML, '<custom-element></custom-element>');
+
+	const el = target.querySelector('custom-element');
+	const widget = el.shadowRoot.querySelector('my-widget');
+
+	const [p1, p2] = widget.shadowRoot.querySelectorAll('p');
+
+	assert.equal(p1.textContent, '3 items');
+	assert.equal(p2.textContent, 'a, b, c');
+
+	el.items = ['d', 'e', 'f', 'g', 'h'];
+
+	assert.equal(p1.textContent, '5 items');
+	assert.equal(p2.textContent, 'd, e, f, g, h');
+}


### PR DESCRIPTION
This changes the behaviour of attributes on custom elements — previously, data would always be passed to custom elements using `setAttribute`, which only works for strings.

Now, it uses a simple heuristic: if the prop exists on the custom element, it is set as a prop, otherwise it's an attribute. (This is similar to what Preact does.)

So in this case...

```html
<fancy-list items={things}/>
```

...as long as `items` is the name of a property on a `FancyList` instance (whether or not it had previously been set), the value of `items` inside the component will be an array rather than the dreaded `"[object Object]"`.

Typically, custom elements use accessors for properties that their consumers should be able to read and write...

```js
class FancyList extends HTMLElement {
  ...
  get items() {
    // ...
  }

  set items(items) {
    // ...
  }
}
```

...and that's similar to the code Svelte generates for custom elements, so this ought to be a reliable heuristic. Meanwhile, unexpected props still become attributes, allowing this sort of thing:

```html
<fancy-list style="font-family: 'Comic Sans MS'" items={things}/>
```

With this PR, we pass all the tests on https://custom-elements-everywhere.com —

<img width="682" alt="screen shot 2018-08-05 at 1 55 22 pm" src="https://user-images.githubusercontent.com/1162160/43688454-39c0efea-98b7-11e8-95aa-b156c3246127.png">

— which is better than React, Preact, and, err... Polymer, the custom element framework 😳