### PR TITLE
Make generated `each` code more consistent

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -214,7 +214,9 @@ export default class EachBlockWrapper extends Wrapper {
 
 		if (this.block.has_intro_method || this.block.has_outro_method) {
 			block.builders.intro.add_block(deindent`
-				for (var #i = 0; #i < ${this.vars.data_length}; #i += 1) @transition_in(${this.vars.iterations}[#i]);
+				for (var #i = 0; #i < ${this.vars.data_length}; #i += 1) {
+					@transition_in(${this.vars.iterations}[#i]);
+				}
 			`);
 		}
 
@@ -343,17 +345,23 @@ export default class EachBlockWrapper extends Wrapper {
 		`);
 
 		block.builders.create.add_block(deindent`
-			for (#i = 0; #i < ${view_length}; #i += 1) ${iterations}[#i].c();
+			for (#i = 0; #i < ${view_length}; #i += 1) {
+				${iterations}[#i].c();
+			}
 		`);
 
 		if (parent_nodes && this.renderer.options.hydratable) {
 			block.builders.claim.add_block(deindent`
-				for (#i = 0; #i < ${view_length}; #i += 1) ${iterations}[#i].l(${parent_nodes});
+				for (#i = 0; #i < ${view_length}; #i += 1) {
+					${iterations}[#i].l(${parent_nodes});
+				}
 			`);
 		}
 
 		block.builders.mount.add_block(deindent`
-			for (#i = 0; #i < ${view_length}; #i += 1) ${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node});
+			for (#i = 0; #i < ${view_length}; #i += 1) {
+				${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node});
+			}
 		`);
 
 		const dynamic = this.block.has_update_method;
@@ -378,12 +386,16 @@ export default class EachBlockWrapper extends Wrapper {
 
 		if (this.block.has_outros) {
 			block.builders.outro.add_block(deindent`
-				for (#i = 0; #i < ${view_length}; #i += 1) @transition_out(${iterations}[#i]);
+				for (#i = 0; #i < ${view_length}; #i += 1) {
+					@transition_out(${iterations}[#i]);
+				}
 			`);
 		}
 
 		block.builders.destroy.add_block(deindent`
-			for (#i = 0; #i < ${view_length}; #i += 1) ${iterations}[#i].d(${parent_node ? '' : 'detaching'});
+			for (#i = 0; #i < ${view_length}; #i += 1) {
+				${iterations}[#i].d(${parent_node ? '' : 'detaching'});
+			}
 		`);
 	}
 
@@ -499,7 +511,9 @@ export default class EachBlockWrapper extends Wrapper {
 				`);
 				remove_old_blocks = deindent`
 					@group_outros();
-					for (#i = ${this.vars.each_block_value}.${length}; #i < ${view_length}; #i += 1) ${out}(#i);
+					for (#i = ${this.vars.each_block_value}.${length}; #i < ${view_length}; #i += 1) {
+						${out}(#i);
+					}
 					@check_outros();
 				`;
 			} else {
@@ -534,8 +548,10 @@ export default class EachBlockWrapper extends Wrapper {
 		if (this.block.has_outros) {
 			block.builders.outro.add_block(deindent`
 				${iterations} = ${iterations}.filter(@_Boolean);
-				for (let #i = 0; #i < ${view_length}; #i += 1) @transition_out(${iterations}[#i]);`
-			);
+				for (let #i = 0; #i < ${view_length}; #i += 1) {
+					@transition_out(${iterations}[#i]);
+				}
+			`);
 		}
 
 		block.builders.destroy.add_block(`@destroy_each(${iterations}, detaching);`);

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -71,17 +71,17 @@ function create_each_block(ctx) {
 function create_fragment(ctx) {
 	var t0, p, t1, t2;
 
-	var each_value = ctx.things;
+	let each_value = ctx.things;
 
-	var each_blocks = [];
+	let each_blocks = [];
 
-	for (var i = 0; i < each_value.length; i += 1) {
+	for (let i = 0; i < each_value.length; i += 1) {
 		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
 	}
 
 	return {
 		c: function create() {
-			for (var i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
 
@@ -97,7 +97,7 @@ function create_fragment(ctx) {
 		},
 
 		m: function mount(target, anchor) {
-			for (var i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
 
@@ -111,7 +111,8 @@ function create_fragment(ctx) {
 			if (changed.things) {
 				each_value = ctx.things;
 
-				for (var i = 0; i < each_value.length; i += 1) {
+				let i;
+				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
 					if (each_blocks[i]) {

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -71,17 +71,17 @@ function create_each_block(ctx) {
 function create_fragment(ctx) {
 	var t0, p, t1, t2;
 
-	var each_value = ctx.things;
+	let each_value = ctx.things;
 
-	var each_blocks = [];
+	let each_blocks = [];
 
-	for (var i = 0; i < each_value.length; i += 1) {
+	for (let i = 0; i < each_value.length; i += 1) {
 		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
 	}
 
 	return {
 		c: function create() {
-			for (var i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
 
@@ -97,7 +97,7 @@ function create_fragment(ctx) {
 		},
 
 		m: function mount(target, anchor) {
-			for (var i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
 
@@ -111,7 +111,8 @@ function create_fragment(ctx) {
 			if (changed.things) {
 				each_value = ctx.things;
 
-				for (var i = 0; i < each_value.length; i += 1) {
+				let i;
+				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
 					if (each_blocks[i]) {

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -52,17 +52,17 @@ function create_each_block(ctx) {
 function create_fragment(ctx) {
 	var each_1_anchor;
 
-	var each_value = ctx.createElement;
+	let each_value = ctx.createElement;
 
-	var each_blocks = [];
+	let each_blocks = [];
 
-	for (var i = 0; i < each_value.length; i += 1) {
+	for (let i = 0; i < each_value.length; i += 1) {
 		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
 	}
 
 	return {
 		c() {
-			for (var i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
 
@@ -70,7 +70,7 @@ function create_fragment(ctx) {
 		},
 
 		m(target, anchor) {
-			for (var i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
 
@@ -81,7 +81,8 @@ function create_fragment(ctx) {
 			if (changed.createElement) {
 				each_value = ctx.createElement;
 
-				for (var i = 0; i < each_value.length; i += 1) {
+				let i;
+				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
 					if (each_blocks[i]) {

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -52,17 +52,17 @@ function create_each_block(ctx) {
 function create_fragment(ctx) {
 	var each_1_anchor;
 
-	var each_value = [ctx.a, ctx.b, ctx.c, ctx.d, ctx.e];
+	let each_value = [ctx.a, ctx.b, ctx.c, ctx.d, ctx.e];
 
-	var each_blocks = [];
+	let each_blocks = [];
 
-	for (var i = 0; i < 5; i += 1) {
+	for (let i = 0; i < 5; i += 1) {
 		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
 	}
 
 	return {
 		c() {
-			for (var i = 0; i < 5; i += 1) {
+			for (let i = 0; i < 5; i += 1) {
 				each_blocks[i].c();
 			}
 
@@ -70,7 +70,7 @@ function create_fragment(ctx) {
 		},
 
 		m(target, anchor) {
-			for (var i = 0; i < 5; i += 1) {
+			for (let i = 0; i < 5; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
 
@@ -81,7 +81,8 @@ function create_fragment(ctx) {
 			if (changed.a || changed.b || changed.c || changed.d || changed.e) {
 				each_value = [ctx.a, ctx.b, ctx.c, ctx.d, ctx.e];
 
-				for (var i = 0; i < each_value.length; i += 1) {
+				let i;
+				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
 					if (each_blocks[i]) {

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -83,17 +83,17 @@ function create_each_block(ctx) {
 function create_fragment(ctx) {
 	var t0, p, t1;
 
-	var each_value = ctx.comments;
+	let each_value = ctx.comments;
 
-	var each_blocks = [];
+	let each_blocks = [];
 
-	for (var i = 0; i < each_value.length; i += 1) {
+	for (let i = 0; i < each_value.length; i += 1) {
 		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
 	}
 
 	return {
 		c() {
-			for (var i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
 
@@ -103,7 +103,7 @@ function create_fragment(ctx) {
 		},
 
 		m(target, anchor) {
-			for (var i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
 
@@ -116,7 +116,8 @@ function create_fragment(ctx) {
 			if (changed.comments || changed.elapsed || changed.time) {
 				each_value = ctx.comments;
 
-				for (var i = 0; i < each_value.length; i += 1) {
+				let i;
+				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
 					if (each_blocks[i]) {

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -74,11 +74,11 @@ function create_each_block(key_1, ctx) {
 function create_fragment(ctx) {
 	var each_blocks = [], each_1_lookup = new Map(), each_1_anchor;
 
-	var each_value = ctx.things;
+	let each_value = ctx.things;
 
 	const get_key = ctx => ctx.thing.id;
 
-	for (var i = 0; i < each_value.length; i += 1) {
+	for (let i = 0; i < each_value.length; i += 1) {
 		let child_ctx = get_each_context(ctx, each_value, i);
 		let key = get_key(child_ctx);
 		each_1_lookup.set(key, each_blocks[i] = create_each_block(key, child_ctx));
@@ -86,7 +86,7 @@ function create_fragment(ctx) {
 
 	return {
 		c() {
-			for (i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
 
@@ -94,7 +94,7 @@ function create_fragment(ctx) {
 		},
 
 		m(target, anchor) {
-			for (i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
 
@@ -112,7 +112,7 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d(detaching) {
-			for (i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].d(detaching);
 			}
 

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -86,13 +86,17 @@ function create_fragment(ctx) {
 
 	return {
 		c() {
-			for (i = 0; i < each_blocks.length; i += 1) each_blocks[i].c();
+			for (i = 0; i < each_blocks.length; i += 1) {
+				each_blocks[i].c();
+			}
 
 			each_1_anchor = empty();
 		},
 
 		m(target, anchor) {
-			for (i = 0; i < each_blocks.length; i += 1) each_blocks[i].m(target, anchor);
+			for (i = 0; i < each_blocks.length; i += 1) {
+				each_blocks[i].m(target, anchor);
+			}
 
 			insert(target, each_1_anchor, anchor);
 		},
@@ -108,7 +112,9 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d(detaching) {
-			for (i = 0; i < each_blocks.length; i += 1) each_blocks[i].d(detaching);
+			for (i = 0; i < each_blocks.length; i += 1) {
+				each_blocks[i].d(detaching);
+			}
 
 			if (detaching) {
 				detach(each_1_anchor);

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -70,13 +70,17 @@ function create_fragment(ctx) {
 
 	return {
 		c() {
-			for (i = 0; i < each_blocks.length; i += 1) each_blocks[i].c();
+			for (i = 0; i < each_blocks.length; i += 1) {
+				each_blocks[i].c();
+			}
 
 			each_1_anchor = empty();
 		},
 
 		m(target, anchor) {
-			for (i = 0; i < each_blocks.length; i += 1) each_blocks[i].m(target, anchor);
+			for (i = 0; i < each_blocks.length; i += 1) {
+				each_blocks[i].m(target, anchor);
+			}
 
 			insert(target, each_1_anchor, anchor);
 		},
@@ -90,7 +94,9 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d(detaching) {
-			for (i = 0; i < each_blocks.length; i += 1) each_blocks[i].d(detaching);
+			for (i = 0; i < each_blocks.length; i += 1) {
+				each_blocks[i].d(detaching);
+			}
 
 			if (detaching) {
 				detach(each_1_anchor);

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -58,11 +58,11 @@ function create_each_block(key_1, ctx) {
 function create_fragment(ctx) {
 	var each_blocks = [], each_1_lookup = new Map(), each_1_anchor;
 
-	var each_value = ctx.things;
+	let each_value = ctx.things;
 
 	const get_key = ctx => ctx.thing.id;
 
-	for (var i = 0; i < each_value.length; i += 1) {
+	for (let i = 0; i < each_value.length; i += 1) {
 		let child_ctx = get_each_context(ctx, each_value, i);
 		let key = get_key(child_ctx);
 		each_1_lookup.set(key, each_blocks[i] = create_each_block(key, child_ctx));
@@ -70,7 +70,7 @@ function create_fragment(ctx) {
 
 	return {
 		c() {
-			for (i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].c();
 			}
 
@@ -78,7 +78,7 @@ function create_fragment(ctx) {
 		},
 
 		m(target, anchor) {
-			for (i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].m(target, anchor);
 			}
 
@@ -94,7 +94,7 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d(detaching) {
-			for (i = 0; i < each_blocks.length; i += 1) {
+			for (let i = 0; i < each_blocks.length; i += 1) {
 				each_blocks[i].d(detaching);
 			}
 


### PR DESCRIPTION
While looking at the generated code of `each` blocks, I noticed that there were some wild inconsistencies:

* some blocks had proper braces and indentations, others didn’t
* some loops used `var`, others used `let`
* some loops were missing either, which was super confusing

To clean this up, I:
* changed all (expect one) case to use braces and indentations
* changed all loops to use `let`
* I added a comment explaining whats going on for the one case where a loop was relying on a *previous* value.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
