### PR TITLE
[v2] Fix issue where class directives wouldn't work with spread props and class prop

### DIFF
--- a/src/compile/render-dom/wrappers/Element/index.ts
+++ b/src/compile/render-dom/wrappers/Element/index.ts
@@ -538,15 +538,19 @@ export default class ElementWrapper extends Wrapper {
 	}
 
 	addAttributes(block: Block) {
+		// Get all the class dependencies first
+		this.attributes.forEach((attribute: Attribute) => {
+			if (attribute.node.name === 'class' && attribute.node.isDynamic) {
+				this.classDependencies.push(...attribute.node.dependencies);
+			}
+		});
+
 		if (this.node.attributes.find(attr => attr.type === 'Spread')) {
 			this.addSpreadAttributes(block);
 			return;
 		}
 
 		this.attributes.forEach((attribute: Attribute) => {
-			if (attribute.node.name === 'class' && attribute.node.isDynamic) {
-				this.classDependencies.push(...attribute.node.dependencies);
-			}
 			attribute.render(block);
 		});
 	}

--- a/src/compile/render-ssr/handlers/Element.ts
+++ b/src/compile/render-ssr/handlers/Element.ts
@@ -84,6 +84,9 @@ export default function(node, renderer, options) {
 				) {
 					// a boolean attribute with one non-Text chunk
 					args.push(`{ ${quoteNameIfNecessary(attribute.name)}: ${attribute.chunks[0].snippet} }`);
+				} else if (attribute.name === 'class' && classExpr) {
+					// Add class expression
+					args.push(`{ ${quoteNameIfNecessary(attribute.name)}: [\`${stringifyAttribute(attribute)}\`, \`\${${classExpr}}\`].join(' ').trim() }`);
 				} else {
 					args.push(`{ ${quoteNameIfNecessary(attribute.name)}: \`${stringifyAttribute(attribute)}\` }`);
 				}

--- a/test/runtime/samples/class-with-dynamic-attribute-and-spread/_config.js
+++ b/test/runtime/samples/class-with-dynamic-attribute-and-spread/_config.js
@@ -1,0 +1,22 @@
+export default {
+	data: {
+		myClass: 'one two',
+		attributes: {
+			role: 'button'
+		}
+	},
+	html: `<div class="one two three" role="button"></div>`,
+
+	test ( assert, component, target, window ) {
+		component.set({
+			attributes: {
+				'aria-label': 'Test'
+			},
+			myClass: 'one'
+		});
+
+		assert.htmlEqual( target.innerHTML, `
+			<div class="one three" aria-label="Test"></div>
+		` );
+	}
+};

--- a/test/runtime/samples/class-with-dynamic-attribute-and-spread/main.html
+++ b/test/runtime/samples/class-with-dynamic-attribute-and-spread/main.html
@@ -1,0 +1,1 @@
+<div class="{ myClass }" class:three="true" {...attributes}></div>

--- a/test/runtime/samples/class-with-spread/_config.js
+++ b/test/runtime/samples/class-with-spread/_config.js
@@ -1,0 +1,22 @@
+export default {
+	data: {
+		myClass: 'one two',
+		attributes: {
+			role: 'button'
+		}
+	},
+	html: `<div class="one two" role="button"></div>`,
+
+	test ( assert, component, target, window ) {
+		component.set({
+			attributes: {
+				'aria-label': 'Test'
+			},
+			myClass: 'one'
+		});
+
+		assert.htmlEqual( target.innerHTML, `
+			<div class="one" aria-label="Test"></div>
+		` );
+	}
+};

--- a/test/runtime/samples/class-with-spread/main.html
+++ b/test/runtime/samples/class-with-spread/main.html
@@ -1,0 +1,1 @@
+<div class="{ myClass }" {...attributes}></div>


### PR DESCRIPTION
Currently, if there is any spread prop along with a dynamic `class` prop on the element, the `class:` directives stop working once the value of the variable that `class` was dependent on changes. This is because it sets the `class` prop of the DOM element directly, removed the class attached by the `class:` directive. And since the variable affecting the directive hasn't changed, a class for it is not applied again.

This should not happen, and `class:` directive should work just fine with spread props.

I have added tests in this PR as well, which were failing with `v2.16.1`, but are fixed with the succeeding commits.

#### Can't save a v2 REPL anymore, so adding an example in the PR description itself.

`WithoutSpread.svelte`
```svelte
<div
  class={allClasses}
  class:reverse
>
  <slot></slot>
</div>

<script>
  export default {
    data: () => ({
      classes: [],
      reverse: false,
    }),

    computed: {
      allClasses: ({ classes }) => {
        const defaultClasses = ['without-spread'];

        return defaultClasses.concat(classes).join(' ');
      }
    }
  }
</script>
```

`withSpread.svelte`
```svelte
<div
  class={allClasses}
  class:reverse
  {...attributes}
>
  <slot></slot>
</div>

<script>
  export default {
    data: () => ({
      classes: [],
      reverse: false,
    }),

    computed: {
      allClasses: ({ classes }) => {
        const defaultClasses = ['with-spread'];

        return defaultClasses.concat(classes).join(' ');
      }
    }
  }
</script>
```

`App.svelte`
```svelte
<div>
	<input type="checkbox" id="round" bind:checked="round" />
	<label for="round">Round</label>
</div>

<WithoutSpread
	{classes}
	{reverse}
>
	Without Spread
</WithoutSpread>

<WithSpread
	{reverse}
	{classes}
	attributes={{
		'aria-label': 'With Spread'
	}}
>
	With Spread
</WithSpread>

<script>

export default {
	components: {
		WithoutSpread: './WithoutSpread.svelte',
		WithSpread: './WithSpread.svelte',
	},

	data: () => ({
		reverse: true,
	}),

	computed: {
		classes: ({ round }) => {
			const allClasses = [];

			if (round) {
				allClasses.push('round');
			}

			return allClasses;
		}
	},
}

</script>

<style>
	label, input {
		display: inline-block;
		vertical-align: top;
	}
</style>
```

### The generated update functions, with version `2.16.1`:
`WithoutSpread.svelte`
```js
p: function update(changed, ctx) {
	if (changed.allClasses) {
		div.className = ctx.allClasses;
	}

	if ((changed.allClasses || changed.reverse)) {
		toggleClass(div, "reverse", ctx.reverse);
	}
}
```

`WithSpread.svelte`
```js
p: function update(changed, ctx) {
	setAttributes(div, getSpreadUpdate(div_levels, [
		(changed.allClasses) && { class: ctx.allClasses },
		(changed.attributes) && ctx.attributes
	]));

	if (changed.reverse) {
		toggleClass(div, "reverse", ctx.reverse);
	}
}
```

### The generated update functions, with changes in this PR:
`WithoutSpread.svelte`
```js
p: function update(changed, ctx) {
	if (changed.allClasses) {
		div.className = ctx.allClasses;
	}

	if ((changed.allClasses || changed.reverse)) {
		toggleClass(div, "reverse", ctx.reverse);
	}
}
```

`WithSpread.svelte`
```js
p: function update(changed, ctx) {
	setAttributes(div, getSpreadUpdate(div_levels, [
		(changed.allClasses) && { class: ctx.allClasses },
		(changed.attributes) && ctx.attributes
	]));

	if ((changed.allClasses || changed.reverse)) {
		toggleClass(div, "reverse", ctx.reverse);
	}
}
```