### PR TITLE
Narrow down checkbox transitions to background and left

### DIFF
--- a/site/static/global.css
+++ b/site/static/global.css
@@ -469,7 +469,6 @@ input[type="checkbox"]::before {
 	top: 0;
 	left: 0;
 	background: var(--second);
-	-webkit-transition: .25s ease-out;
 	/* box-sizing: border-box; */
 	box-sizing: content-box;
 }
@@ -489,7 +488,7 @@ input[type="checkbox"]::after {
 	border-radius: 1em;
 	background: white;
 	box-shadow: 0 0px 1px rgba(0,0,0,.4), 0 4px 2px rgba(0,0,0,.1);
-	-webkit-transition: .2s ease-out;
+	-webkit-transition: background .2s ease-out, left .2s ease-out;
 }
 
 input[type="checkbox"]:checked::after {


### PR DESCRIPTION
This PR narrows down the catch-all checkbox `:before`/`:after` transitions to just the background and left offset to remove flicker.

Fixes https://github.com/sveltejs/svelte/issues/2614.