### PR TITLE
fix input binding fails if type declared last

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -152,14 +152,8 @@ export default class Element extends Node {
 		}
 
 		// Binding relies on Attribute, defer its evaluation
-		const deferreds = ['Binding'];
-
-		info.attributes.sort((node1, node2) => {
-			const deferIndex1 = deferreds.indexOf(node1.type);
-			const deferIndex2 = deferreds.indexOf(node2.type);
-
-			return deferIndex1 - deferIndex2;
-		});
+		const order = ['Binding']; // everything else is -1
+		info.attributes.sort((a, b) => order.indexOf(a.type) - order.indexOf(b.type));
 
 		info.attributes.forEach(node => {
 			switch (node.type) {

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -151,6 +151,16 @@ export default class Element extends Node {
 			}
 		}
 
+		// Binding relies on Attribute, defer its evaluation
+		const deferreds = ['Binding'];
+
+		info.attributes.sort((node1, node2) => {
+			const deferIndex1 = deferreds.indexOf(node1.type);
+			const deferIndex2 = deferreds.indexOf(node2.type);
+
+			return deferIndex1 - deferIndex2;
+		});
+
 		info.attributes.forEach(node => {
 			switch (node.type) {
 				case 'Action':

--- a/test/js/samples/bindings-readonly-order/expected.js
+++ b/test/js/samples/bindings-readonly-order/expected.js
@@ -1,0 +1,82 @@
+import {
+	SvelteComponent,
+	attr,
+	detach,
+	element,
+	init,
+	insert,
+	listen,
+	noop,
+	run_all,
+	safe_not_equal,
+	space
+} from "svelte/internal";
+
+function create_fragment(ctx) {
+	let input0;
+	let t;
+	let input1;
+	let dispose;
+
+	return {
+		c() {
+			input0 = element("input");
+			t = space();
+			input1 = element("input");
+			attr(input0, "type", "file");
+			attr(input1, "type", "file");
+
+			dispose = [
+				listen(input0, "change", ctx.input0_change_handler),
+				listen(input1, "change", ctx.input1_change_handler)
+			];
+		},
+		m(target, anchor) {
+			insert(target, input0, anchor);
+			insert(target, t, anchor);
+			insert(target, input1, anchor);
+		},
+		p: noop,
+		i: noop,
+		o: noop,
+		d(detaching) {
+			if (detaching) detach(input0);
+			if (detaching) detach(t);
+			if (detaching) detach(input1);
+			run_all(dispose);
+		}
+	};
+}
+
+function instance($$self, $$props, $$invalidate) {
+	let { files } = $$props;
+
+	function input0_change_handler() {
+		files = this.files;
+		$$invalidate("files", files);
+	}
+
+	function input1_change_handler() {
+		files = this.files;
+		$$invalidate("files", files);
+	}
+
+	$$self.$set = $$props => {
+		if ("files" in $$props) $$invalidate("files", files = $$props.files);
+	};
+
+	return {
+		files,
+		input0_change_handler,
+		input1_change_handler
+	};
+}
+
+class Component extends SvelteComponent {
+	constructor(options) {
+		super();
+		init(this, options, instance, create_fragment, safe_not_equal, { files: 0 });
+	}
+}
+
+export default Component;

--- a/test/js/samples/bindings-readonly-order/input.svelte
+++ b/test/js/samples/bindings-readonly-order/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	export let files;
+</script>
+
+<input type="file" bind:files>
+<input bind:files type="file">


### PR DESCRIPTION
Should fix #3828 

If type attribute is declared after the binding, evaluating `parent.get_static_attribute_value('type')` in `Binding` returns `null` because type hasn't been pushed to the attributes list. As a result, `type` is null and `type === 'file'` is false, which is used to determine whether it's readonly and to prevent assigning `input.files`.

Forcing all `Attribute`s and `Spread`s  to be evaluated before `Binding` can fix the issue, and I suppose it does not create any kind of side effect. Let me know if there's any problem may arise that I'm not aware of.

Really appreciate for your review!

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
