### PR TITLE
Fix handling of style scoping and `class:` with spread scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix globals shadowing contextual template scope ([#3674](https://github.com/sveltejs/svelte/issues/3674))
 * Fix error resulting from trying to set a read-only property when spreading element attributes ([#3681](https://github.com/sveltejs/svelte/issues/3681))
 * Fix handling of boolean attributes in presence of other spread attributes ([#3764](https://github.com/sveltejs/svelte/issues/3764))
+* Fix handling of style scoping class in presence of spread attributes ([#3790](https://github.com/sveltejs/svelte/issues/3790))
 
 ## 3.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Fix `{#each}` context not shadowing outer scope when using `bind:` ([#1565](https://github.com/sveltejs/svelte/issues/1565))
 * Fix edge cases in matching selectors against elements ([#1710](https://github.com/sveltejs/svelte/issues/1710))
+* Fix several bugs related to interaction of `{...spread}` attributes with other features ([#2721](https://github.com/sveltejs/svelte/issues/2721), [#3421](https://github.com/sveltejs/svelte/issues/3421), [#3681](https://github.com/sveltejs/svelte/issues/3681), [#3764](https://github.com/sveltejs/svelte/issues/3764), [#3790](https://github.com/sveltejs/svelte/issues/3790))
 * Allow exiting a reactive block early with `break $` ([#2828](https://github.com/sveltejs/svelte/issues/2828))
-* Don't lose `class:` directive classes on an element with `{...spread}` attributes when updating ([#3421](https://github.com/sveltejs/svelte/issues/3421))
 * Fix application of style scoping class in cases of ambiguity ([#3544](https://github.com/sveltejs/svelte/issues/3544))
 * Check attributes have changed before setting them to avoid image flicker ([#3579](https://github.com/sveltejs/svelte/pull/3579))
 * Fix generating malformed code for `{@debug}` tags with no dependencies ([#3588](https://github.com/sveltejs/svelte/issue/3588))
@@ -19,9 +19,6 @@
 * Flush changes in newly attached block when using `{#await}` ([#3660](https://github.com/sveltejs/svelte/issues/3660))
 * Throw exception immediately when calling `createEventDispatcher()` after component instantiation ([#3667](https://github.com/sveltejs/svelte/pull/3667))
 * Fix globals shadowing contextual template scope ([#3674](https://github.com/sveltejs/svelte/issues/3674))
-* Fix error resulting from trying to set a read-only property when spreading element attributes ([#3681](https://github.com/sveltejs/svelte/issues/3681))
-* Fix handling of boolean attributes in presence of other spread attributes ([#3764](https://github.com/sveltejs/svelte/issues/3764))
-* Fix handling of style scoping class in presence of spread attributes ([#3790](https://github.com/sveltejs/svelte/issues/3790))
 
 ## 3.12.1
 

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -105,6 +105,7 @@ export default class Element extends Node {
 	animation?: Animation = null;
 	children: INode[];
 	namespace: string;
+	needs_manual_style_scoping: boolean;
 
 	constructor(component, parent, scope, info: any) {
 		super(component, parent, scope, info);
@@ -712,6 +713,11 @@ export default class Element extends Node {
 	}
 
 	add_css_class() {
+		if (this.attributes.some(attr => attr.is_spread)) {
+			this.needs_manual_style_scoping = true;
+			return;
+		}
+
 		const { id } = this.component.stylesheet;
 
 		const class_attribute = this.attributes.find(a => a.name === 'class');

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -344,6 +344,7 @@ export default class ElementWrapper extends Wrapper {
 		this.add_animation(block);
 		this.add_actions(block);
 		this.add_classes(block);
+		this.add_manual_style_scoping(block);
 
 		if (nodes && this.renderer.options.hydratable) {
 			block.chunks.claim.push(
@@ -837,6 +838,14 @@ export default class ElementWrapper extends Wrapper {
 					}`);
 			}
 		});
+	}
+
+	add_manual_style_scoping(block) {
+		if (this.node.needs_manual_style_scoping) {
+			const updater = b`@toggle_class(${this.var}, "${this.node.component.stylesheet.id}", true);`;
+			block.chunks.hydrate.push(updater);
+			block.chunks.update.push(updater);
+		}
 	}
 }
 

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -5,8 +5,15 @@ export const invalid_attribute_name_character = /[\s'">/=\u{FDD0}-\u{FDEF}\u{FFF
 // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
 // https://infra.spec.whatwg.org/#noncharacter
 
-export function spread(args) {
+export function spread(args, classes_to_add) {
 	const attributes = Object.assign({}, ...args);
+	if (classes_to_add) {
+		if (attributes.class == null) {
+			attributes.class = classes_to_add;
+		} else {
+			attributes.class += ' ' + classes_to_add;
+		}
+	}
 	let str = '';
 
 	Object.keys(attributes).forEach(name => {

--- a/test/runtime/samples/spread-element-class/main.svelte
+++ b/test/runtime/samples/spread-element-class/main.svelte
@@ -2,4 +2,4 @@
 	export let blah = 'hello';
 </script>
 
-<div class='foo' class:bar={true} {...{}}>{blah}</div>
+<div class:bar={true} {...{ class: 'foo' }}>{blah}</div>

--- a/test/runtime/samples/spread-element-scope/_config.js
+++ b/test/runtime/samples/spread-element-scope/_config.js
@@ -1,0 +1,7 @@
+export default {
+	html: `
+		<div class="foo svelte-xg5rbo">red</div>
+		<div class="qux svelte-xg5rbo">red</div>
+		<div class="bar svelte-xg5rbo">red and bold</div>
+	`
+};

--- a/test/runtime/samples/spread-element-scope/main.svelte
+++ b/test/runtime/samples/spread-element-scope/main.svelte
@@ -1,0 +1,10 @@
+<style>
+	div { color: red; }
+	.bar { font-weight: bold; }
+</style>
+
+<div {...{ class: 'bar' }} class='foo'>red</div>
+
+<div class='foo' {...{ class: 'qux' }}>red</div>
+
+<div {...{ class: 'bar' }}>red and bold</div>


### PR DESCRIPTION
Fixed #3790 (which also fixes #2721 in a better way than I mentioned on that ticket).

In DOM mode for elements that need the scoping class and have spread attributes, this adds `toggle_class(node, "svelte-xyz", true);` calls to the hydrate and update blocks, rather than trying to add or update a `class=` attribute in the element's AST. This prevents the scoping class and the spread class from clobbering one another.

In SSR mode for elements that need the scoping class and/or have `class:` directives and have spread attributes, this combines the scoping class and/or the `class:` directives into a string of classes that need to be added to the element after all of the spreading. This string is passed as a new second argument to `spread()`, which uses it to update or set the `class` attribute it's been given. This prevents multiple `class=` attributes from being emitted by the code.