### PR TITLE
Defer hoisting until after the template is walked - #2005

### DIFF
--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -11,7 +11,7 @@ function create_fragment($$, ctx) {
 			text1 = createText("\n\n");
 			p = createElement("p");
 			text2 = createText("x: ");
-			text3 = createText(x);
+			text3 = createText(ctx.x);
 			dispose = addListener(button, "click", ctx.click_handler);
 		},
 
@@ -25,7 +25,7 @@ function create_fragment($$, ctx) {
 
 		p(changed, ctx) {
 			if (changed.x) {
-				setData(text3, x);
+				setData(text3, ctx.x);
 			}
 		},
 
@@ -44,15 +44,14 @@ function create_fragment($$, ctx) {
 	};
 }
 
-let x = 0;
-
 function instance($$self, $$props, $$invalidate) {
+	let x = 0;
 
 	function click_handler() {
 		if (true) { x += 1; $$invalidate('x', x); }
 	}
 
-	return { click_handler };
+	return { x, click_handler };
 }
 
 class SvelteComponent extends SvelteComponent_1 {

--- a/test/runtime/samples/component-template-inline-mutation/Widget.html
+++ b/test/runtime/samples/component-template-inline-mutation/Widget.html
@@ -1,0 +1,5 @@
+<script>
+  let count = 0;
+</script>
+
+<button on:click="{() => count += 1}">{count}</button>

--- a/test/runtime/samples/component-template-inline-mutation/_config.js
+++ b/test/runtime/samples/component-template-inline-mutation/_config.js
@@ -1,0 +1,14 @@
+export default {
+	async test({ assert, target }) {
+		const btns = target.querySelectorAll('button');
+		const event = new window.MouseEvent('click');
+
+		await btns[0].dispatchEvent(event);
+		await btns[0].dispatchEvent(event);
+		await btns[1].dispatchEvent(event);
+		await btns[1].dispatchEvent(event);
+		await btns[1].dispatchEvent(event);
+
+		assert.equal(btns[1].innerHTML, '3');
+	}
+};

--- a/test/runtime/samples/component-template-inline-mutation/main.html
+++ b/test/runtime/samples/component-template-inline-mutation/main.html
@@ -1,0 +1,6 @@
+<script>
+	import Widget from './Widget.html';
+</script>
+
+<Widget />
+<Widget />


### PR DESCRIPTION
This splits the instance js walk into pre and post template walk steps, so that hoisting can take template mutations into account. This is probably not the cleanest solution, but since v3 is moving pretty rapidly, I'm hesitant to try to trade this bit of technical debt for the pain of a larger refactor right now.