### PR TITLE
distinguish between lazy and non-lazy expressions

### DIFF
--- a/src/compiler/compile/nodes/Action.ts
+++ b/src/compiler/compile/nodes/Action.ts
@@ -17,7 +17,7 @@ export default class Action extends Node {
 		component.qualify(info.name);
 
 		this.expression = info.expression
-			? new Expression(component, this, scope, info.expression, true)
+			? new Expression(component, this, scope, info.expression)
 			: null;
 
 		this.uses_context = this.expression && this.expression.uses_context;

--- a/src/compiler/compile/nodes/Action.ts
+++ b/src/compiler/compile/nodes/Action.ts
@@ -17,7 +17,7 @@ export default class Action extends Node {
 		component.qualify(info.name);
 
 		this.expression = info.expression
-			? new Expression(component, this, scope, info.expression)
+			? new Expression(component, this, scope, info.expression, true)
 			: null;
 
 		this.uses_context = this.expression && this.expression.uses_context;

--- a/src/compiler/compile/nodes/Animation.ts
+++ b/src/compiler/compile/nodes/Animation.ts
@@ -34,7 +34,7 @@ export default class Animation extends Node {
 		block.has_animation = true;
 
 		this.expression = info.expression
-			? new Expression(component, this, scope, info.expression)
+			? new Expression(component, this, scope, info.expression, true)
 			: null;
 	}
 }

--- a/src/compiler/compile/nodes/EventHandler.ts
+++ b/src/compiler/compile/nodes/EventHandler.ts
@@ -21,7 +21,7 @@ export default class EventHandler extends Node {
 		this.modifiers = new Set(info.modifiers);
 
 		if (info.expression) {
-			this.expression = new Expression(component, this, template_scope, info.expression);
+			this.expression = new Expression(component, this, template_scope, info.expression, true);
 			this.uses_context = this.expression.uses_context;
 
 			if (/FunctionExpression/.test(info.expression.type) && info.expression.params.length === 0) {

--- a/src/compiler/compile/nodes/Transition.ts
+++ b/src/compiler/compile/nodes/Transition.ts
@@ -34,7 +34,7 @@ export default class Transition extends Node {
 		}
 
 		this.expression = info.expression
-			? new Expression(component, this, scope, info.expression)
+			? new Expression(component, this, scope, info.expression, true)
 			: null;
 	}
 }

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -146,11 +146,11 @@ export default class Expression {
 
 						contextual_dependencies.add(name);
 
-						if (!function_expression || !lazy) {
+						if (!lazy) {
 							template_scope.dependencies_for_name.get(name).forEach(name => dependencies.add(name));
 						}
 					} else {
-						if (!function_expression || !lazy) {
+						if (!lazy) {
 							dependencies.add(name);
 						}
 

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -86,7 +86,7 @@ export default class Expression {
 	rendered: string;
 
 	// todo: owner type
-	constructor(component: Component, owner: Owner, template_scope: TemplateScope, info) {
+	constructor(component: Component, owner: Owner, template_scope: TemplateScope, info, lazy?: boolean) {
 		// TODO revert to direct property access in prod?
 		Object.defineProperties(this, {
 			component: {
@@ -146,11 +146,11 @@ export default class Expression {
 
 						contextual_dependencies.add(name);
 
-						if (!function_expression) {
+						if (!function_expression || !lazy) {
 							template_scope.dependencies_for_name.get(name).forEach(name => dependencies.add(name));
 						}
 					} else {
-						if (!function_expression) {
+						if (!function_expression || !lazy) {
 							dependencies.add(name);
 						}
 

--- a/test/js/samples/action-custom-event-handler/expected.js
+++ b/test/js/samples/action-custom-event-handler/expected.js
@@ -23,7 +23,12 @@ function create_fragment(ctx) {
 			foo_action = foo.call(null, button, ctx.foo_function) || {};
 		},
 
-		p: noop,
+		p(changed, ctx) {
+			if (typeof foo_action.update === 'function' && changed.bar) {
+				foo_action.update.call(null, ctx.foo_function);
+			}
+		},
+
 		i: noop,
 		o: noop,
 

--- a/test/runtime/samples/reactive-function-inline/_config.js
+++ b/test/runtime/samples/reactive-function-inline/_config.js
@@ -1,0 +1,8 @@
+export default {
+	html: '<p>0</p>',
+
+	test({ assert, component, target }) {
+		component.selected = 3;
+		assert.htmlEqual(target.innerHTML, '<p>3</p>');
+	}
+};

--- a/test/runtime/samples/reactive-function-inline/main.svelte
+++ b/test/runtime/samples/reactive-function-inline/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let list = [0, 1, 2, 3, 4];
+	export let selected = 0;
+</script>
+
+<p>{list.filter(x => x === selected)}</p>

--- a/test/runtime/samples/reactive-function/_config.js
+++ b/test/runtime/samples/reactive-function/_config.js
@@ -2,10 +2,8 @@ export default {
 	html: '<p>50</p>',
 
 	test({ assert, component, target }) {
-		console.group('range [50,100]');
 		component.range = [50, 100];
 		assert.htmlEqual(target.innerHTML, '<p>75</p>');
-		console.groupEnd();
 
 		component.range = [50, 60];
 		assert.htmlEqual(target.innerHTML, '<p>55</p>');


### PR DESCRIPTION
This fixes #2693 by drawing a distinction between dependencies that are 'lazy' — e.g., in an event handler like `on:click={e => doThing(item)}`, we don't need to re-evaluate anything when `doThing` or `item` change because we only care about their values when the click event happens — and those that are not, such as in `{tags}`.