### PR TITLE
Convey the last element deletion in the markup

### DIFF
--- a/site/content/examples/03-logic/04-keyed-each-blocks/Thing.svelte
+++ b/site/content/examples/03-logic/04-keyed-each-blocks/Thing.svelte
@@ -6,4 +6,12 @@
 	const valueAtStart = value;
 </script>
 
-<p>{valueAtStart} / {value}</p>
+{#if valueAtStart === value}
+	<p>
+		{valueAtStart} / {value}
+	</p>
+{:else}
+	<p>
+		{valueAtStart} / {value} => <i>bye bye last element...!</i>
+	</p>
+{/if}

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
@@ -6,4 +6,12 @@
 	const valueAtStart = value;
 </script>
 
-<p>{valueAtStart} / {value}</p>
+{#if valueAtStart === value}
+	<p>
+		{valueAtStart} / {value}
+	</p>
+{:else}
+	<p>
+		{valueAtStart} / {value} => <i>bye bye last element...!</i>
+	</p>
+{/if}

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
@@ -6,4 +6,12 @@
 	const valueAtStart = value;
 </script>
 
-<p>{valueAtStart} / {value}</p>
+{#if valueAtStart === value}
+	<p>
+		{valueAtStart} / {value}
+	</p>
+{:else}
+	<p>
+		{valueAtStart} / {value} => <i>bye bye last element...!</i>
+	</p>
+{/if}


### PR DESCRIPTION
#### Reason for PR :
* Enhancement to the tutorial section for `Logic: Keyed each blocks`.
* Update the rendered content to convey last element deletion.

#### New output :
![last-block-deletion](https://user-images.githubusercontent.com/7418297/56859577-d0e57480-6941-11e9-8da8-bc8e8362e191.gif)

Let me know if the messaging needs to be more formal or any further updates are required. 