### PR TITLE
Remove v1 each key parsing

### DIFF
--- a/src/parse/state/mustache.ts
+++ b/src/parse/state/mustache.ts
@@ -36,7 +36,7 @@ export default function mustache(parser: Parser) {
 
 	parser.allow_whitespace();
 
-	// {/if} or {/each}
+	// {/if}, {/each} or {/await}
 	if (parser.eat('/')) {
 		let block = parser.current();
 		let expected;
@@ -286,13 +286,6 @@ export default function mustache(parser: Parser) {
 				block.key = read_expression(parser);
 				parser.allow_whitespace();
 				parser.eat(')', true);
-				parser.allow_whitespace();
-			} else if (parser.eat('@')) {
-				block.key = parser.read_identifier();
-				if (!block.key) parser.error({
-					code: `expected-name`,
-					message: `Expected name`
-				});
 				parser.allow_whitespace();
 			}
 		}


### PR DESCRIPTION
By removing the parsing code for the old v1 each block key notation, we can get rid of the current error message when trying to use it ([REPL](https://svelte.dev/repl?version=3.1.0&gist=99d4394b54f093c2b69d683ebff4678c)):

```
(svelte plugin) TypeError: Cannot read property '1' of null
src/App.svelte
TypeError: Cannot read property '1' of null
1   at parts.forEach (…/svelte/compiler.js:14336:42)
```

And get a more descriptive parsing error instead:
```
(svelte plugin) ParseError: Expected }
src/App.svelte
 6: </script>
 7:
 8: {#each items as item @id}
                         ^
 9:   <div>{item.name}</div>
10: {/each}
```
