### PR TITLE
Prevent element property set from throwing errors for readonly properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix tracking of dependencies of compound assignments in reactive statements ([#3634](https://github.com/sveltejs/svelte/issues/3634))
 * Flush changes in newly attached block when using `{#await}` ([#3660](https://github.com/sveltejs/svelte/issues/3660))
 * Throw exception immediately when calling `createEventDispatcher()` after component instantiation ([#3667](https://github.com/sveltejs/svelte/pull/3667))
+* Fix error resulting from trying to set a read-only property when spreading element attributes ([#3681](https://github.com/sveltejs/svelte/issues/3681))
 
 ## 3.12.1
 

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -90,10 +90,12 @@ export function attr(node: Element, attribute: string, value?: string) {
 }
 
 export function set_attributes(node: Element & ElementCSSInlineStyle, attributes: { [x: string]: string }) {
+	// @ts-ignore
+	const descriptors = Object.getOwnPropertyDescriptors(node.__proto__);
 	for (const key in attributes) {
 		if (key === 'style') {
 			node.style.cssText = attributes[key];
-		} else if (key in node) {
+		} else if (descriptors[key] && descriptors[key].set) {
 			node[key] = attributes[key];
 		} else {
 			attr(node, key, attributes[key]);

--- a/test/runtime/samples/spread-element-readonly/_config.js
+++ b/test/runtime/samples/spread-element-readonly/_config.js
@@ -1,0 +1,9 @@
+export default {
+	skip_if_ssr: true, // DOM and SSR output is different, a separate SSR test exists
+	html: `<input form="qux" list="quu" />`,
+
+	test({ assert, target }) {
+		const div = target.querySelector('input');
+		assert.equal(div.value, 'bar');
+	}
+};

--- a/test/runtime/samples/spread-element-readonly/main.svelte
+++ b/test/runtime/samples/spread-element-readonly/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let props = {
+		value: 'bar',
+		form: 'qux',
+		list: 'quu',
+	};
+</script>
+
+<input {...props} />

--- a/test/server-side-rendering/samples/spread-attributes/_expected.html
+++ b/test/server-side-rendering/samples/spread-attributes/_expected.html
@@ -1,0 +1,1 @@
+<input value="bar" form="qux" list="quu" />

--- a/test/server-side-rendering/samples/spread-attributes/main.svelte
+++ b/test/server-side-rendering/samples/spread-attributes/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let props = {
+		value: 'bar',
+		form: 'qux',
+		list: 'quu',
+	};
+</script>
+
+<input {...props} />


### PR DESCRIPTION
Fixes #3681.

When spreading props we were previously doing a `key in obj` check when deciding to assign to the property or set the attribute. This fails when the property exists but the setter is `undefined` which is the case with some (all?) read-only properties.

This PR changes that behaviour and instead uses `Object.getOwnPropertyDescriptor(el.__proto__, key)` and, if it exists, checks that the `set` property exists as well. It is important to provide two checks, one for the descriptors (or the key itself) and one for the actual `set` property of the descriptor, to prevent throwing errors when trying to access `set` of undefined.

I also needed to add `//@ts-ignore` when accessing `node.__proto__` since [the TS people don't think valid properties should be on the node interface if they are deprecated](https://github.com/Microsoft/TypeScript/issues/30587#issuecomment-476780150).


