### PR TITLE
bind to store values in simple cases

### DIFF
--- a/src/compile/render-dom/wrappers/Element/index.ts
+++ b/src/compile/render-dom/wrappers/Element/index.ts
@@ -456,7 +456,7 @@ export default class ElementWrapper extends Wrapper {
 			this.renderer.component.partly_hoisted.push(deindent`
 				function ${handler}(${contextual_dependencies.size > 0 ? `{ ${[...contextual_dependencies].join(', ')} }` : ``}) {
 					${group.bindings.map(b => b.handler.mutation)}
-					${Array.from(dependencies).map(dep => `$$invalidate('${dep}', ${dep});`)}
+					${Array.from(dependencies).filter(dep => dep[0] !== '$').map(dep => `$$invalidate('${dep}', ${dep});`)}
 				}
 			`);
 

--- a/test/runtime/samples/binding-store-deep/_config.js
+++ b/test/runtime/samples/binding-store-deep/_config.js
@@ -1,0 +1,5 @@
+export default {
+	error(assert, err) {
+		assert.equal(err.message, `Cannot bind to a nested property of a store`);
+	}
+};

--- a/test/runtime/samples/binding-store-deep/main.html
+++ b/test/runtime/samples/binding-store-deep/main.html
@@ -1,0 +1,8 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	export const user = writable({ name: 'world' });
+</script>
+
+<input bind:value={$user.name}>
+<p>hello {$user.name}</p>

--- a/test/runtime/samples/binding-store/_config.js
+++ b/test/runtime/samples/binding-store/_config.js
@@ -1,0 +1,41 @@
+export default {
+	html: `
+		<input>
+		<p>hello world</p>
+	`,
+
+	ssrHtml: `
+		<input value="world">
+		<p>hello world</p>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const input = target.querySelector('input');
+		assert.equal(input.value, 'world');
+
+		const event = new window.Event('input');
+
+		const names = [];
+		const unsubscribe = component.name.subscribe(name => {
+			names.push(name);
+		});
+
+		input.value = 'everybody';
+		await input.dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<input>
+			<p>hello everybody</p>
+		`);
+
+		await component.name.set('goodbye');
+		assert.equal(input.value, 'goodbye');
+		assert.htmlEqual(target.innerHTML, `
+			<input>
+			<p>hello goodbye</p>
+		`);
+
+		assert.deepEqual(names, ['world', 'everybody', 'goodbye']);
+		unsubscribe();
+	},
+};

--- a/test/runtime/samples/binding-store/main.html
+++ b/test/runtime/samples/binding-store/main.html
@@ -1,0 +1,8 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	export const name = writable('world');
+</script>
+
+<input bind:value={$name}>
+<p>hello {$name}</p>


### PR DESCRIPTION
fixes #1997. I've come around to the idea that it should be possible to bind to store values, even though there are some caveats around which stores are suitable. Maybe a documentation question more than anything?

One thing you can't do: bind to a nested property, e.g. `bind:value={$user.name}`. That's because stores check referential equality (i.e. they expect immutable data), and there's no way to create a clone of `user` with the new `name` property without making certain assumptions about what `user` is. It will currently throw an error instead. Suggestions for better alternatives welcome.