### PR TITLE
do not display compiler options in embedded REPL

### DIFF
--- a/site/src/routes/repl/_components/Output/index.html
+++ b/site/src/routes/repl/_components/Output/index.html
@@ -5,7 +5,7 @@
 	import PropEditor from './PropEditor.html';
 	import CodeMirror from '../CodeMirror.html';
 
-	export let bundle
+	export let bundle;
 	export let js;
 	export let css;
 	export let dom;
@@ -17,6 +17,7 @@
 	export let sourceErrorLoc;
 	export let runtimeError;
 	export let compileOptions;
+	export let embedded;
 
 	// refs
 	let viewer;
@@ -166,6 +167,14 @@
 			{/if}
 		</section>
 	</SplitPane>
+{:elseif embedded}
+	<CodeMirror
+		mode="javascript"
+		code="{view === 'js' ? js : css}"
+		error={sourceError}
+		errorLoc={sourceErrorLoc}
+		readonly
+	/>
 {:else}
 	<SplitPane type="vertical" pos={67}>
 		<div slot="a">

--- a/site/src/routes/repl/_components/Repl.html
+++ b/site/src/routes/repl/_components/Repl.html
@@ -10,6 +10,7 @@
 
 	export let version = 'alpha'; // TODO change this to latest when the time comes
 	export let app;
+	export let embedded = false;
 
 	export function toJSON() {
 		// TODO there's a bug here — Svelte hoists this function because
@@ -310,6 +311,7 @@
 					{values_store}
 					{sourceError}
 					{runtimeError}
+					{embedded}
 				/>
 			</section>
 		</SplitPane>

--- a/site/src/routes/repl/embed.html
+++ b/site/src/routes/repl/embed.html
@@ -103,6 +103,6 @@
 
 <div class="repl-outer">
 	{#if process.browser}
-		<Repl {version} {app}/>
+		<Repl {version} {app} embedded={true}/>
 	{/if}
 </div>


### PR DESCRIPTION
Slightly less DRY than ideal. An alternative was to have the compiler output pane be `<SplitPane type="vertical" pos={embedded ? 100 : 67}>` but that seemed slightly weirder (and also potentially more confusing, if a user bumps into this strange hidden expandable section).