### PR TITLE
fix: svelte-logo-mask correct file name

### DIFF
--- a/site/content/tutorial/06-bindings/12-bind-this/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/12-bind-this/app-a/App.svelte
@@ -43,8 +43,8 @@
 		width: 100%;
 		height: 100%;
 		background-color: #666;
-		-webkit-mask: url(logo-mask.svg) 50% 50% no-repeat;
-		mask: url(logo-mask.svg) 50% 50% no-repeat;
+		-webkit-mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
+		mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
 	}
 </style>
 

--- a/site/content/tutorial/06-bindings/12-bind-this/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/12-bind-this/app-b/App.svelte
@@ -43,8 +43,8 @@
 		width: 100%;
 		height: 100%;
 		background-color: #666;
-		-webkit-mask: url(logo-mask.svg) 50% 50% no-repeat;
-		mask: url(logo-mask.svg) 50% 50% no-repeat;
+		-webkit-mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
+		mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
 	}
 </style>
 


### PR DESCRIPTION
**Minor fix for a broken path.**
In the tutorial in chapter 6-bindings section *this* the path for the logo mask was broken. So I guessed it was `svelte-logo-mask.svg` instead. 
I've changed both in the exercise and in the solution.

Not a big deal but I hope that it could be appreciated!