### PR TITLE
Fix: dimensions example overflow problem

### DIFF
--- a/site/content/tutorial/06-bindings/11-dimensions/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/11-dimensions/app-a/App.svelte
@@ -8,6 +8,7 @@
 <style>
 	input { display: block; }
 	div { display: inline-block; }
+	span { word-break: break-all; }
 </style>
 
 <input type=range bind:value={size}>

--- a/site/content/tutorial/06-bindings/11-dimensions/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/11-dimensions/app-b/App.svelte
@@ -8,6 +8,7 @@
 <style>
 	input { display: block; }
 	div { display: inline-block; }
+	span { word-break: break-all; }
 </style>
 
 <input type=range bind:value={size}>


### PR DESCRIPTION
Hi,

I fixed the dimensions example overflow problem.

Before:

<img width="1018" alt="before" src="https://user-images.githubusercontent.com/330566/65941367-83f75400-e433-11e9-8fdb-ab1e050fe89b.png">

After:

<img width="988" alt="after" src="https://user-images.githubusercontent.com/330566/65941378-8bb6f880-e433-11e9-9ef3-01d9130c11d2.png">


URL: https://svelte.dev/tutorial/dimensions