### PR TITLE
Tutorial/REPL tweaks

### DIFF
--- a/site/src/components/Repl/CodeMirror.svelte
+++ b/site/src/components/Repl/CodeMirror.svelte
@@ -39,7 +39,9 @@
 		}
 
 		code = new_code;
+		updating_externally = true;
 		if (editor) editor.setValue(code);
+		updating_externally = false;
 	}
 
 	export function update(new_code) {
@@ -73,7 +75,7 @@
 
 	const refs = {};
 	let editor;
-	let updating = false;
+	let updating_externally = false;
 	let marker;
 	let error_line;
 	let destroyed = false;
@@ -131,10 +133,6 @@
 		}
 	});
 
-	beforeUpdate(() => {
-		updating = false;
-	});
-
 	function createEditor(mode) {
 		if (destroyed || !CodeMirror) return;
 
@@ -163,8 +161,8 @@
 		editor = CodeMirror.fromTextArea(refs.editor, opts);
 
 		editor.on('change', instance => {
-			if (!updating) {
-				updating = true;
+			if (!updating_externally) {
+				updating_externally = true;
 				// code = instance.getValue();
 				dispatch('change', { value: instance.getValue() });
 			}

--- a/site/src/components/Repl/CodeMirror.svelte
+++ b/site/src/components/Repl/CodeMirror.svelte
@@ -58,6 +58,10 @@
 		editor.refresh();
 	}
 
+	export function focus() {
+		editor.focus();
+	}
+
 	const modes = {
 		js: {
 			name: 'javascript',

--- a/site/src/components/Repl/CodeMirror.svelte
+++ b/site/src/components/Repl/CodeMirror.svelte
@@ -162,9 +162,8 @@
 
 		editor.on('change', instance => {
 			if (!updating_externally) {
-				updating_externally = true;
-				// code = instance.getValue();
-				dispatch('change', { value: instance.getValue() });
+				const value = instance.getValue();
+				dispatch('change', { value });
 			}
 		});
 

--- a/site/src/components/Repl/Input/ComponentSelector.svelte
+++ b/site/src/components/Repl/Input/ComponentSelector.svelte
@@ -135,7 +135,6 @@
 		border: none;
 		color: var(--flash);
 		outline: none;
-		line-height: 1;
 		background-color: transparent;
 	}
 

--- a/site/src/components/Repl/Input/ComponentSelector.svelte
+++ b/site/src/components/Repl/Input/ComponentSelector.svelte
@@ -83,7 +83,6 @@
 
 	.file-tabs {
 		border: none;
-		padding: 0 0 0 5rem;
 		margin: 0;
 		white-space: nowrap;
 		overflow-x: auto;
@@ -91,16 +90,17 @@
 		height: 10em;
 	}
 
-	.file-tabs button {
+	.file-tabs .button, .file-tabs button {
 		position: relative;
+		display: inline-block;
 		font: 400 1.2rem/1.5 var(--font);
 		border-bottom: var(--border-w) solid transparent;
-		padding: 1.2rem 1.2rem 0.8rem 0.5rem;
+		padding: 1.2rem 1.4rem 0.8rem 0.8rem;
 		margin: 0 0.5rem 0 0;
 		color: #999;
 	}
 
-	.file-tabs button.active {
+	.file-tabs .button.active {
 		/* color: var(--second); */
 		color: #333;
 		border-bottom: var(--border-w) solid var(--prime);
@@ -119,24 +119,14 @@
 	input {
 		position: absolute;
 		width: 100%;
-		left: 0.5rem;
+		left: 0.8rem;
 		top: 1.2rem;
-		/* padding: 0 0.4rem; */
-		/* font-size: 1rem; */
 		font: 400 1.2rem/1.5 var(--font);
 		border: none;
 		color: var(--flash);
 		outline: none;
 		line-height: 1;
 		background-color: transparent;
-	}
-
-	.editable {
-		/* margin-right: 2.4rem; */
-	}
-
-	.uneditable {
-		/* padding-left: 1.2rem; */
 	}
 
 	.remove {
@@ -155,74 +145,78 @@
 		color: var(--flash);
 	}
 
-	.file-tabs button.active .editable {
+	.file-tabs .button.active .editable {
 		cursor: text;
 	}
 
-	.file-tabs button.active .remove {
-		display: inline-block;
+	.file-tabs .button.active .remove {
+		display: block;
 	}
 
 	.add-new {
 		position: absolute;
 		left: 0;
 		top: 0;
-		width: 5rem;
-		height: 100%;
+		padding: 1.2rem 1rem 0.8rem 0 !important;
+		height: 4.2rem;
 		text-align: center;
 		background-color: white;
 	}
 
 	.add-new:hover {
-		color: var(--flash);
+		color: var(--flash) !important;
 	}
 </style>
 
 <div class="component-selector">
-	<div class="file-tabs" on:dblclick="{addNew}">
-		{#each $components as component}
-			<button
-				id={component.name}
-				class:active="{component === $selected}"
-				data-name={component.name}
-				on:click="{() => selectComponent(component)}"
-				on:dblclick="{e => e.stopPropagation()}"
-			>
-				{#if component.name == 'App'}
-					<div class="uneditable">
-						App.svelte
-					</div>
-				{:else}
-					{#if component === editing}
-						<span class="input-sizer">{editing.name + (/\./.test(editing.name) ? '' : `.${editing.type}`)}</span>
-
-						<input
-							autofocus
-							bind:value={editing.name}
-							on:focus={selectInput}
-							on:blur="{() => closeEdit()}"
-							use:enter="{e => e.target.blur()}"
-						>
-					{:else}
-						<div
-							class="editable"
-							title="edit component name"
-							on:click="{() => editTab(component)}"
-						>
-							{component.name}.{component.type}
+	{#if $components.length}
+		<div class="file-tabs" on:dblclick="{addNew}">
+			{#each $components as component}
+				<div
+					id={component.name}
+					class="button"
+					role="button"
+					class:active="{component === $selected}"
+					on:click="{() => selectComponent(component)}"
+					on:dblclick="{e => e.stopPropagation()}"
+				>
+					{#if component.name == 'App'}
+						<div class="uneditable">
+							App.svelte
 						</div>
+					{:else}
+						{#if component === editing}
+							<span class="input-sizer">{editing.name + (/\./.test(editing.name) ? '' : `.${editing.type}`)}</span>
 
-						<span class="remove" on:click="{() => remove(component)}">
-							<Icon name="close" size={12}/>
-							<!-- &times; -->
-						</span>
+							<input
+								autofocus
+								spellcheck={false}
+								bind:value={editing.name}
+								on:focus={selectInput}
+								on:blur="{() => closeEdit()}"
+								use:enter="{e => e.target.blur()}"
+							>
+						{:else}
+							<div
+								class="editable"
+								title="edit component name"
+								on:click="{() => editTab(component)}"
+							>
+								{component.name}.{component.type}
+							</div>
+
+							<span class="remove" on:click="{() => remove(component)}">
+								<Icon name="close" size={12}/>
+								<!-- &times; -->
+							</span>
+						{/if}
 					{/if}
-				{/if}
-			</button>
-		{/each}
-	</div>
+				</div>
+			{/each}
 
-	<button class="add-new" on:click={addNew} title="add new component">
-		<Icon name="plus" />
-	</button>
+			<button class="add-new" on:click={addNew} title="add new component">
+				<Icon name="plus" />
+			</button>
+		</div>
+	{/if}
 </div>

--- a/site/src/components/Repl/Input/ComponentSelector.svelte
+++ b/site/src/components/Repl/Input/ComponentSelector.svelte
@@ -5,7 +5,7 @@
 
 	export let handle_select;
 
-	const { components, selected } = getContext('REPL');
+	const { components, selected, request_focus } = getContext('REPL');
 
 	let editing = null;
 
@@ -32,6 +32,9 @@
 		handle_select($selected);
 
 		components = components; // TODO necessary?
+
+		// focus the editor, but wait a beat (so key events aren't misdirected)
+		setTimeout(request_focus);
 	}
 
 	function remove(component) {
@@ -99,8 +102,12 @@
 		font: 400 1.2rem/1.5 var(--font);
 		border-bottom: var(--border-w) solid transparent;
 		padding: 1.2rem 1.4rem 0.8rem 0.8rem;
-		margin: 0 0.5rem 0 0;
+		margin: 0;
 		color: #999;
+	}
+
+	.file-tabs .button:first-child {
+		padding-left: 1.2rem;
 	}
 
 	.file-tabs .button.active {

--- a/site/src/components/Repl/Input/ComponentSelector.svelte
+++ b/site/src/components/Repl/Input/ComponentSelector.svelte
@@ -28,6 +28,9 @@
 		if (match && match[2]) $selected.type = match[2];
 		editing = null;
 
+		// re-select, in case the type changed
+		handle_select($selected);
+
 		components = components; // TODO necessary?
 	}
 
@@ -43,7 +46,7 @@
 				console.error(`Could not find component! That's... odd`);
 			}
 
-			selected.set($components[index] || $components[$components.length - 1]);
+			handle_select($components[index] || $components[$components.length - 1]);
 		}
 	}
 
@@ -70,7 +73,7 @@
 		});
 
 		components.update(components => components.concat(component));
-		selected.set(component);
+		handle_select(component);
 	}
 </script>
 
@@ -193,7 +196,7 @@
 								spellcheck={false}
 								bind:value={editing.name}
 								on:focus={selectInput}
-								on:blur="{() => closeEdit()}"
+								on:blur={closeEdit}
 								use:enter="{e => e.target.blur()}"
 							>
 						{:else}

--- a/site/src/components/Repl/Input/ModuleEditor.svelte
+++ b/site/src/components/Repl/Input/ModuleEditor.svelte
@@ -11,6 +11,10 @@
 	onMount(() => {
 		register_module_editor(editor);
 	});
+
+	export function focus() {
+		editor.focus();
+	}
 </script>
 
 <style>

--- a/site/src/components/Repl/Output/index.svelte
+++ b/site/src/components/Repl/Output/index.svelte
@@ -100,7 +100,7 @@
 		position: relative;
 		font: 400 1.2rem/1.5 var(--font);
 		border-bottom: var(--border-w) solid transparent;
-		padding: 1.2rem 0.8rem 0.8rem 0.8rem;
+		padding: 1.2rem 1.2rem 0.8rem 1.2rem;
 		color: #999;
 	}
 

--- a/site/src/components/Repl/index.svelte
+++ b/site/src/components/Repl/index.svelte
@@ -113,6 +113,10 @@
 
 		register_output(handlers) {
 			output = handlers;
+		},
+
+		request_focus() {
+			module_editor.focus();
 		}
 	});
 

--- a/site/src/routes/tutorial/[slug]/_components/TableOfContents.svelte
+++ b/site/src/routes/tutorial/[slug]/_components/TableOfContents.svelte
@@ -24,7 +24,6 @@
 		font-weight: 300;
 		font-size: var(--h6);
 		color: white;
-		cursor: pointer;
 	}
 
 	a {
@@ -54,6 +53,7 @@
 		width: 100%;
 		height: 100%;
 		opacity: 0.0001;
+		cursor: pointer;
 	}
 </style>
 


### PR DESCRIPTION
Fixes a number of minor annoyances:

* components can be removed on Firefox (turns out FF doesn't dispatch click events for any children of `<button>` elements???)
* Moved the + button to the right hand side of the component selector, which is more logical and looks nicer
* Fixed some Firefox visual glitches
* Creating a new file focuses the editor once you've picked a name
* Correctly syntax highlights .js files when they're first created, not just when you click back to them
* The bundle isn't recompiled every time you click between components (fixes #2166)
* Minor visual finessing

Also, the tutorial table of contents now has `cursor: pointer`, making it more obviously interactive