### PR TITLE
Fix error in derived store docs example

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -365,7 +365,7 @@ If you return a function from the callback, it will be called when a) the callba
 import { derived } from 'svelte/store';
 
 const tick = derived(frequency, ($frequency, set) => {
-	const interval = setInterval(() => set(Date.now()), 1000 / frequency);
+	const interval = setInterval(() => set(Date.now()), 1000 / $frequency);
 
 	return () => {
 		clearInterval(interval);

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -359,17 +359,21 @@ const delayed = derived(a, ($a, set) => {
 }, 'one moment...');
 ```
 
-If you return a function from the callback, it will be called when a) the callback runs again, or b) the last subscriber unsubscribes:
+---
+
+If you return a function from the callback, it will be called when a) the callback runs again, or b) the last subscriber unsubscribes.
 
 ```js
 import { derived } from 'svelte/store';
 
 const tick = derived(frequency, ($frequency, set) => {
-	const interval = setInterval(() => set(Date.now()), 1000 / $frequency);
+	const interval = setInterval(() => {
+	  set(Date.now());
+	}, 1000 / $frequency);
 
 	return () => {
 		clearInterval(interval);
-	}
+	};
 }, 'one moment...');
 ```
 


### PR DESCRIPTION
Fixes a small issue in the example for derived stores.

In the example, the callback function attempts to read the value of the store `frequency` using `frequency` instead of `$frequency`.