### PR TITLE
remove sourcemaps from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "files": [
     "cli",
-    "compiler",
-    "ssr",
+    "compiler/*.js",
+    "ssr/*.js",
     "shared.js",
     "store.js",
     "store.umd.js",


### PR DESCRIPTION
[compiler/svelte.js.map](https://unpkg.com/svelte@2.12.1/compiler/svelte.js.map) is more than half of the size of the package. It seems a bit unnecessary. Any objections to removing it? It's only really useful when we're developing the compiler itself.