### PR TITLE
update bind:this references when setting to null

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -324,7 +324,7 @@ export default class InlineComponentWrapper extends Wrapper {
 
 			component.partly_hoisted.push(body);
 
-			return `@add_binding_callback(() => @bind(${this.var}, '${binding.name}', ${name}));`;
+			return `@binding_callbacks.push(() => @bind(${this.var}, '${binding.name}', ${name}));`;
 		});
 
 		const munged_handlers = this.node.handlers.map(handler => {

--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -4,11 +4,12 @@ import { set_current_component } from './lifecycle';
 export const dirty_components = [];
 export const intros = { enabled: false };
 
-const resolved_promise = Promise.resolve();
-let update_scheduled = false;
-const binding_callbacks = [];
+export const binding_callbacks = [];
 const render_callbacks = [];
 const flush_callbacks = [];
+
+const resolved_promise = Promise.resolve();
+let update_scheduled = false;
 
 export function schedule_update() {
 	if (!update_scheduled) {
@@ -20,10 +21,6 @@ export function schedule_update() {
 export function tick() {
 	schedule_update();
 	return resolved_promise;
-}
-
-export function add_binding_callback(fn) {
-	binding_callbacks.push(fn);
 }
 
 export function add_render_callback(fn) {

--- a/test/runtime/index.js
+++ b/test/runtime/index.js
@@ -98,12 +98,10 @@ describe("runtime", () => {
 					};
 					set_now(() => raf.time);
 					set_raf(cb => {
-						let called = false;
 						raf.callback = () => {
-							if (!called) {
-								called = true;
-								cb();
-							}
+							raf.callback = null;
+							cb();
+							flush();
 						};
 					});
 

--- a/test/runtime/samples/binding-this-element-reactive-b/_config.js
+++ b/test/runtime/samples/binding-this-element-reactive-b/_config.js
@@ -1,0 +1,21 @@
+export default {
+	skip_if_ssr: true,
+
+	html: `
+		<div>The text is hello</div>
+		<h1>hello</h1>
+	`,
+
+	test({ assert, component, target }) {
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, `
+			<div>The text is missing</div>
+		`);
+
+		component.visible = true;
+		assert.htmlEqual(target.innerHTML, `
+			<div>The text is hello</div>
+			<h1>hello</h1>
+		`);
+	}
+};

--- a/test/runtime/samples/binding-this-element-reactive-b/main.svelte
+++ b/test/runtime/samples/binding-this-element-reactive-b/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	export let visible = true;
+	let h1;
+</script>
+
+<div>The text is {h1 ? h1.textContent : 'missing'}</div>
+{#if visible}
+	<h1 bind:this={h1}>hello</h1>
+{/if}

--- a/test/runtime/samples/transition-js-if-block-outro-timeout/_config.js
+++ b/test/runtime/samples/transition-js-if-block-outro-timeout/_config.js
@@ -8,7 +8,6 @@ export default {
 
 		raf.tick(200);
 		assert.equal(window.getComputedStyle(div).opacity, 0.5);
-		component.blabla = false;
 
 		raf.tick(400);
 		assert.equal(window.getComputedStyle(div).opacity, 0);


### PR DESCRIPTION
This fixes #2034 by using `binding_callbacks` when setting the `foo` in `bind:this={foo}` to `null` as well as when setting it to an element reference. Otherwise, the invalidation has no effect.

We still need to null out references before setting new ones, in order to avoid glitches when lists are reordered. This is done by unshifting to `binding_callbacks` the functions that need to run later, as those functions are run in reverse order.