### PR TITLE
Update global.css

### DIFF
--- a/site/static/global.css
+++ b/site/static/global.css
@@ -233,7 +233,7 @@ h1 { font-size: var(--h1) }
 p, ol, ul {
 	line-height: 1.5;
 	margin: 0 0 1em 0;
-	font-family: Roboto;
+	font-family: Roboto, sans-serif;
 	-webkit-font-smoothing: antialiased;
 	/* font-family: var(--font-system); */
 }


### PR DESCRIPTION
Added a `sans-serif` fallback to the `Roboto`-font on `p, ol, ul`-elements to avoid the initial flashing of `Times New Roman` on loads and reloads of the page.