### PR TITLE
Subscribe to global stores

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -168,7 +168,7 @@ export default class Component {
 			this.add_reference(subscribable_name);
 
 			const variable = this.var_lookup.get(subscribable_name);
-			variable.subscribable = true;
+			if (variable) variable.subscribable = true;
 		} else {
 			this.usedNames.add(name);
 		}

--- a/src/compile/nodes/shared/Expression.ts
+++ b/src/compile/nodes/shared/Expression.ts
@@ -149,13 +149,6 @@ export default class Expression {
 							dependencies.add(name);
 						}
 
-						if (name[0] === '$' && !component.var_lookup.get(name.slice(1)) && name !== '$$props') {
-							component.error(node, {
-								code: `missing-store`,
-								message: `Stores must be declared`
-							});
-						}
-
 						component.add_reference(name);
 						component.warn_if_undefined(nodes[0], template_scope);
 					}

--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -326,7 +326,7 @@ export default function dom(
 	const reactive_store_subscriptions = reactive_stores
 		.filter(store => {
 			const variable = component.var_lookup.get(store.name.slice(1));
-			return variable.hoistable;
+			return !variable || variable.hoistable;
 		})
 		.map(({ name }) => deindent`
 			${component.compileOptions.dev && `@validate_store(${name.slice(1)}, '${name.slice(1)}');`}
@@ -336,7 +336,7 @@ export default function dom(
 	const resubscribable_reactive_store_unsubscribers = reactive_stores
 		.filter(store => {
 			const variable = component.var_lookup.get(store.name.slice(1));
-			return variable.reassigned;
+			return variable && variable.reassigned;
 		})
 		.map(({ name }) => `$$self.$$.on_destroy.push(() => $$unsubscribe_${name.slice(1)}());`);
 
@@ -370,7 +370,7 @@ export default function dom(
 			const name = $name.slice(1);
 
 			const store = component.var_lookup.get(name);
-			if (store.reassigned) {
+			if (store && store.reassigned) {
 				return `${$name}, $$unsubscribe_${name} = @noop, $$subscribe_${name} = () => { $$unsubscribe_${name}(); $$unsubscribe_${name} = ${name}.subscribe($$value => { ${$name} = $$value; $$invalidate('${$name}', ${$name}); }) }`
 			}
 

--- a/src/compile/render-ssr/index.ts
+++ b/src/compile/render-ssr/index.ts
@@ -27,13 +27,14 @@ export default function ssr(
 	const reactive_stores = component.vars.filter(variable => variable.name[0] === '$' && variable.name[1] !== '$');
 	const reactive_store_values = reactive_stores
 		.map(({ name }) => {
-			const store = component.var_lookup.get(name.slice(1));
-			if (store.hoistable) return;
+			const store_name = name.slice(1);
+			const store = component.var_lookup.get(store_name);
+			if (store && store.hoistable) return;
 
-			const assignment = `${name} = @get_store_value(${store.name});`;
+			const assignment = `${name} = @get_store_value(${store_name});`;
 
 			return component.compileOptions.dev
-				? `@validate_store(${store.name}, '${store.name}'); ${assignment}`
+				? `@validate_store(${store_name}, '${store_name}'); ${assignment}`
 				: assignment;
 		});
 
@@ -95,10 +96,11 @@ export default function ssr(
 	const blocks = [
 		reactive_stores.length > 0 && `let ${reactive_stores
 			.map(({ name }) => {
-				const store = component.var_lookup.get(name.slice(1));
-				if (store.hoistable) {
+				const store_name = name.slice(1);
+				const store = component.var_lookup.get(store_name);
+				if (store && store.hoistable) {
 					const get_store_value = component.helper('get_store_value');
-					return `${name} = ${get_store_value}(${store.name})`;
+					return `${name} = ${get_store_value}(${store_name})`;
 				}
 				return name;
 			})

--- a/test/runtime/samples/store-auto-subscribe-missing-global/_config.js
+++ b/test/runtime/samples/store-auto-subscribe-missing-global/_config.js
@@ -1,0 +1,3 @@
+export default {
+	error: 'missingGlobal is not defined'
+};

--- a/test/runtime/samples/store-auto-subscribe-missing-global/main.svelte
+++ b/test/runtime/samples/store-auto-subscribe-missing-global/main.svelte
@@ -1,0 +1,1 @@
+<p>{$missingGlobal}</p>


### PR DESCRIPTION
Per [discussion](https://github.com/sveltejs/svelte/issues/2139#issuecomment-467885387) on #2139, this is an alternative to #2155. If a component has `{$foo}` and `foo` is undefined, Svelte issues the 'foo is not declared' warning as usual, but still compiles, on the assumption that `foo` is a global store. If it's not, then it errors at runtime.