### PR TITLE
Coerce empty input value to empty string

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -180,7 +180,10 @@ export function set_data(text, data) {
 }
 
 export function set_input_value(input, value) {
-	if (value != null || input.value) {
+	if (value === null || value === undefined) {
+		value = "";
+	}
+	if (input.value !== value) {
 		input.value = value;
 	}
 }

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -180,12 +180,8 @@ export function set_data(text, data) {
 }
 
 export function set_input_value(input, value) {
-	if (value === null || value === undefined) {
-		value = "";
-	}
-	if (input.value !== value) {
-		input.value = value;
-	}
+	if (value == null) value = '';
+	if (input.value !== value) input.value = value;
 }
 
 export function set_input_type(input, type) {


### PR DESCRIPTION
Makes input value work with `undefined` values (the input will not display "undefined" as text).

Fixes #3569