### PR TITLE
Respect compiler CSS option in SSR

### DIFF
--- a/src/compile/render-ssr/index.ts
+++ b/src/compile/render-ssr/index.ts
@@ -105,12 +105,12 @@ export default function ssr(
 			.join(', ')};`,
 		component.javascript,
 		parent_bindings.join('\n'),
-		css.code && `$$result.css.add(#css);`,
+		options.css && css.code && `$$result.css.add(#css);`,
 		main
 	].filter(Boolean);
 
 	return (deindent`
-		${css.code && deindent`
+		${options.css && css.code && deindent`
 		const #css = {
 			code: ${css.code ? stringify(css.code) : `''`},
 			map: ${css.map ? stringify(css.map.toString()) : 'null'}

--- a/test/server-side-rendering/index.js
+++ b/test/server-side-rendering/index.js
@@ -25,6 +25,7 @@ describe("ssr", () => {
 	before(() => {
 		require("../../register")({
 			extensions: ['.svelte', '.html'],
+			css: true,
 			sveltePath
 		});
 


### PR DESCRIPTION
Don't produce CSS in server side render when the CSS compiler option is set to false.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
