### PR TITLE
then and catch block expect await, optional then block

### DIFF
--- a/test/parser/samples/await-catch/input.svelte
+++ b/test/parser/samples/await-catch/input.svelte
@@ -1,0 +1,5 @@
+{#await thePromise}
+	<p>loading...</p>
+{:catch theError}
+	<p>oh no! {theError.message}</p>
+{/await}

--- a/test/parser/samples/await-catch/output.json
+++ b/test/parser/samples/await-catch/output.json
@@ -1,0 +1,168 @@
+{
+	"html": {
+		"start": 0,
+		"end": 99,
+		"type": "Fragment",
+		"children": [
+			{
+				"start": 0,
+				"end": 99,
+				"type": "AwaitBlock",
+				"expression": {
+					"type": "Identifier",
+					"start": 8,
+					"end": 18,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 8
+						},
+						"end": {
+							"line": 1,
+							"column": 18
+						}
+					},
+					"name": "thePromise"
+				},
+				"value": null,
+				"error": "theError",
+				"pending": {
+					"start": 19,
+					"end": 39,
+					"type": "PendingBlock",
+					"children": [
+						{
+							"start": 19,
+							"end": 21,
+							"type": "Text",
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"start": 21,
+							"end": 38,
+							"type": "Element",
+							"name": "p",
+							"attributes": [],
+							"children": [
+								{
+									"start": 24,
+									"end": 34,
+									"type": "Text",
+									"raw": "loading...",
+									"data": "loading..."
+								}
+							]
+						},
+						{
+							"start": 38,
+							"end": 39,
+							"type": "Text",
+							"raw": "\n",
+							"data": "\n"
+						}
+					],
+					"skip": false
+				},
+				"then": {
+					"start": null,
+					"end": null,
+					"type": "ThenBlock",
+					"children": [],
+					"skip": true
+				},
+				"catch": {
+					"start": 39,
+					"end": 91,
+					"type": "CatchBlock",
+					"children": [
+						{
+							"start": 56,
+							"end": 58,
+							"type": "Text",
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"start": 58,
+							"end": 90,
+							"type": "Element",
+							"name": "p",
+							"attributes": [],
+							"children": [
+								{
+									"start": 61,
+									"end": 68,
+									"type": "Text",
+									"raw": "oh no! ",
+									"data": "oh no! "
+								},
+								{
+									"start": 68,
+									"end": 86,
+									"type": "MustacheTag",
+									"expression": {
+										"type": "MemberExpression",
+										"start": 69,
+										"end": 85,
+										"loc": {
+											"start": {
+												"line": 4,
+												"column": 12
+											},
+											"end": {
+												"line": 4,
+												"column": 28
+											}
+										},
+										"object": {
+											"type": "Identifier",
+											"start": 69,
+											"end": 77,
+											"loc": {
+												"start": {
+													"line": 4,
+													"column": 12
+												},
+												"end": {
+													"line": 4,
+													"column": 20
+												}
+											},
+											"name": "theError"
+										},
+										"property": {
+											"type": "Identifier",
+											"start": 78,
+											"end": 85,
+											"loc": {
+												"start": {
+													"line": 4,
+													"column": 21
+												},
+												"end": {
+													"line": 4,
+													"column": 28
+												}
+											},
+											"name": "message"
+										},
+										"computed": false
+									}
+								}
+							]
+						},
+						{
+							"start": 90,
+							"end": 91,
+							"type": "Text",
+							"raw": "\n",
+							"data": "\n"
+						}
+					],
+					"skip": false
+				}
+			}
+		]
+	}
+}

--- a/test/parser/samples/error-catch-without-await/error.json
+++ b/test/parser/samples/error-catch-without-await/error.json
@@ -1,0 +1,10 @@
+{
+	"code": "invalid-catch-placement",
+	"message": "Cannot have an {:catch} block outside an {#await ...} block",
+	"start": {
+		"line": 1,
+		"column": 7,
+		"character": 7
+	},
+	"pos": 7
+}

--- a/test/parser/samples/error-catch-without-await/input.svelte
+++ b/test/parser/samples/error-catch-without-await/input.svelte
@@ -1,0 +1,1 @@
+{:catch theValue}

--- a/test/parser/samples/error-then-without-await/error.json
+++ b/test/parser/samples/error-then-without-await/error.json
@@ -1,0 +1,10 @@
+{
+	"code": "invalid-then-placement",
+	"message": "Cannot have an {:then} block outside an {#await ...} block",
+	"start": {
+		"line": 1,
+		"column": 6,
+		"character": 6
+	},
+	"pos": 6
+}

--- a/test/parser/samples/error-then-without-await/input.svelte
+++ b/test/parser/samples/error-then-without-await/input.svelte
@@ -1,0 +1,1 @@
+{:then theValue}


### PR DESCRIPTION
fix:
- `{:then}` block and `{:catch}` block can be used without `{#await}` ([repl for the bug](https://svelte.dev/repl/319a171f525d4d65a4eb378f4ad7e655?version=3.12.1))
- allow `{:catch}` block be used without `{:then}` block.
  - i guess theres use case for showing error only when promise resolve, like input validation?

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
