### PR TITLE
Site: Briefly mention intro:true in the transition directive section.

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -755,6 +755,8 @@ The `in:` and `out:` directives are not bidirectional. An in transition will con
 {/if}
 ```
 
+> By default intro transitions will not play on first render. You can modify this behaviour by setting `intro: true` when you [create a component](docs#Client-side_component_API).
+
 #### Transition parameters
 
 ---


### PR DESCRIPTION
Added a brief mention of `intro: true` in the transition directive section. I didn't actually know this option made it into v3 and there is no mention of it around the transition section. I felt it was worth a brief mention and a link just to highlight it.