### PR TITLE
don't preprocess tags whose names begin with script/style

### DIFF
--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -95,8 +95,8 @@ export default async function preprocess(
 	for (const fn of script) {
 		source = await replace_async(
 			source,
-			/<script([^]*?)>([^]*?)<\/script>/gi,
-			async (match, attributes, content) => {
+			/<script(\s[^]*?)?>([^]*?)<\/script>/gi,
+			async (match, attributes = '', content) => {
 				const processed: Processed = await fn({
 					content,
 					attributes: parse_attributes(attributes),
@@ -111,8 +111,8 @@ export default async function preprocess(
 	for (const fn of style) {
 		source = await replace_async(
 			source,
-			/<style([^]*?)>([^]*?)<\/style>/gi,
-			async (match, attributes, content) => {
+			/<style(\s[^]*?)?>([^]*?)<\/style>/gi,
+			async (match, attributes = '', content) => {
 				const processed: Processed = await fn({
 					content,
 					attributes: parse_attributes(attributes),

--- a/test/preprocess/samples/partial-names/_config.js
+++ b/test/preprocess/samples/partial-names/_config.js
@@ -1,0 +1,6 @@
+export default {
+	preprocess: {
+		script: () => ({ code: '' }),
+		style: () => ({ code: '' })
+	}
+};

--- a/test/preprocess/samples/partial-names/input.svelte
+++ b/test/preprocess/samples/partial-names/input.svelte
@@ -1,0 +1,12 @@
+<script-foo>
+	foo
+</script-foo>
+<script>
+	// bar
+</script>
+<style-foo>
+	foo
+</style-foo>
+<style>
+	bar {}
+</style>

--- a/test/preprocess/samples/partial-names/output.svelte
+++ b/test/preprocess/samples/partial-names/output.svelte
@@ -1,0 +1,8 @@
+<script-foo>
+	foo
+</script-foo>
+<script></script>
+<style-foo>
+	foo
+</style-foo>
+<style></style>


### PR DESCRIPTION
The current regexes for script and style tags for preprocessing match too much - after `<script` or `<style` we need there to either be whitespace or `>`.