### PR TITLE
Fix assignments inside inline function expressions

### DIFF
--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -270,7 +270,7 @@ export default class Expression {
 							});
 						} else {
 							dependencies.add(name);
-							component.add_reference(name);
+							component.add_reference(name); // TODO is this redundant/misplaced?
 						}
 					} else if (!is_synthetic && is_contextual(component, template_scope, name)) {
 						code.prependRight(node.start, key === 'key' && parent.shorthand

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -459,7 +459,7 @@ export default class Expression {
 						if (/^(Break|Continue|Return)Statement/.test(node.type)) {
 							if (node.argument) {
 								code.overwrite(node.start, node.argument.start, `var $$result = `);
-								code.appendLeft(node.argument.end, `${insert}; return $$result`);
+								code.appendLeft(node.end, `${insert}; return $$result`);
 							} else {
 								code.prependRight(node.start, `${insert}; `);
 							}

--- a/test/runtime/samples/function-expression-inline/_config.js
+++ b/test/runtime/samples/function-expression-inline/_config.js
@@ -1,0 +1,22 @@
+export default {
+	html: `
+		<button>click me</button>
+		<p>1</p>
+		<p>2</p>
+		<p>3</p>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const button = target.querySelector('button');
+		const click = new window.MouseEvent('click');
+
+		await button.dispatchEvent(click);
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>click me</button>
+			<p>2</p>
+			<p>4</p>
+			<p>6</p>
+		`);
+	}
+}

--- a/test/runtime/samples/function-expression-inline/main.svelte
+++ b/test/runtime/samples/function-expression-inline/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let list = [1, 2, 3];
+</script>
+
+<button on:click={event => {
+	list = list.map(item => {
+		return item * 2;
+	});
+}}>click me</button>
+
+{#each list as number}
+	<p>{number}</p>
+{/each}


### PR DESCRIPTION
The instrumentation was wonky for two reasons:

* it was inserting code before semi-colons that should have gone *after* semi-colons
* it was tracking which assignments needed instrumentation on the way 'down' the AST, meaning they were getting applied prematurely if a suitable place (i.e. the next expression statement it found) was found further in. now, it tracks those assignments on the way 'up'

fixes #3038 