### PR TITLE
Warn on improper use of reactive declarations

### DIFF
--- a/test/validator/samples/module-script-reactive-declaration/input.svelte
+++ b/test/validator/samples/module-script-reactive-declaration/input.svelte
@@ -1,0 +1,5 @@
+<script context="module">
+	let num = 2;
+	let square;
+	$: square = num * num;
+</script>

--- a/test/validator/samples/module-script-reactive-declaration/warnings.json
+++ b/test/validator/samples/module-script-reactive-declaration/warnings.json
@@ -1,0 +1,7 @@
+[{
+	"message": "$: has no effect in a module script",
+	"code": "module-script-reactive-declaration",
+	"start": { "line": 4, "column": 1, "character": 54 },
+	"end": { "line": 4, "column": 23, "character": 76 },
+	"pos": 54
+}]

--- a/test/validator/samples/reactive-declaration-non-top-level/input.svelte
+++ b/test/validator/samples/reactive-declaration-non-top-level/input.svelte
@@ -1,0 +1,8 @@
+<script>
+	let num = 2;
+	$: square = num * num;
+
+	function myFunc() {
+		$: double = num * 2;
+	}
+</script>

--- a/test/validator/samples/reactive-declaration-non-top-level/warnings.json
+++ b/test/validator/samples/reactive-declaration-non-top-level/warnings.json
@@ -1,0 +1,7 @@
+[{
+	"message": "$: has no effect outside of the top-level",
+	"code": "non-top-level-reactive-declaration",
+	"start": { "line": 6, "column": 2, "character": 71 },
+	"end": { "line": 6, "column": 22, "character": 91 },
+	"pos": 71
+}]


### PR DESCRIPTION
This PR makes it so a warning is raised when a reactive declaration is used in a module script, or when it is used at a non-top-level in an instance script.


Closes https://github.com/sveltejs/svelte/issues/2176.