### PR TITLE
fix invalid blog rss feed

### DIFF
--- a/site/src/routes/blog/rss.xml.js
+++ b/site/src/routes/blog/rss.xml.js
@@ -1,10 +1,10 @@
 import get_posts from '../api/blog/_posts.js';
 
-const months = ',Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec'.split( ',' );
+const months = ',Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec'.split(',');
 
-function formatPubdate ( str ) {
-	const [ y, m, d ] = str.split( '-' );
-	return `${d} ${months[+m]} ${y}`;
+function formatPubdate(str) {
+	const [y, m, d] = str.split('-');
+	return `${d} ${months[+m]} ${y} 12:00 +0000`;
 }
 
 const rss = `
@@ -20,18 +20,18 @@ const rss = `
 		<title>Svelte</title>
 		<link>https://svelte.technology/blog</link>
 	</image>
-	${get_posts().map( post => `
+	${get_posts().map(post => `
 		<item>
 			<title>${post.metadata.title}</title>
 			<link>https://svelte.technology/blog/${post.slug}</link>
 			<description>${post.metadata.description}</description>
 			<pubDate>${formatPubdate(post.metadata.pubdate)}</pubDate>
 		</item>
-	` )}
+	`).join('')}
 </channel>
 
 </rss>
-`.replace( />[^\S]+/gm, '>' ).replace( /[^\S]+</gm, '<' ).trim();
+`.replace(/>[^\S]+/gm, '>').replace(/[^\S]+</gm, '<').trim();
 
 export function get(req, res) {
 	res.set({


### PR DESCRIPTION
Fixes #2085.

All we have for the blog posts is a day, so I'm generating dates at noon UTC on that day. Plus also fixed stray commas between each `<item>`, and some other tidying.

With these changes, the W3 feed validator still has a couple of other 'best practices' notes about the feed (which I didn't look at too closely), but it does now say it is valid.