### PR TITLE
should throw error if createEventDispatch is used after instantiation

### DIFF
--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -28,7 +28,7 @@ export function onDestroy(fn) {
 }
 
 export function createEventDispatcher() {
-	const component = current_component;
+	const component = get_current_component();
 
 	return (type, detail) => {
 		const callbacks = component.$$.callbacks[type];


### PR DESCRIPTION
I read the [tutorial](https://svelte.dev/tutorial/component-events) and it says 
```
createEventDispatcher must be called when the component is first instantiated, — you can't do it later inside e.g. a setTimeout callback.
```

however it does not show error if i use it in a `setTimeout` callback. 

I only see an obscure error `Uncaught TypeError: Cannot read property '$$' of undefined` later on when I tried to dispatch an event.

Should I make this a compile time warning? or a runtime error?

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
