### PR TITLE
Fix #3008: Better SSR docs

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -1019,8 +1019,12 @@ Unlike client-side components, server-side components don't have a lifespan afte
 
 A server-side component exposes a `render` method that can be called with optional props. It returns an object with `head`, `html`, and `css` properties, where `head` contains the contents of any `<svelte:head>` elements encountered.
 
+You can import a Svelte component directly into Node using [`svelte/register`](docs#svelte_register).
+
 ```js
-const App = require('./App.svelte');
+require('svelte/register');
+
+const App = require('./App.svelte').default;
 
 const { head, html, css } = App.render({
 	answer: 42


### PR DESCRIPTION
This aims to improve the documentation on server-side rendering.

As discussed in #3008, the API docs on server-side rendering are a bit confusing since they don't include the use of `svelte/register`.

Fixes #3008.
