### PR TITLE
Fix binding input with event in each and add test case.

### DIFF
--- a/src/compile/nodes/Element.ts
+++ b/src/compile/nodes/Element.ts
@@ -399,6 +399,7 @@ export default class Element extends Node {
 			if (eventHandlerOrBindingUsesContext) {
 				initialProps.push(`ctx`);
 				block.builders.update.addLine(`${node}._svelte.ctx = ctx;`);
+				block.maintainContext = true;
 			}
 
 			if (initialProps.length) {

--- a/test/runtime/samples/binding-input-checkbox-with-event-in-each/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-with-event-in-each/_config.js
@@ -1,0 +1,39 @@
+export default {
+	data: {
+		cats: [
+			{
+				name: "cat 0",
+				checked: false,
+			},
+			{
+				name: "cat 1",
+				checked: false,
+			},
+		],
+	},
+
+	html: `
+		<input type="checkbox">
+		<input type="checkbox">
+	`,
+
+	test(assert, component, target, window) {
+		const { cats } = component.get();
+		const newCats = cats.slice();
+		newCats.push({
+			name: "cat " + cats.length,
+			checked: false,
+		});
+		component.set({ cats: newCats });
+
+		let inputs = target.querySelectorAll('input');
+		assert.equal(inputs.length, 3);
+
+		const event = new window.Event('change');
+		inputs[0].checked = true;
+		inputs[0].dispatchEvent(event);
+
+		inputs = target.querySelectorAll('input');
+		assert.equal(inputs.length, 3);
+	}
+};

--- a/test/runtime/samples/binding-input-checkbox-with-event-in-each/main.html
+++ b/test/runtime/samples/binding-input-checkbox-with-event-in-each/main.html
@@ -1,0 +1,14 @@
+{#each cats as cat (cat.name)}
+	<input type="checkbox" bind:checked="cat.checked" on:change="someCheck()">
+{/each}
+
+<script>
+	export default {
+		oncreate() {},
+		methods: {
+			someCheck() {
+				console.log('Check');
+			}
+		},
+	};
+</script>


### PR DESCRIPTION
This small change fix #1732 . If we have binding inside each we always should set local ctx during an update. Previous logic skip this if we have an event on an element. 

Regards,