### PR TITLE
Fixes setting custom element data to zero

### DIFF
--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -101,7 +101,7 @@ export function setAttributes(node, attributes) {
 export function setCustomElementData(node, prop, value) {
 	if (prop in node) {
 		node[prop] = value;
-	} else if (value) {
+	} else if (value != null) {
 		setAttribute(node, prop, value);
 	} else {
 		node.removeAttribute(prop);


### PR DESCRIPTION
At the moment it is not possible to set an attribute of a custom element to zero, as the setCustomElementData function removes every attribute whose element evaluates to false (false, 0, "", null, undefined, NaN). I would propose to just filter out undefined and null or to remove this if closure completely as this behaviour should already be covered by the setAttribute() function.