### PR TITLE
site: update REPL from svelte@beta to svelte@3

### DIFF
--- a/site/src/components/Repl/ReplWidget.svelte
+++ b/site/src/components/Repl/ReplWidget.svelte
@@ -4,7 +4,7 @@
 	import Repl from '@sveltejs/svelte-repl';
 	import InputOutputToggle from './InputOutputToggle.svelte';
 
-	export let version = 'beta';
+	export let version = '3';
 	export let gist = null;
 	export let example = null;
 	export let embedded = false;

--- a/site/src/routes/repl/embed.svelte
+++ b/site/src/routes/repl/embed.svelte
@@ -11,7 +11,7 @@
 <script>
 	import ReplWidget from '../../components/Repl/ReplWidget.svelte';
 
-	export let version = 'beta';
+	export let version = '3';
 	export let gist;
 	export let example;
 </script>

--- a/site/src/routes/repl/index.svelte
+++ b/site/src/routes/repl/index.svelte
@@ -1,7 +1,7 @@
 <script context="module">
 	export function preload({ query }) {
 		return {
-			version: query.version || 'beta',
+			version: query.version || '3',
 			gist_id: query.gist,
 			example: query.example || 'hello-world'
 		};
@@ -43,7 +43,7 @@
 
 	onMount(() => {
 		if (version !== 'local') {
-			fetch(`https://unpkg.com/svelte@${version || 'beta'}/package.json`)
+			fetch(`https://unpkg.com/svelte@${version || '3'}/package.json`)
 				.then(r => r.json())
 				.then(pkg => {
 					version = pkg.version;

--- a/site/src/routes/tutorial/[slug]/index.svelte
+++ b/site/src/routes/tutorial/[slug]/index.svelte
@@ -101,7 +101,7 @@
 		});
 	}
 
-	const svelteUrl = `https://unpkg.com/svelte@beta`;
+	const svelteUrl = `https://unpkg.com/svelte@3`;
 	const rollupUrl = `https://unpkg.com/rollup@1/dist/rollup.browser.js`;
 
 	// needed for context API tutorial


### PR DESCRIPTION
It makes sense to be explicit about this (and not just point to `latest`) so that we don't break things for people visiting the v3 REPL anew once v4 comes out. This is actually causing a problem on the v2 REPL right now, I'll open an issue over there.