### PR TITLE
encode parts of filename, not entire string

### DIFF
--- a/src/compiler/compile/utils/get_name_from_filename.ts
+++ b/src/compiler/compile/utils/get_name_from_filename.ts
@@ -1,7 +1,7 @@
 export default function get_name_from_filename(filename: string) {
 	if (!filename) return null;
-	// eslint-disable-next-line no-useless-escape
-	const parts = encodeURI(filename).split(/[\/\\]/);
+
+	const parts = filename.split(/[\/\\]/).map(encodeURI);
 
 	if (parts.length > 1) {
 		const index_match = parts[parts.length - 1].match(/^index(\.\w+)/);

--- a/src/compiler/compile/utils/get_name_from_filename.ts
+++ b/src/compiler/compile/utils/get_name_from_filename.ts
@@ -1,7 +1,7 @@
 export default function get_name_from_filename(filename: string) {
 	if (!filename) return null;
 
-	const parts = filename.split(/[\/\\]/).map(encodeURI);
+	const parts = filename.split(/[/\\]/).map(encodeURI);
 
 	if (parts.length > 1) {
 		const index_match = parts[parts.length - 1].match(/^index(\.\w+)/);


### PR DESCRIPTION
Should fix a bug in #3846 whereby the `\` Windows path separator was being treated as a funky character