### PR TITLE
refactor: remove unnecessary return null in style attribute

### DIFF
--- a/src/compile/render-dom/wrappers/Element/StyleAttribute.ts
+++ b/src/compile/render-dom/wrappers/Element/StyleAttribute.ts
@@ -17,6 +17,7 @@ export default class StyleAttributeWrapper extends AttributeWrapper {
 
 	render(block: Block) {
 		const style_props = optimize_style(this.node.chunks);
+		if (!style_props) return super.render(block);
 
 		style_props.forEach((prop: StyleProp) => {
 			let value;

--- a/src/compile/render-dom/wrappers/Element/StyleAttribute.ts
+++ b/src/compile/render-dom/wrappers/Element/StyleAttribute.ts
@@ -17,7 +17,6 @@ export default class StyleAttributeWrapper extends AttributeWrapper {
 
 	render(block: Block) {
 		const style_props = optimize_style(this.node.chunks);
-		if (!style_props) return super.render(block);
 
 		style_props.forEach((prop: StyleProp) => {
 			let value;
@@ -93,7 +92,6 @@ function optimize_style(value: Node[]) {
 		}
 
 		const result = get_style_value(chunks);
-		if (!result) return null;
 
 		props.push({ key, value: result.value });
 		chunks = result.chunks;


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->

- Remove the `result` not null chekcing since it's always an object.
- ~~Remove the `super.render(block)` since `style_props` won't be falsy.~~