### PR TITLE
Add missing types to store.d.ts

### DIFF
--- a/store.d.ts
+++ b/store.d.ts
@@ -6,14 +6,24 @@ interface Cancellable {
 	cancel: () => void;
 }
 
+interface Tuple<T extends any, L extends number> extends Array<T> {
+	0: T;
+	length: L;
+}
+
 type State = Record<string, any>;
 
 export declare class Store {
 	constructor(state: State, options?: Options);
 
-	public compute(key: string, dependencies: string[]): void;
+	public compute<L extends number>(
+		key: string,
+		dependencies: Tuple<string, L>,
+		fn: (...dependencies: Tuple<any, L>) => any,
+	): void;
+
 	public fire(name: string, data?: any): void;
 	public get(): State;
 	public on(name: string, callback: (data: any) => void): Cancellable;
-	public set(state: State);
+	public set(state: State): void;
 }


### PR DESCRIPTION
This adds some missing types to the Store's declaration file.

`set`'s `void` return type is optional but there are compiler options that make it required, so it doesn't hurt to provide it for users.

`compute`'s third argument was missing and I had a couple of options: either go with the simpler `(...deps: any[]) => any` or fiddle a bit with TypeScript.... I don't think it went _completely_ overboard:

```typescript
interface Tuple<T extends any, L extends number> extends Array<T> {
	0: T;
	length: L;
}

declare function compute<L extends number>(
	key: string,
	dependencies: Tuple<string, L>,
	fn: (...dependencies: Tuple<any, L>) => any,
): void;
```

This has the benefit of reporting errors when the function's prototype doesn't match the specified dependencies. [See error reporting in use](https://www.typescriptlang.org/play/#src=interface%20Tuple%3CT%20extends%20any%2C%20L%20extends%20number%3E%20extends%20Array%3CT%3E%20%7B%0D%0A%20%20%20%200%3A%20T%3B%0D%0A%09length%3A%20L%3B%0D%0A%7D%0D%0A%0D%0Adeclare%20function%20compute%3CL%20extends%20number%3E(%0D%0A%09key%3A%20string%2C%0D%0A%09dependencies%3A%20Tuple%3Cstring%2C%20L%3E%2C%0D%0A%09fn%3A%20(...dependencies%3A%20Tuple%3Cany%2C%20L%3E)%20%3D%3E%20any%2C%0D%0A)%3A%20void%3B%0D%0A%0D%0Acompute('area'%2C%20%5B'width'%2C%20'height'%5D%2C%20(w%2C%20h)%20%3D%3E%20w%20*%20h)%3B%0D%0Acompute('volume'%2C%20%5B'width'%2C%20'height'%2C%20'length'%5D%2C%20(w%2C%20h%2C%20l)%20%3D%3E%20w%20*%20h%20*%20l)%3B%0D%0A%0D%0Acompute('area'%2C%20%5B'width'%2C%20'height'%5D%2C%20(w)%20%3D%3E%20w)%3B%0D%0Acompute('volume'%2C%20%5B'width'%2C%20'height'%2C%20'length'%5D%2C%20(w%2C%20h%2C%20l%2C%20x)%20%3D%3E%20w%20*%20h%20*%20l%20*%20x)%3B%0D%0A).