### PR TITLE
Site: Reuse `layers` variable in window bindings tutorial

### DIFF
--- a/site/content/tutorial/16-special-elements/04-svelte-window-bindings/app-a/App.svelte
+++ b/site/content/tutorial/16-special-elements/04-svelte-window-bindings/app-a/App.svelte
@@ -7,7 +7,7 @@
 <svelte:window/>
 
 <a class="parallax-container" href="https://www.firewatchgame.com">
-	{#each [0, 1, 2, 3, 4, 5, 6, 7, 8] as layer}
+	{#each layers as layer}
 		<img
 			style="transform: translate(0,{-y * layer / (layers.length - 1)}px)"
 			src="https://www.firewatchgame.com/images/parallax/parallax{layer}.png"

--- a/site/content/tutorial/16-special-elements/04-svelte-window-bindings/app-b/App.svelte
+++ b/site/content/tutorial/16-special-elements/04-svelte-window-bindings/app-b/App.svelte
@@ -7,7 +7,7 @@
 <svelte:window bind:scrollY={y}/>
 
 <a class="parallax-container" href="https://www.firewatchgame.com">
-	{#each [0, 1, 2, 3, 4, 5, 6, 7, 8] as layer}
+	{#each layers as layer}
 		<img
 			style="transform: translate(0,{-y * layer / (layers.length - 1)}px)"
 			src="https://www.firewatchgame.com/images/parallax/parallax{layer}.png"


### PR DESCRIPTION
Hey,

I've just improved the code of the [tutorial](https://svelte.dev/tutorial/svelte-window-bindings) a little bit. As I understand, someone forgot to do it earlier.