### PR TITLE
fix invalidating stores with UpdateExpression

### DIFF
--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -169,14 +169,15 @@ export default function dom(
 					scope = scope.parent;
 				}
 
-				if (node.type === 'AssignmentExpression') {
+				if (node.type === 'AssignmentExpression' || node.type === 'UpdateExpression') {
+					const assignee = node.type === 'AssignmentExpression' ? node.left : node.argument;
 					let names = [];
 
-					if (node.left.type === 'MemberExpression') {
-						const left_object_name = get_object(node.left).name;
+					if (assignee.type === 'MemberExpression') {
+						const left_object_name = get_object(assignee).name;
 						left_object_name && (names = [left_object_name]);
 					} else {
-						names = extract_names(node.left);
+						names = extract_names(assignee);
 					}
 
 					if (node.operator === '=' && nodes_match(node.left, node.right)) {
@@ -189,9 +190,10 @@ export default function dom(
 						code.overwrite(node.start, node.end, dirty.map(n => component.invalidate(n)).join('; '));
 					} else {
 						const single = (
-							node.left.type === 'Identifier' &&
+							node.type === 'AssignmentExpression' &&
+							assignee.type === 'Identifier' &&
 							parent.type === 'ExpressionStatement' &&
-							node.left.name[0] !== '$'
+							assignee.name[0] !== '$'
 						);
 
 						names.forEach(name => {
@@ -211,18 +213,6 @@ export default function dom(
 							component.has_reactive_assignments = true;
 						});
 					}
-				}
-
-				else if (node.type === 'UpdateExpression') {
-					const { name } = get_object(node.argument);
-
-					if (scope.find_owner(name) !== component.instance_scope) return;
-
-					const variable = component.var_lookup.get(name);
-					if (variable && variable.hoistable) return;
-
-					pending_assignments.add(name);
-					component.has_reactive_assignments = true;
 				}
 
 				if (pending_assignments.size > 0) {

--- a/test/runtime/samples/store-increment-updates-reactive/_config.js
+++ b/test/runtime/samples/store-increment-updates-reactive/_config.js
@@ -1,0 +1,8 @@
+export default {
+	html: `0`,
+
+	async test({ assert, component, target }) {
+		await component.increment();
+		assert.htmlEqual(target.innerHTML, `1`);
+	}
+};

--- a/test/runtime/samples/store-increment-updates-reactive/main.svelte
+++ b/test/runtime/samples/store-increment-updates-reactive/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { writable } from '../../../../store.js';
+
+	const foo = writable(0);
+
+	export function increment() {
+		$foo++;
+	}
+</script>
+
+{$foo}


### PR DESCRIPTION
Fixes #2625. Also dries up the invalidation code a bit. It was in fact an imperfect mirroring of the `AssignmentExpression` branch in the `UpdateExpression` branch that was causing this bug.

~~Possible future optimization: Also allow `UpdateExpression`s to get the `single` treatment here if they are `prefix: true` or if we can safely convert them to `prefix: true` because their value is currently discarded.~~ Never mind, we're further from this than I thought. `$foo += 42;` also does not currently get optimized this way. Maybe someday.