### PR TITLE
Resolve TODO in animate

### DIFF
--- a/src/runtime/animate/index.ts
+++ b/src/runtime/animate/index.ts
@@ -21,7 +21,7 @@ export function flip(node: Element, animation: { from: DOMRect; to: DOMRect }, p
 
 	const {
 		delay = 0,
-		duration = d => Math.sqrt(d) * 120,
+		duration = (d: number) => Math.sqrt(d) * 120,
 		easing = cubicOut
 	} = params;
 

--- a/src/runtime/animate/index.ts
+++ b/src/runtime/animate/index.ts
@@ -1,14 +1,8 @@
 import { cubicOut } from 'svelte/easing';
 import { is_function } from 'svelte/internal';
+import { TransitionConfig } from 'svelte/transition';
 
-// todo: same as Transition, should it be shared?
-export interface AnimationConfig {
-	delay?: number;
-	duration?: number;
-	easing?: (t: number) => number;
-	css?: (t: number, u: number) => string;
-	tick?: (t: number, u: number) => void;
-}
+export interface AnimationConfig extends TransitionConfig {}
 
 interface FlipParams {
 	delay: number;


### PR DESCRIPTION
In animate/index.ts was a open TODO which is solved with this PR.

To no create a breaking change, the AnimationConfig extends the TransitionConfig to keep the naming. Now it would also possible that the AnimationConfig could have more props that the TransitionConfig.

Also resolved an implicit any in this file :)

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
