### PR TITLE
Check if slotted component has an update function during runtime

### DIFF
--- a/src/compile/render-dom/wrappers/Slot.ts
+++ b/src/compile/render-dom/wrappers/Slot.ts
@@ -141,7 +141,7 @@ export default class SlotWrapper extends Wrapper {
 		if (this.dependencies.size > 1) update_conditions = `(${update_conditions})`;
 
 		block.builders.update.addBlock(deindent`
-			if (${slot} && ${update_conditions}) {
+			if (${slot} && ${slot}.p && ${update_conditions}) {
 				${slot}.p(@assign(@assign({}, ${get_slot_changes}(changed)), ctx.$$scope.changed), @get_slot_context(${slot_definition}, ctx, ${get_slot_context}));
 			}
 		`);


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->

Fixes https://github.com/sveltejs/svelte/issues/2122.

As far as I can tell (I might be wrong in my analysis), a slot will call the `.p()` update method of the slotted block, not caring whether the slotted block has or hasn't an update method. Compile-time checks of `block.hasUpdateMethod` only give information about the slot itself, not the slotted block (in other words, https://github.com/IvanSanchez/svelte/commit/14d2651e0aa4c6f194a004df23a7d1154776190b just doesn't fix the issue).

An alternative solution would be to put a `noop` update method in all blocks susceptible of ever being slotted.