### PR TITLE
Fix store bindings in each blocks

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -10,7 +10,7 @@ export interface BlockOptions {
 	renderer?: Renderer;
 	comment?: string;
 	key?: string;
-	bindings?: Map<string, { object: string; property: string; snippet: string }>;
+	bindings?: Map<string, { object: string; property: string; snippet: string; store: string; tail: string }>;
 	dependencies?: Set<string>;
 }
 
@@ -27,7 +27,7 @@ export default class Block {
 
 	dependencies: Set<string>;
 
-	bindings: Map<string, { object: string; property: string; snippet: string }>;
+	bindings: Map<string, { object: string; property: string; snippet: string; store: string; tail: string }>;
 
 	builders: {
 		init: CodeBuilder;

--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -121,7 +121,11 @@ export default class EachBlockWrapper extends Wrapper {
 			view_length: fixed_length === null ? `${iterations}.[✂${c}-${c+4}✂]` : fixed_length
 		};
 
-		const store = node.expression.node.name[0] === '$' ? node.expression.node.name.slice(1) : null;
+		const store = 
+			node.expression.node.type === 'Identifier' && 
+			node.expression.node.name[0] === '$'
+				? node.expression.node.name.slice(1)
+				: null;
 
 		node.contexts.forEach(prop => {
 			this.block.bindings.set(prop.key.name, {

--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -121,11 +121,15 @@ export default class EachBlockWrapper extends Wrapper {
 			view_length: fixed_length === null ? `${iterations}.[✂${c}-${c+4}✂]` : fixed_length
 		};
 
+		const store = node.expression.node.name[0] === '$' ? node.expression.node.name.slice(1) : null;
+
 		node.contexts.forEach(prop => {
 			this.block.bindings.set(prop.key.name, {
 				object: this.vars.each_block_value,
 				property: this.index_name,
-				snippet: attach_head(`${this.vars.each_block_value}[${this.index_name}]`, prop.tail)
+				snippet: attach_head(`${this.vars.each_block_value}[${this.index_name}]`, prop.tail),
+				store,
+				tail: attach_head(`[${this.index_name}]`, prop.tail)
 			});
 		});
 

--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -262,7 +262,7 @@ function get_event_handler(
 		const { object, property, snippet } = binding;
 
 		if (binding.store) {
-			store = store || binding.store;
+			store = binding.store;
 			tail = `${binding.tail}${tail}`;
 		}
 

--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -249,7 +249,7 @@ function get_event_handler(
 		snippet?: string;
 	} {
 	const value = get_value_from_dom(renderer, binding.parent, binding);
-	const store = binding.object[0] === '$' ? binding.object.slice(1) : null;
+	let store = binding.object[0] === '$' ? binding.object.slice(1) : null;
 
 	let tail = '';
 	if (binding.node.expression.node.type === 'MemberExpression') {
@@ -258,7 +258,13 @@ function get_event_handler(
 	}
 
 	if (binding.node.is_contextual) {
-		const { object, property, snippet } = block.bindings.get(name);
+		const binding = block.bindings.get(name);
+		const { object, property, snippet } = binding;
+
+		if (binding.store) {
+			store = store || binding.store;
+			tail = `${binding.tail}${tail}`;
+		}
 
 		return {
 			uses_context: true,

--- a/test/runtime/samples/store-each-binding-destructuring/_config.js
+++ b/test/runtime/samples/store-each-binding-destructuring/_config.js
@@ -1,0 +1,14 @@
+export default {
+	async test({ assert, target, window }) {
+		const input = target.querySelector('input');
+
+		const event = new window.Event('input');
+		input.value = 'changed';
+		await input.dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<input>
+			<p>changed</p>
+		`);
+	}
+};

--- a/test/runtime/samples/store-each-binding-destructuring/main.svelte
+++ b/test/runtime/samples/store-each-binding-destructuring/main.svelte
@@ -6,7 +6,7 @@
 	]);
 </script>
 
-{#each $items as { text }, index}
+{#each $items as { text }}
 	<input bind:value={text}>
 {/each}
 

--- a/test/runtime/samples/store-each-binding-destructuring/main.svelte
+++ b/test/runtime/samples/store-each-binding-destructuring/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	const items = writable([
+		 { id: 0, text: 'inital' }
+	]);
+</script>
+
+{#each $items as { text }, index}
+	<input bind:value={text}>
+{/each}
+
+<p>{$items[0].text}</p>

--- a/test/runtime/samples/store-each-binding-destructuring/main.svelte
+++ b/test/runtime/samples/store-each-binding-destructuring/main.svelte
@@ -2,7 +2,7 @@
 	import { writable } from 'svelte/store';
 
 	const items = writable([
-		 { id: 0, text: 'inital' }
+		 { id: 0, text: 'initial' }
 	]);
 </script>
 

--- a/test/runtime/samples/store-each-binding/_config.js
+++ b/test/runtime/samples/store-each-binding/_config.js
@@ -1,0 +1,14 @@
+export default {
+	async test({ assert, target, window }) {
+		const input = target.querySelector('input');
+
+		const event = new window.Event('input');
+		input.value = 'changed';
+		await input.dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<input>
+			<p>changed</p>
+		`);
+	}
+};

--- a/test/runtime/samples/store-each-binding/main.svelte
+++ b/test/runtime/samples/store-each-binding/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	const items = writable([
+		 { id: 0, text: 'inital' }
+	]);
+</script>
+
+{#each $items as item, index}
+	<input bind:value={item.text}>
+{/each}
+
+<p>{$items[0].text}</p>

--- a/test/runtime/samples/store-each-binding/main.svelte
+++ b/test/runtime/samples/store-each-binding/main.svelte
@@ -6,7 +6,7 @@
 	]);
 </script>
 
-{#each $items as item, index}
+{#each $items as item}
 	<input bind:value={item.text}>
 {/each}
 

--- a/test/runtime/samples/store-each-binding/main.svelte
+++ b/test/runtime/samples/store-each-binding/main.svelte
@@ -2,7 +2,7 @@
 	import { writable } from 'svelte/store';
 
 	const items = writable([
-		 { id: 0, text: 'inital' }
+		 { id: 0, text: 'initial' }
 	]);
 </script>
 


### PR DESCRIPTION
Fixes #3455. Preserves some additional info from the each block binding in order to generate a store mutation instead of a normal assignment expression.
