### PR TITLE
fix type of derived store callback function

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -128,7 +128,7 @@ type StoresValues<T> = T extends Readable<infer U> ? U :
  */
 export function derived<T, S extends Stores>(
 	stores: S,
-	fn: (values: StoresValues<S>, set?: Subscriber<T>) => T | Unsubscriber | void,
+	fn: (values: StoresValues<S>, set: Subscriber<T>) => T | Unsubscriber | void,
 	initial_value?: T,
 ): Readable<T> {
 


### PR DESCRIPTION
The derived store callback type currently has an optional `set` argument, but it should be marked as a regular required argument:

```ts
fn: (values: StoresValues<S>, set?: Subscriber<T>) => T | Unsubscriber | void,
```

So `set?:` is changed to `set:`.

- a non-null `set` is already always provided as the second argument: https://github.com/sveltejs/svelte/blob/565931dff957545bf1b8a9ea57cfc097ed1a7e83/src/runtime/store/index.ts#L142 https://github.com/sveltejs/svelte/blob/565931dff957545bf1b8a9ea57cfc097ed1a7e83/src/runtime/store/index.ts#L154
- the change fixes type errors for consumers that have strict null checks enabled
- this change breaks nothing, and causes no errors when callers provide a function that omits the `set` argument, in the same way you can pass `Array.map` a function with no second `index` argument

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
- [x] Run the tests tests with `npm test` or `yarn test`)
