### PR TITLE
fix dev mode transitions

### DIFF
--- a/site/src/routes/guide/index.html
+++ b/site/src/routes/guide/index.html
@@ -83,6 +83,17 @@
 		overflow: hidden;
 	}
 
+	aside::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		bottom: 0;
+		width: 100%;
+		height: var(--top-offset);
+		background: linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.7) 50%, rgba(255,255,255,1) 100%);
+		pointer-events: none;
+	}
+
 	.sidebar {
 		padding: var(--top-offset) 3.2rem var(--top-offset) 0;
 		font-family: var(--font-ui);

--- a/src/compile/render-dom/wrappers/Element/index.ts
+++ b/src/compile/render-dom/wrappers/Element/index.ts
@@ -632,7 +632,7 @@ export default class ElementWrapper extends Wrapper {
 
 			const fn = component.qualify(intro.name);
 
-			block.builders.intro.addConditional(`@intro.enabled`, deindent`
+			block.builders.intro.addConditional(`@intros.enabled`, deindent`
 				if (${name}) ${name}.invalidate();
 
 				@add_render_callback(() => {
@@ -669,7 +669,7 @@ export default class ElementWrapper extends Wrapper {
 					`);
 				}
 
-				block.builders.intro.addConditional(`@intro.enabled`, deindent`
+				block.builders.intro.addConditional(`@intros.enabled`, deindent`
 					@add_render_callback(() => {
 						${introName} = @wrapTransition(#component, ${this.var}, ${fn}, ${snippet}, true);
 						${introName}.run(1);

--- a/src/internal/Component.js
+++ b/src/internal/Component.js
@@ -1,4 +1,4 @@
-import { add_render_callback, flush, intro, schedule_update } from './scheduler.js';
+import { add_render_callback, flush, intros, schedule_update } from './scheduler.js';
 import { current_component, set_current_component } from './lifecycle.js'
 import { is_function, run, run_all, noop } from './utils.js';
 import { blankObject } from './utils.js';
@@ -101,7 +101,7 @@ export function init(component, options, instance, create_fragment, not_equal) {
 	$$.fragment = create_fragment(component, $$.ctx);
 
 	if (options.target) {
-		intro.enabled = !!options.intro;
+		intros.enabled = !!options.intro;
 
 		if (options.hydrate) {
 			$$.fragment.l(children(options.target));
@@ -111,7 +111,7 @@ export function init(component, options, instance, create_fragment, not_equal) {
 
 		mount_component(component, options.target, options.anchor);
 		flush();
-		intro.enabled = true;
+		intros.enabled = true;
 	}
 
 	set_current_component(previous_component);

--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -6,7 +6,7 @@ let dirty_components = [];
 const binding_callbacks = [];
 const render_callbacks = [];
 
-export const intro = { enabled: false };
+export const intros = { enabled: false };
 
 export function schedule_update(component) {
 	dirty_components.push(component);


### PR DESCRIPTION
well i feel silly

(in dev mode, fragments' `i` method becomes `i: intro`, so `intro.enabled` was shadowed)

closes #1881 