### PR TITLE
swapped out expected and actual for asserts in error

### DIFF
--- a/test/runtime/index.js
+++ b/test/runtime/index.js
@@ -190,7 +190,7 @@ describe("runtime", () => {
 						if (typeof config.error === 'function') {
 							config.error(assert, err);
 						} else {
-							assert.equal(config.error, err.message);
+							assert.equal(err.message, config.error);
 						}
 					} else {
 						throw err;

--- a/test/server-side-rendering/index.js
+++ b/test/server-side-rendering/index.js
@@ -138,7 +138,7 @@ describe("ssr", () => {
 					if (typeof config.error === 'function') {
 						config.error(assert, err);
 					} else {
-						assert.equal(config.error, err.message);
+						assert.equal(err.message, config.error);
 					}
 				} else {
 					showOutput(cwd, compileOptions);


### PR DESCRIPTION
while fixing bugs, found out that for `runtime` and `server-side-rendering` test suite, the `expected` and `actual` for errors are swapped out.