### PR TITLE
Prevent infinite loops with chained bindings

### DIFF
--- a/src/compile/render-dom/wrappers/InlineComponent/index.ts
+++ b/src/compile/render-dom/wrappers/InlineComponent/index.ts
@@ -344,7 +344,6 @@ export default class InlineComponentWrapper extends Wrapper {
 						ctx.${name}.call(null, ${value});
 						${updating} = true;
 						@add_flush_callback(() => ${updating} = false);
-						}
 					}
 				`);
 			}

--- a/src/internal/Component.js
+++ b/src/internal/Component.js
@@ -85,11 +85,10 @@ export function init(component, options, instance, create_fragment, not_equal, p
 
 	$$.ctx = instance
 		? instance(component, props, (key, value) => {
-			if ($$.bound[key]) $$.bound[key](value);
-
 			if ($$.ctx) {
 				const changed = not_equal(value, $$.ctx[key]);
 				if (ready && changed) {
+					if ($$.bound[key]) $$.bound[key](value);
 					make_dirty(component, key);
 				}
 

--- a/src/internal/Component.js
+++ b/src/internal/Component.js
@@ -85,15 +85,9 @@ export function init(component, options, instance, create_fragment, not_equal, p
 
 	$$.ctx = instance
 		? instance(component, props, (key, value) => {
-			if ($$.ctx) {
-				const changed = not_equal(value, $$.ctx[key]);
-				if (ready && changed) {
-					if ($$.bound[key]) $$.bound[key](value);
-					make_dirty(component, key);
-				}
-
-				$$.ctx[key] = value;
-				return changed;
+			if ($$.ctx && not_equal($$.ctx[key], $$.ctx[key] = value)) {
+				if ($$.bound[key]) $$.bound[key](value);
+				if (ready) make_dirty(component, key);
 			}
 		})
 		: props;

--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -7,16 +7,13 @@ export const intros = { enabled: false };
 let update_promise;
 const binding_callbacks = [];
 const render_callbacks = [];
+const flush_callbacks = [];
 
 export function schedule_update() {
 	if (!update_promise) {
 		update_promise = Promise.resolve();
 		update_promise.then(flush);
 	}
-}
-
-export function add_render_callback(fn) {
-	render_callbacks.push(fn);
 }
 
 export function tick() {
@@ -26,6 +23,14 @@ export function tick() {
 
 export function add_binding_callback(fn) {
 	binding_callbacks.push(fn);
+}
+
+export function add_render_callback(fn) {
+	render_callbacks.push(fn);
+}
+
+export function add_flush_callback(fn) {
+	flush_callbacks.push(fn);
 }
 
 export function flush() {
@@ -55,6 +60,10 @@ export function flush() {
 			}
 		}
 	} while (dirty_components.length);
+
+	while (flush_callbacks.length) {
+		flush_callbacks.pop()();
+	}
 
 	update_promise = null;
 }

--- a/test/runtime/samples/component-binding-blowback-d/One.svelte
+++ b/test/runtime/samples/component-binding-blowback-d/One.svelte
@@ -2,14 +2,15 @@
 	import Two from './Two.svelte';
 
 	export let list;
+	export let i;
 
 	function handle_click() {
 		list = [...list, {}];
 	}
 </script>
 
-{#each list as item}
-	<Two bind:value={item.value}/>
+{#each list as item, j}
+	<Two bind:value={item.value} {i} {j}/>
 {/each}
 
 <button on:click={handle_click}>

--- a/test/runtime/samples/component-binding-blowback-d/One.svelte
+++ b/test/runtime/samples/component-binding-blowback-d/One.svelte
@@ -1,0 +1,17 @@
+<script>
+	import Two from './Two.svelte';
+
+	export let list;
+
+	function handle_click() {
+		list = [...list, {}];
+	}
+</script>
+
+{#each list as item}
+	<Two bind:value={item.value}/>
+{/each}
+
+<button on:click={handle_click}>
+	click me
+</button>

--- a/test/runtime/samples/component-binding-blowback-d/Two.svelte
+++ b/test/runtime/samples/component-binding-blowback-d/Two.svelte
@@ -1,3 +1,4 @@
 <script>
-	export let value = 'x';
+	export let i, j;
+	export let value = `${i}:${j}`;
 </script>

--- a/test/runtime/samples/component-binding-blowback-d/Two.svelte
+++ b/test/runtime/samples/component-binding-blowback-d/Two.svelte
@@ -1,0 +1,3 @@
+<script>
+	export let value = 'x';
+</script>

--- a/test/runtime/samples/component-binding-blowback-d/_config.js
+++ b/test/runtime/samples/component-binding-blowback-d/_config.js
@@ -3,7 +3,7 @@ export default {
 		<button>click me</button>
 		<button>click me</button>
 
-		<p>{"value":"x"}</p>
+		<p>{"value":"0:0"}</p>
 		<p></p>
 	`,
 
