### PR TITLE
update now.json

### DIFF
--- a/site/now.json
+++ b/site/now.json
@@ -5,8 +5,8 @@
 	"env": {
 		"NODE_ENV": "production",
 		"BASEURL": "https://svelte.dev",
-		"GITHUB_CLIENT_ID": "@svelte-gist-client-id-v3",
-		"GITHUB_CLIENT_SECRET": "@svelte-gist-client-secret-v3",
+		"GITHUB_CLIENT_ID": "@svelte-dev-client-id",
+		"GITHUB_CLIENT_SECRET": "@svelte-dev-client-secret",
 		"MAPBOX_ACCESS_TOKEN": "@svelte-mapbox-access-token"
 	},
 	"files": [

--- a/site/now.json
+++ b/site/now.json
@@ -1,10 +1,10 @@
 {
 	"version": 1,
-	"name": "v3.svelte.technology",
-	"alias": "v3.svelte.technology",
+	"name": "svelte.dev",
+	"alias": "svelte.dev",
 	"env": {
 		"NODE_ENV": "production",
-		"BASEURL": "https://v3.svelte.technology",
+		"BASEURL": "https://svelte.dev",
 		"GITHUB_CLIENT_ID": "@svelte-gist-client-id-v3",
 		"GITHUB_CLIENT_SECRET": "@svelte-gist-client-secret-v3",
 		"MAPBOX_ACCESS_TOKEN": "@svelte-mapbox-access-token"


### PR DESCRIPTION
Trying to deploy the site to https://svelte.dev. So far doesn't seem to work — I get this in my terminal after running Now:

```
> Assigning alias svelte.dev to deployment sveltedev-kbseobnwsd.now.sh
> Error! We couldn't verify the propagation of the DNS settings for svelte.dev
  The propagation may take a few minutes, but please verify your settings:

name        type         value
            ALIAS        alias.zeit.co
error Command failed with exit code 1.
```

Namecheap doesn't appear to give me the option of assigning an `ALIAS` record... will have to come back to this when less busy