### PR TITLE
fix `bind:this` binding to a store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Allow exiting a reactive block early with `break $` ([#2828](https://github.com/sveltejs/svelte/issues/2828))
 * Check attributes have changed before setting them to avoid image flicker ([#3579](https://github.com/sveltejs/svelte/pull/3579))
 * Fix generating malformed code for `{@debug}` tags with no dependencies ([#3588](https://github.com/sveltejs/svelte/issue/3588))
+* Fix `bind:this` binding to a store ([#3591](https://github.com/sveltejs/svelte/issue/3591))
 * Use safer `HTMLElement` check before extending class ([#3608](https://github.com/sveltejs/svelte/issue/3608))
 * Add `location` as a known global ([#3619](https://github.com/sveltejs/svelte/pull/3619))
 * Fix tracking of dependencies of compound assignments in reactive statements ([#3634](https://github.com/sveltejs/svelte/issues/3634))

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -764,7 +764,7 @@ export default class Component {
 		}
 
 		if (name[0] === '$' && name[1] !== '$') {
-			return x`${name.slice(1)}.set(${name})`;
+			return x`${name.slice(1)}.set(${value || name})`;
 		}
 
 		if (

--- a/test/runtime/samples/binding-this-store/_config.js
+++ b/test/runtime/samples/binding-this-store/_config.js
@@ -1,0 +1,4 @@
+export default {
+	skip_if_ssr: true,
+	html: `<div>object</div>`
+};

--- a/test/runtime/samples/binding-this-store/main.svelte
+++ b/test/runtime/samples/binding-this-store/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { writable } from 'svelte/store';
+	const foo = writable();
+</script>
+
+<div bind:this={$foo}>{typeof $foo}</div>


### PR DESCRIPTION
Fixes #3591, using the change I mentioned in that issue. The change isn't specifically related to `bind:this` at all, but when I took a sweep through instances of `.invalidate` in the code, it looks like `bind:this` is probably the only thing this was affecting for now.