### PR TITLE
HMR hooks

### DIFF
--- a/src/compiler/compile/render-dom/index.ts
+++ b/src/compiler/compile/render-dom/index.ts
@@ -80,10 +80,10 @@ export default function dom(
 			${$$props} => {
 				${uses_props && component.invalidate('$$props', `$$props = @assign(@assign({}, $$props), $$new_props)`)}
 				${writable_props.map(prop =>
-			`if ('${prop.export_name}' in $$props) ${component.invalidate(prop.name, `${prop.name} = $$props.${prop.export_name}`)};`
-		)}
+					`if ('${prop.export_name}' in $$props) ${component.invalidate(prop.name, `${prop.name} = $$props.${prop.export_name}`)};`
+				)}
 				${component.slots.size > 0 &&
-			`if ('$$scope' in ${$$props}) ${component.invalidate('$$scope', `$$scope = ${$$props}.$$scope`)};`}
+				`if ('$$scope' in ${$$props}) ${component.invalidate('$$scope', `$$scope = ${$$props}.$$scope`)};`}
 			}
 		`
 		: null;

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -74,6 +74,14 @@ function instance($$self, $$props, $$invalidate) {
 		if ('name' in $$props) $$invalidate('name', name = $$props.name);
 	};
 
+	$$self.$capture_state = () => {
+		return { name };
+	};
+
+	$$self.$inject_state = $$props => {
+		if ('name' in $$props) $$invalidate('name', name = $$props.name);
+	};
+
 	return { name };
 }
 

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -163,6 +163,17 @@ function instance($$self, $$props, $$invalidate) {
 		if ('baz' in $$props) $$invalidate('baz', baz = $$props.baz);
 	};
 
+	$$self.$capture_state = () => {
+		return { things, foo, bar, baz };
+	};
+		
+	$$self.$inject_state = $$props => {
+		if ('things' in $$props) $$invalidate('things', things = $$props.things);
+		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('bar' in $$props) $$invalidate('bar', bar = $$props.bar);
+		if ('baz' in $$props) $$invalidate('baz', baz = $$props.baz);
+	};
+		
 	return { things, foo, bar, baz };
 }
 

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -161,6 +161,15 @@ function instance($$self, $$props, $$invalidate) {
 		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
 	};
 
+	$$self.$capture_state = () => {
+		return { things, foo };
+	};
+
+	$$self.$inject_state = $$props => {
+		if ('things' in $$props) $$invalidate('things', things = $$props.things);
+		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+	};
+
 	return { things, foo };
 }
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -74,6 +74,15 @@ function instance($$self, $$props, $$invalidate) {
 		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
 	};
 
+	$$self.$capture_state = () => {
+		return { foo, bar };
+	};
+
+	$$self.$inject_state = $$props => {
+		if ('foo' in $$props) $$invalidate('foo', foo = $$props.foo);
+		if ('bar' in $$props) $$invalidate('bar', bar = $$props.bar);
+	};
+
 	$$self.$$.update = ($$dirty = { foo: 1 }) => {
 		if ($$dirty.foo) { $$invalidate('bar', bar = foo * 2); }
 	};


### PR DESCRIPTION
This PR adds hooks needed for HMR support and should fix #2377. `$capture_state()` still returns bindings and handlers but injecting the state still works. I haven't made any tests for the new functions but I have modified the expected result of some existing tests. Here is a [Webpack Demo](https://github.com/Axelen123/demo-svelte3-hmr).

If in the demo you get an error like: 

`ERROR in ./src/App.svelte`
`Module build failed (from ./node_modules/svelte-loader/index.js):`
`Error: Cannot find module 'css-tree/lib/parser/index.js'`

Then you should run:
```sh
git clone "https://github.com/Axelen123/svelte.git#hmr-hooks"
cd svelte
npm install
npm link
cd ..
npm link svelte
```