### PR TITLE
DRY out bind:this code

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -9,7 +9,6 @@ import add_to_set from '../../../utils/add_to_set';
 import deindent from '../../../utils/deindent';
 import Attribute from '../../../nodes/Attribute';
 import get_object from '../../../utils/get_object';
-import flatten_reference from '../../../utils/flatten_reference';
 import create_debugging_comment from '../shared/create_debugging_comment';
 import { get_context_merger } from '../shared/get_context_merger';
 import EachBlock from '../../../nodes/EachBlock';

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -14,6 +14,7 @@ import create_debugging_comment from '../shared/create_debugging_comment';
 import { get_context_merger } from '../shared/get_context_merger';
 import EachBlock from '../../../nodes/EachBlock';
 import TemplateScope from '../../../nodes/shared/TemplateScope';
+import bind_this from '../shared/bind_this';
 
 export default class InlineComponentWrapper extends Wrapper {
 	var: string;
@@ -252,41 +253,7 @@ export default class InlineComponentWrapper extends Wrapper {
 			component.has_reactive_assignments = true;
 
 			if (binding.name === 'this') {
-				const fn = component.get_unique_name(`${this.var}_binding`);
-
-				component.add_var({
-					name: fn,
-					internal: true,
-					referenced: true
-				});
-
-				let lhs;
-				let object;
-
-				if (binding.is_contextual && binding.expression.node.type === 'Identifier') {
-					// bind:x={y} — we can't just do `y = x`, we need to
-					// to `array[index] = x;
-					const { name } = binding.expression.node;
-					const { snippet } = block.bindings.get(name);
-					lhs = snippet;
-
-					// TODO we need to invalidate... something
-				} else {
-					object = flatten_reference(binding.expression.node).name;
-					lhs = component.source.slice(binding.expression.node.start, binding.expression.node.end).trim();
-				}
-
-				const contextual_dependencies = [...binding.expression.contextual_dependencies];
-
-				component.partly_hoisted.push(deindent`
-					function ${fn}(${['$$component', ...contextual_dependencies].join(', ')}) {
-						${lhs} = $$component;
-						${object && component.invalidate(object)}
-					}
-				`);
-
-				block.builders.destroy.add_line(`ctx.${fn}(${['null', ...contextual_dependencies.map(name => `ctx.${name}`)].join(', ')});`);
-				return `@add_binding_callback(() => ctx.${fn}(${[this.var, ...contextual_dependencies.map(name => `ctx.${name}`)].join(', ')}));`;
+				return bind_this(component, block, binding, this.var);
 			}
 
 			const name = component.get_unique_name(`${this.var}_${binding.name}_binding`);

--- a/src/compiler/compile/render_dom/wrappers/shared/bind_this.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/bind_this.ts
@@ -1,0 +1,43 @@
+import flatten_reference from '../../../utils/flatten_reference';
+import deindent from '../../../utils/deindent';
+import Component from '../../../Component';
+import Block from '../../Block';
+import Binding from '../../../nodes/Binding';
+
+export default function bind_this(component: Component, block: Block, binding: Binding, variable: string) {
+	const fn = component.get_unique_name(`${variable}_binding`);
+
+	component.add_var({
+		name: fn,
+		internal: true,
+		referenced: true
+	});
+
+	let lhs;
+	let object;
+
+	if (binding.is_contextual && binding.expression.node.type === 'Identifier') {
+		// bind:x={y} — we can't just do `y = x`, we need to
+		// to `array[index] = x;
+		const { name } = binding.expression.node;
+		const { snippet } = block.bindings.get(name);
+		lhs = snippet;
+
+		// TODO we need to invalidate... something
+	} else {
+		object = flatten_reference(binding.expression.node).name;
+		lhs = component.source.slice(binding.expression.node.start, binding.expression.node.end).trim();
+	}
+
+	const contextual_dependencies = [...binding.expression.contextual_dependencies];
+
+	component.partly_hoisted.push(deindent`
+		function ${fn}(${['$$value', ...contextual_dependencies].join(', ')}) {
+			${lhs} = $$value;
+			${object && component.invalidate(object)}
+		}
+	`);
+
+	block.builders.destroy.add_line(`ctx.${fn}(${['null', ...contextual_dependencies.map(name => `ctx.${name}`)].join(', ')});`);
+	return `@add_binding_callback(() => ctx.${fn}(${[variable, ...contextual_dependencies.map(name => `ctx.${name}`)].join(', ')}));`;
+}

--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -46,7 +46,7 @@ export function flush() {
 			update(component.$$);
 		}
 
-		while (binding_callbacks.length) binding_callbacks.shift()();
+		while (binding_callbacks.length) binding_callbacks.pop()();
 
 		// then, once components are updated, call
 		// afterUpdate functions. This may cause

--- a/test/runtime/samples/binding-this-each-block-property-component/Foo.svelte
+++ b/test/runtime/samples/binding-this-each-block-property-component/Foo.svelte
@@ -1,0 +1,7 @@
+<script>
+	export function isFoo() {
+		return true;
+	}
+</script>
+
+<p><slot></slot></p>

--- a/test/runtime/samples/binding-this-each-block-property-component/_config.js
+++ b/test/runtime/samples/binding-this-each-block-property-component/_config.js
@@ -1,0 +1,12 @@
+export default {
+	html: ``,
+
+	async test({ assert, component, target }) {
+		component.visible = true;
+		assert.htmlEqual(target.innerHTML, `
+			<p>a</p>
+		`);
+
+		assert.ok(component.items[0].ref.isFoo());
+	}
+};

--- a/test/runtime/samples/binding-this-each-block-property-component/main.svelte
+++ b/test/runtime/samples/binding-this-each-block-property-component/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Foo from './Foo.svelte';
+
+	export let visible = false;
+
+	export let items = [{ value: 'a', ref: null }];
+</script>
+
+{#if visible}
+	{#each items as item}
+		<Foo bind:this={item.ref}>{item.value}</Foo>
+	{/each}
+{/if}

--- a/test/runtime/samples/binding-this-each-block-property/_config.js
+++ b/test/runtime/samples/binding-this-each-block-property/_config.js
@@ -1,0 +1,12 @@
+export default {
+	html: ``,
+
+	async test({ assert, component, target }) {
+		component.visible = true;
+		assert.htmlEqual(target.innerHTML, `
+			<div>a</div>
+		`);
+
+		assert.equal(component.items[0].ref, target.querySelector('div'));
+	}
+};

--- a/test/runtime/samples/binding-this-each-block-property/main.svelte
+++ b/test/runtime/samples/binding-this-each-block-property/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let visible = false;
+
+	export let items = [{ value: 'a', ref: null }];
+</script>
+
+{#if visible}
+	{#each items as item}
+		<div bind:this={item.ref}>{item.value}</div>
+	{/each}
+{/if}


### PR DESCRIPTION
Extends https://github.com/sveltejs/svelte/pull/3099 by adding tests, DRYing out the `bind:this` code, and fixing the parallel case where the target is an element rather than a component