### PR TITLE
fix(svelte): Fix child component not being destroyed after each_blocks are nullified

### DIFF
--- a/src/compile/nodes/EachBlock.ts
+++ b/src/compile/nodes/EachBlock.ts
@@ -407,6 +407,8 @@ export default class EachBlock extends Node {
 							}
 							if (fn) fn();
 						});
+					} else {
+						if (fn) fn();
 					}
 				}
 			`);


### PR DESCRIPTION
https://github.com/sveltejs/svelte/issues/1660

I'm not able to reproduce the issue in a test or in the repl. However, the case does occur where each item in the each_blocks array are set to null. Then `outroBlock` is called with the destroy callback.

This is a blocking issue for me, so any help is appreciated.