### PR TITLE
Add Key handling to modal example

### DIFF
--- a/site/content/examples/15-composition/04-modal/Modal.svelte
+++ b/site/content/examples/15-composition/04-modal/Modal.svelte
@@ -2,7 +2,23 @@
 	import { createEventDispatcher } from 'svelte';
 
 	const dispatch = createEventDispatcher();
-</script>
+	
+	const handleClose = () => dispatch('close')
+
+	function handleKeydown(event) {
+		if (event.key == 'Escape') {
+			handleClose()
+		} else if (event.key == 'Tab') {
+			event.preventDefault()
+		}
+	}
+
+	let closeButton
+	onMount(() => {
+		closeButton.focus()
+	})
+
+</cript>
 
 <style>
 	.modal-background {
@@ -16,8 +32,7 @@
 
 	.modal {
 		position: absolute;
-		left: 50%;
-		top: 50%;
+		left: 50%;	top: 50%;
 		width: calc(100vw - 4em);
 		max-width: 32em;
 		max-height: calc(100vh - 4em);
@@ -33,7 +48,7 @@
 	}
 </style>
 
-<div class='modal-background' on:click='{() => dispatch("close")}'></div>
+<div class='modal-background' on:click='{handleClose}'></div>
 
 <div class='modal'>
 	<slot name='header'></slot>
@@ -41,5 +56,5 @@
 	<slot></slot>
 	<hr>
 
-	<button on:click='{() => dispatch("close")}'>close modal</button>
+	<button on:click='{() => dispatch("close")}' bind:this={closeButton}>close modal</button>
 </div>

--- a/site/content/examples/15-composition/04-modal/Modal.svelte
+++ b/site/content/examples/15-composition/04-modal/Modal.svelte
@@ -18,7 +18,7 @@
 		closeButton.focus()
 	})
 
-</cript>
+</script>
 
 <style>
 	.modal-background {


### PR DESCRIPTION
This is a basic accessibility requirement for key access

* Escape key closes the modal
* Tab key does not cycle round focusable elements in background
* Close key gets focus

I'm fast 'n' playing loose with the check list as its an update to one of the examples

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
