### PR TITLE
Fix code generation for non-exported vars after an export

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -839,6 +839,14 @@ export default class Component {
 
 									current_group.declarators.push(declarator);
 								}
+
+								if (next) {
+									const next_variable = component.var_lookup.get(next.id.name)
+									if (next_variable && !next_variable.export_name) {
+										current_group = null
+										code.overwrite(declarator.end, next.start, ` ${node.kind} `);
+									}
+								}
 							} else {
 								current_group = null;
 

--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -843,7 +843,6 @@ export default class Component {
 								if (next) {
 									const next_variable = component.var_lookup.get(next.id.name)
 									if (next_variable && !next_variable.export_name) {
-										current_group = null
 										code.overwrite(declarator.end, next.start, ` ${node.kind} `);
 									}
 								}

--- a/test/runtime/samples/mixed-let-export/_config.js
+++ b/test/runtime/samples/mixed-let-export/_config.js
@@ -1,0 +1,9 @@
+export default {
+  props: {
+    a: 42
+  },
+
+  html: `
+    42
+  `
+}

--- a/test/runtime/samples/mixed-let-export/main.svelte
+++ b/test/runtime/samples/mixed-let-export/main.svelte
@@ -1,0 +1,7 @@
+<script>
+  let a, b, c, d;
+
+  export { a, c }
+</script>
+
+{a}


### PR DESCRIPTION
Forces a new declaration if the next variable is not exported.

```js
let a, b
export { a }
```

Becomes:

```js
let { a } = $$props; let b;
```

Fixes https://github.com/sveltejs/svelte/issues/2165
