### PR TITLE
avoid spread pattern, it causes some problems with some setups somehow???

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte",
-  "version": "3.0.0-alpha23",
+  "version": "3.0.0-alpha25",
   "description": "The magical disappearing UI framework",
   "module": "index.mjs",
   "main": "index.js",

--- a/src/compile/nodes/Attribute.ts
+++ b/src/compile/nodes/Attribute.ts
@@ -83,7 +83,7 @@ export default class Attribute extends Node {
 			}
 		});
 
-		return [...dependencies];
+		return Array.from(dependencies);
 	}
 
 	getValue() {

--- a/src/compile/nodes/Element.ts
+++ b/src/compile/nodes/Element.ts
@@ -598,7 +598,7 @@ export default class Element extends Node {
 				if (!validModifiers.has(modifier)) {
 					component.error(handler, {
 						code: 'invalid-event-modifier',
-						message: `Valid event modifiers are ${list([...validModifiers])}`
+						message: `Valid event modifiers are ${list(Array.from(validModifiers))}`
 					});
 				}
 

--- a/src/compile/nodes/shared/Expression.ts
+++ b/src/compile/nodes/shared/Expression.ts
@@ -343,7 +343,7 @@ export default class Expression {
 					);
 
 					const args = contextual_dependencies.size > 0
-						? [`{ ${[...contextual_dependencies].join(', ')} }`]
+						? [`{ ${Array.from(contextual_dependencies).join(', ')} }`]
 						: [];
 
 					let original_params;
@@ -356,7 +356,7 @@ export default class Expression {
 					let body = code.slice(node.body.start, node.body.end).trim();
 					if (node.body.type !== 'BlockStatement') {
 						if (pending_assignments.size > 0) {
-							const insert = [...pending_assignments].map(name => `$$invalidate('${name}', ${name})`).join('; ');
+							const insert = Array.from(pending_assignments).map(name => `$$invalidate('${name}', ${name})`).join('; ');
 							pending_assignments = new Set();
 
 							component.has_reactive_assignments = true;
@@ -431,7 +431,7 @@ export default class Expression {
 
 						const insert = (
 							(has_semi ? ' ' : '; ') +
-							[...pending_assignments].map(name => `$$invalidate('${name}', ${name})`).join('; ')
+							Array.from(pending_assignments).map(name => `$$invalidate('${name}', ${name})`).join('; ')
 						);
 
 						if (/^(Break|Continue|Return)Statement/.test(node.type)) {

--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -203,7 +203,7 @@ export default function dom(
 
 				if (pending_assignments.size > 0) {
 					if (node.type === 'ArrowFunctionExpression') {
-						const insert = [...pending_assignments].map(name => `$$invalidate('${name}', ${name})`).join(';');
+						const insert = Array.from(pending_assignments).map(name => `$$invalidate('${name}', ${name})`).join(';');
 						pending_assignments = new Set();
 
 						code.prependRight(node.body.start, `{ const $$result = `);
@@ -213,7 +213,7 @@ export default function dom(
 					}
 
 					else if (/Statement/.test(node.type)) {
-						const insert = [...pending_assignments].map(name => `$$invalidate('${name}', ${name})`).join('; ');
+						const insert = Array.from(pending_assignments).map(name => `$$invalidate('${name}', ${name})`).join('; ');
 
 						if (/^(Break|Continue|Return)Statement/.test(node.type)) {
 							if (node.argument) {

--- a/src/compile/render-dom/wrappers/DebugTag.ts
+++ b/src/compile/render-dom/wrappers/DebugTag.ts
@@ -48,7 +48,7 @@ export default class DebugTagWrapper extends Wrapper {
 				addToSet(dependencies, expression.dependencies);
 			});
 
-			const condition = [...dependencies].map(d => `changed.${d}`).join(' || ');
+			const condition = Array.from(dependencies).map(d => `changed.${d}`).join(' || ');
 
 			const identifiers = this.node.expressions.map(e => e.node.name).join(', ');
 

--- a/src/compile/render-dom/wrappers/Element/index.ts
+++ b/src/compile/render-dom/wrappers/Element/index.ts
@@ -459,7 +459,7 @@ export default class ElementWrapper extends Wrapper {
 			}
 
 			this.renderer.component.partly_hoisted.push(deindent`
-				function ${handler}(${contextual_dependencies.size > 0 ? `{ ${[...contextual_dependencies].join(', ')} }` : ``}) {
+				function ${handler}(${contextual_dependencies.size > 0 ? `{ ${Array.from(contextual_dependencies).join(', ')} }` : ``}) {
 					${group.bindings.map(b => b.handler.mutation)}
 					${Array.from(dependencies).filter(dep => dep[0] !== '$').map(dep => `$$invalidate('${dep}', ${dep});`)}
 				}

--- a/src/compile/render-dom/wrappers/InlineComponent/index.ts
+++ b/src/compile/render-dom/wrappers/InlineComponent/index.ts
@@ -181,7 +181,7 @@ export default class InlineComponentWrapper extends Wrapper {
 					const { name, dependencies } = attr;
 
 					const condition = dependencies.size > 0 && (dependencies.size !== allDependencies.size)
-						? `(${[...dependencies].map(d => `changed.${d}`).join(' || ')})`
+						? `(${Array.from(dependencies).map(d => `changed.${d}`).join(' || ')})`
 						: null;
 
 					if (attr.isSpread) {
@@ -209,7 +209,7 @@ export default class InlineComponentWrapper extends Wrapper {
 					}
 				`);
 
-				const conditions = [...allDependencies].map(dep => `changed.${dep}`).join(' || ');
+				const conditions = Array.from(allDependencies).map(dep => `changed.${dep}`).join(' || ');
 
 				updates.push(deindent`
 					var ${name_changes} = ${allDependencies.size === 1 ? `${conditions}` : `(${conditions})`} ? @getSpreadUpdate(${levels}, [
@@ -232,7 +232,7 @@ export default class InlineComponentWrapper extends Wrapper {
 		}
 
 		if (fragment_dependencies.size > 0) {
-			updates.push(`if (${[...fragment_dependencies].map(n => `changed.${n}`).join(' || ')}) ${name_changes}.$$scope = { changed, ctx };`);
+			updates.push(`if (${Array.from(fragment_dependencies).map(n => `changed.${n}`).join(' || ')}) ${name_changes}.$$scope = { changed, ctx };`);
 		}
 
 		const munged_bindings = this.node.bindings.map(binding => {

--- a/src/compile/render-dom/wrappers/Slot.ts
+++ b/src/compile/render-dom/wrappers/Slot.ts
@@ -81,7 +81,7 @@ export default class SlotWrapper extends Wrapper {
 				}
 			});
 
-			const arg = dependencies.size > 0 ? `{ ${[...dependencies].join(', ')} }` : '{}';
+			const arg = dependencies.size > 0 ? `{ ${Array.from(dependencies).join(', ')} }` : '{}';
 
 			renderer.blocks.push(deindent`
 				const ${get_slot_changes} = (${arg}) => (${stringifyProps(changes_props)});

--- a/src/parse/state/tag.ts
+++ b/src/parse/state/tag.ts
@@ -17,7 +17,7 @@ const metaTags = new Map([
 	['svelte:body', 'Body']
 ]);
 
-const valid_meta_tags = [...metaTags.keys(), 'svelte:self', 'svelte:component'];
+const valid_meta_tags = [Array.from(metaTags.keys()), 'svelte:self', 'svelte:component'];
 
 const specials = new Map([
 	[

--- a/src/parse/state/tag.ts
+++ b/src/parse/state/tag.ts
@@ -17,7 +17,7 @@ const metaTags = new Map([
 	['svelte:body', 'Body']
 ]);
 
-const valid_meta_tags = [Array.from(metaTags.keys()), 'svelte:self', 'svelte:component'];
+const valid_meta_tags = Array.from(metaTags.keys()).concat('svelte:self', 'svelte:component');
 
 const specials = new Map([
 	[


### PR DESCRIPTION
Encountering a truly bizarre issue where `[...thing]` is getting compiled by... *something?* to `thing.slice()`, which is incorrect in the case where `thing` is a non-Array iterable. My attempts to figure out where it's failing have stalled, so i'm just going to do this instead