### PR TITLE
disable validation with magic comments

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -111,6 +111,27 @@ Text can also contain JavaScript expressions:
 ```
 
 
+### Comments
+
+---
+
+You can use HTML comments inside components.
+
+```html
+<!-- this is a comment! -->
+<h1>Hello world</h1>
+```
+
+---
+
+Comments beginning with `svelte-ignore` disable warnings for the next block of markup. Usually these are accessibility warnings; make sure that you're disabling them for a good reason.
+
+```html
+<!-- svelte-ignore a11y-autofocus -->
+<input bind:value={name} autofocus>
+```
+
+
 ### {#if ...}
 
 ```sv

--- a/src/compiler/compile/nodes/Comment.ts
+++ b/src/compiler/compile/nodes/Comment.ts
@@ -1,11 +1,17 @@
 import Node from './shared/Node';
 
+const pattern = /^\s*svelte-ignore\s+([\s\S]+)\s*$/m;
+
 export default class Comment extends Node {
 	type: 'Comment';
 	data: string;
+	ignores: string[];
 
 	constructor(component, parent, scope, info) {
 		super(component, parent, scope, info);
 		this.data = info.data;
+
+		const match = pattern.exec(this.data);
+		this.ignores = match ? match[1].split(/[^\S]/).map(x => x.trim()).filter(Boolean) : [];
 	}
 }

