### PR TITLE
Fix: dimensions example overflow problem

### DIFF
--- a/site/content/tutorial/06-bindings/11-dimensions/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/11-dimensions/app-a/App.svelte
@@ -8,6 +8,7 @@
 <style>
 	input { display: block; }
 	div { display: inline-block; }
+	span { word-break: break-all; }
 </style>
 
 <input type=range bind:value={size}>

--- a/site/content/tutorial/06-bindings/11-dimensions/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/11-dimensions/app-b/App.svelte
@@ -8,6 +8,7 @@
 <style>
 	input { display: block; }
 	div { display: inline-block; }
+	span { word-break: break-all; }
 </style>
 
 <input type=range bind:value={size}>


### PR DESCRIPTION
Hi,

I fixed the dimensions example overflow problem.

Before:

<img width="1018" alt="before" src="https://user-images.githubusercontent.com/330566/65938608-10057d80-e42c-11e9-80b1-4ce0573091d2.png">

After:

<img width="988" alt="after" src="https://user-images.githubusercontent.com/330566/65938612-1562c800-e42c-11e9-8031-b84864f30cc4.png">

URL: https://svelte.dev/tutorial/dimensions