### PR TITLE
better transitions

### DIFF
--- a/transition.mjs
+++ b/transition.mjs
@@ -25,15 +25,15 @@ export function fly(node, {
 	const target_opacity = +style.opacity;
 	const transform = style.transform === 'none' ? '' : style.transform;
 
-	const od = target_opacity - opacity;
+	const od = target_opacity * (1 - opacity);
 
 	return {
 		delay,
 		duration,
 		easing,
-		css: t => `
+		css: (t, u) => `
 			transform: ${transform} translate(${(1 - t) * x}px, ${(1 - t) * y}px);
-			opacity: ${1 - (od * u)}`
+			opacity: ${target_opacity - (od * u)}`
 	};
 }
 
@@ -81,7 +81,7 @@ export function scale(node, {
 	const transform = style.transform === 'none' ? '' : style.transform;
 
 	const sd = 1 - start;
-	const od = target_opacity - opacity;
+	const od = target_opacity * (1 - opacity);
 
 	return {
 		delay,
@@ -89,7 +89,7 @@ export function scale(node, {
 		easing,
 		css: (t, u) => `
 			transform: ${transform} scale(${1 - (sd * u)});
-			opacity: ${1 - (od * u)}
+			opacity: ${target_opacity - (od * u)}
 		`
 	};
 }

--- a/transition.mjs
+++ b/transition.mjs
@@ -18,11 +18,14 @@ export function fly(node, {
 	duration = 400,
 	easing = cubicOut,
 	x = 0,
-	y = 0
+	y = 0,
+	opacity = 0
 }) {
 	const style = getComputedStyle(node);
-	const opacity = +style.opacity;
+	const target_opacity = +style.opacity;
 	const transform = style.transform === 'none' ? '' : style.transform;
+
+	const od = target_opacity - opacity;
 
 	return {
 		delay,
@@ -30,7 +33,7 @@ export function fly(node, {
 		easing,
 		css: t => `
 			transform: ${transform} translate(${(1 - t) * x}px, ${(1 - t) * y}px);
-			opacity: ${t * opacity}`
+			opacity: ${1 - (od * u)}`
 	};
 }
 
@@ -73,13 +76,12 @@ export function scale(node, {
 	start = 0,
 	opacity = 0
 }) {
-	const sd = 1 - start;
-	const od = 1 - opacity;
+	const style = getComputedStyle(node);
+	const target_opacity = +style.opacity;
+	const transform = style.transform === 'none' ? '' : style.transform;
 
-	const transform = (
-		node.style.transform ||
-		getComputedStyle(node).transform
-	).replace('none', '');
+	const sd = 1 - start;
+	const od = target_opacity - opacity;
 
 	return {
 		delay,
@@ -94,10 +96,21 @@ export function scale(node, {
 
 export function draw(node, {
 	delay = 0,
-	duration = 800,
+	speed,
+	duration,
 	easing = cubicInOut
 }) {
 	const len = node.getTotalLength();
+
+	if (duration === undefined) {
+		if (speed === undefined) {
+			duration = 800;
+		} else {
+			duration = len / speed;
+		}
+	} else if (typeof duration === 'function') {
+		duration = duration(len);
+	}
 
 	return {
 		delay,


### PR DESCRIPTION
A few small tweaks to the built-in transitions:

* the `fly` transition now accepts an `opacity` parameter between 0 and 1, which defaults to 0. If 1, the opacity is unchanged during the transition
* the `scale` transition respects any existing opacity
* the `draw` transition's `duration` parameter can be a `path_length => milliseconds` function instead of a `milliseconds` number. There's also an alternative `speed: n` parameter which is the same as `duration: len => len / n`