### PR TITLE
#3372 Added a `self` event modifier

### DIFF
--- a/site/content/tutorial/05-events/03-event-modifiers/text.md
+++ b/site/content/tutorial/05-events/03-event-modifiers/text.md
@@ -23,5 +23,6 @@ The full list of modifiers:
 * `passive` — improves scrolling performance on touch/wheel events (Svelte will add it automatically where it's safe to do so)
 * `capture` — fires the handler during the *capture* phase instead of the *bubbling* phase ([MDN docs](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture))
 * `once` — remove the handler after the first time it runs
+* `self` — only trigger handler if event.target is the element itself
 
 You can chain modifiers together, e.g. `on:click|once|capture={...}`.

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -63,7 +63,8 @@ const valid_modifiers = new Set([
 	'stopPropagation',
 	'capture',
 	'once',
-	'passive'
+	'passive',
+	'self'
 ]);
 
 const passive_events = new Set([

--- a/src/compiler/compile/render_dom/wrappers/shared/add_event_handlers.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/add_event_handlers.ts
@@ -10,6 +10,7 @@ export default function add_event_handlers(
 		let snippet = handler.render(block);
 		if (handler.modifiers.has('preventDefault')) snippet = `@prevent_default(${snippet})`;
 		if (handler.modifiers.has('stopPropagation')) snippet = `@stop_propagation(${snippet})`;
+		if (handler.modifiers.has('self')) snippet = `@self(${snippet}, ${target})`;
 
 		const opts = ['passive', 'once', 'capture'].filter(mod => handler.modifiers.has(mod));
 

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -73,6 +73,14 @@ export function stop_propagation(fn) {
 	};
 }
 
+export function self(fn, el) {
+	return function(event) {
+		if(event.target !== el) return;
+		// @ts-ignore
+		return fn.call(this, event);
+	};
+}
+
 export function attr(node: Element, attribute: string, value?: string) {
 	if (value == null) node.removeAttribute(attribute);
 	else node.setAttribute(attribute, value);

--- a/test/runtime/samples/event-handler-modifier-self/_config.js
+++ b/test/runtime/samples/event-handler-modifier-self/_config.js
@@ -1,0 +1,16 @@
+export default {
+	html: `
+		<div>
+			<button>click me</button>
+		</div>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const button = target.querySelector('button');
+		const event = new window.MouseEvent('click');
+
+		await button.dispatchEvent(event);
+
+		assert.ok(!component.inner_clicked);
+	},
+};

--- a/test/runtime/samples/event-handler-modifier-self/main.svelte
+++ b/test/runtime/samples/event-handler-modifier-self/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let inner_clicked;
+
+	function handle_click(event) {
+		inner_clicked = true;
+	}
+</script>
+
+<div on:click|self={handle_click}>
+	<button>click me</button>
+</div>

--- a/test/validator/samples/event-modifiers-invalid/errors.json
+++ b/test/validator/samples/event-modifiers-invalid/errors.json
@@ -1,5 +1,5 @@
 [{
-	"message": "Valid event modifiers are preventDefault, stopPropagation, capture, once or passive",
+	"message": "Valid event modifiers are preventDefault, stopPropagation, capture, once, passive or self",
 	"code": "invalid-event-modifier",
 	"start": {
 		"line": 1,


### PR DESCRIPTION
Added support for a `self` modifier.
The `self` modifier only triggers the handler if event.target is the element itself.

Added and updated the tests, and documentation.
I don't know if the ESlint plugin derives the allowed modifiers from this project so I haven't done anything in that regard, but I'll gladly take care of that if needed.


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
