### PR TITLE
Replace `onMount` with `onDestroy` in _text.md_

### DIFF
--- a/site/content/tutorial/07-lifecycle/01-onmount/text.md
+++ b/site/content/tutorial/07-lifecycle/01-onmount/text.md
@@ -25,4 +25,4 @@ We'll add an `onMount` handler that loads some data over the network:
 
 Lifecycle functions must be called while the component is initialising so that the callback is bound to the component instance — not (say) in a `setTimeout`.
 
-If the `onMount` callback returns a function, that function will be called when the component is destroyed.
+If the `onDestroy` callback returns a function, that function will be called when the component is destroyed.


### PR DESCRIPTION
I fixed the mentioned method in the context of the sentence.