### PR TITLE
Fix adjacent tracking across adjacent scopes - #1985

### DIFF
--- a/src/compile/nodes/shared/TemplateScope.ts
+++ b/src/compile/nodes/shared/TemplateScope.ts
@@ -1,6 +1,6 @@
 export default class TemplateScope {
 	names: Set<string>;
-	dependenciesForName: Map<string, string>;
+	dependenciesForName: Map<string, Set<string>>;
 	mutables: Set<string>;
 	parent?: TemplateScope;
 
@@ -11,7 +11,7 @@ export default class TemplateScope {
 		this.mutables = new Set();
 	}
 
-	add(name, dependencies) {
+	add(name, dependencies: Set<string>) {
 		this.names.add(name);
 		this.dependenciesForName.set(name, dependencies);
 		return this;
@@ -23,8 +23,10 @@ export default class TemplateScope {
 	}
 
 	setMutable(name: string) {
-		if (this.names.has(name)) this.mutables.add(name);
-		else if (this.parent) this.parent.setMutable(name);
+		if (this.names.has(name)) {
+			this.mutables.add(name);
+			if (this.parent && this.dependenciesForName.has(name)) this.dependenciesForName.get(name).forEach(dep => this.parent.setMutable(dep));
+		} else if (this.parent) this.parent.setMutable(name);
 		else this.mutables.add(name);
 	}
 

--- a/test/runtime/samples/mutation-tracking-across-sibling-scopes/_config.js
+++ b/test/runtime/samples/mutation-tracking-across-sibling-scopes/_config.js
@@ -1,0 +1,12 @@
+export default {
+	async test({ assert, component, target }) {
+		assert.htmlEqual(component.div.innerHTML, '<div>+</div><div>-</div>');
+
+		const event = new window.Event('change');
+		const input = target.querySelector('input');
+		input.checked = false;
+		await input.dispatchEvent(event);
+
+		assert.htmlEqual(component.div.innerHTML, '<div>-</div><div>-</div>');
+	}
+};

--- a/test/runtime/samples/mutation-tracking-across-sibling-scopes/main.html
+++ b/test/runtime/samples/mutation-tracking-across-sibling-scopes/main.html
@@ -1,0 +1,18 @@
+{#each things as thing}
+	<div>
+		<input type=checkbox bind:checked={thing.ok} />
+	</div>
+{/each}
+
+<div bind:this={div}>
+	{#each things as other}
+		<div>
+			{other.ok ? '+' : '-'}
+		</div>
+	{/each}
+</div>
+
+<script>
+	const things = [{ ok: true }, { ok: false }];
+	export let div;
+</script>


### PR DESCRIPTION
This sets deps of a reference as mutated along with the reference so that update code is not skipped for the reference deps if they also happen to appear in an adjacent scope.

This is an area that could probably use a little bit of improvement down the road. Right now, deps on any given expression don't really indicate which parts are affected by mutation e.g. in `{#each foo[bar] as whatever}<button on:click={() => whatever.sure += 'yes'}>mutate foo, but not bar</button>{/each}`. With this PR, `bar` will also be flagged as mutated, which isn't exactly ideal, as it's not in this case.