### PR TITLE
[parser] reuse slug for parser error

### DIFF
--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -81,7 +81,7 @@ export default function tag(parser: Parser) {
 				parser.current().children.length
 			) {
 				parser.error({
-					code: `invalid-${name.slice(7)}-content`,
+					code: `invalid-${slug}-content`,
 					message: `<${name}> cannot have children`
 				}, parser.current().children[0].start);
 			}


### PR DESCRIPTION
feels like this should have been `slug` instead of `name.slice(7)`, consistent with the following else case

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
