### PR TITLE
[WIP] implement bitmask-based change tracking

### DIFF
--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -24,10 +24,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.foo) {
-				setData(text, ctx.foo);
-			}
+		p(ctx) {
+			setData(text, ctx.foo);
 		},
 
 		i(target, anchor) {
@@ -49,7 +47,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { foo = 42 } = $$props;
 
 	$$self.$set = $$props => {
-		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('foo' in $$props) $$invalidate('foo', 0, foo = $$props.foo);
 	};
 
 	return { foo };

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -30,10 +30,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p: function update(changed, ctx) {
-			if (changed.name) {
-				setData(text1, ctx.name);
-			}
+		p: function update(ctx) {
+			setData(text1, ctx.name);
 
 			debugger;
 		},
@@ -58,7 +56,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { name } = $$props;
 
 	$$self.$set = $$props => {
-		if ('name' in $$props) $$invalidate('name', name = $$props.name);
+		if ('name' in $$props) $$invalidate('name', 0, name = $$props.name);
 	};
 
 	return { name };

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -33,12 +33,12 @@ function create_each_block($$, ctx) {
 			insert(target, text1, anchor);
 		},
 
-		p: function update(changed, ctx) {
-			if ((changed.things) && text0_value !== (text0_value = ctx.thing.name)) {
+		p: function update(ctx, changed) {
+			if ((changed & /*things*/1) && text0_value !== (text0_value = ctx.thing.name)) {
 				setData(text0, text0_value);
 			}
 
-			if (changed.foo || changed.bar || changed.baz || changed.things) {
+			if (changed & /*foo, bar, baz or things*/15) {
 				const { foo, bar, baz, thing } = ctx;
 				console.log({ foo, bar, baz, thing });
 				debugger;
@@ -94,8 +94,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p: function update(changed, ctx) {
-			if (changed.things) {
+		p: function update(ctx, changed) {
+			if (changed & /*things*/1) {
 				each_value = ctx.things;
 
 				for (var i = 0; i < each_value.length; i += 1) {
@@ -116,7 +116,7 @@ function create_fragment($$, ctx) {
 				each_blocks.length = each_value.length;
 			}
 
-			if (changed.foo) {
+			if (changed & /*foo*/2) {
 				setData(text2, ctx.foo);
 			}
 		},
@@ -143,10 +143,10 @@ function instance($$self, $$props, $$invalidate) {
 	let { things, foo, bar, baz } = $$props;
 
 	$$self.$set = $$props => {
-		if ('things' in $$props) $$invalidate('things', things = $$props.things);
-		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
-		if ('bar' in $$props) $$invalidate('bar', bar = $$props.bar);
-		if ('baz' in $$props) $$invalidate('baz', baz = $$props.baz);
+		if ('things' in $$props) $$invalidate('things', 0, things = $$props.things);
+		if ('foo' in $$props) $$invalidate('foo', 1, foo = $$props.foo);
+		if ('bar' in $$props) $$invalidate('bar', 2, bar = $$props.bar);
+		if ('baz' in $$props) $$invalidate('baz', 3, baz = $$props.baz);
 	};
 
 	return { things, foo, bar, baz };

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -33,12 +33,12 @@ function create_each_block($$, ctx) {
 			insert(target, text1, anchor);
 		},
 
-		p: function update(changed, ctx) {
-			if ((changed.things) && text0_value !== (text0_value = ctx.thing.name)) {
+		p: function update(ctx, changed) {
+			if ((changed & /*things*/1) && text0_value !== (text0_value = ctx.thing.name)) {
 				setData(text0, text0_value);
 			}
 
-			if (changed.foo) {
+			if (changed & /*foo*/2) {
 				const { foo } = ctx;
 				console.log({ foo });
 				debugger;
@@ -94,15 +94,15 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p: function update(changed, ctx) {
-			if (changed.things) {
+		p: function update(ctx, changed) {
+			if (changed & /*things*/1) {
 				each_value = ctx.things;
 
 				for (var i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
 					if (each_blocks[i]) {
-						each_blocks[i].p(changed, child_ctx);
+						each_blocks[i].p(child_ctx, changed);
 					} else {
 						each_blocks[i] = create_each_block($$, child_ctx);
 						each_blocks[i].c();
@@ -116,7 +116,7 @@ function create_fragment($$, ctx) {
 				each_blocks.length = each_value.length;
 			}
 
-			if (changed.foo) {
+			if (changed & /*foo*/2) {
 				setData(text2, ctx.foo);
 			}
 		},
@@ -143,8 +143,8 @@ function instance($$self, $$props, $$invalidate) {
 	let { things, foo } = $$props;
 
 	$$self.$set = $$props => {
-		if ('things' in $$props) $$invalidate('things', things = $$props.things);
-		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('things' in $$props) $$invalidate('things', 0, things = $$props.things);
+		if ('foo' in $$props) $$invalidate('foo', 1, foo = $$props.foo);
 	};
 
 	return { things, foo };

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -22,8 +22,8 @@ function create_each_block($$, ctx) {
 			append(span, text);
 		},
 
-		p(changed, ctx) {
-			if ((changed.createElement) && text_value !== (text_value = ctx.node)) {
+		p(ctx) {
+			if (text_value !== (text_value = ctx.node)) {
 				setData(text, text_value);
 			}
 		},
@@ -65,27 +65,25 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.createElement) {
-				each_value = ctx.createElement;
+		p(ctx) {
+			each_value = ctx.createElement;
 
-				for (var i = 0; i < each_value.length; i += 1) {
-					const child_ctx = get_each_context(ctx, each_value, i);
+			for (var i = 0; i < each_value.length; i += 1) {
+				const child_ctx = get_each_context(ctx, each_value, i);
 
-					if (each_blocks[i]) {
-						each_blocks[i].p(changed, child_ctx);
-					} else {
-						each_blocks[i] = create_each_block($$, child_ctx);
-						each_blocks[i].c();
-						each_blocks[i].m(each_anchor.parentNode, each_anchor);
-					}
+				if (each_blocks[i]) {
+					each_blocks[i].p(child_ctx);
+				} else {
+					each_blocks[i] = create_each_block($$, child_ctx);
+					each_blocks[i].c();
+					each_blocks[i].m(each_anchor.parentNode, each_anchor);
 				}
-
-				for (; i < each_blocks.length; i += 1) {
-					each_blocks[i].d(1);
-				}
-				each_blocks.length = each_value.length;
 			}
+
+			for (; i < each_blocks.length; i += 1) {
+				each_blocks[i].d(1);
+			}
+			each_blocks.length = each_value.length;
 		},
 
 		i(target, anchor) {

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -27,12 +27,12 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p: function update(changed, ctx) {
-			if ((changed.foo) && text0_value !== (text0_value = Math.max(0, ctx.foo))) {
+		p: function update(ctx, changed) {
+			if ((changed & /*foo*/1) && text0_value !== (text0_value = Math.max(0, ctx.foo))) {
 				setData(text0, text0_value);
 			}
 
-			if (changed.bar) {
+			if (changed & /*bar*/2) {
 				setData(text2, ctx.bar);
 			}
 		},
@@ -58,12 +58,12 @@ function instance($$self, $$props, $$invalidate) {
 	let bar;
 
 	$$self.$set = $$props => {
-		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('foo' in $$props) $$invalidate('foo', 0, foo = $$props.foo);
 	};
 
-	$$self.$$.update = ($$dirty = { foo: 1 }) => {
-		if ($$dirty.foo) {
-			bar = foo * 2; $$invalidate('bar', bar);
+	$$self.$$.update = ($$dirty = -1) => {
+		if ($$dirty & /*foo*/1) {
+			bar = foo * 2; $$invalidate('bar', 1, bar);
 		}
 	};
 

--- a/test/js/samples/do-use-dataset/expected.js
+++ b/test/js/samples/do-use-dataset/expected.js
@@ -20,10 +20,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.bar) {
-				div1.dataset.foo = ctx.bar;
-			}
+		p(ctx) {
+			div1.dataset.foo = ctx.bar;
 		},
 
 		i(target, anchor) {
@@ -47,7 +45,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { bar } = $$props;
 
 	$$self.$set = $$props => {
-		if ('bar' in $$props) $$invalidate('bar', bar = $$props.bar);
+		if ('bar' in $$props) $$invalidate('bar', 0, bar = $$props.bar);
 	};
 
 	return { bar };

--- a/test/js/samples/dont-use-dataset-in-legacy/expected.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected.js
@@ -20,10 +20,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.bar) {
-				setAttribute(div1, "data-foo", ctx.bar);
-			}
+		p(ctx) {
+			setAttribute(div1, "data-foo", ctx.bar);
 		},
 
 		i(target, anchor) {

--- a/test/js/samples/dont-use-dataset-in-svg/expected.js
+++ b/test/js/samples/dont-use-dataset-in-svg/expected.js
@@ -20,10 +20,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.bar) {
-				setAttribute(g1, "data-foo", ctx.bar);
-			}
+		p(ctx) {
+			setAttribute(g1, "data-foo", ctx.bar);
 		},
 
 		i(target, anchor) {
@@ -45,7 +43,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { bar } = $$props;
 
 	$$self.$set = $$props => {
-		if ('bar' in $$props) $$invalidate('bar', bar = $$props.bar);
+		if ('bar' in $$props) $$invalidate('bar', 0, bar = $$props.bar);
 	};
 
 	return { bar };

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -44,16 +44,16 @@ function create_each_block($$, ctx) {
 			raw_before.insertAdjacentHTML("afterend", raw_value);
 		},
 
-		p(changed, ctx) {
-			if ((changed.comments) && text2_value !== (text2_value = ctx.comment.author)) {
+		p(ctx, changed) {
+			if ((changed & /*comments*/1) && text2_value !== (text2_value = ctx.comment.author)) {
 				setData(text2, text2_value);
 			}
 
-			if ((changed.elapsed || changed.comments || changed.time) && text4_value !== (text4_value = ctx.elapsed(ctx.comment.time, ctx.time))) {
+			if ((changed & /*elapsed, comments or time*/ 7) && text4_value !== (text4_value = ctx.elapsed(ctx.comment.time, ctx.time))) {
 				setData(text4, text4_value);
 			}
 
-			if ((changed.comments) && raw_value !== (raw_value = ctx.comment.html)) {
+			if ((changed & /*comments*/1) && raw_value !== (raw_value = ctx.comment.html)) {
 				detachAfter(raw_before);
 				raw_before.insertAdjacentHTML("afterend", raw_value);
 			}
@@ -100,15 +100,15 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.comments || changed.elapsed || changed.time) {
+		p(ctx, changed) {
+			if (changed & /*elapsed, comments or time*/ 7) {
 				each_value = ctx.comments;
 
 				for (var i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
 					if (each_blocks[i]) {
-						each_blocks[i].p(changed, child_ctx);
+						each_blocks[i].p(child_ctx, changed);
 					} else {
 						each_blocks[i] = create_each_block($$, child_ctx);
 						each_blocks[i].c();
@@ -122,7 +122,7 @@ function create_fragment($$, ctx) {
 				each_blocks.length = each_value.length;
 			}
 
-			if (changed.foo) {
+			if (changed & /*foo*/8) {
 				setData(text1, ctx.foo);
 			}
 		},
@@ -149,10 +149,10 @@ function instance($$self, $$props, $$invalidate) {
 	let { comments, elapsed, time, foo } = $$props;
 
 	$$self.$set = $$props => {
-		if ('comments' in $$props) $$invalidate('comments', comments = $$props.comments);
-		if ('elapsed' in $$props) $$invalidate('elapsed', elapsed = $$props.elapsed);
-		if ('time' in $$props) $$invalidate('time', time = $$props.time);
-		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('comments' in $$props) $$invalidate('comments', 0, comments = $$props.comments);
+		if ('elapsed' in $$props) $$invalidate('elapsed', 1, elapsed = $$props.elapsed);
+		if ('time' in $$props) $$invalidate('time', 2, time = $$props.time);
+		if ('foo' in $$props) $$invalidate('foo', 3, foo = $$props.foo);
 	};
 
 	return { comments, elapsed, time, foo };

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -27,8 +27,8 @@ function create_each_block($$, key_1, ctx) {
 			append(div, text);
 		},
 
-		p(changed, ctx) {
-			if ((changed.things) && text_value !== (text_value = ctx.thing.name)) {
+		p(ctx) {
+			if (text_value !== (text_value = ctx.thing.name)) {
 				setData(text, text_value);
 			}
 		},
@@ -82,10 +82,10 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
+		p(ctx) {
 			const each_value = ctx.things;
 			for (let i = 0; i < each_blocks_1.length; i += 1) each_blocks_1[i].r();
-			each_blocks_1 = updateKeyedEach(each_blocks_1, $$, changed, get_key, 1, ctx, each_value, each_lookup, each_anchor.parentNode, fixAndOutroAndDestroyBlock, create_each_block, "m", each_anchor, get_each_context);
+			each_blocks_1 = updateKeyedEach(each_blocks_1, $$, 0, get_key, 1, ctx, each_value, each_lookup, each_anchor.parentNode, fixAndOutroAndDestroyBlock, create_each_block, "m", each_anchor, get_each_context);
 			for (let i = 0; i < each_blocks_1.length; i += 1) each_blocks_1[i].a();
 		},
 
@@ -124,7 +124,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { things } = $$props;
 
 	$$self.$set = $$props => {
-		if ('things' in $$props) $$invalidate('things', things = $$props.things);
+		if ('things' in $$props) $$invalidate('things', 0, things = $$props.things);
 	};
 
 	return { things };

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -27,8 +27,8 @@ function create_each_block($$, key_1, ctx) {
 			append(div, text);
 		},
 
-		p(changed, ctx) {
-			if ((changed.things) && text_value !== (text_value = ctx.thing.name)) {
+		p(ctx) {
+			if (text_value !== (text_value = ctx.thing.name)) {
 				setData(text, text_value);
 			}
 		},
@@ -68,9 +68,9 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
+		p(ctx) {
 			const each_value = ctx.things;
-			each_blocks_1 = updateKeyedEach(each_blocks_1, $$, changed, get_key, 1, ctx, each_value, each_lookup, each_anchor.parentNode, destroyBlock, create_each_block, "m", each_anchor, get_each_context);
+			each_blocks_1 = updateKeyedEach(each_blocks_1, $$, 0, get_key, 1, ctx, each_value, each_lookup, each_anchor.parentNode, destroyBlock, create_each_block, "m", each_anchor, get_each_context);
 		},
 
 		i(target, anchor) {
@@ -94,7 +94,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { things } = $$props;
 
 	$$self.$set = $$props => {
-		if ('things' in $$props) $$invalidate('things', things = $$props.things);
+		if ('things' in $$props) $$invalidate('things', 0, things = $$props.things);
 	};
 
 	return { things };

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -68,7 +68,7 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
+		p(ctx) {
 			if (current_block_type !== (current_block_type = select_block_type(ctx))) {
 				if_block.d(1);
 				if_block = current_block_type($$, ctx);
@@ -97,7 +97,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { foo } = $$props;
 
 	$$self.$set = $$props => {
-		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('foo' in $$props) $$invalidate('foo', 0, foo = $$props.foo);
 	};
 
 	return { foo };

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -40,7 +40,7 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
+		p(ctx) {
 			if (ctx.foo) {
 				if (!if_block) {
 					if_block = create_if_block($$, ctx);
@@ -73,7 +73,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { foo } = $$props;
 
 	$$self.$set = $$props => {
-		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('foo' in $$props) $$invalidate('foo', 0, foo = $$props.foo);
 	};
 
 	return { foo };

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -16,12 +16,12 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.color) {
+		p(ctx, changed) {
+			if (changed & /*color*/1) {
 				setStyle(div, "color", ctx.color);
 			}
 
-			if (changed.x || changed.y) {
+			if (changed & /*x or y*/6) {
 				setStyle(div, "transform", "translate(" + ctx.x + "px," + ctx.y + "px)");
 			}
 		},
@@ -45,9 +45,9 @@ function instance($$self, $$props, $$invalidate) {
 	let { color, x, y } = $$props;
 
 	$$self.$set = $$props => {
-		if ('color' in $$props) $$invalidate('color', color = $$props.color);
-		if ('x' in $$props) $$invalidate('x', x = $$props.x);
-		if ('y' in $$props) $$invalidate('y', y = $$props.y);
+		if ('color' in $$props) $$invalidate('color', 0, color = $$props.color);
+		if ('x' in $$props) $$invalidate('x', 1, x = $$props.x);
+		if ('y' in $$props) $$invalidate('y', 2, y = $$props.y);
 	};
 
 	return { color, x, y };

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -15,10 +15,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.data) {
-				setStyle(div, "background", "url(data:image/png;base64," + ctx.data + ")");
-			}
+		p(ctx) {
+			setStyle(div, "background", "url(data:image/png;base64," + ctx.data + ")");
 		},
 
 		i(target, anchor) {
@@ -40,7 +38,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { data } = $$props;
 
 	$$self.$set = $$props => {
-		if ('data' in $$props) $$invalidate('data', data = $$props.data);
+		if ('data' in $$props) $$invalidate('data', 0, data = $$props.data);
 	};
 
 	return { data };

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -15,10 +15,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.color) {
-				setStyle(div, "color", ctx.color);
-			}
+		p(ctx) {
+			setStyle(div, "color", ctx.color);
 		},
 
 		i(target, anchor) {
@@ -40,7 +38,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { color } = $$props;
 
 	$$self.$set = $$props => {
-		if ('color' in $$props) $$invalidate('color', color = $$props.color);
+		if ('color' in $$props) $$invalidate('color', 0, color = $$props.color);
 	};
 
 	return { color };

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -20,12 +20,12 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.style) {
+		p(ctx, changed) {
+			if (changed & /*style*/1) {
 				div0.style.cssText = ctx.style;
 			}
 
-			if ((changed.key || changed.value) && div1_style_value !== (div1_style_value = "" + ctx.key + ": " + ctx.value)) {
+			if (changed & /*key or value*/6 && div1_style_value !== (div1_style_value = "" + ctx.key + ": " + ctx.value)) {
 				div1.style.cssText = div1_style_value;
 			}
 		},
@@ -51,9 +51,9 @@ function instance($$self, $$props, $$invalidate) {
 	let { style, key, value } = $$props;
 
 	$$self.$set = $$props => {
-		if ('style' in $$props) $$invalidate('style', style = $$props.style);
-		if ('key' in $$props) $$invalidate('key', key = $$props.key);
-		if ('value' in $$props) $$invalidate('value', value = $$props.value);
+		if ('style' in $$props) $$invalidate('style', 0, style = $$props.style);
+		if ('key' in $$props) $$invalidate('key', 1, key = $$props.key);
+		if ('value' in $$props) $$invalidate('value', 2, value = $$props.value);
 	};
 
 	return { style, key, value };

--- a/test/js/samples/input-files/expected.js
+++ b/test/js/samples/input-files/expected.js
@@ -41,11 +41,11 @@ function instance($$self, $$props, $$invalidate) {
 
 	function input_input_handler() {
 		files = this.files;
-		$$invalidate('files', files);
+		$$invalidate('files', 0, files);
 	}
 
 	$$self.$set = $$props => {
-		if ('files' in $$props) $$invalidate('files', files = $$props.files);
+		if ('files' in $$props) $$invalidate('files', 0, files = $$props.files);
 	};
 
 	return { files, input_input_handler };

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -23,8 +23,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.value) input.value = ctx.value;
+		p(ctx) {
+			input.value = ctx.value;
 		},
 
 		i(target, anchor) {
@@ -49,11 +49,11 @@ function instance($$self, $$props, $$invalidate) {
 
 	function input_change_input_handler() {
 		value = toNumber(this.value);
-		$$invalidate('value', value);
+		$$invalidate('value', 0, value);
 	}
 
 	$$self.$set = $$props => {
-		if ('value' in $$props) $$invalidate('value', value = $$props.value);
+		if ('value' in $$props) $$invalidate('value', 0, value = $$props.value);
 	};
 
 	return { value, input_change_input_handler };

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -19,8 +19,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.foo) input.checked = ctx.foo;
+		p(ctx) {
+			input.checked = ctx.foo;
 		},
 
 		i(target, anchor) {
@@ -45,11 +45,11 @@ function instance($$self, $$props, $$invalidate) {
 
 	function input_change_handler() {
 		foo = this.checked;
-		$$invalidate('foo', foo);
+		$$invalidate('foo', 0, foo);
 	}
 
 	$$self.$set = $$props => {
-		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('foo' in $$props) $$invalidate('foo', 0, foo = $$props.foo);
 	};
 
 	return { foo, input_change_handler };

--- a/test/js/samples/instrumentation-script-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-script-if-no-block/expected.js
@@ -24,10 +24,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.x) {
-				setData(text3, ctx.x);
-			}
+		p(ctx) {
+			setData(text3, ctx.x);
 		},
 
 		i(target, anchor) {
@@ -53,7 +51,7 @@ function instance($$self, $$props, $$invalidate) {
 	let x = 0;
 
 	function foo() {
-		if (true) { x += 1; $$invalidate('x', x); }
+		if (true) { x += 1; $$invalidate('x', 0, x); }
 	}
 
 	return { x, foo };

--- a/test/js/samples/instrumentation-script-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-script-x-equals-x/expected.js
@@ -24,8 +24,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if ((changed.things) && text3_value !== (text3_value = ctx.things.length)) {
+		p(ctx) {
+			if (text3_value !== (text3_value = ctx.things.length)) {
 				setData(text3, text3_value);
 			}
 		},
@@ -54,7 +54,7 @@ function instance($$self, $$props, $$invalidate) {
 
 	function foo() {
 		things.push(1);
-		$$invalidate('things', things);
+		$$invalidate('things', 0, things);
 	}
 
 	return { things, foo };

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -24,7 +24,7 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
+		p(ctx) {
 			if (changed.x) {
 				setData(text3, ctx.x);
 			}
@@ -53,7 +53,7 @@ function instance($$self, $$props, $$invalidate) {
 	let x = 0;
 
 	function click_handler() {
-		if (true) { x += 1; $$invalidate('x', x); }
+		if (true) { x += 1; $$invalidate('x', 0, x); }
 	}
 
 	return { x, click_handler };

--- a/test/js/samples/instrumentation-template-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-template-x-equals-x/expected.js
@@ -24,8 +24,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if ((changed.things) && text3_value !== (text3_value = ctx.things.length)) {
+		p(ctx) {
+			if (text3_value !== (text3_value = ctx.things.length)) {
 				setData(text3, text3_value);
 			}
 		},
@@ -52,7 +52,7 @@ function create_fragment($$, ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let things = [];
 
-	function click_handler() { things.push(1); $$invalidate('things', things) }
+	function click_handler() { things.push(1); $$invalidate('things', 0, things) }
 
 	return { things, click_handler };
 }

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -38,10 +38,10 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (!audio_updating && changed.currentTime && !isNaN(ctx.currentTime)) audio.currentTime = ctx.currentTime;
-			if (changed.paused && audio_is_paused !== (audio_is_paused = ctx.paused)) audio[audio_is_paused ? "pause" : "play"]();
-			if (changed.volume && !isNaN(ctx.volume)) audio.volume = ctx.volume;
+		p(ctx, changed) {
+			if (!audio_updating && changed & /*currentTime*/3 && !isNaN(ctx.currentTime)) audio.currentTime = ctx.currentTime;
+			if (changed & /*paused*/5 && audio_is_paused !== (audio_is_paused = ctx.paused)) audio[audio_is_paused ? "pause" : "play"]();
+			if (changed & /*volume*/6 && !isNaN(ctx.volume)) audio.volume = ctx.volume;
 			audio_updating = false;
 		},
 
@@ -68,45 +68,45 @@ function instance($$self, $$props, $$invalidate) {
 	function audio_timeupdate_handler() {
 		played = timeRangesToArray(this.played);
 		currentTime = this.currentTime;
-		$$invalidate('played', played);
-		$$invalidate('currentTime', currentTime);
+		$$invalidate('played', 2, played);
+		$$invalidate('currentTime', 3, currentTime);
 	}
 
 	function audio_durationchange_handler() {
 		duration = this.duration;
-		$$invalidate('duration', duration);
+		$$invalidate('duration', 4, duration);
 	}
 
 	function audio_play_pause_handler() {
 		paused = this.paused;
-		$$invalidate('paused', paused);
+		$$invalidate('paused', 5, paused);
 	}
 
 	function audio_progress_handler() {
 		buffered = timeRangesToArray(this.buffered);
-		$$invalidate('buffered', buffered);
+		$$invalidate('buffered', 0, buffered);
 	}
 
 	function audio_loadedmetadata_handler() {
 		buffered = timeRangesToArray(this.buffered);
 		seekable = timeRangesToArray(this.seekable);
-		$$invalidate('buffered', buffered);
-		$$invalidate('seekable', seekable);
+		$$invalidate('buffered', 0, buffered);
+		$$invalidate('seekable', 1, seekable);
 	}
 
 	function audio_volumechange_handler() {
 		volume = this.volume;
-		$$invalidate('volume', volume);
+		$$invalidate('volume', 6, volume);
 	}
 
 	$$self.$set = $$props => {
-		if ('buffered' in $$props) $$invalidate('buffered', buffered = $$props.buffered);
-		if ('seekable' in $$props) $$invalidate('seekable', seekable = $$props.seekable);
-		if ('played' in $$props) $$invalidate('played', played = $$props.played);
-		if ('currentTime' in $$props) $$invalidate('currentTime', currentTime = $$props.currentTime);
-		if ('duration' in $$props) $$invalidate('duration', duration = $$props.duration);
-		if ('paused' in $$props) $$invalidate('paused', paused = $$props.paused);
-		if ('volume' in $$props) $$invalidate('volume', volume = $$props.volume);
+		if ('buffered' in $$props) $$invalidate('buffered', 0, buffered = $$props.buffered);
+		if ('seekable' in $$props) $$invalidate('seekable', 1, seekable = $$props.seekable);
+		if ('played' in $$props) $$invalidate('played', 2, played = $$props.played);
+		if ('currentTime' in $$props) $$invalidate('currentTime', 3, currentTime = $$props.currentTime);
+		if ('duration' in $$props) $$invalidate('duration', 4, duration = $$props.duration);
+		if ('paused' in $$props) $$invalidate('paused', 5, paused = $$props.paused);
+		if ('volume' in $$props) $$invalidate('volume', 6, volume = $$props.volume);
 	};
 
 	return {

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -35,8 +35,8 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if ((changed.current) && select_value_value !== (select_value_value = ctx.current)) {
+		p(ctx) {
+			if (select_value_value !== (select_value_value = ctx.current)) {
 				for (var i = 0; i < select.options.length; i += 1) {
 					var option = select.options[i];
 
@@ -67,7 +67,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { current } = $$props;
 
 	$$self.$set = $$props => {
-		if ('current' in $$props) $$invalidate('current', current = $$props.current);
+		if ('current' in $$props) $$invalidate('current', 0, current = $$props.current);
 	};
 
 	return { current };

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -10,8 +10,8 @@ function create_fragment($$, ctx) {
 		c: noop,
 		m: noop,
 
-		p(changed, ctx) {
-			if ((changed.custom) && title_value !== (title_value = "a " + ctx.custom + " title")) {
+		p(ctx) {
+			if (title_value !== (title_value = "a " + ctx.custom + " title")) {
 				document.title = title_value;
 			}
 		},
@@ -26,7 +26,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { custom } = $$props;
 
 	$$self.$set = $$props => {
-		if ('custom' in $$props) $$invalidate('custom', custom = $$props.custom);
+		if ('custom' in $$props) $$invalidate('custom', 0, custom = $$props.custom);
 	};
 
 	return { custom };

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -164,7 +164,7 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
+		p(ctx) {
 			if (ctx.a) {
 				if (!if_block0) {
 					if_block0 = create_if_block_4($$, ctx);
@@ -253,11 +253,11 @@ function instance($$self, $$props, $$invalidate) {
 	let { a, b, c, d, e } = $$props;
 
 	$$self.$set = $$props => {
-		if ('a' in $$props) $$invalidate('a', a = $$props.a);
-		if ('b' in $$props) $$invalidate('b', b = $$props.b);
-		if ('c' in $$props) $$invalidate('c', c = $$props.c);
-		if ('d' in $$props) $$invalidate('d', d = $$props.d);
-		if ('e' in $$props) $$invalidate('e', e = $$props.e);
+		if ('a' in $$props) $$invalidate('a', 0, a = $$props.a);
+		if ('b' in $$props) $$invalidate('b', 1, b = $$props.b);
+		if ('c' in $$props) $$invalidate('c', 2, c = $$props.c);
+		if ('d' in $$props) $$invalidate('d', 3, d = $$props.d);
+		if ('e' in $$props) $$invalidate('e', 4, e = $$props.e);
 	};
 
 	return { a, b, c, d, e };

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -26,17 +26,15 @@ function create_fragment($$, ctx) {
 			current = true;
 		},
 
-		p(changed, ctx) {
-			if (changed.y && !scrolling) {
+		p(ctx) {
+			if (!scrolling) {
 				scrolling = true;
 				clearTimeout(scrolling_timeout);
 				window.scrollTo(window.pageXOffset, current["y"]);
 				scrolling_timeout = setTimeout(clear_scrolling, 100);
 			}
 
-			if (changed.y) {
-				setData(text1, ctx.y);
-			}
+			setData(text1, ctx.y);
 		},
 
 		i(target, anchor) {
@@ -60,11 +58,11 @@ function instance($$self, $$props, $$invalidate) {
 	let { y } = $$props;
 
 	function onwindowscroll() {
-		y = window.pageYOffset; $$invalidate('y', y);
+		y = window.pageYOffset; $$invalidate('y', 0, y);
 	}
 
 	$$self.$set = $$props => {
-		if ('y' in $$props) $$invalidate('y', y = $$props.y);
+		if ('y' in $$props) $$invalidate('y', 0, y = $$props.y);
 	};
 
 	return { y, onwindowscroll };


### PR DESCRIPTION
Just some test output for now — manually tweaked all the `expected.js` files to help me think about the problem a bit more. Couple of takeaways:

* I was wrong about being able to represent up to 53 values in a bitmask. JS bitwise operators work in 32 bits, which means we can represent up to 31 values. I don't know if that's a dealbreaker
* If a component only has one reactive value (where 'reactive' means 'referenced in the template or in a reactive declaration'), there's no need for *any* change tracking — if `changed === 0` then we can skip updates altogether, which means that if an update *is* happening then that single reactive value definitely has changed
* Since `changed` is therefore an optional argument to `update` functions, the order of arguments should be reversed — `(ctx, changed) => {...}` rather than `(changed, ctx) => {...}` — so that we can omit it where possible.
* `n & -1` is only `0` when `n === 0` (in fact, for integers up to a certain size, `n & -1 === n`). This gives us an easy way to say 'everything changed,' e.g. when initialising reactive declarations

We might be able to use that insight to reduce duplication between create and update code. If you have a template [like this](https://v3.svelte.technology/repl?version=3.0.0-alpha15&gist=cc1fa26b91ba15a791525c49728b26c9)...

```html
<h1>Hello {name.split('').reverse().reverse().join('').toUpperCase()}!</h1>
```

...that expression is output twice:

```js
function create_fragment($$, ctx) {
  var h1, text0, text1_value = ctx.name.split('').reverse().reverse().join('').toUpperCase(), text1, text2, current;

  return {
    c() {
      h1 = createElement("h1");
      text0 = createText("Hello ");
      text1 = createText(text1_value);
      text2 = createText("!");
    },

    // ...

    p(changed, ctx) {
      if ((changed.name) && text1_value !== (text1_value = ctx.name.split('').reverse().reverse().join('').toUpperCase())) {
        setData(text1, text1_value);
      }
    },

    // ...
  };
}
```

Usually we're not duplicating code as contrived as that, but it's a problem nonetheless. A neater version would look like this:

```diff
function create_fragment($$, ctx) {
-  var h1, text0, text1_value = ctx.name.split('').reverse().reverse().join('').toUpperCase(), text1, text2, current;
+  var h1, text0, text1, text1_value, text2, current;

  return {
    c() {
      h1 = createElement("h1");
      text0 = createText("Hello ");
-     text1 = createText(text1_value);
+     text1 = createText();
      text2 = createText("!");
+     this.p(ctx, -1);
    },

    // ...

-    p(changed, ctx) {
+    p(ctx, changed) {
-      if ((changed.name) && text1_value !== (text1_value = ctx.name.split('').reverse().reverse().join('').toUpperCase())) {
+      if (changed & /*name*/1 && text1_value !== (text1_value = ctx.name.split('').reverse().reverse().join('').toUpperCase())) {
        setData(text1, text1_value);
      }
    },

    // ...
  };
}
```

I had a run that problem a while back but it proved too difficult, particularly around instantiating nested components. It might be easier now.

Also, at present, the `$$dirty` object passed into the reactive declaration update block (which is the same as `changed` elsewhere; we should make that consistent) is conveniently mutable, which means that [sequential updates work](https://v3.svelte.technology/repl?version=3.0.0-alpha15&gist=3ea7951bdff4c875d89d2dcdcd660e7f):

```html
<script>
  export let a = 1;
  let b, c, d;
	
  $: b = a + 1;
  $: c = b + 1;
  $: d = c + 1;
</script>
```

```js
// becomes...
$$self.$$.update = ($$dirty = { a: 1, b: 1, c: 1 }) => {
  if ($$dirty.a) {
    b = a + 1; $$invalidate('b', b);
  }
  if ($$dirty.b) {
    c = b + 1; $$invalidate('c', c);
  }
  if ($$dirty.c) {
    d = c + 1; $$invalidate('d', d);
  }
};
```

Here, `$$dirty.b` is true because of the `$$invalidate('b', b)` right before it. If `$$dirty` isn't an object that would no longer work. So I guess we'd need to do this instead:

```diff
-$$self.$$.update = ($$dirty = { a: 1, b: 1, c: 1 }) => {
+$$self.$$.update = ($$dirty = -1) => {
-  if ($$dirty.a) {
-    b = a + 1; $$invalidate('b', b);
+  if ($$dirty & /*a*/1) {
+    b = a + 1; $$invalidate('b', 1, b); $$dirty |= 2;
  }
-  if ($$dirty.b) {
-    c = b + 1; $$invalidate('c', c);
+  if ($$dirty & /*b*/2) {
+    c = b + 1; $$invalidate('c', 2, c); $$dirty |= 4;
  }
-  if ($$dirty.c) {
-    d = c + 1; $$invalidate('d', d);
+  if ($$dirty & /*c*/4) {
+    d = c + 1; $$invalidate('d', 3, d); $$dirty |= 8;
  }
+  return $$dirty;
};
```