### PR TITLE
Don't hoist non-renamed exports

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -925,7 +925,7 @@ export default class Component {
 
 					const v = this.var_lookup.get(d.id.name)
 					if (v.reassigned) return false
-					if (v.export_name && v.export_name !== v.name) return false
+					if (v.export_name) return false
 
 					if (this.var_lookup.get(d.id.name).reassigned) return false;
 					if (this.vars.find(variable => variable.name === d.id.name && variable.module)) return false;

--- a/test/runtime/samples/prop-exports/_config.js
+++ b/test/runtime/samples/prop-exports/_config.js
@@ -22,6 +22,7 @@ export default {
     v2=4
     vi1=4
     $vs1=1
+    vl0=hello
     vl1=test
     $s3=29
     loop...

--- a/test/runtime/samples/prop-exports/main.svelte
+++ b/test/runtime/samples/prop-exports/main.svelte
@@ -19,6 +19,10 @@
   let vs1 = v1
   export { vs1 as a4 }
 
+  // literal initializer
+  let vl0 = 'hello'
+  export { vl0 }
+
   // aliased with literal initializer
   let vl1 = 'test'
   export { vl1 as a5 }
@@ -41,6 +45,7 @@ $v1={$v1}
 v2={v2}
 vi1={vi1}
 $vs1={$vs1}
+vl0={vl0}
 vl1={vl1}
 $s3={$s3}
 {k1}{k2}


### PR DESCRIPTION
Non-renamed exports initialized with a literal were being hoisted, leading to a `$$props` reference outside the component instance.

```js
let name = 'world';
	
export { name };
```

> $$props is not defined


Fixes https://github.com/sveltejs/svelte/issues/2347