### PR TITLE
3187 check-parent-node-when-detaching

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -7,6 +7,8 @@ export function insert(target: Node, node: Node, anchor?: Node) {
 }
 
 export function detach(node: Node) {
+	if (!node.parentNode) return;
+
 	node.parentNode.removeChild(node);
 }
 


### PR DESCRIPTION
https://github.com/sveltejs/svelte/issues/3187

This fix problem when parent node is null while detaching. Same problem spotted in Sapper in the same function:
https://github.com/sveltejs/sapper-template/pull/158