### PR TITLE
Change use of "e.g." to "for example"

### DIFF
--- a/site/content/tutorial/05-events/03-event-modifiers/text.md
+++ b/site/content/tutorial/05-events/03-event-modifiers/text.md
@@ -18,7 +18,7 @@ DOM event handlers can have *modifiers* that alter their behaviour. For example,
 
 The full list of modifiers:
 
-* `preventDefault` — calls `event.preventDefault()` before running the handler. Useful for e.g. client-side form handling
+* `preventDefault` — calls `event.preventDefault()` before running the handler. Useful for client-side form handling, for example.
 * `stopPropagation` — calls `event.stopPropagation()`, preventing the event reaching the next element
 * `passive` — improves scrolling performance on touch/wheel events (Svelte will add it automatically where it's safe to do so)
 * `capture` — fires the handler during the *capture* phase instead of the *bubbling* phase ([MDN docs](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture))


### PR DESCRIPTION
*E.g.* is an English language idiom that can be said in a plainer way, easier for non-native speakers to understand.

Personal preference is to use plainer language when possible, but I wouldn't be offended if this were rejected.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
