### PR TITLE
expose get() from svelte/store

### DIFF
--- a/store.mjs
+++ b/store.mjs
@@ -1,4 +1,4 @@
-import { run_all, noop } from './internal';
+import { run_all, noop, get_store_value } from './internal';
 
 export function readable(start, value) {
 	const subscribers = [];
@@ -103,3 +103,5 @@ export function derive(stores, fn) {
 		};
 	});
 }
+
+export { get_store_value as get };

--- a/test/store/index.js
+++ b/test/store/index.js
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { readable, writable, derive } from '../../store.js';
+import { readable, writable, derive, get } from '../../store.js';
 
 describe('store', () => {
 	describe('writable', () => {
@@ -170,6 +170,13 @@ describe('store', () => {
 			]);
 
 			unsubscribe();
+		});
+	});
+
+	describe('get', () => {
+		it('gets the current value of a store', () => {
+			const store = readable(() => {}, 42);
+			assert.equal(get(store), 42);
 		});
 	});
 });


### PR DESCRIPTION
Resolves #2060. There have been a few people asking for some nice way to get a store's current value (in contexts where autosubscription is not possible). This simply exposes the existing function in `svelte/internal` as `get` in `svelte/store`. I'm not positive this is a good idea, but it's definitely a better idea than requiring a `.get()` as part of the store contract or blessing such a method by having it be part of the default `readable` and `writable` stores.