### PR TITLE
Fix "this._recompute is not a function"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -289,8 +289,6 @@ export default function dom(
 					target.insertBefore(this, anchor);
 				}
 			});
-
-			customElements.define("${component.tag}", ${name});
 		`);
 	} else {
 		builder.addBlock(deindent`
@@ -327,6 +325,10 @@ export default function dom(
 
 		${immutable && `${name}.prototype._differs = @_differsImmutable;`}
 	`);
+
+	if (component.customElement) {
+		builder.addBlock(`customElements.define("${component.tag}", ${name});`);
+	}
 
 	let result = builder.toString();
 

--- a/test/cli/samples/custom-element/expected/Main.js
+++ b/test/cli/samples/custom-element/expected/Main.js
@@ -67,9 +67,9 @@ assign(Main.prototype, {
 	}
 });
 
-customElements.define("my-element", Main);
-
 Main.prototype._recompute = noop;
+
+customElements.define("my-element", Main);
 
 function createElement(name) {
 	return document.createElement(name);

--- a/test/custom-elements/index.js
+++ b/test/custom-elements/index.js
@@ -7,6 +7,7 @@ import { addLineNumbers, loadConfig, loadSvelte } from "../helpers.js";
 
 const page = `
 <body>
+	<custom-element name="world"></custom-element>
 	<main></main>
 	<script src='/bundle.js'></script>
 </body>

--- a/test/custom-elements/samples/initial-props/main.html
+++ b/test/custom-elements/samples/initial-props/main.html
@@ -1,0 +1,8 @@
+<p>Hello {name}</p>
+
+<script>
+  export default {
+    tag: 'custom-element',
+    props: ['name']
+  };
+</script>

--- a/test/custom-elements/samples/initial-props/test.js
+++ b/test/custom-elements/samples/initial-props/test.js
@@ -1,0 +1,8 @@
+import * as assert from 'assert';
+import './main.html';
+
+export default function (target) {
+  const el = target.ownerDocument.body.querySelector('custom-element');
+  const p = el.shadowRoot.querySelector('p');
+  assert.equal(p.textContent, 'Hello world');
+}

--- a/test/js/samples/css-shadow-dom-keyframes/expected.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected.js
@@ -59,5 +59,7 @@ assign(SvelteComponent.prototype, {
 	}
 });
 
+
+
 customElements.define("custom-element", SvelteComponent);
 export default SvelteComponent;


### PR DESCRIPTION
There is kind of a race condition when loading a Svelte custom element. `customElements.define` seems to synchronously mount all existing matching elements and calls `attributeChangedCallback` which ends up calling `this._recompute` which is undefined at that point.

This happens in several cases, see => #2049.