### PR TITLE
repl: deal with named module exports from main App

### DIFF
--- a/site/src/components/Repl/Output/Viewer.svelte
+++ b/site/src/components/Repl/Output/Viewer.svelte
@@ -76,7 +76,7 @@
 				window.location.hash = '';
 				window._svelteTransitionManager = null;
 
-				window.component = new SvelteComponent({
+				window.component = new SvelteComponent.default({
 					target: document.body
 				});
 			`);

--- a/site/static/workers/bundler.js
+++ b/site/static/workers/bundler.js
@@ -174,6 +174,7 @@ async function bundle(components) {
 				import_map.set(id, name);
 				return name;
 			},
+			exports: 'named',
 			sourcemap: true
 		});
 
@@ -197,6 +198,7 @@ async function bundle(components) {
 				format: 'iife',
 				name: 'SvelteComponent',
 				globals: id => import_map.get(id),
+				exports: 'named',
 				sourcemap: true
 			})
 			: null;


### PR DESCRIPTION
If the main App in the REPL has named module exports, Rollup complains about bundling to IIFE and puts the default export under `.default` in the IIFE's return value. This passes the `output.exports = 'named'` option to Rollup so that it doesn't complain and will instead always include the default export under `.default` regardless of whether there are other named exports - and then it uses `new SvelteComponent.default()` rather than `new SvelteComponent()` when instantiating the component.