### PR TITLE
Initialize `get_slot_changes` to null when not needed

### DIFF
--- a/src/compile/render-dom/wrappers/Slot.ts
+++ b/src/compile/render-dom/wrappers/Slot.ts
@@ -90,6 +90,7 @@ export default class SlotWrapper extends Wrapper {
 				const ${get_slot_context} = (${arg}) => (${stringify_props(context_props)});
 			`);
 		} else {
+			get_slot_changes = 'null';
 			get_slot_context = 'null';
 		}
 


### PR DESCRIPTION
Fixes #2697

