### PR TITLE
Check 'injected' and 'fixed_reactive_declarations' independently

### DIFF
--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -423,14 +423,15 @@ export default function dom(
 
 				${set && `$$self.$set = ${set};`}
 
-				${reactive_declarations.length > 0 && deindent`
 				${injected.length && `let ${injected.join(', ')};`}
+
+				${reactive_declarations.length > 0 && deindent`
 				$$self.$$.update = ($$dirty = { ${Array.from(all_reactive_dependencies).map(n => `${n}: 1`).join(', ')} }) => {
 					${reactive_declarations}
 				};
+				`}
 
 				${fixed_reactive_declarations}
-				`}
 
 				return ${stringify_props(filtered_declarations)};
 			}

--- a/test/runtime/samples/reactive-values-fixed/_config.js
+++ b/test/runtime/samples/reactive-values-fixed/_config.js
@@ -1,0 +1,11 @@
+export default {
+	html: `
+		<p>4</p>
+	`,
+
+	test({ assert, component, target }) {
+		assert.htmlEqual(target.innerHTML, `
+			<p>4</p>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-values-fixed/main.svelte
+++ b/test/runtime/samples/reactive-values-fixed/main.svelte
@@ -1,0 +1,6 @@
+<script>
+  const num = 2;
+  $: squared = num * num;
+</script>
+
+<p>{squared}</p>


### PR DESCRIPTION
`injected` and `fixed_reactive_declarations` are currently only checked if `reactive_declarations` has any elements, which makes it so reactive values derived from non-writable values will not end up in the rendered code unless there is at least one reactive value derived from writable values in the component.

By checking `injected` and `fixed_reactive_declarations` independently from `reactive_declarations` it works as expected.

Closes https://github.com/sveltejs/svelte/issues/2285