### PR TITLE
Disable warnings through comments.

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -92,6 +92,7 @@ childKeys.Attribute = ['value'];
 
 export default class Component {
 	stats: Stats;
+	disableWarn: boolean;
 
 	ast: Ast;
 	source: string;
@@ -164,6 +165,7 @@ export default class Component {
 		stats: Stats
 	) {
 		this.stats = stats;
+		this.disableWarn = false;
 
 		this.ast = ast;
 		this.source = source;
@@ -541,6 +543,10 @@ export default class Component {
 			message: string
 		}
 	) {
+		if (this.disableWarn) {
+			return;
+		}
+
 		if (!this.locator) {
 			this.locator = getLocator(this.source, { offsetLine: 1 });
 		}

--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -556,6 +556,13 @@ export default class Component {
 
 		const frame = getCodeFrame(this.source, start.line - 1, start.column);
 
+		if (start && warning.code && frame) {
+			const regex = new RegExp(`(?:${start.line - 1}:\\s*<!--\\s*svelte-disable-next-line|${start.line}:[^\\n]+<!--\\s*svelte-disable-line)\\s+${warning.code}.*?-->`);
+			if (regex.test(frame)) {
+				return;
+			}
+		}
+
 		this.stats.warn({
 			code: warning.code,
 			message: warning.message,

--- a/src/compile/index.ts
+++ b/src/compile/index.ts
@@ -25,7 +25,7 @@ function should_ignore({ start, code, frame }: Warning) {
 		return false;
 	}
 
-	const regex = new RegExp(`(?:${start.line - 1}:\\s*|${start.line}:[^\\n]+)<!--\\s*warn-disable\\s+${code}.*?-->`);
+	const regex = new RegExp(`(?:${start.line - 1}:\\s*<!--\\s*svelte-disable-next-line|${start.line}:[^\\n]+<!--\\s*svelte-disable-line)\\s+${code}.*?-->`);
 	return regex.test(frame);
 }
 

--- a/src/compile/index.ts
+++ b/src/compile/index.ts
@@ -11,22 +11,11 @@ function normalize_options(options: CompileOptions): CompileOptions {
 	let normalized = assign({ generate: 'dom', dev: false }, options);
 	const { onwarn } = normalized;
 
-	normalized.onwarn = (warning: Warning) => {
-		if (!should_ignore(warning)) {
-			onwarn ? onwarn(warning, default_onwarn) : default_onwarn(warning);
-		}
-	}
+	normalized.onwarn = onwarn
+		? (warning: Warning) => onwarn(warning, default_onwarn)
+		: default_onwarn;
 
 	return normalized;
-}
-
-function should_ignore({ start, code, frame }: Warning) {
-	if (!(start && code && frame)) {
-		return false;
-	}
-
-	const regex = new RegExp(`(?:${start.line - 1}:\\s*<!--\\s*svelte-disable-next-line|${start.line}:[^\\n]+<!--\\s*svelte-disable-line)\\s+${code}.*?-->`);
-	return regex.test(frame);
 }
 
 function default_onwarn({ start, message }: Warning) {

--- a/src/compile/nodes/Comment.ts
+++ b/src/compile/nodes/Comment.ts
@@ -7,5 +7,12 @@ export default class Comment extends Node {
 	constructor(component, parent, scope, info) {
 		super(component, parent, scope, info);
 		this.data = info.data;
+
+		const value = this.data.trim();
+		if (value === 'svelte-disable') {
+			component.disableWarn = true;
+		} else if (value === 'svelte-enable') {
+			component.disableWarn = false;
+		}
 	}
 }


### PR DESCRIPTION
Allows disabling warnings using comments. In this example

    <div>
      <!-- warn-disable a11y-missing-attribute -->
      <a></a>
    </div>

The svelte compiler would warn `A11y: <a> element should have child content` but not `A11y: <a> element should have an href attribute`. 

The comments can be place anywhere on the line the error occurred or by themselves on the previous line. For a comment to be valid it must start with `warn-disable` followed by the error code to ignore. White-space is ignored. After the error code comments can contain any text (like a normal comment) to allow the developer to describe why the warning is being ignored.

The test whether of not to ignore a warning is done *before* custom `onwarn` or `default_onwarn` is called. This is to ensure cases like the rollup plugin don't override this functionality.

# The name
I'm not sure `warn-disable` is the best name. Some alternatives

* disable-warning
* a11y-disable
* a11y-ignore
* warn-ignore
* ignore-warning

leaving a11y out of the name might be a good idea to in case we ever add other types of warnings that might want to be ignored (unless we already do? I didn't see anything else). `ignore-warning` is more expressive of the purpose but `warn-disable` is closer to what `eslint` uses.