@@ -16,8 +16,8 @@ export default {
 			<button>click me</button>
 			<button>click me</button>
 
-			<p>{"value":"x"}</p>
-			<p>{"value":"x"}</p>
+			<p>{"value":"0:0"}</p>
+			<p>{"value":"1:0"}</p>
 		`);
 	}
 };

--- a/test/runtime/samples/component-binding-blowback-d/_config.js
+++ b/test/runtime/samples/component-binding-blowback-d/_config.js
@@ -1,0 +1,23 @@
+export default {
+	html: `
+		<button>click me</button>
+		<button>click me</button>
+
+		<p>{"value":"x"}</p>
+		<p></p>
+	`,
+
+	async test({ assert, target, window }) {
+		const button = target.querySelectorAll('button')[1];
+
+		await button.dispatchEvent(new window.Event('click'));
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>click me</button>
+			<button>click me</button>
+
+			<p>{"value":"x"}</p>
+			<p>{"value":"x"}</p>
+		`);
+	}
+};

--- a/test/runtime/samples/component-binding-blowback-d/main.svelte
+++ b/test/runtime/samples/component-binding-blowback-d/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import One from "./One.svelte";
+
+	const obj = {
+		a: [{}],
+		b: []
+	};
+</script>
+
+<One bind:list={obj.a}/>
+<One bind:list={obj.b}/>
+
+<p>{obj.a.map(JSON.stringify)}</p>
+<p>{obj.b.map(JSON.stringify)}</p>

--- a/test/runtime/samples/component-binding-blowback-d/main.svelte
+++ b/test/runtime/samples/component-binding-blowback-d/main.svelte
@@ -7,8 +7,8 @@
 	};
 </script>
 
-<One bind:list={obj.a}/>
-<One bind:list={obj.b}/>
+<One bind:list={obj.a} i={0}/>
+<One bind:list={obj.b} i={1}/>
 
 <p>{obj.a.map(JSON.stringify)}</p>
 <p>{obj.b.map(JSON.stringify)}</p>

--- a/test/runtime/samples/component-binding-blowback-e/One.svelte
+++ b/test/runtime/samples/component-binding-blowback-e/One.svelte
@@ -2,14 +2,15 @@
 	import Two from './Two.svelte';
 
 	export let list;
+	export let i;
 
 	function handle_click() {
 		list = [...list, {}];
 	}
 </script>
 
