### PR TITLE
Fix vars `referenced` for actions/animations/transitions in non-DOM generate mode

### DIFF
--- a/src/compile/nodes/Action.ts
+++ b/src/compile/nodes/Action.ts
@@ -14,6 +14,7 @@ export default class Action extends Node {
 		component.warn_if_undefined(info, scope);
 
 		this.name = info.name;
+		component.qualify(info.name);
 
 		this.expression = info.expression
 			? new Expression(component, this, scope, info.expression)

--- a/src/compile/nodes/Animation.ts
+++ b/src/compile/nodes/Animation.ts
@@ -13,6 +13,7 @@ export default class Animation extends Node {
 		component.warn_if_undefined(info, scope);
 
 		this.name = info.name;
+		component.qualify(info.name);
 
 		if (parent.animation) {
 			component.error(this, {

--- a/src/compile/nodes/Transition.ts
+++ b/src/compile/nodes/Transition.ts
@@ -15,6 +15,8 @@ export default class Transition extends Node {
 		component.warn_if_undefined(info, scope);
 
 		this.name = info.name;
+		component.qualify(info.name);
+
 		this.directive = info.intro && info.outro ? 'transition' : info.intro ? 'in' : 'out';
 		this.is_local = info.modifiers.includes('local');
 

--- a/test/vars/index.js
+++ b/test/vars/index.js
@@ -14,47 +14,41 @@ describe('vars', () => {
 			throw new Error('Forgot to remove `solo: true` from test');
 		}
 
-		(solo ? it.only : skip ? it.skip : it)(dir, () => {
-			const config = loadConfig(`./vars/samples/${dir}/_config.js`);
-			const filename = `test/vars/samples/${dir}/input.svelte`;
-			const input = fs.readFileSync(filename, 'utf-8').replace(/\s+$/, '');
+		for (const generate of ['dom', 'ssr', false]) {
+			(solo ? it.only : skip ? it.skip : it)(`${dir}, generate: ${generate}`, () => {
+				const config = loadConfig(`./vars/samples/${dir}/_config.js`);
+				const filename = `test/vars/samples/${dir}/input.svelte`;
+				const input = fs.readFileSync(filename, 'utf-8').replace(/\s+$/, '');
 
-			const expectedError = tryToLoadJson(
-				`test/vars/samples/${dir}/error.json`
-			);
+				const expectedError = tryToLoadJson(
+					`test/vars/samples/${dir}/error.json`
+				);
 
-			let result;
-			let error;
+				let result;
+				let error;
 
-			try {
-				result = svelte.compile(input, config.options);
-				config.test(assert, result.vars);
-			} catch (e) {
-				error = e;
-			}
-
-			if (error || expectedError) {
-				if (error && !expectedError) {
-					throw error;
+				try {
+					result = svelte.compile(input, { ...config.options, generate });
+					config.test(assert, result.vars);
+				} catch (e) {
+					error = e;
 				}
 
-				if (expectedError && !error) {
-					throw new Error(`Expected an error: ${expectedError.message}`);
+				if (error || expectedError) {
+					if (error && !expectedError) {
+						throw error;
+					}
+
+					if (expectedError && !error) {
+						throw new Error(`Expected an error: ${expectedError.message}`);
+					}
+
+					assert.equal(error.message, expectedError.message);
+					assert.deepEqual(error.start, expectedError.start);
+					assert.deepEqual(error.end, expectedError.end);
+					assert.equal(error.pos, expectedError.pos);
 				}
-
-				assert.equal(error.message, expectedError.message);
-				assert.deepEqual(error.start, expectedError.start);
-				assert.deepEqual(error.end, expectedError.end);
-				assert.equal(error.pos, expectedError.pos);
-			}
-		});
-	});
-
-	it('returns a vars object when options.generate is false', () => {
-		const { vars } = svelte.compile('', {
-			generate: false
-		});
-
-		assert.ok(Array.isArray(vars));
+			});
+		}
 	});
 });

--- a/test/vars/samples/actions/_config.js
+++ b/test/vars/samples/actions/_config.js
@@ -1,0 +1,16 @@
+export default {
+	test(assert, vars) {
+		assert.deepEqual(vars, [
+			{
+				export_name: null,
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'foo',
+				reassigned: false,
+				referenced: true,
+				writable: true
+			}
+		]);
+	}
+};

--- a/test/vars/samples/actions/input.svelte
+++ b/test/vars/samples/actions/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	let foo;
+</script>
+
+<div use:foo/>

--- a/test/vars/samples/animations/_config.js
+++ b/test/vars/samples/animations/_config.js
@@ -1,0 +1,16 @@
+export default {
+	test(assert, vars) {
+		assert.deepEqual(vars, [
+			{
+				export_name: null,
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'foo',
+				reassigned: false,
+				referenced: true,
+				writable: true
+			}
+		]);
+	}
+};

--- a/test/vars/samples/animations/input.svelte
+++ b/test/vars/samples/animations/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	let foo;
+</script>
+
+{#each [] as x (x)}
+	<div animate:foo/>
+{/each}

--- a/test/vars/samples/transitions/_config.js
+++ b/test/vars/samples/transitions/_config.js
@@ -1,0 +1,36 @@
+export default {
+	test(assert, vars) {
+		assert.deepEqual(vars, [
+			{
+				export_name: null,
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'foo',
+				reassigned: false,
+				referenced: true,
+				writable: true
+			},
+			{
+				export_name: null,
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'bar',
+				reassigned: false,
+				referenced: true,
+				writable: true
+			},
+			{
+				export_name: null,
+				injected: false,
+				module: false,
+				mutated: false,
+				name: 'baz',
+				reassigned: false,
+				referenced: true,
+				writable: true
+			}
+		]);
+	}
+};

--- a/test/vars/samples/transitions/input.svelte
+++ b/test/vars/samples/transitions/input.svelte
@@ -1,0 +1,9 @@
+<script>
+	let foo;
+	let bar;
+	let baz;
+</script>
+
+<div in:foo/>
+<div out:bar/>
+<div transition:baz/>


### PR DESCRIPTION
Fixes #2133, using the last method I commented about in that issue. I'm not completely confident that this is the way to fix it, it seems to work and doesn't seem to break any other tests.