### PR TITLE
Fix request animation frame context

### DIFF
--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -96,9 +96,7 @@ export let now: () => number = is_client
 	? () => window.performance.now()
 	: () => Date.now();
 
-export let raf = (callback) => is_client && window.requestAnimationFrame
-	? window.requestAnimationFrame.call(window, callback)
-	: undefined;
+export let raf = cb => requestAnimationFrame(cb);
 
 // used internally for testing
 export function set_now(fn) {

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -87,7 +87,7 @@ export function once(fn) {
 		if (ran) return;
 		ran = true;
 		fn.call(this, ...args);
-	}
+	};
 }
 
 const is_client = typeof window !== 'undefined';
@@ -96,7 +96,9 @@ export let now: () => number = is_client
 	? () => window.performance.now()
 	: () => Date.now();
 
-export let raf = is_client ? requestAnimationFrame.bind(window) : noop;
+export let raf = (callback) => is_client && window.requestAnimationFrame
+	? window.requestAnimationFrame.apply(window, callback)
+	: undefined;
 
 // used internally for testing
 export function set_now(fn) {

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -97,7 +97,7 @@ export let now: () => number = is_client
 	: () => Date.now();
 
 export let raf = (callback) => is_client && window.requestAnimationFrame
-	? window.requestAnimationFrame.apply(window, callback)
+	? window.requestAnimationFrame.call(window, callback)
 	: undefined;
 
 // used internally for testing

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -96,7 +96,7 @@ export let now: () => number = is_client
 	? () => window.performance.now()
 	: () => Date.now();
 
-export let raf = is_client ? requestAnimationFrame : noop;
+export let raf = is_client ? requestAnimationFrame.bind(window) : noop;
 
 // used internally for testing
 export function set_now(fn) {


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->

This fixes: https://github.com/sveltejs/svelte/issues/2933
Issue has been in place since 3.4.3 and later, 3.4.2 is working as expected.
Reproduction of the issue can be found here:
[![Edit icy-grass-vv0y6](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/icy-grass-vv0y6?fontsize=14)
Check the console of the browser to see the error mentioned.

Basically the requestAnimationFrame is extracted from the window, which gives it the wrong context when triggered during animation time. The context when triggering a requestAnimationFrame should always be the window. So binding it when reassigning it fixes this issue.

I haven't added tests to cover for this change. I'm not sure how to approach that, anyone that can help me and figure that out?