### PR TITLE
Adds class directive shortcut and encapsulate styles

### DIFF
--- a/src/compile/nodes/Element.ts
+++ b/src/compile/nodes/Element.ts
@@ -895,9 +895,8 @@ export default class Element extends Node {
 				snippet = expression.snippet;
 				dependencies = expression.dependencies;
 			} else {
-				const varName = camelCase(name);
-				snippet = `ctx.${varName}`;
-				dependencies = [varName];
+				snippet = `ctx${propertize(name)}`;
+				dependencies = [name];
 			}
 			const updater = `@toggleClass(${this.var}, "${name}", ${snippet});`;
 
@@ -905,7 +904,7 @@ export default class Element extends Node {
 
 			if ((dependencies && dependencies.size > 0) || this.classDependencies.length) {
 				const allDeps = this.classDependencies.concat(...dependencies);
-				const deps = allDeps.map(dependency => `changed.${dependency}`).join(' || ');
+				const deps = allDeps.map(dependency => `changed${propertize(dependency)}`).join(' || ');
 				const condition = allDeps.length > 1 ? `(${deps})` : deps;
 
 				block.builders.update.addConditional(
@@ -988,7 +987,7 @@ export default class Element extends Node {
 
 		const classExpr = this.classes.map((classDir: Class) => {
 			const { expression, name } = classDir;
-			const snippet = expression ? expression.snippet : `ctx.${camelCase(name)}`;
+			const snippet = expression ? expression.snippet : `ctx${propertize(name)}`;
 			return `${snippet} ? "${name}" : ""`;
 		}).join(', ');
 
@@ -1170,8 +1169,6 @@ const events = [
 	}
 ];
 
-function camelCase(str) {
-	return str.replace(/(-\w)/g, function (m) {
-		return m[1].toUpperCase();
-	});
+function propertize(prop) {
+	return /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(prop) ? `.${prop}` : `["${prop}"]`;
 }

--- a/src/compile/nodes/Element.ts
+++ b/src/compile/nodes/Element.ts
@@ -895,7 +895,7 @@ export default class Element extends Node {
 				snippet = expression.snippet;
 				dependencies = expression.dependencies;
 			} else {
-				snippet = `ctx${propertize(name)}`;
+				snippet = `ctx${quotePropIfNecessary(name)}`;
 				dependencies = [name];
 			}
 			const updater = `@toggleClass(${this.var}, "${name}", ${snippet});`;
@@ -904,7 +904,7 @@ export default class Element extends Node {
 
 			if ((dependencies && dependencies.size > 0) || this.classDependencies.length) {
 				const allDeps = this.classDependencies.concat(...dependencies);
-				const deps = allDeps.map(dependency => `changed${propertize(dependency)}`).join(' || ');
+				const deps = allDeps.map(dependency => `changed${quotePropIfNecessary(dependency)}`).join(' || ');
 				const condition = allDeps.length > 1 ? `(${deps})` : deps;
 
 				block.builders.update.addConditional(
@@ -987,7 +987,7 @@ export default class Element extends Node {
 
 		const classExpr = this.classes.map((classDir: Class) => {
 			const { expression, name } = classDir;
-			const snippet = expression ? expression.snippet : `ctx${propertize(name)}`;
+			const snippet = expression ? expression.snippet : `ctx${quotePropIfNecessary(name)}`;
 			return `${snippet} ? "${name}" : ""`;
 		}).join(', ');
 
@@ -1168,7 +1168,3 @@ const events = [
 			name === 'volume'
 	}
 ];
-
-function propertize(prop) {
-	return /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(prop) ? `.${prop}` : `["${prop}"]`;
-}

--- a/src/css/Selector.ts
+++ b/src/css/Selector.ts
@@ -157,7 +157,7 @@ function applySelector(stylesheet: Stylesheet, blocks: Block[], node: Node, stac
 		}
 
 		if (selector.type === 'ClassSelector') {
-			if (!attributeMatches(node, 'class', selector.name, '~=', false)) return false;
+			if (!attributeMatches(node, 'class', selector.name, '~=', false) && !classMatches(node, selector.name)) return false;
 		}
 
 		else if (selector.type === 'IdSelector') {
@@ -256,6 +256,12 @@ function attributeMatches(node: Node, name: string, expectedValue: string, opera
 	}
 
 	return false;
+}
+
+function classMatches(node, name: string) {
+	return node.classes.some(function(classDir) {
+		return classDir.name === name;
+	});
 }
 
 function isDynamic(value: Node) {

--- a/test/runtime/samples/class-shortcut/_config.js
+++ b/test/runtime/samples/class-shortcut/_config.js
@@ -1,13 +1,13 @@
 export default {
 	data: {
-		isActive: true,
+		"is-active": true,
 		isSelected: true,
 		myClass: 'one two'
 	},
 	html: `<div class="one two is-active isSelected"></div>`,
 
 	test ( assert, component, target, window ) {
-		component.set({ isActive: false });
+		component.set({ "is-active": false });
 
 		assert.htmlEqual( target.innerHTML, `
 			<div class="one two isSelected"></div>

--- a/test/runtime/samples/class-shortcut/_config.js
+++ b/test/runtime/samples/class-shortcut/_config.js
@@ -1,0 +1,16 @@
+export default {
+	data: {
+		isActive: true,
+		isSelected: true,
+		myClass: 'one two'
+	},
+	html: `<div class="one two is-active isSelected"></div>`,
+
+	test ( assert, component, target, window ) {
+		component.set({ isActive: false });
+
+		assert.htmlEqual( target.innerHTML, `
+			<div class="one two isSelected"></div>
+		` );
+	}
+};

--- a/test/runtime/samples/class-shortcut/main.html
+++ b/test/runtime/samples/class-shortcut/main.html
@@ -1,0 +1,1 @@
+<div class="{ myClass }" class:is-active class:isSelected class:not-used></div>


### PR DESCRIPTION
When no expression is used in a class directive the class name will be used to evaluate whether the class should be added/removed.

E.g. the following will add the class "active" when you call `component.set({ active });`.

```html
<div class:active></div>
```

Also, classes added this way are encapsulated in the stylesheet.

Old
```html
<div class="{active ? 'active' : ''}"></div>
<style>
.active {
  /* Will be removed from the stylesheet since the compiler can't know it is used */
}
</style>
```
New
```html
<div class:active="active"></div>
<style>
.active {
  /* Will be kept and encapsulate styles */
}
</style>
```