### PR TITLE
preserve attributes during preprocess

### DIFF
--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -60,7 +60,7 @@ export default async function preprocess(
 						attributes: parseAttributes(attributes),
 						filename: options.filename,
 					}));
-				return processed ? `<${type}>${processed.code}</${type}>` : match;
+				return processed ? `<${type}${attributes}>${processed.code}</${type}>` : match;
 			}
 		);
 	}

--- a/test/preprocess/index.js
+++ b/test/preprocess/index.js
@@ -151,6 +151,10 @@ describe('preprocess', () => {
 			<style type='text/scss' data-foo="bar" bool></style>
 		`;
 
+		const expected = `
+			<style type='text/scss' data-foo="bar" bool>PROCESSED</style>
+		`;
+
 		return svelte.preprocess(source, {
 			style: ({ attributes }) => {
 				assert.deepEqual(attributes, {
@@ -158,7 +162,10 @@ describe('preprocess', () => {
 					'data-foo': 'bar',
 					bool: true
 				});
+				return { code: 'PROCESSED' };
 			}
+		}).then(processed => {
+			assert.equal(processed.toString(), expected);
 		});
 	});
 


### PR DESCRIPTION
This just always preserves attributes when passing components through `.preprocess` (#1873). It doesn't provide any way to control these attributes. I think we should see how well we do with this. We can always add the ability to adjust the attributes later post-3.0.