### PR TITLE
bugfix: exempt the :root psuedo-selector from the random css prefix

### DIFF
--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -62,7 +62,9 @@ export default class Selector {
 			while (i--) {
 				const selector = block.selectors[i];
 				if (selector.type === 'PseudoElementSelector' || selector.type === 'PseudoClassSelector') {
-					if (i === 0) code.prependRight(selector.start, attr);
+					if (selector.name !== 'root') {
+						if (i === 0) code.prependRight(selector.start, attr);
+					}
 					continue;
 				}
 

--- a/test/css/samples/css-vars/expected.css
+++ b/test/css/samples/css-vars/expected.css
@@ -1,1 +1,1 @@
-div.svelte-xyz{--test:10}
+:root{--root-test:20}div.svelte-xyz{--test:10}

--- a/test/css/samples/css-vars/input.svelte
+++ b/test/css/samples/css-vars/input.svelte
@@ -1,6 +1,9 @@
 <div></div>
 
 <style>
+	:root {
+		--root-test: 20;
+	}
 	div {
 		--test: 10;
 	}


### PR DESCRIPTION
- the change in #1705 introduced a small bug for users who were relying on assigning global CSS variables via the :root selector
- this change adds a small exemption to avoid prefixing the `:root` pseudo-selector with the random prefix that svelte adds

here is a screenshot that illustrates the bug (pre 3.6.3 [working], post 3.6.3 [broken]), and the corresponding source in my `App.svelte` component file:

```css
<style>
  :root {
    --unchecked-box: '\02610';
    --checked-box: '\02611';
    --snowman: '\02603';
  }
</style>
```

<img width="1063" alt="Screen Shot 2019-07-15 at 6 55 59 PM" src="https://user-images.githubusercontent.com/69559/61255266-d464ec80-a735-11e9-84db-02e43fab2042.png">

