### PR TITLE
 handle unknown nodes in extract_identifiers

### DIFF
--- a/src/compile/utils/scope.ts
+++ b/src/compile/utils/scope.ts
@@ -106,7 +106,7 @@ export function extract_names(param: Node) {
 
 export function extract_identifiers(param: Node) {
 	const nodes: Node[] = [];
-	extractors[param.type](nodes, param);
+	extractors[param.type] && extractors[param.type](nodes, param);
 	return nodes;
 }
 

--- a/test/runtime/samples/reactive-value-mutate/_config.js
+++ b/test/runtime/samples/reactive-value-mutate/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `{"bar":42}`
+};

--- a/test/runtime/samples/reactive-value-mutate/main.svelte
+++ b/test/runtime/samples/reactive-value-mutate/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let foo = {};
+	let bar = 42;
+	$: foo.bar = bar;
+</script>
+
+{JSON.stringify(foo)}


### PR DESCRIPTION
Fixes #2510 and #2514. Any reactive assignment where the LHS was a mutation causes an exception currently.