### PR TITLE
prevent commas in attributes

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -240,7 +240,7 @@ export default class AttributeWrapper {
 			return chunk.type === 'Text'
 				? chunk.data.replace(/"/g, '\\"')
 				: `\${${chunk.render()}}`;
-		})}"`;
+		}).join('')}"`;
 	}
 }
 

--- a/test/runtime/samples/innerhtml-interpolated-literal/_config.js
+++ b/test/runtime/samples/innerhtml-interpolated-literal/_config.js
@@ -1,0 +1,7 @@
+export default {
+	html: `
+		<div>
+			<span class="a/42"/>
+		</div>
+	`
+}

--- a/test/runtime/samples/innerhtml-interpolated-literal/main.svelte
+++ b/test/runtime/samples/innerhtml-interpolated-literal/main.svelte
@@ -1,0 +1,3 @@
+<div>
+	<span class="a/{42}"/>
+</div>


### PR DESCRIPTION
fixes #3341, but only the first part (interpolated constants still cause Svelte to bail out of the `innerHTML` optimisation)