### PR TITLE
Alternative fix for #3508

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Also:
 * Fix edge cases in matching selectors against elements ([#1710](https://github.com/sveltejs/svelte/issues/1710))
 * Fix several bugs related to interaction of `{...spread}` attributes with other features ([#2721](https://github.com/sveltejs/svelte/issues/2721), [#2916](https://github.com/sveltejs/svelte/issues/2916), [#3421](https://github.com/sveltejs/svelte/issues/3421), [#3681](https://github.com/sveltejs/svelte/issues/3681), [#3764](https://github.com/sveltejs/svelte/issues/3764), [#3790](https://github.com/sveltejs/svelte/issues/3790))
 * Allow exiting a reactive block early with `break $` ([#2828](https://github.com/sveltejs/svelte/issues/2828))
+* Fix binding to props that have been renamed with `export { ... as ... }` ([#3508](https://github.com/sveltejs/svelte/issues/3508))
 * Fix application of style scoping class in cases of ambiguity ([#3544](https://github.com/sveltejs/svelte/issues/3544))
 * Check attributes have changed before setting them to avoid image flicker ([#3579](https://github.com/sveltejs/svelte/pull/3579))
 * Fix generating malformed code for `{@debug}` tags with no dependencies ([#3588](https://github.com/sveltejs/svelte/issues/3588))

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -223,7 +223,7 @@ export default function dom(
 
 		component.rewrite_props(({ name, reassigned, export_name }) => {
 			const value = `$${name}`;
-			
+
 			const insert = (reassigned || export_name)
 				? b`${`$$subscribe_${name}`}()`
 				: b`@component_subscribe($$self, ${name}, #value => $$invalidate('${value}', ${value} = #value))`;
@@ -426,10 +426,14 @@ export default function dom(
 	}
 
 	const prop_names = x`[]`;
+	const renamed_prop_names = [];
 
 	// TODO find a more idiomatic way of doing this
 	props.forEach(v => {
 		(prop_names as any).elements.push({ type: 'Literal', value: v.export_name });
+		if (v.name !== v.export_name) {
+			renamed_prop_names.push(p`${v.export_name}: "${v.name}"`);
+		}
 	});
 
 	if (options.customElement) {
@@ -440,7 +444,7 @@ export default function dom(
 
 					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(/\\/g, '\\\\')}${options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
 
-					@init(this, { target: this.shadowRoot }, ${definition}, create_fragment, ${not_equal}, ${prop_names});
+					@init(this, { target: this.shadowRoot }, ${definition}, create_fragment, ${not_equal}, ${prop_names}, ${renamed_prop_names.length > 0 && x`{ ${renamed_prop_names} }`});
 
 					${dev_props_check}
 
@@ -492,7 +496,7 @@ export default function dom(
 				constructor(options) {
 					super(${options.dev && `options`});
 					${should_add_css && b`if (!@_document.getElementById("${component.stylesheet.id}-style")) ${add_css}();`}
-					@init(this, options, ${definition}, create_fragment, ${not_equal}, ${prop_names});
+					@init(this, options, ${definition}, create_fragment, ${not_equal}, ${prop_names}, ${renamed_prop_names.length > 0 && x`{ ${renamed_prop_names} }`});
 					${options.dev && b`@dispatch_dev("SvelteRegisterComponent", { component: this, tagName: "${name.name}", options, id: create_fragment.name });`}
 
 					${dev_props_check}

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -425,16 +425,9 @@ export default function dom(
 		`);
 	}
 
-	const prop_names = x`{}` as ObjectExpression;
-
-	// TODO find a more idiomatic way of doing this
-	props.forEach(v => {
-		prop_names.properties.push(
-			v.name === v.export_name
-				? p`${v.name}: 0`
-				: p`${v.export_name}: "${v.name}"`
-		);
-	});
+	const prop_names = x`{
+		${props.map(v => p`${v.export_name}: ${v.export_name === v.name ? 0 : x`"${v.name}"`}}`)}
+	}` as ObjectExpression;
 
 	if (options.customElement) {
 		const declaration = b`

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -7,7 +7,7 @@ import add_to_set from '../utils/add_to_set';
 import { extract_names } from '../utils/scope';
 import { invalidate } from '../utils/invalidate';
 import Block from './Block';
-import { ClassDeclaration, FunctionExpression, Node, Statement } from 'estree';
+import { ClassDeclaration, FunctionExpression, Node, Statement, ObjectExpression } from 'estree';
 
 export default function dom(
 	component: Component,
@@ -425,15 +425,15 @@ export default function dom(
 		`);
 	}
 
-	const prop_names = x`[]`;
-	const renamed_prop_names = [];
+	const prop_names = x`{}` as ObjectExpression;
 
 	// TODO find a more idiomatic way of doing this
 	props.forEach(v => {
-		(prop_names as any).elements.push({ type: 'Literal', value: v.export_name });
-		if (v.name !== v.export_name) {
-			renamed_prop_names.push(p`${v.export_name}: "${v.name}"`);
-		}
+		prop_names.properties.push(
+			v.name === v.export_name
+				? p`${v.name}: 0`
+				: p`${v.export_name}: "${v.name}"`
+		);
 	});
 
 	if (options.customElement) {
@@ -444,7 +444,7 @@ export default function dom(
 
 					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(/\\/g, '\\\\')}${options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
 
-					@init(this, { target: this.shadowRoot }, ${definition}, create_fragment, ${not_equal}, ${prop_names}, ${renamed_prop_names.length > 0 && x`{ ${renamed_prop_names} }`});
+					@init(this, { target: this.shadowRoot }, ${definition}, create_fragment, ${not_equal}, ${prop_names});
 
 					${dev_props_check}
 
@@ -496,7 +496,7 @@ export default function dom(
 				constructor(options) {
 					super(${options.dev && `options`});
 					${should_add_css && b`if (!@_document.getElementById("${component.stylesheet.id}-style")) ${add_css}();`}
-					@init(this, options, ${definition}, create_fragment, ${not_equal}, ${prop_names}, ${renamed_prop_names.length > 0 && x`{ ${renamed_prop_names} }`});
+					@init(this, options, ${definition}, create_fragment, ${not_equal}, ${prop_names});
 					${options.dev && b`@dispatch_dev("SvelteRegisterComponent", { component: this, tagName: "${name.name}", options, id: create_fragment.name });`}
 
 					${dev_props_check}

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -1,6 +1,6 @@
 import { add_render_callback, flush, schedule_update, dirty_components } from './scheduler';
 import { current_component, set_current_component } from './lifecycle';
-import { blank_object, is_function, run, run_all, noop } from './utils';
+import { blank_object, is_function, run, run_all, noop, has_prop } from './utils';
 import { children } from './dom';
 import { transition_in } from './transitions';
 
@@ -22,7 +22,7 @@ interface T$$ {
 }
 
 export function bind(component, name, callback) {
-	if (component.$$.props.hasOwnProperty(name)) {
+	if (has_prop(component.$$.props, name)) {
 		name = component.$$.props[name] || name;
 		component.$$.bound[name] = callback;
 		callback(component.$$.ctx[name]);

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -12,8 +12,7 @@ interface T$$ {
 	update: () => void;
 	callbacks: any;
 	after_update: any[];
-	props: any;
-	renamed_props: any;
+	props: Record<string, 0 | string>;
 	fragment: null|any;
 	not_equal: any;
 	before_update: any[];
@@ -23,12 +22,11 @@ interface T$$ {
 }
 
 export function bind(component, name, callback) {
-	if (component.$$.props.indexOf(name) === -1) return;
-	if (component.$$.renamed_props && name in component.$$.renamed_props) {
-		name = component.$$.renamed_props[name];
+	if (name in component.$$.props) {
+		name = component.$$.props[name] || name;
+		component.$$.bound[name] = callback;
+		callback(component.$$.ctx[name]);
 	}
-	component.$$.bound[name] = callback;
-	callback(component.$$.ctx[name]);
 }
 
 export function mount_component(component, target, anchor) {
@@ -74,19 +72,18 @@ function make_dirty(component, key) {
 	component.$$.dirty[key] = true;
 }
 
-export function init(component, options, instance, create_fragment, not_equal, prop_names, renamed_props) {
+export function init(component, options, instance, create_fragment, not_equal, props) {
 	const parent_component = current_component;
 	set_current_component(component);
 
-	const props = options.props || {};
+	const prop_values = options.props || {};
 
 	const $$: T$$ = component.$$ = {
 		fragment: null,
 		ctx: null,
 
 		// state
-		props: prop_names,
-		renamed_props,
+		props,
 		update: noop,
 		not_equal,
 		bound: blank_object(),
@@ -106,14 +103,14 @@ export function init(component, options, instance, create_fragment, not_equal, p
 	let ready = false;
 
 	$$.ctx = instance
-		? instance(component, props, (key, ret, value = ret) => {
+		? instance(component, prop_values, (key, ret, value = ret) => {
 			if ($$.ctx && not_equal($$.ctx[key], $$.ctx[key] = value)) {
 				if ($$.bound[key]) $$.bound[key](value);
 				if (ready) make_dirty(component, key);
 			}
 			return ret;
 		})
-		: props;
+		: prop_values;
 
 	$$.update();
 	ready = true;

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -22,7 +22,7 @@ interface T$$ {
 }
 
 export function bind(component, name, callback) {
-	if (name in component.$$.props) {
+	if (component.$$.props.hasOwnProperty(name)) {
 		name = component.$$.props[name] || name;
 		component.$$.bound[name] = callback;
 		callback(component.$$.ctx[name]);

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -13,6 +13,7 @@ interface T$$ {
 	callbacks: any;
 	after_update: any[];
 	props: any;
+	renamed_props: any;
 	fragment: null|any;
 	not_equal: any;
 	before_update: any[];
@@ -23,6 +24,9 @@ interface T$$ {
 
 export function bind(component, name, callback) {
 	if (component.$$.props.indexOf(name) === -1) return;
+	if (component.$$.renamed_props && name in component.$$.renamed_props) {
+		name = component.$$.renamed_props[name];
+	}
 	component.$$.bound[name] = callback;
 	callback(component.$$.ctx[name]);
 }
@@ -70,7 +74,7 @@ function make_dirty(component, key) {
 	component.$$.dirty[key] = true;
 }
 
-export function init(component, options, instance, create_fragment, not_equal, prop_names) {
+export function init(component, options, instance, create_fragment, not_equal, prop_names, renamed_props) {
 	const parent_component = current_component;
 	set_current_component(component);
 
@@ -82,6 +86,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 
 		// state
 		props: prop_names,
+		renamed_props,
 		update: noop,
 		not_equal,
 		bound: blank_object(),

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -1,3 +1,5 @@
+import { has_prop } from "./utils";
+
 export function append(target: Node, node: Node) {
 	target.appendChild(node);
 }
@@ -29,7 +31,7 @@ export function object_without_properties<T, K extends keyof T>(obj: T, exclude:
 	const target = {} as Pick<T, Exclude<keyof T, K>>;
 	for (const k in obj) {
 		if (
-			Object.prototype.hasOwnProperty.call(obj, k)
+			has_prop(obj, k)
 			// @ts-ignore
 			&& exclude.indexOf(k) === -1
 		) {

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -105,3 +105,5 @@ export function set_store_value(store, ret, value = ret) {
 	store.set(value);
 	return ret;
 }
+
+export const has_prop = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);

--- a/test/js/samples/action-custom-event-handler/expected.js
+++ b/test/js/samples/action-custom-event-handler/expected.js
@@ -39,7 +39,7 @@ function handleFoo(bar) {
 }
 
 function foo(node, callback) {
-
+	
 }
 
 function instance($$self, $$props, $$invalidate) {
@@ -56,7 +56,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["bar"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { bar: 0 });
 	}
 }
 

--- a/test/js/samples/action/expected.js
+++ b/test/js/samples/action/expected.js
@@ -52,7 +52,7 @@ function link(node) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/bind-online/expected.js
+++ b/test/js/samples/bind-online/expected.js
@@ -42,7 +42,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/bind-open/expected.js
+++ b/test/js/samples/bind-open/expected.js
@@ -58,7 +58,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["open"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { open: 0 });
 	}
 }
 

--- a/test/js/samples/bind-width-height/expected.js
+++ b/test/js/samples/bind-width-height/expected.js
@@ -56,7 +56,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["w", "h"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { w: 0, h: 0 });
 	}
 }
 

--- a/test/js/samples/capture-inject-dev-only/expected.js
+++ b/test/js/samples/capture-inject-dev-only/expected.js
@@ -68,7 +68,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -58,7 +58,7 @@ class Component extends SvelteComponent {
 	constructor(options) {
 		super();
 		if (!document.getElementById("svelte-1a7i8ec-style")) add_css();
-		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
 	}
 }
 

--- a/test/js/samples/component-static-array/expected.js
+++ b/test/js/samples/component-static-array/expected.js
@@ -45,7 +45,7 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/component-static-immutable/expected.js
+++ b/test/js/samples/component-static-immutable/expected.js
@@ -45,7 +45,7 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, not_equal, []);
+		init(this, options, instance, create_fragment, not_equal, {});
 	}
 }
 

--- a/test/js/samples/component-static-immutable2/expected.js
+++ b/test/js/samples/component-static-immutable2/expected.js
@@ -45,7 +45,7 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, not_equal, []);
+		init(this, options, instance, create_fragment, not_equal, {});
 	}
 }
 

--- a/test/js/samples/component-static-var/expected.js
+++ b/test/js/samples/component-static-var/expected.js
@@ -91,7 +91,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/component-static/expected.js
+++ b/test/js/samples/component-static/expected.js
@@ -45,7 +45,7 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/component-store-access-invalidate/expected.js
+++ b/test/js/samples/component-store-access-invalidate/expected.js
@@ -48,7 +48,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/component-store-file-invalidate/expected.js
+++ b/test/js/samples/component-store-file-invalidate/expected.js
@@ -34,7 +34,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["increment"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { increment: 0 });
 	}
 
 	get increment() {

--- a/test/js/samples/component-store-reassign-invalidate/expected.js
+++ b/test/js/samples/component-store-reassign-invalidate/expected.js
@@ -67,7 +67,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -32,7 +32,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["x", "a", "b"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { x: 0, a: 0, b: 0 });
 	}
 
 	get a() {

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -41,7 +41,7 @@ class Component extends SvelteComponent {
 	constructor(options) {
 		super();
 		if (!document.getElementById("svelte-1slhpfn-style")) add_css();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/css-shadow-dom-keyframes/expected.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected.js
@@ -33,7 +33,7 @@ class Component extends SvelteElement {
 	constructor(options) {
 		super();
 		this.shadowRoot.innerHTML = `<style>div{animation:foo 1s}@keyframes foo{0%{opacity:0}100%{opacity:1}}</style>`;
-		init(this, { target: this.shadowRoot }, null, create_fragment, safe_not_equal, []);
+		init(this, { target: this.shadowRoot }, null, create_fragment, safe_not_equal, {});
 
 		if (options) {
 			if (options.target) {

--- a/test/js/samples/data-attribute/expected.js
+++ b/test/js/samples/data-attribute/expected.js
@@ -56,7 +56,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["bar"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { bar: 0 });
 	}
 }
 

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -92,7 +92,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, ["name"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { name: 0 });
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -192,7 +192,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, ["things", "foo", "bar", "baz"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { things: 0, foo: 0, bar: 0, baz: 0 });
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -186,7 +186,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, ["things", "foo"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { things: 0, foo: 0 });
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/debug-hoisted/expected.js
+++ b/test/js/samples/debug-hoisted/expected.js
@@ -64,7 +64,7 @@ function instance($$self) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/debug-no-dependencies/expected.js
+++ b/test/js/samples/debug-no-dependencies/expected.js
@@ -132,7 +132,7 @@ function create_fragment(ctx) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -112,7 +112,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["createElement"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { createElement: 0 });
 	}
 }
 

--- a/test/js/samples/deconflict-globals/expected.js
+++ b/test/js/samples/deconflict-globals/expected.js
@@ -29,7 +29,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
 	}
 }
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -96,7 +96,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/dont-invalidate-this/expected.js
+++ b/test/js/samples/dont-invalidate-this/expected.js
@@ -38,7 +38,7 @@ function make_uppercase() {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/dynamic-import/expected.js
+++ b/test/js/samples/dynamic-import/expected.js
@@ -44,7 +44,7 @@ const func = () => import("./Foo.svelte");
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -118,7 +118,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["a", "b", "c", "d", "e"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { a: 0, b: 0, c: 0, d: 0, e: 0 });
 	}
 }
 

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -163,7 +163,13 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["comments", "elapsed", "time", "foo"]);
+
+		init(this, options, instance, create_fragment, safe_not_equal, {
+			comments: 0,
+			elapsed: 0,
+			time: 0,
+			foo: 0
+		});
 	}
 }
 

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -134,7 +134,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["things"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { things: 0 });
 	}
 }
 

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -103,7 +103,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["things"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { things: 0 });
 	}
 }
 

--- a/test/js/samples/event-handler-no-passive/expected.js
+++ b/test/js/samples/event-handler-no-passive/expected.js
@@ -39,7 +39,7 @@ const touchstart_handler = e => e.preventDefault();
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/event-modifiers/expected.js
+++ b/test/js/samples/event-modifiers/expected.js
@@ -61,17 +61,17 @@ function create_fragment(ctx) {
 }
 
 function handleTouchstart() {
-
+	
 }
 
 function handleClick() {
-
+	
 }
 
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/head-no-whitespace/expected.js
+++ b/test/js/samples/head-no-whitespace/expected.js
@@ -39,7 +39,7 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/hoisted-const/expected.js
+++ b/test/js/samples/hoisted-const/expected.js
@@ -37,7 +37,7 @@ function get_answer() {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/hoisted-let/expected.js
+++ b/test/js/samples/hoisted-let/expected.js
@@ -37,7 +37,7 @@ function get_answer() {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/if-block-complex/expected.js
+++ b/test/js/samples/if-block-complex/expected.js
@@ -59,7 +59,7 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -96,7 +96,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
 	}
 }
 

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -46,7 +46,7 @@ function create_fragment(ctx) {
 					if_block.c();
 					if_block.m(if_block_anchor.parentNode, if_block_anchor);
 				} else {
-
+					
 				}
 			} else if (if_block) {
 				if_block.d(1);
@@ -75,7 +75,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
 	}
 }
 

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -55,7 +55,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["color", "x", "y"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { color: 0, x: 0, y: 0 });
 	}
 }
 

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -46,7 +46,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["data"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { data: 0 });
 	}
 }
 

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -46,7 +46,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["color"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { color: 0 });
 	}
 }
 

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -64,7 +64,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["style", "key", "value"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { style: 0, key: 0, value: 0 });
 	}
 }
 

--- a/test/js/samples/inline-style-without-updates/expected.js
+++ b/test/js/samples/inline-style-without-updates/expected.js
@@ -34,7 +34,7 @@ let color = "red";
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/input-files/expected.js
+++ b/test/js/samples/input-files/expected.js
@@ -52,7 +52,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["files"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { files: 0 });
 	}
 }
 

--- a/test/js/samples/input-no-initial-value/expected.js
+++ b/test/js/samples/input-no-initial-value/expected.js
@@ -80,7 +80,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -63,7 +63,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["value"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { value: 0 });
 	}
 }
 

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -56,7 +56,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["foo"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
 	}
 }
 

--- a/test/js/samples/instrumentation-script-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-script-if-no-block/expected.js
@@ -65,7 +65,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/instrumentation-script-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-script-x-equals-x/expected.js
@@ -67,7 +67,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -65,7 +65,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/instrumentation-template-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-template-x-equals-x/expected.js
@@ -67,7 +67,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/legacy-input-type/expected.js
+++ b/test/js/samples/legacy-input-type/expected.js
@@ -32,7 +32,7 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -166,16 +166,16 @@ class Component extends SvelteComponent {
 	constructor(options) {
 		super();
 
-		init(this, options, instance, create_fragment, safe_not_equal, [
-			"buffered",
-			"seekable",
-			"played",
-			"currentTime",
-			"duration",
-			"paused",
-			"volume",
-			"playbackRate"
-		]);
+		init(this, options, instance, create_fragment, safe_not_equal, {
+			buffered: 0,
+			seekable: 0,
+			played: 0,
+			currentTime: 0,
+			duration: 0,
+			paused: 0,
+			volume: 0,
+			playbackRate: 0
+		});
 	}
 }
 

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -55,7 +55,7 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/non-mutable-reference/expected.js
+++ b/test/js/samples/non-mutable-reference/expected.js
@@ -33,7 +33,7 @@ let name = "world";
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/reactive-values-non-topologically-ordered/expected.js
+++ b/test/js/samples/reactive-values-non-topologically-ordered/expected.js
@@ -36,7 +36,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["x"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { x: 0 });
 	}
 }
 

--- a/test/js/samples/reactive-values-non-writable-dependencies/expected.js
+++ b/test/js/samples/reactive-values-non-writable-dependencies/expected.js
@@ -32,7 +32,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["a", "b"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { a: 0, b: 0 });
 	}
 }
 

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -75,7 +75,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["current"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { current: 0 });
 	}
 }
 

--- a/test/js/samples/setup-method/expected.js
+++ b/test/js/samples/setup-method/expected.js
@@ -20,7 +20,7 @@ function foo(bar) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, ["foo"]);
+		init(this, options, null, create_fragment, safe_not_equal, { foo: 0 });
 	}
 
 	get foo() {

--- a/test/js/samples/ssr-no-oncreate-etc/expected.js
+++ b/test/js/samples/ssr-no-oncreate-etc/expected.js
@@ -10,7 +10,7 @@ function foo() {
 }
 
 function swipe(node, callback) {
-
+	
 }
 
 const Component = create_ssr_component(($$result, $$props, $$bindings, $$slots) => {

--- a/test/js/samples/svg-title/expected.js
+++ b/test/js/samples/svg-title/expected.js
@@ -38,7 +38,7 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, []);
+		init(this, options, null, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -31,7 +31,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["custom"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { custom: 0 });
 	}
 }
 

--- a/test/js/samples/transition-local/expected.js
+++ b/test/js/samples/transition-local/expected.js
@@ -113,7 +113,7 @@ function create_fragment(ctx) {
 }
 
 function foo() {
-
+	
 }
 
 function instance($$self, $$props, $$invalidate) {
@@ -131,7 +131,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["x", "y"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { x: 0, y: 0 });
 	}
 }
 

--- a/test/js/samples/transition-repeated-outro/expected.js
+++ b/test/js/samples/transition-repeated-outro/expected.js
@@ -109,7 +109,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["num"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { num: 0 });
 	}
 }
 

--- a/test/js/samples/unchanged-expression/expected.js
+++ b/test/js/samples/unchanged-expression/expected.js
@@ -71,7 +71,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/unreferenced-state-not-invalidated/expected.js
+++ b/test/js/samples/unreferenced-state-not-invalidated/expected.js
@@ -72,7 +72,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -157,7 +157,7 @@ function create_fragment(ctx) {
 					if_block0.c();
 					if_block0.m(div, t0);
 				} else {
-
+					
 				}
 			} else if (if_block0) {
 				if_block0.d(1);
@@ -170,7 +170,7 @@ function create_fragment(ctx) {
 					if_block1.c();
 					if_block1.m(div, t3);
 				} else {
-
+					
 				}
 			} else if (if_block1) {
 				if_block1.d(1);
@@ -183,7 +183,7 @@ function create_fragment(ctx) {
 					if_block2.c();
 					if_block2.m(div, t4);
 				} else {
-
+					
 				}
 			} else if (if_block2) {
 				if_block2.d(1);
@@ -196,7 +196,7 @@ function create_fragment(ctx) {
 					if_block3.c();
 					if_block3.m(div, null);
 				} else {
-
+					
 				}
 			} else if (if_block3) {
 				if_block3.d(1);
@@ -209,7 +209,7 @@ function create_fragment(ctx) {
 					if_block4.c();
 					if_block4.m(if_block4_anchor.parentNode, if_block4_anchor);
 				} else {
-
+					
 				}
 			} else if (if_block4) {
 				if_block4.d(1);
@@ -252,7 +252,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["a", "b", "c", "d", "e"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { a: 0, b: 0, c: 0, d: 0, e: 0 });
 	}
 }
 

--- a/test/js/samples/window-binding-online/expected.js
+++ b/test/js/samples/window-binding-online/expected.js
@@ -42,7 +42,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, []);
+		init(this, options, instance, create_fragment, safe_not_equal, {});
 	}
 }
 

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -81,7 +81,7 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, ["y"]);
+		init(this, options, instance, create_fragment, safe_not_equal, { y: 0 });
 	}
 }
 

--- a/test/runtime/samples/component-binding-aliased/Widget.svelte
+++ b/test/runtime/samples/component-binding-aliased/Widget.svelte
@@ -1,0 +1,4 @@
+<script>
+	let foo = 42;
+	export { foo as bar };
+</script>

--- a/test/runtime/samples/component-binding-aliased/_config.js
+++ b/test/runtime/samples/component-binding-aliased/_config.js
@@ -1,0 +1,5 @@
+export default {
+	html: `
+		<div>42</div>
+	`
+};

--- a/test/runtime/samples/component-binding-aliased/main.svelte
+++ b/test/runtime/samples/component-binding-aliased/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Widget from './Widget.svelte';
+	let bar;
+</script>
+
+<Widget bind:bar/>
+
+<div>{bar}</div>


### PR DESCRIPTION
This is an alternative to #3809 (fixes #3508). It feels like a bit of a hack, but if we replace the array passed to the end of `init` with an object whose values are zeroes...

```diff
-init(this, options, instance, create_fragment, safe_not_equal, ["a", "b"]);
+init(this, options, instance, create_fragment, safe_not_equal, {a:0, b:0});
```

...then we can add renamed properties to the same object...

```js
init(this, options, instance, create_fragment, safe_not_equal, {a:0, b:0, c:"d"});
```

...and handle aliased exports while adding slightly less code:

```js
export function bind(component, name, callback) {
  if (name in component.$$.props) {
    name = component.$$.props[name] || name;
    component.$$.bound[name] = callback;
    callback(component.$$.ctx[name]);
  }
}
```

I don't feel *great* about it, but it works. @Conduitry thoughts?