### PR TITLE
Disallow `export ... from` statements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,9 +61,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
     "acorn-dynamic-import": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.0",
     "@types/node": "^10.5.5",
-    "acorn": "^6.0.5",
+    "acorn": "^6.1.1",
     "acorn-dynamic-import": "^4.0.0",
     "agadoo": "^1.0.1",
     "c8": "^3.4.0",

--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -438,6 +438,12 @@ export default class Component {
 			}
 
 			if (node.type === 'ExportNamedDeclaration') {
+				if (node.source) {
+					this.error(node, {
+						code: `not-implemented`,
+						message: `A component currently cannot have an export ... from`
+					});
+				}
 				if (node.declaration) {
 					if (node.declaration.type === 'VariableDeclaration') {
 						node.declaration.declarations.forEach(declarator => {


### PR DESCRIPTION
Works around #2214 for the time being. Also upgrades Acorn so that `export { some_undeclared_global };` is a parsing error.