### PR TITLE
Augment Writable<T> store interface with a get() method, and amend wr…

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -29,6 +29,11 @@ export interface Readable<T> {
 /** Writable interface for both updating and subscribing. */
 export interface Writable<T> extends Readable<T> {
 	/**
+	 * Get value.
+	 */
+	get(): T;
+
+	/**
 	 * Set value and inform subscribers.
 	 * @param value to set
 	 */
@@ -63,6 +68,10 @@ export function readable<T>(value: T, start: StartStopNotifier<T>): Readable<T> 
 export function writable<T>(value: T, start: StartStopNotifier<T> = noop): Writable<T> {
 	let stop: Unsubscriber;
 	const subscribers: Array<SubscribeInvalidateTuple<T>> = [];
+
+	function get(): T {
+		return value;
+	}
 
 	function set(new_value: T): void {
 		if (safe_not_equal(value, new_value)) {
@@ -99,7 +108,7 @@ export function writable<T>(value: T, start: StartStopNotifier<T> = noop): Writa
 		};
 	}
 
-	return { set, update, subscribe };
+	return { get, set, update, subscribe };
 }
 
 /** One or more `Readable`s. */

--- a/test/store/index.ts
+++ b/test/store/index.ts
@@ -19,6 +19,7 @@ describe('store', () => {
 			count.set(3);
 			count.update(n => n + 1);
 
+			assert.equal(count.get(), 4);
 			assert.deepEqual(values, [0, 1, 2]);
 		});
 


### PR DESCRIPTION
…itable implementation accordingly

Sorry for not raising an issue in advance. The change is tiny and speaks for itself :)
Feel free to reject if you don't agree with the arguments below. 

After a careful consideration I am suggesting we'd augment the Writable store interface with a get() method.
The rationale is:
1. All stores implementing Writable<T> are already implementing update, which means there's an easy access to the underlying state (passed to update), so a default implementation could look like:
`function get() { let state;  update(s => state = s); return state; }`
2. There are situations where we need direct state access, but cannot use update (or have to use it in an ugly way like the default implementation above). One situation that comes to mind is writing asynchronous actions: routines outside of any component that need to access the state without a prior subscription, but cannot use update directly, because the new state is produced asynchronously.
3. I am aware I can just use get(store), but it works by creating a subscription and destroying it straight away, which is even uglier than the update workaround in point 1.