### PR TITLE
A proof-of-concept fix for Custom Element Overrides

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -2,6 +2,7 @@ import Renderer from '../../Renderer';
 import Element from '../../../nodes/Element';
 import Wrapper from '../shared/Wrapper';
 import Block from '../../Block';
+import Text from '../../../nodes/Text';
 import { is_void, quote_prop_if_necessary, quote_name_if_necessary, sanitize } from '../../../../utils/names';
 import FragmentWrapper from '../Fragment';
 import { stringify, escape_html, escape } from '../../../utils/stringify';
@@ -374,6 +375,17 @@ export default class ElementWrapper extends Wrapper {
 
 	get_render_statement() {
 		const { name, namespace } = this.node;
+		let isList = this.node.attributes.filter(attr => attr.type === 'Attribute' && attr.name === 'is');
+		let is = null;
+		if (isList.length === 1) {
+			let isAttribute = isList[0];
+			
+			let chunk = isAttribute.chunks[0];
+			if (chunk.type === 'Text') {
+				let text = chunk as Text
+				is = text.data
+			}
+		}
 
 		if (namespace === 'http://www.w3.org/2000/svg') {
 			return `@svg_element("${name}")`;
@@ -381,6 +393,10 @@ export default class ElementWrapper extends Wrapper {
 
 		if (namespace) {
 			return `@_document.createElementNS("${namespace}", "${name}")`;
+		}
+
+		if (is) {
+			return `@element("${name}", "${is}")`;
 		}
 
 		return `@element("${name}")`;

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -34,7 +34,10 @@ export function destroy_each(iterations, detaching) {
 	}
 }
 
-export function element<K extends keyof HTMLElementTagNameMap>(name: K) {
+export function element<K extends keyof HTMLElementTagNameMap>(name: K, is=null) {
+	if (is) {
+		return document.createElement<K>(name, { is })
+	}
 	return document.createElement<K>(name);
 }
 


### PR DESCRIPTION
This is a proof-of-concept change that fixes the issues with Custom Element Overrides detailed in issue #3182 where using the "is" property to define a native element overridden with a custom element does not work as expected.

The code is a bit of a cludge right now, as it's my first stab into this environment. As of 10554c9, it does not support binding the "is" property to an Expression. It would seem to me that in order to support this, one would have to remove and recreate the element entirely to support it correctly, and I do not know how to go about doing that.

Any feedback, tips, or admonishment welcome.