### PR TITLE
Factor out each-block code into helper functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -422,7 +422,7 @@ export default class Block {
 
 		return deindent`
 			${this.comment && `// ${escape(this.comment, { only_escape_at_symbol: true })}`}
-			function ${this.name}(${this.key ? `${local_key}, ` : ''}ctx) {
+			function ${this.name}(ctx${this.key ? `, ${local_key}` : ''}) {
 				${this.get_contents(local_key)}
 			}
 		`;

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -10,12 +10,6 @@ export function detach(node: Node) {
 	node.parentNode.removeChild(node);
 }
 
-export function destroy_each(iterations, detaching) {
-	for (let i = 0; i < iterations.length; i += 1) {
-		if (iterations[i]) iterations[i].d(detaching);
-	}
-}
-
 export function element<K extends keyof HTMLElementTagNameMap>(name: K) {
 	return document.createElement<K>(name);
 }

--- a/src/runtime/internal/each_block.ts
+++ b/src/runtime/internal/each_block.ts
@@ -1,0 +1,126 @@
+interface Fragment {
+	key: string;
+
+	/** create */
+	c: () => void;
+
+	/** claim */
+	l?: (nodes: Array<Node>) => void;
+
+	/** hydrate */
+	h?: () => void;
+
+	/** mount */
+	m: (target: Node, anchor?: Node | null) => void;
+
+	/** update */
+	p?: (changed: unknown, context: unknown) => void;
+
+	/** intro */
+	i?: () => void;
+
+	/** outro */
+	o?: () => void;
+
+	/** destroy */
+	d: (detaching: boolean) => void;
+}
+
+export interface EachBlock {
+	/** each_blocks */
+	b: Array<Fragment>;
+	/** each_lookup */
+	l: Map<unknown, Fragment>;
+	/** else_block */
+	e: Fragment | null;
+
+	/** get_each_context */
+	gc: (context: unknown, each_value: unknown, i: number) => unknown;
+	/** get_each_value */
+	gv: (context: unknown) => Array<unknown>;
+	/** get_key */
+	gk?: (child_context: unknown) => string;
+	/** create_each_block */
+	cb: (context: unknown, key?: unknown) => Fragment;
+	/** create_else_block */
+	ce?: (context: unknown) => Fragment;
+}
+
+export function init_each_block(
+	context: unknown,
+	get_each_context: EachBlock['gc'],
+	get_each_value: EachBlock['gv'],
+	get_key: EachBlock['gk'],
+	create_each_block: EachBlock['cb'],
+	create_else_block: EachBlock['ce']
+): EachBlock {
+	const each_value = get_each_value(context);
+	const each_blocks = [];
+	const each_lookup = new Map();
+
+	for (let i = 0; i < each_value.length; i += 1) {
+		let child_ctx = get_each_context(context, each_value, i);
+		let key = get_key && get_key(child_ctx);
+		each_lookup.set(key, (each_blocks[i] = create_each_block(child_ctx, key)));
+	}
+
+	let else_block = null;
+	if (create_else_block && !each_value.length) {
+		else_block = create_else_block(context);
+		// TODO: Why exactly is this here and not in the `create` hook?
+		else_block.c();
+	}
+
+	return {
+		b: each_blocks,
+		l: each_lookup,
+		e: else_block,
+		gc: get_each_context,
+		gv: get_each_value,
+		gk: get_key,
+		cb: create_each_block,
+		ce: create_else_block,
+	};
+}
+
+export function create_each_blocks(each_block: EachBlock) {
+	for (const block of each_block.b) {
+		block.c();
+	}
+}
+
+export function claim_each_blocks(each_blocks: EachBlock, nodes: Array<Node>) {
+	for (const block of each_blocks.b) {
+		if (block.l) {
+			block.l(nodes);
+		}
+	}
+}
+
+export function mount_each_blocks(
+	each_blocks: EachBlock,
+	target: Node,
+	anchor?: Node | null
+) {
+	for (const block of each_blocks.b) {
+		block.m(target, anchor);
+	}
+	if (each_blocks.e) {
+		each_blocks.e.m(target, anchor);
+	}
+}
+
+export function destroy_each_blocks(
+	each_blocks: EachBlock,
+	detaching: boolean
+) {
+	for (const block of each_blocks.b) {
+		if (block) {
+			block.d(detaching);
+		}
+	}
+
+	if (each_blocks.e) {
+		each_blocks.e.d(detaching);
+	}
+}

--- a/src/runtime/internal/index.ts
+++ b/src/runtime/internal/index.ts
@@ -13,3 +13,4 @@ export * from './transitions';
 export * from './utils';
 export * from './Component';
 export * from './dev';
+export * from './each_block';

--- a/src/runtime/internal/keyed_each.ts
+++ b/src/runtime/internal/keyed_each.ts
@@ -1,3 +1,4 @@
+import { EachBlock } from './each_block';
 import { transition_in, transition_out } from './transitions';
 
 export function destroy_block(block, lookup) {
@@ -21,7 +22,15 @@ export function fix_and_outro_and_destroy_block(block, lookup) {
 	outro_and_destroy_block(block, lookup);
 }
 
-export function update_keyed_each(old_blocks, changed, get_key, dynamic, ctx, list, lookup, node, destroy, create_each_block, next, get_context) {
+export function update_keyed_each(each_block: EachBlock, changed, dynamic, ctx, node, destroy, next) {
+	const {
+		b: old_blocks,
+		l: lookup,
+		cb: create_each_block,
+		gk: get_key,
+		gc: get_context,
+	} = each_block;
+	const list = each_block.gv(ctx);
 	let o = old_blocks.length;
 	let n = list.length;
 
@@ -40,7 +49,7 @@ export function update_keyed_each(old_blocks, changed, get_key, dynamic, ctx, li
 		let block = lookup.get(key);
 
 		if (!block) {
-			block = create_each_block(key, child_ctx);
+			block = create_each_block(child_ctx, key);
 			block.c();
 		} else if (dynamic) {
 			block.p(changed, child_ctx);
@@ -105,7 +114,7 @@ export function update_keyed_each(old_blocks, changed, get_key, dynamic, ctx, li
 
 	while (n) insert(new_blocks[n - 1]);
 
-	return new_blocks;
+	each_block.b = new_blocks;
 }
 
 export function measure(blocks) {

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -3,12 +3,15 @@ import {
 	SvelteComponentDev,
 	add_location,
 	append_dev,
-	destroy_each,
+	create_each_blocks,
+	destroy_each_blocks,
 	detach_dev,
 	dispatch_dev,
 	element,
 	init,
+	init_each_block,
 	insert_dev,
+	mount_each_blocks,
 	noop,
 	safe_not_equal,
 	set_data_dev,
@@ -76,17 +79,18 @@ function create_fragment(ctx) {
 
 	let each_value = ctx.things;
 
-	let each_blocks = [];
-
-	for (let i = 0; i < each_value.length; i += 1) {
-		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
-	}
+	let each_blocks = init_each_block(
+		ctx,
+		get_each_context,
+		ctx => ctx.things,
+		null,
+		create_each_block,
+		null
+	);
 
 	const block = {
 		c: function create() {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].c();
-			}
+			create_each_blocks(each_blocks);
 
 			t0 = space();
 			p = element("p");
@@ -100,9 +104,7 @@ function create_fragment(ctx) {
 		},
 
 		m: function mount(target, anchor) {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
-			}
+			mount_each_blocks(each_blocks, target, anchor);
 
 			insert_dev(target, t0, anchor);
 			insert_dev(target, p, anchor);
@@ -118,19 +120,19 @@ function create_fragment(ctx) {
 				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
-					if (each_blocks[i]) {
-						each_blocks[i].p(changed, child_ctx);
+					if (each_blocks.b[i]) {
+						each_blocks.b[i].p(changed, child_ctx);
 					} else {
-						each_blocks[i] = create_each_block(child_ctx);
-						each_blocks[i].c();
-						each_blocks[i].m(t0.parentNode, t0);
+						each_blocks.b[i] = create_each_block(child_ctx);
+						each_blocks.b[i].c();
+						each_blocks.b[i].m(t0.parentNode, t0);
 					}
 				}
 
-				for (; i < each_blocks.length; i += 1) {
-					each_blocks[i].d(1);
+				for (; i < each_blocks.b.length; i += 1) {
+					each_blocks.b[i].d(1);
 				}
-				each_blocks.length = each_value.length;
+				each_blocks.b.length = each_value.length;
 			}
 
 			if (changed.foo) {
@@ -142,7 +144,7 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d: function destroy(detaching) {
-			destroy_each(each_blocks, detaching);
+			destroy_each_blocks(each_blocks, detaching);
 
 			if (detaching) {
 				detach_dev(t0);

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -3,12 +3,15 @@ import {
 	SvelteComponentDev,
 	add_location,
 	append_dev,
-	destroy_each,
+	create_each_blocks,
+	destroy_each_blocks,
 	detach_dev,
 	dispatch_dev,
 	element,
 	init,
+	init_each_block,
 	insert_dev,
+	mount_each_blocks,
 	noop,
 	safe_not_equal,
 	set_data_dev,
@@ -76,17 +79,18 @@ function create_fragment(ctx) {
 
 	let each_value = ctx.things;
 
-	let each_blocks = [];
-
-	for (let i = 0; i < each_value.length; i += 1) {
-		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
-	}
+	let each_blocks = init_each_block(
+		ctx,
+		get_each_context,
+		ctx => ctx.things,
+		null,
+		create_each_block,
+		null
+	);
 
 	const block = {
 		c: function create() {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].c();
-			}
+			create_each_blocks(each_blocks);
 
 			t0 = space();
 			p = element("p");
@@ -100,9 +104,7 @@ function create_fragment(ctx) {
 		},
 
 		m: function mount(target, anchor) {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
-			}
+			mount_each_blocks(each_blocks, target, anchor);
 
 			insert_dev(target, t0, anchor);
 			insert_dev(target, p, anchor);
@@ -118,19 +120,19 @@ function create_fragment(ctx) {
 				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
-					if (each_blocks[i]) {
-						each_blocks[i].p(changed, child_ctx);
+					if (each_blocks.b[i]) {
+						each_blocks.b[i].p(changed, child_ctx);
 					} else {
-						each_blocks[i] = create_each_block(child_ctx);
-						each_blocks[i].c();
-						each_blocks[i].m(t0.parentNode, t0);
+						each_blocks.b[i] = create_each_block(child_ctx);
+						each_blocks.b[i].c();
+						each_blocks.b[i].m(t0.parentNode, t0);
 					}
 				}
 
-				for (; i < each_blocks.length; i += 1) {
-					each_blocks[i].d(1);
+				for (; i < each_blocks.b.length; i += 1) {
+					each_blocks.b[i].d(1);
 				}
-				each_blocks.length = each_value.length;
+				each_blocks.b.length = each_value.length;
 			}
 
 			if (changed.foo) {
@@ -142,7 +144,7 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d: function destroy(detaching) {
-			destroy_each(each_blocks, detaching);
+			destroy_each_blocks(each_blocks, detaching);
 
 			if (detaching) {
 				detach_dev(t0);

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -2,12 +2,15 @@
 import {
 	SvelteComponent,
 	append,
-	destroy_each,
+	create_each_blocks,
+	destroy_each_blocks,
 	detach,
 	element,
 	empty,
 	init,
+	init_each_block,
 	insert,
+	mount_each_blocks,
 	noop,
 	safe_not_equal,
 	set_data,
@@ -54,25 +57,24 @@ function create_fragment(ctx) {
 
 	let each_value = ctx.createElement;
 
-	let each_blocks = [];
-
-	for (let i = 0; i < each_value.length; i += 1) {
-		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
-	}
+	let each_blocks = init_each_block(
+		ctx,
+		get_each_context,
+		ctx => ctx.createElement,
+		null,
+		create_each_block,
+		null
+	);
 
 	return {
 		c() {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].c();
-			}
+			create_each_blocks(each_blocks);
 
 			each_1_anchor = empty();
 		},
 
 		m(target, anchor) {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
-			}
+			mount_each_blocks(each_blocks, target, anchor);
 
 			insert(target, each_1_anchor, anchor);
 		},
@@ -85,19 +87,19 @@ function create_fragment(ctx) {
 				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
-					if (each_blocks[i]) {
-						each_blocks[i].p(changed, child_ctx);
+					if (each_blocks.b[i]) {
+						each_blocks.b[i].p(changed, child_ctx);
 					} else {
-						each_blocks[i] = create_each_block(child_ctx);
-						each_blocks[i].c();
-						each_blocks[i].m(each_1_anchor.parentNode, each_1_anchor);
+						each_blocks.b[i] = create_each_block(child_ctx);
+						each_blocks.b[i].c();
+						each_blocks.b[i].m(each_1_anchor.parentNode, each_1_anchor);
 					}
 				}
 
-				for (; i < each_blocks.length; i += 1) {
-					each_blocks[i].d(1);
+				for (; i < each_blocks.b.length; i += 1) {
+					each_blocks.b[i].d(1);
 				}
-				each_blocks.length = each_value.length;
+				each_blocks.b.length = each_value.length;
 			}
 		},
 
@@ -105,7 +107,7 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d(detaching) {
-			destroy_each(each_blocks, detaching);
+			destroy_each_blocks(each_blocks, detaching);
 
 			if (detaching) {
 				detach(each_1_anchor);

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -2,12 +2,15 @@
 import {
 	SvelteComponent,
 	append,
-	destroy_each,
+	create_each_blocks,
+	destroy_each_blocks,
 	detach,
 	element,
 	empty,
 	init,
+	init_each_block,
 	insert,
+	mount_each_blocks,
 	noop,
 	safe_not_equal,
 	set_data,
@@ -54,25 +57,24 @@ function create_fragment(ctx) {
 
 	let each_value = [ctx.a, ctx.b, ctx.c, ctx.d, ctx.e];
 
-	let each_blocks = [];
-
-	for (let i = 0; i < 5; i += 1) {
-		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
-	}
+	let each_blocks = init_each_block(
+		ctx,
+		get_each_context,
+		ctx => [ctx.a, ctx.b, ctx.c, ctx.d, ctx.e],
+		null,
+		create_each_block,
+		null
+	);
 
 	return {
 		c() {
-			for (let i = 0; i < 5; i += 1) {
-				each_blocks[i].c();
-			}
+			create_each_blocks(each_blocks);
 
 			each_1_anchor = empty();
 		},
 
 		m(target, anchor) {
-			for (let i = 0; i < 5; i += 1) {
-				each_blocks[i].m(target, anchor);
-			}
+			mount_each_blocks(each_blocks, target, anchor);
 
 			insert(target, each_1_anchor, anchor);
 		},
@@ -85,17 +87,17 @@ function create_fragment(ctx) {
 				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
-					if (each_blocks[i]) {
-						each_blocks[i].p(changed, child_ctx);
+					if (each_blocks.b[i]) {
+						each_blocks.b[i].p(changed, child_ctx);
 					} else {
-						each_blocks[i] = create_each_block(child_ctx);
-						each_blocks[i].c();
-						each_blocks[i].m(each_1_anchor.parentNode, each_1_anchor);
+						each_blocks.b[i] = create_each_block(child_ctx);
+						each_blocks.b[i].c();
+						each_blocks.b[i].m(each_1_anchor.parentNode, each_1_anchor);
 					}
 				}
 
 				for (; i < 5; i += 1) {
-					each_blocks[i].d(1);
+					each_blocks.b[i].d(1);
 				}
 			}
 		},
@@ -104,7 +106,7 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d(detaching) {
-			destroy_each(each_blocks, detaching);
+			destroy_each_blocks(each_blocks, detaching);
 
 			if (detaching) {
 				detach(each_1_anchor);

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -4,11 +4,14 @@ import {
 	SvelteComponent,
 	append,
 	attr,
-	destroy_each,
+	create_each_blocks,
+	destroy_each_blocks,
 	detach,
 	element,
 	init,
+	init_each_block,
 	insert,
+	mount_each_blocks,
 	noop,
 	safe_not_equal,
 	set_data,
@@ -85,17 +88,18 @@ function create_fragment(ctx) {
 
 	let each_value = ctx.comments;
 
-	let each_blocks = [];
-
-	for (let i = 0; i < each_value.length; i += 1) {
-		each_blocks[i] = create_each_block(get_each_context(ctx, each_value, i));
-	}
+	let each_blocks = init_each_block(
+		ctx,
+		get_each_context,
+		ctx => ctx.comments,
+		null,
+		create_each_block,
+		null
+	);
 
 	return {
 		c() {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].c();
-			}
+			create_each_blocks(each_blocks);
 
 			t0 = space();
 			p = element("p");
@@ -103,9 +107,7 @@ function create_fragment(ctx) {
 		},
 
 		m(target, anchor) {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
-			}
+			mount_each_blocks(each_blocks, target, anchor);
 
 			insert(target, t0, anchor);
 			insert(target, p, anchor);
@@ -120,19 +122,19 @@ function create_fragment(ctx) {
 				for (i = 0; i < each_value.length; i += 1) {
 					const child_ctx = get_each_context(ctx, each_value, i);
 
-					if (each_blocks[i]) {
-						each_blocks[i].p(changed, child_ctx);
+					if (each_blocks.b[i]) {
+						each_blocks.b[i].p(changed, child_ctx);
 					} else {
-						each_blocks[i] = create_each_block(child_ctx);
-						each_blocks[i].c();
-						each_blocks[i].m(t0.parentNode, t0);
+						each_blocks.b[i] = create_each_block(child_ctx);
+						each_blocks.b[i].c();
+						each_blocks.b[i].m(t0.parentNode, t0);
 					}
 				}
 
-				for (; i < each_blocks.length; i += 1) {
-					each_blocks[i].d(1);
+				for (; i < each_blocks.b.length; i += 1) {
+					each_blocks.b[i].d(1);
 				}
-				each_blocks.length = each_value.length;
+				each_blocks.b.length = each_value.length;
 			}
 
 			if (changed.foo) {
@@ -144,7 +146,7 @@ function create_fragment(ctx) {
 		o: noop,
 
 		d(detaching) {
-			destroy_each(each_blocks, detaching);
+			destroy_each_blocks(each_blocks, detaching);
 
 			if (detaching) {
 				detach(t0);

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -3,13 +3,17 @@ import {
 	SvelteComponent,
 	append,
 	create_animation,
+	create_each_blocks,
+	destroy_each_blocks,
 	detach,
 	element,
 	empty,
 	fix_and_destroy_block,
 	fix_position,
 	init,
+	init_each_block,
 	insert,
+	mount_each_blocks,
 	noop,
 	safe_not_equal,
 	set_data,
@@ -24,7 +28,7 @@ function get_each_context(ctx, list, i) {
 }
 
 // (19:0) {#each things as thing (thing.id)}
-function create_each_block(key_1, ctx) {
+function create_each_block(ctx, key_1) {
 	var div, t_value = ctx.thing.name + "", t, rect, stop_animation = noop;
 
 	return {
@@ -72,49 +76,52 @@ function create_each_block(key_1, ctx) {
 }
 
 function create_fragment(ctx) {
-	var each_blocks = [], each_1_lookup = new Map(), each_1_anchor;
+	var each_1_anchor;
 
 	let each_value = ctx.things;
 
-	const get_key = ctx => ctx.thing.id;
-
-	for (let i = 0; i < each_value.length; i += 1) {
-		let child_ctx = get_each_context(ctx, each_value, i);
-		let key = get_key(child_ctx);
-		each_1_lookup.set(key, each_blocks[i] = create_each_block(key, child_ctx));
-	}
+	let each_blocks = init_each_block(
+		ctx,
+		get_each_context,
+		ctx => ctx.things,
+		ctx => ctx.thing.id,
+		create_each_block,
+		null
+	);
 
 	return {
 		c() {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].c();
-			}
+			create_each_blocks(each_blocks);
 
 			each_1_anchor = empty();
 		},
 
 		m(target, anchor) {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
-			}
+			mount_each_blocks(each_blocks, target, anchor);
 
 			insert(target, each_1_anchor, anchor);
 		},
 
 		p(changed, ctx) {
 			const each_value = ctx.things;
-			for (let i = 0; i < each_blocks.length; i += 1) each_blocks[i].r();
-			each_blocks = update_keyed_each(each_blocks, changed, get_key, 1, ctx, each_value, each_1_lookup, each_1_anchor.parentNode, fix_and_destroy_block, create_each_block, each_1_anchor, get_each_context);
-			for (let i = 0; i < each_blocks.length; i += 1) each_blocks[i].a();
+			for (let i = 0; i < each_blocks.b.length; i += 1) each_blocks.b[i].r();
+			update_keyed_each(
+				each_blocks,
+				changed,
+				1,
+				ctx,
+				each_1_anchor.parentNode,
+				fix_and_destroy_block,
+				each_1_anchor
+			);
+			for (let i = 0; i < each_blocks.b.length; i += 1) each_blocks.b[i].a();
 		},
 
 		i: noop,
 		o: noop,
 
 		d(detaching) {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].d(detaching);
-			}
+			destroy_each_blocks(each_blocks, detaching);
 
 			if (detaching) {
 				detach(each_1_anchor);

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -2,12 +2,16 @@
 import {
 	SvelteComponent,
 	append,
+	create_each_blocks,
 	destroy_block,
+	destroy_each_blocks,
 	detach,
 	element,
 	empty,
 	init,
+	init_each_block,
 	insert,
+	mount_each_blocks,
 	noop,
 	safe_not_equal,
 	set_data,
@@ -22,7 +26,7 @@ function get_each_context(ctx, list, i) {
 }
 
 // (5:0) {#each things as thing (thing.id)}
-function create_each_block(key_1, ctx) {
+function create_each_block(ctx, key_1) {
 	var div, t_value = ctx.thing.name + "", t;
 
 	return {
@@ -56,47 +60,50 @@ function create_each_block(key_1, ctx) {
 }
 
 function create_fragment(ctx) {
-	var each_blocks = [], each_1_lookup = new Map(), each_1_anchor;
+	var each_1_anchor;
 
 	let each_value = ctx.things;
 
-	const get_key = ctx => ctx.thing.id;
-
-	for (let i = 0; i < each_value.length; i += 1) {
-		let child_ctx = get_each_context(ctx, each_value, i);
-		let key = get_key(child_ctx);
-		each_1_lookup.set(key, each_blocks[i] = create_each_block(key, child_ctx));
-	}
+	let each_blocks = init_each_block(
+		ctx,
+		get_each_context,
+		ctx => ctx.things,
+		ctx => ctx.thing.id,
+		create_each_block,
+		null
+	);
 
 	return {
 		c() {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].c();
-			}
+			create_each_blocks(each_blocks);
 
 			each_1_anchor = empty();
 		},
 
 		m(target, anchor) {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
-			}
+			mount_each_blocks(each_blocks, target, anchor);
 
 			insert(target, each_1_anchor, anchor);
 		},
 
 		p(changed, ctx) {
 			const each_value = ctx.things;
-			each_blocks = update_keyed_each(each_blocks, changed, get_key, 1, ctx, each_value, each_1_lookup, each_1_anchor.parentNode, destroy_block, create_each_block, each_1_anchor, get_each_context);
+			update_keyed_each(
+				each_blocks,
+				changed,
+				1,
+				ctx,
+				each_1_anchor.parentNode,
+				destroy_block,
+				each_1_anchor
+			);
 		},
 
 		i: noop,
 		o: noop,
 
 		d(detaching) {
-			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].d(detaching);
-			}
+			destroy_each_blocks(each_blocks, detaching);
 
 			if (detaching) {
 				detach(each_1_anchor);


### PR DESCRIPTION
This changes the generated code for `EachBlock`s into a bunch of helpers, as suggested here: #3504 (comment)

What still needs to be done is everything around animations/transitions and unkeyed updates, but even without it, it is ready now and passes all the current tests.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
