### PR TITLE
Only include writable vars in reactive declaration dependencies

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -1034,7 +1034,10 @@ export default class Component {
 							if (!assignee_nodes.has(identifier)) {
 								const { name } = identifier;
 								const owner = scope.findOwner(name);
-								if ((!owner || owner === component.instance_scope) && (name[0] === '$' || component.var_lookup.has(name))) {
+								if (
+									(!owner || owner === component.instance_scope) &&
+									(name[0] === '$' || component.var_lookup.has(name) && component.var_lookup.get(name).writable)
+								) {
 									dependencies.add(name);
 								}
 							}

--- a/test/js/samples/reactive-values-non-writable-dependencies/expected.js
+++ b/test/js/samples/reactive-values-non-writable-dependencies/expected.js
@@ -17,11 +17,11 @@ let a = 1;
 let b = 2;
 
 function instance($$self, $$props, $$invalidate) {
-	
+
 
 	let max;
 
-	$$self.$$.update = ($$dirty = { Math: 1, a: 1, b: 1 }) => {
+	$$self.$$.update = ($$dirty = { a: 1, b: 1 }) => {
 		if ($$dirty.a || $$dirty.b) {
 			max = Math.max(a, b); $$invalidate('max', max);
 		}

--- a/test/validator/samples/reactive-declaration-no-deps/errors.json
+++ b/test/validator/samples/reactive-declaration-no-deps/errors.json
@@ -1,0 +1,7 @@
+[{
+	"message": "Invalid reactive declaration — must depend on local state",
+	"code": "invalid-reactive-declaration",
+	"start": { "line": 2, "column": 1, "character": 10 },
+	"end": { "line": 2, "column": 23, "character": 32 },
+	"pos": 10
+}]

--- a/test/validator/samples/reactive-declaration-no-deps/input.svelte
+++ b/test/validator/samples/reactive-declaration-no-deps/input.svelte
@@ -1,0 +1,3 @@
+<script>
+	$: console.log('foo');
+</script>


### PR DESCRIPTION
Fixes #2173. As a bonus, also produces nicer output in [this case](https://github.com/sveltejs/svelte/pull/2228/files#diff-4824807d0852d37b0cb95a3c50b4ecc4R24).