### PR TITLE
various spring fixes

### DIFF
--- a/site/content/examples/08-motion/01-spring/App.svelte
+++ b/site/content/examples/08-motion/01-spring/App.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <style>
-	svg { width: 100%; height: 100% }
+	svg { width: 100%; height: 100%; margin: -8px }
 	circle { fill: #ff3e00 }
 </style>
 


### PR DESCRIPTION
Ref #2167. Fixes:

* `precision` is now configurable, and defaults to 0.001 rather than 0.000001
* the `threshold` derived from `precision` applies to both delta and velocity
* only the promise from the most recent `set`/`update` call will resolve, if those functions are called again before the spring has completed (previously, when the spring settled it would resolve many promises simultaneously, helping no-one)