### PR TITLE
fix renamed instance exports

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -834,8 +834,8 @@ export default class Component {
 									current_group.declarators.push(declarator);
 								}
 
-								if (variable.name !== variable.export_name) {
-									code.prependRight(declarator.id.start, `${variable.export_name}:`)
+								if (variable.writable && variable.name !== variable.export_name) {
+									code.prependRight(declarator.id.start, `${variable.export_name}: `)
 								}
 
 								if (next) {

--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -114,7 +114,7 @@ export default function dom(
 			if (component.component_options.accessors) {
 				body.push(deindent`
 					set ${x.export_name}(${x.name}) {
-						this.$set({ ${x.name} });
+						this.$set({ ${x.name === x.export_name ? x.name : `${x.export_name}: ${x.name}`} });
 						@flush();
 					}
 				`);

--- a/test/runtime/samples/renamed-instance-exports/_config.js
+++ b/test/runtime/samples/renamed-instance-exports/_config.js
@@ -1,0 +1,10 @@
+export default {
+	test({ assert, component }) {
+		assert.equal(component.bar1, 42);
+		assert.equal(component.bar2, 42);
+		component.bar1 = 100;
+		component.bar2 = 100;
+		assert.equal(component.bar1, 42);
+		assert.equal(component.bar2, 100);
+	}
+};

--- a/test/runtime/samples/renamed-instance-exports/main.svelte
+++ b/test/runtime/samples/renamed-instance-exports/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	const foo1 = 42;
+	let foo2 = 42;
+	export { foo1 as bar1, foo2 as bar2 };
+</script>


### PR DESCRIPTION
Fixes #2253.

There's a lot of other extraneous stuff going on in my comments on the issue, which I think boils down to `const` exports not being present unless `accessors: true` is specified, which I don't think is the intended behavior. I'll open a separate issue for that.