### PR TITLE
3165 fix out transition

### DIFF
--- a/src/runtime/internal/transitions.ts
+++ b/src/runtime/internal/transitions.ts
@@ -48,7 +48,7 @@ export function transition_in(block, local?: 0 | 1) {
 
 export function transition_out(block, local: 0 | 1, callback) {
 	if (block && block.o) {
-		if (outroing.has(block)) return;
+		if (outroing.has(block) || !outros.callbacks) return;
 		outroing.add(block);
 
 		outros.callbacks.push(() => {


### PR DESCRIPTION
https://github.com/sveltejs/svelte/issues/3165

Fix for broken out page transition when `outro.callbacks` is undefined.