### PR TITLE
Glitch free reactive stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte",
-  "version": "3.0.0-alpha3",
+  "version": "3.0.0-alpha6",
   "description": "The magical disappearing UI framework",
   "main": "index.js",
   "bin": {
@@ -12,6 +12,7 @@
     "register.js",
     "index.js",
     "internal.js",
+    "store.js",
     "svelte",
     "README.md"
   ],

--- a/test/store/index.js
+++ b/test/store/index.js
@@ -128,5 +128,27 @@ describe('store', () => {
 			number.set(7);
 			assert.deepEqual(values, [0, 2, 4]);
 		});
+
+		it('prevents glitches', () => {
+			const lastname = writable('Jekyll');
+			const firstname = derive(lastname, n => n === 'Jekyll' ? 'Henry' : 'Edward');
+
+			const fullname = derive([firstname, lastname], names => names.join(' '));
+
+			const values = [];
+
+			const unsubscribe = fullname.subscribe(value => {
+				values.push(value);
+			});
+
+			lastname.set('Hyde');
+
+			assert.deepEqual(values, [
+				'Henry Jekyll',
+				'Edward Hyde'
+			]);
+
+			unsubscribe();
+		});
 	});
 });


### PR DESCRIPTION
Started replying to @marvinhagemeister on https://github.com/sveltejs/rfcs/pull/5 but got side-tracked by trying to see if we could make our reactive stores glitch-free (i.e. if a derived store depends on `a` and `b`, and `b` is also a derived store that depends on `a`, don't recalculate when `a` changes until `b` is also up-to-date).

I *think* this works? But would appreciate a sanity check if anyone is familiar with this problem space...

Explanation: each store's `subscribe` method now takes an optional second `invalidate` method:

```js
store.subscribe(
  value => console.log(`the value is`, value),
  () => console.log(`here comes a new value... I wonder what it will be?`)
);
```

When a store's value changes, it should call all the invalidate functions and *then* call the main callback. Most of the time the second argument is unnecessary, but the `derive` function uses it to update an internal number that keeps track of which inputs are invalid.