--- a/src/compiler/compile/nodes/shared/map_children.ts
+++ b/src/compiler/compile/nodes/shared/map_children.ts
@@ -42,9 +42,20 @@ function get_constructor(type) {
 
 export default function map_children(component, parent, scope, children: Node[]) {
 	let last = null;
+	let ignores = [];
+
 	return children.map(child => {
 		const constructor = get_constructor(child.type);
+
+		const use_ignores = child.type !== 'Text' && child.type !== 'Comment' && ignores.length;
+
+		if (use_ignores) component.push_ignores(ignores);
 		const node = new constructor(component, parent, scope, child);
+		if (use_ignores) component.pop_ignores(), ignores = [];
+
+		if (node.type === 'Comment' && node.ignores.length) {
+			ignores.push(...node.ignores);
+		}
 
 		if (last) last.next = node;
 		node.prev = last;

--- a/test/validator/samples/ignore-warning/input.svelte
+++ b/test/validator/samples/ignore-warning/input.svelte
@@ -1,0 +1,7 @@
+<!-- svelte-ignore a11y-missing-attribute -->
+<div>
+	<img src="this-is-fine.jpg">
+	<marquee>but this is still discouraged</marquee>
+</div>
+
+<img src="potato.jpg">

--- a/test/validator/samples/ignore-warning/warnings.json
+++ b/test/validator/samples/ignore-warning/warnings.json
@@ -1,0 +1,32 @@
+[
+	{
+		"code": "a11y-distracting-elements",
+		"end": {
+			"character": 131,
+			"column": 49,
+			"line": 4
+		},
+		"message": "A11y: Avoid <marquee> elements",
+		"pos": 83,
+		"start": {
+			"character": 83,
+			"column": 1,
+			"line": 4
+		}
+	},
+	{
+		"code": "a11y-missing-attribute",
+		"end": {
+			"character": 162,
+			"column": 22,
+			"line": 7
+		},
+		"message": "A11y: <img> element should have an alt attribute",
+		"pos": 140,
+		"start": {
+			"character": 140,
+			"column": 0,
+			"line": 7
+		}
+	}
+]

--- a/test/validator/samples/ignore-warnings-cumulative/input.svelte
+++ b/test/validator/samples/ignore-warnings-cumulative/input.svelte
@@ -1,0 +1,17 @@
+<!-- svelte-ignore a11y-structure a11y-missing-attribute -->
+<div>
+	<figure>
+		<img src="potato.jpg">
+		<marquee>
+			<figcaption>potato</figcaption>
+		</marquee>
+	</figure>
+
+	<!-- svelte-ignore a11y-distracting-elements -->
+	<figure>
+		<img src="potato.jpg">
+		<marquee>
+			<figcaption>potato</figcaption>
+		</marquee>
+	</figure>
+</div>

--- a/test/validator/samples/ignore-warnings-cumulative/warnings.json
+++ b/test/validator/samples/ignore-warnings-cumulative/warnings.json
@@ -1,0 +1,17 @@
+[
+	{
+		"code": "a11y-distracting-elements",
+		"end": {
+			"character": 161,
+			"column": 12,
+			"line": 7
+		},
+		"message": "A11y: Avoid <marquee> elements",
+		"pos": 104,
+		"start": {
+			"character": 104,
+			"column": 2,
+			"line": 5
+		}
+	}
+]

--- a/test/validator/samples/ignore-warnings-newline/input.svelte
+++ b/test/validator/samples/ignore-warnings-newline/input.svelte
@@ -1,0 +1,8 @@
+<!-- svelte-ignore a11y-missing-attribute
+                   a11y-distracting-elements -->
+<div>
+	<img src="this-is-fine.jpg">
+	<marquee>but this is still discouraged</marquee>
+</div>
+
+<img src="potato.jpg">

--- a/test/validator/samples/ignore-warnings-newline/warnings.json
+++ b/test/validator/samples/ignore-warnings-newline/warnings.json
@@ -1,0 +1,17 @@
+[
+	{
+		"code": "a11y-missing-attribute",
+		"end": {
+			"character": 207,
+			"column": 22,
+			"line": 8
+		},
+		"message": "A11y: <img> element should have an alt attribute",
+		"pos": 185,
+		"start": {
+			"character": 185,
+			"column": 0,
+			"line": 8
+		}
+	}
+]

--- a/test/validator/samples/ignore-warnings-stacked/input.svelte
+++ b/test/validator/samples/ignore-warnings-stacked/input.svelte
@@ -1,0 +1,8 @@
+<!-- svelte-ignore a11y-missing-attribute -->
+<!-- svelte-ignore a11y-distracting-elements -->
+<div>
+	<img src="this-is-fine.jpg">
+	<marquee>but this is still discouraged</marquee>
+</div>
+
+<img src="potato.jpg">

--- a/test/validator/samples/ignore-warnings-stacked/warnings.json
+++ b/test/validator/samples/ignore-warnings-stacked/warnings.json
@@ -1,0 +1,17 @@
+[
+	{
+		"code": "a11y-missing-attribute",
+		"end": {
+			"character": 211,
+			"column": 22,
+			"line": 8
+		},
+		"message": "A11y: <img> element should have an alt attribute",
+		"pos": 189,
+		"start": {
+			"character": 189,
+			"column": 0,
+			"line": 8
+		}
+	}
+]

--- a/test/validator/samples/ignore-warnings/input.svelte
+++ b/test/validator/samples/ignore-warnings/input.svelte
@@ -1,0 +1,7 @@
+<!-- svelte-ignore a11y-missing-attribute a11y-distracting-elements -->
+<div>
+	<img src="this-is-fine.jpg">
+	<marquee>but this is still discouraged</marquee>
+</div>
+
+<img src="potato.jpg">

--- a/test/validator/samples/ignore-warnings/warnings.json
+++ b/test/validator/samples/ignore-warnings/warnings.json
@@ -1,0 +1,17 @@
+[
+	{
+		"code": "a11y-missing-attribute",
+		"end": {
+			"character": 188,
+			"column": 22,
+			"line": 7
+		},
+		"message": "A11y: <img> element should have an alt attribute",
+		"pos": 166,
+		"start": {
+			"character": 166,
+			"column": 0,
+			"line": 7
+		}
+	}
+]


### PR DESCRIPTION
This is an alternative to #1861 with more specificity.

The idea is that you can add a comment like this...

```svelte
<!-- svelte-ignore a11y-missing-attribute -->
```

...and it will ignore any `a11y-missing-attribute` warnings on *the next non-text, non-comment node* (and any of its children). That includes `{#if ...}` etc and components.

So in a case like this...

```svelte
<img src="whatever.jpg">

<!-- svelte-ignore a11y-missing-attribute -->
<div>
  <marquee>
    <img src="whatever.jpg">
  </marquee>

  <img src="whatever.jpg">
</div>
```

...we'd get an accessibility warning for the first `<img>` but not the second or third, and we'd get a separate warning for the `<marquee>`.

Multiple codes can be passed at once:

```svelte
<!-- svelte-ignore a11y-missing-attribute a11y-distracting-elements -->
<div>
  <marquee>
    <img src="whatever.jpg">
  </marquee>
</div>
```

They can be separated by newlines:

```svelte
<!-- svelte-ignore a11y-missing-attribute
                   a11y-distracting-elements -->
<div>
  <marquee>
    <img src="whatever.jpg">
  </marquee>
</div>
```

They can be stacked:

```svelte
<!-- svelte-ignore a11y-missing-attribute -->
<!-- svelte-ignore a11y-distracting-elements -->
<div>
  <marquee>
    <img src="whatever.jpg">
  </marquee>
</div>
```

And they accumulate (i.e. earlier ignores are not cancelled out by newer ignores):

```svelte
<!-- svelte-ignore a11y-distracting-elements -->
<div>
  <!-- svelte-ignore a11y-missing-attribute -->
  <marquee>
    <img src="whatever.jpg">
  </marquee>
</div>
```

Thoughts?