### PR TITLE
Update text.data only when necessary

### DIFF
--- a/src/internal/dom.js
+++ b/src/internal/dom.js
@@ -154,7 +154,8 @@ export function claim_text(nodes, data) {
 }
 
 export function set_data(text, data) {
-	if (text.data !== '' + data) text.data = '' + data;
+	data = '' + data;
+	if (text.data !== data) text.data = data;
 }
 
 export function set_input_type(input, type) {

--- a/src/internal/dom.js
+++ b/src/internal/dom.js
@@ -154,7 +154,7 @@ export function claim_text(nodes, data) {
 }
 
 export function set_data(text, data) {
-	text.data = '' + data;
+	if (text.data !== '' + data) text.data = '' + data;
 }
 
 export function set_input_type(input, type) {


### PR DESCRIPTION
Only update the text node if the text node's value is not equal. This fix is for contenteditable usage where text content may change outside of Svelte's control in order to preserve text composition.

Accomplishes the same thing as #2341 without the added API.