### PR TITLE
Applying read only property form onto elements using `attr` instead

### DIFF
--- a/src/compile/render-dom/wrappers/Element/Attribute.ts
+++ b/src/compile/render-dom/wrappers/Element/Attribute.ts
@@ -308,21 +308,6 @@ const attribute_lookup = {
 	dropzone: {},
 	enctype: { applies_to: ['form'] },
 	for: { property_name: 'htmlFor', applies_to: ['label', 'output'] },
-	form: {
-		applies_to: [
-			'button',
-			'fieldset',
-			'input',
-			'keygen',
-			'label',
-			'meter',
-			'object',
-			'output',
-			'progress',
-			'select',
-			'textarea',
-		],
-	},
 	formaction: { applies_to: ['input', 'button'] },
 	headers: { applies_to: ['td', 'th'] },
 	height: {


### PR DESCRIPTION
Using this we treat `form` as if it doesn't have a property on element, since that one is read only.
This should generate the wanted behavior, without generating an exception.

Closes #1742 