### PR TITLE
Don't use shorthand binding in textarea example

### DIFF
--- a/site/content/examples/05-bindings/04-textarea-inputs/App.svelte
+++ b/site/content/examples/05-bindings/04-textarea-inputs/App.svelte
@@ -9,4 +9,4 @@
 
 <textarea bind:value={text}></textarea>
 
-{@html marked(value)}
+{@html marked(text)}

--- a/site/content/examples/05-bindings/04-textarea-inputs/App.svelte
+++ b/site/content/examples/05-bindings/04-textarea-inputs/App.svelte
@@ -1,12 +1,12 @@
 <script>
 	import marked from 'marked';
-	let value = `Some words are *italic*, some are **bold**`;
+	let text = `Some words are *italic*, some are **bold**`;
 </script>
 
 <style>
 	textarea { width: 100%; height: 200px; }
 </style>
 
-<textarea bind:value></textarea>
+<textarea bind:value={text}></textarea>
 
 {@html marked(value)}


### PR DESCRIPTION
The [example](https://svelte.dev/examples#textarea-inputs) uses a variable called `value` and a shorthand binding notation `<textarea bind:value>`. I think the example is simpler, and more consistent with other binding examples, if it doesn't rely on the reader knowing about the shorthand notation. For example, I was confused when I renamed the `value` variable to `text`, and it didn't work:

```js
<script>
	let text = `Some words are *italic*, some are **bold**`;
</script>
<textarea bind:text></textarea>
```

This commit uses a variable named `text`, rather than `value`, and avoids the shorthand binding form.
