### PR TITLE
Add some properties to ObjectPattern Property nodes

### DIFF
--- a/src/parse/read/context.ts
+++ b/src/parse/read/context.ts
@@ -87,7 +87,7 @@ export default function readContext(parser: Parser) {
 				end: value.end,
 				type: 'Property',
 				kind: 'init',
-				shorthand: key === value,
+				shorthand: value.type === 'Identifier' && value.name === name,
 				key,
 				value
 			};

--- a/src/parse/read/context.ts
+++ b/src/parse/read/context.ts
@@ -11,6 +11,8 @@ type Property = {
 	start: number;
 	end: number;
 	type: 'Property';
+	kind: string;
+	shorthand: boolean;
 	key: Identifier;
 	value: Context;
 };
@@ -84,6 +86,8 @@ export default function readContext(parser: Parser) {
 				start,
 				end: value.end,
 				type: 'Property',
+				kind: 'init',
+				shorthand: key === value,
 				key,
 				value
 			};


### PR DESCRIPTION
Just adds a couple of properties that I needed when trying to print the svelte ast to string using [astring](https://github.com/davidbonnet/astring) for the javascript parts (it would error as it expected `kind` to be defined)