### PR TITLE
Fixes #1440 await blocks gets out of order

### DIFF
--- a/src/compile/render-dom/wrappers/AwaitBlock.ts
+++ b/src/compile/render-dom/wrappers/AwaitBlock.ts
@@ -174,6 +174,9 @@ export default class AwaitBlockWrapper extends Wrapper {
 		block.builders.mount.addBlock(deindent`
 			${info}.block.${hasTransitions ? 'i' : 'm'}(${initialMountNode}, ${info}.anchor = ${anchorNode});
 			${info}.mount = () => ${updateMountNode};
+			if (${info}.anchor == null) {
+				${info}.anchor = ${anchor};
+			}
 		`);
 
 		const conditions = [];

--- a/test/runtime/samples/await-then-catch-order/_config.js
+++ b/test/runtime/samples/await-then-catch-order/_config.js
@@ -1,0 +1,27 @@
+let fulfil;
+
+let thePromise = new Promise(f => {
+	fulfil = f;
+});
+
+export default {
+	data: {
+		thePromise
+	},
+
+	html: `
+		<p>loading...</p><p>true!</p>
+	`,
+
+	test(assert, component, target) {
+		fulfil(42);
+
+		return thePromise
+			.then(() => {
+				assert.htmlEqual(target.innerHTML, `
+					<p>the value is 42</p><p>true!</p>
+				`);
+			});
+
+	}
+};

--- a/test/runtime/samples/await-then-catch-order/main.html
+++ b/test/runtime/samples/await-then-catch-order/main.html
@@ -1,0 +1,11 @@
+{#await thePromise}
+	<p>loading...</p>
+{:then theValue}
+	<p>the value is {theValue}</p>
+{:catch theError}
+	<p>oh no! {theError.message}</p>
+{/await}
+
+{#if true}
+	<p>true!</p>
+{/if}

--- a/test/runtime/samples/transition-js-await-block/_config.js
+++ b/test/runtime/samples/transition-js-await-block/_config.js
@@ -26,10 +26,10 @@ export default {
 		return promise.then(() => {
 			raf.tick(80);
 			let ps = document.querySelectorAll('p');
-			assert.equal(ps[0].className, 'pending');
-			assert.equal(ps[1].className, 'then');
-			assert.equal(ps[0].foo, 0.2);
-			assert.equal(ps[1].foo, 0.3);
+			assert.equal(ps[1].className, 'pending');
+			assert.equal(ps[0].className, 'then');
+			assert.equal(ps[1].foo, 0.2);
+			assert.equal(ps[0].foo, 0.3);
 		});
 	}
 };


### PR DESCRIPTION
Added a failing test for async blocks getting out of order in some situations as shown in #1440.