### PR TITLE
Allows custom element to be defined without a tag

### DIFF
--- a/src/compile/render-dom/index.ts
+++ b/src/compile/render-dom/index.ts
@@ -462,9 +462,13 @@ export default function dom(
 
 				${body.length > 0 && body.join('\n\n')}
 			}
-
-			customElements.define("${component.tag}", ${name});
 		`);
+
+		if (component.tag != null) {
+			builder.add_block(deindent`
+				customElements.define("${component.tag}", ${name});
+			`);
+		}
 	} else {
 		const superclass = options.dev ? 'SvelteComponentDev' : 'SvelteComponent';
 

--- a/test/custom-elements/samples/no-tag-warning/_config.js
+++ b/test/custom-elements/samples/no-tag-warning/_config.js
@@ -1,0 +1,17 @@
+export default {
+	warnings: [{
+		code: "custom-element-no-tag",
+		message: "No custom element 'tag' option was specified. To automatically register a custom element, specify a name with a hyphen in it, e.g. <svelte:options tag=\"my-thing\"/>. To hide this warning, use <svelte:options tag={null}/>",
+		pos: 0,
+		start: {
+			character: 0,
+			column: 0,
+			line: 1
+		},
+		end: {
+			character: 18,
+			column: 18,
+			line: 1
+		}
+	}]
+};

--- a/test/custom-elements/samples/no-tag-warning/main.svelte
+++ b/test/custom-elements/samples/no-tag-warning/main.svelte
@@ -1,0 +1,7 @@
+<svelte:options />
+
+<script>
+	export let name;
+</script>
+
+<h1>Hello {name}!</h1>

--- a/test/custom-elements/samples/no-tag-warning/test.js
+++ b/test/custom-elements/samples/no-tag-warning/test.js
@@ -1,0 +1,12 @@
+import * as assert from 'assert';
+import CustomElement from './main.svelte';
+
+export default function (target) {
+	customElements.define('no-tag', CustomElement);
+	target.innerHTML = `<no-tag name="world"></no-tag>`;
+
+	const el = target.querySelector('no-tag');
+	const h1 = el.shadowRoot.querySelector('h1');
+
+	assert.equal(h1.textContent, 'Hello world!');
+}

--- a/test/custom-elements/samples/no-tag/_config.js
+++ b/test/custom-elements/samples/no-tag/_config.js
@@ -1,0 +1,3 @@
+export default {
+	warnings: []
+};

--- a/test/custom-elements/samples/no-tag/main.svelte
+++ b/test/custom-elements/samples/no-tag/main.svelte
@@ -1,0 +1,7 @@
+<svelte:options tag={null} />
+
+<script>
+	export let name;
+</script>
+
+<h1>Hello {name}!</h1>

--- a/test/custom-elements/samples/no-tag/test.js
+++ b/test/custom-elements/samples/no-tag/test.js
@@ -1,0 +1,12 @@
+import * as assert from 'assert';
+import CustomElement from './main.svelte';
+
+export default function (target) {
+	customElements.define('no-tag', CustomElement);
+	target.innerHTML = `<no-tag name="world"></no-tag>`;
+
+	const el = target.querySelector('no-tag');
+	const h1 = el.shadowRoot.querySelector('h1');
+
+	assert.equal(h1.textContent, 'Hello world!');
+}


### PR DESCRIPTION
FIX #2417
* warning given on compile if tag is absent
* no warning if tag is set to `null`
