### PR TITLE
Fix code generation when $$props is present

### DIFF
--- a/src/compiler/compile/render-dom/index.ts
+++ b/src/compiler/compile/render-dom/index.ts
@@ -80,7 +80,7 @@ export default function dom(
 			${$$props} => {
 				${uses_props && component.invalidate('$$props', `$$props = @assign(@assign({}, $$props), $$new_props)`)}
 				${writable_props.map(prop =>
-					`if ('${prop.export_name}' in $$props) ${component.invalidate(prop.name, `${prop.name} = $$props.${prop.export_name}`)};`
+					`if ('${prop.export_name}' in ${$$props}) ${component.invalidate(prop.name, `${prop.name} = ${$$props}.${prop.export_name}`)};`
 				)}
 				${component.slots.size > 0 &&
 				`if ('$$scope' in ${$$props}) ${component.invalidate('$$scope', `$$scope = ${$$props}.$$scope`)};`}

--- a/test/runtime/samples/binding-using-props/TextInput.svelte
+++ b/test/runtime/samples/binding-using-props/TextInput.svelte
@@ -1,0 +1,6 @@
+<script>
+    export let actualValue;
+    let x = $$props;
+</script>
+
+<input bind:value={actualValue}>

--- a/test/runtime/samples/binding-using-props/_config.js
+++ b/test/runtime/samples/binding-using-props/_config.js
@@ -1,0 +1,14 @@
+export default {
+	async test({ assert, target, window }) {
+		const input = target.querySelector('input');
+	
+		const event = new window.Event('input');
+		input.value = 'changed';
+		await input.dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<input>
+			<p>changed</p>
+		`);
+	}
+};

--- a/test/runtime/samples/binding-using-props/main.svelte
+++ b/test/runtime/samples/binding-using-props/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Input from './TextInput.svelte';
+	export let actualValue = '';
+</script>
+
+<Input bind:actualValue />
+<p>{actualValue}</p>


### PR DESCRIPTION
This PR fixes #2725.

The issue was that the code generated for `$set` references the wrong variable when `$$props` is present.