### PR TITLE
Add bind:text and bind:html support for contenteditable elements

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -605,7 +605,26 @@ export default class Element extends Node {
 						message: `'${binding.name}' is not a valid binding on void elements like <${this.name}>. Use a wrapper element instead`
 					});
 				}
-			} else if (name !== 'this') {
+			} else if (
+				name === 'text' ||
+				name === 'html'
+			){
+				const contenteditable = this.attributes.find(
+					(attribute: Attribute) => attribute.name === 'contenteditable'
+				);
+
+				if (!contenteditable) {
+					component.error(binding, {
+						code: `missing-contenteditable-attribute`,
+						message: `'contenteditable' attribute is required for text and html two-way bindings`
+					});
+				} else if (contenteditable && !contenteditable.is_static) {
+					component.error(contenteditable, {
+						code: `dynamic-contenteditable-attribute`,
+						message: `'contenteditable' attribute cannot be dynamic if element uses two-way binding`
+					});
+				}
+		} else if (name !== 'this') {
 				component.error(binding, {
 					code: `invalid-binding`,
 					message: `'${binding.name}' is not a valid binding`

--- a/src/compiler/compile/render-dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render-dom/wrappers/Element/Binding.ts
@@ -195,6 +195,14 @@ function get_dom_updater(
 		return `${element.var}.checked = ${condition};`
 	}
 
+	if (binding.node.name === 'text') {
+		return `${element.var}.textContent = ${binding.snippet};`;
+	}
+
+	if (binding.node.name === 'html') {
+		return `${element.var}.innerHTML = ${binding.snippet};`;
+	}
+
 	return `${element.var}.${binding.node.name} = ${binding.snippet};`;
 }
 
@@ -305,6 +313,14 @@ function get_value_from_dom(
 
 	if ((name === 'buffered' || name === 'seekable' || name === 'played')) {
 		return `@time_ranges_to_array(this.${name})`
+	}
+
+	if (name === 'text') {
+		return `this.textContent`;
+	}
+
+	if (name === 'html') {
+		return `this.innerHTML`;
 	}
 
 	// everything else

--- a/src/compiler/compile/render-dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render-dom/wrappers/Element/Binding.ts
@@ -196,11 +196,11 @@ function get_dom_updater(
 	}
 
 	if (binding.node.name === 'text') {
-		return `${element.var}.textContent = ${binding.snippet};`;
+		return `if (${binding.snippet} !== ${element.var}.textContent) ${element.var}.textContent = ${binding.snippet};`;
 	}
 
 	if (binding.node.name === 'html') {
-		return `${element.var}.innerHTML = ${binding.snippet};`;
+		return `if (${binding.snippet} !== ${element.var}.innerHTML) ${element.var}.innerHTML = ${binding.snippet};`;
 	}
 
 	return `${element.var}.${binding.node.name} = ${binding.snippet};`;

--- a/src/compiler/compile/render-dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render-dom/wrappers/Element/index.ts
@@ -29,6 +29,12 @@ const events = [
 			node.name === 'input' && !/radio|checkbox|range/.test(node.get_static_attribute_value('type') as string)
 	},
 	{
+		event_names: ['input'],
+		filter: (node: Element, name: string) =>
+			(name === 'text' || name === 'html') &&
+			node.attributes.some(attribute => attribute.name === 'contenteditable')
+	},
+	{
 		event_names: ['change'],
 		filter: (node: Element, name: string) =>
 			node.name === 'select' ||

--- a/src/compiler/compile/render-ssr/handlers/Element.ts
+++ b/src/compiler/compile/render-ssr/handlers/Element.ts
@@ -58,7 +58,7 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 	const contenteditable = (
 		node.name !== 'textarea' &&
 		node.name !== 'input' &&
-		node.attributes.some((attribute: Node) => attribute.name === 'contenteditable')
+		node.attributes.some((attribute) => attribute.name === 'contenteditable')
 	);
 
 	const slot = node.get_static_attribute_value('slot');

--- a/src/compiler/compile/render-ssr/handlers/Element.ts
+++ b/src/compiler/compile/render-ssr/handlers/Element.ts
@@ -151,7 +151,7 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 
 		if (name === 'group') {
 			// TODO server-render group bindings
-		} else if (contenteditable && (node === 'text' || node === 'html')) {
+		} else if (contenteditable && (name === 'text' || name === 'html')) {
 			const snippet = snip(expression)
 			if (name == 'text') {
 				node_contents = '${@escape(' + snippet + ')}'

--- a/test/runtime/samples/contenteditable-html/_config.js
+++ b/test/runtime/samples/contenteditable-html/_config.js
@@ -1,0 +1,43 @@
+export default {
+	props: {
+		name: '<b>world</b>',
+	},
+
+	html: `
+		<editor><b>world</b></editor>
+		<p>hello <b>world</b></p>
+	`,
+
+	ssrHtml: `
+		<editor contenteditable="true"><b>world</b></editor>
+		<p>hello <b>world</b></p>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const el = target.querySelector('editor');
+		assert.equal(el.innerHTML, '<b>world</b>');
+
+		el.innerHTML = 'every<span>body</span>';
+
+        // No updates to data yet
+		assert.htmlEqual(target.innerHTML, `
+			<editor>every<span>body</span></editor>
+			<p>hello <b>world</b></p>
+		`);
+
+        // Handle user input
+        const event = new window.Event('input');
+		await el.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<editor>every<span>body</span></editor>
+			<p>hello every<span>body</span></p>
+		`);
+
+		component.name = 'good<span>bye</span>';
+		assert.equal(el.innerHTML, 'good<span>bye</span>');
+		assert.htmlEqual(target.innerHTML, `
+			<editor>good<span>bye</span></editor>
+			<p>hello good<span>bye</span></p>
+		`);
+	},
+};

--- a/test/runtime/samples/contenteditable-html/main.svelte
+++ b/test/runtime/samples/contenteditable-html/main.svelte
@@ -1,0 +1,6 @@
+<script>
+    export let name;
+</script>
+
+<editor contenteditable="true" bind:html={name}></editor>
+<p>hello {@html name}</p>

--- a/test/runtime/samples/contenteditable-text/_config.js
+++ b/test/runtime/samples/contenteditable-text/_config.js
@@ -1,0 +1,37 @@
+export default {
+	props: {
+		name: 'world',
+	},
+
+	html: `
+		<editor>world</editor>
+		<p>hello world</p>
+	`,
+
+	ssrHtml: `
+		<editor contenteditable="true">world</editor>
+		<p>hello world</p>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const el = target.querySelector('editor');
+		assert.equal(el.textContent, 'world');
+
+		const event = new window.Event('input');
+
+		el.textContent = 'everybody';
+		await el.dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<editor>everybody</editor>
+			<p>hello everybody</p>
+		`);
+
+		component.name = 'goodbye';
+		assert.equal(el.textContent, 'goodbye');
+		assert.htmlEqual(target.innerHTML, `
+			<editor>goodbye</editor>
+			<p>hello goodbye</p>
+		`);
+	},
+};

--- a/test/runtime/samples/contenteditable-text/main.svelte
+++ b/test/runtime/samples/contenteditable-text/main.svelte
@@ -1,0 +1,6 @@
+<script>
+    export let name;
+</script>
+
+<editor contenteditable="true" bind:text={name}></editor>
+<p>hello {name}</p>

--- a/test/validator/samples/contenteditable-dynamic/errors.json
+++ b/test/validator/samples/contenteditable-dynamic/errors.json
@@ -1,0 +1,15 @@
+[{
+	"code": "dynamic-contenteditable-attribute",
+	"message": "'contenteditable' attribute cannot be dynamic if element uses two-way binding",
+	"start": {
+		"line": 6,
+		"column": 8,
+		"character": 73
+	},
+	"end": {
+		"line": 6,
+		"column": 32,
+		"character": 97
+	},
+	"pos": 73
+}]

--- a/test/validator/samples/contenteditable-dynamic/input.svelte
+++ b/test/validator/samples/contenteditable-dynamic/input.svelte
@@ -1,0 +1,6 @@
+<script>
+    export let name;
+
+    let toggle = false;
+</script>
+<editor contenteditable={toggle} bind:html={name}></editor>

--- a/test/validator/samples/contenteditable-missing/errors.json
+++ b/test/validator/samples/contenteditable-missing/errors.json
@@ -1,0 +1,15 @@
+[{
+	"code": "missing-contenteditable-attribute",
+	"message": "'contenteditable' attribute is required for text and html two-way bindings",
+	"start": {
+		"line": 4,
+		"column": 8,
+		"character": 48
+	},
+	"end": {
+		"line": 4,
+		"column": 24,
+		"character": 64
+	},
+	"pos": 48
+}]

--- a/test/validator/samples/contenteditable-missing/input.svelte
+++ b/test/validator/samples/contenteditable-missing/input.svelte
@@ -1,0 +1,4 @@
+<script>
+    export let name;
+</script>
+<editor bind:text={name}></editor>


### PR DESCRIPTION
Fixes #310

Adds a special :text and :html bindings for contenteditable elements.