### PR TITLE
Add REPL compiler options scroll

### DIFF
--- a/site/src/routes/repl/_components/Output/CompilerOptions.html
+++ b/site/src/routes/repl/_components/Output/CompilerOptions.html
@@ -5,6 +5,7 @@
 <style>
 	.options {
 		padding: 0 1rem;
+		overflow-y: auto;
 		font-family: var(--font-ui);
 		font-size: 1.3rem;
 		color: #999;


### PR DESCRIPTION
In mobile view Compiler options useless, fixed it
<img width="433" alt="svelte repl 2019-01-03 13-51-24" src="https://user-images.githubusercontent.com/23132107/50634365-6ad27d00-0f5f-11e9-9183-e23ff05ad4fb.png">

