### PR TITLE
Allow custom element to be declared with no tag and no options

### DIFF
--- a/src/compile/Component.ts
+++ b/src/compile/Component.ts
@@ -153,7 +153,7 @@ export default class Component {
 
 		if (compile_options.customElement) {
 			if (this.component_options.tag === undefined && compile_options.tag === undefined) {
-				const svelteOptions = ast.html.children.find(child => child.name === 'svelte:options');
+				const svelteOptions = ast.html.children.find(child => child.name === 'svelte:options') || { start: 0, end: 0 };
 				this.warn(svelteOptions, {
 					code: 'custom-element-no-tag',
 					message: `No custom element 'tag' option was specified. To automatically register a custom element, specify a name with a hyphen in it, e.g. <svelte:options tag="my-thing"/>. To hide this warning, use <svelte:options tag={null}/>`

--- a/test/custom-elements/samples/no-svelte-options/_config.js
+++ b/test/custom-elements/samples/no-svelte-options/_config.js
@@ -1,0 +1,17 @@
+export default {
+	warnings: [{
+		code: "custom-element-no-tag",
+		message: "No custom element 'tag' option was specified. To automatically register a custom element, specify a name with a hyphen in it, e.g. <svelte:options tag=\"my-thing\"/>. To hide this warning, use <svelte:options tag={null}/>",
+		pos: 0,
+		start: {
+			character: 0,
+			column: 0,
+			line: 1
+		},
+		end: {
+			character: 0,
+			column: 0,
+			line: 1
+		}
+	}]
+};

--- a/test/custom-elements/samples/no-svelte-options/main.svelte
+++ b/test/custom-elements/samples/no-svelte-options/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let name;
+</script>
+
+<h1>Hello {name}!</h1>

--- a/test/custom-elements/samples/no-svelte-options/test.js
+++ b/test/custom-elements/samples/no-svelte-options/test.js
@@ -1,0 +1,12 @@
+import * as assert from 'assert';
+import CustomElement from './main.svelte';
+
+export default function (target) {
+	customElements.define('no-tag', CustomElement);
+	target.innerHTML = `<no-tag name="world"></no-tag>`;
+
+	const el = target.querySelector('no-tag');
+	const h1 = el.shadowRoot.querySelector('h1');
+
+	assert.equal(h1.textContent, 'Hello world!');
+}


### PR DESCRIPTION
Fix for #2821 where no `<svelte:options />` are declared and compiler configured with `customElement: true`