### PR TITLE
Allow transitions to be local

### DIFF
--- a/src/compile/dom/Block.ts
+++ b/src/compile/dom/Block.ts
@@ -241,7 +241,7 @@ export default class Block {
 			properties.addBlock(`m: @noop,`);
 		} else {
 			properties.addBlock(deindent`
-				${dev ? 'm: function mount' : 'm'}(#target, anchor) {
+				${dev ? 'm: function mount' : 'm'}(#target, anchor${this.compiler.options.nestedTransitions && ', introing'}) {
 					${this.builders.mount}
 				},
 			`);
@@ -281,10 +281,10 @@ export default class Block {
 				properties.addBlock(`i: @noop,`);
 			} else {
 				properties.addBlock(deindent`
-					${dev ? 'i: function intro' : 'i'}(#target, anchor) {
+					${dev ? 'i: function intro' : 'i'}(#target, anchor${this.compiler.options.nestedTransitions && ', introing'}) {
 						if (#current) return;
 						${this.builders.intro}
-						this.m(#target, anchor);
+						this.m(#target, anchor${this.compiler.options.nestedTransitions && ', introing'});
 					},
 				`);
 			}
@@ -293,7 +293,7 @@ export default class Block {
 				properties.addBlock(`o: @run,`);
 			} else {
 				properties.addBlock(deindent`
-					${dev ? 'o: function outro' : 'o'}(#outrocallback) {
+					${dev ? 'o: function outro' : 'o'}(#outrocallback${this.compiler.options.nestedTransitions && ', outroing'}) {
 						if (!#current) return;
 
 						${this.outros > 1 && `#outrocallback = @callAfter(#outrocallback, ${this.outros});`}

--- a/src/compile/dom/index.ts
+++ b/src/compile/dom/index.ts
@@ -227,7 +227,7 @@ export default function dom(
 			this._fragment.c();
 			this._fragment.${block.hasIntroMethod ? 'i' : 'm'}(this.shadowRoot, null);
 
-			if (options.target) this._mount(options.target, options.anchor);
+			if (options.target) this._mount(options.target, options.anchor${compiler.options.nestedTransitions && ', 1'});
 		` : deindent`
 			if (options.target) {
 				${compiler.options.hydratable
@@ -239,7 +239,7 @@ export default function dom(
 				${options.dev &&
 				`if (options.hydrate) throw new Error("options.hydrate only works if the component was compiled with the \`hydratable: true\` option");`}
 				this._fragment.c();`}
-				this._mount(options.target, options.anchor);
+				this._mount(options.target, options.anchor${compiler.options.nestedTransitions && ', 1'});
 
 				${(compiler.hasComponents || target.hasComplexBindings || hasInitHooks || target.hasIntroTransitions) &&
 				`@flush(this);`}

--- a/src/compile/nodes/AwaitBlock.ts
+++ b/src/compile/nodes/AwaitBlock.ts
@@ -177,7 +177,7 @@ export default class AwaitBlock extends Node {
 				const ${countdown} = @callAfter(#outrocallback, 3);
 				for (let #i = 0; #i < 3; #i += 1) {
 					const block = ${info}.blocks[#i];
-					if (block) block.o(${countdown});
+					if (block) block.o(${countdown}, 1);
 					else ${countdown}();
 				}
 			`);

--- a/src/compile/nodes/Component.ts
+++ b/src/compile/nodes/Component.ts
@@ -386,7 +386,7 @@ export default class Component extends Node {
 
 			block.builders.mount.addBlock(deindent`
 				if (${name}) {
-					${name}._mount(${parentNode || '#target'}, ${parentNode ? 'null' : 'anchor'});
+					${name}._mount(${parentNode || '#target'}, ${parentNode ? 'null' : 'anchor'}${compiler.options.nestedTransitions && ', introing'});
 					${this.ref && `#component.refs.${this.ref} = ${name};`}
 				}
 			`);
@@ -486,7 +486,7 @@ export default class Component extends Node {
 			}
 
 			block.builders.mount.addLine(
-				`${name}._mount(${parentNode || '#target'}, ${parentNode ? 'null' : 'anchor'});`
+				`${name}._mount(${parentNode || '#target'}, ${parentNode ? 'null' : 'anchor'}${compiler.options.nestedTransitions ? ', introing' : ''});`
 			);
 
 			if (updates.length) {
@@ -505,7 +505,7 @@ export default class Component extends Node {
 
 		if (this.compiler.options.nestedTransitions) {
 			block.builders.outro.addLine(
-				`if (${name}) ${name}._fragment.o(#outrocallback);`
+				`if (${name}) ${name}._fragment.o(#outrocallback, outroing);`
 			);
 		}
 	}

--- a/src/compile/nodes/IfBlock.ts
+++ b/src/compile/nodes/IfBlock.ts
@@ -140,7 +140,7 @@ export default class IfBlock extends Node {
 
 				if (this.compiler.options.nestedTransitions) {
 					block.builders.outro.addBlock(deindent`
-						if (${name}) ${name}.o(#outrocallback);
+						if (${name}) ${name}.o(#outrocallback, 1);
 						else #outrocallback();
 					`);
 				}
@@ -152,7 +152,7 @@ export default class IfBlock extends Node {
 
 			if (hasOutros && this.compiler.options.nestedTransitions) {
 				block.builders.outro.addBlock(deindent`
-					if (${name}) ${name}.o(#outrocallback);
+					if (${name}) ${name}.o(#outrocallback, 1);
 					else #outrocallback();
 				`);
 			}
@@ -206,7 +206,7 @@ export default class IfBlock extends Node {
 		const initialMountNode = parentNode || '#target';
 		const anchorNode = parentNode ? 'null' : 'anchor';
 		block.builders.mount.addLine(
-			`${if_name}${name}.${mountOrIntro}(${initialMountNode}, ${anchorNode});`
+			`${if_name}${name}.${mountOrIntro}(${initialMountNode}, ${anchorNode}${this.compiler.options.nestedTransitions ? ', 1' : ''});`
 		);
 
 		const updateMountNode = this.getUpdateMountNode(anchor);
@@ -292,7 +292,7 @@ export default class IfBlock extends Node {
 		const anchorNode = parentNode ? 'null' : 'anchor';
 
 		block.builders.mount.addLine(
-			`${if_current_block_type_index}${if_blocks}[${current_block_type_index}].${mountOrIntro}(${initialMountNode}, ${anchorNode});`
+			`${if_current_block_type_index}${if_blocks}[${current_block_type_index}].${mountOrIntro}(${initialMountNode}, ${anchorNode}${this.compiler.options.nestedTransitions ? ', 1' : ''});`
 		);
 
 		const updateMountNode = this.getUpdateMountNode(anchor);
@@ -374,7 +374,7 @@ export default class IfBlock extends Node {
 		const anchorNode = parentNode ? 'null' : 'anchor';
 
 		block.builders.mount.addLine(
-			`if (${name}) ${name}.${mountOrIntro}(${initialMountNode}, ${anchorNode});`
+			`if (${name}) ${name}.${mountOrIntro}(${initialMountNode}, ${anchorNode}${this.compiler.options.nestedTransitions ? ', 1' : ''});`
 		);
 
 		const updateMountNode = this.getUpdateMountNode(anchor);

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -147,8 +147,8 @@ export function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-export function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+export function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 export var PENDING = {};

--- a/src/validate/html/validateElement.ts
+++ b/src/validate/html/validateElement.ts
@@ -85,11 +85,11 @@ export default function validateElement(
 		if (attribute.type === 'Ref') {
 			if (!isValidIdentifier(attribute.name)) {
 				const suggestion = attribute.name.replace(/[^_$a-z0-9]/ig, '_').replace(/^\d/, '_$&');
-				
+
 				validator.error(attribute, {
 					code: `invalid-reference-name`,
 					message: `Reference name '${attribute.name}' is invalid — must be a valid identifier such as ${suggestion}`
-				});	
+				});
 			} else {
 				if (!refs.has(attribute.name)) refs.set(attribute.name, []);
 				refs.get(attribute.name).push(node);
@@ -213,7 +213,7 @@ export default function validateElement(
 			validator.used.events.add(attribute.name);
 			validateEventHandler(validator, attribute, refCallees);
 		} else if (attribute.type === 'Transition') {
-			validator.used.transitions.add(attribute.name);
+			validator.used.transitions.add(attribute.name.split('|')[0]);
 
 			const bidi = attribute.intro && attribute.outro;
 
@@ -249,7 +249,7 @@ export default function validateElement(
 			if (attribute.outro) hasOutro = true;
 			if (bidi) hasTransition = true;
 
-			if (!validator.transitions.has(attribute.name)) {
+			if (!validator.transitions.has(attribute.name.split('|')[0])) {
 				validator.error(attribute, {
 					code: `missing-transition`,
 					message: `Missing transition '${attribute.name}'`

--- a/test/cli/samples/amd/expected/Main.js
+++ b/test/cli/samples/amd/expected/Main.js
@@ -165,8 +165,8 @@ define("test", function() { "use strict";
 		assign(this._staged, newState);
 	}
 
-	function _mount(target, anchor) {
-		this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+	function _mount(target, anchor, introing) {
+		this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 	}
 
 	function _differs(a, b) {

--- a/test/cli/samples/basic/expected/Main.js
+++ b/test/cli/samples/basic/expected/Main.js
@@ -165,8 +165,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/custom-element/expected/Main.js
+++ b/test/cli/samples/custom-element/expected/Main.js
@@ -186,8 +186,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dev/expected/Main.js
+++ b/test/cli/samples/dev/expected/Main.js
@@ -191,8 +191,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir-sourcemap/expected/Main.js
+++ b/test/cli/samples/dir-sourcemap/expected/Main.js
@@ -167,8 +167,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir-sourcemap/expected/Widget.js
+++ b/test/cli/samples/dir-sourcemap/expected/Widget.js
@@ -165,8 +165,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir-subdir/expected/Main.js
+++ b/test/cli/samples/dir-subdir/expected/Main.js
@@ -167,8 +167,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir-subdir/expected/widget/Widget.js
+++ b/test/cli/samples/dir-subdir/expected/widget/Widget.js
@@ -165,8 +165,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir/expected/Main.js
+++ b/test/cli/samples/dir/expected/Main.js
@@ -167,8 +167,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/dir/expected/Widget.js
+++ b/test/cli/samples/dir/expected/Widget.js
@@ -165,8 +165,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/globals/expected/Main.js
+++ b/test/cli/samples/globals/expected/Main.js
@@ -190,8 +190,8 @@ var Main = (function(answer) { "use strict";
 		assign(this._staged, newState);
 	}
 
-	function _mount(target, anchor) {
-		this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+	function _mount(target, anchor, introing) {
+		this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 	}
 
 	function _differs(a, b) {

--- a/test/cli/samples/sourcemap-inline/expected/Main.js
+++ b/test/cli/samples/sourcemap-inline/expected/Main.js
@@ -165,8 +165,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/sourcemap/expected/Main.js
+++ b/test/cli/samples/sourcemap/expected/Main.js
@@ -165,8 +165,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/cli/samples/store/expected/Main.js
+++ b/test/cli/samples/store/expected/Main.js
@@ -189,8 +189,8 @@ function _stage(newState) {
 	assign(this._staged, newState);
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 function _differs(a, b) {

--- a/test/js/samples/action/expected-bundle.js
+++ b/test/js/samples/action/expected-bundle.js
@@ -133,8 +133,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/bind-width-height/expected-bundle.js
+++ b/test/js/samples/bind-width-height/expected-bundle.js
@@ -165,8 +165,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/collapses-text-around-comments/expected-bundle.js
+++ b/test/js/samples/collapses-text-around-comments/expected-bundle.js
@@ -145,8 +145,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/component-static-array/expected-bundle.js
+++ b/test/js/samples/component-static-array/expected-bundle.js
@@ -121,8 +121,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/component-static-immutable/expected-bundle.js
+++ b/test/js/samples/component-static-immutable/expected-bundle.js
@@ -125,8 +125,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/component-static-immutable2/expected-bundle.js
+++ b/test/js/samples/component-static-immutable2/expected-bundle.js
@@ -125,8 +125,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/component-static/expected-bundle.js
+++ b/test/js/samples/component-static/expected-bundle.js
@@ -121,8 +121,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/computed-collapsed-if/expected-bundle.js
+++ b/test/js/samples/computed-collapsed-if/expected-bundle.js
@@ -121,8 +121,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/css-media-query/expected-bundle.js
+++ b/test/js/samples/css-media-query/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/css-shadow-dom-keyframes/expected-bundle.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected-bundle.js
@@ -133,8 +133,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/debug-empty/expected-bundle.js
+++ b/test/js/samples/debug-empty/expected-bundle.js
@@ -169,8 +169,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var protoDev = {

--- a/test/js/samples/debug-foo-bar-baz-things/expected-bundle.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected-bundle.js
@@ -175,8 +175,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var protoDev = {

--- a/test/js/samples/debug-foo/expected-bundle.js
+++ b/test/js/samples/debug-foo/expected-bundle.js
@@ -175,8 +175,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var protoDev = {

--- a/test/js/samples/deconflict-builtins/expected-bundle.js
+++ b/test/js/samples/deconflict-builtins/expected-bundle.js
@@ -155,8 +155,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/deconflict-globals/expected-bundle.js
+++ b/test/js/samples/deconflict-globals/expected-bundle.js
@@ -126,8 +126,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected-bundle.js
@@ -169,8 +169,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var protoDev = {

--- a/test/js/samples/do-use-dataset/expected-bundle.js
+++ b/test/js/samples/do-use-dataset/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected-bundle.js
@@ -141,8 +141,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/dont-use-dataset-in-svg/expected-bundle.js
+++ b/test/js/samples/dont-use-dataset-in-svg/expected-bundle.js
@@ -141,8 +141,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/each-block-changed-check/expected-bundle.js
+++ b/test/js/samples/each-block-changed-check/expected-bundle.js
@@ -157,8 +157,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/each-block-keyed-animated/expected-bundle.js
+++ b/test/js/samples/each-block-keyed-animated/expected-bundle.js
@@ -460,8 +460,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/each-block-keyed/expected-bundle.js
+++ b/test/js/samples/each-block-keyed/expected-bundle.js
@@ -240,8 +240,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/event-handlers-custom/expected-bundle.js
+++ b/test/js/samples/event-handlers-custom/expected-bundle.js
@@ -133,8 +133,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/head-no-whitespace/expected-bundle.js
+++ b/test/js/samples/head-no-whitespace/expected-bundle.js
@@ -133,8 +133,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/if-block-no-update/expected-bundle.js
+++ b/test/js/samples/if-block-no-update/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/if-block-simple/expected-bundle.js
+++ b/test/js/samples/if-block-simple/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/inline-style-optimized-url/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized-url/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/inline-style-optimized/expected-bundle.js
+++ b/test/js/samples/inline-style-optimized/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/inline-style-unoptimized/expected-bundle.js
+++ b/test/js/samples/inline-style-unoptimized/expected-bundle.js
@@ -137,8 +137,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/input-files/expected-bundle.js
+++ b/test/js/samples/input-files/expected-bundle.js
@@ -145,8 +145,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/input-range/expected-bundle.js
+++ b/test/js/samples/input-range/expected-bundle.js
@@ -149,8 +149,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/input-without-blowback-guard/expected-bundle.js
+++ b/test/js/samples/input-without-blowback-guard/expected-bundle.js
@@ -145,8 +145,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/legacy-input-type/expected-bundle.js
+++ b/test/js/samples/legacy-input-type/expected-bundle.js
@@ -139,8 +139,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/media-bindings/expected-bundle.js
+++ b/test/js/samples/media-bindings/expected-bundle.js
@@ -149,8 +149,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/non-imported-component/expected-bundle.js
+++ b/test/js/samples/non-imported-component/expected-bundle.js
@@ -135,8 +135,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/select-dynamic-value/expected-bundle.js
+++ b/test/js/samples/select-dynamic-value/expected-bundle.js
@@ -141,8 +141,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/setup-method/expected-bundle.js
+++ b/test/js/samples/setup-method/expected-bundle.js
@@ -121,8 +121,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/svg-title/expected-bundle.js
+++ b/test/js/samples/svg-title/expected-bundle.js
@@ -141,8 +141,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/title/expected-bundle.js
+++ b/test/js/samples/title/expected-bundle.js
@@ -121,8 +121,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/use-elements-as-anchors/expected-bundle.js
+++ b/test/js/samples/use-elements-as-anchors/expected-bundle.js
@@ -145,8 +145,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/js/samples/window-binding-scroll/expected-bundle.js
+++ b/test/js/samples/window-binding-scroll/expected-bundle.js
@@ -145,8 +145,8 @@ function callAll(fns) {
 	while (fns && fns.length) fns.shift()();
 }
 
-function _mount(target, anchor) {
-	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null);
+function _mount(target, anchor, introing) {
+	this._fragment[this._fragment.i ? 'i' : 'm'](target, anchor || null, introing);
 }
 
 var proto = {

--- a/test/runtime/samples/transition-js-local-nested-await/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-await/_config.js
@@ -1,0 +1,33 @@
+let fulfil;
+
+const promise = new Promise(f => {
+	fulfil = f;
+});
+
+export default {
+	nestedTransitions: true,
+
+	data: {
+		x: false,
+		promise
+	},
+
+	test(assert, component, target, window, raf) {
+		component.set({ x: true });
+		fulfil();
+
+		return promise.then(() => {
+			const div = target.querySelector('div');
+			assert.equal(div.foo, 0);
+
+			raf.tick(100);
+			assert.equal(div.foo, 1);
+
+			component.set({ x: false });
+			assert.htmlEqual(target.innerHTML, '');
+
+			raf.tick(150);
+			assert.equal(div.foo, 1);
+		});
+	}
+};

--- a/test/runtime/samples/transition-js-local-nested-await/main.html
+++ b/test/runtime/samples/transition-js-local-nested-await/main.html
@@ -1,0 +1,20 @@
+{#if x}
+	{#await promise then value}
+		<div transition:foo|local></div>
+	{/await}
+{/if}
+
+<script>
+	export default {
+		transitions: {
+			foo(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.foo = t;
+					}
+				};
+			}
+		}
+	};
+</script>

--- a/test/runtime/samples/transition-js-local-nested-component/Widget.html
+++ b/test/runtime/samples/transition-js-local-nested-component/Widget.html
@@ -1,0 +1,16 @@
+<div transition:foo|local></div>
+
+<script>
+	export default {
+		transitions: {
+			foo(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.foo = t;
+					}
+				};
+			}
+		}
+	};
+</script>

--- a/test/runtime/samples/transition-js-local-nested-component/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-component/_config.js
@@ -1,0 +1,26 @@
+export default {
+	nestedTransitions: true,
+
+	data: {
+		x: false
+	},
+
+	test(assert, component, target, window, raf) {
+		component.set({ x: true });
+
+		const div = target.querySelector('div');
+		assert.equal(div.foo, 0);
+
+		raf.tick(100);
+		assert.equal(div.foo, 1);
+
+		component.set({ x: false });
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+
+		raf.tick(150);
+		assert.equal(div.foo, 0.5);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+	}
+};

--- a/test/runtime/samples/transition-js-local-nested-component/main.html
+++ b/test/runtime/samples/transition-js-local-nested-component/main.html
@@ -1,0 +1,13 @@
+{#if x}
+	<Widget/>
+{/if}
+
+<script>
+	import Widget from './Widget.html';
+
+	export default {
+		components: {
+			Widget: './Widget.html'
+		}
+	};
+</script>

--- a/test/runtime/samples/transition-js-local-nested-each-keyed/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-each-keyed/_config.js
@@ -1,0 +1,32 @@
+export default {
+	nestedTransitions: true,
+
+	data: {
+		x: false,
+		things: ['a']
+	},
+
+	test(assert, component, target, window, raf) {
+		component.set({ x: true });
+
+		const div1 = target.querySelector('div');
+		assert.equal(div1.foo, undefined);
+
+		raf.tick(100);
+		assert.equal(div1.foo, undefined);
+
+		component.set({ things: ['a', 'b'] });
+		assert.htmlEqual(target.innerHTML, '<div></div><div></div>');
+
+		const div2 = target.querySelector('div:last-child');
+		assert.equal(div1.foo, undefined);
+		assert.equal(div2.foo, 0);
+
+		raf.tick(200);
+		assert.equal(div1.foo, undefined);
+		assert.equal(div2.foo, 1);
+
+		component.set({ x: false });
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local-nested-each-keyed/main.html
+++ b/test/runtime/samples/transition-js-local-nested-each-keyed/main.html
@@ -1,0 +1,20 @@
+{#if x}
+	{#each things as thing (thing)}
+		<div transition:foo|local></div>
+	{/each}
+{/if}
+
+<script>
+	export default {
+		transitions: {
+			foo(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.foo = t;
+					}
+				};
+			}
+		}
+	};
+</script>

--- a/test/runtime/samples/transition-js-local-nested-each/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-each/_config.js
@@ -1,0 +1,32 @@
+export default {
+	nestedTransitions: true,
+
+	data: {
+		x: false,
+		things: ['a']
+	},
+
+	test(assert, component, target, window, raf) {
+		component.set({ x: true });
+
+		const div1 = target.querySelector('div');
+		assert.equal(div1.foo, undefined);
+
+		raf.tick(100);
+		assert.equal(div1.foo, undefined);
+
+		component.set({ things: ['a', 'b'] });
+		assert.htmlEqual(target.innerHTML, '<div></div><div></div>');
+
+		const div2 = target.querySelector('div:last-child');
+		assert.equal(div1.foo, undefined);
+		assert.equal(div2.foo, 0);
+
+		raf.tick(200);
+		assert.equal(div1.foo, undefined);
+		assert.equal(div2.foo, 1);
+
+		component.set({ x: false });
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local-nested-each/main.html
+++ b/test/runtime/samples/transition-js-local-nested-each/main.html
@@ -1,0 +1,20 @@
+{#if x}
+	{#each things as thing}
+		<div transition:foo|local></div>
+	{/each}
+{/if}
+
+<script>
+	export default {
+		transitions: {
+			foo(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.foo = t;
+					}
+				};
+			}
+		}
+	};
+</script>

--- a/test/runtime/samples/transition-js-local-nested-if/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-if/_config.js
@@ -1,0 +1,41 @@
+export default {
+	nestedTransitions: true,
+
+	data: {
+		x: false,
+		y: true
+	},
+
+	test(assert, component, target, window, raf) {
+		component.set({ x: true });
+
+		let div = target.querySelector('div');
+		assert.equal(div.foo, undefined);
+
+		component.set({ y: false });
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		div = target.querySelector('div');
+
+		raf.tick(50);
+		assert.equal(div.foo, 0.5);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '');
+
+		component.set({ x: false, y: true });
+		assert.htmlEqual(target.innerHTML, '');
+
+		component.set({ x: true });
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		div = target.querySelector('div');
+
+		component.set({ y: false });
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+
+		raf.tick(150);
+		assert.equal(div.foo, 0.5);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local-nested-if/main.html
+++ b/test/runtime/samples/transition-js-local-nested-if/main.html
@@ -1,0 +1,20 @@
+{#if x}
+	{#if y}
+		<div transition:foo|local></div>
+	{/if}
+{/if}
+
+<script>
+	export default {
+		transitions: {
+			foo(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.foo = t;
+					}
+				};
+			}
+		}
+	};
+</script>

--- a/test/runtime/samples/transition-js-local/_config.js
+++ b/test/runtime/samples/transition-js-local/_config.js
@@ -1,0 +1,41 @@
+export default {
+	nestedTransitions: true,
+
+	data: {
+		x: false,
+		y: true
+	},
+
+	test(assert, component, target, window, raf) {
+		component.set({ x: true });
+
+		let div = target.querySelector('div');
+		assert.equal(div.foo, undefined);
+
+		component.set({ y: false });
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		div = target.querySelector('div');
+
+		raf.tick(50);
+		assert.equal(div.foo, 0.5);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '');
+
+		component.set({ x: false, y: true });
+		assert.htmlEqual(target.innerHTML, '');
+
+		component.set({ x: true });
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		div = target.querySelector('div');
+
+		component.set({ y: false });
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+
+		raf.tick(120);
+		assert.equal(div.foo, 0.8);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local/main.html
+++ b/test/runtime/samples/transition-js-local/main.html
@@ -1,0 +1,20 @@
+{#if x}
+	{#if y}
+		<div transition:foo|local></div>
+	{/if}
+{/if}
+
+<script>
+	export default {
+		transitions: {
+			foo(node, params) {
+				return {
+					duration: 100,
+					tick: t => {
+						node.foo = t;
+					}
+				};
+			}
+		}
+	};
+</script>


### PR DESCRIPTION
Allows transitions to only run locally, skipping running when they are added to the DOM or removed from it.

Example:

```html
{#if visible}
{#each things as thing}
<div transition:fade|local></div>
{/each}
{/if}

<script>
export default {
  transitions: {
    fade(node, params) {
      return {
        duration: 400,
        css: t => {
          return `opacity: ${t}`;
        }
      };
    }
  }
};
</script>
```

In this example items in the each-block will fade in and fade out when they are added to or removed from `things` but the list will appear suddenly and disappear suddenly (no fade) when `visible` is toggled to `true` or `false`.

This is another try at #1480.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
