### PR TITLE
resubscribe props if reassigned

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -772,7 +772,7 @@ export default class Component {
 	invalidate(name, value?) {
 		const variable = this.var_lookup.get(name);
 
-		if (variable && (variable.subscribable && variable.reassigned)) {
+		if (variable && (variable.subscribable && (variable.reassigned || variable.export_name))) {
 			return x`${`$$subscribe_${name}`}($$invalidate('${name}', ${value || name}))`;
 		}
 

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -224,7 +224,7 @@ export default function dom(
 		component.rewrite_props(({ name, reassigned, export_name }) => {
 			const value = `$${name}`;
 			
-			let insert: string;
+			let insert: Node[];
 			if (reassigned || export_name) {
 				insert = b`${`$$subscribe_${name}`}()`;
 			} else {

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -224,17 +224,12 @@ export default function dom(
 		component.rewrite_props(({ name, reassigned, export_name }) => {
 			const value = `$${name}`;
 			
-			let insert: Node[];
-			if (reassigned || export_name) {
-				insert = b`${`$$subscribe_${name}`}()`;
-			} else {
-				const callback = x`$$value => $$invalidate('${value}', ${value} = $$value)`;
-
-				insert = b`@component_subscribe($$self, ${name}, $${callback})`;
-			}
+			const insert = (reassigned || export_name)
+				? b`${`$$subscribe_${name}`}()`
+				: b`@component_subscribe($$self, ${name}, #value => $$invalidate('${value}', ${value} = #value))`;
 
 			if (component.compile_options.dev) {
-				insert = b`@validate_store(${name}, '${name}'); ${insert}`;
+				return b`@validate_store(${name}, '${name}'); ${insert}`;
 			}
 
 			return insert;

--- a/test/runtime/samples/store-resubscribe-export/_config.js
+++ b/test/runtime/samples/store-resubscribe-export/_config.js
@@ -1,0 +1,27 @@
+let subscribeCalled = false;
+
+const fakeStore = val => ({
+	subscribe: cb => {
+		cb(val);
+		return {
+			unsubscribe: () => {
+				subscribeCalled = true;
+			},
+		};
+	},
+});
+
+export default {
+	props: {
+		foo: fakeStore(1),
+	},
+	html: `
+		<h1>1</h1>
+	`,
+
+	async test({ assert, component, target }) {
+		component.foo = fakeStore(5);
+
+		return assert.htmlEqual(target.innerHTML, `<h1>5</h1>`);
+	},
+};

--- a/test/runtime/samples/store-resubscribe-export/main.svelte
+++ b/test/runtime/samples/store-resubscribe-export/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { writable } from 'svelte/store';
+	export let foo = writable(0);
+</script>
+
+<h1>{$foo}</h1>


### PR DESCRIPTION
Fixes #3662

If subscribing props, make sure to unsubscribe if the prop changed.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
