### PR TITLE
Small update to allow class directives to work in IE11

### DIFF
--- a/src/shared/dom.js
+++ b/src/shared/dom.js
@@ -239,5 +239,5 @@ export function addResizeListener(element, fn) {
 }
 
 export function toggleClass(element, name, toggle) {
-	element.classList.toggle(name, !!toggle);
+	element.classList[toggle ? 'add' : 'remove'](name);
 }


### PR DESCRIPTION
In IE11 the second argument to `classList.toggle` is not respected.  This leads to the class always being added as its initial state and toggled thereafter.  
