### PR TITLE
escape html quotes in `.innerHtml` statement

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -894,7 +894,7 @@ function to_html(wrappers: Array<ElementWrapper | TextWrapper | TagWrapper>, blo
 
 				attr.node.chunks.forEach(chunk => {
 					if (chunk.type === 'Text') {
-						state.quasi.value.raw += chunk.data;
+						state.quasi.value.raw += escape_html(chunk.data);
 					} else {
 						literal.quasis.push(state.quasi);
 						literal.expressions.push(chunk.manipulate(block));

--- a/src/compiler/compile/utils/stringify.ts
+++ b/src/compiler/compile/utils/stringify.ts
@@ -12,13 +12,15 @@ export function escape(data: string, { only_escape_at_symbol = false } = {}) {
 }
 
 const escaped = {
+  '"': '&quot;',
+  "'": '&#39;',
 	'&': '&amp;',
 	'<': '&lt;',
 	'>': '&gt;',
 };
 
 export function escape_html(html) {
-	return String(html).replace(/[&<>]/g, match => escaped[match]);
+	return String(html).replace(/["'&<>]/g, match => escaped[match]);
 }
 
 export function escape_template(str) {

--- a/test/runtime/samples/attribute-static-quotemarks/_config.js
+++ b/test/runtime/samples/attribute-static-quotemarks/_config.js
@@ -1,3 +1,8 @@
 export default {
-	html: `<span title='"foo"'>foo</span>`
+	html: `
+		<span title='"foo"'>
+			foo
+  		<span title='"bar"'>bar</span>
+		</span>
+	`
 };

--- a/test/runtime/samples/attribute-static-quotemarks/main.svelte
+++ b/test/runtime/samples/attribute-static-quotemarks/main.svelte
@@ -1,1 +1,4 @@
-<span title='"foo"'>foo</span>
+<span title='"foo"'>
+  foo
+  <span title='"bar"'>bar</span>
+</span>


### PR DESCRIPTION
when using `innerHtml`, the quotemarks in the attribute are not escaped