### PR TITLE
Fix boolean attributes in presence of spread attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Throw exception immediately when calling `createEventDispatcher()` after component instantiation ([#3667](https://github.com/sveltejs/svelte/pull/3667))
 * Fix globals shadowing contextual template scope ([#3674](https://github.com/sveltejs/svelte/issues/3674))
 * Fix error resulting from trying to set a read-only property when spreading element attributes ([#3681](https://github.com/sveltejs/svelte/issues/3681))
+* Fix handling of boolean attributes in presence of other spread attributes ([#3764](https://github.com/sveltejs/svelte/issues/3764))
 
 ## 3.12.1
 

--- a/src/compiler/compile/nodes/Attribute.ts
+++ b/src/compiler/compile/nodes/Attribute.ts
@@ -9,7 +9,7 @@ import TemplateScope from './shared/TemplateScope';
 import { x } from 'code-red';
 
 export default class Attribute extends Node {
-	type: 'Attribute';
+	type: 'Attribute' | 'Spread';
 	start: number;
 	end: number;
 	scope: TemplateScope;

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -44,9 +44,7 @@ export default class AttributeWrapper {
 		const element = this.parent;
 		const name = fix_attribute_casing(this.node.name);
 
-		let metadata = element.node.namespace ? null : attribute_lookup[name];
-		if (metadata && metadata.applies_to && !~metadata.applies_to.indexOf(element.node.name))
-			metadata = null;
+		const metadata = this.get_metadata();
 
 		const is_indirectly_bound_value =
 			name === 'value' &&
@@ -191,6 +189,13 @@ export default class AttributeWrapper {
 			block.chunks.hydrate.push(update_value);
 			if (this.node.get_dependencies().length > 0) block.chunks.update.push(update_value);
 		}
+	}
+
+	get_metadata() {
+		if (this.parent.node.namespace) return null;
+		const metadata = attribute_lookup[fix_attribute_casing(this.node.name)];
+		if (metadata && metadata.applies_to && !metadata.applies_to.includes(this.parent.node.name)) return null;
+		return metadata;
 	}
 
 	get_class_name_text() {

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -573,8 +573,7 @@ export default class ElementWrapper extends Wrapper {
 			}
 		});
 
-		// @ts-ignore todo:
-		if (this.node.attributes.find(attr => attr.type === 'Spread')) {
+		if (this.node.attributes.some(attr => attr.is_spread)) {
 			this.add_spread_attributes(block);
 			return;
 		}
@@ -591,21 +590,24 @@ export default class ElementWrapper extends Wrapper {
 		const initial_props = [];
 		const updates = [];
 
-		this.node.attributes
-			.filter(attr => attr.type === 'Attribute' || attr.type === 'Spread')
+		this.attributes
 			.forEach(attr => {
-				const condition = attr.dependencies.size > 0
-					? changed(Array.from(attr.dependencies))
+				const condition = attr.node.dependencies.size > 0
+					? changed(Array.from(attr.node.dependencies))
 					: null;
 
-				if (attr.is_spread) {
-					const snippet = attr.expression.manipulate(block);
+				if (attr.node.is_spread) {
+					const snippet = attr.node.expression.manipulate(block);
 
 					initial_props.push(snippet);
 
 					updates.push(condition ? x`${condition} && ${snippet}` : snippet);
 				} else {
-					const snippet = x`{ ${attr.name}: ${attr.get_value(block)} }`;
+					const metadata = attr.get_metadata();
+					const snippet = x`{ ${
+						(metadata && metadata.property_name) ||
+						fix_attribute_casing(attr.node.name)
+					}: ${attr.node.get_value(block)} }`;
 					initial_props.push(snippet);
 
 					updates.push(condition ? x`${condition} && ${snippet}` : snippet);

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -93,7 +93,9 @@ export function set_attributes(node: Element & ElementCSSInlineStyle, attributes
 	// @ts-ignore
 	const descriptors = Object.getOwnPropertyDescriptors(node.__proto__);
 	for (const key in attributes) {
-		if (key === 'style') {
+		if (attributes[key] == null) {
+			node.removeAttribute(key);
+		} else if (key === 'style') {
 			node.style.cssText = attributes[key];
 		} else if (descriptors[key] && descriptors[key].set) {
 			node[key] = attributes[key];

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -13,7 +13,7 @@ export function spread(args) {
 		if (invalid_attribute_name_character.test(name)) return;
 
 		const value = attributes[name];
-		if (value === undefined) return;
+		if (value == null) return;
 		if (value === true) str += " " + name;
 
 		const escaped = String(value)

--- a/test/runtime/samples/attribute-boolean-case-insensitive/_config.js
+++ b/test/runtime/samples/attribute-boolean-case-insensitive/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<input readonly>`
+};

--- a/test/runtime/samples/attribute-boolean-case-insensitive/main.svelte
+++ b/test/runtime/samples/attribute-boolean-case-insensitive/main.svelte
@@ -1,0 +1,1 @@
+<input READONLY={true} REQUIRED={false}>

--- a/test/runtime/samples/attribute-boolean-with-spread/_config.js
+++ b/test/runtime/samples/attribute-boolean-with-spread/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<input>`
+};

--- a/test/runtime/samples/attribute-boolean-with-spread/main.svelte
+++ b/test/runtime/samples/attribute-boolean-with-spread/main.svelte
@@ -1,0 +1,1 @@
+<input {...{ foo: null }} readonly={false} required={false} disabled={null}>

--- a/test/runtime/samples/spread-element-removal/_config.js
+++ b/test/runtime/samples/spread-element-removal/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<input>`
+};

--- a/test/runtime/samples/spread-element-removal/main.svelte
+++ b/test/runtime/samples/spread-element-removal/main.svelte
@@ -1,0 +1,1 @@
+<input placeholder='foo' {...{ placeholder: null }}>


### PR DESCRIPTION
Fixes #3764, with the assumption that #3750 may mean that it would become even more impractical to ship attribute-to-property tables along with the runtime.

In short:

- For each boolean attribute (more precisely, for each attribute with `attribute_lookup` metadata) given for a node that has at least one spread, the compiler will emit the appropriate property key in the object in the spread arrays. For example, `{ readOnly: whatever }` instead of `{ readonly: whatever }`.
- In SSR mode, the corresponding object in the spread array now contains `{ readonly: whatever || null }` instead of `{readonly: whatever }` for boolean attributes, to ensure that the `spread()` function does not serialize falsy attributes.

Bonus SSR bugs I bumped into and fixed while addressing this:

- `{...{ foo: null }}` was getting serialized as `foo="null"` because `spread()` was checking for strict equality with `undefined`. It's now checking for loose equality with `null`.
- Attributes had to be lowercase for the special logic for `value`, `class`, or any boolean attribute to take effect. These checks are now done case-insensitively.