### PR TITLE
Correcting word error

### DIFF
--- a/site/content/tutorial/16-special-elements/01-svelte-self/text.md
+++ b/site/content/tutorial/16-special-elements/01-svelte-self/text.md
@@ -14,7 +14,7 @@ It's useful for things like this folder tree view, where folders can contain *ot
 {/if}
 ```
 
-...but that's impossible, because a file can't import itself. Instead, we use `<svelte:self>`:
+...but that's impossible, because a folder can't import itself. Instead, we use `<svelte:self>`:
 
 ```html
 {#if file.type === 'folder'}


### PR DESCRIPTION
Looks like this was meant to indicate the folder, not the file