### PR TITLE
Update alt text in 01.03 to clarify "shorthand attributes"

### DIFF
--- a/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
+++ b/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
@@ -30,6 +30,6 @@ We can use curly braces *inside* attributes. Try changing it to `"{name} dancing
 It's not uncommon to have an attribute where the name and value are the same, like `src={src}`. Svelte gives us a convenient shorthand for these cases:
 
 ```html
-<img {src} alt="...">
+<img {src} alt="A man dancing">
 ```
 


### PR DESCRIPTION
Alternatively, `alt="A man dancing"` could also be removed with no detrimental side effects IMO.