### PR TITLE
fixed #3199

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -109,7 +109,8 @@ export default class BindingWrapper {
 		if (parent.node.name === 'input') {
 			const type = parent.node.get_static_attribute_value('type');
 
-			if (type === null || type === "" || type === "text") {
+      if (type === null || type === "" || type === "text"
+      || type === "email" || type === "password") {
 				update_conditions.push(`(${parent.var}.${this.node.name} !== ${this.snippet})`);
 			}
 		}


### PR DESCRIPTION
fix cursor jumping when input type="email" or type="password" for Safari 12.1 and iOS Safari