### PR TITLE
support debug tag in SSR mode

### DIFF
--- a/src/shared/ssr.js
+++ b/src/shared/ssr.js
@@ -55,3 +55,9 @@ export function validateSsrComponent(component, name) {
 
 	return component;
 }
+
+export function debug(file, line, column, values) {
+	console.log(`{@debug} ${file ? file + ' ' : ''}(${line}:${column})`);
+	console.log(values);
+	return '';
+}

--- a/test/js/samples/debug-ssr-foo/_config.js
+++ b/test/js/samples/debug-ssr-foo/_config.js
@@ -1,0 +1,6 @@
+export default {
+	options: {
+		generate: 'ssr',
+		dev: true
+	}
+};

--- a/test/js/samples/debug-ssr-foo/expected-bundle.js
+++ b/test/js/samples/debug-ssr-foo/expected-bundle.js
@@ -1,0 +1,46 @@
+var { debug, each, escape } = require("svelte/shared.js");
+
+var SvelteComponent = {};
+SvelteComponent.data = function() {
+	return {};
+};
+
+SvelteComponent.render = function(state, options = {}) {
+	var components = new Set();
+
+	function addComponent(component) {
+		components.add(component);
+	}
+
+	var result = { head: '', addComponent };
+	var html = SvelteComponent._render(result, state, options);
+
+	var cssCode = Array.from(components).map(c => c.css && c.css.code).filter(Boolean).join('\n');
+
+	return {
+		html,
+		head: result.head,
+		css: { code: cssCode, map: null },
+		toString() {
+			return html;
+		}
+	};
+};
+
+SvelteComponent._render = function(__result, ctx, options) {
+	__result.addComponent(SvelteComponent);
+
+	ctx = Object.assign({}, ctx);
+
+	return `${ each(ctx.things, item => Object.assign({}, ctx, { thing: item }), ctx => `<span>${escape(ctx.thing.name)}</span>
+	${debug(null, 2, 2, { foo: ctx.foo })}`)}
+
+<p>foo: ${escape(ctx.foo)}</p>`;
+};
+
+SvelteComponent.css = {
+	code: '',
+	map: null
+};
+
+module.exports = SvelteComponent;

--- a/test/js/samples/debug-ssr-foo/expected.js
+++ b/test/js/samples/debug-ssr-foo/expected.js
@@ -1,0 +1,51 @@
+"use strict";
+
+var { debug, each, escape } = require("svelte/shared.js");
+
+var SvelteComponent = {};;
+
+SvelteComponent.data = function() {
+	return {};
+};
+
+SvelteComponent.render = function(state, options = {}) {
+	var components = new Set();
+
+	function addComponent(component) {
+		components.add(component);
+	}
+
+	var result = { head: '', addComponent };
+	var html = SvelteComponent._render(result, state, options);
+
+	var cssCode = Array.from(components).map(c => c.css && c.css.code).filter(Boolean).join('\n');
+
+	return {
+		html,
+		head: result.head,
+		css: { code: cssCode, map: null },
+		toString() {
+			return html;
+		}
+	};
+}
+
+SvelteComponent._render = function(__result, ctx, options) {
+	__result.addComponent(SvelteComponent);
+
+	ctx = Object.assign({}, ctx);
+
+	return `${ each(ctx.things, item => Object.assign({}, ctx, { thing: item }), ctx => `<span>${escape(ctx.thing.name)}</span>
+	${debug(null, 2, 2, { foo: ctx.foo })}`)}
+
+<p>foo: ${escape(ctx.foo)}</p>`;
+};
+
+SvelteComponent.css = {
+	code: '',
+	map: null
+};
+
+var warned = false;
+
+module.exports = SvelteComponent;

--- a/test/js/samples/debug-ssr-foo/input.html
+++ b/test/js/samples/debug-ssr-foo/input.html
@@ -1,0 +1,6 @@
+{#each things as thing}
+	<span>{thing.name}</span>
+	{@debug foo}
+{/each}
+
+<p>foo: {foo}</p>


### PR DESCRIPTION
fixes #1659. Since `debugger` doesn't really make sense in SSR mode, this just logs out the requested values (or all of them, if none are specified) to the console, along with location information for the tag itself.