### PR TITLE
set context in await blocks

### DIFF
--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -1,6 +1,7 @@
 import { assign, is_promise } from './utils';
 import { check_outros, group_outros, transition_in, transition_out } from './transitions';
 import { flush } from './scheduler';
+import { get_current_component, set_current_component } from './lifecycle';
 
 export function handle_promise(promise, info) {
 	const token = info.token = {};
@@ -40,10 +41,15 @@ export function handle_promise(promise, info) {
 	}
 
 	if (is_promise(promise)) {
+		const current_component = get_current_component();
 		promise.then(value => {
+			set_current_component(current_component);
 			update(info.then, 1, info.value, value);
+			set_current_component(null);
 		}, error => {
+			set_current_component(current_component);
 			update(info.catch, 2, info.error, error);
+			set_current_component(null);
 		});
 
 		// if we previously had a then/catch block, destroy it

--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -6,7 +6,7 @@ export function set_current_component(component) {
 	current_component = component;
 }
 
-function get_current_component() {
+export function get_current_component() {
 	if (!current_component) throw new Error(`Function called outside component initialization`);
 	return current_component;
 }

--- a/test/runtime/samples/context-in-await/Child.svelte
+++ b/test/runtime/samples/context-in-await/Child.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { getContext } from 'svelte';
+	const num = getContext('test');
+</script>
+
+<p>Context value: {num}</p>

--- a/test/runtime/samples/context-in-await/_config.js
+++ b/test/runtime/samples/context-in-await/_config.js
@@ -1,0 +1,13 @@
+export default {
+	html: `
+		<p>...waiting</p>
+	`,
+
+	async test({ assert, component, target }) {
+		await component.promise;
+
+		assert.htmlEqual(target.innerHTML, `
+			<p>Context value: 123</p>
+		`);
+	}
+};

--- a/test/runtime/samples/context-in-await/main.svelte
+++ b/test/runtime/samples/context-in-await/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { setContext } from 'svelte';
+	import Child from './Child.svelte';
+
+	setContext('test', 123);
+
+	export let promise = Promise.resolve();
+</script>
+
+{#await promise}
+	<p>...waiting</p>
+{:then}
+	<Child />
+{/await}


### PR DESCRIPTION
fixes #2443 with the patch @Conduitry proposed, with a minor tweak (resetting the current component to `null` immediately afterwards)