### PR TITLE
hoist globals even if they are mentioned in a script block

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -569,6 +569,7 @@ export default class Component {
 				this.add_var({
 					name,
 					global: true,
+					hoistable: true
 				});
 			}
 		});
@@ -661,6 +662,7 @@ export default class Component {
 				this.add_var({
 					name,
 					global: true,
+					hoistable: true
 				});
 			}
 		});


### PR DESCRIPTION
I don't really know what sort of test to write for this besides a js sample one, and I'm not really sure what I'd say in the changelog, but this should fix #3607.