### PR TITLE
site: support new folder structure in REPL

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1362,9 +1362,9 @@
       }
     },
     "@sveltejs/svelte-repl": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/svelte-repl/-/svelte-repl-0.1.2.tgz",
-      "integrity": "sha512-OHIj01ly4+/WwNb0zGqLSQL7POSs2BPx47CzryVsbu0omVDe7olYTJnCYV4ePUENnlL5JzZihzvlvxmVGP6knw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@sveltejs/svelte-repl/-/svelte-repl-0.1.5.tgz",
+      "integrity": "sha512-gk7Ny/i19g3njob9lGGV5JzDed8eAaFphHidxquFGW5QgMCScEu+YgweBo+tRkRE0sJObFzMz3MjudH5o+KdIw==",
       "dev": true,
       "requires": {
         "codemirror": "^5.45.0",

--- a/site/package.json
+++ b/site/package.json
@@ -39,7 +39,7 @@
     "@babel/runtime": "^7.4.4",
     "@sindresorhus/slugify": "^0.9.1",
     "@sveltejs/site-kit": "^1.0.4",
-    "@sveltejs/svelte-repl": "^0.1.2",
+    "@sveltejs/svelte-repl": "^0.1.5",
     "degit": "^2.1.3",
     "dotenv": "^8.0.0",
     "eslint-plugin-svelte3": "^1.0.0",

--- a/site/src/routes/repl/local/[...file].js
+++ b/site/src/routes/repl/local/[...file].js
@@ -1,12 +1,13 @@
 import { createReadStream } from 'fs';
 
 export function get(req, res) {
-	if (process.env.NODE_ENV !== 'development' || !/^[a-z.]+$/.test(req.params.file)) {
+	const path = req.params.file.join('/');
+	if (process.env.NODE_ENV !== 'development' || ('/' + path).includes('/.')) {
 		res.writeHead(403);
 		res.end();
 		return;
 	}
-	createReadStream('../' + req.params.file)
+	createReadStream('../' + path)
 		.on('error', () => {
 			res.writeHead(403);
 			res.end();


### PR DESCRIPTION
The mate to https://github.com/sveltejs/svelte-repl/pull/27

This endpoint was turned into a spread to support requesting files down in directories. The old regex check `/^[a-z.]+$/` has also been removed because it's now too restrictive. Hopefully this won't be too much of a security risk, as this endpoint is only allowed to run in development. This could still be tightened up if desired though.