### PR TITLE
Remove null and undefined attributes

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -100,7 +100,7 @@ export function set_attributes(node: Element & ElementCSSInlineStyle, attributes
 	for (const key in attributes) {
 		if (key === 'style') {
 			node.style.cssText = attributes[key];
-		} else if (key in node) {
+		} else if (key in node && attributes[key] != null) {
 			node[key] = attributes[key];
 		} else {
 			attr(node, key, attributes[key]);


### PR DESCRIPTION
set_attributes() should delete attributes from node when new value is `null` or `undefined`.

I meet the issue for this case
```HTML
<script>
	let size
</script>
<input type="text" { size } />
vs
<input type="text" { ...{ size } } />
```

Thank you! Svelte is amazing!