### PR TITLE
Issue #2898 -- Fix overwrite of 'offset' value in reactive statement

### DIFF
--- a/site/src/routes/examples/index.svelte
+++ b/site/src/routes/examples/index.svelte
@@ -39,6 +39,10 @@
 	let isLoading = false;
 	const cache = {};
 
+	function showExampleCodeOnChange() {
+		offset = 1;
+	}
+
 	$: title = title_by_slug[active_slug] || '';
 	$: first_slug = sections[0].examples[0].slug;
 	$: mobile = width < 768; // note: same as per media query below
@@ -46,7 +50,7 @@
 	$: if (repl && active_slug) {
 		if (active_slug in cache) {
 			repl.set({ components: cache[active_slug] });
-			offset = 1;
+			showExampleCodeOnChange();
 		} else {
 			isLoading = true;
 			fetch(`examples/${active_slug}.json`)
@@ -59,7 +63,7 @@
 				.then(components => {
 					cache[active_slug] = components;
 					repl.set({components});
-					offset = 1;
+					showExampleCodeOnChange();
 					isLoading = false;
 				})
 				.catch(() => {


### PR DESCRIPTION
Addresses #2898 

The `offset` property was being overwritten to `1` every time `offset` changed, so the viewport wasn't being set to anything else. It looks like the issue was present in all browsers.

FYI, I'm new to svelte, so if there's a more idiomatic way to do this, let me know. Thanks!