### PR TITLE
Add failing test for null hydration

### DIFF
--- a/test/hydration/samples/dynamic-text-nil/_after.html
+++ b/test/hydration/samples/dynamic-text-nil/_after.html
@@ -1,0 +1,2 @@
+<p></p>
+<p>undefined</p>

--- a/test/hydration/samples/dynamic-text-nil/_before.html
+++ b/test/hydration/samples/dynamic-text-nil/_before.html
@@ -1,0 +1,2 @@
+<p>null</p>
+<p>undefined</p>

--- a/test/hydration/samples/dynamic-text-nil/_config.js
+++ b/test/hydration/samples/dynamic-text-nil/_config.js
@@ -1,0 +1,21 @@
+export default {
+	props: {},
+
+	snapshot(target) {
+		const nullText = target.querySelectorAll('p')[0].textContent;
+		const undefinedText = target.querySelectorAll('p')[1].textContent;
+
+		return {
+			nullText,
+			undefinedText,
+		};
+	},
+
+	test(assert, target, snapshot) {
+		const nullText = target.querySelectorAll('p')[0].textContent;
+		const undefinedText = target.querySelectorAll('p')[1].textContent;
+
+		assert.equal(nullText, snapshot.nullText);
+		assert.equal(undefinedText, snapshot.undefinedText);
+	},
+};

--- a/test/hydration/samples/dynamic-text-nil/main.svelte
+++ b/test/hydration/samples/dynamic-text-nil/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let maybeNull = null;
+	let maybeUndefined = undefined;
+</script>
+
+<p>{maybeNull}</p>
+<p>{maybeUndefined}</p>


### PR DESCRIPTION
This is only a failing test for inconsistent server vs client side behavior for `null` children. For `undefined` both server and client stringify them but for `null` only the server stringifies them. The client removes children if it encounters `null`.

Would like to fix those but I would need to know who's at fault here: client, server or user and where a good starting point for fixing this would be.