### PR TITLE
don't cache attribute values

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -95,7 +95,7 @@ export default class AttributeWrapper {
 			const is_select_value_attribute =
 				name === 'value' && element.node.name === 'select';
 
-			const should_cache = (this.node.should_cache() || is_select_value_attribute);
+			const should_cache = is_select_value_attribute; // TODO is this necessary?
 
 			const last = should_cache && block.get_unique_name(
 				`${element.var.name}_${name.replace(/[^a-zA-Z_$]/g, '_')}_value`

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -14,7 +14,6 @@ function create_fragment(ctx) {
 	let div0;
 	let t;
 	let div1;
-	let div1_style_value;
 
 	return {
 		c() {
@@ -22,7 +21,7 @@ function create_fragment(ctx) {
 			t = space();
 			div1 = element("div");
 			attr(div0, "style", ctx.style);
-			attr(div1, "style", div1_style_value = "" + (ctx.key + ": " + ctx.value));
+			attr(div1, "style", "" + (ctx.key + ": " + ctx.value));
 		},
 		m(target, anchor) {
 			insert(target, div0, anchor);
@@ -34,8 +33,8 @@ function create_fragment(ctx) {
 				attr(div0, "style", ctx.style);
 			}
 
-			if ((changed.key || changed.value) && div1_style_value !== (div1_style_value = "" + (ctx.key + ": " + ctx.value))) {
-				attr(div1, "style", div1_style_value);
+			if (changed.key || changed.value) {
+				attr(div1, "style", "" + (ctx.key + ": " + ctx.value));
 			}
 		},
 		i: noop,


### PR DESCRIPTION
Follow-up to #3579. Not certain off the top of my head why there's special logic for `<select value>` attributes, so have left that untouched for now.