### PR TITLE
add digital climate strike banner

### DIFF
--- a/site/src/template.html
+++ b/site/src/template.html
@@ -16,6 +16,8 @@
 	<meta name='twitter:creator' content='@sveltejs'>
 	<meta name='twitter:image' content='https://svelte.dev/images/twitter-card.png'>
 
+	<script src="https://assets.digitalclimatestrike.net/widget.js" async></script>
+
 	<!-- Sapper generates a <style> tag containing critical CSS
 	     for the current page. CSS for the rest of the app is
 	     lazily loaded when it precaches secondary pages -->


### PR DESCRIPTION
This adds a fullscreen banner that will activate tomorrow (20 Sep) to encourage people to take part in the [Digital Climate Strike](https://digital.globalclimatestrike.net/). The idea is to show solidarity with people striking IRL, and to encourage people — if they can — to do something other than be on a computer, since computers are a major factor in our impending doom (fun fact: data centres have a worse carbon footprint than the airline industry).

Of course, people can hide the banner iframe with devtools if they really need to access https://svelte.dev. But I think this is a movement worth supporting, however symbolically, and one that's aligned with Svelte's 'spend less time writing code and let browsers spend less time running code' goals.