### PR TITLE
Render default slot content event handlers conditionally (with bonus) - #1977

### DIFF
--- a/src/compile/render-dom/Block.ts
+++ b/src/compile/render-dom/Block.ts
@@ -234,29 +234,7 @@ export default class Block {
 			this.builders.mount.addLine(`${this.autofocus}.focus();`);
 		}
 
-		if (this.event_listeners.length > 0) {
-			this.addVariable('#dispose');
-
-			if (this.event_listeners.length === 1) {
-				this.builders.hydrate.addLine(
-					`#dispose = ${this.event_listeners[0]};`
-				);
-
-				this.builders.destroy.addLine(
-					`#dispose();`
-				)
-			} else {
-				this.builders.hydrate.addBlock(deindent`
-					#dispose = [
-						${this.event_listeners.join(',\n')}
-					];
-				`);
-
-				this.builders.destroy.addLine(
-					`@run_all(#dispose);`
-				);
-			}
-		}
+		this.renderListeners();
 
 		const properties = new CodeBuilder();
 
@@ -401,6 +379,32 @@ export default class Block {
 		`.replace(/(#+)(\w*)/g, (match: string, sigil: string, name: string) => {
 			return sigil === '#' ? this.alias(name) : sigil.slice(1) + name;
 		});
+	}
+
+	renderListeners(chunk: string = '') {
+		if (this.event_listeners.length > 0) {
+			this.addVariable(`#dispose${chunk}`);
+
+			if (this.event_listeners.length === 1) {
+				this.builders.hydrate.addLine(
+					`#dispose${chunk} = ${this.event_listeners[0]};`
+				);
+
+				this.builders.destroy.addLine(
+					`#dispose${chunk}();`
+				)
+			} else {
+				this.builders.hydrate.addBlock(deindent`
+					#dispose${chunk} = [
+						${this.event_listeners.join(',\n')}
+					];
+				`);
+
+				this.builders.destroy.addLine(
+					`@run_all(#dispose${chunk});`
+				);
+			}
+		}
 	}
 
 	toString() {

--- a/src/compile/render-dom/wrappers/Slot.ts
+++ b/src/compile/render-dom/wrappers/Slot.ts
@@ -72,7 +72,11 @@ export default class SlotWrapper extends Wrapper {
 		block.builders.update.pushCondition(`!${content_name}`);
 		block.builders.destroy.pushCondition(`!${content_name}`);
 
+		const listeners = block.event_listeners;
+		block.event_listeners = [];
 		this.fragment.render(block, parentNode, parentNodes);
+		block.renderListeners(`_${content_name}`);
+		block.event_listeners = listeners;
 
 		block.builders.create.popCondition();
 		block.builders.hydrate.popCondition();

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -86,6 +86,7 @@ function create_fragment($$, ctx) {
 
 		d(detach) {
 			if_block.d(detach);
+			
 			if (detach) {
 				detachNode(if_block_anchor);
 			}

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -62,6 +62,7 @@ function create_fragment($$, ctx) {
 
 		d(detach) {
 			if (if_block) if_block.d(detach);
+			
 			if (detach) {
 				detachNode(if_block_anchor);
 			}

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -237,11 +237,13 @@ function create_fragment($$, ctx) {
 			if (if_block1) if_block1.d();
 			if (if_block2) if_block2.d();
 			if (if_block3) if_block3.d();
+
 			if (detach) {
 				detachNode(text7);
 			}
 
 			if (if_block4) if_block4.d(detach);
+			
 			if (detach) {
 				detachNode(if_block4_anchor);
 			}

--- a/test/runtime/samples/component-slot-used-with-default-event/Nested.html
+++ b/test/runtime/samples/component-slot-used-with-default-event/Nested.html
@@ -1,0 +1,7 @@
+<script>
+	function click() {}
+</script>
+
+<p>
+	<slot><button on:click>Should not appear</button></slot>
+</p>

--- a/test/runtime/samples/component-slot-used-with-default-event/_config.js
+++ b/test/runtime/samples/component-slot-used-with-default-event/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: '<p>Hello</p>', show: true
+};

--- a/test/runtime/samples/component-slot-used-with-default-event/main.html
+++ b/test/runtime/samples/component-slot-used-with-default-event/main.html
@@ -1,0 +1,7 @@
+<script>
+	import Nested from './Nested.html';
+</script>
+
+<Nested>
+	Hello
+</Nested>


### PR DESCRIPTION
This adds a little step to slot rendering that makes event handlers render inside a conditional for the slot default content, which fixes #1977, but...

There's an issue with code builder that causes some weird end of block `}`s to get misplaced with stacked `addConditional` and `pushCondition`s, generating invalid code in the destroy handler. I got a little lost trying to track the stringy handling in the code builder, so I wimpled out and rewrote it as a tree of collected statements that handle stringification in the `toString` method. This may totally not be a direction anybody wants to take, but it simplified the management of statements quite a bit. The stringification is a little complex, but it is all bundled together in one relatively readable chunk.

If it's a reasonable approach, this could also open up a path for dropping some redundant `if` blocks. For instance, `addConditional` could get another param that allowed reusing an existing `if` block for statements that aren't order-sensitive, so things like:

```js
		d(detach) {
			if (detach) {
				detachNode(div);
			}

			if (if_block0) if_block0.d();
			if (if_block1) if_block1.d();
			if (if_block2) if_block2.d();
			if (if_block3) if_block3.d();

			if (detach) {
				detachNode(text7);
			}

			if (if_block4) if_block4.d(detach);
			
			if (detach) {
				detachNode(if_block4_anchor);
			}
		}
```

could become

```js
		d(detach) {
			if (detach) {
				detachNode(div);
				detachNode(text7);
				detachNode(if_block4_anchor);
			}

			if (if_block0) if_block0.d();
			if (if_block1) if_block1.d();
			if (if_block2) if_block2.d();
			if (if_block3) if_block3.d();
		}
```