### PR TITLE
Correct preprocessor api doc

### DIFF
--- a/site/content/docs/04-compile-time.md
+++ b/site/content/docs/04-compile-time.md
@@ -186,15 +186,15 @@ result: {
 } = svelte.preprocess(
 	source: string,
 	preprocessors: Array<{
-		markup?: (input: { source: string, filename: string }) => Promise<{
+		markup?: (input: { content: string, filename: string }) => Promise<{
 			code: string,
 			dependencies?: Array<string>
 		}>,
-		script?: (input: { source: string, attributes: Record<string, string>, filename: string }) => Promise<{
+		script?: (input: { content: string, attributes: Record<string, string>, filename: string }) => Promise<{
 			code: string,
 			dependencies?: Array<string>
 		}>,
-		style?: (input: { source: string, attributes: Record<string, string>, filename: string }) => Promise<{
+		style?: (input: { content: string, attributes: Record<string, string>, filename: string }) => Promise<{
 			code: string,
 			dependencies?: Array<string>
 		}>


### PR DESCRIPTION
According to the definition in svelte/src/compiler/preprocess/index.ts, Preprocessor is defined as:
```
export type Preprocessor = (options: {
	content: string;
	attributes: Record<string, string | boolean>;
	filename?: string;
}) => { code: string; map?: SourceMap | string; dependencies?: string[] };
```
The api doc mentioned `source` instead of `content` which conflicts with the implementation (also conflicts with the example right below the definition doc).
