### PR TITLE
Handle store assignments in reactive statements

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -593,7 +593,7 @@ export default class Component {
 
 			const { type, name } = node.body.expression.left;
 
-			if (type === 'Identifier' && !this.var_lookup.has(name)) {
+			if (type === 'Identifier' && !this.var_lookup.has(name) && name[0] !== '$') {
 				this.injected_reactive_declaration_vars.add(name);
 			}
 		});
@@ -761,7 +761,7 @@ export default class Component {
 
 	rewrite_props(get_insert: (variable: Var) => string) {
 		const component = this;
-		const { code, instance_scope, instance_scope_map: map, component_options } = this;
+		const { code, instance_scope, instance_scope_map: map } = this;
 		let scope = instance_scope;
 
 		const coalesced_declarations = [];

--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -1097,6 +1097,7 @@ export default class Component {
 						node.body.type === 'ExpressionStatement' &&
 						node.body.expression.type === 'AssignmentExpression' &&
 						node.body.expression.left.type === 'Identifier' &&
+						node.body.expression.left.name[0] !== '$' &&
 						this.var_lookup.get(node.body.expression.left.name).injected
 					)
 				});

--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -364,7 +364,7 @@ export default function dom(
 
 		const injected = Array.from(component.injected_reactive_declaration_vars).filter(name => {
 			const variable = component.var_lookup.get(name);
-			return variable.injected;
+			return variable.injected && variable.name[0] !== '$';
 		});
 
 		const reactive_store_declarations = reactive_stores.map(variable => {

--- a/test/runtime/samples/store-assignment-updates-reactive/_config.js
+++ b/test/runtime/samples/store-assignment-updates-reactive/_config.js
@@ -1,13 +1,18 @@
 import { writable } from '../../../../store.js';
 
+const c = writable(0);
+
 export default {
 	props: {
-		count: writable(0)
+		c
 	},
 
 	html: `
-		<button>count 0</button>
-		<p>doubled: 0</p>
+		<p>a: 0</p>
+		<p>b: 0</p>
+		<p>c: 0</p>
+
+		<button>+1</button>
 	`,
 
 	async test({ assert, component, target, window }) {
@@ -17,15 +22,21 @@ export default {
 		await button.dispatchEvent(click);
 
 		assert.htmlEqual(target.innerHTML, `
-			<button>count 1</button>
-			<p>doubled: 2</p>
+			<p>a: 1</p>
+			<p>b: 1</p>
+			<p>c: 1</p>
+
+			<button>+1</button>
 		`);
 
-		await component.count.set(42);
+		await component.c.set(42);
 
 		assert.htmlEqual(target.innerHTML, `
-			<button>count 42</button>
-			<p>doubled: 84</p>
+			<p>a: 42</p>
+			<p>b: 42</p>
+			<p>c: 42</p>
+
+			<button>+1</button>
 		`);
 	}
 };

--- a/test/runtime/samples/store-assignment-updates-reactive/main.svelte
+++ b/test/runtime/samples/store-assignment-updates-reactive/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { writable } from '../../../../store.js';
+
+	const a = writable();
+	const b = writable();
+	export let c;
+
+	$: $a = $b;
+	$: $b = $c;
+
+	function increment() {
+		$c += 1;
+	}
+</script>
+
+<p>a: {$a}</p>
+<p>b: {$b}</p>
+<p>c: {$c}</p>
+
+<button on:click={increment}>+1</button>


### PR DESCRIPTION
Fixes #2119, sort of. 'Sort of' because it doesn't (and can't) reorder statements based on what function calls they make, but it makes it possible to use the idiomatic `$store = value` form which *can* cause statements to be reordered.

(I'm ok with topological ordering failing in these pathological cases, since the fix is simple — manually order them correctly. In most cases I suspect people will naturally do that anyway. So this PR just takes us from 99% to 99.9%.)