### PR TITLE
perf: Reuse the same promise instance in the scheduler

### DIFF
--- a/src/internal/scheduler.js
+++ b/src/internal/scheduler.js
@@ -4,21 +4,22 @@ import { set_current_component } from './lifecycle.js';
 export const dirty_components = [];
 export const intros = { enabled: false };
 
-let update_promise;
+const resolved_promise = Promise.resolve();
+let update_scheduled = false;
 const binding_callbacks = [];
 const render_callbacks = [];
 const flush_callbacks = [];
 
 export function schedule_update() {
-	if (!update_promise) {
-		update_promise = Promise.resolve();
-		update_promise.then(flush);
+	if (!update_scheduled) {
+		update_scheduled = true;
+		resolved_promise.then(flush);
 	}
 }
 
 export function tick() {
 	schedule_update();
-	return update_promise;
+	return resolved_promise;
 }
 
 export function add_binding_callback(fn) {
@@ -65,7 +66,7 @@ export function flush() {
 		flush_callbacks.pop()();
 	}
 
-	update_promise = null;
+	update_scheduled = false;
 }
 
 function update($$) {


### PR DESCRIPTION
- Scheduling an update no longer allocates two new promises, only one via `then`.
- The `tick` method was really returning an empty, resolved promise, so just reusing the same promise (`resolved_promise`) there as well. It was a little confusing because it _looked_ like it would return a promise to when the flush had completed, but in fact it was returning a promise that would resolve before the flush completed, as it was the promise that was "thenned" for the flush.

@Rich-Harris I tried to follow your coding conventions, hopefully it's adequate.
