### PR TITLE
add regular <meta> tags

### DIFF
--- a/site/src/routes/blog/[slug].svelte
+++ b/site/src/routes/blog/[slug].svelte
@@ -14,6 +14,7 @@
 
 	<meta name="twitter:title" content={post.metadata.title}>
 	<meta name="twitter:description" content={post.metadata.description}>
+	<meta name="Description" content={post.metadata.description}>
 </svelte:head>
 
 <article class='post linkify listify'>

--- a/site/src/routes/blog/index.svelte
+++ b/site/src/routes/blog/index.svelte
@@ -13,7 +13,9 @@
 	<title>Blog • Svelte</title>
 	<link rel="alternate" type="application/rss+xml" title="Svelte blog" href="blog/rss.xml">
 
-	<meta name='twitter:title' content='Svelte blog'>
+	<meta name="twitter:title" content="Svelte blog">
+	<meta name="twitter:description" content="Articles about Svelte and UI development">
+	<meta name="Description" content="Articles about Svelte and UI development">
 </svelte:head>
 
 <div class='posts stretch'>

--- a/site/src/routes/docs/index.svelte
+++ b/site/src/routes/docs/index.svelte
@@ -361,8 +361,9 @@
 <svelte:head>
 	<title>API Docs • Svelte</title>
 
-	<meta name='twitter:title' content='Svelte API docs'>
-	<meta name='twitter:description' content='Cybernetically enhanced web apps'>
+	<meta name="twitter:title" content="Svelte API docs">
+	<meta name="twitter:description" content="Cybernetically enhanced web apps">
+	<meta name="Description" content="Cybernetically enhanced web apps">
 </svelte:head>
 
 <div bind:this={container} class='content linkify listify'>

--- a/site/src/routes/examples/index.svelte
+++ b/site/src/routes/examples/index.svelte
@@ -76,8 +76,9 @@
 <svelte:head>
 	<title>Examples • Svelte</title>
 
-	<meta name='twitter:title' content='Svelte examples'>
-	<meta name='twitter:description' content='Cybernetically enhanced web apps'>
+	<meta name="twitter:title" content="Svelte examples">
+	<meta name="twitter:description" content="Cybernetically enhanced web apps">
+	<meta name="Description" content="Interactive example Svelte apps">
 </svelte:head>
 
 <div class="content">

--- a/site/src/routes/index.svelte
+++ b/site/src/routes/index.svelte
@@ -138,8 +138,9 @@
 <svelte:head>
 	<title>Svelte • Cybernetically enhanced web apps</title>
 
-	<meta name='twitter:title' content='Svelte'>
-	<meta name='twitter:description' content='Cybernetically enhanced web apps'>
+	<meta name="twitter:title" content="Svelte">
+	<meta name="twitter:description" content="Cybernetically enhanced web apps">
+	<meta name="Description" content="Cybernetically enhanced web apps">
 </svelte:head>
 
 <svelte:window bind:scrollY={sy}/>

--- a/site/src/routes/repl/embed.svelte
+++ b/site/src/routes/repl/embed.svelte
@@ -33,8 +33,9 @@
 <svelte:head>
 	<title>REPL • Svelte</title>
 
-	<meta name='twitter:title' content='Svelte REPL'>
-	<meta name='twitter:description' content='Cybernetically enhanced web apps'>
+	<meta name="twitter:title" content="Svelte REPL">
+	<meta name="twitter:description" content="Cybernetically enhanced web apps">
+	<meta name="Description" content="Interactive Svelte playground">
 </svelte:head>
 
 <div class="repl-outer">

--- a/site/src/routes/repl/index.svelte
+++ b/site/src/routes/repl/index.svelte
@@ -183,8 +183,9 @@
 <svelte:head>
 	<title>REPL • Svelte</title>
 
-	<meta name='twitter:title' content='Svelte REPL'>
-	<meta name='twitter:description' content='Cybernetically enhanced web apps'>
+	<meta name="twitter:title" content="Svelte REPL">
+	<meta name="twitter:description" content="Cybernetically enhanced web apps">
+	<meta name="Description" content="Interactive Svelte playground">
 </svelte:head>
 
 <svelte:window bind:innerWidth={width}/>

--- a/site/src/routes/tutorial/[slug]/index.svelte
+++ b/site/src/routes/tutorial/[slug]/index.svelte
@@ -253,8 +253,9 @@
 <svelte:head>
 	<title>{selected.section.title} / {selected.chapter.title} • Svelte Tutorial</title>
 
-	<meta name='twitter:title' content='Svelte tutorial'>
-	<meta name='twitter:description' content="{selected.section.title} / {selected.chapter.title}">
+	<meta name="twitter:title" content="Svelte tutorial">
+	<meta name="twitter:description" content="{selected.section.title} / {selected.chapter.title}">
+	<meta name="Description" content="{selected.section.title} / {selected.chapter.title}">
 </svelte:head>
 
 <svelte:window bind:innerWidth={width}/>


### PR DESCRIPTION
this should improve our lighthouse score, which is currently being penalised in the SEO section

<img width="689" alt="Screen Shot 2019-04-21 at 14 04 47" src="https://user-images.githubusercontent.com/1162160/56473805-72e6f780-643e-11e9-8f70-f0c4f7eabac9.png">
