### PR TITLE
use .classList.toggle instead of add / remove

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -247,8 +247,8 @@ export function add_resize_listener(element, fn) {
 	};
 }
 
-export function toggle_class(element, name, toggle) {
-	element.classList[toggle ? 'add' : 'remove'](name);
+export function toggle_class(element: Node, name: string, toggle?: boolean) {
+	element.classList.toggle(name, toggle);
 }
 
 export function custom_event<T=any>(type: string, detail?: T) {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -247,7 +247,7 @@ export function add_resize_listener(element, fn) {
 	};
 }
 
-export function toggle_class(element: Node, name: string, toggle?: boolean) {
+export function toggle_class(element: Element, name: string, toggle?: boolean) {
 	element.classList.toggle(name, toggle);
 }
 


### PR DESCRIPTION
if toggle is undefined, `.toggle` will act as a flip flop (wich the name "toggle" should imply)
if toggle is true, it will add the class unless it is already contained
if toggle is false, it will remove the class unless it is already removed

alternatively i'd probably suggest renaming it from toggle_class to something else. a toggle is a state aware flip flop by default.

any objections?

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
