### PR TITLE
Implement local transitions

### DIFF
--- a/src/compile/nodes/Transition.ts
+++ b/src/compile/nodes/Transition.ts
@@ -7,6 +7,7 @@ export default class Transition extends Node {
 	name: string;
 	directive: string;
 	expression: Expression;
+	is_local: boolean;
 
 	constructor(component: Component, parent, scope, info) {
 		super(component, parent, scope, info);
@@ -15,6 +16,7 @@ export default class Transition extends Node {
 
 		this.name = info.name;
 		this.directive = info.intro && info.outro ? 'transition' : info.intro ? 'in' : 'out';
+		this.is_local = info.modifiers.includes('local');
 
 		if ((info.intro && parent.intro) || (info.outro && parent.outro)) {
 			const parentTransition = (parent.intro || parent.outro);

--- a/src/compile/render-dom/Block.ts
+++ b/src/compile/render-dom/Block.ts
@@ -327,7 +327,7 @@ export default class Block {
 				properties.addLine(`i: @noop,`);
 			} else {
 				properties.addBlock(deindent`
-					${dev ? 'i: function intro' : 'i'}() {
+					${dev ? 'i: function intro' : 'i'}(#local) {
 						${this.hasOutros && `if (#current) return;`}
 						${this.builders.intro}
 					},
@@ -338,7 +338,7 @@ export default class Block {
 				properties.addLine(`o: @noop,`);
 			} else {
 				properties.addBlock(deindent`
-					${dev ? 'o: function outro' : 'o'}() {
+					${dev ? 'o: function outro' : 'o'}(#local) {
 						${this.builders.outro}
 					},
 				`);

--- a/src/compile/render-dom/wrappers/Element/index.ts
+++ b/src/compile/render-dom/wrappers/Element/index.ts
@@ -622,17 +622,34 @@ export default class ElementWrapper extends Wrapper {
 
 			const fn = component.qualify(intro.name);
 
-			block.builders.intro.addBlock(deindent`
+			const intro_block = deindent`
 				@add_render_callback(() => {
 					if (!${name}) ${name} = @create_bidirectional_transition(${this.var}, ${fn}, ${snippet}, true);
 					${name}.run(1);
 				});
-			`);
+			`;
 
-			block.builders.outro.addBlock(deindent`
+			const outro_block = deindent`
 				if (!${name}) ${name} = @create_bidirectional_transition(${this.var}, ${fn}, ${snippet}, false);
 				${name}.run(0);
-			`);
+			`;
+
+			if (intro.is_local) {
+				block.builders.intro.addBlock(deindent`
+					if (#local) {
+						${intro_block}
+					}
+				`);
+
+				block.builders.outro.addBlock(deindent`
+					if (#local) {
+						${outro_block}
+					}
+				`);
+			} else {
+				block.builders.intro.addBlock(intro_block);
+				block.builders.outro.addBlock(outro_block);
+			}
 
 			block.builders.destroy.addConditional('detach', `if (${name}) ${name}.end();`);
 		}
@@ -649,25 +666,37 @@ export default class ElementWrapper extends Wrapper {
 
 				const fn = component.qualify(intro.name);
 
+				let intro_block;
+
 				if (outro) {
-					block.builders.intro.addBlock(deindent`
+					intro_block = deindent`
 						@add_render_callback(() => {
 							if (!${introName}) ${introName} = @create_in_transition(${this.var}, ${fn}, ${snippet});
 							${introName}.start();
 						});
-					`);
+					`;
 
 					block.builders.outro.addLine(`if (${introName}) ${introName}.invalidate()`);
 				} else {
-					block.builders.intro.addBlock(deindent`
+					intro_block = deindent`
 						if (!${introName}) {
 							@add_render_callback(() => {
 								${introName} = @create_in_transition(${this.var}, ${fn}, ${snippet});
 								${introName}.start();
 							});
 						}
-					`);
+					`;
 				}
+
+				if (intro.is_local) {
+					intro_block = deindent`
+						if (#local) {
+							${intro_block}
+						}
+					`;
+				}
+
+				block.builders.intro.addBlock(intro_block);
 			}
 
 			if (outro) {
@@ -684,9 +713,19 @@ export default class ElementWrapper extends Wrapper {
 
 				// TODO hide elements that have outro'd (unless they belong to a still-outroing
 				// group) prior to their removal from the DOM
-				block.builders.outro.addBlock(deindent`
+				let outro_block = deindent`
 					${outroName} = @create_out_transition(${this.var}, ${fn}, ${snippet});
-				`);
+				`;
+
+				if (outro_block) {
+					outro_block = deindent`
+						if (#local) {
+							${outro_block}
+						}
+					`;
+				}
+
+				block.builders.outro.addBlock(outro_block);
 
 				block.builders.destroy.addConditional('detach', `if (${outroName}) ${outroName}.end();`);
 			}

--- a/src/compile/render-dom/wrappers/IfBlock.ts
+++ b/src/compile/render-dom/wrappers/IfBlock.ts
@@ -239,7 +239,7 @@ export default class IfBlockWrapper extends Wrapper {
 			if (${name}) {
 				${name}.c();
 				${name}.m(${updateMountNode}, ${anchor});
-				${has_transitions && `${name}.i();`}
+				${has_transitions && `${name}.i(1);`}
 			}
 		`;
 
@@ -327,7 +327,7 @@ export default class IfBlockWrapper extends Wrapper {
 				${if_blocks}[${previous_block_index}].d(1);
 				${if_blocks}[${previous_block_index}] = null;
 			});
-			${name}.o();
+			${name}.o(1);
 			@check_outros();
 		`;
 
@@ -338,7 +338,7 @@ export default class IfBlockWrapper extends Wrapper {
 				${name}.c();
 			}
 			${name}.m(${updateMountNode}, ${anchor});
-			${has_transitions && `${name}.i();`}
+			${has_transitions && `${name}.i(1);`}
 		`;
 
 		const changeBlock = hasElse
@@ -415,7 +415,7 @@ export default class IfBlockWrapper extends Wrapper {
 					${name}.c();
 					${name}.m(${updateMountNode}, ${anchor});
 				}
-				${has_transitions && `${name}.i();`}
+				${has_transitions && `${name}.i(1);`}
 			`
 			: deindent`
 				if (!${name}) {
@@ -423,7 +423,7 @@ export default class IfBlockWrapper extends Wrapper {
 					${name}.c();
 					${name}.m(${updateMountNode}, ${anchor});
 				}
-				${has_transitions && `${name}.i();`}
+				${has_transitions && `${name}.i(1);`}
 			`;
 
 		// no `p()` here — we don't want to update outroing nodes,
@@ -436,7 +436,7 @@ export default class IfBlockWrapper extends Wrapper {
 					${name} = null;
 				});
 
-				${name}.o();
+				${name}.o(1);
 				@check_outros();
 			`
 			: deindent`

--- a/src/compile/render-dom/wrappers/InlineComponent/index.ts
+++ b/src/compile/render-dom/wrappers/InlineComponent/index.ts
@@ -397,7 +397,7 @@ export default class InlineComponentWrapper extends Wrapper {
 						@on_outro(() => {
 							old_component.$destroy();
 						});
-						old_component.$$.fragment.o();
+						old_component.$$.fragment.o(1);
 						@check_outros();
 					}
 
@@ -409,7 +409,7 @@ export default class InlineComponentWrapper extends Wrapper {
 
 						${name}.$$.fragment.c();
 						@mount_component(${name}, ${updateMountNode}, ${anchor});
-						${name}.$$.fragment.i();
+						${name}.$$.fragment.i(1);
 					} else {
 						${name} = null;
 					}
@@ -417,7 +417,7 @@ export default class InlineComponentWrapper extends Wrapper {
 			`);
 
 			block.builders.intro.addBlock(deindent`
-				if (${name}) ${name}.$$.fragment.i();
+				if (${name}) ${name}.$$.fragment.i(#local);
 			`);
 
 			if (updates.length) {
@@ -429,6 +429,10 @@ export default class InlineComponentWrapper extends Wrapper {
 					${postupdates.length > 0 && `${postupdates.join(' = ')} = false;`}
 				`);
 			}
+
+			block.builders.outro.addLine(
+				`if (${name}) ${name}.$$.fragment.o(#local);`
+			);
 
 			block.builders.destroy.addLine(`if (${name}) ${name}.$destroy(${parentNode ? '' : 'detach'});`);
 		} else {
@@ -459,7 +463,7 @@ export default class InlineComponentWrapper extends Wrapper {
 			);
 
 			block.builders.intro.addBlock(deindent`
-				${name}.$$.fragment.i();
+				${name}.$$.fragment.i(#local);
 			`);
 
 			if (updates.length) {
@@ -473,11 +477,11 @@ export default class InlineComponentWrapper extends Wrapper {
 			block.builders.destroy.addBlock(deindent`
 				${name}.$destroy(${parentNode ? '' : 'detach'});
 			`);
-		}
 
-		block.builders.outro.addLine(
-			`if (${name}) ${name}.$$.fragment.o();`
-		);
+			block.builders.outro.addLine(
+				`${name}.$$.fragment.o(#local);`
+			);
+		}
 	}
 }
 

--- a/src/internal/await-block.js
+++ b/src/internal/await-block.js
@@ -22,7 +22,7 @@ export function handlePromise(promise, info) {
 							block.d(1);
 							info.blocks[i] = null;
 						});
-						block.o();
+						block.o(1);
 						check_outros();
 					}
 				});
@@ -32,7 +32,7 @@ export function handlePromise(promise, info) {
 
 			block.c();
 			block.m(info.mount(), info.anchor);
-			if (block.i) block.i();
+			if (block.i) block.i(1);
 
 			flush();
 		}

--- a/src/internal/keyed-each.js
+++ b/src/internal/keyed-each.js
@@ -10,7 +10,7 @@ export function outroAndDestroyBlock(block, lookup) {
 		destroyBlock(block, lookup);
 	});
 
-	block.o();
+	block.o(1);
 }
 
 export function fixAndOutroAndDestroyBlock(block, lookup) {
@@ -53,7 +53,7 @@ export function updateKeyedEach(old_blocks, changed, get_key, dynamic, ctx, list
 
 	function insert(block) {
 		block.m(node, next);
-		if (block.i) block.i();
+		if (block.i) block.i(1);
 		lookup[block.key] = block;
 		next = block.first;
 		n--;

--- a/test/js/samples/component-static-array/expected.js
+++ b/test/js/samples/component-static-array/expected.js
@@ -17,15 +17,15 @@ function create_fragment(ctx) {
 
 		p: noop,
 
-		i() {
+		i(local) {
 			if (current) return;
-			nested.$$.fragment.i();
+			nested.$$.fragment.i(local);
 
 			current = true;
 		},
 
-		o() {
-			if (nested) nested.$$.fragment.o();
+		o(local) {
+			nested.$$.fragment.o(local);
 			current = false;
 		},
 

--- a/test/js/samples/component-static-immutable/expected.js
+++ b/test/js/samples/component-static-immutable/expected.js
@@ -17,15 +17,15 @@ function create_fragment(ctx) {
 
 		p: noop,
 
-		i() {
+		i(local) {
 			if (current) return;
-			nested.$$.fragment.i();
+			nested.$$.fragment.i(local);
 
 			current = true;
 		},
 
-		o() {
-			if (nested) nested.$$.fragment.o();
+		o(local) {
+			nested.$$.fragment.o(local);
 			current = false;
 		},
 

--- a/test/js/samples/component-static-immutable2/expected.js
+++ b/test/js/samples/component-static-immutable2/expected.js
@@ -17,15 +17,15 @@ function create_fragment(ctx) {
 
 		p: noop,
 
-		i() {
+		i(local) {
 			if (current) return;
-			nested.$$.fragment.i();
+			nested.$$.fragment.i(local);
 
 			current = true;
 		},
 
-		o() {
-			if (nested) nested.$$.fragment.o();
+		o(local) {
+			nested.$$.fragment.o(local);
 			current = false;
 		},
 

--- a/test/js/samples/component-static/expected.js
+++ b/test/js/samples/component-static/expected.js
@@ -17,15 +17,15 @@ function create_fragment(ctx) {
 
 		p: noop,
 
-		i() {
+		i(local) {
 			if (current) return;
-			nested.$$.fragment.i();
+			nested.$$.fragment.i(local);
 
 			current = true;
 		},
 
-		o() {
-			if (nested) nested.$$.fragment.o();
+		o(local) {
+			nested.$$.fragment.o(local);
 			current = false;
 		},
 

--- a/test/js/samples/dynamic-import/expected.js
+++ b/test/js/samples/dynamic-import/expected.js
@@ -18,15 +18,15 @@ function create_fragment(ctx) {
 
 		p: noop,
 
-		i() {
+		i(local) {
 			if (current) return;
-			lazyload.$$.fragment.i();
+			lazyload.$$.fragment.i(local);
 
 			current = true;
 		},
 
-		o() {
-			if (lazyload) lazyload.$$.fragment.o();
+		o(local) {
+			lazyload.$$.fragment.o(local);
 			current = false;
 		},
 

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -24,18 +24,18 @@ function create_fragment(ctx) {
 
 		p: noop,
 
-		i() {
+		i(local) {
 			if (current) return;
-			imported.$$.fragment.i();
+			imported.$$.fragment.i(local);
 
-			nonimported.$$.fragment.i();
+			nonimported.$$.fragment.i(local);
 
 			current = true;
 		},
 
-		o() {
-			if (imported) imported.$$.fragment.o();
-			if (nonimported) nonimported.$$.fragment.o();
+		o(local) {
+			imported.$$.fragment.o(local);
+			nonimported.$$.fragment.o(local);
 			current = false;
 		},
 

--- a/test/runtime/samples/transition-js-local-and-global/_config.js
+++ b/test/runtime/samples/transition-js-local-and-global/_config.js
@@ -33,7 +33,8 @@ export default {
 		assert.htmlEqual(target.innerHTML, '');
 
 		// then toggle y
-		component.set({ x: true, y: false });
+		component.y = false;
+		component.x = true;
 		component.y = true;
 
 		assert.htmlEqual(target.innerHTML, `

--- a/test/runtime/samples/transition-js-local-and-global/_config.js
+++ b/test/runtime/samples/transition-js-local-and-global/_config.js
@@ -1,0 +1,66 @@
+export default {
+	props: {
+		x: false,
+		y: true
+	},
+
+	test({ assert, component, target, raf }) {
+		// first, toggle x — first element should snap in
+		// and out while second one transitions
+		component.x = true;
+
+		let divs = target.querySelectorAll('div');
+		assert.equal(divs[0].foo, undefined);
+		assert.equal(divs[1].foo, 0);
+
+		raf.tick(50);
+		assert.equal(divs[0].foo, undefined);
+		assert.equal(divs[1].foo, 0.5);
+
+		raf.tick(100);
+
+		component.x = false;
+		assert.htmlEqual(target.innerHTML, `
+			<div>snaps if x changes</div>
+			<div>transitions if x changes</div>
+		`);
+
+		raf.tick(150);
+		assert.equal(divs[0].foo, undefined);
+		assert.equal(divs[1].foo, 0.5);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+
+		// then toggle y
+		component.set({ x: true, y: false });
+		component.y = true;
+
+		assert.htmlEqual(target.innerHTML, `
+			<div>snaps if x changes</div>
+			<div>transitions if x changes</div>
+		`);
+		divs = target.querySelectorAll('div');
+
+		raf.tick(250);
+		assert.equal(divs[0].foo, 0.5);
+		assert.equal(divs[1].foo, 0.5);
+
+		raf.tick(300);
+		assert.equal(divs[0].foo, 1);
+		assert.equal(divs[1].foo, 1);
+
+		component.y = false;
+		assert.htmlEqual(target.innerHTML, `
+			<div>snaps if x changes</div>
+			<div>transitions if x changes</div>
+		`);
+
+		raf.tick(320);
+		assert.equal(divs[0].foo, 0.8);
+		assert.equal(divs[1].foo, 0.8);
+
+		raf.tick(400);
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local-and-global/main.html
+++ b/test/runtime/samples/transition-js-local-and-global/main.html
@@ -1,0 +1,20 @@
+<script>
+	export let x;
+	export let y;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: t => {
+				node.foo = t;
+			}
+		};
+	}
+</script>
+
+{#if x}
+	{#if y}
+		<div transition:foo|local>snaps if x changes</div>
+		<div transition:foo>transitions if x changes</div>
+	{/if}
+{/if}

--- a/test/runtime/samples/transition-js-local-nested-await/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-await/_config.js
@@ -1,0 +1,31 @@
+let fulfil;
+
+const promise = new Promise(f => {
+	fulfil = f;
+});
+
+export default {
+	props: {
+		x: false,
+		promise
+	},
+
+	test({ assert, component, target, raf }) {
+		component.x = true;
+		fulfil();
+
+		return promise.then(() => {
+			const div = target.querySelector('div');
+			assert.equal(div.foo, 0);
+
+			raf.tick(100);
+			assert.equal(div.foo, 1);
+
+			component.x = false;
+			assert.htmlEqual(target.innerHTML, '');
+
+			raf.tick(150);
+			assert.equal(div.foo, 1);
+		});
+	}
+};

--- a/test/runtime/samples/transition-js-local-nested-await/main.html
+++ b/test/runtime/samples/transition-js-local-nested-await/main.html
@@ -1,0 +1,19 @@
+<script>
+	export let x;
+	export let promise;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: t => {
+				node.foo = t;
+			}
+		};
+	}
+</script>
+
+{#if x}
+	{#await promise then value}
+		<div transition:foo|local></div>
+	{/await}
+{/if}

--- a/test/runtime/samples/transition-js-local-nested-component/Widget.html
+++ b/test/runtime/samples/transition-js-local-nested-component/Widget.html
@@ -1,0 +1,12 @@
+<script>
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: t => {
+				node.foo = t;
+			}
+		};
+	}
+</script>
+
+<div transition:foo|local></div>

--- a/test/runtime/samples/transition-js-local-nested-component/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-component/_config.js
@@ -1,0 +1,24 @@
+export default {
+	props: {
+		x: false
+	},
+
+	test({ assert, component, target, raf }) {
+		component.x = true;
+
+		const div = target.querySelector('div');
+		assert.equal(div.foo, 0);
+
+		raf.tick(100);
+		assert.equal(div.foo, 1);
+
+		component.x = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+
+		raf.tick(150);
+		assert.equal(div.foo, 0.5);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+	}
+};

--- a/test/runtime/samples/transition-js-local-nested-component/main.html
+++ b/test/runtime/samples/transition-js-local-nested-component/main.html
@@ -1,0 +1,9 @@
+<script>
+	export let x;
+
+	import Widget from './Widget.html';
+</script>
+
+{#if x}
+	<Widget/>
+{/if}

--- a/test/runtime/samples/transition-js-local-nested-each-keyed/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-each-keyed/_config.js
@@ -13,7 +13,7 @@ export default {
 		raf.tick(100);
 		assert.equal(div1.foo, undefined);
 
-		component.set({ things: ['a', 'b'] });
+		component.things = ['a', 'b'];
 		assert.htmlEqual(target.innerHTML, '<div></div><div></div>');
 
 		const div2 = target.querySelector('div:last-child');

--- a/test/runtime/samples/transition-js-local-nested-each-keyed/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-each-keyed/_config.js
@@ -1,0 +1,30 @@
+export default {
+	props: {
+		x: false,
+		things: ['a']
+	},
+
+	test({ assert, component, target, raf }) {
+		component.x = true;
+
+		const div1 = target.querySelector('div');
+		assert.equal(div1.foo, undefined);
+
+		raf.tick(100);
+		assert.equal(div1.foo, undefined);
+
+		component.set({ things: ['a', 'b'] });
+		assert.htmlEqual(target.innerHTML, '<div></div><div></div>');
+
+		const div2 = target.querySelector('div:last-child');
+		assert.equal(div1.foo, undefined);
+		assert.equal(div2.foo, 0);
+
+		raf.tick(200);
+		assert.equal(div1.foo, undefined);
+		assert.equal(div2.foo, 1);
+
+		component.x = false;
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local-nested-each-keyed/main.html
+++ b/test/runtime/samples/transition-js-local-nested-each-keyed/main.html
@@ -1,0 +1,19 @@
+<script>
+	export let x;
+	export let things;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: t => {
+				node.foo = t;
+			}
+		};
+	}
+</script>
+
+{#if x}
+	{#each things as thing (thing)}
+		<div transition:foo|local></div>
+	{/each}
+{/if}

--- a/test/runtime/samples/transition-js-local-nested-each/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-each/_config.js
@@ -13,7 +13,7 @@ export default {
 		raf.tick(100);
 		assert.equal(div1.foo, undefined);
 
-		component.set({ things: ['a', 'b'] });
+		component.things = ['a', 'b'];
 		assert.htmlEqual(target.innerHTML, '<div></div><div></div>');
 
 		const div2 = target.querySelector('div:last-child');

--- a/test/runtime/samples/transition-js-local-nested-each/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-each/_config.js
@@ -1,0 +1,30 @@
+export default {
+	props: {
+		x: false,
+		things: ['a']
+	},
+
+	test({ assert, component, target, raf }) {
+		component.x = true;
+
+		const div1 = target.querySelector('div');
+		assert.equal(div1.foo, undefined);
+
+		raf.tick(100);
+		assert.equal(div1.foo, undefined);
+
+		component.set({ things: ['a', 'b'] });
+		assert.htmlEqual(target.innerHTML, '<div></div><div></div>');
+
+		const div2 = target.querySelector('div:last-child');
+		assert.equal(div1.foo, undefined);
+		assert.equal(div2.foo, 0);
+
+		raf.tick(200);
+		assert.equal(div1.foo, undefined);
+		assert.equal(div2.foo, 1);
+
+		component.x = false;
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local-nested-each/main.html
+++ b/test/runtime/samples/transition-js-local-nested-each/main.html
@@ -1,0 +1,19 @@
+<script>
+	export let x;
+	export let things;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: t => {
+				node.foo = t;
+			}
+		};
+	}
+</script>
+
+{#if x}
+	{#each things as thing}
+		<div transition:foo|local></div>
+	{/each}
+{/if}

--- a/test/runtime/samples/transition-js-local-nested-if/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-if/_config.js
@@ -20,7 +20,8 @@ export default {
 		raf.tick(100);
 		assert.htmlEqual(target.innerHTML, '');
 
-		component.set({ x: false, y: true });
+		component.x = false;
+		component.y = true;
 		assert.htmlEqual(target.innerHTML, '');
 
 		component.x = true;

--- a/test/runtime/samples/transition-js-local-nested-if/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-if/_config.js
@@ -1,0 +1,39 @@
+export default {
+	props: {
+		x: false,
+		y: true
+	},
+
+	test({ assert, component, target, raf }) {
+		component.x = true;
+
+		let div = target.querySelector('div');
+		assert.equal(div.foo, undefined);
+
+		component.y = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		div = target.querySelector('div');
+
+		raf.tick(50);
+		assert.equal(div.foo, 0.5);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '');
+
+		component.set({ x: false, y: true });
+		assert.htmlEqual(target.innerHTML, '');
+
+		component.x = true;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		div = target.querySelector('div');
+
+		component.y = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+
+		raf.tick(150);
+		assert.equal(div.foo, 0.5);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local-nested-if/main.html
+++ b/test/runtime/samples/transition-js-local-nested-if/main.html
@@ -1,0 +1,19 @@
+<script>
+	export let x;
+	export let y;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: t => {
+				node.foo = t;
+			}
+		};
+	}
+</script>
+
+{#if x}
+	{#if y}
+		<div transition:foo|local></div>
+	{/if}
+{/if}

--- a/test/runtime/samples/transition-js-local/_config.js
+++ b/test/runtime/samples/transition-js-local/_config.js
@@ -1,0 +1,40 @@
+export default {
+	props: {
+		x: false,
+		y: true
+	},
+
+	test({ assert, component, target, window, raf }) {
+		component.x = true;
+
+		let div = target.querySelector('div');
+		assert.equal(div.foo, undefined);
+
+		component.y = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		div = target.querySelector('div');
+
+		raf.tick(50);
+		assert.equal(div.foo, 0.5);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '');
+
+		component.x = false;
+		component.y = true;
+		assert.htmlEqual(target.innerHTML, '');
+
+		component.x = true;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		div = target.querySelector('div');
+
+		component.y = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+
+		raf.tick(120);
+		assert.equal(div.foo, 0.8);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+	},
+};

--- a/test/runtime/samples/transition-js-local/main.html
+++ b/test/runtime/samples/transition-js-local/main.html
@@ -1,0 +1,19 @@
+<script>
+	export let x;
+	export let y;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: t => {
+				node.foo = t;
+			}
+		};
+	}
+</script>
+
+{#if x}
+	{#if y}
+		<div transition:foo|local></div>
+	{/if}
+{/if}


### PR DESCRIPTION
I was dreading this task but it turned out to be fairly simple. With this change, we call `.i()` and `.o()` methods on fragments with a `1` argument if the change is local (i.e. the call is in a `p` aka `update` method). Then, local transitions are wrapped in an `if (local) ...` block.

Local transitions present an opportunity to generate more optimal code — in a situation like this...

```html
{#if x}
  {#if y}
    <div in:foo|local>...</div>
  {/if}
{/if}
```

...the outer block doesn't need any transition code at all. Am in two minds about whether to try and implement that now or worry about it later.

This PR is dedicated to @jacwright 😀 