### PR TITLE
get name based on filename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte",
-  "version": "3.0.0-alpha20",
+  "version": "3.0.0-alpha23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -130,7 +130,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -209,7 +209,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -541,7 +541,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -711,7 +711,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -741,7 +741,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -756,7 +756,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -995,7 +995,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
@@ -1092,7 +1092,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -1324,7 +1324,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -1441,7 +1441,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -1681,7 +1681,7 @@
     },
     "fs-extra": {
       "version": "0.30.0",
-      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {
@@ -2662,7 +2662,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -2941,7 +2941,7 @@
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
@@ -2977,7 +2977,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
@@ -3053,7 +3053,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -3198,7 +3198,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -3226,7 +3226,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -3239,7 +3239,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -3348,7 +3348,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -3363,7 +3363,7 @@
       "dependencies": {
         "commander": {
           "version": "1.0.4",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.4.tgz",
           "integrity": "sha1-Xt6xruI8T7VBprcNaSq+8ZZpotM=",
           "dev": true,
           "requires": {
@@ -3395,7 +3395,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -3475,7 +3475,7 @@
     },
     "multiline": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/multiline/-/multiline-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/multiline/-/multiline-1.0.2.tgz",
       "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
       "dev": true,
       "requires": {
@@ -3685,7 +3685,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -3856,7 +3856,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -3952,7 +3952,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3997,7 +3997,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -4066,7 +4066,7 @@
     },
     "pretty-bytes": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
       "dev": true,
       "requires": {
@@ -4169,7 +4169,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -4509,7 +4509,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -4524,7 +4524,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -4876,7 +4876,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -5013,7 +5013,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -5267,7 +5267,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -5282,7 +5282,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -5633,13 +5633,13 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "0.2.3",
-      "resolved": "http://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dev": true,
       "requires": {
@@ -5655,7 +5655,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -5667,7 +5667,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }

--- a/src/compile/index.ts
+++ b/src/compile/index.ts
@@ -38,7 +38,13 @@ function get_name(filename) {
 	const parts = filename.split(/[\/\\]/);
 	if (/index\.\w+/.test(parts)) parts.pop();
 
-	const base = parts.pop().replace(/\..+/, "");
+	const base = parts.pop()
+		.replace(/\..+/, "")
+		.replace(/[^a-zA-Z_$0-9]+/g, '_')
+		.replace(/^_/, '')
+		.replace(/_$/, '')
+		.replace(/^(\d)/, '_$1');
+
 	return base[0].toUpperCase() + base.slice(1);
 }
 

--- a/src/compile/index.ts
+++ b/src/compile/index.ts
@@ -33,6 +33,15 @@ function validate_options(options: CompileOptions, stats: Stats) {
 	}
 }
 
+function get_name(filename) {
+	if (!filename) return null;
+	const parts = filename.split(/[\/\\]/);
+	if (/index\.\w+/.test(parts)) parts.pop();
+
+	const base = parts.pop().replace(/\..+/, "");
+	return base[0].toUpperCase() + base.slice(1);
+}
+
 export default function compile(source: string, options: CompileOptions = {}) {
 	options = assign({ generate: 'dom', dev: false }, options);
 
@@ -54,7 +63,7 @@ export default function compile(source: string, options: CompileOptions = {}) {
 	const component = new Component(
 		ast,
 		source,
-		options.name || 'SvelteComponent',
+		options.name || get_name(options.filename) || 'SvelteComponent',
 		options,
 		stats
 	);

--- a/test/css/index.js
+++ b/test/css/index.js
@@ -62,7 +62,6 @@ describe('css', () => {
 				input,
 				Object.assign(config, {
 					format: 'cjs',
-					name: 'SvelteComponent',
 					onwarn: warning => {
 						domWarnings.push(warning);
 					}
@@ -76,7 +75,6 @@ describe('css', () => {
 				Object.assign(config, {
 					format: 'cjs',
 					generate: 'ssr',
-					name: 'SvelteComponent',
 					onwarn: warning => {
 						ssrWarnings.push(warning);
 					}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,7 +2,6 @@ import * as jsdom from 'jsdom';
 import * as assert from 'assert';
 import * as glob from 'tiny-glob/sync.js';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as colors from 'kleur';
 
 // for coverage purposes, we need to test source files,
@@ -171,24 +170,14 @@ export function addLineNumbers(code) {
 		.join('\n');
 }
 
-function capitalise(str) {
-	return str[0].toUpperCase() + str.slice(1);
-}
-
 export function showOutput(cwd, options = {}, compile = svelte.compile) {
 	glob('**/*.html', { cwd }).forEach(file => {
 		if (file[0] === '_') return;
 
-		const name = path.basename(file)
-			.slice(0, -path.extname(file).length)
-			.replace(/^\d/, '_$&')
-			.replace(/[^a-zA-Z0-9_$]/g, '');
-
 		const { js } = compile(
 			fs.readFileSync(`${cwd}/${file}`, 'utf-8'),
 			Object.assign(options, {
-				filename: file,
-				name: capitalise(name)
+				filename: file
 			})
 		);
 

--- a/test/hydration/index.js
+++ b/test/hydration/index.js
@@ -12,11 +12,6 @@ import {
 
 let compileOptions = null;
 
-function getName(filename) {
-	const base = path.basename(filename).replace('.html', '');
-	return base[0].toUpperCase() + base.slice(1);
-}
-
 const sveltePath = process.cwd();
 
 describe('hydration', () => {
@@ -27,7 +22,6 @@ describe('hydration', () => {
 			const options = Object.assign(
 				{
 					filename,
-					name: getName(filename),
 					hydratable: true,
 					format: 'cjs',
 					sveltePath

--- a/test/runtime/index.js
+++ b/test/runtime/index.js
@@ -19,11 +19,6 @@ let svelte;
 let compileOptions = null;
 let compile = null;
 
-function getName(filename) {
-	const base = path.basename(filename).replace(".html", "");
-	return base[0].toUpperCase() + base.slice(1);
-}
-
 const sveltePath = process.cwd().split('\\').join('/');
 const internal = `${sveltePath}/internal.js`;
 
@@ -33,10 +28,11 @@ describe("runtime", () => {
 		svelte$ = loadSvelte(true);
 
 		require.extensions[".html"] = function(module, filename) {
-			const options = Object.assign(
-				{ filename, name: compileOptions.name || getName(filename), format: 'cjs', sveltePath },
-				compileOptions
-			);
+			const options = Object.assign({
+				filename,
+				format: 'cjs',
+				sveltePath
+			}, compileOptions);
 
 			const { js: { code } } = compile(fs.readFileSync(filename, "utf-8"), options);
 
@@ -118,7 +114,7 @@ describe("runtime", () => {
 						mod = require(`./samples/${dir}/main.html`);
 						SvelteComponent = mod.default;
 					} catch (err) {
-						showOutput(cwd, { internal, hydratable: hydrate, format: 'cjs' }, svelte.compile); // eslint-disable-line no-console
+						showOutput(cwd, compileOptions, svelte.compile); // eslint-disable-line no-console
 						throw err;
 					}
 
@@ -189,22 +185,13 @@ describe("runtime", () => {
 						}
 					} else {
 						failed.add(dir);
-						showOutput(cwd, {
-							internal,
-							hydratable: hydrate,
-							dev: compileOptions.dev,
-							format: 'cjs'
-						}, svelte.compile); // eslint-disable-line no-console
+						showOutput(cwd, compileOptions, svelte.compile); // eslint-disable-line no-console
 						throw err;
 					}
 				})
 				.then(() => {
 					if (config.show) {
-						showOutput(cwd, {
-							internal,
-							hydratable: hydrate,
-							format: 'cjs'
-						}, svelte.compile);
+						showOutput(cwd, compileOptions, svelte.compile);
 					}
 
 					flush();

--- a/test/server-side-rendering/index.js
+++ b/test/server-side-rendering/index.js
@@ -109,7 +109,9 @@ describe("ssr", () => {
 				delete require.cache[resolved];
 			});
 
-			const compileOptions = Object.assign({ sveltePath }, config.compileOptions);
+			const compileOptions = Object.assign({ sveltePath }, config.compileOptions, {
+				generate: 'ssr'
+			});
 
 			require("../../register")(compileOptions);
 
@@ -128,6 +130,10 @@ describe("ssr", () => {
 				}
 
 				if (config.after_test) config.after_test();
+
+				if (config.show) {
+					showOutput(cwd, compileOptions);
+				}
 			} catch (err) {
 				if (config.error) {
 					if (typeof config.error === 'function') {
@@ -136,7 +142,7 @@ describe("ssr", () => {
 						assert.equal(config.error, err.message);
 					}
 				} else {
-					showOutput(cwd, { generate: "ssr" });
+					showOutput(cwd, compileOptions);
 					throw err;
 				}
 			}


### PR DESCRIPTION
Still trying to fix a weird bug exposed by the Sapper test suite, and hoping that this will somehow help. As a bonus, it means that bundler integrations no longer need to [generate a name themselves](https://github.com/rollup/rollup-plugin-svelte/blob/22d834558a6ef0bc00fc771d899d7151dfa93602/index.js#L230), and that fewer components will unhelpfully be called `<Index>` when debugging.

Though I've just realised we need to sanitise the name as well...