### PR TITLE
remove unnecessary dupe check

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -142,11 +142,6 @@ export default class Component {
 	}
 
 	add_var(variable: Var) {
-		// TODO remove this
-		if (this.var_lookup.has(variable.name)) {
-			throw new Error(`dupe: ${variable.name}`);
-		}
-
 		this.vars.push(variable);
 		this.var_lookup.set(variable.name, variable);
 	}
@@ -530,7 +525,8 @@ export default class Component {
 				this.add_var({
 					name,
 					module: true,
-					hoistable: true
+					hoistable: true,
+					writable: kind === 'var' || kind === 'let'
 				});
 			}
 		});
@@ -840,7 +836,16 @@ export default class Component {
 
 		this.ast.instance.content.body.forEach(node => {
 			if (node.type === 'VariableDeclaration') {
-				if (node.declarations.every(d => d.init && d.init.type === 'Literal' && !this.var_lookup.get(d.id.name).reassigned)) {
+				const all_hoistable = node.declarations.every(d => {
+					if (!d.init) return false;
+					if (d.init.type !== 'Literal') return false;
+					if (this.var_lookup.get(d.id.name).reassigned) return false;
+					if (this.vars.find(variable => variable.name === d.id.name && variable.module)) return false;
+
+					return true;
+				});
+
+				if (all_hoistable) {
 					node.declarations.forEach(d => {
 						const variable = this.var_lookup.get(d.id.name);
 						variable.hoistable = true;

--- a/test/stats/samples/duplicate-globals/_config.js
+++ b/test/stats/samples/duplicate-globals/_config.js
@@ -1,0 +1,5 @@
+export default {
+	test(assert, stats) {
+		assert.deepEqual(stats.vars, []);
+	},
+};

--- a/test/stats/samples/duplicate-globals/input.html
+++ b/test/stats/samples/duplicate-globals/input.html
@@ -1,0 +1,7 @@
+<script context="module">
+	console.log(1);
+</script>
+
+<script>
+	console.log(2);
+</script>

--- a/test/stats/samples/duplicate-non-hoistable/_config.js
+++ b/test/stats/samples/duplicate-non-hoistable/_config.js
@@ -1,0 +1,16 @@
+export default {
+	test(assert, stats) {
+		assert.deepEqual(stats.vars, [
+			{
+				name: 'console',
+				injected: false,
+				export_name: null,
+				module: false,
+				mutated: false,
+				reassigned: false,
+				referenced: true,
+				writable: true
+			}
+		]);
+	},
+};

--- a/test/stats/samples/duplicate-non-hoistable/input.html
+++ b/test/stats/samples/duplicate-non-hoistable/input.html
@@ -1,0 +1,9 @@
+<script context="module">
+	console.log(1);
+</script>
+
+<script>
+	var console = 42;
+</script>
+
+<p>{console}</p>

--- a/test/stats/samples/duplicate-vars/_config.js
+++ b/test/stats/samples/duplicate-vars/_config.js
@@ -1,0 +1,26 @@
+export default {
+	test(assert, stats) {
+		assert.deepEqual(stats.vars, [
+			{
+				name: 'foo',
+				injected: false,
+				export_name: null,
+				module: true,
+				mutated: false,
+				reassigned: false,
+				referenced: false,
+				writable: true
+			},
+			{
+				name: 'foo',
+				injected: false,
+				export_name: null,
+				module: false,
+				mutated: false,
+				reassigned: false,
+				referenced: true,
+				writable: true
+			}
+		]);
+	},
+};

--- a/test/stats/samples/duplicate-vars/input.html
+++ b/test/stats/samples/duplicate-vars/input.html
@@ -1,0 +1,9 @@
+<script context="module">
+	var foo = 1;
+</script>
+
+<script>
+	var foo = 2;
+</script>
+
+<p>{foo}</p>


### PR DESCRIPTION
fixes #2036. Turns out to be less complicated than i thought — since the dupe check was only an internal sanity check during the recent factor, and since instance variables naturally take precedence over module variables (because the module context is analysed first), all we need to do is remove the dupe check.

Smuggled in a couple of other fixes while I was at it.