### PR TITLE
Add error for missing equals after attribute name

### DIFF
--- a/src/parse/state/tag.ts
+++ b/src/parse/state/tag.ts
@@ -358,7 +358,7 @@ function read_attribute(parser: Parser, unique_names: Set<string>) {
 		}
 	}
 
-	let name = parser.read_until(/(\s|=|\/|>)/);
+	let name = parser.read_until(/[\s=\/>"']/);
 	if (!name) return null;
 
 	let end = parser.index;
@@ -383,6 +383,11 @@ function read_attribute(parser: Parser, unique_names: Set<string>) {
 	if (parser.eat('=')) {
 		value = read_attribute_value(parser);
 		end = parser.index;
+	} else if (parser.match_regex(/["']/)) {
+		parser.error({
+			code: `unexpected-token`,
+			message: `Expected =`
+		}, parser.index);
 	}
 
 	if (type) {

--- a/test/validator/samples/attribute-expected-equals/errors.json
+++ b/test/validator/samples/attribute-expected-equals/errors.json
@@ -1,0 +1,15 @@
+[{
+	"code": "unexpected-token",
+	"message": "Expected =",
+	"start": {
+		"line": 5,
+		"column": 9,
+		"character": 50
+	},
+	"end": {
+		"line": 5,
+		"column": 9,
+		"character": 50
+	},
+	"pos": 50
+}]

--- a/test/validator/samples/attribute-expected-equals/input.svelte
+++ b/test/validator/samples/attribute-expected-equals/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	let name = 'world';
+</script>
+
+<h1 class"=foo">Hello {name}!</h1>


### PR DESCRIPTION
This PR excludes quotation marks and apostrophes when reading an attribute name to [comply with the HTML 5 parser spec](https://stackoverflow.com/questions/925994/what-characters-are-allowed-in-an-html-attribute-name#answer-926136), and also raises `ParseError: Expected =` if a quotation mark or apostrophe is found after an attribute name instead of an equals sign.

Closes https://github.com/sveltejs/svelte/issues/1513