### PR TITLE
[unit-test] show generated output if the error message does not match

### DIFF
--- a/test/runtime/index.js
+++ b/test/runtime/index.js
@@ -192,10 +192,12 @@ describe("runtime", () => {
 							assert.equal(config.error, err.message);
 						}
 					} else {
-						failed.add(dir);
-						showOutput(cwd, compileOptions, compile); // eslint-disable-line no-console
 						throw err;
 					}
+				 }).catch(err => {
+					failed.add(dir);
+					showOutput(cwd, compileOptions, compile); // eslint-disable-line no-console
+					throw err;
 				})
 				.then(() => {
 					if (config.show) {


### PR DESCRIPTION
Currently, the compiled output did not shown when the error message asserts failed.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
