### PR TITLE
Docs: Exporting function expression vs declaration

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -47,11 +47,14 @@ Svelte uses the `export` keyword to mark a variable declaration as a *property* 
 	// Values that are passed in as props
 	// are immediately available
 	console.log(foo, bar);
+	
+	// Function expressions can also be props
+	export let format = (number) => (number.toFixed(2));
 
-	// function declarations cannot be set externally,
-	// but can be accessed from outside
-	export function instanceMethod() {
-		alert(foo);
+	// Function declarations are added as methods
+	// on the component, rather than props
+	export function greetMethod() {
+		alert(`I'm a <${this.constructor.name}>!`);
 	}
 
 	// you can also use export { ... as ... } to have


### PR DESCRIPTION
Current docs give the impression that functions can not be default values for props. Suggestion to make the distinction between expressions and declarations clearer.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
