### PR TITLE
Use consistent tag closing for <svelte:*> elements

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1241,7 +1241,7 @@ It cannot appear at the top level of your markup; it must be inside an if or eac
 ### `<svelte:component>`
 
 ```sv
-<svelte:component this={expression}>
+<svelte:component this={expression}/>
 ```
 
 ---
@@ -1318,7 +1318,7 @@ As with `<svelte:window>`, this element allows you to add listeners to events on
 ### `<svelte:head>`
 
 ```sv
-<svelte:head>
+<svelte:head>...</svelte:head>
 ```
 
 ---
@@ -1335,7 +1335,7 @@ This element makes it possible to insert elements into `document.head`. During s
 ### `<svelte:options>`
 
 ```sv
-<svelte:options option={value}>
+<svelte:options option={value}/>
 ```
 
 ---


### PR DESCRIPTION
Fixes #3061

See the discussion at https://github.com/sveltejs/svelte/pull/3062

