### PR TITLE
fix #1600 for ios

### DIFF
--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -234,7 +234,7 @@ export function addResizeListener(element, fn) {
 
 	return {
 		cancel: () => {
-			win && win.removeEventListener('resize', fn);
+			win && win.removeEventListener && win.removeEventListener('resize', fn);
 			element.removeChild(object);
 		}
 	};

--- a/test/js/samples/bind-width-height/expected-bundle.js
+++ b/test/js/samples/bind-width-height/expected-bundle.js
@@ -43,7 +43,7 @@ function addResizeListener(element, fn) {
 
 	return {
 		cancel: () => {
-			win && win.removeEventListener('resize', fn);
+			win && win.removeEventListener && win.removeEventListener('resize', fn);
 			element.removeChild(object);
 		}
 	};


### PR DESCRIPTION
In iOS, the window object hangs around as an object husk with no methods in it.
Instead of the whole object being `null`ed on removal of the target.