### PR TITLE
Consume and generate sourcemaps

### DIFF
--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -107,6 +107,7 @@ function compileFile(input, output, options) {
 	let compiled;
 
 	try {
+		delete options.sourceMap; // compiler doesn't use this option
 		compiled = svelte.compile(source, options);
 	} catch (err) {
 		error(err);

--- a/src/compile/index.ts
+++ b/src/compile/index.ts
@@ -7,6 +7,7 @@ import renderSSR from './render-ssr/index';
 import { CompileOptions, Warning, Ast } from '../interfaces';
 import Component from './Component';
 import deprecate from '../utils/deprecate';
+import { relative } from 'path';
 
 function normalize_options(options: CompileOptions): CompileOptions {
 	let normalized = assign({ generate: 'dom', dev: false }, options);
@@ -93,13 +94,24 @@ export default function compile(source: string, options: CompileOptions = {}) {
 		const result = renderDOM(component, options);
 
 		if (options.sourceMap) {
+			const cwd = process.cwd();
 			const inputConsumer = new SourceMapConsumer(options.sourceMap);
 
-			const jsSourceMap = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(result.js.map));
+			result.js.map.sources = result.js.map.sources.map(file =>
+				relative(cwd, file)
+			);
+			const jsSourceMap = SourceMapGenerator.fromSourceMap(
+				new SourceMapConsumer(result.js.map)
+			);
 			jsSourceMap.applySourceMap(inputConsumer);
 			result.js.map = jsSourceMap.toJSON();
 
-			const cssSourceMap = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(result.css.map));
+			result.css.map.sources = result.css.map.sources.map(file =>
+				relative(cwd, file)
+			);
+			const cssSourceMap = SourceMapGenerator.fromSourceMap(
+				new SourceMapConsumer(result.css.map)
+			);
 			cssSourceMap.applySourceMap(inputConsumer);
 			result.css.map = cssSourceMap.toJSON();
 		}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,6 +57,7 @@ export interface CompileOptions {
 	legacy?: boolean;
 	customElement?: CustomElementOptions | true;
 	css?: boolean;
+	sourceMap?: string | object;
 
 	preserveComments?: boolean | false;
 

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -92,10 +92,11 @@ async function replaceTagContents(
 				// Shift sourcemap to the appropriate line
 				if (processed.map) {
 					const consumer = new SourceMapConsumer(processed.map);
-
-					const generator = new SourceMapGenerator({
-						file: relative(process.cwd(), options.filename),
-					});
+					const generator = new SourceMapGenerator(
+						options.filename
+							? { file: relative(process.cwd(), options.filename) }
+							: {}
+					);
 					consumer.eachMapping(mapping => {
 						generator.addMapping({
 							source: mapping.source,
@@ -172,9 +173,9 @@ export default async function preprocess(
 		}
 	}
 
-	let allMaps = new SourceMapGenerator({
-		file: relative(process.cwd(), options.filename),
-	});
+	let allMaps = new SourceMapGenerator(
+		options.filename ? { file: relative(process.cwd(), options.filename) } : {}
+	);
 
 	if (!!style) {
 		const { code, map } = await replaceTagContents(source, 'style', style, options);

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -1,6 +1,7 @@
 import { SourceMap } from 'magic-string';
 import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
 import getCodeFrame from '../utils/getCodeFrame.js';
+import { relative } from 'path';
 
 export interface PreprocessOptions {
 	markup?: (options: {
@@ -92,7 +93,9 @@ async function replaceTagContents(
 				if (processed.map) {
 					const consumer = new SourceMapConsumer(processed.map);
 
-					const generator = new SourceMapGenerator({ file: options.filename });
+					const generator = new SourceMapGenerator({
+						file: relative(process.cwd(), options.filename),
+					});
 					consumer.eachMapping(mapping => {
 						generator.addMapping({
 							source: mapping.source,
@@ -169,7 +172,9 @@ export default async function preprocess(
 		}
 	}
 
-	let allMaps = new SourceMapGenerator({ file: options.filename });
+	let allMaps = new SourceMapGenerator({
+		file: relative(process.cwd(), options.filename),
+	});
 
 	if (!!style) {
 		const { code, map } = await replaceTagContents(source, 'style', style, options);


### PR DESCRIPTION
`preprocess` composes any sourcemaps the preprocessors generate and returns them through a `getMap` function.

`compile` can be provided a sourcemap to consume through a new option `sourceMap`.

I tried to update `source-map` to the latest version but they moved to a promise based api which causes problems with our synchronous compile function.

As far as I can tell it works correctly but test need to be written.