### PR TITLE
fix(site): invoke `authenticate` factory

### DIFF
--- a/site/src/server.js
+++ b/site/src/server.js
@@ -15,7 +15,7 @@ const app = polka({
 });
 
 if (process.env.PGHOST) {
-	app.use(authenticate);
+	app.use(authenticate());
 }
 
 app.use(


### PR DESCRIPTION
Arrived in https://github.com/sveltejs/svelte/commit/84b0e865830a2f4cc943975c2683342ea651069f 

This mounted the `authenticate` function itself, which itself isn't a middleware.