### PR TITLE
Add alert, confirm, and prompt to globals

### DIFF
--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -2,8 +2,10 @@ import { isIdentifierStart, isIdentifierChar } from 'acorn';
 import full_char_code_at from './full_char_code_at';
 
 export const globals = new Set([
+	'alert',
 	'Array',
 	'Boolean',
+	'confirm',
 	'console',
 	'Date',
 	'decodeURI',
@@ -24,6 +26,7 @@ export const globals = new Set([
 	'parseInt',
 	'process',
 	'Promise',
+	'prompt',
 	'RegExp',
 	'Set',
 	'String',


### PR DESCRIPTION
Adding `alert`, `confirm`, and `prompt` to `globals` makes is so Svelte doesn't warn when using it in an inlined event handler.

Closes https://github.com/sveltejs/svelte/issues/2648