### PR TITLE
Fixes #2714: Provide non-decoded text to `parse` consumers

### DIFF
--- a/src/parse/state/tag.ts
+++ b/src/parse/state/tag.ts
@@ -490,8 +490,13 @@ function read_sequence(parser: Parser, done: () => boolean) {
 			if (current_chunk.data) chunks.push(current_chunk);
 
 			chunks.forEach(chunk => {
-				if (chunk.type === 'Text')
-					chunk.data = decode_character_references(chunk.data);
+				if (chunk.type === 'Text') {
+					let decoded = decode_character_references(chunk.data);
+					if (chunk.data != decoded) {
+						chunk.raw = chunk.data;
+						chunk.data = decoded;
+					}
+				}
 			});
 
 			return chunks;

--- a/src/parse/state/text.ts
+++ b/src/parse/state/text.ts
@@ -14,10 +14,15 @@ export default function text(parser: Parser) {
 		data += parser.template[parser.index++];
 	}
 
-	parser.current().children.push({
+	let node = {
 		start,
 		end: parser.index,
 		type: 'Text',
 		data: decode_character_references(data),
-	});
+	};
+
+	if (node.data != data)
+		node.raw = data;
+
+	parser.current().children.push(node);
 }

--- a/test/parser/samples/attribute-escaped/output.json
+++ b/test/parser/samples/attribute-escaped/output.json
@@ -20,7 +20,8 @@
 								"start": 15,
 								"end": 33,
 								"type": "Text",
-								"data": "\"quoted\""
+								"data": "\"quoted\"",
+								"raw": "&quot;quoted&quot;"
 							}
 						]
 					}

--- a/test/parser/samples/convert-entities-in-element/output.json
+++ b/test/parser/samples/convert-entities-in-element/output.json
@@ -15,7 +15,8 @@
 						"start": 3,
 						"end": 20,
 						"type": "Text",
-						"data": "Hello & World"
+						"data": "Hello & World",
+						"raw": "Hello &amp; World"
 					}
 				]
 			}

--- a/test/parser/samples/convert-entities/output.json
+++ b/test/parser/samples/convert-entities/output.json
@@ -8,7 +8,8 @@
 				"start": 0,
 				"end": 17,
 				"type": "Text",
-				"data": "Hello & World"
+				"data": "Hello & World",
+				"raw": "Hello &amp; World"
 			}
 		]
 	},

--- a/test/parser/samples/nbsp/output.json
+++ b/test/parser/samples/nbsp/output.json
@@ -15,7 +15,8 @@
 						"start": 6,
 						"end": 12,
 						"type": "Text",
-						"data": " "
+						"data": " ",
+						"raw": "&nbsp;"
 					}
 				]
 			}


### PR DESCRIPTION
Adds a `raw` property to text nodes with decoded html entities set to the original data.