### PR TITLE
Simple type-checking in dev-mode

### DIFF
--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -138,8 +138,16 @@ export function setDev(newState) {
 			this._debugName + '.set was called without an object of data key-values to update.'
 		);
 	}
-
+	
 	this._checkReadOnly(newState);
+
+	Object.keys(newState).forEach(prop => {
+		if (prop in this._state && typeof this._state[prop] !== 'undefined' 
+			&& typeof this._state[prop] !== typeof newState[prop]) {
+			console.warn('Type of data property "' + prop + '" not match with previous one.');
+		}
+	});
+	
 	set.call(this, newState);
 }
 


### PR DESCRIPTION
Displays the warning in console if the type of the new value of data property isn't equal to previous. Important in development when interfaces of components are still too fluid.