### PR TITLE
fix: Ensure RxJS users don't create memory leaks

### DIFF
--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -50,7 +50,7 @@ export function validate_store(store, name) {
 export function subscribe(component, store, callback) {
 	let unsub = store.subscribe(callback);
 	// Prevent memory leaks for RxJS users.
-	if (typeof unsub === 'object' && typeof unsub.unsubscribe === 'function') {
+	if (unsub.unsubscribe) {
 		unsub = () => unsub.unsubscribe();
 	}
 	component.$$.on_destroy.push(unsub);

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -48,7 +48,12 @@ export function validate_store(store, name) {
 }
 
 export function subscribe(component, store, callback) {
-	component.$$.on_destroy.push(store.subscribe(callback));
+	let unsub = store.subscribe(callback);
+	// Prevent memory leaks for RxJS users.
+	if (typeof unsub === 'object' && typeof unsub.unsubscribe === 'function') {
+		unsub = () => unsub.unsubscribe();
+	}
+	component.$$.on_destroy.push(unsub);
 }
 
 export function create_slot(definition, ctx, fn) {


### PR DESCRIPTION
There is a bit of excitement in the RxJS community about Svelte.

- It seems like the rest of Svelte "just works™" with RxJS!
- **BUT** The danger is that unwary users will figure out how smooth this API is and accidentally create nasty memory leaks if the returned RxJS Subscriptions are not handled. Fortunately the required change is small.

NOTE: I am not entirely sure how to test this change. The goal here is to make sure that whenever you would normally teardown your store subscriptions, it is also tearing down these RxJS-shaped subscriptions. This is most commonly something you want in a component scenario. Say you have a timer component in your app that you show and remove with an `{#if}` block, when the `{#if}` block hides the component, you'd want to tear down the underlying Observable that is "ticking".

Also worth noting: I _totally_ understand if this sort of change isn't palatable. It's mostly my concern that RxJS users excited about Svelte will make mistakes that are really nasty to debug. If two lines of code solves that, then I had to try. :smile: 

Related #2549
