### PR TITLE
Fix broken link to CSS in JS blog post

### DIFF
--- a/site/src/routes/index.svelte
+++ b/site/src/routes/index.svelte
@@ -173,7 +173,7 @@
 	</section>
 
 	<section class="container example">
-		<p>CSS is component-scoped by default — no more style collisions or specificity wars. Or you can <a href="TODO-blog-post-on-css-in-js">use your favourite CSS-in-JS library</a>.</p>
+		<p>CSS is component-scoped by default — no more style collisions or specificity wars. Or you can <a href="/blog/svelte-css-in-js">use your favourite CSS-in-JS library</a>.</p>
 
 		<div class="repl-container">
 			<IntersectionObserver once let:intersecting top={400}>


### PR DESCRIPTION
there's a 404 link to https://svelte.dev/TODO-blog-post-on-css-in-js on the homepage which I believe should link to this blog post instead: https://svelte.dev/blog/svelte-css-in-js
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
