### PR TITLE
Attribute class support array type

### DIFF
--- a/src/compiler/compile/render-dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render-dom/wrappers/Element/Attribute.ts
@@ -146,9 +146,15 @@ export default class AttributeWrapper {
 					${updater}
 				`);
 			} else if (property_name) {
-				block.builders.hydrate.add_line(
-					`${element.var}.${property_name} = ${init};`
-				);
+				if (property_name === attribute_lookup.class.property_name) {
+					block.builders.hydrate.add_line(
+						`${element.var}.${property_name} = [].concat(${init} || []).join(' ');`
+					);
+				} else {
+					block.builders.hydrate.add_line(
+						`${element.var}.${property_name} = ${init};`
+					);
+				}
 				updater = `${element.var}.${property_name} = ${should_cache ? last : value};`;
 			} else if (is_dataset) {
 				block.builders.hydrate.add_line(

--- a/test/hydration/samples/attribute-class-array/_after.html
+++ b/test/hydration/samples/attribute-class-array/_after.html
@@ -1,0 +1,1 @@
+<div class="bg-red text-white size-sm"></div>

--- a/test/hydration/samples/attribute-class-array/_before.html
+++ b/test/hydration/samples/attribute-class-array/_before.html
@@ -1,0 +1,1 @@
+<div class="bg-red text-white size-sm"></div>

--- a/test/hydration/samples/attribute-class-array/_config.js
+++ b/test/hydration/samples/attribute-class-array/_config.js
@@ -1,0 +1,15 @@
+export default {
+	snapshot(target) {
+		const div = target.querySelector('div');
+
+		return {
+			div
+		};
+	},
+
+	test(assert, target, snapshot) {
+		const div = target.querySelector('div');
+
+		assert.equal(div, snapshot.div);
+	}
+};

--- a/test/hydration/samples/attribute-class-array/main.svelte
+++ b/test/hydration/samples/attribute-class-array/main.svelte
@@ -1,0 +1,5 @@
+<script>
+  const collection = ['bg-red', 'text-white', 'size-sm'];
+</script>
+
+<div class={collection}></div>


### PR DESCRIPTION
Hi!  I started to learn Svetle a couple of days ago. And I noticed that the attribute class does not support an array. To be more precise, the values are displayed separated by commas. 

> Example: https://svelte.dev/repl/62907cf957fd4638892207e988e1cd59?version=3.4.4


![image](https://user-images.githubusercontent.com/1014551/59088271-af4bb580-890f-11e9-9c72-4860a60108ef.png)

I inspect the sources and tried to fix this situation. If I'm wrong, correct me. Thanks!