### PR TITLE
Site: Default Cache-Control value

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3286,16 +3286,6 @@
       "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
       "dev": true
     },
-    "globalyzer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
-      "integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA=="
-    },
-    "globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
-    },
     "golden-fleece": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/golden-fleece/-/golden-fleece-1.0.9.tgz",
@@ -5267,13 +5257,12 @@
       "dev": true
     },
     "sirv": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-0.2.4.tgz",
-      "integrity": "sha512-0YaLzpD6dPiJZUqDEwDqk9NLGZDm/nNWvpg8Rym+3hdt5pWGRrlggjjt1KtF0+tZgGtyI4F5f5JZ9XTCp53Oqw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-0.3.1.tgz",
+      "integrity": "sha512-03p4fuXPfhlNrDjUBw5bGF//4i0Rjwf7hVm8XhuKgeguHGQPr4pV+lgAJZKSP9BaJKn+QG9QvTxLX1wSYshccg==",
       "requires": {
         "@polka/url": "^0.5.0",
-        "mime": "^2.3.1",
-        "tiny-glob": "^0.2.0"
+        "mime": "^2.3.1"
       },
       "dependencies": {
         "mime": {
@@ -5656,15 +5645,6 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "optional": true
-    },
-    "tiny-glob": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.6.tgz",
-      "integrity": "sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==",
-      "requires": {
-        "globalyzer": "^0.1.0",
-        "globrex": "^0.1.1"
-      }
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/site/package.json
+++ b/site/package.json
@@ -30,7 +30,7 @@
     "prismjs": "^1.15.0",
     "session-file-store": "^1.2.0",
     "shelljs": "^0.8.3",
-    "sirv": "^0.2.2",
+    "sirv": "^0.3.1",
     "yootils": "0.0.14"
   },
   "devDependencies": {

--- a/site/src/server.js
+++ b/site/src/server.js
@@ -1,11 +1,11 @@
 import 'dotenv/config';
+import sirv from 'sirv';
 import express from 'express';
 import compression from 'compression';
 import session from 'express-session';
 import passport from 'passport';
 import { Strategy } from 'passport-github';
 import sessionFileStore from 'session-file-store';
-import serve from 'serve-static';
 import devalue from 'devalue';
 import * as sapper from '@sapper/server';
 

--- a/site/src/server.js
+++ b/site/src/server.js
@@ -94,7 +94,12 @@ if (process.env.GITHUB_CLIENT_ID) {
 
 app.use(
 	compression({ threshold: 0 }),
-	serve('static', { setHeaders: res => res.setHeader('Access-Control-Allow-Origin', '*') }),
+	serve('static', {
+		setHeaders(res, pathname) {
+			res.setHeader('Access-Control-Allow-Origin', '*');
+			res.hasHeader('Cache-Control') || res.setHeader('Cache-Control', 'max-age=600'); // 10min default
+		}
+	}),
 	sapper.middleware({
 		// TODO update Sapper so that we can pass props to the client
 		props: req => {

--- a/site/src/server.js
+++ b/site/src/server.js
@@ -95,7 +95,7 @@ if (process.env.GITHUB_CLIENT_ID) {
 app.use(
 	compression({ threshold: 0 }),
 	serve('static', {
-		setHeaders(res, pathname) {
+		setHeaders(res) {
 			res.setHeader('Access-Control-Allow-Origin', '*');
 			res.hasHeader('Cache-Control') || res.setHeader('Cache-Control', 'max-age=600'); // 10min default
 		}

--- a/site/src/server.js
+++ b/site/src/server.js
@@ -94,7 +94,7 @@ if (process.env.GITHUB_CLIENT_ID) {
 
 app.use(
 	compression({ threshold: 0 }),
-	serve('static', {
+	sirv('static', {
 		setHeaders(res) {
 			res.setHeader('Access-Control-Allow-Origin', '*');
 			res.hasHeader('Cache-Control') || res.setHeader('Cache-Control', 'max-age=600'); // 10min default


### PR DESCRIPTION
The site has a lot of unspecified Cache-Control values for _many_ files.

For example, all images, SVGs, and fonts had no caching declared. There were also some straggler `.json` and `.css|js` files that had no values.

It seemed like 10m was the preferred value elsewhere in the site, so I used that as the default value.
To change a file or mark it as not cacheable, you'd set a value elsewhere, ([example](https://github.com/sveltejs/svelte/blob/b1312175bc8a803b4a5236decfd7731b0186f8bb/site/src/routes/blog/%5Bslug%5D.json.js#L16)).

I also verified that the `service-worker.js` maintains its `no-cache, no-store, must-revalidate` setting.