### PR TITLE
Fixed bind:checked tutorial example

### DIFF
--- a/site/content/tutorial/06-bindings/03-checkbox-inputs/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/03-checkbox-inputs/app-a/App.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <label>
-	<input type=checkbox checked={yes}>
+	<input type=checkbox bind:checked={yes}>
 	Yes! Send me regular email spam
 </label>
 


### PR DESCRIPTION
Clicking the checkbox wasn't changing the text properly at https://svelte.dev/tutorial/checkbox-inputs. It seems like the "bind:" got left out somehow

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
