### PR TITLE
improve testing experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,11 @@ Test samples are kept in `/test/xxx/samples` folder.
 1. To run only one test suite, rename the test suite folder to end with `.solo`. For example, to run the `test/js` test suite only, rename it to `test/js.solo`.
 1. Remember to rename the test folder back. The CI will fail if there's a solo test.
 
+##### Updating `.expected` files
+
+1. Tests suites like `css`, `js`, `server-side-rendering` asserts that the generated output has to match the content in the `.expected` file. For example, in the `js` test suites, the generated js code is compared against the content in `expected.js`.
+1. To update the content of the `.expected` file, run the test with `--update` flag. (`npm run test --update`)
+
 #### Breaking changes
 
 When adding a new breaking change, follow this template in your pull request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,12 @@ Test samples are kept in `/test/xxx/samples` folder.
 1. To run test, run `npm run test`
 1. To run test for a specific feature, you can use the `-g` (aka `--grep`) option. For example, to only run test involving transitions, run `npm run test -- -g transition`.
 
+##### Running solo test
+
+1. To run only one test, rename the test sample folder to end with `.solo`. For example, to run the `test/js/samples/action` only, rename it to `test/js/samples/action.solo`.
+1. To run only one test suite, rename the test suite folder to end with `.solo`. For example, to run the `test/js` test suite only, rename it to `test/js.solo`.
+1. Remember to rename the test folder back. The CI will fail if there's a solo test.
+
 #### Breaking changes
 
 When adding a new breaking change, follow this template in your pull request:

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -206,6 +206,10 @@ export function showOutput(cwd, options = {}, compile = svelte.compile) {
 	});
 }
 
+export function shouldUpdateExpected() {
+	return process.argv.includes('--update');
+}
+
 export function spaces(i) {
 	let result = '';
 	while (i--) result += ' ';

--- a/test/hydration/index.js
+++ b/test/hydration/index.js
@@ -7,7 +7,8 @@ import {
 	loadConfig,
 	loadSvelte,
 	env,
-	setupHtmlEqual
+	setupHtmlEqual,
+	shouldUpdateExpected
 } from '../helpers.js';
 
 let compileOptions = null;
@@ -76,7 +77,16 @@ describe('hydration', () => {
 					props: config.props
 				});
 
-				assert.htmlEqual(target.innerHTML, fs.readFileSync(`${cwd}/_after.html`, 'utf-8'));
+				try {
+					assert.htmlEqual(target.innerHTML, fs.readFileSync(`${cwd}/_after.html`, 'utf-8'));
+				} catch (error) {
+					if (shouldUpdateExpected()) {
+						fs.writeFileSync(`${cwd}/_after.html`, target.innerHTML);
+						console.log(`Updated ${cwd}/_after.html.`);
+					} else {
+						throw error;
+					}
+				}
 
 				if (config.test) {
 					config.test(assert, target, snapshot, component, window);

--- a/test/js/index.js
+++ b/test/js/index.js
@@ -14,8 +14,11 @@ describe("js", () => {
 			throw new Error("Forgot to remove `solo: true` from test");
 		}
 
-		(solo ? it.only : it)(dir, () => {
-			dir = path.resolve(`${__dirname}/samples`, dir);
+		dir = path.resolve(`${__dirname}/samples`, dir);
+
+		const skip = !fs.existsSync(`${dir}/input.svelte`);
+
+		(skip ? it.skip : solo ? it.only : it)(dir, () => {
 			const config = loadConfig(`${dir}/_config.js`);
 
 			const input = fs.readFileSync(`${dir}/input.svelte`, "utf-8").replace(/\s+$/, "");

--- a/test/js/index.js
+++ b/test/js/index.js
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
+import * as kleur from "kleur";
 import { loadConfig, svelte, shouldUpdateExpected } from "../helpers.js";
 
 describe("js", () => {
@@ -16,7 +17,10 @@ describe("js", () => {
 
 		dir = path.resolve(`${__dirname}/samples`, dir);
 
-		const skip = !fs.existsSync(`${dir}/input.svelte`);
+		if (!fs.existsSync(`${dir}/input.svelte`)) {
+			console.log(colors.red().bold(`Missing file ${dir}/input.svelte. If you recently switched branches you may need to delete this directory`));
+			return;
+		}
 
 		(skip ? it.skip : solo ? it.only : it)(dir, () => {
 			const config = loadConfig(`${dir}/_config.js`);

--- a/test/js/index.js
+++ b/test/js/index.js
@@ -22,7 +22,7 @@ describe("js", () => {
 			return;
 		}
 
-		(skip ? it.skip : solo ? it.only : it)(dir, () => {
+		(solo ? it.only : it)(dir, () => {
 			const config = loadConfig(`${dir}/_config.js`);
 
 			const input = fs.readFileSync(`${dir}/input.svelte`, "utf-8").replace(/\s+$/, "");

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -15,7 +15,9 @@ describe('parse', () => {
 			);
 		}
 
-		(solo ? it.only : it)(dir, () => {
+		const skip = !fs.existsSync(`${__dirname}/samples/${dir}/input.svelte`);
+
+		(skip ? it.skip : solo ? it.only : it)(dir, () => {
 			const options = tryToLoadJson(`${__dirname}/samples/${dir}/options.json`) || {};
 
 			const input = fs.readFileSync(`${__dirname}/samples/${dir}/input.svelte`, 'utf-8').replace(/\s+$/, '');

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
-import { svelte, tryToLoadJson } from '../helpers.js';
+import { svelte, tryToLoadJson, shouldUpdateExpected } from '../helpers.js';
 
 describe('parse', () => {
 	fs.readdirSync(`${__dirname}/samples`).forEach(dir => {


### PR DESCRIPTION
- while switching between branches, the test runner will run test that was created in the other branch. that's because `_actual.*` file is git ignored, and therefore still preserves the folder when switching branches.
   - if `input.svelte` does not exists, skip the test.

- when changing `render_*` code, may break more than 1 test. it's cumbersome to update them one by one after reviewing the changes.
   - Provide a `--update` flag for test to update the `expected.*` file automatically.