### PR TITLE
store prop names as $$.props, prevent leaky bindings

### DIFF
--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -407,6 +407,8 @@ export default function dom(
 		`);
 	}
 
+	const prop_names = `[${props.map(v => JSON.stringify(v.export_name)).join(', ')}]`;
+
 	if (options.customElement) {
 		builder.addBlock(deindent`
 			class ${name} extends @SvelteElement {
@@ -415,7 +417,7 @@ export default function dom(
 
 					${css.code && `this.shadowRoot.innerHTML = \`<style>${escape(css.code, { onlyEscapeAtSymbol: true }).replace(/\\/g, '\\\\')}${options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
 
-					@init(this, { target: this.shadowRoot }, ${definition}, create_fragment, ${not_equal});
+					@init(this, { target: this.shadowRoot }, ${definition}, create_fragment, ${not_equal}, ${prop_names});
 
 					${dev_props_check}
 
@@ -449,7 +451,7 @@ export default function dom(
 				constructor(options) {
 					super(${options.dev && `options`});
 					${should_add_css && `if (!document.getElementById("${component.stylesheet.id}-style")) @add_css();`}
-					@init(this, options, ${definition}, create_fragment, ${not_equal});
+					@init(this, options, ${definition}, create_fragment, ${not_equal}, ${prop_names});
 
 					${dev_props_check}
 				}

--- a/src/internal/Component.js
+++ b/src/internal/Component.js
@@ -5,6 +5,7 @@ import { blankObject } from './utils.js';
 import { children } from './dom.js';
 
 export function bind(component, name, callback) {
+	if (component.$$.props.indexOf(name) === -1) return;
 	component.$$.bound[name] = callback;
 	callback(component.$$.ctx[name]);
 }
@@ -53,7 +54,7 @@ function make_dirty(component, key) {
 	component.$$.dirty[key] = true;
 }
 
-export function init(component, options, instance, create_fragment, not_equal) {
+export function init(component, options, instance, create_fragment, not_equal, prop_names) {
 	const parent_component = current_component;
 	set_current_component(component);
 
@@ -64,6 +65,7 @@ export function init(component, options, instance, create_fragment, not_equal) {
 		ctx: null,
 
 		// state
+		props: prop_names,
 		update: noop,
 		not_equal,
 		bound: blankObject(),

--- a/test/js/samples/action-custom-event-handler/expected.js
+++ b/test/js/samples/action-custom-event-handler/expected.js
@@ -54,7 +54,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["bar"]);
 	}
 
 	get bar() {

--- a/test/js/samples/action/expected.js
+++ b/test/js/samples/action/expected.js
@@ -48,7 +48,7 @@ function link(node) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/bind-width-height/expected.js
+++ b/test/js/samples/bind-width-height/expected.js
@@ -51,7 +51,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["w", "h"]);
 	}
 
 	get w() {

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -54,7 +54,7 @@ class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
 		if (!document.getElementById("svelte-1a7i8ec-style")) add_css();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
 	}
 
 	get foo() {

--- a/test/js/samples/component-static-array/expected.js
+++ b/test/js/samples/component-static-array/expected.js
@@ -45,7 +45,7 @@ function instance($$self) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/component-static-immutable/expected.js
+++ b/test/js/samples/component-static-immutable/expected.js
@@ -45,7 +45,7 @@ function instance($$self) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, not_equal);
+		init(this, options, instance, create_fragment, not_equal, []);
 	}
 }
 

--- a/test/js/samples/component-static-immutable2/expected.js
+++ b/test/js/samples/component-static-immutable2/expected.js
@@ -45,7 +45,7 @@ function instance($$self) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, not_equal);
+		init(this, options, instance, create_fragment, not_equal, []);
 	}
 }
 

--- a/test/js/samples/component-static/expected.js
+++ b/test/js/samples/component-static/expected.js
@@ -45,7 +45,7 @@ function instance($$self) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -33,7 +33,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["x", "a", "b"]);
 	}
 
 	get x() {

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -37,7 +37,7 @@ class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
 		if (!document.getElementById("svelte-1slhpfn-style")) add_css();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/css-shadow-dom-keyframes/expected.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected.js
@@ -33,7 +33,7 @@ class SvelteComponent extends SvelteElement {
 
 		this.shadowRoot.innerHTML = `<style>div{animation:foo 1s}@keyframes foo{0%{opacity:0}100%{opacity:1}}</style>`;
 
-		init(this, { target: this.shadowRoot }, null, create_fragment, safe_not_equal);
+		init(this, { target: this.shadowRoot }, null, create_fragment, safe_not_equal, []);
 
 		if (options) {
 			if (options.target) {

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -62,7 +62,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["name"]);
 
 		const { ctx } = this.$$;
 		const props = options.props || {};

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -150,7 +150,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["things", "foo", "bar", "baz"]);
 
 		const { ctx } = this.$$;
 		const props = options.props || {};

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -148,7 +148,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["things", "foo"]);
 
 		const { ctx } = this.$$;
 		const props = options.props || {};

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -113,7 +113,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["createElement"]);
 	}
 
 	get createElement() {

--- a/test/js/samples/deconflict-globals/expected.js
+++ b/test/js/samples/deconflict-globals/expected.js
@@ -30,7 +30,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
 	}
 
 	get foo() {

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -68,7 +68,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
 
 		const { ctx } = this.$$;
 		const props = options.props || {};

--- a/test/js/samples/do-use-dataset/expected.js
+++ b/test/js/samples/do-use-dataset/expected.js
@@ -51,7 +51,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["bar"]);
 	}
 
 	get bar() {

--- a/test/js/samples/dont-invalidate-this/expected.js
+++ b/test/js/samples/dont-invalidate-this/expected.js
@@ -35,7 +35,7 @@ function make_uppercase() {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/dont-use-dataset-in-legacy/expected.js
+++ b/test/js/samples/dont-use-dataset-in-legacy/expected.js
@@ -51,7 +51,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["bar"]);
 	}
 
 	get bar() {

--- a/test/js/samples/dont-use-dataset-in-svg/expected.js
+++ b/test/js/samples/dont-use-dataset-in-svg/expected.js
@@ -49,7 +49,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["bar"]);
 	}
 
 	get bar() {

--- a/test/js/samples/dynamic-import/expected.js
+++ b/test/js/samples/dynamic-import/expected.js
@@ -44,7 +44,7 @@ function func() {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -116,7 +116,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["a", "b", "c", "d", "e"]);
 	}
 
 	get a() {

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -156,7 +156,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["comments", "elapsed", "time", "foo"]);
 	}
 
 	get comments() {

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -128,7 +128,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["things"]);
 	}
 
 	get things() {

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -98,7 +98,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["things"]);
 	}
 
 	get things() {

--- a/test/js/samples/event-handler-no-passive/expected.js
+++ b/test/js/samples/event-handler-no-passive/expected.js
@@ -37,7 +37,7 @@ function touchstart_handler(e) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/event-modifiers/expected.js
+++ b/test/js/samples/event-modifiers/expected.js
@@ -57,7 +57,7 @@ function handleClick() {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/head-no-whitespace/expected.js
+++ b/test/js/samples/head-no-whitespace/expected.js
@@ -33,7 +33,7 @@ function create_fragment(ctx) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/hoisted-const/expected.js
+++ b/test/js/samples/hoisted-const/expected.js
@@ -34,7 +34,7 @@ function get_answer() { return ANSWER; }
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/hoisted-let/expected.js
+++ b/test/js/samples/hoisted-let/expected.js
@@ -34,7 +34,7 @@ function get_answer() { return ANSWER; }
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -104,7 +104,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
 	}
 
 	get foo() {

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -78,7 +78,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
 	}
 
 	get foo() {

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -51,7 +51,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["color", "x", "y"]);
 	}
 
 	get color() {

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -44,7 +44,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["data"]);
 	}
 
 	get data() {

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -44,7 +44,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["color"]);
 	}
 
 	get color() {

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -57,7 +57,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["style", "key", "value"]);
 	}
 
 	get style() {

--- a/test/js/samples/input-files/expected.js
+++ b/test/js/samples/input-files/expected.js
@@ -48,7 +48,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["files"]);
 	}
 
 	get files() {

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -56,7 +56,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["value"]);
 	}
 
 	get value() {

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -52,7 +52,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
 	}
 
 	get foo() {

--- a/test/js/samples/instrumentation-script-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-script-if-no-block/expected.js
@@ -57,7 +57,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/instrumentation-script-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-script-x-equals-x/expected.js
@@ -58,7 +58,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -57,7 +57,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/instrumentation-template-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-template-x-equals-x/expected.js
@@ -55,7 +55,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/legacy-input-type/expected.js
+++ b/test/js/samples/legacy-input-type/expected.js
@@ -29,7 +29,7 @@ function create_fragment(ctx) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -123,7 +123,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["buffered", "seekable", "played", "currentTime", "duration", "paused", "volume"]);
 	}
 
 	get buffered() {

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -55,7 +55,7 @@ function create_fragment(ctx) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/non-mutable-reference/expected.js
+++ b/test/js/samples/non-mutable-reference/expected.js
@@ -36,7 +36,7 @@ let name = 'world';
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/reactive-values-non-topologically-ordered/expected.js
+++ b/test/js/samples/reactive-values-non-topologically-ordered/expected.js
@@ -37,7 +37,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["x"]);
 	}
 
 	get x() {

--- a/test/js/samples/reactive-values-non-writable-dependencies/expected.js
+++ b/test/js/samples/reactive-values-non-writable-dependencies/expected.js
@@ -33,7 +33,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -70,7 +70,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["current"]);
 	}
 
 	get current() {

--- a/test/js/samples/setup-method/expected.js
+++ b/test/js/samples/setup-method/expected.js
@@ -21,7 +21,7 @@ function foo(bar) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, ["foo"]);
 	}
 
 	get foo() {

--- a/test/js/samples/svg-title/expected.js
+++ b/test/js/samples/svg-title/expected.js
@@ -32,7 +32,7 @@ function create_fragment(ctx) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal);
+		init(this, options, null, create_fragment, safe_not_equal, []);
 	}
 }
 

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -35,7 +35,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["custom"]);
 	}
 
 	get custom() {

--- a/test/js/samples/transition-local/expected.js
+++ b/test/js/samples/transition-local/expected.js
@@ -139,7 +139,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["x", "y"]);
 	}
 
 	get x() {

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -263,7 +263,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["a", "b", "c", "d", "e"]);
 	}
 
 	get a() {

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -68,7 +68,7 @@ function instance($$self, $$props, $$invalidate) {
 class SvelteComponent extends SvelteComponent_1 {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal);
+		init(this, options, instance, create_fragment, safe_not_equal, ["y"]);
 	}
 
 	get y() {

--- a/test/runtime/samples/component-binding-non-leaky/Counter.svelte
+++ b/test/runtime/samples/component-binding-non-leaky/Counter.svelte
@@ -1,0 +1,5 @@
+<script>
+	let count = 0;
+</script>
+
+<button on:click='{() => count += 1}'>{count}</button>

--- a/test/runtime/samples/component-binding-non-leaky/_config.js
+++ b/test/runtime/samples/component-binding-non-leaky/_config.js
@@ -1,0 +1,27 @@
+export default {
+	html: `
+		<button>0</button>
+		<p>count: undefined</p>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const click = new window.MouseEvent('click');
+		const button = target.querySelector('button');
+
+		await button.dispatchEvent(click);
+
+		assert.equal(component.x, undefined);
+		assert.htmlEqual(target.innerHTML, `
+			<button>1</button>
+			<p>count: undefined</p>
+		`);
+
+		await button.dispatchEvent(click);
+
+		assert.equal(component.x, undefined);
+		assert.htmlEqual(target.innerHTML, `
+			<button>2</button>
+			<p>count: undefined</p>
+		`);
+	}
+};

--- a/test/runtime/samples/component-binding-non-leaky/main.svelte
+++ b/test/runtime/samples/component-binding-non-leaky/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Counter from './Counter.svelte';
+
+	let x;
+</script>
+
+<Counter bind:count={x}/>
+<p>count: {x}</p>


### PR DESCRIPTION
fixes #2222. Can't think of a better solution than this