### PR TITLE
Some fixes for REPL props editor

### DIFF
--- a/site/static/workers/compiler.js
+++ b/site/static/workers/compiler.js
@@ -37,7 +37,7 @@ function compile({ source, options, entry }) {
 		);
 
 		const props = entry
-			? (vars || stats.vars).map(v => v.export_name).filter(Boolean) // TODO remove stats post-launch
+			? (vars || stats.vars).map(v => v.writable && v.export_name).filter(Boolean) // TODO remove stats post-launch
 			: null;
 
 		return { js: js.code, css: css.code, props };

--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -330,7 +330,7 @@ export default class Component {
 			css,
 			ast: this.ast,
 			warnings: this.warnings,
-			vars: this.vars.filter(v => !v.global && !v.implicit && !v.internal).map(v => ({
+			vars: this.vars.filter(v => !v.global && !v.internal).map(v => ({
 				name: v.name,
 				export_name: v.export_name || null,
 				injected: v.injected || false,

--- a/test/vars/samples/implicit/_config.js
+++ b/test/vars/samples/implicit/_config.js
@@ -1,5 +1,16 @@
 export default {
 	test(assert, vars) {
-		assert.deepEqual(vars, []);
+		assert.deepEqual(vars, [
+			{
+				export_name: 'foo',
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'foo',
+				reassigned: false,
+				referenced: true,
+				writable: true,
+			},
+		]);
 	},
 };

--- a/test/vars/samples/template-references/_config.js
+++ b/test/vars/samples/template-references/_config.js
@@ -1,5 +1,36 @@
 export default {
 	test(assert, vars) {
-		assert.deepEqual(vars, []);
+		assert.deepEqual(vars, [
+			{
+				export_name: 'foo',
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'foo',
+				reassigned: false,
+				referenced: true,
+				writable: true,
+			},
+			{
+				export_name: 'Bar',
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'Bar',
+				reassigned: false,
+				referenced: true,
+				writable: true,
+			},
+			{
+				export_name: 'baz',
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'baz',
+				reassigned: false,
+				referenced: true,
+				writable: true,
+			},
+		]);
 	},
 };


### PR DESCRIPTION
1. Makes the `vars` output from the compiler also include implicit vars in script-less components (so that these vars will appear in the REPL props editor)
2. Makes the props editor only display `writable` vars, so exported constants and methods will not appear