### PR TITLE
Ending alt text with a period

### DIFF
--- a/site/content/tutorial/01-introduction/03-dynamic-attributes/app-b/App.svelte
+++ b/site/content/tutorial/01-introduction/03-dynamic-attributes/app-b/App.svelte
@@ -3,4 +3,4 @@
 	let name = 'Rick Astley';
 </script>
 
-<img {src} alt="{name} dancing.">
+<img {src} alt="{name} dances.">

--- a/site/content/tutorial/01-introduction/03-dynamic-attributes/app-b/App.svelte
+++ b/site/content/tutorial/01-introduction/03-dynamic-attributes/app-b/App.svelte
@@ -3,4 +3,4 @@
 	let name = 'Rick Astley';
 </script>
 
-<img {src} alt="{name} dancing">
+<img {src} alt="{name} dancing.">


### PR DESCRIPTION
Added a period at the end of the alt text example, recently learned that it improves UX for screen-reader users as it provides a pause.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
