### PR TITLE
Link to label syntax page on MDN

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -89,7 +89,7 @@ Because Svelte's reactivity is based on assignments, using array methods like `.
 
 ---
 
-Any top-level statement (i.e. not inside a block or a function) can be made reactive by prefixing it with the `$:` label. Reactive statements run immediately before the component updates, whenever the values that they depend on have changed.
+Any top-level statement (i.e. not inside a block or a function) can be made reactive by prefixing it with the `$:` [JS label syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label). Reactive statements run immediately before the component updates, whenever the values that they depend on have changed.
 
 ```html
 <script>


### PR DESCRIPTION
Inspired by https://github.com/sveltejs/svelte/issues/98#issuecomment-491586072 , I wanted to make it a bit more explicit that the `$:` label was actual JS syntax.
