### PR TITLE
Add instructions for setting filetype in Vim

### DIFF
--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -11,3 +11,17 @@ draft: true
 * eslint-plugin-svelte3
 * svelte-vscode
 * associating .svelte files with HTML in VSCode, Sublime, Atom, etc etc etc
+
+## Vim/Neovim
+
+To treat all `*.svelte` files as HTML, add the following line to your `init.vim`:
+
+    au! BufNewFile,BufRead *.svelte set ft=html
+
+To temporarily turn on HTML syntax highlighting for the current buffer, use:
+
+    :set ft=html
+
+To set the filetype for a single file, use a [modeline](https://vim.fandom.com/wiki/Modeline_magic):
+
+    <!-- vim: set ft=html :-->


### PR DESCRIPTION
This PR adds instructions for setting the filetype in Vim for `*.svelte` files to HTML. This will enable syntax highlighting if the user has it enabled, along with any other settings the user has configured for HTML files.

Feel free to edit my language as you see fit, or to add or remove sections. I believe the vast majority of vim users will set this up in their `init.vim` once and not think about it again.