### PR TITLE
Remove the $$scope key from $$props when calculating spread

### DIFF
--- a/src/internal/spread.js
+++ b/src/internal/spread.js
@@ -2,7 +2,7 @@ export function get_spread_update(levels, updates) {
 	const update = {};
 
 	const to_null_out = {};
-	const accounted_for = {};
+	const accounted_for = { $$scope: 1 };
 
 	let i = levels.length;
 	while (i--) {

--- a/test/runtime/samples/component-slot-spread-props/Nested.svelte
+++ b/test/runtime/samples/component-slot-spread-props/Nested.svelte
@@ -1,0 +1,4 @@
+<div>
+  <slot />
+  <div {...$$props}></div>
+</div>

--- a/test/runtime/samples/component-slot-spread-props/_config.js
+++ b/test/runtime/samples/component-slot-spread-props/_config.js
@@ -1,0 +1,19 @@
+export default {
+	html: `
+		<div>
+			<input />
+			<div class="foo"></div>
+		</div>
+	`,
+
+	async test({ assert, component, target }) {
+		component.value = 'foo';
+
+		assert.htmlEqual(target.innerHTML, `
+			<div>
+				<input />
+				<div class="foo"></div>
+			</div>
+		`);
+	}
+};

--- a/test/runtime/samples/component-slot-spread-props/main.svelte
+++ b/test/runtime/samples/component-slot-spread-props/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Nested from './Nested.svelte';
+	export let value = '';
+</script>
+
+<Nested class="foo">
+	<input bind:value />
+</Nested>


### PR DESCRIPTION
This PR makes is so the `$$scope` property of the `$$props` object will not be included in a spread update to avoid errors like `DOMException: Failed to execute 'setAttribute' on 'Element': '$$scope' is not a valid attribute name.`

By setting `$$scope` as accounted for straight away in `get_spread_update` it will not be part of the update.

Fixes https://github.com/sveltejs/svelte/issues/2520