### PR TITLE
Clarify when sanitization is done and when not

### DIFF
--- a/site/content/tutorial/01-introduction/06-html-tags/text.md
+++ b/site/content/tutorial/01-introduction/06-html-tags/text.md
@@ -12,4 +12,4 @@ In Svelte, you do this with the special `{@html ...}` tag:
 <p>{@html string}</p>
 ```
 
-> Svelte doesn't perform any sanitization of the data before it gets inserted into the DOM via a @html-tag. In other words, if you use `{@html ...}` it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to XSS attacks.
+> Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. In other words, if you use this feature it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to XSS attacks.

--- a/site/content/tutorial/01-introduction/06-html-tags/text.md
+++ b/site/content/tutorial/01-introduction/06-html-tags/text.md
@@ -12,4 +12,4 @@ In Svelte, you do this with the special `{@html ...}` tag:
 <p>{@html string}</p>
 ```
 
-> Svelte doesn't perform any sanitization of the data before it gets inserted into the DOM. In other words, it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to XSS attacks.
+> Svelte doesn't perform any sanitization of the data before it gets inserted into the DOM via a @html-tag. In other words, if you use `{@html ...}` it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to XSS attacks.


### PR DESCRIPTION
When reading this part of the tutorial I was a bit suprised, I made this doc change to clarify the intents in my eyes. Maybe I'm wrong in this change (I don't know svelte that long yet), but from what I see in that tutorial step the normal `{string}` does escape for html context.