### PR TITLE
Fix task to prevent warning about <button> left open

### DIFF
--- a/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
+++ b/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
@@ -7,7 +7,7 @@ At the heart of Svelte is a powerful system of *reactivity* for keeping the DOM 
 To demonstrate it, we first need to wire up an event handler. Replace line 9 with this:
 
 ```html
-<button on:click={handleClick}>
+<button on:click={handleClick}/>
 ```
 
 Inside the `handleClick` function, all we need to do is change the value of `count`:


### PR DESCRIPTION
Fixes this warning:

<img width="927" alt="Screen Shot 2019-04-22 at 13 27 09" src="https://user-images.githubusercontent.com/137916/56527355-6330e700-6502-11e9-8bc5-802fe8dbd225.png">

... in this tutorial: https://svelte.dev/tutorial/reactive-assignments