### PR TITLE
reverse readable stores arg order in tutorial, fixes #2330

### DIFF
--- a/site/content/tutorial/08-stores/03-readable-stores/app-a/stores.js
+++ b/site/content/tutorial/08-stores/03-readable-stores/app-a/stores.js
@@ -1,9 +1,7 @@
 import { readable } from 'svelte/store';
 
-export const time = readable(function start(set) {
+export const time = readable(null, function start(set) {
 	// implementation goes here
 
-	return function stop() {
-
-	};
+	return function stop() {};
 });

--- a/site/content/tutorial/08-stores/03-readable-stores/app-b/stores.js
+++ b/site/content/tutorial/08-stores/03-readable-stores/app-b/stores.js
@@ -1,6 +1,6 @@
 import { readable } from 'svelte/store';
 
-export const time = readable(function start(set) {
+export const time = readable(new Date(), function start(set) {
 	const interval = setInterval(() => {
 		set(new Date());
 	}, 1000);
@@ -8,4 +8,4 @@ export const time = readable(function start(set) {
 	return function stop() {
 		clearInterval(interval);
 	};
-}, new Date());
+});

--- a/site/content/tutorial/08-stores/03-readable-stores/text.md
+++ b/site/content/tutorial/08-stores/03-readable-stores/text.md
@@ -4,10 +4,10 @@ title: Readable stores
 
 Not all stores should be writable by whoever has a reference to them. For example, you might have a store representing the mouse position or the user's geolocation, and it doesn't make sense to be able to set those values from 'outside'. For those cases, we have *readable* stores.
 
-Click over to the `stores.js` tab. The first argument to `readable` is an initial value, which can be null. The second argument is a `start` function that takes a `set` callback and returns a `stop` function. The `start` function is called when the store gets its first subscriber; `stop` is called when the last subscriber unsubscribes.
+Click over to the `stores.js` tab. The first argument to `readable` is an initial value, which can be `null` or `undefined` if you don't have one yet. The second argument is a `start` function that takes a `set` callback and returns a `stop` function. The `start` function is called when the store gets its first subscriber; `stop` is called when the last subscriber unsubscribes.
 
 ```js
-export const time = readable(function start(set) {
+export const time = readable(new Date(), function start(set) {
 	const interval = setInterval(() => {
 		set(new Date());
 	}, 1000);
@@ -15,5 +15,5 @@ export const time = readable(function start(set) {
 	return function stop() {
 		clearInterval(interval);
 	};
-}, new Date());
+});
 ```

--- a/site/content/tutorial/08-stores/03-readable-stores/text.md
+++ b/site/content/tutorial/08-stores/03-readable-stores/text.md
@@ -4,7 +4,7 @@ title: Readable stores
 
 Not all stores should be writable by whoever has a reference to them. For example, you might have a store representing the mouse position or the user's geolocation, and it doesn't make sense to be able to set those values from 'outside'. For those cases, we have *readable* stores.
 
-Click over to the `stores.js` tab. The first argument to `readable` is a `start` function that takes a `set` callback and returns a `stop` function. The `start` function is called when the store gets its first subscriber; `stop` is called when the last subscriber unsubscribes. The second (optional) argument is the initial value.
+Click over to the `stores.js` tab. The first argument to `readable` is an initial value, which can be null. The second argument is a `start` function that takes a `set` callback and returns a `stop` function. The `start` function is called when the store gets its first subscriber; `stop` is called when the last subscriber unsubscribes.
 
 ```js
 export const time = readable(function start(set) {


### PR DESCRIPTION
The argument order for readable stores was changed to keep it consistent with writable. As a result the tutorial stopped working. This fixes that, which is discussed in #2330