### PR TITLE
subscribable declarations trigger a new group (#2127)

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -826,6 +826,7 @@ export default class Component {
 										declarators: [declarator],
 										insert: get_insert(variable)
 									});
+									current_group = null;
 								} else {
 									if (current_group && current_group.kind !== node.kind) {
 										current_group = null;


### PR DESCRIPTION
I _think_ this fixes https://github.com/sveltejs/svelte/issues/2127. I don't fully understand the magic string stuff, but it looks like declarations below a _subscribable_ were being grouped with declarations above it, and that caused it to overwrite part of the declaration for the subscribable.

I am not sure how to add test cases yet, but with this change the [example component](https://v3.svelte.technology/repl?version=3.0.0-beta.8&gist=9e08a9527c9fe70db79681d9f0d46a78) in #2127 compiles correctly, if not optimally in all cases.

```js
function instance($$self, $$props, $$invalidate) {
        let $b;

        let { a } = $$props;
        let { b } = $$props; subscribe($$self, b, $$value => { $b = $$value; $$invalidate('$b', $b) });
        let { c } = $$props;

        $$self.$set = $$props => {
                if ('a' in $$props) $$invalidate('a', a = $$props.a);
                if ('b' in $$props) $$invalidate('b', b = $$props.b);
                if ('c' in $$props) $$invalidate('c', c = $$props.c);
        };

        return { a, b, c, $b };
}
```