### PR TITLE
prevent writing to reactive values

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -881,15 +881,10 @@ export default class Component {
 							scope = map.get(node);
 						}
 
-						if (parent && parent.type === 'AssignmentExpression' && node === parent.left) {
-							return this.skip();
-						}
-
 						if (node.type === 'AssignmentExpression') {
 							assignees.add(getObject(node.left).name);
 						} else if (node.type === 'UpdateExpression') {
 							assignees.add(getObject(node.argument).name);
-							this.skip();
 						} else if (isReference(node, parent)) {
 							const object = getObject(node);
 							const { name } = object;

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -56,8 +56,8 @@ function instance($$self, $$props, $$invalidate) {
 		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
 	};
 
-	$$self.$$.update = ($$dirty = { foo: 1 }) => {
-		if ($$dirty.foo) {
+	$$self.$$.update = ($$dirty = { bar: 1, foo: 1 }) => {
+		if ($$dirty.bar || $$dirty.foo) {
 			bar = foo * 2; $$invalidate('bar', bar);
 		}
 	};

--- a/test/runtime/samples/reactive-values-readonly/_config.js
+++ b/test/runtime/samples/reactive-values-readonly/_config.js
@@ -1,0 +1,21 @@
+export default {
+	html: `
+		<p>doubled: 2</p>
+	`,
+
+	test({ assert, component, target }) {
+		component.a = 2;
+
+		assert.equal(component.doubled, 4);
+		assert.htmlEqual(target.innerHTML, `
+			<p>doubled: 4</p>
+		`);
+
+		component.doubled = 6;
+
+		assert.equal(component.doubled, 4);
+		assert.htmlEqual(target.innerHTML, `
+			<p>doubled: 4</p>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-values-readonly/main.html
+++ b/test/runtime/samples/reactive-values-readonly/main.html
@@ -1,0 +1,8 @@
+<script>
+	export let a = 1;
+	export let doubled;
+
+	$: doubled = a * 2;
+</script>
+
+<p>doubled: {doubled}</p>


### PR DESCRIPTION
fixes #1920. Specifically, `$: doubled = a * 2` will run when *either* `a` or `doubled` are dirty, meaning that as soon as you write to it, it changes back to the correct value.