### PR TITLE
more export codegen fixes

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -839,7 +839,7 @@ export default class Component {
 								}
 
 								if (variable.name !== variable.export_name) {
-                  code.prependRight(declarator.id.start, `${variable.export_name}:`)
+									code.prependRight(declarator.id.start, `${variable.export_name}:`)
 								}
 
 								if (next) {

--- a/test/runtime/samples/prop-exports/_config.js
+++ b/test/runtime/samples/prop-exports/_config.js
@@ -1,0 +1,29 @@
+import { writable } from '../../../../store';
+
+export default {
+	props: {
+    s1: writable(42),
+    s2: writable(43),
+    p1: 2,
+    p3: 3,
+    a1: writable(1),
+    a2: 4,
+    a6: writable(29),
+    for: 'loop',
+    continue: '...',
+	},
+
+	html: `
+    $s1=42
+    $s2=43
+    p1=2
+    p3=3
+    $v1=1
+    v2=4
+    vi1=4
+    $vs1=1
+    vl1=test
+    $s3=29
+    loop...
+  `
+}

--- a/test/runtime/samples/prop-exports/main.svelte
+++ b/test/runtime/samples/prop-exports/main.svelte
@@ -1,0 +1,46 @@
+<script>
+  // export multiple subscribables in one line
+  export let u1, s1, u2, s2
+
+  let p1, p2, p3
+
+  // export previously declared props
+  export { p1, p3 }
+
+  // aliased props <component a1={...} a2={...}> assign to v1, v2
+  let v1, v2
+  export { v1 as a1, v2 as a2 }
+
+  // aliased export with initializer
+  let vi1 = v2
+  export { vi1 as a3 }
+
+  // aliased subscribable export
+  let vs1 = v1
+  export { vs1 as a4 }
+
+  // aliased with literal initializer
+  let vl1 = 'test'
+  export { vl1 as a5 }
+
+  // aliased store surrounded by non-aliased non-stores
+  let n1, n2, s3
+  export { n1, s3 as a6, n2 }
+
+  // keyword exports
+  let k1, k2
+  export { k1 as for, k2 as continue }
+
+</script>
+
+$s1={$s1}
+$s2={$s2}
+p1={p1}
+p3={p3}
+$v1={$v1}
+v2={v2}
+vi1={vi1}
+$vs1={$vs1}
+vl1={vl1}
+$s3={$s3}
+{k1}{k2}


### PR DESCRIPTION
Hopefully the last one of these for a while! A few other edge cases came up in discord where subtle ordering of exports, or single-line exports with stores would cause svelte to generate invalid code. I tried to cover these all, as well as other valid [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) syntaxes that weren't supported before.

### Simplification + eager grouping

This set of changes simplifies code generation for exports/props a little; there should be fewer edge cases around stores with the `if variable.subscribable` conditional inlined with the rest of the logic instead of branching around it.

The declaration grouping is a little different here too - instead of treating stores as their own group, and creating a new group after every store, stores are now added to the current group, and a new group is only created once a second store is found, etc. This should mean slightly more compact code is generated in some cases:

```
<script>
export let s1, l1, l2
</script>
{$s1} {l1} {l2}
```

```diff
-let { s1 } = $$props; subscribe($$self, s1, $$value => { $s1 = $$value; $$invalidate('$s1', $s1) }); let { l1, l2 } = $$props;
+let { s1, l1, l2 } = $$props; subscribe($$self, s1, $$value => { $s1 = $$value; $$invalidate('$s1', $s1) });
```

### Named + aliased exports, keyword props

This also adds support for using `export { name as othername }` - where `othername` is the prop name, and `name` is how it is referenced internal to the component.

I didn't see any examples of this in the RFCs or anywhere, but most of the generated code already supported this - the initial `= $$props` assignment just didn't generate the right destructuring for it - now it does!

One interesting thing this enables is props that use JS reserved keywords - as long as they're renamed by the `export`, e.g. `export _for as for`:

```js
// <Component for="Steph" />
<script>
let _for
export { _for as for }
</script>

{_for}
```