### PR TITLE
fix Literally undefined class #3283

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -91,9 +91,16 @@ export default class AttributeWrapper {
 							if (chunk.type === 'Text') {
 								return stringify(chunk.data);
 							} else {
-								return chunk.get_precedence() <= 13
-									? `(${chunk.render()})`
-									: chunk.render();
+								const renderedChunk = chunk.render();
+								if (this.node.name === 'class') {
+									return chunk.get_precedence() <= 13
+										? `(${renderedChunk})`
+									  : `(${renderedChunk} || '')`;
+								} else {
+									return chunk.get_precedence() <= 13
+									  ? `(${renderedChunk})`
+									  : renderedChunk;
+								}
 							}
 						})
 						.join(' + ');

--- a/test/runtime/samples/attribute-null-classname/_config.js
+++ b/test/runtime/samples/attribute-null-classname/_config.js
@@ -1,0 +1,32 @@
+export default {
+	skip_if_ssr: true,
+
+	props: {
+		testName: "testClassName"
+	},
+
+	html: `<div class="testClassName svelte-x1o6ra"></div>`,
+
+	test({ assert, component, target }) {
+		const div = target.querySelector('div');
+		assert.equal(div.className, 'testClassName svelte-x1o6ra');
+
+		component.testName = null;
+		assert.equal(div.className, ' svelte-x1o6ra');
+
+		component.testName = undefined;
+		assert.equal(div.className, ' svelte-x1o6ra');
+
+		component.testName = undefined + '';
+		assert.equal(div.className, 'undefined svelte-x1o6ra');
+
+		component.testName = null + '';
+		assert.equal(div.className, 'null svelte-x1o6ra');
+
+		component.testName = 1;
+		assert.equal(div.className, '1 svelte-x1o6ra');
+
+		component.testName = '';
+		assert.equal(div.className, ' svelte-x1o6ra');
+	}
+};

--- a/test/runtime/samples/attribute-null-classname/main.svelte
+++ b/test/runtime/samples/attribute-null-classname/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let testName;
+</script>
+
+<style>
+  div {
+    color: purple;
+  }
+</style>
+
+<div class={testName}></div>

--- a/test/runtime/samples/attribute-null-classnames/_config.js
+++ b/test/runtime/samples/attribute-null-classnames/_config.js
@@ -1,0 +1,39 @@
+export default {
+	skip_if_ssr: true,
+
+	props: {
+		testName1: "test1",
+		testName2: "test2",
+	},
+
+	html: `<div class="test1test2 svelte-x1o6ra"></div>`,
+
+	test({ assert, component, target }) {
+		const div = target.querySelector('div');
+		assert.equal(div.className, 'test1test2 svelte-x1o6ra');
+
+		component.testName1 = null;
+		component.testName2 = null;
+		assert.equal(div.className, '0 svelte-x1o6ra');
+
+		component.testName1 = null;
+		component.testName2 = "test";
+		assert.equal(div.className, 'nulltest svelte-x1o6ra');
+
+		component.testName1 = undefined;
+		component.testName2 = "test";
+		assert.equal(div.className, 'undefinedtest svelte-x1o6ra');
+
+		component.testName1 = undefined;
+		component.testName2 = undefined;
+		assert.equal(div.className, 'NaN svelte-x1o6ra');
+
+		component.testName1 = null;
+		component.testName2 = 1;
+		assert.equal(div.className, '1 svelte-x1o6ra');
+
+		component.testName1 = undefined;
+		component.testName2 = 1;
+		assert.equal(div.className, 'NaN svelte-x1o6ra');
+	}
+};

--- a/test/runtime/samples/attribute-null-classnames/main.svelte
+++ b/test/runtime/samples/attribute-null-classnames/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	export let testName1;
+	export let testName2;
+</script>
+
+<style>
+  div {
+    color: purple;
+  }
+</style>
+
+<div class={testName1 + testName2}></div>


### PR DESCRIPTION

**Literally undefined class #3283**

Added check for className. In compiled file its look like:

![image](https://user-images.githubusercontent.com/12611926/62211023-319fa580-b3a6-11e9-81a2-950951786a45.png)

Its no option to modify ‘attr’ function because it gets concatenated className string from image above (null + " svelte-abc"):

![image](https://user-images.githubusercontent.com/12611926/62211128-6d3a6f80-b3a6-11e9-9d85-bae30a53fbd8.png):

I prefer logical 'or' to ternary operator because className token may be a function with side effects and we will call function twice:

![image](https://user-images.githubusercontent.com/12611926/62211344-d9b56e80-b3a6-11e9-9f00-254676cd8101.png)
![image](https://user-images.githubusercontent.com/12611926/62211353-e0dc7c80-b3a6-11e9-8429-84bf97a6fe65.png)

I think in future we must add special class name resolver function. Also added tests.
Thanks
