### PR TITLE
Fix bug on tutorial step 14d

### DIFF
--- a/site/content/tutorial/14-composition/04-slot-props/app-a/App.svelte
+++ b/site/content/tutorial/14-composition/04-slot-props/app-a/App.svelte
@@ -1,5 +1,7 @@
 <script>
 	import Hoverable from './Hoverable.svelte';
+	
+	let hovering;
 </script>
 
 <style>


### PR DESCRIPTION
Line 19 was accessing a "hovering" variable that hadn't been initialized in the top script tag. This just initializes the variable.

Offending page: https://svelte.dev/tutorial/slot-props

*Note* -- there aren't any tests for the tutorial as far as I can see. I'm including a screenshot with the issue.

<img width="665" alt="Screen Shot 2019-07-27 at 11 09 40 PM" src="https://user-images.githubusercontent.com/397982/62001711-75ec2680-b0c4-11e9-8481-6cf10b6ea2b5.png">

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
