### PR TITLE
Set quote_mark to null when closing quote mark is found

### DIFF
--- a/src/compile/render-dom/wrappers/Element/StyleAttribute.ts
+++ b/src/compile/render-dom/wrappers/Element/StyleAttribute.ts
@@ -122,7 +122,7 @@ function get_style_value(chunks: Node[]) {
 				} else if (char === '\\') {
 					escaped = true;
 				} else if (char === quote_mark) {
-					quote_mark === null;
+					quote_mark = null;
 				} else if (char === '"' || char === "'") {
 					quote_mark = char;
 				} else if (char === ')' && in_url) {

--- a/test/runtime/samples/attribute-url/_config.js
+++ b/test/runtime/samples/attribute-url/_config.js
@@ -1,0 +1,8 @@
+export default {
+	test({ assert, target }) {
+		const div = target.querySelector( 'div' );
+
+		assert.equal( div.style.backgroundImage, 'url(https://example.com/foo.jpg)');
+		assert.equal( div.style.color, 'red' );
+	}
+};

--- a/test/runtime/samples/attribute-url/main.svelte
+++ b/test/runtime/samples/attribute-url/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let bgImage = 'https://example.com/foo.jpg';
+	let color = 'red';
+</script>
+
+<div style="background-image: url('{bgImage}'); color: {color};">{color}</div>


### PR DESCRIPTION
Everything in the `style` attribute after the opening quote mark in `url('...` is included in the chunk text. This PR sets `quote_mark` to `null` when the closing quote mark is found.

Closes https://github.com/sveltejs/svelte/issues/2715