### PR TITLE
Add browser support linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,6 @@ trim_trailing_whitespace = true
 [test/**/expected.css]
 insert_final_newline = false
 
-[{package.json,.travis.yml,.eslintrc.json}]
+[{package.json,.travis.yml,.eslintrc.json,.eslintrc.browser-check.json}]
 indent_style = space
 indent_size = 2

--- a/.eslintrc.browser-check.json
+++ b/.eslintrc.browser-check.json
@@ -1,27 +1,27 @@
 {
-	"root": true,
-	"plugins": [
-		"builtin-compat"
-	],
-	"rules": {
-		"builtin-compat/no-incompatible-builtins": 2
-	},
-	"env": {
-		"es6": true,
-		"browser": true,
-		"node": true,
-		"mocha": true
-	},
-	"parserOptions": {
-		"ecmaVersion": 9,
-		"sourceType": "module"
-	},
-	"settings": {
-		"import/core-modules": [
-			"svelte"
-		],
-		"svelte3/extensions": [
-			"html"
-		]
-	}
+  "root": true,
+  "plugins": [
+    "builtin-compat"
+  ],
+  "rules": {
+    "builtin-compat/no-incompatible-builtins": 2
+  },
+  "env": {
+    "es6": true,
+    "browser": true,
+    "node": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 9,
+    "sourceType": "module"
+  },
+  "settings": {
+    "import/core-modules": [
+      "svelte"
+    ],
+    "svelte3/extensions": [
+      "html"
+    ]
+  }
 }

--- a/.eslintrc.browser-check.json
+++ b/.eslintrc.browser-check.json
@@ -1,0 +1,27 @@
+{
+	"root": true,
+	"plugins": [
+		"builtin-compat"
+	],
+	"rules": {
+		"builtin-compat/no-incompatible-builtins": 2
+	},
+	"env": {
+		"es6": true,
+		"browser": true,
+		"node": true,
+		"mocha": true
+	},
+	"parserOptions": {
+		"ecmaVersion": 9,
+		"sourceType": "module"
+	},
+	"settings": {
+		"import/core-modules": [
+			"svelte"
+		],
+		"svelte3/extensions": [
+			"html"
+		]
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -380,6 +380,16 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
+      }
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -487,6 +497,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
       "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000969",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000969.tgz",
+      "integrity": "sha512-Kus0yxkoAJgVc0bax7S4gLSlFifCa7MnSZL9p9VuS/HIKEL4seaqh28KIQAAO50cD/rJ5CiJkJFapkdDAlhFxQ==",
       "dev": true
     },
     "caseless": {
@@ -935,6 +951,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.134",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.134.tgz",
+      "integrity": "sha512-C3uK2SrtWg/gSWaluLHWSHjyebVZCe4ZC0NVgTAoTq8tCR9FareRK5T7R7AS/nPZShtlEcjVMX1kQ8wi4nU68w==",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1098,6 +1120,19 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-builtin-compat": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-builtin-compat/-/eslint-plugin-builtin-compat-0.0.2.tgz",
+      "integrity": "sha1-BHnasKsOD9e1MLxmvH2OHON/Uik=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^3.2.4",
+        "lodash": "^4.17.5",
+        "mdn-browser-compat-data": "0.0.29",
+        "requireindex": "~1.1.0",
+        "semver": "^5.5.0"
       }
     },
     "eslint-plugin-html": {
@@ -2223,6 +2258,23 @@
         "object-visit": "^1.0.0"
       }
     },
+    "mdn-browser-compat-data": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.29.tgz",
+      "integrity": "sha512-gA/BC81dAoKtFXYYQaWmU6f/TJ9GhEWi5yY5LV933yCYoTVd9UvkCrTcV2mQ01x87XKH0zSIpEKc55aeNyQbdQ==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true
+        }
+      }
+    },
     "mdn-data": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.2.0.tgz",
@@ -2982,6 +3034,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
     "codecov": "codecov",
     "precodecov": "npm run coverage",
     "lint": "eslint src test/*.js",
+    "lint:browser-check": "npm run prepare && eslint --no-eslintrc -c .eslintrc.browser-check.json ./*.js --no-ignore",
     "build": "rollup -c",
     "prepare": "npm run build && npm run tsd",
     "dev": "rollup -cw",
     "pretest": "npm run build",
     "posttest": "agadoo src/internal/index.js",
     "prepublishOnly": "export PUBLISH=true && npm run lint && npm test",
+    "supportedbrowsers": "browserslist",
     "tsd": "tsc -d src/store.ts --outDir ."
   },
   "repository": {
@@ -95,5 +97,10 @@
     "sourceMap": true,
     "instrument": true
   },
-  "dependencies": {}
+  "dependencies": {},
+  "browserslist": [
+    "> 1%",
+    "not ie <= 11",
+    "not dead"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "codecov": "^3.0.0",
     "css-tree": "1.0.0-alpha22",
     "eslint": "^5.3.0",
+    "eslint-plugin-builtin-compat": "0.0.2",
     "eslint-plugin-html": "^5.0.0",
     "eslint-plugin-import": "^2.11.0",
     "estree-walker": "^0.6.0",


### PR DESCRIPTION
### Description
Adds a way to check whether the functionality is compatible with specified `browserlist`.

### Aproach taken
I used the [eslint-plugin-builtin-compat](https://github.com/instea/eslint-plugin-builtin-compat) in order to check for functionality not supported by browsers specified in `browserlist`.
I did not include it in the current `lint` command as it serves a bit different purpose in my opinion, so I created a separate `.eslintrc` config for it.
I also added `npm run supportedbrowsers` to list minimum version of all supported browsers.

#### Disclaimer
_The browser list specified is not a final be all end all that I decided is the minimal version Svelte will support. Instead, it is the minimal config that currently passes the check and can be improved by various polyfills._

Closes #558 
Closes #2788