### PR TITLE
Change package.json stubs to work with webpack's module resolution

### DIFF
--- a/scripts/create-stubs.js
+++ b/scripts/create-stubs.js
@@ -4,7 +4,7 @@ fs.readdirSync('src/runtime')
 	.filter(dir => fs.statSync(`src/runtime/${dir}`).isDirectory())
 	.forEach(dir => {
 		fs.writeFileSync(`${dir}/package.json`, JSON.stringify({
-			main: './index.js',
+			main: './index',
 			module: './index.mjs'
 		}, null, '  '));
 


### PR DESCRIPTION
For reasons that I won't begin to try and understand, when webpack imports something like `svelte/internal` from (say) `svelte/store`, it ignores the `resolve.mainFields` and `resolve.extensions` that the developer has explicitly specified in `webpack.config.js`, and only respects the `main` property of the package.json.

Luckily, we can omit the file extension for `main` and it will basically work *as if* that weren't the case. Hopefully it doesn't break anything else in the meantime.