### PR TITLE
Avoid an error on double detaching a node

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -7,7 +7,7 @@ export function insert(target: Node, node: Node, anchor?: Node) {
 }
 
 export function detach(node: Node) {
-	node.parentNode.removeChild(node);
+	if (node.parentNode) node.parentNode.removeChild(node);
 }
 
 export function destroy_each(iterations, detaching) {


### PR DESCRIPTION
I'm still diagnosing the deeper issue, which occurs when updating a store in an asynchronous function, having a promise reject, and in the catch block removing the pending promise that a subcomponent has rendered an `{#await}` block for (but no `:catch`), but the `node.parentNode` is null and this throws.