### PR TITLE
Make sure a hoistable name is not also shadowed when rendering and expr - #2002

### DIFF
--- a/src/compile/nodes/shared/Expression.ts
+++ b/src/compile/nodes/shared/Expression.ts
@@ -240,7 +240,7 @@ export default class Expression {
 							dependencies.add(name);
 							component.template_references.add(name);
 						}
-					} else if (!is_synthetic && !(component.hoistable_names.has(name) && template_scope.isTopLevel(name)) && !component.imported_declarations.has(name)) {
+					} else if (!is_synthetic && isContextual(component, template_scope, name)) {
 						code.prependRight(node.start, key === 'key' && parent.shorthand
 							? `${name}: ctx.`
 							: 'ctx.');
@@ -436,4 +436,17 @@ function get_function_name(node, parent) {
 	}
 
 	return 'func';
+}
+
+function isContextual(component: Component, scope: TemplateScope, name: string) {
+	// if it's a name below root scope, it's contextual
+	if (!scope.isTopLevel(name)) return true;
+
+	// hoistables, module declarations, and imports are non-contextual
+	if (component.hoistable_names.has(name)) return false;
+	if (component.module_scope && component.module_scope.declarations.has(name)) return false;
+	if (component.imported_declarations.has(name)) return false;
+
+	// assume contextual
+	return true;
 }

--- a/src/compile/nodes/shared/Expression.ts
+++ b/src/compile/nodes/shared/Expression.ts
@@ -240,7 +240,7 @@ export default class Expression {
 							dependencies.add(name);
 							component.template_references.add(name);
 						}
-					} else if (!is_synthetic && !component.hoistable_names.has(name) && !component.imported_declarations.has(name)) {
+					} else if (!is_synthetic && !(component.hoistable_names.has(name) && template_scope.isTopLevel(name)) && !component.imported_declarations.has(name)) {
 						code.prependRight(node.start, key === 'key' && parent.shorthand
 							? `${name}: ctx.`
 							: 'ctx.');

--- a/src/compile/nodes/shared/TemplateScope.ts
+++ b/src/compile/nodes/shared/TemplateScope.ts
@@ -40,4 +40,8 @@ export default class TemplateScope {
 		if (this.parent) return this.parent.containsMutable(names);
 		else return false;
 	}
+
+	isTopLevel(name: string) {
+		return !this.parent || !this.names.has(name) && this.parent.isTopLevel(name);
+	}
 }

--- a/test/runtime/samples/each-block-scope-shadow/_config.js
+++ b/test/runtime/samples/each-block-scope-shadow/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: '(alpaca)(baboon)(capybara)'
+};

--- a/test/runtime/samples/each-block-scope-shadow/main.html
+++ b/test/runtime/samples/each-block-scope-shadow/main.html
@@ -1,0 +1,8 @@
+{#each animals as animal}
+	({animal})
+{/each}
+
+<script>
+	let animal = 'lemur';
+	let animals = ['alpaca', 'baboon', 'capybara'];
+</script>

--- a/test/runtime/samples/module-context-with-instance-script/_config.js
+++ b/test/runtime/samples/module-context-with-instance-script/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<p>(42)(99)</p>`
+};

--- a/test/runtime/samples/module-context-with-instance-script/main.html
+++ b/test/runtime/samples/module-context-with-instance-script/main.html
@@ -1,0 +1,9 @@
+<script context="module">
+	const foo = 42;
+</script>
+
+<script>
+	export let bar = 99;
+</script>
+
+<p>({foo})({bar})</p>


### PR DESCRIPTION
I think this is pretty straightforward - a name must be flagged as hoistable at the component level _and_ be referring to a name in the root template scope in order to not require `ctx.` for access. See #2002.