### PR TITLE
add link_renderer to handle external links

### DIFF
--- a/site/src/routes/blog/_posts.js
+++ b/site/src/routes/blog/_posts.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { extract_frontmatter, langs } from '../../utils/markdown.js';
+import { extract_frontmatter, langs, link_renderer } from '../../utils/markdown.js';
 import marked from 'marked';
 import PrismJS from 'prismjs';
 import 'prismjs/components/prism-bash';
@@ -19,6 +19,8 @@ export default function() {
 			metadata.dateString = date.toDateString();
 
 			const renderer = new marked.Renderer();
+
+			renderer.link = link_renderer;
 
 			renderer.code = (source, lang) => {
 				const plang = langs[lang];

--- a/site/src/routes/docs/_sections.js
+++ b/site/src/routes/docs/_sections.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { extract_frontmatter, extract_metadata, langs } from '../../utils/markdown.js';
+import { extract_frontmatter, extract_metadata, langs, link_renderer } from '../../utils/markdown.js';
 import marked from 'marked';
 import PrismJS from 'prismjs';
 import 'prismjs/components/prism-bash';
@@ -49,6 +49,8 @@ export default function() {
 			const renderer = new marked.Renderer();
 
 			let block_open = false;
+
+			renderer.link = link_renderer;
 
 			renderer.hr = (...args) => {
 				block_open = true;

--- a/site/src/routes/tutorial/[slug]/index.json.js
+++ b/site/src/routes/tutorial/[slug]/index.json.js
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import marked from 'marked';
 import PrismJS from 'prismjs';
-import { extract_frontmatter, extract_metadata, langs } from '../../../utils/markdown';
+import { extract_frontmatter, extract_metadata, langs, link_renderer } from '../../../utils/markdown';
 
 const cache = new Map();
 
@@ -32,6 +32,8 @@ function get_tutorial(slug) {
 	const { content } = extract_frontmatter(markdown);
 
 	const renderer = new marked.Renderer();
+
+	renderer.link = link_renderer;
 
 	renderer.code = (source, lang) => {
 		source = source.replace(/^ +/gm, match =>

--- a/site/src/utils/markdown.js
+++ b/site/src/utils/markdown.js
@@ -42,3 +42,20 @@ export const langs = {
 	js: 'javascript',
 	css: 'css'
 };
+
+
+// links renderer
+export function link_renderer(href,title,text) {
+	let target_attr = '';
+	let title_attr = '';
+	
+	if(href.startsWith("http")) {
+		target_attr = ' target="_blank"';
+	}
+
+	if(title !== null) {
+		title_attr = ` title="${title}"`;
+	}
+	
+	return `<a href="${href}"${target_attr}${title_attr}>${text}</a>`;
+};


### PR DESCRIPTION
This PR solves the problem when external links in Tutorial, Docs and Blog are open in the same browser tab. 

I added `link_renderer` for Marked, that looking for links with hrefs which started from "http" and adding `target="_blank"` attribute to them. 
