### PR TITLE
make crossfade scale the element to target rect

### DIFF
--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -202,6 +202,7 @@ export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
 			easing,
 			css: (t, u) => `
 				opacity: ${t * opacity};
+				transform-origin: top left;
 				transform: ${transform} translate(${u * dx}px,${u * dy}px) scale(${t + (1-t) * dw}, ${t + (1-t) * dh});
 			`
 		};

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -188,6 +188,8 @@ export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
 		const to = node.getBoundingClientRect();
 		const dx = from.left - to.left;
 		const dy = from.top - to.top;
+		const dw = from.width / to.width;
+		const dh = from.height / to.height;
 		const d = Math.sqrt(dx * dx + dy * dy);
 
 		const style = getComputedStyle(node);
@@ -200,7 +202,7 @@ export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
 			easing,
 			css: (t, u) => `
 				opacity: ${t * opacity};
-				transform: ${transform} translate(${u * dx}px,${u * dy}px);
+				transform: ${transform} translate(${u * dx}px,${u * dy}px) scale(${t + (1-t) * dw}, ${t + (1-t) * dh});
 			`
 		};
 	}


### PR DESCRIPTION
Just thought it would be cool if the crossfade transition also scales the element to its new size

![rkO24Wit7J](https://user-images.githubusercontent.com/51177/60680272-9f4ed380-9ec5-11e9-9943-5df487b7a65b.gif)
