### PR TITLE
Add failing test for missing class on elem with bind and spread

### DIFF
--- a/test/runtime/samples/class-with-spread-and-bind/_config.js
+++ b/test/runtime/samples/class-with-spread-and-bind/_config.js
@@ -1,0 +1,18 @@
+export default {
+	props: {
+		primary: true,
+	},
+
+	html: `<div class="test-class primary" role="button"></div>`,
+
+	test({ assert, component, target, window }) {
+		component.primary = true;
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<div class="test-class primary" role="button"></div>
+		`
+		);
+	},
+};

--- a/test/runtime/samples/class-with-spread-and-bind/main.svelte
+++ b/test/runtime/samples/class-with-spread-and-bind/main.svelte
@@ -1,0 +1,11 @@
+<script>	
+	let primary = true;	
+	let elem;
+</script>
+
+<div
+	bind:this={elem}
+	class="test-class"
+	class:primary
+  {...{ role: 'button' }} 
+></div>


### PR DESCRIPTION
This PR introduces a failing test for the issue described in #2707. It's not mergeable in its current state since the tests are by definition failing, but I'm hoping this will be a starting point for me (or somebody else) to pick up and fix the issue.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
