### PR TITLE
site: use gcloud CLI to build Docker image

### DIFF
--- a/site/.dockerignore
+++ b/site/.dockerignore
@@ -1,0 +1,9 @@
+/*
+!/Dockerfile
+!/package.json
+!/package-lock.json
+!/__sapper__
+/__sapper__/*
+!/__sapper__/build
+!/static
+!/content

--- a/site/.gcloudignore
+++ b/site/.gcloudignore
@@ -1,0 +1,1 @@
+#!include:.dockerignore

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -2,11 +2,8 @@ FROM mhart/alpine-node:10.15
 
 # install dependencies
 WORKDIR /app
-COPY static /app/static
-COPY content /app/content
-COPY __sapper__ /app/__sapper__
-COPY package.json package-lock.json /app/
-RUN npm install --production
+COPY package.json package-lock.json ./
+RUN npm ci --production
 
 ###
 # Only copy over the Node pieces we need
@@ -16,6 +13,7 @@ FROM mhart/alpine-node:base-10.15
 
 WORKDIR /app
 COPY --from=0 /app .
+COPY . .
 
 EXPOSE 3000
 CMD ["node", "__sapper__/build"]

--- a/site/Makefile
+++ b/site/Makefile
@@ -14,9 +14,7 @@ sapper:
 
 docker:
 	@echo "\n~> building docker image"
-	@docker build . -t $(IMAGE)
-	@echo "\n~> pushing docker image"
-	@docker push $(IMAGE)
+	@gcloud builds submit -t $(IMAGE)
 
 
 deploy: sapper docker


### PR DESCRIPTION
A few changes here:

- the Makefile now uses `gcloud builds submit` to build the image (remotely) rather than locally with Docker and then pushing it
- there's now a `.dockerignore` which whitelists only the files needed by the Sapper app
- there's a `.gcloudignore` that just points to that `.dockerignore` (the reason for having both is so that the old `docker build` will continue to work nicely if so desired)
- the `Dockerfile` now only copies the `package[-lock].json` files to the first container before installing deps, and then copies the installed packages and every (non-ignored) file in the directory to the second and final container (this is to avoid a little bit of extra copying of the app itself to the first container, which isn't really necessary)
- installation of npm packages is now done with `npm ci`