### PR TITLE
Add Event to globals list

### DIFF
--- a/src/compiler/utils/names.ts
+++ b/src/compiler/utils/names.ts
@@ -15,6 +15,7 @@ export const globals = new Set([
 	'encodeURIComponent',
 	'Error',
 	'EvalError',
+	'Event',
 	'history',
 	'Infinity',
 	'InternalError',


### PR DESCRIPTION
### Changes
Add `Event` to the list of globals.

### Background
When trying to create `new Event()`, the compiler complains that `Event is not defined`.

Relates to #3805 

### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`

There are at least more events that could be added and possibly even more things, but I figured I'd start with this one at least.