### PR TITLE
update issue templates to new format and add more detail

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,21 +1,26 @@
-<!--
-Thanks for raising an issue! (For *questions*, we recommend instead using https://stackoverflow.com and adding the 'svelte' tag.)
+------
+Before filing an issue we'd appreciate it if you could take a moment to ensure
+there isn't already an open issue or pull-request.
+-----
 
-To help us help you, if you've found a bug please consider the following:
+If there's an existing issue, please add a :+1: reaction to the description of
+the issue. One way we prioritize issues is by the number of :+1: reactions on
+their descriptions. Please DO NOT add `+1` or :+1: comments.
 
-* If you can demonstrate the bug using https://svelte.dev/repl, please do.
-* If that's not possible, we recommend creating a small repo that illustrates the problem.
-* Make sure you include information about the browser, and which version of Svelte you're using
+### Feature requests and proposals
+We're excited to hear how we can make Svelte better. Please add as much detail
+as you can on your use case.
 
-Reproductions should be small, self-contained, correct examples – http://sscce.org.
+### Bugs
+If you're filing an issue about a bug please include as much information
+as you can including the following.
 
-Occasionally, this won't be possible, and that's fine – we still appreciate you raising the issue. But please understand that Svelte is run by unpaid volunteers in their free time, and issues that follow these instructions will get fixed faster.
+- Your browser and the version: (e.x. Chrome 52.1, Firefox 48.0, IE 10)
+- Your operating system: (e.x. OS X 10, Windows XP, etc)
+- Svelte version (Please check you can reproduce the issue with the latest release!)
+- Whether your project uses Webpack or Rollup
 
-If you have a stack trace to include, we recommend putting inside a `<details>` block for the sake of the thread's readability:
+- *Repeatable steps to reproduce the issue*
 
-<details>
-  <summary>Stack trace</summary>
-
-  Stack trace goes here...
-</details>
--->
+Thanks for being part of Svelte!
+-------

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'Bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Logs**
+Please include browser console and server logs around the time this bug occured.
+
+**To Reproduce**
+To help us help you, if you've found a bug please consider the following:
+
+* If you can demonstrate the bug using https://svelte.dev/repl, please do.
+* If that's not possible, we recommend creating a small repo that illustrates the problem.
+* Reproductions should be small, self-contained, correct examples – http://sscce.org.
+
+Occasionally, this won't be possible, and that's fine – we still appreciate you raising the issue. But please understand that Svelte is run by unpaid volunteers in their free time, and issues that follow these instructions will get fixed faster.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Stacktraces**
+If you have a stack trace to include, we recommend putting inside a `<details>` block for the sake of the thread's readability:
+
+<details>
+  <summary>Stack trace</summary>
+
+  Stack trace goes here...
+</details>
+
+**Information about your Svelte project:**
+- Your browser and the version: (e.x. Chrome 52.1, Firefox 48.0, IE 10)
+
+- Your operating system: (e.x. OS X 10, Ubuntu Linux 19.10, Windows XP, etc)
+
+- Svelte version (Please check you can reproduce the issue with the latest release!)
+
+- Whether your project uses Webpack or Rollup
+
+**Severity**
+How severe an issue is this bug to you? Is this annoying, blocking some users, blocking an upgrade or blocking your usage of Svelte entirely?
+
+Note: the more honest and specific you are here the more we will take you seriously. 
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **Logs**
-Please include browser console and server logs around the time this bug occured.
+Please include browser console and server logs around the time this bug occurred.
 
 **To Reproduce**
 To help us help you, if you've found a bug please consider the following:
@@ -46,7 +46,7 @@ If you have a stack trace to include, we recommend putting inside a `<details>` 
 **Severity**
 How severe an issue is this bug to you? Is this annoying, blocking some users, blocking an upgrade or blocking your usage of Svelte entirely?
 
-Note: the more honest and specific you are here the more we will take you seriously. 
+Note: the more honest and specific you are here the more we will take you seriously.
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'New Feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**How important is this feature to you?**
+Note: the more honest and specific you are here the more we will take you seriously. 
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. For example: I'm always frustrated when [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
@@ -17,7 +17,7 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **How important is this feature to you?**
-Note: the more honest and specific you are here the more we will take you seriously. 
+Note: the more honest and specific you are here the more we will take you seriously.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/questions-and-help.md
+++ b/.github/ISSUE_TEMPLATE/questions-and-help.md
@@ -9,4 +9,4 @@ assignees: ''
 
 This issue tracker is intended to collect bug reports and feature requests.
 
-For help with installation, information on how features work, or questions about specific features of Svelte, please come and join us in the [Svelte Discord](https://discord.gg/A4KjDkY) Any issues open for help requests will be closed to keep from clogging up the issue tracker.
+For help with installation, information on how features work, or questions about specific features of Svelte, please come and join us in the [Svelte Discord](https://discord.gg/A4KjDkY), or ask your question on  [Stackoverflow](https://stackoverflow.com/questions/tagged/svelte). Any issues open for help requests will be closed to keep from clogging up the issue tracker.

--- a/.github/ISSUE_TEMPLATE/questions-and-help.md
+++ b/.github/ISSUE_TEMPLATE/questions-and-help.md
@@ -1,0 +1,12 @@
+---
+name: Questions and help
+about: If you think you need help with something related to Svelte
+title: ''
+labels: 'Question'
+assignees: ''
+
+---
+
+This issue tracker is intended to collect bug reports and feature requests.
+
+For help with installation, information on how features work, or questions about specific features of Svelte, please come and join us in the [Svelte Discord](https://discord.gg/A4KjDkY) Any issues open for help requests will be closed to keep from clogging up the issue tracker.

--- a/.github/ISSUE_TEMPLATE/questions-and-help.md
+++ b/.github/ISSUE_TEMPLATE/questions-and-help.md
@@ -9,4 +9,4 @@ assignees: ''
 
 This issue tracker is intended to collect bug reports and feature requests.
 
-For help with installation, information on how features work, or questions about specific features of Svelte, please come and join us in the [Svelte Discord](https://discord.gg/A4KjDkY), or ask your question on  [Stackoverflow](https://stackoverflow.com/questions/tagged/svelte). Any issues open for help requests will be closed to keep from clogging up the issue tracker.
+For help with installation, information on how features work, or questions about specific features of Svelte, please come and join us in the [Svelte Discord](https://svelte.dev/chat), or ask your question on [Stack Overflow](https://stackoverflow.com/questions/tagged/svelte). Any issues open for help requests will be closed to keep from clogging up the issue tracker.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 
 
 ###### Before submitting the PR, please make sure you do the following
-- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one.
+- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
+- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
+- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
 ### Tests
 -  [ ] Run the tests tests with `npm test` or `yarn test`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 
 
-###### Before submitting the PR, please make sure you do the following
+### Before submitting the PR, please make sure you do the following
 - [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
 - [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
 - [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
-<!--
-Thank you for creating a pull request. Before submitting, please note the following:
 
-* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
-* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
-* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
--->
+
+###### Before submitting the PR, please make sure you do the following
+- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one.
+### Tests
+-  [ ] Run the tests tests with `npm test` or `yarn test`)


### PR DESCRIPTION
As per my earlier PR on sveltejs/sapper

This PR provides templates for Bugs/Feature Requests/PRs opened against Svelte. The goal of this is noise reduction, as there are now 180 open issues and as Svelte grows, the number of unclosed/abandoned issues does too. This PR:

Auto labels issues according to their type when opened.
Asks for specific details regarding bugs, to allow them to be investigated more easily.
Provides links to the discord chat for support issues.
These are completely borrowed from https://github.com/metabase/metabase since having raised an issue there, I thought their system was fantastic.

Hope this helps!