### PR TITLE
Fix is_hoistable cycle

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -1002,9 +1002,11 @@ export default class Component {
 
 								if (walking.has(other_declaration)) {
 									hoistable = false;
+								} else if (other_declaration.type === 'ExportNamedDeclaration' && walking.has(other_declaration.declaration)) {
+									hoistable = false;
 								} else if (!is_hoistable(other_declaration)) {
 									hoistable = false;
-								}
+                }
 							}
 
 							else {

--- a/test/runtime/samples/export-function-hoisting/_config.js
+++ b/test/runtime/samples/export-function-hoisting/_config.js
@@ -1,0 +1,3 @@
+export default {
+  html: 'Compile plz'
+}

--- a/test/runtime/samples/export-function-hoisting/main.svelte
+++ b/test/runtime/samples/export-function-hoisting/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	export function one () {
+    two()
+	}
+
+	export function two () {
+		return one()
+	}
+</script>
+
+Compile plz


### PR DESCRIPTION
For exported function declarations, the child declaration is the node that gets added to the `walking` set, so we have to check that too to detect a cycle in this case

Closes https://github.com/sveltejs/svelte/issues/2542