### PR TITLE
fix reactive declaration cycle detection + clearer error on cycle

### DIFF
--- a/src/compiler/compile/utils/checkGraphForCycles.ts
+++ b/src/compiler/compile/utils/checkGraphForCycles.ts
@@ -1,0 +1,36 @@
+export default function checkGraphForCycles(edges: Array<[any, any]>): any[] {
+	const graph: Map<any, any[]> = edges.reduce((g, edge) => {
+		const [u, v] = edge;
+		if (!g.has(u)) g.set(u, []);
+		if (!g.has(v)) g.set(v, []);
+		g.get(u).push(v);
+		return g;
+	}, new Map());
+
+	const visited = new Set();
+	const onStack = new Set();
+	const cycles = [];
+
+	function visit (v) {
+		visited.add(v);
+		onStack.add(v);
+
+		graph.get(v).forEach(w => {
+			if (!visited.has(w)) {
+				visit(w);
+			} else if (onStack.has(w)) {
+				cycles.push([...onStack, w]);
+			}
+		});
+
+		onStack.delete(v);
+	}
+
+	graph.forEach((_, v) => {
+		if (!visited.has(v)) {
+			visit(v);
+		}
+	});
+
+	return cycles[0];
+}

--- a/test/runtime/samples/reactive-values-non-cyclical-declaration-order-independent/_config.js
+++ b/test/runtime/samples/reactive-values-non-cyclical-declaration-order-independent/_config.js
@@ -1,0 +1,11 @@
+export default {
+	html: `
+		<p>2+2=4</p>
+	`,
+
+	test({ assert, target }) {
+		assert.htmlEqual(target.innerHTML, `
+			<p>2+2=4</p>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-values-non-cyclical-declaration-order-independent/main.svelte
+++ b/test/runtime/samples/reactive-values-non-cyclical-declaration-order-independent/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	$: c = a + b;
+	$: a = 2;
+	$: b = a;
+</script>
+
+<p>{a}+{b}={c}</p>

--- a/test/validator/samples/reactive-declaration-cyclical/errors.json
+++ b/test/validator/samples/reactive-declaration-cyclical/errors.json
@@ -1,5 +1,5 @@
 [{
-	"message": "Cyclical dependency detected",
+	"message": "Cyclical dependency detected: a → b → a",
 	"code": "cyclical-reactive-declaration",
 	"start": { "line": 5, "column": 1, "character": 35 },
 	"end": { "line": 5, "column": 14, "character": 48 },


### PR DESCRIPTION
- fixes #3459
- uses DFS traversal to inspect reactive declarations for cycles
- returns the cycle detected (e.g.; `a → b → a`) for error messaging
