### PR TITLE
Fix store validation code generation

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -301,7 +301,7 @@ export default function dom(
 			return !variable || variable.hoistable;
 		})
 		.map(({ name }) => b`
-			${component.compile_options.dev && `@validate_store(${name.slice(1)}, '${name.slice(1)}');`}
+			${component.compile_options.dev && b`@validate_store(${name.slice(1)}, '${name.slice(1)}');`}
 			@component_subscribe($$self, ${name.slice(1)}, $$value => $$invalidate('${name}', ${name} = $$value));
 		`);
 

--- a/test/runtime/samples/store-imported/_config.js
+++ b/test/runtime/samples/store-imported/_config.js
@@ -1,4 +1,6 @@
 export default {
+	compileOptions: { dev: true }, // tests `@validate_store` code generation
+
 	html: `
 		<p>42</p>
 	`


### PR DESCRIPTION
Fixes #3735. It was just a slight `code-red` misuse typo.