### PR TITLE
Pass block to the render of an expression in an attribute

### DIFF
--- a/src/compile/render-dom/wrappers/Element/Attribute.ts
+++ b/src/compile/render-dom/wrappers/Element/Attribute.ts
@@ -78,7 +78,7 @@ export default class AttributeWrapper {
 			// DRY it out if that's possible without introducing crazy indirection
 			if (this.node.chunks.length === 1) {
 				// single {tag} — may be a non-string
-				value = this.node.chunks[0].render();
+				value = this.node.chunks[0].render(block);
 			} else {
 				// '{foo} {bar}' — treat as string concatenation
 				value =

--- a/test/runtime/samples/contextual-callback-b/_config.js
+++ b/test/runtime/samples/contextual-callback-b/_config.js
@@ -1,0 +1,12 @@
+export default {
+	html: `
+		<select>
+			<option value="">please choose</option>
+			<option value="1">1</option>
+			<option disabled="" value="2">2</option>
+			<option value="3">3</option>
+			<option disabled="" value="4">4</option>
+			<option value="5">5</option>
+		</select>
+	`
+};

--- a/test/runtime/samples/contextual-callback-b/main.svelte
+++ b/test/runtime/samples/contextual-callback-b/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	let available = [1, 2, 3, 4, 5];
+	let taken = [2, 4];
+</script>
+
+<select>
+	<option value="">please choose</option>
+	{#each available as a}
+		<option disabled="{!!taken.find(f => f == a)}" value="{a}">{a}</option>
+	{/each}
+</select>


### PR DESCRIPTION
Fixes #2348. Same issue as in #2115.