### PR TITLE
Correctly restore current_atrule when leaving an Atrule node

### DIFF
--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -315,7 +315,14 @@ export default class Stylesheet {
 
 				leave: (node: Node) => {
 					if (node.type === 'Rule' || node.type === 'Atrule') stack.pop();
-					if (node.type === 'Atrule') current_atrule = stack[stack.length - 1] as Atrule;
+					if (node.type === 'Atrule') {
+						current_atrule = null;
+						for (let i = stack.length - 1; i >= 0; i--) {
+							if (stack[i] instanceof Atrule) {
+								current_atrule = stack[i] as Atrule;
+							}
+						}
+					}
 				}
 			});
 		} else {

--- a/test/css/samples/unknown-at-rule-with-following-rules/expected.css
+++ b/test/css/samples/unknown-at-rule-with-following-rules/expected.css
@@ -1,0 +1,1 @@
+div.svelte-xyz{@apply --funky-div;}

--- a/test/css/samples/unknown-at-rule-with-following-rules/input.svelte
+++ b/test/css/samples/unknown-at-rule-with-following-rules/input.svelte
@@ -1,0 +1,11 @@
+<div></div>
+
+<style>
+	div {
+		@apply --funky-div;
+	}
+
+	div {
+		
+	}
+</style>


### PR DESCRIPTION
Fixes #3135.

When exiting an Atrule node, the broken code assumes that the next value in the stack is an Atrule, which is not always the case.