### PR TITLE
documentation - binding this remove 256 canvas size

### DIFF
--- a/site/content/tutorial/06-bindings/12-bind-this/text.md
+++ b/site/content/tutorial/06-bindings/12-bind-this/text.md
@@ -7,8 +7,8 @@ The readonly `this` binding applies to every element (and component) and allows 
 ```html
 <canvas
 	bind:this={canvas}
-	width={256}
-	height={256}
+	width={32}
+	height={32}
 ></canvas>
 ```
 


### PR DESCRIPTION
**Summary**
Remove confusing change to canvas size on the `binding:this` section of the tutorial

**Summary**
In the documentation tutorial, the `binding:this` page shows how to bind a reference to an element. The helper text also shows a change to the canvas size attributes without any further explanation. The show me example does not mimic the `256` resolution of the canvas that is displayed in the help section.

**Notes**
- If we do want to show the relationship between the canvas element and referencing `canvas.width` then maybe we can change `app-b/App.svelte` to include the new dimensions that are shown in the help side panel.
- If we do want to change the resolution to show the binding, instead of changing the canvas from `32` to `256` which causes my mac book pro to whistle a little. Maybe we can go from `32` to `64`.

Loving svelte so far! Seriously awesome :D
