### PR TITLE
store.ts without dependencies

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -94,26 +94,21 @@ export default [
 			{
 				file: `store.mjs`,
 				format: 'esm',
-				paths: id => id.startsWith('svelte/') && id.replace('svelte', '.')
 			},
 			{
 				file: `store.js`,
 				format: 'cjs',
-				paths: id => id.startsWith('svelte/') && id.replace('svelte', '.')
 			}
 		],
 		plugins: [
 			is_publish
 				? typescript({
-					include: 'src/**',
-					exclude: 'src/internal/**',
 					typescript: require('typescript')
 				})
 				: sucrase({
 					transforms: ['typescript']
 				})
-		],
-		external: id => id.startsWith('svelte/')
+		]
 	},
 
 	// everything else

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,10 @@
-import { run_all, noop, safe_not_equal, is_function } from './internal/utils';
+/** Safe not equal. */
+function safe_not_equal(a: any, b: any) {
+	return a !== a ? b === b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
+}
+
+/** No operation. */
+function noop() { }
 
 /** Callback to inform of a value updates. */
 type Subscriber<T> = (value: T) => void;
@@ -143,7 +149,7 @@ export function derived<T, S extends Stores>(
 			if (auto) {
 				set(result as T);
 			} else {
-				cleanup = is_function(result) ? result as Unsubscriber : noop;
+				cleanup = result instanceof Function ? result as Unsubscriber : noop;
 			}
 		};
 
@@ -164,7 +170,7 @@ export function derived<T, S extends Stores>(
 		sync();
 
 		return function stop() {
-			run_all(unsubscribers);
+			unsubscribers.forEach((unsubscribe) => unsubscribe());
 			cleanup();
 		};
 	});


### PR DESCRIPTION
Was looking at issue #2786 (Don't bundle the store) and this is just an idea/proposal. Because i am not sure what the unintended consequences are and if this would resolve them. This pull request makes `store.ts` independent of `internal` by inlining as workaround.