### PR TITLE
Remove external dependencies from exported files

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,5 +1,6 @@
 export { default as compile } from './compile/index';
 export { default as parse } from './parse/index';
 export { default as preprocess } from './preprocess/index';
+export { walk } from 'estree-walker';
 
 export const VERSION = '__VERSION__';

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,6 +1,5 @@
 export { default as compile } from './compile/index';
 export { default as parse } from './parse/index';
 export { default as preprocess } from './preprocess/index';
-export { walk } from 'estree-walker';
 
 export const VERSION = '__VERSION__';

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -1,10 +1,14 @@
-import { SourceMap } from 'magic-string';
+export interface Processed {
+	code: string;
+	map?: object | string;
+	dependencies?: string[];
+}
 
 export interface PreprocessorGroup {
 	markup?: (options: {
 		content: string;
 		filename: string;
-	}) => { code: string; map?: SourceMap | string; dependencies?: string[] };
+	}) => Processed;
 	style?: Preprocessor;
 	script?: Preprocessor;
 }
@@ -13,13 +17,7 @@ export type Preprocessor = (options: {
 	content: string;
 	attributes: Record<string, string | boolean>;
 	filename?: string;
-}) => { code: string; map?: SourceMap | string; dependencies?: string[] };
-
-interface Processed {
-	code: string;
-	map?: SourceMap | string;
-	dependencies?: string[];
-}
+}) => Processed;
 
 function parse_attributes(str: string) {
 	const attrs = {};
@@ -85,7 +83,7 @@ export default async function preprocess(
 	const style = preprocessors.map(p => p.style).filter(Boolean);
 
 	for (const fn of markup) {
-		const processed: Processed = await fn({
+		const processed = await fn({
 			content: source,
 			filename
 		});
@@ -98,7 +96,7 @@ export default async function preprocess(
 			source,
 			/<script(\s[^]*?)?>([^]*?)<\/script>/gi,
 			async (match, attributes = '', content) => {
-				const processed: Processed = await fn({
+				const processed = await fn({
 					content,
 					attributes: parse_attributes(attributes),
 					filename


### PR DESCRIPTION
Solves issue #3397 by removing external lib references from definition files. In one case (`estree-walker`), it seems to be unnecessary. In the other, as the `map` property apparently is not used by Svelte, it seemed reasonable not to force any specific type on the property.

This PR also refactors code to make better use the interface `Processed` and make it public.