### PR TITLE
Fix exception and warning for global variables

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -1182,7 +1182,7 @@ export default class Component {
 			if (name[0] === '$') return; // $$props
 		}
 
-		if (this.var_lookup.has(name)) return;
+		if (this.var_lookup.has(name) && !this.var_lookup.get(name).global) return;
 		if (template_scope && template_scope.names.has(name)) return;
 		if (globals.has(name)) return;
 

--- a/src/compile/nodes/Binding.ts
+++ b/src/compile/nodes/Binding.ts
@@ -39,7 +39,7 @@ export default class Binding extends Node {
 		} else {
 			const variable = component.var_lookup.get(name);
 
-			if (!variable) component.error(this.expression.node, {
+			if (!variable || variable.global) component.error(this.expression.node, {
 				code: 'binding-undeclared',
 				message: `${name} is not declared`
 			});

--- a/test/validator/samples/binding-invalid-value-global/errors.json
+++ b/test/validator/samples/binding-invalid-value-global/errors.json
@@ -1,0 +1,15 @@
+[{
+	"code": "binding-undeclared",
+	"message": "foo is not declared",
+	"pos": 58,
+	"start": {
+		"line": 4,
+		"column": 19,
+		"character": 58
+	},
+	"end": {
+		"line": 4,
+		"column": 22,
+		"character": 61
+	}
+}]

--- a/test/validator/samples/binding-invalid-value-global/input.svelte
+++ b/test/validator/samples/binding-invalid-value-global/input.svelte
@@ -1,0 +1,4 @@
+<script>
+		console.log(foo);
+</script>
+<input bind:value={foo}>

--- a/test/validator/samples/undefined-value-global/input.svelte
+++ b/test/validator/samples/undefined-value-global/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	console.log(potato);
+</script>
+
+<p>{potato}</p>

--- a/test/validator/samples/undefined-value-global/warnings.json
+++ b/test/validator/samples/undefined-value-global/warnings.json
@@ -1,0 +1,15 @@
+[{
+	"code": "missing-declaration",
+	"message": "'potato' is not defined",
+	"pos": 46,
+	"start": {
+		"line": 5,
+		"column": 4,
+		"character": 46
+	},
+	"end": {
+		"line": 5,
+		"column": 10,
+		"character": 52
+	}
+}]


### PR DESCRIPTION
Fixes #2295. An exception and a warning about global variables were not raised when the variable was also referenced in the script. A couple of checks for presence in `var_lookup` have also been augmented to check whether the variable has `global` equal to true.