### PR TITLE
Fix small typo in tutorial

### DIFF
--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
@@ -10,7 +10,7 @@ To do that, we specify a unique identifier for the `each` block:
 
 ```html
 {#each things as thing (thing.id)}
-	<Thing value={thing.value}/>
+	<Thing current={thing.value}/>
 {/each}
 ```
 


### PR DESCRIPTION
The name of the prop is current, not value. With value, fails

