### PR TITLE
failing test for #1917

### DIFF
--- a/test/runtime/samples/binding-input-text-const/_config.js
+++ b/test/runtime/samples/binding-input-text-const/_config.js
@@ -1,0 +1,26 @@
+export default {
+	html: `
+		<input>
+		<p>hello alice</p>
+	`,
+
+	ssrHtml: `
+		<input value="alice">
+		<p>hello alice</p>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const input = target.querySelector('input');
+		assert.equal(input.value, 'alice');
+
+		const event = new window.Event('input');
+
+		input.value = 'bob';
+		await input.dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<input>
+			<p>hello bob</p>
+		`);
+	},
+};

--- a/test/runtime/samples/binding-input-text-const/main.html
+++ b/test/runtime/samples/binding-input-text-const/main.html
@@ -1,0 +1,8 @@
+<script>
+    const user = {
+        name: 'alice'
+    };
+</script>
+
+<input bind:value={user.name}>
+<p>hello {user.name}</p>


### PR DESCRIPTION
Tempted to kick this can down the road for now, as it's slightly tricky — in order to avoid generating update code for `const` values *generally*, we need to know which `const` values are mutated (either in the `<script>` block, in inline event handlers, or in bindings) before traversing the template AST. Which might mean that we need to walk the AST an extra time?