### PR TITLE
Fix(Tutorial): Add missing email information in tutorial, section 14-3

### DIFF
--- a/site/content/tutorial/14-composition/03-named-slots/app-b/App.svelte
+++ b/site/content/tutorial/14-composition/03-named-slots/app-b/App.svelte
@@ -11,4 +11,6 @@
 		42 Wallaby Way<br>
 		Sydney
 	</span>
+
+	<a href="mailto:p.sherman@example.com" slot="email">p.sherman@example.com</a>
 </ContactCard>


### PR DESCRIPTION
The solution of the tutorial in the section 14-composition, 03-named slots, is missing the email slot.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
