### PR TITLE
Exported properties let vs const clarification

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -35,6 +35,9 @@ Svelte uses the `export` keyword to mark a variable declaration as a *property* 
 	// these properties can be set externally
 	export let foo;
 	export let bar = 'optional default value';
+	
+	// this property is readonly externally
+	export const buzz = 'buzz';
 
 	// Values that are passed in as props
 	// are immediately available


### PR DESCRIPTION
Just adding a bit of extra example code to clarify that an exported const is read only externally, to avoid confusion.