### PR TITLE
Site: Fix tiny font size on iOS

### DIFF
--- a/site/static/global.css
+++ b/site/static/global.css
@@ -113,8 +113,7 @@ body {
 /*	base reset ----------------------------- */
 html {
 	font-size: 62.5%;
-	-ms-text-size-adjust: 62.5%;
-	-webkit-text-size-adjust: 62.5%;
+	-webkit-text-size-adjust: 100%;
 	-ms-overflow-style: -ms-autohiding-scrollbar;
 	box-sizing: border-box;
 	border-collapse: collapse;


### PR DESCRIPTION
Fix for https://github.com/sveltejs/svelte/issues/2551. The site really does look quite odd on iOS devices.

I'm pretty sure `-webkit-text-size-adjust` originates from normalize.css which has `-webkit-text-size-adjust: 100%` to "Prevent adjustments of font size after orientation changes in iOS.", https://github.com/necolas/normalize.css/blob/master/normalize.css#L8. 

I'm _guessing_ the drop to `62.5%` was a mistake when applying `font-size: 62.5%` to change the base font size from 16px to 10px.

I noticed that recent versions of normalize doesn't use the `-ms` vendor prefix so I removed that.