### PR TITLE
hoist all hoistable functions

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -1023,7 +1023,7 @@ export default class Component {
 		};
 
 		for (const [name, node] of top_level_function_declarations) {
-			if (!checked.has(node) && is_hoistable(node)) {
+			if (is_hoistable(node)) {
 				const variable = this.var_lookup.get(name);
 				variable.hoistable = true;
 				hoistable_nodes.add(node);

--- a/test/runtime/samples/function-hoisting/_config.js
+++ b/test/runtime/samples/function-hoisting/_config.js
@@ -1,0 +1,7 @@
+export default {
+  props: {
+    greeting: 'Good day'
+  },
+
+  html: '<h1>Good day, world</h1>'
+}

--- a/test/runtime/samples/function-hoisting/main.svelte
+++ b/test/runtime/samples/function-hoisting/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	export let greeting = 'Hello'
+	let name = 'world';
+
+  // both functions, and `name` are hoistable, but hoistMe does not get hoisted
+	function hoistMeMaybe () {
+		return hoistMe(name) // comment out this line => hoistMe is hoisted
+	}
+
+	function hoistMe (name) {
+		return name
+	}
+</script>
+
+<h1>{greeting}, {hoistMeMaybe()}</h1>


### PR DESCRIPTION
Top-level functions that are hoistable, but referenced by other functions, were not being hoisted because of this `!checked.has(node)`. If the referencing function was defined first, it would be hoisted, leaving the referenced function inside the instance scope and causing a reference error.

Fixes https://github.com/sveltejs/svelte/issues/2278