### PR TITLE
Fix typo (tutorial)

### DIFF
--- a/site/content/tutorial/06-bindings/01-text-inputs/text.md
+++ b/site/content/tutorial/06-bindings/01-text-inputs/text.md
@@ -4,7 +4,7 @@ title: Text inputs
 
 As a general rule, data flow in Svelte is *top down* — a parent component can set props on a child component, and a component can set attributes on an element, but not the other way around.
 
-Sometimes it's useful to break that rule. Take the case of the `<input>` element in this component — we *could* add an `on:input` event handler that set the value of `name` to `event.target.value`, but it's a bit... boilerplatey. It gets even worse with other form elements, as we'll see.
+Sometimes it's useful to break that rule. Take the case of the `<input>` element in this component — we *could* add an `on:input` event handler that sets the value of `name` to `event.target.value`, but it's a bit... boilerplatey. It gets even worse with other form elements, as we'll see.
 
 Instead, we can use the `bind:value` directive:
 


### PR DESCRIPTION
Performed pluralization via the `s` operator (non recursively for optimum performance).