### PR TITLE
site: docs: {@html} clarifications

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -320,9 +320,9 @@ If you don't care about the pending state, you can also omit the initial block.
 
 In a text expression, characters like `<` and `>` are escaped; however, with HTML expressions, they're not.
 
-> Svelte does not sanitize expressions before injecting HTML. If the data comes from an untrusted source, you must sanitize it, or you are exposing your users to an XSS vulnerability.
+The expression should be valid standalone HTML — `{@html "<div>"}content{@html "</div>"}` will *not* work, because `</div>` is not valid HTML.
 
-> Due to the limitations of the DOM APIs available to insert raw HTML fragments, this directive cannot be used to surround content with additional markup.
+> Svelte does not sanitize expressions before injecting HTML. If the data comes from an untrusted source, you must sanitize it, or you are exposing your users to an XSS vulnerability.
 
 ```html
 <div class="blog-post">

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -318,9 +318,11 @@ If you don't care about the pending state, you can also omit the initial block.
 
 ---
 
-In a text expression, characters like `<` and `>` are escaped. With HTML expressions, they're not.
+In a text expression, characters like `<` and `>` are escaped; however, with HTML expressions, they're not.
 
 > Svelte does not sanitize expressions before injecting HTML. If the data comes from an untrusted source, you must sanitize it, or you are exposing your users to an XSS vulnerability.
+
+> Due to the limitations of the DOM APIs available to insert raw HTML fragments, this directive cannot be used to surround content with additional markup.
 
 ```html
 <div class="blog-post">


### PR DESCRIPTION
Adds a note that `{@html}` directives cannot be used to surround markup with additional tags.
Also corrected the grammar in the descriptive text to remove dangling fragment.

See issue: #3456

@pngwn, is this what you had in mind?

I was going to include an example of what not to do, but then I thought people wouldn't read the description and just copy the wrong way into their code.