### PR TITLE
Add `window` and `document` to globals

### DIFF
--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -10,6 +10,7 @@ export const globals = new Set([
 	'Date',
 	'decodeURI',
 	'decodeURIComponent',
+	'document',
 	'encodeURI',
 	'encodeURIComponent',
 	'Infinity',
@@ -31,6 +32,7 @@ export const globals = new Set([
 	'Set',
 	'String',
 	'undefined',
+	'window',
 ]);
 
 export const reserved = new Set([


### PR DESCRIPTION
To prevent the following warning message:

```
(!) svelte plugin: 'window' is not defined
src/templates/Share.svelte
20: </script>
21:
22: {#if window.navigator.share}
         ^
23:   <button class="icon-share2" on:click="{shareNatively}" title="Share"></button>
24: {:else}
```

Related PR: #2649