### PR TITLE
Update await-block to use on_outro and check_outros - #1995

### DIFF
--- a/src/internal/await-block.js
+++ b/src/internal/await-block.js
@@ -1,5 +1,5 @@
 import { assign, isPromise } from './utils.js';
-import { group_outros } from './transitions.js';
+import { check_outros, group_outros, on_outro } from './transitions.js';
 import { flush } from '../internal/scheduler.js';
 
 export function handlePromise(promise, info) {
@@ -18,10 +18,12 @@ export function handlePromise(promise, info) {
 				info.blocks.forEach((block, i) => {
 					if (i !== index && block) {
 						group_outros();
-						block.o(() => {
+						on_outro(() => {
 							block.d(1);
 							info.blocks[i] = null;
 						});
+						block.o();
+						check_outros();
 					}
 				});
 			} else {

--- a/test/runtime/samples/await-with-components/Widget.html
+++ b/test/runtime/samples/await-with-components/Widget.html
@@ -1,0 +1,5 @@
+{value}
+
+<script>
+  export let value = 'Loading...';
+</script>

--- a/test/runtime/samples/await-with-components/_config.js
+++ b/test/runtime/samples/await-with-components/_config.js
@@ -1,0 +1,29 @@
+export default {
+	async test({ assert, component, target }) {
+		let resolve, reject;
+		let promise = new Promise(ok => resolve = ok);
+
+		component.promise = promise;
+		assert.htmlEqual(target.innerHTML, 'Loading...');
+
+		resolve(42);
+		await promise;
+		assert.htmlEqual(target.innerHTML, '42');
+
+		promise = new Promise((ok, fail) => reject = fail);
+		component.promise = promise;
+		assert.htmlEqual(target.innerHTML, 'Loading...');
+
+		reject(99);
+		await promise.then(null, () => {});
+		assert.htmlEqual(target.innerHTML, '99');
+
+		promise = new Promise(ok => resolve = ok);
+		component.promise = promise;
+		assert.htmlEqual(target.innerHTML, 'Loading...');
+
+		resolve(1);
+		await promise;
+		assert.htmlEqual(target.innerHTML, '1');
+	}
+};

--- a/test/runtime/samples/await-with-components/main.html
+++ b/test/runtime/samples/await-with-components/main.html
@@ -1,0 +1,12 @@
+{#await promise}
+	<Widget />
+{:then result}
+	<Widget value="{result}" />
+{:catch err}
+	<Widget value="{err}" />
+{/await}
+
+<script>
+	import Widget from './Widget.html';
+	export let promise = Promise.resolve();
+</script>


### PR DESCRIPTION
It looks like the `o` API changed a bit and the await block handling code didn't quite get updated to match. I _think_ this should take care of #1995.