### PR TITLE
allow reactive declarations without dependencies

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -1134,13 +1134,6 @@ export default class Component {
 
 			seen.add(declaration);
 
-			if (declaration.dependencies.size === 0) {
-				this.error(declaration.node, {
-					code: 'invalid-reactive-declaration',
-					message: 'Invalid reactive declaration — must depend on local state'
-				});
-			}
-
 			declaration.dependencies.forEach(name => {
 				if (declaration.assignees.has(name)) return;
 				const earlier_declarations = lookup.get(name);

--- a/src/compile/utils/get_object.ts
+++ b/src/compile/utils/get_object.ts
@@ -1,7 +1,8 @@
 import { Node } from '../../interfaces';
+import unwrap_parens from './unwrap_parens';
 
 export default function get_object(node: Node) {
-	while (node.type === 'ParenthesizedExpression') node = node.expression;
+	node = unwrap_parens(node);
 	while (node.type === 'MemberExpression') node = node.object;
 	return node;
 }

--- a/src/compile/utils/scope.ts
+++ b/src/compile/utils/scope.ts
@@ -101,37 +101,41 @@ export class Scope {
 }
 
 export function extract_names(param: Node) {
-	const names: string[] = [];
-	extractors[param.type](names, param);
-	return names;
+	return extract_identifiers(param).map(node => node.name);
+}
+
+export function extract_identifiers(param: Node) {
+	const nodes: Node[] = [];
+	extractors[param.type](nodes, param);
+	return nodes;
 }
 
 const extractors = {
-	Identifier(names: string[], param: Node) {
-		names.push(param.name);
+	Identifier(nodes: Node[], param: Node) {
+		nodes.push(param);
 	},
 
-	ObjectPattern(names: string[], param: Node) {
+	ObjectPattern(nodes: Node[], param: Node) {
 		param.properties.forEach((prop: Node) => {
 			if (prop.type === 'RestElement') {
-				names.push(prop.argument.name);
+				nodes.push(prop.argument);
 			} else {
-				extractors[prop.value.type](names, prop.value);
+				extractors[prop.value.type](nodes, prop.value);
 			}
 		});
 	},
 
-	ArrayPattern(names: string[], param: Node) {
+	ArrayPattern(nodes: Node[], param: Node) {
 		param.elements.forEach((element: Node) => {
-			if (element) extractors[element.type](names, element);
+			if (element) extractors[element.type](nodes, element);
 		});
 	},
 
-	RestElement(names: string[], param: Node) {
-		extractors[param.argument.type](names, param.argument);
+	RestElement(nodes: Node[], param: Node) {
+		extractors[param.argument.type](nodes, param.argument);
 	},
 
-	AssignmentPattern(names: string[], param: Node) {
-		extractors[param.left.type](names, param.left);
+	AssignmentPattern(nodes: Node[], param: Node) {
+		extractors[param.left.type](nodes, param.left);
 	}
 };

--- a/src/compile/utils/unwrap_parens.ts
+++ b/src/compile/utils/unwrap_parens.ts
@@ -1,0 +1,6 @@
+import { Node } from '../../interfaces';
+
+export default function unwrap_parens(node: Node) {
+	while (node.type === 'ParenthesizedExpression') node = node.expression;
+	return node;
+}

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -70,9 +70,7 @@ function instance($$self, $$props, $$invalidate) {
 	};
 
 	$$self.$$.update = ($$dirty = { foo: 1 }) => {
-		if ($$dirty.foo) {
-			bar = foo * 2; $$invalidate('bar', bar);
-		}
+		if ($$dirty.foo) { bar = foo * 2; $$invalidate('bar', bar); }
 	};
 
 	return { foo, bar };

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -70,7 +70,7 @@ function instance($$self, $$props, $$invalidate) {
 	};
 
 	$$self.$$.update = ($$dirty = { foo: 1 }) => {
-		if ($$dirty.foo) { bar = foo * 2; $$invalidate('bar', bar); }
+		if ($$dirty.foo) { $$invalidate('bar', bar = foo * 2); }
 	};
 
 	return { foo, bar };

--- a/test/js/samples/instrumentation-script-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-script-if-no-block/expected.js
@@ -61,7 +61,7 @@ function instance($$self, $$props, $$invalidate) {
 	let x = 0;
 
 	function foo() {
-		if (true) { x += 1; $$invalidate('x', x); }
+		if (true) $$invalidate('x', x += 1);
 	}
 
 	return { x, foo };

--- a/test/js/samples/reactive-values-non-topologically-ordered/expected.js
+++ b/test/js/samples/reactive-values-non-topologically-ordered/expected.js
@@ -28,12 +28,8 @@ function instance($$self, $$props, $$invalidate) {
 	};
 
 	$$self.$$.update = ($$dirty = { x: 1, b: 1 }) => {
-		if ($$dirty.x) {
-			b = x; $$invalidate('b', b);
-		}
-		if ($$dirty.b) {
-			a = b; $$invalidate('a', a);
-		}
+		if ($$dirty.x) { b = x; $$invalidate('b', b); }
+		if ($$dirty.b) { a = b; $$invalidate('a', a); }
 	};
 
 	return { x };

--- a/test/js/samples/reactive-values-non-topologically-ordered/expected.js
+++ b/test/js/samples/reactive-values-non-topologically-ordered/expected.js
@@ -28,8 +28,8 @@ function instance($$self, $$props, $$invalidate) {
 	};
 
 	$$self.$$.update = ($$dirty = { x: 1, b: 1 }) => {
-		if ($$dirty.x) { b = x; $$invalidate('b', b); }
-		if ($$dirty.b) { a = b; $$invalidate('a', a); }
+		if ($$dirty.x) { $$invalidate('b', b = x); }
+		if ($$dirty.b) { $$invalidate('a', a = b); }
 	};
 
 	return { x };

--- a/test/js/samples/reactive-values-non-writable-dependencies/expected.js
+++ b/test/js/samples/reactive-values-non-writable-dependencies/expected.js
@@ -27,7 +27,7 @@ function instance($$self, $$props, $$invalidate) {
 	let max;
 
 	$$self.$$.update = ($$dirty = { a: 1, b: 1 }) => {
-		if ($$dirty.a || $$dirty.b) { max = Math.max(a, b); $$invalidate('max', max); }
+		if ($$dirty.a || $$dirty.b) { $$invalidate('max', max = Math.max(a, b)); }
 	};
 
 	return {};

--- a/test/js/samples/reactive-values-non-writable-dependencies/expected.js
+++ b/test/js/samples/reactive-values-non-writable-dependencies/expected.js
@@ -27,9 +27,7 @@ function instance($$self, $$props, $$invalidate) {
 	let max;
 
 	$$self.$$.update = ($$dirty = { a: 1, b: 1 }) => {
-		if ($$dirty.a || $$dirty.b) {
-			max = Math.max(a, b); $$invalidate('max', max);
-		}
+		if ($$dirty.a || $$dirty.b) { max = Math.max(a, b); $$invalidate('max', max); }
 	};
 
 	return {};

--- a/test/runtime/samples/reactive-values-implicit-destructured/_config.js
+++ b/test/runtime/samples/reactive-values-implicit-destructured/_config.js
@@ -1,0 +1,16 @@
+export default {
+	props: {
+		coords: [0, 0]
+	},
+
+	html: `
+		<p>0,0</p>
+	`,
+
+	test({ assert, component, target }) {
+		component.coords = [1, 2];
+		assert.htmlEqual(target.innerHTML, `
+			<p>1,2</p>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-values-implicit-destructured/_config.js
+++ b/test/runtime/samples/reactive-values-implicit-destructured/_config.js
@@ -1,16 +1,25 @@
 export default {
 	props: {
-		coords: [0, 0]
+		coords: [0, 0],
+		numbers: { answer: 42 }
 	},
 
 	html: `
 		<p>0,0</p>
+		<p>42</p>
 	`,
 
 	test({ assert, component, target }) {
 		component.coords = [1, 2];
 		assert.htmlEqual(target.innerHTML, `
 			<p>1,2</p>
+			<p>42</p>
+		`);
+
+		component.numbers = { answer: 43 };
+		assert.htmlEqual(target.innerHTML, `
+			<p>1,2</p>
+			<p>43</p>
 		`);
 	}
 };

--- a/test/runtime/samples/reactive-values-implicit-destructured/main.svelte
+++ b/test/runtime/samples/reactive-values-implicit-destructured/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	export let coords;
+
+	$: [x, y] = coords;
+</script>
+
+<p>{x},{y}</p>

--- a/test/runtime/samples/reactive-values-implicit-destructured/main.svelte
+++ b/test/runtime/samples/reactive-values-implicit-destructured/main.svelte
@@ -1,7 +1,10 @@
 <script>
 	export let coords;
+	export let numbers;
 
 	$: [x, y] = coords;
+	$: ({ answer } = numbers);
 </script>
 
 <p>{x},{y}</p>
+<p>{answer}</p>

--- a/test/runtime/samples/reactive-values-implicit-self-dependency/_config.js
+++ b/test/runtime/samples/reactive-values-implicit-self-dependency/_config.js
@@ -1,0 +1,20 @@
+export default {
+	show: 1,
+	html: `
+		<p>1 / 1</p>
+	`,
+
+	test({ assert, component, target }) {
+		component.num = 3;
+
+		assert.htmlEqual(target.innerHTML, `
+			<p>3 / 3</p>
+		`);
+
+		component.num = 2;
+
+		assert.htmlEqual(target.innerHTML, `
+			<p>2 / 3</p>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-values-implicit-self-dependency/main.svelte
+++ b/test/runtime/samples/reactive-values-implicit-self-dependency/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	export let num = 1;
+
+	$: max = Math.max(num, max || 0);
+</script>
+
+<p>{num} / {max}</p>

--- a/test/runtime/samples/reactive-values-no-dependencies/_config.js
+++ b/test/runtime/samples/reactive-values-no-dependencies/_config.js
@@ -1,20 +1,12 @@
 export default {
-	props: {
-		a: 1,
-		b: 2,
-		c: 3,
-		d: 4
-	},
-
 	html: `
-		<p>4</p>
+		<p>10 - 90</p>
 	`,
 
 	test({ assert, component, target }) {
-		component.d = 5;
-
+		component.width = 50;
 		assert.htmlEqual(target.innerHTML, `
-			<p>5</p>
+			<p>10 - 40</p>
 		`);
 	}
 };

--- a/test/runtime/samples/reactive-values-no-dependencies/main.svelte
+++ b/test/runtime/samples/reactive-values-no-dependencies/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	export let width = 100;
+
+	const padding = 10;
+
+	$: x1 = padding;
+	$: x2 = width - padding;
+</script>
+
+<p>{x1} - {x2}</p>

--- a/test/validator/samples/reactive-declaration-no-deps/errors.json
+++ b/test/validator/samples/reactive-declaration-no-deps/errors.json
@@ -1,7 +1,0 @@
-[{
-	"message": "Invalid reactive declaration — must depend on local state",
-	"code": "invalid-reactive-declaration",
-	"start": { "line": 2, "column": 1, "character": 10 },
-	"end": { "line": 2, "column": 23, "character": 32 },
-	"pos": 10
-}]

--- a/test/validator/samples/reactive-declaration-no-deps/input.svelte
+++ b/test/validator/samples/reactive-declaration-no-deps/input.svelte
@@ -1,3 +1,0 @@
-<script>
-	$: console.log('foo');
-</script>


### PR DESCRIPTION
fixes #2285. Would be nice if we could eliminate any `$$invalidate(...)` calls at the top level, but I think that would require an extra pass, so going to ignore that for now