### PR TITLE
Ending alt text with a period

### DIFF
--- a/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
+++ b/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
@@ -19,10 +19,10 @@ When building web apps, it's important to make sure that they're *accessible* to
 In this case, we're missing the `alt` attribute that describes the image for people using screenreaders, or people with slow or flaky internet connections that can't download the image. Let's add one:
 
 ```html
-<img src={src} alt="A man dancing">
+<img src={src} alt="A man dancing.">
 ```
 
-We can use curly braces *inside* attributes. Try changing it to `"{name} dancing"` — remember to declare a `name` variable in the `<script>` block.
+We can use curly braces *inside* attributes. Try changing it to `"{name} dancing."` — remember to declare a `name` variable in the `<script>` block.
 
 
 ## Shorthand attributes
@@ -30,6 +30,6 @@ We can use curly braces *inside* attributes. Try changing it to `"{name} dancing
 It's not uncommon to have an attribute where the name and value are the same, like `src={src}`. Svelte gives us a convenient shorthand for these cases:
 
 ```html
-<img {src} alt="A man dancing">
+<img {src} alt="A man dancing.">
 ```
 

--- a/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
+++ b/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
@@ -19,10 +19,10 @@ When building web apps, it's important to make sure that they're *accessible* to
 In this case, we're missing the `alt` attribute that describes the image for people using screenreaders, or people with slow or flaky internet connections that can't download the image. Let's add one:
 
 ```html
-<img src={src} alt="A man dancing.">
+<img src={src} alt="A man dances.">
 ```
 
-We can use curly braces *inside* attributes. Try changing it to `"{name} dancing."` — remember to declare a `name` variable in the `<script>` block.
+We can use curly braces *inside* attributes. Try changing it to `"{name} dances."` — remember to declare a `name` variable in the `<script>` block.
 
 
 ## Shorthand attributes
@@ -30,6 +30,6 @@ We can use curly braces *inside* attributes. Try changing it to `"{name} dancing
 It's not uncommon to have an attribute where the name and value are the same, like `src={src}`. Svelte gives us a convenient shorthand for these cases:
 
 ```html
-<img {src} alt="A man dancing.">
+<img {src} alt="A man dances.">
 ```
 


### PR DESCRIPTION
Added a period at the end of the alt text example, recently learned that it improves UX for screen-reader users as it provides a pause.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
