### PR TITLE
fix resubscriptions inside script block

### DIFF
--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -201,7 +201,7 @@ export default function dom(
 							const variable = component.var_lookup.get(name);
 							if (variable && (variable.hoistable || variable.global || variable.module)) return;
 
-							if (single) {
+							if (single && !(variable.subscribable && variable.reassigned)) {
 								code.prependRight(node.start, `$$invalidate('${name}', `);
 								code.appendLeft(node.end, `)`);
 							} else {

--- a/test/runtime/samples/store-resubscribe-b/_config.js
+++ b/test/runtime/samples/store-resubscribe-b/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `42`,
+};

--- a/test/runtime/samples/store-resubscribe-b/main.svelte
+++ b/test/runtime/samples/store-resubscribe-b/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { writable } from 'svelte/store';
+	let foo = writable(0);
+	foo = writable(42);
+</script>
+
+{$foo}


### PR DESCRIPTION
Fixes #2435, hopefully. I _think_ that all that's necessary here is to skip the optimization that was added as part of #2398 when we're invalidating a variable that is subscribable and reassigned. The stuff in `pending_assignments` will later all get run through `component.invalidate` which will generate the appropriate code.