### PR TITLE
hoist vars and lets that don't change

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -750,18 +750,18 @@ export default class Component {
 	}
 
 	hoist_instance_declarations() {
-		// we can safely hoist `const` declarations that are
+		// we can safely hoist variable declarations that are
 		// initialised to literals, and functions that don't
 		// reference instance variables other than other
 		// hoistable functions. TODO others?
 
-		const { hoistable_names, hoistable_nodes, imported_declarations } = this;
+		const { hoistable_names, hoistable_nodes, imported_declarations, instance_scope: scope } = this;
 
 		const top_level_function_declarations = new Map();
 
 		this.instance_script.content.body.forEach(node => {
-			if (node.kind === 'const') { // TODO or let or var, if never reassigned in <script> or template
-				if (node.declarations.every(d => d.init.type === 'Literal')) {
+			if (node.type === 'VariableDeclaration') {
+				if (node.declarations.every(d => d.init && d.init.type === 'Literal' && !this.mutable_props.has(d.id.name))) {
 					node.declarations.forEach(d => {
 						hoistable_names.add(d.id.name);
 					});

--- a/test/js/samples/hoisted-let/expected.js
+++ b/test/js/samples/hoisted-let/expected.js
@@ -2,21 +2,17 @@
 import { SvelteComponent as SvelteComponent_1, append, createElement, createText, detachNode, identity, init, insert, noop, safe_not_equal } from "svelte/internal";
 
 function create_fragment($$, ctx) {
-	var h1, text0, text1, text2;
+	var b, text_value = get_answer(), text;
 
 	return {
 		c() {
-			h1 = createElement("h1");
-			text0 = createText("Hello ");
-			text1 = createText(name);
-			text2 = createText("!");
+			b = createElement("b");
+			text = createText(text_value);
 		},
 
 		m(target, anchor) {
-			insert(target, h1, anchor);
-			append(h1, text0);
-			append(h1, text1);
-			append(h1, text2);
+			insert(target, b, anchor);
+			append(b, text);
 		},
 
 		p: noop,
@@ -25,13 +21,15 @@ function create_fragment($$, ctx) {
 
 		d(detach) {
 			if (detach) {
-				detachNode(h1);
+				detachNode(b);
 			}
 		}
 	};
 }
 
-let name = 'world';
+let ANSWER = 42;
+
+function get_answer() { return ANSWER; }
 
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {

--- a/test/js/samples/hoisted-let/input.html
+++ b/test/js/samples/hoisted-let/input.html
@@ -1,0 +1,6 @@
+<script>
+	let ANSWER = 42;
+	function get_answer() { return ANSWER; }
+</script>
+
+<b>{get_answer()}</b>

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -83,7 +83,7 @@ function create_fragment($$, ctx) {
 
 		d(detach) {
 			if_block.d(detach);
-			
+
 			if (detach) {
 				detachNode(if_block_anchor);
 			}

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -57,7 +57,7 @@ function create_fragment($$, ctx) {
 
 		d(detach) {
 			if (if_block) if_block.d(detach);
-			
+
 			if (detach) {
 				detachNode(if_block_anchor);
 			}

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -11,7 +11,7 @@ function create_fragment($$, ctx) {
 			text1 = createText("\n\n");
 			p = createElement("p");
 			text2 = createText("x: ");
-			text3 = createText(ctx.x);
+			text3 = createText(x);
 			dispose = addListener(button, "click", ctx.click_handler);
 		},
 
@@ -25,7 +25,7 @@ function create_fragment($$, ctx) {
 
 		p(changed, ctx) {
 			if (changed.x) {
-				setData(text3, ctx.x);
+				setData(text3, x);
 			}
 		},
 
@@ -44,14 +44,15 @@ function create_fragment($$, ctx) {
 	};
 }
 
+let x = 0;
+
 function instance($$self, $$props, $$invalidate) {
-	let x = 0;
 
 	function click_handler() {
 		if (true) { x += 1; $$invalidate('x', x); }
 	}
 
-	return { x, click_handler };
+	return { click_handler };
 }
 
 class SvelteComponent extends SvelteComponent_1 {

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -238,7 +238,7 @@ function create_fragment($$, ctx) {
 			}
 
 			if (if_block4) if_block4.d(detach);
-			
+
 			if (detach) {
 				detachNode(if_block4_anchor);
 			}


### PR DESCRIPTION
This addresses the second part of #1952 — `let x = 1` and `const x = 1` are both treated the same way if `x` is never reassigned, which can result in slightly less code.