### PR TITLE
Add more bindings for media element properties

### DIFF
--- a/src/compiler/compile/nodes/Binding.ts
+++ b/src/compiler/compile/nodes/Binding.ts
@@ -12,7 +12,8 @@ const read_only_media_attributes = new Set([
 	'buffered',
 	'seekable',
 	'played',
-	'seeking'
+	'seeking',
+	'ended'
 ]);
 
 export default class Binding extends Node {

--- a/src/compiler/compile/nodes/Binding.ts
+++ b/src/compiler/compile/nodes/Binding.ts
@@ -11,7 +11,8 @@ const read_only_media_attributes = new Set([
 	'duration',
 	'buffered',
 	'seekable',
-	'played'
+	'played',
+	'seeking'
 ]);
 
 export default class Binding extends Node {

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -596,7 +596,8 @@ export default class Element extends Node {
 				name === 'seekable' ||
 				name === 'played' ||
 				name === 'volume' ||
-				name === 'playbackRate'
+				name === 'playbackRate' ||
+				name === 'seeking'
 			) {
 				if (this.name !== 'audio' && this.name !== 'video') {
 					component.error(binding, {

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -597,7 +597,8 @@ export default class Element extends Node {
 				name === 'played' ||
 				name === 'volume' ||
 				name === 'playbackRate' ||
-				name === 'seeking'
+				name === 'seeking' ||
+				name === 'ended'
 			) {
 				if (this.name !== 'audio' && this.name !== 'video') {
 					component.error(binding, {

--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -86,6 +86,7 @@ export default class BindingWrapper {
 		const { parent } = this;
 
 		const update_conditions: any[] = this.needs_lock ? [x`!${lock}`] : [];
+		const mount_conditions: any[] = [];
 
 		const dependency_array = [...this.node.expression.dependencies];
 
@@ -103,6 +104,7 @@ export default class BindingWrapper {
 
 		// model to view
 		let update_dom = get_dom_updater(parent, this);
+		let mount_dom = update_dom;
 
 		// special cases
 		switch (this.node.name) {
@@ -122,13 +124,19 @@ export default class BindingWrapper {
 
 			case 'textContent':
 				update_conditions.push(x`${this.snippet} !== ${parent.var}.textContent`);
+				mount_conditions.push(x`${this.snippet} !== void 0`);
 				break;
 
 			case 'innerHTML':
 				update_conditions.push(x`${this.snippet} !== ${parent.var}.innerHTML`);
+				mount_conditions.push(x`${this.snippet} !== void 0`);
 				break;
 
 			case 'currentTime':
+				update_conditions.push(x`!@_isNaN(${this.snippet})`);
+				mount_dom = null;
+				break;
+
 			case 'playbackRate':
 			case 'volume':
 				update_conditions.push(x`!@_isNaN(${this.snippet})`);
@@ -142,12 +150,14 @@ export default class BindingWrapper {
 
 				update_conditions.push(x`${last} !== (${last} = ${this.snippet})`);
 				update_dom = b`${parent.var}[${last} ? "pause" : "play"]();`;
+				mount_dom = null;
 				break;
 			}
 
 			case 'value':
 				if (parent.node.get_static_attribute_value('type') === 'file') {
 					update_dom = null;
+					mount_dom = null;
 				}
 		}
 
@@ -165,13 +175,18 @@ export default class BindingWrapper {
 			}
 		}
 
-		if (this.node.name === 'innerHTML' || this.node.name === 'textContent') {
-			block.chunks.mount.push(b`
-				if (${this.snippet} !== void 0) {
-					${update_dom}
-				}`);
-		} else if (!/(currentTime|paused)/.test(this.node.name)) {
-			block.chunks.mount.push(update_dom);
+		if (mount_dom) {
+			if (mount_conditions.length > 0) {
+				const condition = mount_conditions.reduce((lhs, rhs) => x`${lhs} && ${rhs}`);
+
+				block.chunks.mount.push(b`
+					if (${condition}) {
+						${mount_dom}
+					}
+				`);
+			} else {
+				block.chunks.mount.push(mount_dom);
+			}
 		}
 	}
 }

--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -140,6 +140,7 @@ export default class BindingWrapper {
 			case 'playbackRate':
 			case 'volume':
 				update_conditions.push(x`!@_isNaN(${this.snippet})`);
+				mount_conditions.push(x`!@_isNaN(${this.snippet})`);
 				break;
 
 			case 'paused':

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -62,7 +62,7 @@ const events = [
 		event_names: ['timeupdate'],
 		filter: (node: Element, name: string) =>
 			node.is_media_node() &&
-			(name === 'currentTime' || name === 'played')
+			(name === 'currentTime' || name === 'played' || name === 'ended')
 	},
 	{
 		event_names: ['durationchange'],
@@ -105,6 +105,12 @@ const events = [
 		filter: (node: Element, name: string) =>
 			node.is_media_node() &&
 			(name === 'seeking')
+	},
+	{
+		event_names: ['ended'],
+		filter: (node: Element, name: string) =>
+			node.is_media_node() &&
+			name === 'ended'
 	},
 
 	// details event

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -100,6 +100,12 @@ const events = [
 			node.is_media_node() &&
 			name === 'playbackRate'
 	},
+	{
+		event_names: ['seeking', 'seeked'],
+		filter: (node: Element, name: string) =>
+			node.is_media_node() &&
+			(name === 'seeking')
+	},
 
 	// details event
 	{

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -35,11 +35,12 @@ function create_fragment(ctx) {
 	return {
 		c() {
 			audio = element("audio");
-			if (ctx.played === void 0 || ctx.currentTime === void 0) add_render_callback(audio_timeupdate_handler);
+			if (ctx.played === void 0 || ctx.currentTime === void 0 || ctx.ended === void 0) add_render_callback(audio_timeupdate_handler);
 			if (ctx.duration === void 0) add_render_callback(() => ctx.audio_durationchange_handler.call(audio));
 			if (ctx.buffered === void 0) add_render_callback(() => ctx.audio_progress_handler.call(audio));
 			if (ctx.buffered === void 0 || ctx.seekable === void 0) add_render_callback(() => ctx.audio_loadedmetadata_handler.call(audio));
 			if (ctx.seeking === void 0) add_render_callback(() => ctx.audio_seeking_seeked_handler.call(audio));
+			if (ctx.ended === void 0) add_render_callback(() => ctx.audio_ended_handler.call(audio));
 
 			dispose = [
 				listen(audio, "timeupdate", audio_timeupdate_handler),
@@ -51,7 +52,8 @@ function create_fragment(ctx) {
 				listen(audio, "volumechange", ctx.audio_volumechange_handler),
 				listen(audio, "ratechange", ctx.audio_ratechange_handler),
 				listen(audio, "seeking", ctx.audio_seeking_seeked_handler),
-				listen(audio, "seeked", ctx.audio_seeking_seeked_handler)
+				listen(audio, "seeked", ctx.audio_seeking_seeked_handler),
+				listen(audio, "ended", ctx.audio_ended_handler)
 			];
 		},
 		m(target, anchor) {
@@ -97,12 +99,15 @@ function instance($$self, $$props, $$invalidate) {
 	let { volume } = $$props;
 	let { playbackRate } = $$props;
 	let { seeking } = $$props;
+	let { ended } = $$props;
 
 	function audio_timeupdate_handler() {
 		played = time_ranges_to_array(this.played);
 		currentTime = this.currentTime;
+		ended = this.ended;
 		$$invalidate("played", played);
 		$$invalidate("currentTime", currentTime);
+		$$invalidate("ended", ended);
 	}
 
 	function audio_durationchange_handler() {
@@ -142,6 +147,11 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate("seeking", seeking);
 	}
 
+	function audio_ended_handler() {
+		ended = this.ended;
+		$$invalidate("ended", ended);
+	}
+
 	$$self.$set = $$props => {
 		if ("buffered" in $$props) $$invalidate("buffered", buffered = $$props.buffered);
 		if ("seekable" in $$props) $$invalidate("seekable", seekable = $$props.seekable);
@@ -152,6 +162,7 @@ function instance($$self, $$props, $$invalidate) {
 		if ("volume" in $$props) $$invalidate("volume", volume = $$props.volume);
 		if ("playbackRate" in $$props) $$invalidate("playbackRate", playbackRate = $$props.playbackRate);
 		if ("seeking" in $$props) $$invalidate("seeking", seeking = $$props.seeking);
+		if ("ended" in $$props) $$invalidate("ended", ended = $$props.ended);
 	};
 
 	return {
@@ -164,6 +175,7 @@ function instance($$self, $$props, $$invalidate) {
 		volume,
 		playbackRate,
 		seeking,
+		ended,
 		audio_timeupdate_handler,
 		audio_durationchange_handler,
 		audio_play_pause_handler,
@@ -171,7 +183,8 @@ function instance($$self, $$props, $$invalidate) {
 		audio_loadedmetadata_handler,
 		audio_volumechange_handler,
 		audio_ratechange_handler,
-		audio_seeking_seeked_handler
+		audio_seeking_seeked_handler,
+		audio_ended_handler
 	};
 }
 
@@ -188,7 +201,8 @@ class Component extends SvelteComponent {
 			paused: 0,
 			volume: 0,
 			playbackRate: 0,
-			seeking: 0
+			seeking: 0,
+			ended: 0
 		});
 	}
 }

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -39,6 +39,7 @@ function create_fragment(ctx) {
 			if (ctx.duration === void 0) add_render_callback(() => ctx.audio_durationchange_handler.call(audio));
 			if (ctx.buffered === void 0) add_render_callback(() => ctx.audio_progress_handler.call(audio));
 			if (ctx.buffered === void 0 || ctx.seekable === void 0) add_render_callback(() => ctx.audio_loadedmetadata_handler.call(audio));
+			if (ctx.seeking === void 0) add_render_callback(() => ctx.audio_seeking_seeked_handler.call(audio));
 
 			dispose = [
 				listen(audio, "timeupdate", audio_timeupdate_handler),
@@ -48,7 +49,9 @@ function create_fragment(ctx) {
 				listen(audio, "progress", ctx.audio_progress_handler),
 				listen(audio, "loadedmetadata", ctx.audio_loadedmetadata_handler),
 				listen(audio, "volumechange", ctx.audio_volumechange_handler),
-				listen(audio, "ratechange", ctx.audio_ratechange_handler)
+				listen(audio, "ratechange", ctx.audio_ratechange_handler),
+				listen(audio, "seeking", ctx.audio_seeking_seeked_handler),
+				listen(audio, "seeked", ctx.audio_seeking_seeked_handler)
 			];
 		},
 		m(target, anchor) {
@@ -93,6 +96,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { paused } = $$props;
 	let { volume } = $$props;
 	let { playbackRate } = $$props;
+	let { seeking } = $$props;
 
 	function audio_timeupdate_handler() {
 		played = time_ranges_to_array(this.played);
@@ -133,6 +137,11 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate("playbackRate", playbackRate);
 	}
 
+	function audio_seeking_seeked_handler() {
+		seeking = this.seeking;
+		$$invalidate("seeking", seeking);
+	}
+
 	$$self.$set = $$props => {
 		if ("buffered" in $$props) $$invalidate("buffered", buffered = $$props.buffered);
 		if ("seekable" in $$props) $$invalidate("seekable", seekable = $$props.seekable);
@@ -142,6 +151,7 @@ function instance($$self, $$props, $$invalidate) {
 		if ("paused" in $$props) $$invalidate("paused", paused = $$props.paused);
 		if ("volume" in $$props) $$invalidate("volume", volume = $$props.volume);
 		if ("playbackRate" in $$props) $$invalidate("playbackRate", playbackRate = $$props.playbackRate);
+		if ("seeking" in $$props) $$invalidate("seeking", seeking = $$props.seeking);
 	};
 
 	return {
@@ -153,13 +163,15 @@ function instance($$self, $$props, $$invalidate) {
 		paused,
 		volume,
 		playbackRate,
+		seeking,
 		audio_timeupdate_handler,
 		audio_durationchange_handler,
 		audio_play_pause_handler,
 		audio_progress_handler,
 		audio_loadedmetadata_handler,
 		audio_volumechange_handler,
-		audio_ratechange_handler
+		audio_ratechange_handler,
+		audio_seeking_seeked_handler
 	};
 }
 
@@ -175,7 +187,8 @@ class Component extends SvelteComponent {
 			duration: 0,
 			paused: 0,
 			volume: 0,
-			playbackRate: 0
+			playbackRate: 0,
+			seeking: 0
 		});
 	}
 }

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -58,8 +58,14 @@ function create_fragment(ctx) {
 		},
 		m(target, anchor) {
 			insert(target, audio, anchor);
-			audio.volume = ctx.volume;
-			audio.playbackRate = ctx.playbackRate;
+
+			if (!isNaN(ctx.volume)) {
+				audio.volume = ctx.volume;
+			}
+
+			if (!isNaN(ctx.playbackRate)) {
+				audio.playbackRate = ctx.playbackRate;
+			}
 		},
 		p(changed, ctx) {
 			if (!audio_updating && changed.currentTime && !isNaN(ctx.currentTime)) {

--- a/test/js/samples/media-bindings/input.svelte
+++ b/test/js/samples/media-bindings/input.svelte
@@ -8,6 +8,7 @@
 	export let volume;
 	export let playbackRate;
 	export let seeking;
+	export let ended;
 </script>
 
-<audio bind:buffered bind:seekable bind:played bind:currentTime bind:duration bind:paused bind:volume bind:playbackRate bind:seeking/>
+<audio bind:buffered bind:seekable bind:played bind:currentTime bind:duration bind:paused bind:volume bind:playbackRate bind:seeking bind:ended/>

--- a/test/js/samples/media-bindings/input.svelte
+++ b/test/js/samples/media-bindings/input.svelte
@@ -7,6 +7,7 @@
 	export let paused;
 	export let volume;
 	export let playbackRate;
+	export let seeking;
 </script>
 
-<audio bind:buffered bind:seekable bind:played bind:currentTime bind:duration bind:paused bind:volume bind:playbackRate/>
+<audio bind:buffered bind:seekable bind:played bind:currentTime bind:duration bind:paused bind:volume bind:playbackRate bind:seeking/>


### PR DESCRIPTION
This adds read-only bindings for [`seeking`](https://html.spec.whatwg.org/multipage/media.html#dom-media-seeking) and [`ended`](https://html.spec.whatwg.org/multipage/media.html#dom-media-ended) to `<audio>` and `<video>` elements.

These can be used to build a custom video UI, similar to [the media elements example](https://svelte.dev/examples#media-elements). For example:
* The `ended` property can be used to show a replay button instead of a regular play/pause button:
```svelte
<button on:click={() => paused = !paused}>
	{#if ended}
		Replay
	{:else if paused}
		Play
	{:else}
		Pause
	{/if}
</button>
```
* The `seeking` property can be used to show a loading spinner while the media element is seeking.

---

I also noticed that the current compiler would generate code for `bind:volume` like this:
```javascript
m(target, anchor) {
	insert(target, audio, anchor);

	audio.volume = ctx.volume;
}
```
However, if `ctx.volume` is still `undefined`, then this would throw a `TypeError` because it's not a number between 0 and 1 ([spec](https://html.spec.whatwg.org/multipage/media.html#dom-media-volume)).

To fix this, I've added an `!isNaN(ctx.volume)` check, so we don't set an invalid value when mounting. I've also refactored the code rendering for bindings a bit to make it easier to add such "mount conditions", similar to how we add "update conditions". 🙂