### PR TITLE
fix &nbsp; getting mapped as normal space

### DIFF
--- a/src/compiler/compile/nodes/Text.ts
+++ b/src/compiler/compile/nodes/Text.ts
@@ -12,7 +12,7 @@ export default class Text extends Node {
 		super(component, parent, scope, info);
 		this.data = info.data;
 
-		if (!component.component_options.preserveWhitespace && !/\S/.test(info.data)) {
+		if (!component.component_options.preserveWhitespace && !/[\S\u00A0]/.test(info.data)) {
 			let node = parent;
 			while (node) {
 				if (node.type === 'Element' && node.name === 'pre') {


### PR DESCRIPTION
In few cases (refer issue #3014) the nbsp; was getting mapped to space (code: 32) character instead of non-breaking space (code: 160). The regex to decide non-space characters is updated, so that non-breaking space is not represented as space but as Text with non breaking space.
