### PR TITLE
Expose `parse` to the public

### DIFF
--- a/site/content/docs/04-compile-time.md
+++ b/site/content/docs/04-compile-time.md
@@ -153,6 +153,30 @@ compiled: {
 -->
 
 
+### `svelte.parse`
+
+```js
+ast: object = svelte.parse(
+	source: string,
+	options?: {
+		filename?: string,
+		customElement?: boolean
+	}
+)
+```
+
+---
+
+The `parse` function parses a component, returning only its abstract syntax tree. Unlike compiling with the `generate: false` option, this will not perform any validation or other analysis of the component beyond parsing it.
+
+
+```js
+const svelte = require('svelte/compiler');
+
+const ast = svelte.parse(source, { filename: 'App.svelte' });
+```
+
+
 ### `svelte.preprocess`
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as compile } from './compile/index';
+export { default as parse } from './parse/index';
 export { default as preprocess } from './preprocess/index';
 
 export const VERSION = '__VERSION__';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -61,6 +61,11 @@ export interface CompileOptions {
 	preserveWhitespace?: boolean;
 }
 
+export interface ParserOptions {
+	filename?: string;
+	customElement?: boolean;
+}
+
 export interface Visitor {
 	enter: (node: Node) => void;
 	leave?: (node: Node) => void;

--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -3,13 +3,8 @@ import fragment from './state/fragment';
 import { whitespace } from '../utils/patterns';
 import { reserved } from '../utils/names';
 import full_char_code_at from '../utils/full_char_code_at';
-import { Node, Ast } from '../interfaces';
+import { Node, Ast, ParserOptions } from '../interfaces';
 import error from '../utils/error';
-
-interface ParserOptions {
-	filename?: string;
-	customElement?: boolean;
-}
 
 type ParserState = (parser: Parser) => (ParserState | void);
 


### PR DESCRIPTION
I am currently working on making the `prettier-plugin-svelte` compatible with Svelte 3. I noticed that `compile` has to be called to get the AST. This leads to errors in some tests, because they cannot be compiled.

For example, the following test: https://github.com/UnwrittenFun/prettier-plugin-svelte/blob/master/test/printer/samples/binding-shorthand.html
**Error: `value is not declared`**

But regardless of my use case, I think it makes sense to get the AST without a compilation step.