### PR TITLE
cli: Add option --shared

### DIFF
--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -49,7 +49,8 @@ export function compile(input, opts) {
 		immutable: opts.immutable,
 		generate: opts.generate || 'dom',
 		customElement: opts.customElement,
-		store: opts.store
+		store: opts.store,
+		shared: opts.shared
 	};
 
 	if (isDir) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ prog
 	.option('--generate', 'Change generate format between `dom` and `ssr`')
 	.option('--no-css', `Don't include CSS (useful with SSR)`)
 	.option('--immutable', 'Support immutable data structures')
+	.option('--shared', 'Don\'t include shared helpers')
 
 	.example('compile App.html > App.js')
 	.example('compile src -o dest')


### PR DESCRIPTION
This just adds a `--shared` option that is passed to the compiler. I found it useful to gain a better understanding of what the compiler produces by repeatedly running this in the console:

`./svelte compile test.html --shared`