### PR TITLE
Make null the default anchor of insertBefore

### DIFF
--- a/src/internal/dom.js
+++ b/src/internal/dom.js
@@ -3,7 +3,7 @@ export function append(target, node) {
 }
 
 export function insert(target, node, anchor) {
-	target.insertBefore(node, anchor);
+	target.insertBefore(node, anchor || null);
 }
 
 export function detach(node) {


### PR DESCRIPTION
This PR defaults the second argument of `insertBefore` to `null`, so that environments that require that the anchor is either a node or `null` won't throw an error when the anchor is `undefined`.

Fixes https://github.com/sveltejs/svelte/issues/2573