### PR TITLE
rework attribute selector matching to not use regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svelte changelog
 
+## Unreleased
+
+* Fix edge cases in matching selectors against elements ([#1710](https://github.com/sveltejs/svelte/issues/1710))
+
 ## 3.12.1
 
 * Escape `@` symbols in props, again ([#3545](https://github.com/sveltejs/svelte/issues/3545))

--- a/test/css/samples/weird-selectors/expected.css
+++ b/test/css/samples/weird-selectors/expected.css
@@ -1,0 +1,1 @@
+.-foo.svelte-xyz{color:red}[title='['].svelte-xyz{color:blue}

--- a/test/css/samples/weird-selectors/input.svelte
+++ b/test/css/samples/weird-selectors/input.svelte
@@ -1,0 +1,12 @@
+<div class='-foo'>foo</div>
+
+<div title='['>bar</div>
+
+<style>
+	.-foo {
+		color: red;
+	}
+	[title='['] {
+		color: blue;
+	}
+</style>


### PR DESCRIPTION
Fixes #1710. Using regular expressions when matching selectors to elements was causing a number of problems, which are discussed in the issue.