### PR TITLE
Fix each blocks not unmounting components correctly

### DIFF
--- a/src/runtime/internal/keyed-each.ts
+++ b/src/runtime/internal/keyed-each.ts
@@ -1,13 +1,17 @@
 import { transition_in, transition_out } from './transitions';
 
+export function remove_block_from_lookup(block, lookup) {
+	lookup.delete(block.key);
+}
+
 export function destroy_block(block, lookup) {
 	block.d(1);
-	lookup.delete(block.key);
+	remove_block_from_lookup(block, lookup);
 }
 
 export function outro_and_destroy_block(block, lookup) {
 	transition_out(block, 1, () => {
-		destroy_block(block, lookup);
+		remove_block_from_lookup(block, lookup);
 	});
 }
 

--- a/src/runtime/internal/keyed-each.ts
+++ b/src/runtime/internal/keyed-each.ts
@@ -1,17 +1,13 @@
 import { transition_in, transition_out } from './transitions';
 
-export function remove_block_from_lookup(block, lookup) {
-	lookup.delete(block.key);
-}
-
 export function destroy_block(block, lookup) {
 	block.d(1);
-	remove_block_from_lookup(block, lookup);
+	lookup.delete(block.key);
 }
 
 export function outro_and_destroy_block(block, lookup) {
 	transition_out(block, 1, () => {
-		remove_block_from_lookup(block, lookup);
+		lookup.delete(block.key);
 	});
 }
 

--- a/test/runtime/samples/each-block-keyed-shift/Nested.svelte
+++ b/test/runtime/samples/each-block-keyed-shift/Nested.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let title;
+</script>
+
+<p>{title}</p>

--- a/test/runtime/samples/each-block-keyed-shift/_config.js
+++ b/test/runtime/samples/each-block-keyed-shift/_config.js
@@ -1,0 +1,27 @@
+export default {
+	props: {
+		titles: [{ name: 'a', }, { name: 'b' }, { name: 'c' }]
+	},
+
+	html: `
+		<p>a</p>
+		<p>b</p>
+		<p>c</p>
+	`,
+
+	test({ assert, component, target }) {
+		component.titles = [{ name: 'b' }, { name: 'c' }];
+
+		assert.htmlEqual(target.innerHTML, `
+			<p>b</p>
+			<p>c</p>
+		`);
+
+		component.titles = [{ name: 'c' }];
+
+		assert.htmlEqual(target.innerHTML, `
+			<p>c</p>
+		`);
+
+	}
+};

--- a/test/runtime/samples/each-block-keyed-shift/main.svelte
+++ b/test/runtime/samples/each-block-keyed-shift/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Nested from './Nested.svelte';
+
+	export let titles;
+</script>
+
+{#each titles as title (title.name)}
+	<Nested title="{title.name}"/>
+{/each}


### PR DESCRIPTION
This should fix #3055. This PR prevents `outro_and_destroy_block` from calling `block.d()` in the `transition_out` callback, since `transition_out` already calls `block.d()`.