-{#each list as item}
-	<Two bind:value={item.value}/>
+{#each list as item, j}
+	<Two bind:value={item.value} {i} {j}/>
 {/each}
 
 <button on:click={handle_click}>

--- a/test/runtime/samples/component-binding-blowback-e/One.svelte
+++ b/test/runtime/samples/component-binding-blowback-e/One.svelte
@@ -1,0 +1,17 @@
+<script>
+	import Two from './Two.svelte';
+
+	export let list;
+
+	function handle_click() {
+		list = [...list, {}];
+	}
+</script>
+
+{#each list as item}
+	<Two bind:value={item.value}/>
+{/each}
+
+<button on:click={handle_click}>
+	click me
+</button>

--- a/test/runtime/samples/component-binding-blowback-e/Two.svelte
+++ b/test/runtime/samples/component-binding-blowback-e/Two.svelte
@@ -1,3 +1,4 @@
 <script>
-	export let value = { x: true };
+	export let i, j;
+	export let value = { i, j };
 </script>

--- a/test/runtime/samples/component-binding-blowback-e/Two.svelte
+++ b/test/runtime/samples/component-binding-blowback-e/Two.svelte
@@ -1,0 +1,3 @@
+<script>
+	export let value = { x: true };
+</script>

--- a/test/runtime/samples/component-binding-blowback-e/_config.js
+++ b/test/runtime/samples/component-binding-blowback-e/_config.js
@@ -1,0 +1,23 @@
+export default {
+	html: `
+		<button>click me</button>
+		<button>click me</button>
+
+		<p>{"value":{"x":true}}</p>
+		<p></p>
+	`,
+
+	async test({ assert, target, window }) {
+		const button = target.querySelectorAll('button')[1];
+
+		await button.dispatchEvent(new window.Event('click'));
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>click me</button>
+			<button>click me</button>
+
+			<p>{"value":{"x":true}}</p>
+			<p>{"value":{"x":true}}</p>
+		`);
+	}
+};

--- a/test/runtime/samples/component-binding-blowback-e/_config.js
+++ b/test/runtime/samples/component-binding-blowback-e/_config.js
@@ -3,7 +3,7 @@ export default {
 		<button>click me</button>
 		<button>click me</button>
 
-		<p>{"value":{"x":true}}</p>
+		<p>{"value":{"i":0,"j":0}}</p>
 		<p></p>
 	`,
 
@@ -16,8 +16,8 @@ export default {
 			<button>click me</button>
 			<button>click me</button>
 
-			<p>{"value":{"x":true}}</p>
-			<p>{"value":{"x":true}}</p>
+			<p>{"value":{"i":0,"j":0}}</p>
+			<p>{"value":{"i":1,"j":0}}</p>
 		`);
 	}
 };

--- a/test/runtime/samples/component-binding-blowback-e/main.svelte
+++ b/test/runtime/samples/component-binding-blowback-e/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import One from "./One.svelte";
+
+	const obj = {
+		a: [{}],
+		b: []
+	};
+</script>
+
+<One bind:list={obj.a}/>
+<One bind:list={obj.b}/>
+
+<p>{obj.a.map(JSON.stringify)}</p>
+<p>{obj.b.map(JSON.stringify)}</p>

--- a/test/runtime/samples/component-binding-blowback-e/main.svelte
+++ b/test/runtime/samples/component-binding-blowback-e/main.svelte
@@ -7,8 +7,8 @@
 	};
 </script>
 
-<One bind:list={obj.a}/>
-<One bind:list={obj.b}/>
+<One bind:list={obj.a} i={0}/>
+<One bind:list={obj.b} i={1}/>
 
 <p>{obj.a.map(JSON.stringify)}</p>
 <p>{obj.b.map(JSON.stringify)}</p>

--- a/test/runtime/samples/component-binding-blowback-f/One.svelte
+++ b/test/runtime/samples/component-binding-blowback-f/One.svelte
@@ -2,14 +2,15 @@
 	import Two from './Two.svelte';
 
 	export let list;
+	export let i;
 
 	function handle_click() {
 		list = [...list, {}];
 	}
 </script>
 
-{#each list as item}
-	<Two bind:value={item.value}/>
+{#each list as item, j}
+	<Two bind:value={item.value} {i} {j}/>
 {/each}
 
 <button on:click={handle_click}>

--- a/test/runtime/samples/component-binding-blowback-f/One.svelte
+++ b/test/runtime/samples/component-binding-blowback-f/One.svelte
@@ -1,0 +1,17 @@
+<script>
+	import Two from './Two.svelte';
+
+	export let list;
+
+	function handle_click() {
+		list = [...list, {}];
+	}
+</script>
+
+{#each list as item}
+	<Two bind:value={item.value}/>
+{/each}
+
+<button on:click={handle_click}>
+	click me
+</button>

--- a/test/runtime/samples/component-binding-blowback-f/Two.svelte
+++ b/test/runtime/samples/component-binding-blowback-f/Two.svelte
@@ -1,9 +1,10 @@
 <script>
 	import { onMount } from 'svelte';
 
+	export let i, j;
 	export let value;
 
 	onMount(() => {
-		value = { x: true };
+		value = { i, j };
 	});
 </script>

--- a/test/runtime/samples/component-binding-blowback-f/Two.svelte
+++ b/test/runtime/samples/component-binding-blowback-f/Two.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { onMount } from 'svelte';
+
+	export let value;
+
+	onMount(() => {
+		value = { x: true };
+	});
+</script>

--- a/test/runtime/samples/component-binding-blowback-f/_config.js
+++ b/test/runtime/samples/component-binding-blowback-f/_config.js
@@ -1,11 +1,17 @@
 export default {
-	skip: 1,
-
 	html: `
 		<button>click me</button>
 		<button>click me</button>
 
-		<p>{"value":{"x":true}}</p>
+		<p>{"value":{"i":0,"j":0}}</p>
+		<p></p>
+	`,
+
+	ssrHtml: `
+		<button>click me</button>
+		<button>click me</button>
+
+		<p>{}</p>
 		<p></p>
 	`,
 
@@ -18,8 +24,8 @@ export default {
 			<button>click me</button>
 			<button>click me</button>
 
-			<p>{"value":{"x":true}}</p>
-			<p>{"value":{"x":true}}</p>
+			<p>{"value":{"i":0,"j":0}}</p>
+			<p>{"value":{"i":1,"j":0}}</p>
 		`);
 	}
 };

--- a/test/runtime/samples/component-binding-blowback-f/_config.js
+++ b/test/runtime/samples/component-binding-blowback-f/_config.js
@@ -1,0 +1,25 @@
+export default {
+	skip: 1,
+
+	html: `
+		<button>click me</button>
+		<button>click me</button>
+
+		<p>{"value":{"x":true}}</p>
+		<p></p>
+	`,
+
+	async test({ assert, target, window }) {
+		const button = target.querySelectorAll('button')[1];
+
+		await button.dispatchEvent(new window.Event('click'));
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>click me</button>
+			<button>click me</button>
+
+			<p>{"value":{"x":true}}</p>
+			<p>{"value":{"x":true}}</p>
+		`);
+	}
+};

--- a/test/runtime/samples/component-binding-blowback-f/main.svelte
+++ b/test/runtime/samples/component-binding-blowback-f/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import One from "./One.svelte";
+
+	const obj = {
+		a: [{}],
+		b: []
+	};
+</script>
+
+<One bind:list={obj.a}/>
+<One bind:list={obj.b}/>
+
+<p>{obj.a.map(JSON.stringify)}</p>
+<p>{obj.b.map(JSON.stringify)}</p>

--- a/test/runtime/samples/component-binding-blowback-f/main.svelte
+++ b/test/runtime/samples/component-binding-blowback-f/main.svelte
@@ -7,8 +7,8 @@
 	};
 </script>
 
-<One bind:list={obj.a}/>
-<One bind:list={obj.b}/>
+<One bind:list={obj.a} i={0}/>
+<One bind:list={obj.b} i={1}/>
 
 <p>{obj.a.map(JSON.stringify)}</p>
 <p>{obj.b.map(JSON.stringify)}</p>


### PR DESCRIPTION
I hate these kinds of bugs. So far this PR fixes the simple case (where values are primitives) by only firing the binding callback when values have changed. It gets a little trickier with non-primitives