### PR TITLE
Prevent outro callback corruption

### DIFF
--- a/src/runtime/internal/transitions.ts
+++ b/src/runtime/internal/transitions.ts
@@ -28,15 +28,17 @@ let outros;
 
 export function group_outros() {
 	outros = {
-		remaining: 0,
-		callbacks: []
+		r: 0,     // remaining outros
+		c: [],    // callbacks
+		p: outros // parent group
 	};
 }
 
 export function check_outros() {
-	if (!outros.remaining) {
-		run_all(outros.callbacks);
+	if (!outros.r) {
+		run_all(outros.c);
 	}
+	outros = outros.p;
 }
 
 export function transition_in(block, local?: 0 | 1) {
@@ -51,7 +53,7 @@ export function transition_out(block, local: 0 | 1, detach: 0 | 1, callback) {
 		if (outroing.has(block)) return;
 		outroing.add(block);
 
-		outros.callbacks.push(() => {
+		outros.c.push(() => {
 			outroing.delete(block);
 			if (callback) {
 				if (detach) block.d(1);
@@ -153,7 +155,7 @@ export function create_out_transition(node: Element & ElementCSSInlineStyle, fn:
 
 	const group = outros;
 
-	group.remaining += 1;
+	group.r += 1;
 
 	function go() {
 		const {
@@ -178,10 +180,10 @@ export function create_out_transition(node: Element & ElementCSSInlineStyle, fn:
 
 					dispatch(node, false, 'end');
 
-					if (!--group.remaining) {
+					if (!--group.r) {
 						// this will result in `end()` being called,
 						// so we don't need to clean up here
-						run_all(group.callbacks);
+						run_all(group.c);
 					}
 
 					return false;
@@ -266,7 +268,7 @@ export function create_bidirectional_transition(node: Element & ElementCSSInline
 		if (!b) {
 			// @ts-ignore todo: improve typings
 			program.group = outros;
-			outros.remaining += 1;
+			outros.r += 1;
 		}
 
 		if (running_program) {
@@ -309,7 +311,7 @@ export function create_bidirectional_transition(node: Element & ElementCSSInline
 								clear_animation();
 							} else {
 								// outro — needs to be coordinated
-								if (!--running_program.group.remaining) run_all(running_program.group.callbacks);
+								if (!--running_program.group.r) run_all(running_program.group.c);
 							}
 						}
 

--- a/test/runtime/samples/each-block-keyed-nested/Child.svelte
+++ b/test/runtime/samples/each-block-keyed-nested/Child.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let id;
+</script>
+
+{id}

--- a/test/runtime/samples/each-block-keyed-nested/_config.js
+++ b/test/runtime/samples/each-block-keyed-nested/_config.js
@@ -7,10 +7,10 @@ export default {
 		component.desks = [
 			{
 				id: 1,
-				teams: [{ id: 2 }]
+				teams: []
 			}
 		];
 
-		assert.htmlEqual(target.innerHTML, '2');
+		assert.htmlEqual(target.innerHTML, '');
 	}
 };

--- a/test/runtime/samples/each-block-keyed-nested/_config.js
+++ b/test/runtime/samples/each-block-keyed-nested/_config.js
@@ -1,0 +1,16 @@
+export default {
+	html: `
+		1
+	`,
+
+	test({ assert, component, target }) {
+		component.desks = [
+			{
+				id: 1,
+				teams: [{ id: 2 }]
+			}
+		];
+
+		assert.htmlEqual(target.innerHTML, '2');
+	}
+};

--- a/test/runtime/samples/each-block-keyed-nested/main.svelte
+++ b/test/runtime/samples/each-block-keyed-nested/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	import Child from './Child.svelte';
+
+	export let desks = [
+		{
+			id: 1,
+			teams: [{ id: 1 }]
+		}
+	];
+</script>
+
+{#each desks as desk (desk.id)}
+	{#each desk.teams as team (team.id)}
+		<Child id={team.id} />
+	{/each}
+{/each}

--- a/test/runtime/samples/head-detached-in-dynamic-component/A.svelte
+++ b/test/runtime/samples/head-detached-in-dynamic-component/A.svelte
@@ -1,0 +1,5 @@
+<svelte:head>
+	<meta name="description" content="A"/>
+</svelte:head>
+
+A

--- a/test/runtime/samples/head-detached-in-dynamic-component/B.svelte
+++ b/test/runtime/samples/head-detached-in-dynamic-component/B.svelte
@@ -1,0 +1,5 @@
+<svelte:head>
+	<meta name="description" content="B"/>
+</svelte:head>
+
+B

--- a/test/runtime/samples/head-detached-in-dynamic-component/_config.js
+++ b/test/runtime/samples/head-detached-in-dynamic-component/_config.js
@@ -1,0 +1,15 @@
+export default {
+	html: `
+		A
+	`,
+
+	test({ assert, component, window }) {
+		component.x = false;
+
+		const meta = window.document.querySelectorAll('meta');
+
+		assert.equal(meta.length, 1);
+		assert.equal(meta[0].name, 'description');
+		assert.equal(meta[0].content, 'B');
+	}
+};

--- a/test/runtime/samples/head-detached-in-dynamic-component/main.svelte
+++ b/test/runtime/samples/head-detached-in-dynamic-component/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import A from './A.svelte';
+	import B from './B.svelte';
+
+	export let x = true;
+</script>
+
+<svelte:component this="{x ? A : B}"/>


### PR DESCRIPTION
This fixes the second bug in #2086, in which nested keyed each blocks could create a situation in which outro callbacks got corrupted. Also brings a test over from #3159 