### PR TITLE
Site: Fix slot typo in docs

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -983,7 +983,7 @@ Named slots can also expose values. The `let:` directive goes on the element wit
 	{/each}
 </ul>
 
-</slot name="footer"></slot>
+<slot name="footer"></slot>
 ```
 
 


### PR DESCRIPTION
Just a small typo fix for the docs here https://svelte.dev/docs#Slots