### PR TITLE
Only update inputs when the value changed

### DIFF
--- a/test/js/samples/input-files/expected-bundle.js
+++ b/test/js/samples/input-files/expected-bundle.js
@@ -188,7 +188,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		p(changed, ctx) {
-			if (!input_updating) input.files = ctx.files;
+			if (!input_updating && changed.files) input.files = ctx.files;
 		},
 
 		d(detach) {

--- a/test/js/samples/input-files/expected.js
+++ b/test/js/samples/input-files/expected.js
@@ -25,7 +25,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		p(changed, ctx) {
-			if (!input_updating) input.files = ctx.files;
+			if (!input_updating && changed.files) input.files = ctx.files;
 		},
 
 		d(detach) {

--- a/test/js/samples/input-range/expected-bundle.js
+++ b/test/js/samples/input-range/expected-bundle.js
@@ -190,7 +190,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		p(changed, ctx) {
-			input.value = ctx.value;
+			if (changed.value) input.value = ctx.value;
 		},
 
 		d(detach) {

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -23,7 +23,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		p(changed, ctx) {
-			input.value = ctx.value;
+			if (changed.value) input.value = ctx.value;
 		},
 
 		d(detach) {

--- a/test/js/samples/input-without-blowback-guard/expected-bundle.js
+++ b/test/js/samples/input-without-blowback-guard/expected-bundle.js
@@ -185,7 +185,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		p(changed, ctx) {
-			input.checked = ctx.foo;
+			if (changed.foo) input.checked = ctx.foo;
 		},
 
 		d(detach) {

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -22,7 +22,7 @@ function create_main_fragment(component, ctx) {
 		},
 
 		p(changed, ctx) {
-			input.checked = ctx.foo;
+			if (changed.foo) input.checked = ctx.foo;
 		},
 
 		d(detach) {

--- a/test/js/samples/media-bindings/expected-bundle.js
+++ b/test/js/samples/media-bindings/expected-bundle.js
@@ -226,9 +226,9 @@ function create_main_fragment(component, ctx) {
 		},
 
 		p(changed, ctx) {
-			if (!audio_updating && !isNaN(ctx.currentTime )) audio.currentTime = ctx.currentTime ;
-			if (!audio_updating && audio_is_paused !== (audio_is_paused = ctx.paused )) audio[audio_is_paused ? "pause" : "play"]();
-			if (!audio_updating && !isNaN(ctx.volume)) audio.volume = ctx.volume;
+			if (!audio_updating && !isNaN(ctx.currentTime ) && changed.currentTime) audio.currentTime = ctx.currentTime ;
+			if (!audio_updating && audio_is_paused !== (audio_is_paused = ctx.paused ) && changed.paused) audio[audio_is_paused ? "pause" : "play"]();
+			if (!audio_updating && !isNaN(ctx.volume) && changed.volume) audio.volume = ctx.volume;
 		},
 
 		d(detach) {

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -59,9 +59,9 @@ function create_main_fragment(component, ctx) {
 		},
 
 		p(changed, ctx) {
-			if (!audio_updating && !isNaN(ctx.currentTime )) audio.currentTime = ctx.currentTime ;
-			if (!audio_updating && audio_is_paused !== (audio_is_paused = ctx.paused )) audio[audio_is_paused ? "pause" : "play"]();
-			if (!audio_updating && !isNaN(ctx.volume)) audio.volume = ctx.volume;
+			if (!audio_updating && !isNaN(ctx.currentTime ) && changed.currentTime) audio.currentTime = ctx.currentTime ;
+			if (!audio_updating && audio_is_paused !== (audio_is_paused = ctx.paused ) && changed.paused) audio[audio_is_paused ? "pause" : "play"]();
+			if (!audio_updating && !isNaN(ctx.volume) && changed.volume) audio.volume = ctx.volume;
 		},
 
 		d(detach) {


### PR DESCRIPTION
Fixes #1699

I originally started adding new conditions to [the array in `Elements.ts`](https://github.com/sveltejs/svelte/blob/63276479497a2255c8cc8be535455a0366164700/src/compile/nodes/Element.ts#L499), but once I figured out where to get the dependencies from, it seemed to make more sense to do it in `Bindings.ts` to keep from exposing anything more from the `munge` method.

I didn't add any new tests, I updated/was guided by the existing test suite.  I could add a new test if someone can think of an appropriate one.