### PR TITLE
add crossfade and flip functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 /easing.js
 /motion.*
 /transition.js
+/animate.js
 /scratch/
 /coverage/
 /coverage.lcov/

--- a/animate.mjs
+++ b/animate.mjs
@@ -1,0 +1,25 @@
+import { cubicOut } from './easing';
+import { is_function } from './internal';
+
+export function flip(node, animation, params) {
+	const style = getComputedStyle(node);
+	const transform = style.transform === 'none' ? '' : style.transform;
+
+	const dx = animation.from.left - animation.to.left;
+	const dy = animation.from.top - animation.to.top;
+
+	const d = Math.sqrt(dx * dx + dy * dy);
+
+	const {
+		delay = 0,
+		duration = d => Math.sqrt(d) * 120,
+		easing = cubicOut
+	} = params;
+
+	return {
+		delay,
+		duration: is_function(duration) ? duration(d) : duration,
+		easing,
+		css: (t, u) => `transform: ${transform} translate(${u * dx}px, ${u * dy}px);`
+	};
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -88,7 +88,7 @@ export default [
 	},
 
 	// everything else
-	...['index', 'store', 'easing', 'transition'].map(name => ({
+	...['index', 'store', 'easing', 'transition', 'animate'].map(name => ({
 		input: `${name}.mjs`,
 		output: {
 			file: `${name}.js`,

--- a/transition.mjs
+++ b/transition.mjs
@@ -129,7 +129,7 @@ export function crossfade({ fallback, ...defaults }) {
 				// (i.e. wasn't claimed by the other list)
 				// then we need to supply an outro
 				items.delete(params.key);
-				return fallback(node, params, intro);
+				return fallback && fallback(node, params, intro);
 			};
 		};
 	}

--- a/transition.mjs
+++ b/transition.mjs
@@ -1,4 +1,5 @@
 import { cubicOut, cubicInOut } from './easing';
+import { assign, is_function } from './internal';
 
 export function fade(node, {
 	delay = 0,
@@ -79,4 +80,62 @@ export function draw(node, {
 		easing,
 		css: (t, u) => `stroke-dasharray: ${t * len} ${u * len}`
 	};
+}
+
+export function crossfade({ fallback, ...defaults }) {
+	let to_receive = new Map();
+	let to_send = new Map();
+
+	function crossfade(from, node, params) {
+		const {
+			delay = 0,
+			duration = d => Math.sqrt(d) * 30,
+			easing = cubicOut
+		} = assign(assign({}, defaults), params);
+
+		const to = node.getBoundingClientRect();
+		const dx = from.left - to.left;
+		const dy = from.top - to.top;
+
+		const style = getComputedStyle(node);
+		const transform = style.transform === 'none' ? '' : style.transform;
+
+		return {
+			delay,
+			duration: is_function(duration) ? duration(d) : duration,
+			easing,
+			css: (t, u) => `
+				opacity: ${t};
+				transform: ${transform} translate(${u * dx}px,${u * dy}px);
+			`
+		};
+	}
+
+	function transition(items, counterparts, intro) {
+		return (node, params) => {
+			items.set(params.key, {
+				rect: node.getBoundingClientRect()
+			});
+
+			return () => {
+				if (counterparts.has(params.key)) {
+					const { rect } = counterparts.get(params.key);
+					counterparts.delete(params.key);
+
+					return crossfade(rect, node, params);
+				}
+
+				// if the node is disappearing altogether
+				// (i.e. wasn't claimed by the other list)
+				// then we need to supply an outro
+				items.delete(params.key);
+				return fallback(node, params, intro);
+			};
+		};
+	}
+
+	return [
+		transition(to_send, to_receive, false),
+		transition(to_receive, to_send, true)
+	];
 }


### PR DESCRIPTION
Ref #2241.

Not sure if these are ready to be promoted to built-in functions yet. I'm encountering occasional hard-to-reproduce positioning bugs, and `crossfade` doesn't handle changes in size (but maybe that's ok given its intended use? I think we *can* accommodate size changes, it just involves `style.transformOrigin` and some arithmetic).

Also, if you look really closely the `crossfade` opacity isn't quite right — since one side goes from 0 to 1 and the other goes from 1 to 0, in the middle they're both 0.5 which results in a total opacity of 0.75, when you really want the total opacity to stay at 1 throughout. Unfortunately the only way to achieve that is to use [this blending formula](https://github.com/Rich-Harris/ramjet/blob/master/src/interpolators/opacity.js) which requires that you know which element is on top, which you could *maybe* do with `getElementsFromPoint` but otherwise you have to figure out stacking order using something like https://gitlab.com/Rich-Harris/stacking-order. 

On the other hand, these effects are difficult to achieve by hand, so maybe we should include these functions and treat any updates as bugfixes so as not to anger the semver gods? At the very least I think we have the right API now:

```js
const [send, receive] = crossfade({
  // can supply default parameters
  easing: elasticOut,

  // duration can be a number or a function based on distance to travel
  duration: distance => Math.sqrt(distance) * 50,
  
  fallback: (node, params, intro) => {
    // can return different transitions based on `intro`, if desired.
    // structuring `params` for fallback transitions is easily
    // done in whatever way the user sees fit
  }
});
```