### PR TITLE
Fix 2929

### DIFF
--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -239,7 +239,8 @@ function attribute_matches(node: Node, name: string, expected_value: string, ope
 
 function class_matches(node, name: string) {
 	return node.classes.some(function(class_directive) {
-		return class_directive.name === name;
+		name = new RegExp(`\\b${name}\\b`);
+		return name.test(class_directive.name);
 	});
 }
 

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -239,8 +239,7 @@ function attribute_matches(node: Node, name: string, expected_value: string, ope
 
 function class_matches(node, name: string) {
 	return node.classes.some(function(class_directive) {
-		name = new RegExp(`\\b${name}\\b`);
-		return name.test(class_directive.name);
+		return new RegExp(`\\b${name}\\b`).test(class_directive.name);
 	});
 }
 


### PR DESCRIPTION
This fixes #2929, however it is my first pull request to a public repository so I may have made a mistake unknowingly and I am having trouble understanding the test files and making one.

It fixes by implementing the same logic of attribute_matches to class_matches.

Edit : I've tested it on a local svelte project.