### PR TITLE
update context if event handler uses index in keyed each block

### DIFF
--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -147,7 +147,10 @@ export default class Expression {
 
 						contextual_dependencies.add(name);
 
-						if (!lazy) {
+						const owner = template_scope.get_owner(name);
+						const is_index = owner.type === 'EachBlock' && owner.key && name === owner.index;
+
+						if (!lazy || is_index) {
 							template_scope.dependencies_for_name.get(name).forEach(name => dependencies.add(name));
 						}
 					} else {

--- a/test/runtime/samples/each-block-keyed-index-in-event-handler/_config.js
+++ b/test/runtime/samples/each-block-keyed-index-in-event-handler/_config.js
@@ -1,0 +1,18 @@
+export default {
+	html: `
+		<button>remove</button>
+		<button>remove</button>
+		<button>remove</button>
+	`,
+
+	async test({ assert, target, window }) {
+		const click = new window.MouseEvent('click');
+
+		await target.querySelectorAll('button')[1].dispatchEvent(click);
+		await target.querySelectorAll('button')[1].dispatchEvent(click);
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>remove</button>
+		`);
+	}
+};

--- a/test/runtime/samples/each-block-keyed-index-in-event-handler/main.svelte
+++ b/test/runtime/samples/each-block-keyed-index-in-event-handler/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	let list = ["a", "b", "c"];
+
+	const remove = index => {
+		list.splice(index, 1);
+		list = list;
+	};
+</script>
+
+{#each list as value, index (value)}
+	{#if value}
+		<button on:click="{e => remove(index)}">
+			remove
+		</button>
+	{/if}
+{/each}


### PR DESCRIPTION
fixes #2569. I *think* this is the right fix — it's a fairly specific confluence of factors that leads to this situation. At the very least, it gets the test passing and doesn't break anything else.