### PR TITLE
parser warnings

### DIFF
--- a/src/compiler/compile/index.ts
+++ b/src/compiler/compile/index.ts
@@ -65,7 +65,7 @@ export default function compile(source: string, options: CompileOptions = {}) {
 	validate_options(options, warnings);
 
 	stats.start('parse');
-	const ast = parse(source, options);
+	const ast = parse(source, options, warnings);
 	stats.stop('parse');
 
 	stats.start('create component');

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -91,7 +91,7 @@ export interface Ast {
 }
 
 export interface Warning {
-	type?: string,
+	type?: string;
 	start?: { line: number; column: number; pos?: number };
 	end?: { line: number; column: number };
 	pos?: number;

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -91,6 +91,7 @@ export interface Ast {
 }
 
 export interface Warning {
+	type?: string,
 	start?: { line: number; column: number; pos?: number };
 	end?: { line: number; column: number };
 	pos?: number;

--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -142,6 +142,11 @@ export default function tag(parser: Parser) {
 			parent.end = start;
 			parser.stack.pop();
 
+			parser.warn(parent, {
+				code: `missing-closing-tag`,
+				message: `Missing </${parent.name}> before </${name}>`
+			});
+
 			parent = parser.current();
 		}
 
@@ -152,6 +157,11 @@ export default function tag(parser: Parser) {
 	} else if (closing_tag_omitted(parent.name, name)) {
 		parent.end = start;
 		parser.stack.pop();
+
+		parser.warn(parent, {
+			code: `missing-closing-tag`,
+			message: `Missing </${parent.name}> before <${name}>`
+		});
 	}
 
 	const unique_names: Set<string> = new Set();

--- a/test/parser/samples/implicitly-closed-li-block/warnings.json
+++ b/test/parser/samples/implicitly-closed-li-block/warnings.json
@@ -1,0 +1,10 @@
+[
+	{
+		"code": "missing-closing-tag",
+		"fullMessage": "Missing </li> before <li> (2:1)\n1: <ul>\n2:   <li>a\n     ^\n3:   {#if true}\n4:     <li>b"
+	},
+	{
+		"code": "missing-closing-tag",
+		"fullMessage": "Missing </li> before </ul> (6:1)\n4:     <li>b\n5:   {/if}\n6:   <li>c\n     ^\n7: </ul>"
+	}
+]

--- a/test/parser/samples/implicitly-closed-li/warnings.json
+++ b/test/parser/samples/implicitly-closed-li/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "missing-closing-tag",
+		"fullMessage": "Missing </li> before <li> (2:1)\n1: <ul>\n2:   <li>a\n     ^\n3:   <li>b\n4:   <li>c"
+	},
+	{
+		"code": "missing-closing-tag",
+		"fullMessage": "Missing </li> before <li> (3:1)\n1: <ul>\n2:   <li>a\n3:   <li>b\n     ^\n4:   <li>c\n5: </ul>"
+	},
+	{
+		"code": "missing-closing-tag",
+		"fullMessage": "Missing </li> before </ul> (4:1)\n2:   <li>a\n3:   <li>b\n4:   <li>c\n     ^\n5: </ul>"
+	}
+]


### PR DESCRIPTION
Although svelte is permissive about missing closing tags, eg ([repl](https://svelte.dev/repl/12479181369245b8af6042585e7ba277?version=3.12.1)), but maybe Svelte should give some parser warnings when that happens?

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
