### PR TITLE
Update parallax example to use https: URLs

### DIFF
--- a/site/content/examples/parallax/App.html
+++ b/site/content/examples/parallax/App.html
@@ -8,11 +8,11 @@
 <!-- try changing the values that `sy` is multiplied by -
      values closer to 0 appear further away -->
 <div class="parallax-container">
-	<img style="transform: translate(0,{-sy * 0.2}px)" src="http://www.firewatchgame.com/images/parallax/parallax0.png">
-	<img style="transform: translate(0,{-sy * 0.3}px)" src="http://www.firewatchgame.com/images/parallax/parallax1.png">
-	<img style="transform: translate(0,{-sy * 0.4}px)" src="http://www.firewatchgame.com/images/parallax/parallax3.png">
-	<img style="transform: translate(0,{-sy * 0.5}px)" src="http://www.firewatchgame.com/images/parallax/parallax5.png">
-	<img style="transform: translate(0,{-sy * 0.6}px)" src="http://www.firewatchgame.com/images/parallax/parallax7.png">
+	<img style="transform: translate(0,{-sy * 0.2}px)" src="https://www.firewatchgame.com/images/parallax/parallax0.png">
+	<img style="transform: translate(0,{-sy * 0.3}px)" src="https://www.firewatchgame.com/images/parallax/parallax1.png">
+	<img style="transform: translate(0,{-sy * 0.4}px)" src="https://www.firewatchgame.com/images/parallax/parallax3.png">
+	<img style="transform: translate(0,{-sy * 0.5}px)" src="https://www.firewatchgame.com/images/parallax/parallax5.png">
+	<img style="transform: translate(0,{-sy * 0.6}px)" src="https://www.firewatchgame.com/images/parallax/parallax7.png">
 </div>
 
 <div class="text">


### PR DESCRIPTION
It’s very common for http: URLs not to load in https: page now. These images are served on https: also, so use that.

Another note on this example: the lack of an `alt` tag is causing a11y warnings. I haven’t taken any action on *that*.