### PR TITLE
fix text nodes in .innerHTML-optimized output

### DIFF
--- a/src/compiler/compile/render-dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render-dom/wrappers/Element/index.ts
@@ -335,6 +335,8 @@ export default class ElementWrapper extends Wrapper {
 
 		function to_html(wrapper: ElementWrapper | TextWrapper) {
 			if (wrapper.node.type === 'Text') {
+				if (wrapper.node.use_space) return ' ';
+
 				const parent = wrapper.node.parent as Element;
 
 				const raw = parent && (
@@ -342,9 +344,9 @@ export default class ElementWrapper extends Wrapper {
 					parent.name === 'style'
 				);
 
-				return raw
+				return (raw
 					? wrapper.node.data
-					: escape_html(wrapper.node.data)
+					: escape_html(wrapper.node.data))
 						.replace(/\\/g, '\\\\')
 						.replace(/`/g, '\\`')
 						.replace(/\$/g, '\\$');

--- a/test/runtime/samples/script-style-non-top-level/_config.js
+++ b/test/runtime/samples/script-style-non-top-level/_config.js
@@ -2,7 +2,7 @@ export default {
 	html: `
 		<div>
 			<style>div { color: red; }</style>
-			<script>alert('<>');</script>
+			<script>alert(\`<>\`);</script>
 		</div>
 	`
 };

--- a/test/runtime/samples/script-style-non-top-level/main.svelte
+++ b/test/runtime/samples/script-style-non-top-level/main.svelte
@@ -1,4 +1,4 @@
 <div>
 	<style>div { color: red; }</style>
-	<script>alert('<>');</script>
+	<script>alert(`<>`);</script>
 </div>


### PR DESCRIPTION
Fixes #2745, and also fixes another bug I discovered while looking at that one. The .innerHTML representation of 'raw' (non-top-level script and style) tags wasn't escaping the character it needed to for use in string templates.