### PR TITLE
fix: class directives combined with spread attrs (SSR)

### DIFF
--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -111,7 +111,8 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 					args.push(`{ ${quote_name_if_necessary(attribute.name)}: ${snip(attribute.chunks[0])} }`);
 				} else if (attribute.name === 'class' && class_expression) {
 					// Add class expression
-					args.push(`{ ${quote_name_if_necessary(attribute.name)}: [\`${stringify_class_attribute(attribute)}\`, \`\${${class_expression}}\`].join(' ').trim() }`);
+					add_class_attribute = false;
+					args.push(`{ ${quote_name_if_necessary(attribute.name)}: [\`${stringify_class_attribute(attribute)}\`, ${class_expression}].join(' ').trim() }`);
 				} else {
 					args.push(`{ ${quote_name_if_necessary(attribute.name)}: \`${attribute.name === 'class' ? stringify_class_attribute(attribute) : stringify_attribute(attribute, true)}\` }`);
 				}


### PR DESCRIPTION
Class directives were being output in secondary `class` attribute if element defined spread attributes, e.g.

```html
<button class="btn" class:dense class:rounded {...{}} />
```
Was resulting in:
```html
<button class="btn rounded" class="dense rounded" />
```

Note also that only the last class directive was included in the former `class` because of code:

```js
`\`\${${class_expression}}\``
```
and e.g.:
```js
`${true ? 'foo' : '', true ? 'bar' : ''}`
// => "bar"
```

Fixes [sveltejs/sapper#925](https://github.com/sveltejs/sapper/issues/925).