### PR TITLE
Fixes 'Keyed each block' broken link in Docs

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -982,7 +982,7 @@ DOMRect {
 
 ---
 
-An animation is triggered when the contents of a [keyed each block](docs#Each_blocks) are re-ordered. Animations do not run when an element is removed, only when the each block's data is reordered. Animate directives must be on an element that is an *immediate* child of a keyed each block.
+An animation is triggered when the contents of a [keyed each block](docs#each) are re-ordered. Animations do not run when an element is removed, only when the each block's data is reordered. Animate directives must be on an element that is an *immediate* child of a keyed each block.
 
 Animations can be used with Svelte's [built-in animation functions](docs#svelte_animate) or [custom animation functions](docs#Custom_animation_functions).
 


### PR DESCRIPTION
On the docs page, clicking on the 'keyed each block' link in the animate section did nothing before, now it takes you to the each blocks section like it's supposed to.

(This is my first open source pull request, let me know if you have any feedback for me, thanks!)
