### PR TITLE
prevent duplicate declaration of store values

### DIFF
--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -257,6 +257,7 @@ export default function dom(
 	const filtered_props = component.props.filter(prop => {
 		if (component.hoistable_names.has(prop.name)) return false;
 		if (component.imported_declarations.has(prop.name)) return false;
+		if (prop.name[0] === '$') return false;
 		return true;
 	});
 

--- a/src/compile/render-ssr/index.ts
+++ b/src/compile/render-ssr/index.ts
@@ -28,11 +28,7 @@ export default function ssr(
 		component.rewrite_props();
 		user_code = component.javascript;
 	} else if (component.ast.js.length === 0 && component.props.length > 0) {
-		const props = component.props.map(prop => {
-			return prop.as === prop.name
-				? prop.as
-				: `${prop.as}: ${prop.name}`
-		});
+		const props = component.props.map(prop => prop.as).filter(name => name[0] !== '$');
 
 		user_code = `let { ${props.join(', ')} } = $$props;`
 	}

--- a/test/runtime/samples/store-auto-subscribe-implicit/_config.js
+++ b/test/runtime/samples/store-auto-subscribe-implicit/_config.js
@@ -1,0 +1,28 @@
+import { writable } from '../../../../store.js';
+
+export default {
+	props: {
+		count: writable(0)
+	},
+
+	html: `
+		<button>count 0</button>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const button = target.querySelector('button');
+		const click = new window.MouseEvent('click');
+
+		await button.dispatchEvent(click);
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>count 1</button>
+		`);
+
+		await component.count.set(42);
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>count 42</button>
+		`);
+	}
+};

--- a/test/runtime/samples/store-auto-subscribe-implicit/main.html
+++ b/test/runtime/samples/store-auto-subscribe-implicit/main.html
@@ -1,0 +1,1 @@
+<button on:click="{() => count.update(n => n + 1)}">count {$count}</button>


### PR DESCRIPTION
fixes #1883. This is the minimal fix, that just removes props with a leading `$`; it doesn't change anything in `stats` since that'll presumably get a larger overhaul separately