### PR TITLE
Chore: Deploy with Node 11.14

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:10.15
+FROM mhart/alpine-node:11.14
 
 # install dependencies
 WORKDIR /app
@@ -12,7 +12,7 @@ RUN npm install --production
 # Only copy over the Node pieces we need
 # ~> Saves 35MB
 ###
-FROM mhart/alpine-node:base-10.15
+FROM mhart/alpine-node:base-11.14
 
 WORKDIR /app
 COPY --from=0 /app .


### PR DESCRIPTION
This just uses the latest Node docker image. 

I saw message in Discord about it solving the `node-gyp` stderr output, but it doesn't solve it.
Oh well, might as well use latest Node version.