### PR TITLE
Examples: Remove unused variable

### DIFF
--- a/site/content/examples/05-bindings/10-bind-this/App.svelte
+++ b/site/content/examples/05-bindings/10-bind-this/App.svelte
@@ -2,7 +2,6 @@
 	import { onMount } from 'svelte';
 
 	let canvas;
-	let ctx;
 	let running = false;
 
 	const r = Math.random();


### PR DESCRIPTION
Removes the `let ctx` declaration in the scope outside the `loop` since it is shadowed by the `const ctx` declaration inside it.