### PR TITLE
Return promise from nextTick

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -5,6 +5,6 @@ export {
 	afterUpdate,
 	setContext,
 	getContext,
-	nextTick,
+	tick,
 	createEventDispatcher
 } from './internal';

--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -18,8 +18,7 @@ export function add_render_callback(fn) {
 	render_callbacks.push(fn);
 }
 
-export function nextTick(fn) {
-	if (fn) add_render_callback(fn);
+export function tick() {
 	schedule_update();
 	return update_promise;
 }

--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -4,14 +4,13 @@ import { set_current_component } from './lifecycle.js';
 export let dirty_components = [];
 export const intros = { enabled: false };
 
-let update_scheduled = false;
+let update_promise;
 const binding_callbacks = [];
 const render_callbacks = [];
 
 export function schedule_update() {
-	if (!update_scheduled) {
-		update_scheduled = true;
-		queue_microtask(flush);
+	if (!update_promise) {
+		update_promise = Promise.resolve().then(flush);
 	}
 }
 
@@ -22,6 +21,7 @@ export function add_render_callback(fn) {
 export function nextTick(fn) {
 	add_render_callback(fn);
 	schedule_update();
+	return update_promise;
 }
 
 export function add_binding_callback(fn) {
@@ -56,7 +56,7 @@ export function flush() {
 		}
 	} while (dirty_components.length);
 
-	update_scheduled = false;
+	update_promise = null;
 }
 
 function update($$) {
@@ -68,10 +68,4 @@ function update($$) {
 
 		$$.after_render.forEach(add_render_callback);
 	}
-}
-
-function queue_microtask(callback) {
-	Promise.resolve().then(() => {
-		if (update_scheduled) callback();
-	});
 }

--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -19,7 +19,7 @@ export function add_render_callback(fn) {
 }
 
 export function nextTick(fn) {
-	add_render_callback(fn);
+	if (fn) add_render_callback(fn);
 	schedule_update();
 	return update_promise;
 }

--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -10,7 +10,8 @@ const render_callbacks = [];
 
 export function schedule_update() {
 	if (!update_promise) {
-		update_promise = Promise.resolve().then(flush);
+		update_promise = Promise.resolve();
+		update_promise.then(flush);
 	}
 }
 

--- a/test/runtime/samples/lifecycle-next-tick/_config.js
+++ b/test/runtime/samples/lifecycle-next-tick/_config.js
@@ -3,13 +3,13 @@ export default {
 		const buttons = target.querySelectorAll('button');
 		const click = new window.MouseEvent('click');
 
-		await (await buttons[0].dispatchEvent(click));
+		await buttons[0].dispatchEvent(click);
 		assert.deepEqual(component.snapshots, [
 			'before 0',
 			'after 1'
 		]);
 
-		await (await buttons[0].dispatchEvent(click));
+		await buttons[0].dispatchEvent(click);
 		assert.deepEqual(component.snapshots, [
 			'before 0',
 			'after 1',
@@ -17,7 +17,7 @@ export default {
 			'after 2'
 		]);
 
-		await (await buttons[1].dispatchEvent(click));
+		await buttons[1].dispatchEvent(click);
 		assert.deepEqual(component.snapshots, [
 			'before 0',
 			'after 1',

--- a/test/runtime/samples/lifecycle-next-tick/_config.js
+++ b/test/runtime/samples/lifecycle-next-tick/_config.js
@@ -3,13 +3,13 @@ export default {
 		const buttons = target.querySelectorAll('button');
 		const click = new window.MouseEvent('click');
 
-		await buttons[0].dispatchEvent(click);
+		await (await buttons[0].dispatchEvent(click));
 		assert.deepEqual(component.snapshots, [
 			'before 0',
 			'after 1'
 		]);
 
-		await buttons[0].dispatchEvent(click);
+		await (await buttons[0].dispatchEvent(click));
 		assert.deepEqual(component.snapshots, [
 			'before 0',
 			'after 1',
@@ -17,7 +17,7 @@ export default {
 			'after 2'
 		]);
 
-		await buttons[1].dispatchEvent(click);
+		await (await buttons[1].dispatchEvent(click));
 		assert.deepEqual(component.snapshots, [
 			'before 0',
 			'after 1',

--- a/test/runtime/samples/lifecycle-next-tick/main.html
+++ b/test/runtime/samples/lifecycle-next-tick/main.html
@@ -1,5 +1,5 @@
 <script>
-	import { nextTick } from 'svelte';
+	import { tick } from 'svelte';
 
 	export let snapshots = [];
 
@@ -14,7 +14,7 @@
 	function log() {
 		snapshots.push(`before ${buttons[0].textContent}`);
 
-		nextTick(() => {
+		tick().then(() => {
 			snapshots.push(`after ${buttons[0].textContent}`);
 		});
 	}


### PR DESCRIPTION
I think this is an improvement — it allows this sort of thing...

```js
import { nextTick } from 'svelte';

async function indentTextarea() {
  const { value, selectionStart, selectionEnd } = indent(textarea);

  // trigger update
  code = value;

  // wait until update has occurred
  await nextTick();

  // do DOM manipulation that would otherwise be clobbered
  textarea.selectionStart = selectionStart;
  textarea.selectionEnd = selectionEnd;
}
```

...as opposed to putting the post-update stuff in a callback. One question: should the callback style still be supported?