### PR TITLE
Allow repl to use alert

### DIFF
--- a/site/src/routes/repl/_components/Output/Viewer.svelte
+++ b/site/src/routes/repl/_components/Output/Viewer.svelte
@@ -289,7 +289,7 @@
 </style>
 
 <div class="iframe-container">
-	<iframe title="Result" bind:this={refs.child} sandbox="allow-scripts allow-popups allow-forms allow-pointer-lock allow-top-navigation" class="{error || pending || pendingImports ? 'greyed-out' : ''}" srcdoc='
+	<iframe title="Result" bind:this={refs.child} sandbox="allow-scripts allow-popups allow-forms allow-pointer-lock allow-top-navigation allow-modals" class="{error || pending || pendingImports ? 'greyed-out' : ''}" srcdoc='
 		<!doctype html>
 		<html>
 			<head>


### PR DESCRIPTION
This adds allow-modal to the iframe sandbox allowing the use of `alert` from components. Fixes some demos including the 7guis-flight-booker
