### PR TITLE
[v3] Fix issue where class directives wouldn't work with spread props and class prop

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -548,6 +548,13 @@ export default class ElementWrapper extends Wrapper {
 	}
 
 	add_attributes(block: Block) {
+		// Get all the class dependencies first
+		this.attributes.forEach((attribute) => {
+			if (attribute.node.name === 'class' && attribute.node.is_dynamic) {
+				this.class_dependencies.push(...attribute.node.dependencies);
+			}
+		});
+
 		// @ts-ignore todo:
 		if (this.node.attributes.find(attr => attr.type === 'Spread')) {
 			this.add_spread_attributes(block);
@@ -555,9 +562,6 @@ export default class ElementWrapper extends Wrapper {
 		}
 
 		this.attributes.forEach((attribute) => {
-			if (attribute.node.name === 'class' && attribute.node.is_dynamic) {
-				this.class_dependencies.push(...attribute.node.dependencies);
-			}
 			attribute.render(block);
 		});
 	}

--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -109,6 +109,9 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 				) {
 					// a boolean attribute with one non-Text chunk
 					args.push(`{ ${quote_name_if_necessary(attribute.name)}: ${snip(attribute.chunks[0])} }`);
+				} else if (attribute.name === 'class' && class_expression) {
+					// Add class expression
+					args.push(`{ ${quote_name_if_necessary(attribute.name)}: [\`${stringify_attribute(attribute, true)}\`, \`\${${class_expression}}\`].join(' ').trim() }`);
 				} else {
 					args.push(`{ ${quote_name_if_necessary(attribute.name)}: \`${stringify_attribute(attribute, true)}\` }`);
 				}

--- a/test/runtime/samples/class-with-dynamic-attribute-and-spread/_config.js
+++ b/test/runtime/samples/class-with-dynamic-attribute-and-spread/_config.js
@@ -1,0 +1,21 @@
+export default {
+	props: {
+		myClass: 'one two',
+		attributes: {
+			role: 'button'
+		}
+	},
+
+	html: `<div class="one two three" role="button"></div>`,
+
+	test({ assert, component, target, window }) {
+		component.myClass = 'one';
+		component.attributes = {
+			'aria-label': 'Test'
+		};
+
+		assert.htmlEqual(target.innerHTML, `
+			<div class="one three" aria-label="Test"></div>
+		`);
+	}
+};

--- a/test/runtime/samples/class-with-dynamic-attribute-and-spread/main.svelte
+++ b/test/runtime/samples/class-with-dynamic-attribute-and-spread/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	export let myClass;
+	export let attributes = {};
+</script>
+
+<div class={myClass} class:three={true} {...attributes}></div>

--- a/test/runtime/samples/class-with-spread/_config.js
+++ b/test/runtime/samples/class-with-spread/_config.js
@@ -1,0 +1,21 @@
+export default {
+	props: {
+		myClass: 'one two',
+		attributes: {
+			role: 'button'
+		}
+	},
+
+	html: `<div class="one two" role="button"></div>`,
+
+	test({ assert, component, target, window }) {
+		component.myClass = 'one';
+		component.attributes = {
+			'aria-label': 'Test'
+		};
+
+		assert.htmlEqual(target.innerHTML, `
+			<div class="one" aria-label="Test"></div>
+		`);
+	}
+};

--- a/test/runtime/samples/class-with-spread/main.svelte
+++ b/test/runtime/samples/class-with-spread/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	export let myClass;
+	export let attributes = {};
+</script>
+
+<div class={myClass} {...attributes}></div>


### PR DESCRIPTION
Currently, if there is any spread prop along with a dynamic `class` prop on the element, the `class:` directives stop working once the value of the variable that `class` was dependent on changes. This is because it sets the `class` prop of the DOM element directly, removed the class attached by the `class:` directive. And since the variable affecting the directive hasn't changed, a class for it is not applied again.

This should not happen, and `class:` directive should work just fine with spread props.

I have added tests in this PR as well, which were failing with `v3.6.7`, but are fixed with the succeeding commits.

[REPL](https://svelte.dev/repl/70b4e4245520495194168acff6bc0cd0?version=3.6.7)

### The generated update functions, with version `3.6.7`:
`WithoutSpread.svelte`
```js
p(changed, ctx) {
	if (default_slot && default_slot.p && changed.$$scope) {
		default_slot.p(get_slot_changes(default_slot_1, ctx, changed, null), get_slot_context(default_slot_1, ctx, null));
	}

	if (!current || changed.allClasses) {
		attr(div, "class", ctx.allClasses);
	}

	if ((changed.allClasses || changed.reverse)) {
		toggle_class(div, "reverse", ctx.reverse);
	}
}
```

`WithSpread.svelte`
```js
p(changed, ctx) {
	if (default_slot && default_slot.p && changed.$$scope) {
		default_slot.p(get_slot_changes(default_slot_1, ctx, changed, null), get_slot_context(default_slot_1, ctx, null));
	}

	set_attributes(div, get_spread_update(div_levels, [
		(changed.allClasses) && { class: ctx.allClasses },
		(changed.attributes) && ctx.attributes
	]));

	if (changed.reverse) {
		toggle_class(div, "reverse", ctx.reverse);
	}
}
```

### The generated update functions, with changes in this PR:
`WithoutSpread.svelte`
```js
p(changed, ctx) {
	if (default_slot && default_slot.p && changed.$$scope) {
		default_slot.p(get_slot_changes(default_slot_1, ctx, changed, null), get_slot_context(default_slot_1, ctx, null));
	}

	if (!current || changed.allClasses) {
		attr(div, "class", ctx.allClasses);
	}

	if ((changed.allClasses || changed.reverse)) {
		toggle_class(div, "reverse", ctx.reverse);
	}
}
```

`WithSpread.svelte`
```js
p(changed, ctx) {
	if (default_slot && default_slot.p && changed.$$scope) {
		default_slot.p(get_slot_changes(default_slot_1, ctx, changed, null), get_slot_context(default_slot_1, ctx, null));
	}

	set_attributes(div, get_spread_update(div_levels, [
		(changed.allClasses) && { class: ctx.allClasses },
		(changed.attributes) && ctx.attributes
	]));

	if ((changed.allClasses || changed.reverse)) {
		toggle_class(div, "reverse", ctx.reverse);
	}
}
```