### PR TITLE
fix: if/else case with no dependencies

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/IfBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/IfBlock.ts
@@ -243,7 +243,7 @@ export default class IfBlockWrapper extends Wrapper {
 			function ${select_block_type}(changed, ctx) {
 				${this.branches.map(({ dependencies, condition, snippet, block }) => condition
 				? deindent`
-				${snippet && `if ((${condition} == null) || ${dependencies.map(n => `changed.${n}`).join(' || ')}) ${condition} = !!(${snippet})`}
+				${snippet && `if ((${condition} == null) || ${dependencies.length > 0 ? dependencies.map(n => `changed.${n}`).join(' || ') : false}) ${condition} = !!(${snippet})`}
 				if (${condition}) return ${block.name};`
 				: `return ${block.name};`)}
 			}


### PR DESCRIPTION
Related to : #3505

Adds an additional check to #3478 to deal with this case :

```javascript
{#if "Eva".startsWith('E')}
eee
{:else}
rrr
{/if}
```
that generate this code :

```javascript
if ((show_if == null) || ) show_if = !!("Eva".startsWith('E') == true)
```

This fix now generate the following when there are no dependencies :

```javascript
if ((show_if == null) || false) show_if = !!("Eva".startsWith('E') == true)
```