### PR TITLE
Fixed bug with slot props variables

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -311,6 +311,9 @@ export default function dom(
 	const reactive_stores = component.vars.filter(variable => variable.name[0] === '$' && variable.name[1] !== '$');
 
 	if (component.slots.size > 0) {
+		component.vars.map(v => {
+			if (v.hoistable) filtered_declarations.push(v.name);
+		});
 		filtered_declarations.push('$$slots', '$$scope');
 	}
 

--- a/test/runtime/samples/component-slot-let-e/Nested.svelte
+++ b/test/runtime/samples/component-slot-let-e/Nested.svelte
@@ -1,0 +1,7 @@
+<script>
+	let fooText = 'foo';
+</script>
+
+<div>
+	<slot someText={fooText}></slot>
+</div>

--- a/test/runtime/samples/component-slot-let-e/_config.js
+++ b/test/runtime/samples/component-slot-let-e/_config.js
@@ -1,0 +1,20 @@
+export default {
+	html: `
+		<div>
+			<p>foo</p>
+		</div>
+	`,
+
+	async test({ assert, target, window }) {
+		const div = target.querySelector('div');
+		const click = new window.MouseEvent('click');
+
+		await div.dispatchEvent(click);
+
+		assert.htmlEqual(target.innerHTML, `
+			<div>
+				<p>foo</p>
+			</div>
+		`);
+	}
+};

--- a/test/runtime/samples/component-slot-let-e/main.svelte
+++ b/test/runtime/samples/component-slot-let-e/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Nested from './Nested.svelte';
+</script>
+
+<Nested let:someText={someText}>
+	<p>{someText}</p>
+</Nested>


### PR DESCRIPTION
#2586

Fixes issue when declaring and initializing a variable used in a slot.
The variable is hoisted and subsequently not added to filtered_declarations. The return statement for the component instance would be
`return { $$slots, $$scope };`

when it should be
`return { worldText, $$slots, $$scope };`

Test component-slot-let-e will fail when worldText is not part of the return object.
 ```
1) runtime
       component-slot-let-e :

      AssertionError [ERR_ASSERTION]: '<div><p>undefined</p></div>' deepEqual '<div><p>foo</p></div>'
      + expected - actual

      -<div><p>undefined</p></div>
      +<div><p>foo</p></div>
      
      at Function.assert.htmlEqual (test/helpers.js:141:10)
      at Promise.resolve.then (test/runtime/index.js:155:14)
```
Other slot tests did not fail because the on:click handler caused the variable to be not be hoisted.