### PR TITLE
exclude current prop in computed properties using entire state #1544

### DIFF
--- a/src/compile/dom/index.ts
+++ b/src/compile/dom/index.ts
@@ -89,10 +89,8 @@ export default function dom(
 			} else {
 				// computed property depends on entire state object —
 				// these must go at the end
-				const arg = hasRestParam ? `@exclude(state, "${key}")` : `state`;
-
 				computationBuilder.addLine(
-					`if (this._differs(state.${key}, (state.${key} = %computed-${key}(${arg})))) changed.${key} = true;`
+					`if (this._differs(state.${key}, (state.${key} = %computed-${key}(@exclude(state, "${key}"))))) changed.${key} = true;`
 				);
 			}
 		});

--- a/test/runtime/samples/computed-whole-state/_config.js
+++ b/test/runtime/samples/computed-whole-state/_config.js
@@ -1,0 +1,25 @@
+export default {
+	html: `
+		<pre>{"wanted":2}</pre>
+	`,
+
+	test(assert, component, target) {
+		component.set({
+			unwanted: 3,
+			wanted: 4,
+		});
+
+		assert.htmlEqual(target.innerHTML, `
+			<pre>{"wanted":4}</pre>
+		`);
+
+		component.set({
+			unwanted: 5,
+			wanted: 6,
+		});
+
+		assert.htmlEqual(target.innerHTML, `
+			<pre>{"wanted":6}</pre>
+		`);
+	},
+};

--- a/test/runtime/samples/computed-whole-state/main.html
+++ b/test/runtime/samples/computed-whole-state/main.html
@@ -1,0 +1,22 @@
+<pre>{JSON.stringify(props)}</pre>
+<script>
+	export default {
+		data: () => ({
+			unwanted: 1,
+			wanted: 2
+		}),
+
+		helpers: {
+			// prevent this being mixed in with data
+			JSON
+		},
+
+		computed: {
+      props: (state) => {
+				var result = Object.assign({}, state);
+				delete result.unwanted;
+				return result;
+			}
+		}
+	};
+</script>


### PR DESCRIPTION
Similar to what was done with rest params in computed properties, but does the same excluding-the-current-prop thing when computed properties don't use destructuring and thus depend on the entire state.