### PR TITLE
inline $$invalidate calls

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -813,7 +813,7 @@ export default class Component {
 		const variable = this.var_lookup.get(name);
 
 		if (variable && (variable.subscribable && variable.reassigned)) {
-			return `$$subscribe_${name}(), $$invalidate('${name}', ${value || name})`;
+			return `$$subscribe_${name}($$invalidate('${name}', ${value || name}))`;
 		}
 
 		if (name[0] === '$' && name[1] !== '$') {

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -399,7 +399,7 @@ export default class Expression {
 						}
 					});
 
-					invalidate(component, scope, code, node, Array.from(traced));
+					invalidate(component, scope, code, node, traced);
 				}
 			}
 		});

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -322,15 +322,11 @@ export default class Expression {
 						args.push(original_params);
 					}
 
-					// TODO is this still necessary?
-					let body = code.slice(node.body.start, node.body.end).trim();
-					if (node.body.type !== 'BlockStatement') {
-						body = `{\n\treturn ${body};\n}`;
-					}
+					const body = code.slice(node.body.start, node.body.end).trim();
 
-					const fn = deindent`
-						${node.async && 'async '}function${node.generator && '*'} ${name}(${args.join(', ')}) ${body}
-					`;
+					const fn = node.type === 'FunctionExpression'
+						? `${node.async ? 'async ' : ''}function${node.generator ? '*' : ''} ${name}(${args.join(', ')}) ${body}`
+						: `const ${name} = ${node.async ? 'async ' : ''}(${args.join(', ')}) => ${body};`;
 
 					if (dependencies.size === 0 && contextual_dependencies.size === 0) {
 						// we can hoist this out of the component completely

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -7,10 +7,8 @@ import { Node } from '../../../interfaces';
 import { globals , sanitize } from '../../../utils/names';
 import deindent from '../../utils/deindent';
 import Wrapper from '../../render_dom/wrappers/shared/Wrapper';
-
 import TemplateScope from './TemplateScope';
 import get_object from '../../utils/get_object';
-// import { nodes_match } from '../../../utils/nodes_match';
 import Block from '../../render_dom/Block';
 import { INode } from '../interfaces';
 import is_dynamic from '../../render_dom/wrappers/shared/is_dynamic';
@@ -394,9 +392,7 @@ export default class Expression {
 					// (a or b). In destructuring cases (`[d, e] = [e, d]`) there
 					// may be more, in which case we need to tack the extra ones
 					// onto the initial function call
-					const names = new Set(assignee.type === 'MemberExpression'
-						? [get_object(assignee).name]
-						: extract_names(assignee));
+					const names = new Set(extract_names(assignee));
 
 					const traced: Set<string> = new Set();
 					names.forEach(name => {

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -7,8 +7,6 @@ import { CompileOptions } from '../../interfaces';
 import { walk } from 'estree-walker';
 import { stringify_props } from '../utils/stringify_props';
 import add_to_set from '../utils/add_to_set';
-import get_object from '../utils/get_object';
-// import { extract_names } from '../utils/scope';
 import { nodes_match } from '../../utils/nodes_match';
 import { extract_names } from '../utils/scope';
 
@@ -179,9 +177,7 @@ export default function dom(
 					// (a or b). In destructuring cases (`[d, e] = [e, d]`) there
 					// may be more, in which case we need to tack the extra ones
 					// onto the initial function call
-					const names = new Set(assignee.type === 'MemberExpression'
-						? [get_object(assignee).name]
-						: extract_names(assignee));
+					const names = new Set(extract_names(assignee));
 
 					const [head, ...tail] = Array.from(names).filter(name => {
 						const owner = scope.find_owner(name);

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -179,7 +179,7 @@ export default function dom(
 					// onto the initial function call
 					const names = new Set(extract_names(assignee));
 
-					invalidate(component, scope, code, node, Array.from(names));
+					invalidate(component, scope, code, node, names);
 				}
 			}
 		});

--- a/src/compiler/compile/utils/invalidate.ts
+++ b/src/compiler/compile/utils/invalidate.ts
@@ -4,7 +4,7 @@ import { Node } from '../../interfaces';
 import { nodes_match } from '../../utils/nodes_match';
 import { Scope } from './scope';
 
-export function invalidate(component: Component, scope: Scope, code: MagicString, node: Node, names: string[]) {
+export function invalidate(component: Component, scope: Scope, code: MagicString, node: Node, names: Set<string>) {
 	const [head, ...tail] = Array.from(names).filter(name => {
 		const owner = scope.find_owner(name);
 		if (owner && owner !== component.instance_scope) return false;

--- a/src/compiler/compile/utils/invalidate.ts
+++ b/src/compiler/compile/utils/invalidate.ts
@@ -1,0 +1,65 @@
+import Component from '../Component';
+import MagicString from 'magic-string';
+import { Node } from '../../interfaces';
+import { nodes_match } from '../../utils/nodes_match';
+import { Scope } from './scope';
+
+export function invalidate(component: Component, scope: Scope, code: MagicString, node: Node, names: string[]) {
+	const [head, ...tail] = Array.from(names).filter(name => {
+		const owner = scope.find_owner(name);
+		if (owner && owner !== component.instance_scope) return false;
+
+		const variable = component.var_lookup.get(name);
+
+		return variable && (
+			!variable.hoistable &&
+			!variable.global &&
+			!variable.module &&
+			(
+				variable.referenced ||
+				variable.is_reactive_dependency ||
+				variable.export_name
+			)
+		);
+	});
+
+	if (head) {
+		component.has_reactive_assignments = true;
+
+		if (node.operator === '=' && nodes_match(node.left, node.right) && tail.length === 0) {
+			code.overwrite(node.start, node.end, component.invalidate(head));
+		} else {
+			let suffix = ')';
+
+			if (head[0] === '$') {
+				code.prependRight(node.start, `${component.helper('set_store_value')}(${head.slice(1)}, `);
+			} else {
+				let prefix = `$$invalidate`;
+
+				const variable = component.var_lookup.get(head);
+				if (variable.subscribable && variable.reassigned) {
+					prefix = `$$subscribe_${head}($$invalidate`;
+					suffix += `)`;
+				}
+
+				code.prependRight(node.start, `${prefix}('${head}', `);
+			}
+
+			const extra_args = tail.map(name => component.invalidate(name));
+
+			const pass_value = (
+				extra_args.length > 0 ||
+				(node.type === 'AssignmentExpression' && node.left.type !== 'Identifier') ||
+				(node.type === 'UpdateExpression' && !node.prefix)
+			);
+
+			if (pass_value) {
+				extra_args.unshift(head);
+			}
+
+			suffix = `${extra_args.map(arg => `, ${arg}`).join('')}${suffix}`;
+
+			code.appendLeft(node.end, suffix);
+		}
+	}
+}

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -101,11 +101,12 @@ export function init(component, options, instance, create_fragment, not_equal, p
 	let ready = false;
 
 	$$.ctx = instance
-		? instance(component, props, (key, value) => {
+		? instance(component, props, (key, ret, value = ret) => {
 			if ($$.ctx && not_equal($$.ctx[key], $$.ctx[key] = value)) {
 				if ($$.bound[key]) $$.bound[key](value);
 				if (ready) make_dirty(component, key);
 			}
+			return ret;
 		})
 		: props;
 

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -100,3 +100,8 @@ export function once(fn) {
 export function null_to_empty(value) {
 	return value == null ? '' : value;
 }
+
+export function set_store_value(store, ret, value = ret) {
+	store.set(value);
+	return ret;
+}

--- a/test/js/samples/action-custom-event-handler/expected.js
+++ b/test/js/samples/action-custom-event-handler/expected.js
@@ -53,9 +53,7 @@ function foo(node, callback) {
 function instance($$self, $$props, $$invalidate) {
 	let { bar } = $$props;
 
-	function foo_function() {
-		return handleFoo(bar);
-	}
+	const foo_function = () => handleFoo(bar);
 
 	$$self.$set = $$props => {
 		if ('bar' in $$props) $$invalidate('bar', bar = $$props.bar);

--- a/test/js/samples/dynamic-import/expected.js
+++ b/test/js/samples/dynamic-import/expected.js
@@ -46,9 +46,7 @@ function create_fragment(ctx) {
 	};
 }
 
-function func() {
-	return import('./Foo.svelte');
-}
+const func = () => import('./Foo.svelte');
 
 class Component extends SvelteComponent {
 	constructor(options) {

--- a/test/js/samples/event-handler-no-passive/expected.js
+++ b/test/js/samples/event-handler-no-passive/expected.js
@@ -40,9 +40,7 @@ function create_fragment(ctx) {
 	};
 }
 
-function touchstart_handler(e) {
-	return e.preventDefault();
-}
+const touchstart_handler = (e) => e.preventDefault();
 
 class Component extends SvelteComponent {
 	constructor(options) {

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -61,7 +61,7 @@ function instance($$self, $$props, $$invalidate) {
 	let x = 0;
 
 	function click_handler() {
-		if (true) { x += 1; $$invalidate('x', x); }
+		if (true) $$invalidate('x', x += 1);
 	}
 
 	return { x, click_handler };

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -60,9 +60,9 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let x = 0;
 
-	function click_handler() {
+	const click_handler = () => {
 		if (true) $$invalidate('x', x += 1);
-	}
+	};
 
 	return { x, click_handler };
 }

--- a/test/js/samples/instrumentation-template-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-template-x-equals-x/expected.js
@@ -60,7 +60,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let things = [];
 
-	function click_handler() { things.push(1); $$invalidate('things', things) }
+	const click_handler = () => { things.push(1); $$invalidate('things', things) };
 
 	return { things, click_handler };
 }

--- a/test/runtime/samples/invalidation-in-if-condition/_config.js
+++ b/test/runtime/samples/invalidation-in-if-condition/_config.js
@@ -1,0 +1,18 @@
+export default {
+	show: 1,
+	html: `<button>false 0</button>`,
+
+	async test({ assert, target, window }) {
+		const button = target.querySelector('button');
+		const click = new window.MouseEvent('click');
+
+		await button.dispatchEvent(click);
+		assert.htmlEqual(target.innerHTML, `<button>true 1</button>`);
+
+		await button.dispatchEvent(click);
+		assert.htmlEqual(target.innerHTML, `<button>false 1</button>`);
+
+		await button.dispatchEvent(click);
+		assert.htmlEqual(target.innerHTML, `<button>true 2</button>`);
+	}
+};

--- a/test/runtime/samples/invalidation-in-if-condition/main.svelte
+++ b/test/runtime/samples/invalidation-in-if-condition/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let current = { active: false };
+	let count = 0;
+
+	function toggle() {
+		if (current.active = !current.active) {
+			count += 1;
+		}
+	}
+</script>
+
+<button on:click={toggle}>{current.active} {count}</button>

--- a/test/runtime/samples/store-resubscribe/_config.js
+++ b/test/runtime/samples/store-resubscribe/_config.js
@@ -5,7 +5,7 @@ export default {
 		<button>reset</button>
 	`,
 
-	async test({ assert, component, target, window }) {
+	async test({ assert, target, window }) {
 		const buttons = target.querySelectorAll('button');
 		const click = new window.MouseEvent('click');
 


### PR DESCRIPTION
fixes #3512. This is an alternative to #3532 — it's definitely not as elegant, as PRs go, but it means we can eliminate a decent chunk of code, and should handle some funky edge cases around destructuring assignments.

Still a bit of tidying up to do — it should be possible to remove some more lines of code, as there's currently some duplication between `Expression.ts` and `render_dom/index.ts`.