### PR TITLE
fix(create-stubs): An import path cannot end with a '.d.ts' extension.

### DIFF
--- a/scripts/create-stubs.js
+++ b/scripts/create-stubs.js
@@ -8,5 +8,5 @@ fs.readdirSync('src/runtime')
 			module: './index.mjs'
 		}, null, '  '));
 
-		fs.writeFileSync(`${dir}/index.d.ts`, `export * from '../types/runtime/${dir}/index.d.ts';`);
+		fs.writeFileSync(`${dir}/index.d.ts`, `export * from '../types/runtime/${dir}/index';`);
 	});


### PR DESCRIPTION
Hi, 
I created this branch to reproduce the error https://github.com/pyoner/svelte-ts-template/tree/3.5.1
I got error
```bash
svelte-ts-template git:(3.5.1) ✗ npm run build

> svelte-ts-app@1.0.0 build /home/jungle/repo/svelte-ts-template
> rollup -c


src/main.ts → public/bundle.js...
node_modules/svelte/internal/index.d.ts:1:15 - error TS2691: An import path cannot end with a '.d.ts' extension. Consider importing '../types/runtime/internal/index' instead.

1 export * from '../types/runtime/internal/index.d.ts';
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
node_modules/svelte/store/index.d.ts:1:15 - error TS2691: An import path cannot end with a '.d.ts' extension. Consider importing '../types/runtime/store/index' instead.

1 export * from '../types/runtime/store/index.d.ts';
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
node_modules/svelte/types/runtime/index.d.ts:1:10 - error TS2305: Module '"../../internal"' has no exported member 'onMount'.

1 export { onMount, onDestroy, beforeUpdate, afterUpdate, setContext, getContext, tick, createEventDispatcher } from 'svelte/internal';
           ~~~~~~~
node_modules/svelte/types/runtime/index.d.ts:1:19 - error TS2305: Module '"../../internal"' has no exported member 'onDestroy'.

1 export { onMount, onDestroy, beforeUpdate, afterUpdate, setContext, getContext, tick, createEventDispatcher } from 'svelte/internal';
                    ~~~~~~~~~
node_modules/svelte/types/runtime/index.d.ts:1:30 - error TS2305: Module '"../../internal"' has no exported member 'beforeUpdate'.

1 export { onMount, onDestroy, beforeUpdate, afterUpdate, setContext, getContext, tick, createEventDispatcher } from 'svelte/internal';
                               ~~~~~~~~~~~~
node_modules/svelte/types/runtime/index.d.ts:1:44 - error TS2305: Module '"../../internal"' has no exported member 'afterUpdate'.

1 export { onMount, onDestroy, beforeUpdate, afterUpdate, setContext, getContext, tick, createEventDispatcher } from 'svelte/internal';
                                             ~~~~~~~~~~~
node_modules/svelte/types/runtime/index.d.ts:1:57 - error TS2305: Module '"../../internal"' has no exported member 'setContext'.

1 export { onMount, onDestroy, beforeUpdate, afterUpdate, setContext, getContext, tick, createEventDispatcher } from 'svelte/internal';
                                                          ~~~~~~~~~~
node_modules/svelte/types/runtime/index.d.ts:1:69 - error TS2305: Module '"../../internal"' has no exported member 'getContext'.

1 export { onMount, onDestroy, beforeUpdate, afterUpdate, setContext, getContext, tick, createEventDispatcher } from 'svelte/internal';
                                                                      ~~~~~~~~~~
node_modules/svelte/types/runtime/index.d.ts:1:81 - error TS2305: Module '"../../internal"' has no exported member 'tick'.

1 export { onMount, onDestroy, beforeUpdate, afterUpdate, setContext, getContext, tick, createEventDispatcher } from 'svelte/internal';
                                                                                  ~~~~
node_modules/svelte/types/runtime/index.d.ts:1:87 - error TS2305: Module '"../../internal"' has no exported member 'createEventDispatcher'.

1 export { onMount, onDestroy, beforeUpdate, afterUpdate, setContext, getContext, tick, createEventDispatcher } from 'svelte/internal';
                                                                                        ~~~~~~~~~~~~~~~~~~~~~
src/App.svelte:3:12 - error TS2305: Module '"../node_modules/svelte/store"' has no exported member 'writable'.

3   import { writable } from "svelte/store";
             ~~~~~~~~

created public/bundle.js in 7.5s

```