### PR TITLE
Fix removing next link during strip whitespaces for first element.

### DIFF
--- a/src/compile/render-dom/wrappers/Fragment.ts
+++ b/src/compile/render-dom/wrappers/Fragment.ts
@@ -99,9 +99,7 @@ export default class FragmentWrapper {
 				this.nodes.unshift(wrapper);
 
 				link(lastChild, lastChild = wrapper);
-			}
-
-			else {
+			} else {
 				const Wrapper = wrappers[child.type];
 				if (!Wrapper) continue;
 

--- a/src/compile/render-dom/wrappers/Fragment.ts
+++ b/src/compile/render-dom/wrappers/Fragment.ts
@@ -120,10 +120,6 @@ export default class FragmentWrapper {
 				if (!first.data) {
 					first.var = null;
 					this.nodes.shift();
-
-					if (this.nodes.length) {
-						link(null, this.nodes[0]);
-					}
 				}
 			}
 		}

--- a/test/runtime/samples/if-block-first/_config.js
+++ b/test/runtime/samples/if-block-first/_config.js
@@ -1,0 +1,12 @@
+export default {
+	data: {
+		visible: false
+	},
+
+	html: '<div><div>before me</div></div>',
+
+	test ( assert, component, target ) {
+		component.set({ visible: true });
+		assert.htmlEqual(target.innerHTML, '<div><div>i am visible</div><div>before me</div></div>' );
+	}
+};

--- a/test/runtime/samples/if-block-first/main.html
+++ b/test/runtime/samples/if-block-first/main.html
@@ -1,0 +1,6 @@
+<div>
+	{#if visible}
+		<div>i am visible</div>
+	{/if}
+	<div>before me</div>
+</div>


### PR DESCRIPTION
This PR fix my issue https://github.com/sveltejs/svelte/issues/1778 .
The main problem this we shouldn't change the link to the next element after remove first when we have forward motion it's actual for reverse motion only. 
By current code logic next state:
elem1 -> elem2
elem2 -> elem3
elem3 -> null
changed to:
elem2 -> null
elem3 -> null
(we removed first element and for second element set next link as null)