### PR TITLE
deprecate onerror

### DIFF
--- a/src/compile/wrapModule.ts
+++ b/src/compile/wrapModule.ts
@@ -276,7 +276,7 @@ function getCompatibilityStatements(dependencies: Dependency[]) {
 }
 
 function getGlobals(dependencies: Dependency[], options: CompileOptions) {
-	const { globals, onerror, onwarn } = options;
+	const { globals, onwarn } = options;
 	const globalFn = getGlobalFn(globals);
 
 	return dependencies.map(d => {
@@ -284,10 +284,9 @@ function getGlobals(dependencies: Dependency[], options: CompileOptions) {
 
 		if (!name) {
 			if (d.name.startsWith('__import')) {
-				const error = new Error(
+				throw new Error(
 					`Could not determine name for imported module '${d.source}' – use options.globals`
 				);
-				onerror(error);
 			} else {
 				const warning = {
 					code: `options-missing-globals`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,30 @@
 import compile from './compile/index';
 import { CompileOptions } from './interfaces';
+import deprecate from './utils/deprecate';
 
 export function create(source: string, options: CompileOptions = {}) {
-	options.format = 'eval';
+	const onerror = options.onerror || (err => {
+		throw err;
+	});
 
-	const compiled = compile(source, options);
-
-	if (!compiled || !compiled.js.code) {
-		return;
+	if (options.onerror) {
+		// TODO remove in v3
+		deprecate(`Instead of using options.onerror, wrap svelte.create in a try-catch block`);
+		delete options.onerror;
 	}
 
+	options.format = 'eval';
+
 	try {
+		const compiled = compile(source, options);
+
+		if (!compiled || !compiled.js.code) {
+			return;
+		}
+
 		return (new Function(`return ${compiled.js.code}`))();
 	} catch (err) {
-		if (options.onerror) {
-			options.onerror(err);
-			return;
-		} else {
-			throw err;
-		}
+		onerror(err);
 	}
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -60,10 +60,10 @@ export interface CompileOptions {
 
 	preserveComments?: boolean | false;
 
-	onerror?: (error: Error) => void;
 	onwarn?: (warning: Warning) => void;
 
 	// to remove in v3
+	onerror?: (error: Error) => void;
 	skipIntroByDefault?: boolean;
 	nestedTransitions?: boolean;
 }

--- a/src/utils/deprecate.ts
+++ b/src/utils/deprecate.ts
@@ -1,0 +1,8 @@
+const seen = new Set();
+
+export default function deprecate(message: string, code = message) {
+	if (seen.has(code)) return;
+	seen.add(code);
+
+	console.warn(`[svelte] DEPRECATION: ${message}`);
+}

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -48,6 +48,7 @@ describe('parse', () => {
 		});
 	});
 
+	// TODO remove in v3
 	it('handles errors with options.onerror', () => {
 		let errored = false;
 
@@ -61,6 +62,7 @@ describe('parse', () => {
 		assert.ok(errored);
 	});
 
+	// TODO remove in v3
 	it('throws without options.onerror', () => {
 		assert.throws(() => {
 			svelte.compile(`<h1>unclosed`);


### PR DESCRIPTION
fixes #1745. we'll want to update svelte-loader and rollup-plugin-svelte etc before releasing this