### PR TITLE
Change HTMLElement type check

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -132,7 +132,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 }
 
 export let SvelteElement;
-if (typeof HTMLElement !== 'undefined') {
+if (typeof HTMLElement === 'function') {
 	SvelteElement = class extends HTMLElement {
 		$$: T$$;
 		constructor() {


### PR DESCRIPTION
Fix HTMLElement class extending problem for iOS 8 and 9, described in this issue: #3608 

`class extends HTMLElement` fails on iOS 8 and 9, because the type of HTMLElement is object rather than function on these OS versions. The now existing `if (typeof HTMLElement !== 'undefined')` guard won't work in this case.