### PR TITLE
Fix CRUD example to allow changing input values.

### DIFF
--- a/site/content/examples/19-7guis/05-7guis-crud/App.svelte
+++ b/site/content/examples/19-7guis/05-7guis-crud/App.svelte
@@ -30,10 +30,7 @@
 
 	$: selected = filteredPeople[i];
 
-	$: {
-		first = selected ? selected.first : '';
-		last = selected ? selected.last : '';
-	}
+	$: reset_inputs(selected);
 
 	function create() {
 		people = people.concat({ first, last });
@@ -53,7 +50,8 @@
 	}
 
 	function reset_inputs(person) {
-		({ first, last } = person);
+		first = person ? person.first : '';
+		last = person ? person.last : '';
 	}
 </script>
 


### PR DESCRIPTION
Currently, the first name and last name inputs fields can't be edited without the changes immediately being overwritten back to the selected person's first name and last name. This change will make it so that the input fields only get overwritten with the selected person's first name and last name when the selected person is changed.

Issue:
https://github.com/sveltejs/svelte/issues/2852

Current version (not working):
https://svelte.dev/repl/783f270559c64b2d95253088acd97f26?version=3.4.2

Proposed version (working):
https://svelte.dev/repl/65d2dbc9b60f4a9e9c9fdc6abc8a831c?version=3.4.2
