### PR TITLE
Fix: lifecycle update example overflow problem

### DIFF
--- a/site/content/tutorial/07-lifecycle/03-update/app-a/App.svelte
+++ b/site/content/tutorial/07-lifecycle/03-update/app-a/App.svelte
@@ -88,6 +88,7 @@
 		background-color: #0074D9;
 		color: white;
 		border-radius: 1em 1em 0 1em;
+		word-break: break-all;
 	}
 </style>
 

--- a/site/content/tutorial/07-lifecycle/03-update/app-b/App.svelte
+++ b/site/content/tutorial/07-lifecycle/03-update/app-b/App.svelte
@@ -88,6 +88,7 @@
 		background-color: #0074D9;
 		color: white;
 		border-radius: 1em 1em 0 1em;
+		word-break: break-all;
 	}
 </style>
 


### PR DESCRIPTION
Hi,

I fixed the lifecycle update example overflow problem.

Before:

<img width="1073" alt="before" src="https://user-images.githubusercontent.com/330566/65941536-f10ae980-e433-11e9-8da0-65fee824ad75.png">

After:

<img width="1074" alt="after" src="https://user-images.githubusercontent.com/330566/65941540-f49e7080-e433-11e9-8ad0-c81306bf6bfe.png">


URL: https://svelte.dev/tutorial/update