### PR TITLE
Add ambient types for `*.svelte` files

### DIFF
--- a/src/runtime/ambient.ts
+++ b/src/runtime/ambient.ts
@@ -1,0 +1,19 @@
+declare module '*.svelte' {
+	type Props = Record<string, any>;
+
+	export default class {
+		constructor(options: {
+			target: Element;
+			anchor?: Element;
+			props?: Props;
+			hydrate?: boolean;
+			intro?: boolean;
+		});
+
+		$set(props: Props): void;
+		$on<T = any>(event: string, callback: (event: CustomEvent<T>) => void): () => void;
+		$destroy(): void;
+
+		[accessor: string]: any;
+	}
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,3 +1,5 @@
+import './ambient';
+
 export {
 	onMount,
 	onDestroy,


### PR DESCRIPTION
Currently, TypeScript will complain about `.svelte` files with `Cannot find module './App.svelte'.ts(2307)`.

If we include an ambient declaration with svelte's types, these will go away and instead users will get a generic svelte component. They won't see their specific accessors or named exports, but at least they won't get an error out of the box.