### PR TITLE
remove empty value declaration from style tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1180,9 +1180,9 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.8.1.tgz",
-      "integrity": "sha512-H6cJORkqvrNziu0KX2hqOMAlA2CiuAxHeGJXSIoKA/KLv229Dw806J3II6mKTm5xiDX1At1EXCfsOQPB+tMB+g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.9.0.tgz",
+      "integrity": "sha512-12U47o7XHUX329+x3FzNVjCx3SHEzMF0nkDv7r/HnBzX/xNTKxajBk6gyygaxrAFtLj39219oMfbtxv4KpaOiA==",
       "dev": true
     },
     "esutils": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint": "^6.3.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-svelte3": "^2.7.3",
-    "estree-walker": "^0.8.1",
+    "estree-walker": "^0.9.0",
     "is-reference": "^1.1.4",
     "jsdom": "^15.1.1",
     "kleur": "^3.0.3",

--- a/src/compiler/parse/read/style.ts
+++ b/src/compiler/parse/read/style.ts
@@ -47,7 +47,7 @@ export default function read_style(parser: Parser, start: number, attributes: No
 				}
 			}
 
-			if (node.type === 'Declaration' && node.value.children.length === 0) {
+			if (node.type === 'Declaration' && node.value.type === 'Value' && node.value.children.length === 0) {
 				this.remove();
 			}
 

--- a/src/compiler/parse/read/style.ts
+++ b/src/compiler/parse/read/style.ts
@@ -31,7 +31,7 @@ export default function read_style(parser: Parser, start: number, attributes: No
 
 	// tidy up AST
 	walk(ast, {
-		enter: (node: any) => { // `any` because this isn't an ESTree node
+		enter(node: any) { // `any` because this isn't an ESTree node
 			// replace `ref:a` nodes
 			if (node.type === 'Selector') {
 				for (let i = 0; i < node.children.length; i += 1) {
@@ -45,6 +45,10 @@ export default function read_style(parser: Parser, start: number, attributes: No
 						}, a.loc.start.offset);
 					}
 				}
+			}
+
+			if (node.type === 'Declaration' && node.value.children.length === 0) {
+				this.remove();
 			}
 
 			if (node.loc) {

--- a/test/css/samples/empty-value/expected.css
+++ b/test/css/samples/empty-value/expected.css
@@ -1,0 +1,1 @@
+.bar.svelte-xyz{color:blue}

--- a/test/css/samples/empty-value/input.svelte
+++ b/test/css/samples/empty-value/input.svelte
@@ -1,0 +1,11 @@
+<div class='foo bar'></div>
+
+<style>
+	.foo {
+		color:;
+	}
+	.bar {
+		font:;
+		color: blue;
+	}
+</style>


### PR DESCRIPTION
Fix #3801 
If the value is empty, will cause compile error down the road.
Remove it upfront, will be able to treat it as empty rule, if there's no other declaration for the rule.