### PR TITLE
fix example: Props/Default values

### DIFF
--- a/site/content/tutorial/03-props/02-default-values/text.md
+++ b/site/content/tutorial/03-props/02-default-values/text.md
@@ -13,6 +13,5 @@ We can easily specify default values for props:
 If we now instantiate the component without an `answer` prop, it will fall back to the default:
 
 ```html
-<Nested answer={42}/>
-<Nested/>
+<Nested />
 ```


### PR DESCRIPTION
Updated example code for calling component w/o props to show the default taking effect.

Here's the tutorial link: https://svelte.dev/tutorial/default-values

Current example:
```html
<Nested answer={42}/>
<Nested/>
```

Suggested example:
```html
<Nested />
```


<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
