### PR TITLE
fix: <input type=number> with spread operator breaks float data entry

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -94,7 +94,9 @@ export function set_attributes(node: Element & ElementCSSInlineStyle, attributes
 		if (key === 'style') {
 			node.style.cssText = attributes[key];
 		} else if (key in node) {
-			node[key] = attributes[key];
+			if (node[key] !== attributes[key]) {
+				node[key] = attributes[key];
+			}
 		} else {
 			attr(node, key, attributes[key]);
 		}


### PR DESCRIPTION
Fixes #3426 by not setting attributes which haven't changed.  

This eliminates the usability issue with the cursor observed in Chrome.  This may be the only browser affected since others like Firefox automatically remove the `.` character when deleting the fractional part of a number which avoids the series of interactions that trigger this edge case.

This change should be covered by existing tests but no sample to replicate the bug could be created though an attempt was made using the following approaches:
- observing changes to the the cursor position 
> this is impossible since, [according to the spec](https://html.spec.whatwg.org/multipage/input.html#input-type-attr-summary), selection capabilities on an `<input type=number>` element are not allowed
- observing unexpected changes on the `value` field by triggering `input` events

