### PR TITLE
escape `@` sigils in debug filename

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -28,7 +28,7 @@ export default function dom(
 	const builder = new CodeBuilder();
 
 	if (component.compile_options.dev) {
-		builder.add_line(`const ${renderer.file_var} = ${JSON.stringify(component.file)};`);
+		builder.add_line(`const ${renderer.file_var} = ${component.file && stringify(component.file, { only_escape_at_symbol: true })};`);
 	}
 
 	const css = component.stylesheet.render(options.filename, !options.customElement);


### PR DESCRIPTION
One of the changes in #2963 was to throw an error when decoding a `@` sigil that wasn't actually exported from `svelte/internal`. This causes a problem when we neglect to properly escape this elsewhere, like what was happening in the debug filename. When the filename included, for example, `@sapper`, this would throw an error. We're now properly escaping the sigil.