### PR TITLE
Fix #3555 ; scale elements in FLIP animations

### DIFF
--- a/src/runtime/animate/index.ts
+++ b/src/runtime/animate/index.ts
@@ -19,9 +19,11 @@ interface FlipParams {
 export function flip(node: Element, animation: { from: DOMRect; to: DOMRect }, params: FlipParams): AnimationConfig {
 	const style = getComputedStyle(node);
 	const transform = style.transform === 'none' ? '' : style.transform;
+	const scaleX = animation.from.width / node.clientWidth;
+	const scaleY = animation.from.height / node.clientHeight;
 
-	const dx = animation.from.left - animation.to.left;
-	const dy = animation.from.top - animation.to.top;
+	const dx = (animation.from.left - animation.to.left) / scaleX;
+	const dy = (animation.from.top - animation.to.top) / scaleY;
 
 	const d = Math.sqrt(dx * dx + dy * dy);
 


### PR DESCRIPTION
### Changes
- divide the getBoundingClientRect dimensions by clientHeight or clientWidth
  - this gives us the element's scaled values as scaleX and scaleY
- divide the "dx" and "dy" by the "scaleX" and "scaleY"

This aims to fix #3555 by using the node's un-scaled width/height to
calculate the amount it has been scaled. Then dividing the distance by
this scale factor removes the janky start position which was shown in
the test case. 

- [repl before fix](https://svelte.dev/repl/765bdee52e9d4537bbe78f3f7835d154?version=3.12.1)
- [repl after fix](https://svelte.dev/repl/67052a761c214c1a8247f4521ddfaa06?version=3.12.1)

resolves #3555



### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
