### PR TITLE
preserve async/generator-ness of hoisted function expressions

### DIFF
--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -363,7 +363,7 @@ export default class Expression {
 					}
 
 					const fn = deindent`
-						function ${name}(${args.join(', ')}) ${body}
+						${node.async && 'async '}function${node.generator && '*'} ${name}(${args.join(', ')}) ${body}
 					`;
 
 					if (dependencies.size === 0 && contextual_dependencies.size === 0) {

--- a/test/runtime/samples/event-handler-async/_config.js
+++ b/test/runtime/samples/event-handler-async/_config.js
@@ -1,0 +1,5 @@
+export default {
+	html: `
+		<button>nothing</button>
+	`,
+};

--- a/test/runtime/samples/event-handler-async/main.svelte
+++ b/test/runtime/samples/event-handler-async/main.svelte
@@ -1,0 +1,1 @@
+<button on:click={async () => { await null; }}>nothing</button>


### PR DESCRIPTION
Fixes #3179. I don't know when generators would come up, but we ought to be able to correctly hoist those as well.