### PR TITLE
Document "gotcha" regarding `dispatch`.

### DIFF
--- a/site/content/tutorial/05-events/04-component-events/text.md
+++ b/site/content/tutorial/05-events/04-component-events/text.md
@@ -19,3 +19,4 @@ Components can also dispatch events. To do so, they must create an event dispatc
 ```
 
 > `createEventDispatcher` must be called when the component is first instantiated — you can't do it later inside e.g. a `setTimeout` callback. This links `dispatch` to the component instance.
+> `dispatch` can only be called once the component has been mounted. It is therefore not possible to call `dispatch` from the `beforeUpdate` lifecycle.


### PR DESCRIPTION
This PR adds an explanatory remark to the component events tutorial.

The reason I think this additional sentence could be useful is that I tried to call dispatch in `beforeUpdate` (which sounded like the potentially more performant implementation compared to `afterUpdate`). It did not work and I spend twenty minutes trying to find out why `dispatch` didn't
trigger an event until I realised my mistake.