### PR TITLE
Prevent image flicker and reloading by checking attribute before setting it

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -86,7 +86,7 @@ export function self(fn) {
 
 export function attr(node: Element, attribute: string, value?: string) {
 	if (value == null) node.removeAttribute(attribute);
-	else node.setAttribute(attribute, value);
+	else if (node.getAttribute(attribute) !== value) node.setAttribute(attribute, value);
 }
 
 export function set_attributes(node: Element & ElementCSSInlineStyle, attributes: { [x: string]: string }) {


### PR DESCRIPTION
# What does it do?

Before setting an attribute it checks if the value is different.

# Why?

If you look at the network log in the developer console you will notice that if you render SSR, then hydrate, it will reset the `src` attribute, and then re-download the image.

Usually the image is cached so the time to load it is very fast. However it still flickers when doing this.

---

I think the merits of this approach should be debated but it's useful in my project and the tests still pass.

---

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

I'm not sure how to check for image re-downloads in the tests. Sorry!

### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)