### PR TITLE
add sourcemaps to debug tags

### DIFF
--- a/test/js/samples/debug-foo-bar-baz-things/expected-bundle.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected-bundle.js
@@ -259,9 +259,11 @@ function create_each_block(component, ctx) {
 			text = createText(text_value);
 			text_1 = createText("\n\t");
 
-			const { foo, bar, baz, thing } = ctx;
-			console.log({ foo, bar, baz, thing });
-			debugger;
+			{
+				const { foo, bar, baz, thing } = ctx;
+				console.log({ foo, bar, baz, thing });
+				debugger;
+			}
 			addLoc(span, file, 1, 1, 25);
 		},
 

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -86,9 +86,11 @@ function create_each_block(component, ctx) {
 			text = createText(text_value);
 			text_1 = createText("\n\t");
 
-			const { foo, bar, baz, thing } = ctx;
-			console.log({ foo, bar, baz, thing });
-			debugger;
+			{
+				const { foo, bar, baz, thing } = ctx;
+				console.log({ foo, bar, baz, thing });
+				debugger;
+			}
 			addLoc(span, file, 1, 1, 25);
 		},
 

--- a/test/js/samples/debug-foo/expected-bundle.js
+++ b/test/js/samples/debug-foo/expected-bundle.js
@@ -259,9 +259,11 @@ function create_each_block(component, ctx) {
 			text = createText(text_value);
 			text_1 = createText("\n\t");
 
-			const { foo } = ctx;
-			console.log({ foo });
-			debugger;
+			{
+				const { foo } = ctx;
+				console.log({ foo });
+				debugger;
+			}
 			addLoc(span, file, 1, 1, 25);
 		},
 

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -86,9 +86,11 @@ function create_each_block(component, ctx) {
 			text = createText(text_value);
 			text_1 = createText("\n\t");
 
-			const { foo } = ctx;
-			console.log({ foo });
-			debugger;
+			{
+				const { foo } = ctx;
+				console.log({ foo });
+				debugger;
+			}
 			addLoc(span, file, 1, 1, 25);
 		},
 


### PR DESCRIPTION
Follow-up to #1640 — with a little trickery, we can get source mappings:

<img width="1306" alt="screen shot 2018-08-11 at 6 49 06 pm" src="https://user-images.githubusercontent.com/1162160/43996743-7ad0347a-9d97-11e8-94e8-f8b34500d725.png">

