### PR TITLE
Don't hoist functions dependent on injected reactive variables

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -920,7 +920,7 @@ export default class Component {
 		// reference instance variables other than other
 		// hoistable functions. TODO others?
 
-		const { hoistable_nodes, var_lookup } = this;
+		const { hoistable_nodes, var_lookup, injected_reactive_declaration_vars } = this;
 
 		const top_level_function_declarations = new Map();
 
@@ -987,11 +987,11 @@ export default class Component {
 						const { name } = flatten_reference(node);
 						const owner = scope.find_owner(name);
 
-						if (name[0] === '$' && !owner) {
+						if (node.type === 'Identifier' && injected_reactive_declaration_vars.has(name)) {
 							hoistable = false;
-						}
-
-						else if (owner === instance_scope) {
+						} else if (name[0] === '$' && !owner) {
+							hoistable = false;
+						} else if (owner === instance_scope) {
 							if (name === fn_declaration.id.name) return;
 
 							const variable = var_lookup.get(name);

--- a/test/runtime/samples/reactive-value-function-hoist/_config.js
+++ b/test/runtime/samples/reactive-value-function-hoist/_config.js
@@ -1,0 +1,15 @@
+export default {
+	html: `
+		<button>Click me</button>
+	`,
+
+	async test({ assert, target, window }) {
+		const event = new window.MouseEvent('click');
+		const button = target.querySelector('button');
+
+		await button.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>4</button>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-value-function-hoist/main.svelte
+++ b/test/runtime/samples/reactive-value-function-hoist/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let num = 2;
+	$: square = num * num;
+
+	function onClick() {
+		this.innerHTML = square;
+	}
+</script>
+
+<button on:click={onClick}>Click me</button>


### PR DESCRIPTION
This PR makes it so functions dependent on injected reactive declaration variables are not hoisted out of the instance.

Closes https://github.com/sveltejs/svelte/issues/2687