### PR TITLE
Fix ambiguous entities

### DIFF
--- a/src/compiler/parse/utils/html.ts
+++ b/src/compiler/parse/utils/html.ts
@@ -36,7 +36,7 @@ const windows_1252 = [
 ];
 
 const entity_pattern = new RegExp(
-	`&(#?(?:x[\\w\\d]+|\\d+|${Object.keys(entities).join('|')}));?`,
+	`&(#?(?:x[\\w\\d]+|\\d+|${Object.keys(entities).join('|')}))(?:;|\\b)`,
 	'g'
 );
 

--- a/test/parser/samples/attribute-escaped/input.svelte
+++ b/test/parser/samples/attribute-escaped/input.svelte
@@ -1,1 +1,1 @@
-<div data-foo='&quot;quoted&quot;'></div>
+<div data-foo='semi:&quot;space:&quot letter:&quote number:&quot1 end:&quot'></div>

--- a/test/parser/samples/attribute-escaped/output.json
+++ b/test/parser/samples/attribute-escaped/output.json
@@ -1,27 +1,27 @@
 {
 	"html": {
 		"start": 0,
-		"end": 41,
+		"end": 83,
 		"type": "Fragment",
 		"children": [
 			{
 				"start": 0,
-				"end": 41,
+				"end": 83,
 				"type": "Element",
 				"name": "div",
 				"attributes": [
 					{
 						"start": 5,
-						"end": 34,
+						"end": 76,
 						"type": "Attribute",
 						"name": "data-foo",
 						"value": [
 							{
 								"start": 15,
-								"end": 33,
+								"end": 75,
 								"type": "Text",
-								"raw": "&quot;quoted&quot;",
-								"data": "\"quoted\""
+								"raw": "semi:&quot;space:&quot letter:&quote number:&quot1 end:&quot",
+								"data": "semi:\"space:\" letter:&quote number:&quot1 end:\""
 							}
 						]
 					}

--- a/test/runtime/samples/html-entities/_config.js
+++ b/test/runtime/samples/html-entities/_config.js
@@ -9,6 +9,6 @@ export default {
 		<span>A</span>
 		<span>€</span>
 
-		<span>&notanentity;</span>
+		<span>&amp;notanentity;</span>
 	`
 };


### PR DESCRIPTION
Attributes are not properly decoded, see sveltejs/sapper#759
This PR makes it a little better, but is still not perfect. For example `&#123abcd;` will be interpreted as `&#123` while throwing away `abcd;`. That code is invalid so I wouldn't worry about it.

More info: https://mathiasbynens.be/notes/ambiguous-ampersands

Fix sveltejs/sapper#759

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
