### PR TITLE
find this= in <svelte:component> in presence of bind:this=

### DIFF
--- a/src/parse/state/tag.ts
+++ b/src/parse/state/tag.ts
@@ -191,8 +191,7 @@ export default function tag(parser: Parser) {
 	}
 
 	if (name === 'svelte:component') {
-		// TODO post v2, treat this just as any other attribute
-		const index = element.attributes.findIndex(attr => attr.name === 'this');
+		const index = element.attributes.findIndex(attr => attr.type === 'Attribute' && attr.name === 'this');
 		if (!~index) {
 			parser.error({
 				code: `missing-component-definition`,

--- a/test/runtime/samples/dynamic-component-ref/main.svelte
+++ b/test/runtime/samples/dynamic-component-ref/main.svelte
@@ -4,4 +4,4 @@
 	export let test;
 </script>
 
-<svelte:component this={Foo} bind:this={test}/>
+<svelte:component bind:this={test} this={Foo}/>


### PR DESCRIPTION
Fixes #2284.

I'm not sure what the `// TODO post v2, treat this just as any other attribute` comment here is referring to. It looks like this was added just before the v1 -> v2 switch, but I don't think there's anything we want to change here. I've removed the comment, but can put it back in if there's something still pending here.