### PR TITLE
Make modal example more obvious

### DIFF
--- a/site/content/examples/14-composition/04-modal/App.svelte
+++ b/site/content/examples/14-composition/04-modal/App.svelte
@@ -1,8 +1,12 @@
 <script>
 	import Modal from './Modal.svelte';
 
-	let showModal = true;
+	let showModal = false;
 </script>
+
+<button on:click="{() => showModal = true}">
+	show modal
+</button>
 
 {#if showModal}
 	<Modal on:close="{() => showModal = false}">
@@ -22,8 +26,4 @@
 
 		<a href="https://www.merriam-webster.com/dictionary/modal">merriam-webster.com</a>
 	</Modal>
-{:else}
-	<button on:click="{() => showModal = true}">
-		show modal
-	</button>
 {/if}


### PR DESCRIPTION
I think most newcomers would expect an example that initially & always shows a button for launching the modal, and then shows the modal after clicking on the button.  

I was originally confused by the modal showing up first, and essentially swapping spots with the button.  It misled me to wonder if there was logic that needed to be moved into the Modal component.  