### PR TITLE
warn if using svelte:options tag without compile_options.customElement

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -1307,6 +1307,13 @@ function process_component_options(component: Component, nodes) {
 							});
 						}
 
+						if (tag && !component.compile_options.customElement) {
+							component.warn(attribute, {
+								code: 'missing-custom-element-compile-options',
+								message: `tag name is used when compiling the compenent as a custom element. Did you forgot to add "customElement" for compile options?`
+							});
+						}
+
 						component_options.tag = tag;
 						break;
 					}

--- a/test/validator/samples/missing-custom-element-compile-options/input.svelte
+++ b/test/validator/samples/missing-custom-element-compile-options/input.svelte
@@ -1,0 +1,1 @@
+<svelte:options tag="custom-element" />

--- a/test/validator/samples/missing-custom-element-compile-options/warnings.json
+++ b/test/validator/samples/missing-custom-element-compile-options/warnings.json
@@ -1,0 +1,17 @@
+[
+	{
+		"code": "missing-custom-element-compile-options",
+		"end": {
+			"character": 36,
+			"column": 36,
+			"line": 1
+		},
+		"message": "tag name is used when compiling the compenent as a custom element. Did you forgot to add \"customElement\" for compile options?",
+		"pos": 16,
+		"start": {
+			"character": 16,
+			"column": 16,
+			"line": 1
+		}
+	}
+]


### PR DESCRIPTION
currently using `<svelte:options tag="foo-bar" />` without `compileOptions.customElement = true` is a noop.

Warn to remind about missing `customElement` flag.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
