### PR TITLE
Fix textarea tutorial example code

### DIFF
--- a/site/content/tutorial/06-bindings/05-textarea-inputs/text.md
+++ b/site/content/tutorial/06-bindings/05-textarea-inputs/text.md
@@ -5,5 +5,5 @@ title: Textarea inputs
 The `<textarea>` element behaves similarly to a text input in Svelte — use `bind:value`:
 
 ```html
-<textarea bind:value={markdown}></textarea
+<textarea bind:value={markdown}></textarea>
 ```


### PR DESCRIPTION
The textarea tutorial example code was missing a `>` at the end.