### PR TITLE
fix: 🐛 data attributes without value outputting as "true"

### DIFF
--- a/src/compile/render-dom/wrappers/Element/Attribute.ts
+++ b/src/compile/render-dom/wrappers/Element/Attribute.ts
@@ -187,7 +187,7 @@ export default class AttributeWrapper {
 					: property_name
 						? `${element.var}.${property_name} = ${value};`
 						: is_dataset
-							? `${element.var}.dataset.${camel_case_name} = ${value};`
+							? `${element.var}.dataset.${camel_case_name} = ${value === true ? '""' : value};`
 							: `${method}(${element.var}, "${name}", ${value === true ? '""' : value});`
 			);
 

--- a/test/runtime/samples/attribute-dataset-without-value/_config.js
+++ b/test/runtime/samples/attribute-dataset-without-value/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: '<div data-potato=""></div>',
+};

--- a/test/runtime/samples/attribute-dataset-without-value/main.svelte
+++ b/test/runtime/samples/attribute-dataset-without-value/main.svelte
@@ -1,0 +1,1 @@
+<div data-potato></div>


### PR DESCRIPTION
Closes #2803