### PR TITLE
refactor: better parsing name of file

### DIFF
--- a/register.js
+++ b/register.js
@@ -25,8 +25,7 @@ function deregisterExtension(extension) {
 
 function registerExtension(extension) {
 	require.extensions[extension] = function(module, filename) {
-		const name = path.basename(filename)
-			.slice(0, -path.extname(filename).length)
+		const name = path.parse(filename).name
 			.replace(/^\d/, '_$&')
 			.replace(/[^a-zA-Z0-9_$]/g, '');
 


### PR DESCRIPTION
```js
path.parse(filename).name
// is same result and better
path.basename(filename)
  .slice(0, -path.extname(filename).length)
```
Why better:
 - Faster: You can check [here](https://repl.it/@Hongarc/test-parse-name)
 - Easy to understand

