### PR TITLE
preprocess: fix handling of attribute values containing `=`

### DIFF
--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -21,17 +21,17 @@ interface Processed {
 	dependencies?: string[];
 }
 
-function parse_attribute_value(value: string) {
-	return /^['"]/.test(value) ?
-		value.slice(1, -1) :
-		value;
-}
-
 function parse_attributes(str: string) {
 	const attrs = {};
 	str.split(/\s+/).filter(Boolean).forEach(attr => {
-		const [name, value] = attr.split('=');
-		attrs[name] = value ? parse_attribute_value(value) : true;
+		const p = attr.indexOf('=');
+		if (p === -1) {
+			attrs[attr] = true;
+		} else {
+			attrs[attr.slice(0, p)] = `'"`.includes(attr[p + 1]) ?
+				attr.slice(p + 2, -1) :
+				attr.slice(p + 1);
+		}
 	});
 	return attrs;
 }

--- a/test/preprocess/samples/attributes-with-equals/_config.js
+++ b/test/preprocess/samples/attributes-with-equals/_config.js
@@ -1,0 +1,5 @@
+export default {
+	preprocess: {
+		style: ({ attributes }) => attributes.foo && attributes.foo.includes('=') ? { code: '' } : null
+	}
+};

--- a/test/preprocess/samples/attributes-with-equals/input.svelte
+++ b/test/preprocess/samples/attributes-with-equals/input.svelte
@@ -1,0 +1,3 @@
+<style foo="bar=baz">
+	foo {}
+</style>

--- a/test/preprocess/samples/attributes-with-equals/output.svelte
+++ b/test/preprocess/samples/attributes-with-equals/output.svelte
@@ -1,0 +1,1 @@
+<style foo="bar=baz"></style>


### PR DESCRIPTION
Another weird edge case that I did not actually bump into, but thought of while looking at the code I borrowed for the ESLint plugin.