### PR TITLE
make resize listener object element unfocusable

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -223,6 +223,7 @@ export function add_resize_listener(element, fn) {
 	const object = document.createElement('object');
 	object.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;');
 	object.type = 'text/html';
+	object.tabIndex = -1;
 
 	let win;
 


### PR DESCRIPTION
Fixes #3206 by adding tabIndex = -1 to the resize listener `<object>` element.