### PR TITLE
Document that context is not reactive.

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -156,7 +156,7 @@ Like lifecycle functions, this must be called during component initialisation.
 </script>
 ```
 
-> Context is not inherently reactive, if you need reactive values in context then you can pass a store into context, which *will* be reactive.
+> Context is not inherently reactive. If you need reactive values in context then you can pass a store into context, which *will* be reactive.
 
 #### `getContext`
 

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -156,6 +156,8 @@ Like lifecycle functions, this must be called during component initialisation.
 </script>
 ```
 
+> Context is not inherently reactive, if you need reactive values in context then you can pass a store into context, which *will* be reactive.
+
 #### `getContext`
 
 ```js

--- a/site/content/tutorial/15-context/01-context-api/text.md
+++ b/site/content/tutorial/15-context/01-context-api/text.md
@@ -45,3 +45,5 @@ const key = {};
 ```
 
 We can use anything as a key — we could do `setContext('mapbox', ...)` for example. The downside of using a string is that different component libraries might accidentally use the same one; using an object literal means the keys are guaranteed not to conflict in any circumstance, even when you have multiple different contexts operating across many component layers.
+
+> Remember that context is not inherently reactive. If you need context values to be reactive then you can pass a store into context, which *will* be reactive.


### PR DESCRIPTION
Is this enough? Is this the right place?

I put it in both so that it is clear regardless of where you are looking. I don't think we need an example of passing store into context since it is just another value but maybe I'm wrong.

Closes #3271.