### PR TITLE
Trim Duplicate Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2766,9 +2766,9 @@
       }
     },
     "kleur": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.1.tgz",
-      "integrity": "sha512-Zq/jyANIJ2uX8UZjWlqLwbyhcxSXJtT/Y89lClyeZd3l++3ztL1I5SSCYrbcbwSunTjC88N3WuMk0kRDQD6gzA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.0.tgz",
+      "integrity": "sha512-acHc4xKlqTNuAGmbvtd3KuNi1bnlHsdPg6Os1P5s/Ii/6g8MY3caVPDp4md04/twbh4wwPvdpnol1bc9zFsI3w==",
       "dev": true
     },
     "left-pad": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "acorn": "^5.4.1",
     "acorn-dynamic-import": "^3.0.0",
     "agadoo": "^1.0.1",
-    "chalk": "^2.4.0",
     "codecov": "^3.0.0",
     "css-tree": "1.0.0-alpha22",
     "eslint": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "estree-walker": "^0.6.0",
     "is-reference": "^1.1.0",
     "jsdom": "^11.8.0",
-    "kleur": "^2.0.1",
+    "kleur": "^3.0.0",
     "locate-character": "^2.0.5",
     "magic-string": "^0.25.0",
     "mocha": "^5.2.0",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import * as glob from 'tiny-glob/sync.js';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as chalk from 'chalk';
+import * as colors from 'kleur';
 
 // for coverage purposes, we need to test source files,
 // but for sanity purposes, we need to test dist files
@@ -162,7 +162,7 @@ export function addLineNumbers(code) {
 			while (i.length < 3) i = ` ${i}`;
 
 			return (
-				chalk.grey(`  ${i}: `) +
+				colors.gray(`  ${i}: `) +
 				line.replace(/^\t+/, match => match.split('\t').join('    '))
 			);
 		})
@@ -191,7 +191,7 @@ export function showOutput(cwd, options = {}, compile = svelte.compile) {
 		);
 
 		console.log( // eslint-disable-line no-console
-			`\n>> ${chalk.cyan.bold(file)}\n${addLineNumbers(js.code)}\n<< ${chalk.cyan.bold(file)}`
+			`\n>> ${colors.cyan.bold(file)}\n${addLineNumbers(js.code)}\n<< ${colors.cyan.bold(file)}`
 		);
 	});
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -191,7 +191,7 @@ export function showOutput(cwd, options = {}, compile = svelte.compile) {
 		);
 
 		console.log( // eslint-disable-line no-console
-			`\n>> ${colors.cyan.bold(file)}\n${addLineNumbers(js.code)}\n<< ${colors.cyan.bold(file)}`
+			`\n>> ${colors.cyan().bold(file)}\n${addLineNumbers(js.code)}\n<< ${colors.cyan().bold(file)}`
 		);
 	});
 }


### PR DESCRIPTION
We had `chalk` installed for tests only – replaced it for the runtime variant.

> FWIW, `rfc-1` is failing on my machine with no changes