### PR TITLE
fix: add check for template store to conditional

### DIFF
--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -153,7 +153,7 @@ export default function dom(
 				throw new Error("'target' is a required option");
 			}`}
 			${storeProps.length > 0 && deindent`
-			if (!options.store) {
+			if (!options.store && !${templateProperties.store}) {
 				throw new Error("${debugName} references store properties, but no store was provided");
 			}`}
 		`}

--- a/src/compile/render-ssr/index.ts
+++ b/src/compile/render-ssr/index.ts
@@ -116,7 +116,7 @@ export default function ssr(
 			__result.addComponent(${name});
 
 			${options.dev && storeProps.length > 0 && deindent`
-				if (!options.store) {
+				if (!options.store && !${templateProperties.store}) {
 					throw new Error("${debugName} references store properties, but no store was provided");
 				}
 			`}


### PR DESCRIPTION
Fixes #1828 

This adds to the check introduced in #1811 so that it also handles components that set their own `store` via a function. Previously the check only looked for a passed-in `store` from `options`.

Svelte tests have traditionally been very cranky on my machine, presumably due to being on Windows, but I'm working to try and update some tests and add at least one test to check this functionality.