### PR TITLE
site: update readme and tidy package.json

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,75 +1,36 @@
-# sapper-template-rollup
+## Running locally
 
-A version of the default [Sapper](https://github.com/sveltejs/sapper) template that uses Rollup instead of webpack. To clone it and get started:
+Set up the project:
 
 ```bash
-npx degit sveltejs/sapper-template#rollup my-app
-cd my-app
-npm install # or yarn!
+git clone https://github.com/sveltejs/svelte.git
+cd svelte/site
+npm ci
+npm run update
+```
+
+Start the server with `npm run dev`, and navigate to [localhost:3000](http://localhost:3000).
+
+## Using a local copy of Svelte
+
+By default, the REPL will fetch the most recent version of Svelte from https://unpkg.com/svelte. If you need to test a local version of Svelte, you can do so by linking it and navigating to [localhost:3000/repl?version=local](http://localhost:3000/repl?version=local):
+
+```bash
+cd /path/to/svelte
+npm link
+npm run dev # rebuild Svelte on changes
+
+cd /path/to/svelte/site
+npm link svelte
 npm run dev
 ```
 
-Open up [localhost:3000](http://localhost:3000) and start clicking around.
+## REPL GitHub integration
 
-Consult [sapper.svelte.technology](https://sapper.svelte.technology) for help getting started.
+In order for the REPL's GitHub integration to work properly when running locally, you will need to create a GitHub OAuth app. Set its authorization callback URL to `http://localhost:3000/auth/callback`, and in this project, create `site/.env` containing:
 
-*[Click here for the webpack version of this template](https://github.com/sveltejs/sapper-template)*
-
-## Structure
-
-Sapper expects to find three directories in the root of your project —  `app`, `assets` and `routes`.
-
-
-### app
-
-The [app](app) directory contains the entry points for your app — `client.js`, `server.js` and (optionally) a `service-worker.js` — along with a `template.html` file.
-
-
-### assets
-
-The [assets](assets) directory contains any static assets that should be available. These are served using [sirv](https://github.com/lukeed/sirv).
-
-In your [service-worker.js](app/service-worker.js) file, you can import these as `assets` from the generated manifest...
-
-```js
-import { assets } from './manifest/service-worker.js';
 ```
-
-...so that you can cache them (though you can choose not to, for example if you don't want to cache very large files).
-
-
-### routes
-
-This is the heart of your Sapper app. There are two kinds of routes — *pages*, and *server routes*.
-
-**Pages** are Svelte components written in `.html` files. When a user first visits the application, they will be served a server-rendered version of the route in question, plus some JavaScript that 'hydrates' the page and initialises a client-side router. From that point forward, navigating to other pages is handled entirely on the client for a fast, app-like feel. (Sapper will preload and cache the code for these subsequent pages, so that navigation is instantaneous.)
-
-**Server routes** are modules written in `.js` files, that export functions corresponding to HTTP methods. Each function receives Express `request` and `response` objects as arguments, plus a `next` function. This is useful for creating a JSON API, for example.
-
-There are three simple rules for naming the files that define your routes:
-
-* A file called `routes/about.html` corresponds to the `/about` route. A file called `routes/blog/[slug].html` corresponds to the `/blog/:slug` route, in which case `params.slug` is available to the route
-* The file `routes/index.html` (or `routes/index.js`) corresponds to the root of your app. `routes/about/index.html` is treated the same as `routes/about.html`.
-* Files and directories with a leading underscore do *not* create routes. This allows you to colocate helper modules and components with the routes that depend on them — for example you could have a file called `routes/_helpers/datetime.js` and it would *not* create a `/_helpers/datetime` route
-
-
-## Rollup config
-
-Sapper uses Rollup to provide code-splitting and dynamic imports, as well as compiling your Svelte components. As long as you don't do anything daft, you can edit the configuration files to add whatever plugins you'd like.
-
-
-## Production mode and deployment
-
-To start a production version of your app, run `npm run build && npm start`.
-
-You can deploy your application to any environment that supports Node 8 or above. As an example, to deploy to [Now](https://zeit.co/now), run these commands:
-
-```bash
-npm install -g now
-now
+GITHUB_CLIENT_ID=[your app's client id]
+GITHUB_CLIENT_SECRET=[your app's client secret]
+BASEURL=http://localhost:3000
 ```
-
-
-## Bugs and feedback
-
-Sapper is in early development, and may have the odd rough edge here and there. Please be vocal over on the [Sapper issue tracker](https://github.com/sveltejs/sapper/issues).

--- a/site/package.json
+++ b/site/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "TODO",
-  "description": "TODO",
-  "version": "0.0.1",
+  "name": "svelte.technology",
+  "version": "1.0.0",
+  "description": "Docs and examples for Svelte",
   "scripts": {
     "dev": "sapper dev",
     "sapper": "sapper build --legacy",
-    "update_template": "sh ./scripts/update_template.sh",
+    "update": "sh scripts/update_template.sh && node scripts/get-contributors.js",
     "start": "node __sapper__/build",
     "cy:run": "cypress run",
     "cy:open": "cypress open",
     "test": "run-p --race dev cy:run",
     "deploy": "npm run stage && now alias",
-    "prestage": "npm run update_template && node scripts/get-contributors.js && npm run sapper",
+    "prestage": "npm run update && npm run sapper",
     "stage": "now"
   },
   "dependencies": {


### PR DESCRIPTION
Brings over and updates the helpful bits from svelte.technology's readme. Also tidies a couple of things in site/package.json, including a new `npm run update` (not thrilled with this name) that calls `update_template.sh` and `get-contributors.js` and going forward anything else we only really need to do once after cloning and then right before deploying.