### PR TITLE
Use initCustomEvent instead of new CustomEvent

### DIFF
--- a/src/internal/dom.js
+++ b/src/internal/dom.js
@@ -250,3 +250,9 @@ export function addResizeListener(element, fn) {
 export function toggleClass(element, name, toggle) {
 	element.classList[toggle ? 'add' : 'remove'](name);
 }
+
+export function custom_event(type, detail) {
+	const e = document.createEvent('CustomEvent');
+	e.initCustomEvent(type, false, false, detail);
+	return e;
+}

--- a/src/internal/lifecycle.js
+++ b/src/internal/lifecycle.js
@@ -1,3 +1,5 @@
+import { custom_event } from './dom';
+
 export let current_component;
 
 export function set_current_component(component) {
@@ -34,7 +36,7 @@ export function createEventDispatcher() {
 		if (callbacks) {
 			// TODO are there situations where events could be dispatched
 			// in a server (non-DOM) environment?
-			const event = new window.CustomEvent(type, { detail });
+			const event = custom_event(type, detail);
 			callbacks.slice().forEach(fn => {
 				fn.call(component, event);
 			});

--- a/src/internal/transitions.js
+++ b/src/internal/transitions.js
@@ -1,6 +1,7 @@
 import { identity as linear, noop, run_all } from './utils.js';
 import { loop } from './loop.js';
 import { create_rule, delete_rule } from './style_manager.js';
+import { custom_event } from './dom.js';
 
 let promise;
 
@@ -238,14 +239,14 @@ export function create_bidirectional_transition(node, fn, params, intro) {
 			if (b) tick(0, 1);
 
 			running_program = init(program, duration);
-			node.dispatchEvent(new window.CustomEvent(`${running_program.b ? 'intro' : 'outro'}start`));
+			node.dispatchEvent(custom_event(`${running_program.b ? 'intro' : 'outro'}start`));
 
 			loop(now => {
 				if (pending_program && now > pending_program.start) {
 					running_program = init(pending_program, duration);
 					pending_program = null;
 
-					node.dispatchEvent(new window.CustomEvent(`${running_program.b ? 'intro' : 'outro'}start`));
+					node.dispatchEvent(custom_event(`${running_program.b ? 'intro' : 'outro'}start`));
 
 					if (css) {
 						clear_animation();
@@ -256,7 +257,7 @@ export function create_bidirectional_transition(node, fn, params, intro) {
 				if (running_program) {
 					if (now >= running_program.end) {
 						tick(t = running_program.b, 1 - t);
-						node.dispatchEvent(new window.CustomEvent(`${running_program.b ? 'intro' : 'outro'}end`));
+						node.dispatchEvent(custom_event(`${running_program.b ? 'intro' : 'outro'}end`));
 
 						if (!pending_program) {
 							// we're done


### PR DESCRIPTION
This is one possible solution to #2018. It penalises non-IE11 users, which I don't like, but I'm not sure there's a clean alternative that doesn't involve polyfilling (which is a nuisance, even if the polyfill is small and simple).

Also, maybe it's better *not* to use `legacy` for this, since the other two places where it's used (for try-catching `input.type = type`, and replacing `element.dataset.foo = bar` with `element.setAttribute('data-foo', bar)`) are for IE9 (I think?), and it'd be nice if Svelte supported IE11 *without* the legacy flag since a lot of people are still in the unfortunate position of supporting it.

Any strong feelings either way?