### PR TITLE
Allow non-existent dynamic components to be destroyed

### DIFF
--- a/src/compile/nodes/Component.ts
+++ b/src/compile/nodes/Component.ts
@@ -505,7 +505,7 @@ export default class Component extends Node {
 
 		if (this.compiler.options.nestedTransitions) {
 			block.builders.outro.addLine(
-				`${name}._fragment.o(#outrocallback);`
+				`if (${name}) ${name}._fragment.o(#outrocallback);`
 			);
 		}
 	}

--- a/test/cli/samples/amd/expected/Main.js
+++ b/test/cli/samples/amd/expected/Main.js
@@ -65,11 +65,18 @@ define("test", function() { "use strict";
 
 	function init(component, options) {
 		component._handlers = blankObject();
+		component._slots = blankObject();
 		component._bind = options._bind;
 
 		component.options = options;
 		component.root = options.root || component;
 		component.store = options.store || component.root.store;
+
+		if (!options.root) {
+			component._beforecreate = [];
+			component._oncreate = [];
+			component._aftercreate = [];
+		}
 	}
 
 	function assign(tar, src) {
@@ -125,11 +132,7 @@ define("test", function() { "use strict";
 	function set(newState) {
 		this._set(assign({}, newState));
 		if (this.root._lock) return;
-		this.root._lock = true;
-		callAll(this.root._beforecreate);
-		callAll(this.root._oncreate);
-		callAll(this.root._aftercreate);
-		this.root._lock = false;
+		flush(this.root);
 	}
 
 	function _set(newState) {
@@ -163,6 +166,14 @@ define("test", function() { "use strict";
 
 	function blankObject() {
 		return Object.create(null);
+	}
+
+	function flush(component) {
+		component._lock = true;
+		callAll(component._beforecreate);
+		callAll(component._oncreate);
+		callAll(component._aftercreate);
+		component._lock = false;
 	}
 
 	function callAll(fns) {

--- a/test/runtime/samples/dynamic-component-destroy-null/_config.js
+++ b/test/runtime/samples/dynamic-component-destroy-null/_config.js
@@ -1,0 +1,13 @@
+export default {
+	data: {
+		x: true
+	},
+
+	nestedTransitions: true,
+
+	test(assert, component) {
+		component.set({
+			x: false
+		});
+	}
+};

--- a/test/runtime/samples/dynamic-component-destroy-null/main.html
+++ b/test/runtime/samples/dynamic-component-destroy-null/main.html
@@ -1,0 +1,3 @@
+{#if x}
+	<svelte:component this={null}/>
+{/if}


### PR DESCRIPTION
Fixes one of the bugs in #1660 (the one not covered by #1662)