### PR TITLE
Set prop's initialised property based on declarator

### DIFF
--- a/src/compile/utils/scope.ts
+++ b/src/compile/utils/scope.ts
@@ -75,9 +75,8 @@ export class Scope {
 		if (node.kind === 'var' && this.block && this.parent) {
 			this.parent.add_declaration(node);
 		} else if (node.type === 'VariableDeclaration') {
-			const initialised = !!node.init;
-
 			node.declarations.forEach((declarator: Node) => {
+				const initialised = !!declarator.init;
 				extract_names(declarator.id).forEach(name => {
 					this.declarations.set(name, node);
 					if (initialised) this.initialised_declarations.add(name);

--- a/test/custom-elements/samples/no-warn-initialised-props/_config.js
+++ b/test/custom-elements/samples/no-warn-initialised-props/_config.js
@@ -1,0 +1,3 @@
+export default {
+	dev: true
+};

--- a/test/custom-elements/samples/no-warn-initialised-props/main.svelte
+++ b/test/custom-elements/samples/no-warn-initialised-props/main.svelte
@@ -1,0 +1,7 @@
+<svelte:options tag="my-app"/>
+
+<script>
+	export let foo = undefined;
+</script>
+
+<p>foo: {foo}</p>

--- a/test/custom-elements/samples/no-warn-initialised-props/test.js
+++ b/test/custom-elements/samples/no-warn-initialised-props/test.js
@@ -1,0 +1,17 @@
+import * as assert from 'assert';
+import './main.svelte';
+
+export default function (target) {
+	const warnings = [];
+	const warn = console.warn;
+
+	console.warn = warning => {
+		warnings.push(warning);
+	};
+
+	target.innerHTML = '<my-app />';
+
+	assert.equal(warnings.length, 0);
+
+	console.warn = warn;
+}


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
Currently, a variable's `initialised` value is set based on the `init` property of a `VariableDeclaration`. However, the `init` property exists on `VariableDeclarator`s, not `VariableDeclaration`s, so `initialised` is always `false`.

```html
<script>
  export let myVar = 3;
  // internally, myVar.initialised = false
</script>
```

This PR sets `initialised` based on the `init` value of a `VariableDeclarator`.

This change allows a prop to be explicitly initialized to `undefined` without receiving a warning.
```html
<script>
  export let thing = undefined; // will not warn if not provided
  export let other; // will warn if not provided
</script>
```