### PR TITLE
Fix REPL save and fork when code doesn't compile

### DIFF
--- a/site/src/routes/repl/_components/Repl.svelte
+++ b/site/src/routes/repl/_components/Repl.svelte
@@ -20,7 +20,7 @@
 		version; // workaround
 
 		return {
-			imports: bundle.imports,
+			imports: bundle && bundle.imports || [],
 			components: $component_store,
 			values: $values_store
 		};


### PR DESCRIPTION
The REPL save crashes on broken code because the bundle is null. 
The save and fork features only use the `components` and `values` properties, so I have just made it put an empty imports if bundle is not defined. 
This solves the immediate problem of not being able to fork or save when there is a bug in svelte compiler or the code. The downside is that downloads will work but will not have the imports applied. I thought about maybe caching the last valid bundle.imports and using that in case of error, but decided to leave that alone.