### PR TITLE
API docs: remove an absolute URL

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -737,7 +737,7 @@ A custom transition function can also return a `tick` function, which is called 
 {/if}
 ```
 
-If a transition returns a function instead of a transition object, the function will be called in the next microtask. This allows multiple transitions to coordinate, making [crossfade effects](https://v3.svelte.technology/tutorial/deferred-transitions) possible.
+If a transition returns a function instead of a transition object, the function will be called in the next microtask. This allows multiple transitions to coordinate, making [crossfade effects](tutorial/deferred-transitions) possible.
 
 ---
 

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -393,7 +393,7 @@ A `spring` store gradually changes to its target value based on its `stiffness` 
 
 As with `tweened` stores, `set` and `update` return a Promise that resolves if the spring settles. The `store.stiffness` and `store.damping` properties can be changed while the spring is in motion, and will take immediate effect.
 
-[See a full example here.](tutorial/spring)
+[See a full example on the spring tutorial.](tutorial/spring)
 
 ```html
 <script>


### PR DESCRIPTION
I originally started this PR because the link `[stores](tutorial/writable-stores)`
renders as http://localhost:3000/tutorial/writable-stores on https://v3.svelte.technology/docs#svelte-store.
No idea why because the rest of the relative links in content/ have the same format.
