### PR TITLE
fix reactive updates not reflected when handle promise

### DIFF
--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -14,6 +14,8 @@ export function handle_promise(promise, info) {
 		const child_ctx = assign(assign({}, info.ctx), info.resolved);
 		const block = type && (info.current = type)(child_ctx);
 
+		let needFlush = false;
+
 		if (info.block) {
 			if (info.blocks) {
 				info.blocks.forEach((block, i) => {
@@ -33,11 +35,15 @@ export function handle_promise(promise, info) {
 			transition_in(block, 1);
 			block.m(info.mount(), info.anchor);
 
-			flush();
+			needFlush = true;
 		}
 
 		info.block = block;
 		if (info.blocks) info.blocks[index] = block;
+
+		if (needFlush) {
+			flush();
+		}
 	}
 
 	if (is_promise(promise)) {

--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -14,7 +14,7 @@ export function handle_promise(promise, info) {
 		const child_ctx = assign(assign({}, info.ctx), info.resolved);
 		const block = type && (info.current = type)(child_ctx);
 
-		let needFlush = false;
+		let needs_flush = false;
 
 		if (info.block) {
 			if (info.blocks) {
@@ -35,13 +35,13 @@ export function handle_promise(promise, info) {
 			transition_in(block, 1);
 			block.m(info.mount(), info.anchor);
 
-			needFlush = true;
+			needs_flush = true;
 		}
 
 		info.block = block;
 		if (info.blocks) info.blocks[index] = block;
 
-		if (needFlush) {
+		if (needs_flush) {
 			flush();
 		}
 	}

--- a/test/runtime/samples/await-set-simultaneous-reactive/_config.js
+++ b/test/runtime/samples/await-set-simultaneous-reactive/_config.js
@@ -1,0 +1,13 @@
+export default {
+	html: `<p>wait for it...</p>`,
+	test({ assert, component, target }) {
+
+		return component.promise
+			.then(() => {
+				assert.htmlEqual(target.innerHTML, `
+					<p>the answer is 42!</p>
+					<p>the answer100 is 4200!</p>
+				`);
+			});
+	}
+};

--- a/test/runtime/samples/await-set-simultaneous-reactive/main.svelte
+++ b/test/runtime/samples/await-set-simultaneous-reactive/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let answer = 0;
+	$: answer100 = answer * 100;
+	export let promise = new Promise(resolve => {
+		setTimeout(() => {
+			resolve();
+			answer = 42;
+		}, 0)
+	});
+</script>
+
+{#if promise}
+	{#await promise}
+		<p>wait for it...</p>
+	{:then _}
+		<p>the answer is {answer}!</p>
+		<p>the answer100 is {answer100}!</p>
+	{:catch error}
+		<p>well that's odd</p>
+	{/await}
+{/if}

--- a/test/runtime/samples/await-set-simultaneous-reactive/promise.js
+++ b/test/runtime/samples/await-set-simultaneous-reactive/promise.js
@@ -1,7 +1,0 @@
-let _resolvePromise;
-
-export const resolvePromise = () => _resolvePromise();
-
-export const promise = new Promise(resolve => {
-	_resolvePromise = resolve();
-});

--- a/test/runtime/samples/await-set-simultaneous-reactive/promise.js
+++ b/test/runtime/samples/await-set-simultaneous-reactive/promise.js
@@ -1,0 +1,7 @@
+let _resolvePromise;
+
+export const resolvePromise = () => _resolvePromise();
+
+export const promise = new Promise(resolve => {
+	_resolvePromise = resolve();
+});


### PR DESCRIPTION
Fix #3660

Added a test that would fail otherwise (test/runtime/samples/await-set-simultaneous-reactive/)

When flushing changes after promise, the newly attached block is not updated.
This is more obvious, when the newly attached block props takes value from a reactive declared variables, because their value only changed right before patching the dom

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
