### PR TITLE
Fix #3634 compound operators in reactive statement

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -46,9 +46,6 @@ childKeys.EachBlock = childKeys.IfBlock = ['children', 'else'];
 childKeys.Attribute = ['value'];
 childKeys.ExportNamedDeclaration = ['declaration', 'specifiers'];
 
-// There is no datatype that describes only the compound operators so we create this list here
-const compoundAssignmentOperators = ["+=" , "-=" ,"*=", "/=" ,"%=" ,"**=", "<<=" ,">>=", ">>>=", "|=" ,"^=" ,"&="];
-
 function remove_node(
 	code: MagicString,
 	start: number,
@@ -1275,9 +1272,7 @@ export default class Component {
 								assignees.add(node.name);
 							});
 
-
-
-							if (compoundAssignmentOperators.findIndex(op => op === node.operator) !== -1) {
+							if (node.operator !== '=') {
 								dependencies.add(left.name);
 							}
 						} else if (node.type === 'UpdateExpression') {

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -46,6 +46,9 @@ childKeys.EachBlock = childKeys.IfBlock = ['children', 'else'];
 childKeys.Attribute = ['value'];
 childKeys.ExportNamedDeclaration = ['declaration', 'specifiers'];
 
+// There is no datatype that describes only the compound operators so we create this list here
+const compoundAssignmentOperators = ["+=" , "-=" ,"*=", "/=" ,"%=" ,"**=", "<<=" ,">>=", ">>>=", "|=" ,"^=" ,"&="];
+
 function remove_node(
 	code: MagicString,
 	start: number,
@@ -1265,10 +1268,18 @@ export default class Component {
 						}
 
 						if (node.type === 'AssignmentExpression') {
-							extract_identifiers(get_object(node.left)).forEach(node => {
+							const left = get_object(node.left);
+
+							extract_identifiers(left).forEach(node => {
 								assignee_nodes.add(node);
 								assignees.add(node.name);
 							});
+
+
+
+							if (compoundAssignmentOperators.findIndex(op => op === node.operator) !== -1) {
+								dependencies.add(left.name);
+							}
 						} else if (node.type === 'UpdateExpression') {
 							const identifier = get_object(node.argument);
 							assignees.add(identifier.name);

--- a/test/runtime/samples/reactive-compound-operator/_config.js
+++ b/test/runtime/samples/reactive-compound-operator/_config.js
@@ -13,7 +13,7 @@ export default {
 		assert.equal(component.x, 2);
 		assert.htmlEqual(target.innerHTML, `
 			<button>+1</button>
-			<p>count:2</p>
+			<p>count: 2</p>
 		`);
 
 		await button.dispatchEvent(click);
@@ -21,7 +21,7 @@ export default {
 		assert.equal(component.x, 6);
 		assert.htmlEqual(target.innerHTML, `
 			<button>+1</button>
-			<p>count:6</p>
+			<p>count: 6</p>
 		`);
 	}
 };

--- a/test/runtime/samples/reactive-compound-operator/_config.js
+++ b/test/runtime/samples/reactive-compound-operator/_config.js
@@ -1,7 +1,7 @@
 export default {
 	html: `
 		<button>+1</button>
-		<p>count:0</p>
+		<p>count: 0</p>
 	`,
 
 	async test({ assert, component, target, window }) {

--- a/test/runtime/samples/reactive-compound-operator/_config.js
+++ b/test/runtime/samples/reactive-compound-operator/_config.js
@@ -1,0 +1,27 @@
+export default {
+	html: `
+		<button>+1</button>
+		<p>count:0</p>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const click = new window.MouseEvent('click');
+		const button = target.querySelector('button');
+
+		await button.dispatchEvent(click);
+
+		assert.equal(component.x, 2);
+		assert.htmlEqual(target.innerHTML, `
+			<button>+1</button>
+			<p>count:2</p>
+		`);
+
+		await button.dispatchEvent(click);
+
+		assert.equal(component.x, 6);
+		assert.htmlEqual(target.innerHTML, `
+			<button>+1</button>
+			<p>count:6</p>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-compound-operator/main.svelte
+++ b/test/runtime/samples/reactive-compound-operator/main.svelte
@@ -1,8 +1,8 @@
 <script>
 	export let x = 0;
 
-    $: x *= 2;
+	$: x *= 2;
 </script>
 
 <button on:click='{() => x += 1}'>+1</button>
-<p>count:{x}</p>
+<p>count: {x}</p>

--- a/test/runtime/samples/reactive-compound-operator/main.svelte
+++ b/test/runtime/samples/reactive-compound-operator/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	export let x = 0;
+
+    $: x *= 2;
+</script>
+
+<button on:click='{() => x += 1}'>+1</button>
+<p>count:{x}</p>

--- a/test/runtime/samples/reactive-update-expression/_config.js
+++ b/test/runtime/samples/reactive-update-expression/_config.js
@@ -1,0 +1,29 @@
+export default {
+	html: `
+	<button>+1</button>
+	<p>count:1</p>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const click = new window.MouseEvent('click');
+		const button = target.querySelector('button');
+
+		assert.equal(component.x, 1);
+
+		await button.dispatchEvent(click);
+
+		assert.equal(component.x, 3);
+		assert.htmlEqual(target.innerHTML, `
+			<button>+1</button>
+			<p>count:3</p>
+		`);
+
+		await button.dispatchEvent(click);
+
+		assert.equal(component.x, 5);
+		assert.htmlEqual(target.innerHTML, `
+			<button>+1</button>
+			<p>count:5</p>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-update-expression/_config.js
+++ b/test/runtime/samples/reactive-update-expression/_config.js
@@ -1,7 +1,7 @@
 export default {
 	html: `
 	<button>+1</button>
-	<p>count:1</p>
+	<p>count: 1</p>
 	`,
 
 	async test({ assert, component, target, window }) {

--- a/test/runtime/samples/reactive-update-expression/_config.js
+++ b/test/runtime/samples/reactive-update-expression/_config.js
@@ -15,7 +15,7 @@ export default {
 		assert.equal(component.x, 3);
 		assert.htmlEqual(target.innerHTML, `
 			<button>+1</button>
-			<p>count:3</p>
+			<p>count: 3</p>
 		`);
 
 		await button.dispatchEvent(click);
@@ -23,7 +23,7 @@ export default {
 		assert.equal(component.x, 5);
 		assert.htmlEqual(target.innerHTML, `
 			<button>+1</button>
-			<p>count:5</p>
+			<p>count: 5</p>
 		`);
 	}
 };

--- a/test/runtime/samples/reactive-update-expression/main.svelte
+++ b/test/runtime/samples/reactive-update-expression/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	export let x = 0;
+
+    $: x++;
+
+    function onClick() {
+      x += 1;
+    }
+</script>
+
+<button on:click='{() => x += 1}'>+1</button>
+<p>count:{x}</p>

--- a/test/runtime/samples/reactive-update-expression/main.svelte
+++ b/test/runtime/samples/reactive-update-expression/main.svelte
@@ -1,12 +1,12 @@
 <script>
 	export let x = 0;
 
-    $: x++;
+  $: x++;
 
-    function onClick() {
-      x += 1;
-    }
+  function onClick() {
+    x += 1;
+  }
 </script>
 
 <button on:click='{() => x += 1}'>+1</button>
-<p>count:{x}</p>
+<p>count: {x}</p>


### PR DESCRIPTION
Adds 2 sets of tests, one for the compound assignment operators (x += y) that did not actually work yet, and one for the update expressions (x--, y++) which already worked but did not have specific tests.

I haven't figured out yet why the update expressions just work, but the test will at least ensure they won't randomly break anymore.

One thing I wasn't exactly sure about is if the way I'm detecting a compound assignment operator is the best way to do it. This should work because I basically took all the operators in the `AssignmentOperator` type except actual assignment and put them in a list. But if ever another operator is added this will have to be added in that list as well which is not optimal.