### PR TITLE
repl: implement version=local

### DIFF
--- a/site/src/routes/repl/embed.html
+++ b/site/src/routes/repl/embed.html
@@ -14,11 +14,13 @@
 	let name = 'loading...';
 
 	onMount(() => {
-		fetch(`https://unpkg.com/svelte@${version}/package.json`)
-			.then(r => r.json())
-			.then(pkg => {
-				version = pkg.version;
-			});
+		if (version !== 'local') {
+			fetch(`https://unpkg.com/svelte@${version}/package.json`)
+				.then(r => r.json())
+				.then(pkg => {
+					version = pkg.version;
+				});
+		}
 
 		if (query.gist) {
 			fetch(`gist/${query.gist}`).then(r => r.json()).then(data => {

--- a/site/src/routes/repl/index.html
+++ b/site/src/routes/repl/index.html
@@ -45,11 +45,13 @@
 	});
 
 	onMount(() => {
-		fetch(`https://unpkg.com/svelte@${version || 'alpha'}/package.json`)
-			.then(r => r.json())
-			.then(pkg => {
-				version = pkg.version;
-			});
+		if (version !== 'local') {
+			fetch(`https://unpkg.com/svelte@${version || 'alpha'}/package.json`)
+				.then(r => r.json())
+				.then(pkg => {
+					version = pkg.version;
+				});
+		}
 
 		if (gist_id) {
 			fetch(`gist/${gist_id}`).then(r => r.json()).then(data => {

--- a/site/src/routes/repl/local.js
+++ b/site/src/routes/repl/local.js
@@ -1,0 +1,16 @@
+import { createReadStream } from 'fs';
+
+export function get(req, res) {
+	if (process.env.NODE_ENV !== 'development' || !/^[a-z.]+$/.test(req.query.file)) {
+		res.writeHead(403);
+		res.end();
+		return;
+	}
+	createReadStream('../' + req.query.file)
+		.on('error', () => {
+			res.writeHead(403);
+			res.end();
+		})
+		.pipe(res);
+	res.writeHead(200, { 'Content-Type': 'text/javascript' });
+}

--- a/site/static/workers/bundler.js
+++ b/site/static/workers/bundler.js
@@ -11,7 +11,9 @@ self.addEventListener('message', async event => {
 			version = event.data.version;
 
 			importScripts(
-				`https://unpkg.com/svelte@${version}/compiler.js`,
+				version === 'local' ?
+					'/repl/local?file=compiler.js' :
+					`https://unpkg.com/svelte@${version}/compiler.js`,
 				`https://unpkg.com/rollup@0.68/dist/rollup.browser.js`
 			);
 			fulfil();
@@ -47,7 +49,7 @@ const is_svelte_module = id => id === 'svelte' || id.startsWith('svelte/');
 const cache = new Map();
 function fetch_if_uncached(url) {
 	if (!cache.has(url)) {
-		cache.set(url, fetch(url)
+		cache.set(url, fetch(url.startsWith('https://unpkg.com/svelte@local/') ? '/repl/local?file=' + url.slice(31) : url)
 			.then(r => r.text())
 			.catch(err => {
 				console.error(err);
@@ -78,7 +80,7 @@ async function getBundle(mode, cache, lookup) {
 				resolveId(importee, importer) {
 					// v3 hack
 					if (importee === `svelte`) return `https://unpkg.com/svelte@${version}/index.mjs`;
-					if (importee.startsWith(`svelte`)) return `https://unpkg.com/svelte@${version}/${importee.slice(7)}.mjs`;
+					if (importee.startsWith(`svelte/`)) return `https://unpkg.com/svelte@${version}/${importee.slice(7)}.mjs`;
 
 					if (importer && importer.startsWith(`https://`)) {
 						return new URL(`${importee}.mjs`, importer).href;

--- a/site/static/workers/compiler.js
+++ b/site/static/workers/compiler.js
@@ -8,7 +8,11 @@ const ready = new Promise(f => {
 self.addEventListener('message', async event => {
 	switch (event.data.type) {
 		case 'init':
-			importScripts(`https://unpkg.com/svelte@${event.data.version}/compiler.js`);
+			importScripts(
+				event.data.version === 'local' ?
+					'/repl/local?file=compiler.js' :
+					`https://unpkg.com/svelte@${event.data.version}/compiler.js`
+			);
 			fulfil_ready();
 			break;
 


### PR DESCRIPTION
There's still some weirdness surrounding navigation/history API that I wasn't able to track down. If you are on a given example with `version=local` and then you navigate to another example and then press 'Back', you will end up on the first example with the latest alpha version, and I have no idea why. I don't know where else popstate is being handled.