### PR TITLE
Update cli spec to include --customElement option

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ prog
 	.option('--no-css', `Don't include CSS (useful with SSR)`)
 	.option('--immutable', 'Support immutable data structures')
 	.option('--shared', 'Don\'t include shared helpers')
+	.option('--customElement', 'Generate a custom element')
 
 	.example('compile App.html > App.js')
 	.example('compile src -o dest')


### PR DESCRIPTION
I noticed as I was testing that the CLI supported the --customElement option, but it was not part of the help command. This just adds a simple explanation of what the option does.
