### PR TITLE
Add option to writable for immutable

### DIFF
--- a/test/store/index.ts
+++ b/test/store/index.ts
@@ -278,6 +278,22 @@ describe('store', () => {
 			b.set(2);
 			assert.deepEqual(get(c), 'two 2');
 		});
+
+		it('allows immutable stores', () => {
+			const obj = { value: 1 };
+			const a = writable(obj, { immutable: true });
+			let called = 0;
+			a.subscribe(() => {
+				called++;
+			})
+
+			assert.equal(called, 1);
+			obj.value += 1;
+			a.set(obj);
+			assert.equal(called, 1);
+			a.set({ value: 2 });
+			assert.equal(called, 2);
+		});
 	});
 
 	describe('get', () => {


### PR DESCRIPTION
Workaround was proposed in [chat](https://discordapp.com/channels/457912077277855764/506988048375087114/582594608702423050). This PR intends to make it easier to construct a writable with an immutable set operation and the signature of the writable function is backwards compatible.