### PR TITLE
whitelist process, and fallback to globals

### DIFF
--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -279,7 +279,7 @@ export default function dom(
 
 	const user_code = component.javascript || (
 		component.ast.js.length === 0 && filtered_props.length > 0
-			? `let { ${filtered_props.map(x => x.name === x.as ? x.as : `${x.as}: ${x.name}`).join(', ')} } = $$props;`
+			? `let { ${filtered_props.map(x => x.name).join(', ')} } = $$props;`
 			: null
 	);
 

--- a/src/utils/globalWhitelist.ts
+++ b/src/utils/globalWhitelist.ts
@@ -19,6 +19,7 @@ export default new Set([
 	'Object',
 	'parseFloat',
 	'parseInt',
+	'process',
 	'Promise',
 	'RegExp',
 	'Set',

--- a/test/runtime/index.js
+++ b/test/runtime/index.js
@@ -126,7 +126,9 @@ describe("runtime", () => {
 
 					global.window = window;
 
-					// Put the constructor on window for testing
+					if (config.before_test) config.before_test();
+
+					// Put things we need on window for testing
 					window.SvelteComponent = SvelteComponent;
 
 					const target = window.document.querySelector("main");
@@ -208,6 +210,8 @@ describe("runtime", () => {
 					}
 
 					flush();
+
+					if (config.after_test) config.after_test();
 				});
 		});
 	}

--- a/test/runtime/samples/globals-accessible-directly-process/_config.js
+++ b/test/runtime/samples/globals-accessible-directly-process/_config.js
@@ -1,0 +1,11 @@
+export default {
+	html: '<h1>Hello world!</h1>',
+
+	before_test() {
+		process.env.TMP_VAR = 'world';
+	},
+
+	after_test() {
+		delete process.env.TMP_VAR;
+	}
+};

--- a/test/runtime/samples/globals-accessible-directly-process/main.html
+++ b/test/runtime/samples/globals-accessible-directly-process/main.html
@@ -1,0 +1,1 @@
+<h1>Hello {process.env.TMP_VAR}!</h1>

--- a/test/server-side-rendering/index.js
+++ b/test/server-side-rendering/index.js
@@ -114,6 +114,8 @@ describe("ssr", () => {
 			require("../../register")(compileOptions);
 
 			try {
+				if (config.before_test) config.before_test();
+
 				const Component = require(`../runtime/samples/${dir}/main.html`).default;
 				const { html } = Component.render(config.props, {
 					store: (config.store !== true) && config.store
@@ -124,6 +126,8 @@ describe("ssr", () => {
 				} else if (config.html) {
 					assert.htmlEqual(html, config.html);
 				}
+
+				if (config.after_test) config.after_test();
 			} catch (err) {
 				if (config.error) {
 					if (typeof config.error === 'function') {


### PR DESCRIPTION
fixes #1894. Realised `process` is probably a bit of a special case, and should always be treated as a global.

Now that I've implemented it though, I'm not sure if we *do* want to fall back to globals for other names. It's more generated code for a somewhat rare situation. Maybe we're better off just whitelisting stuff and saying 'if you need more control, add a `<script>` tag'?