### PR TITLE
fix range input if max is changed at same time as value

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -342,9 +342,9 @@ export default class ElementWrapper extends Wrapper {
 			block.maintain_context = true;
 		}
 
+		this.add_attributes(block);
 		this.add_bindings(block);
 		this.add_event_handlers(block);
-		this.add_attributes(block);
 		this.add_transitions(block);
 		this.add_animation(block);
 		this.add_actions(block);

--- a/test/runtime/samples/binding-input-range-change-with-max/_config.js
+++ b/test/runtime/samples/binding-input-range-change-with-max/_config.js
@@ -1,0 +1,33 @@
+export default {
+	html: `
+		<button></button>
+		<input type=range min=0 max=10>
+		<p>10 of 10</p>
+	`,
+
+	ssrHtml: `
+		<button></button>
+		<input type=range min=0 max=10 value=10>
+		<p>10 of 10</p>
+	`,
+
+	async test({ assert, target, window }) {
+		const input = target.querySelector('input');
+		assert.equal(input.value, '10');
+
+		// should not change because max is 10, input range behaviour
+		// seems there is bug in jsdom (HTMLInputElement-impl) which behaviour is different from real browsers
+		// input.value = '20';
+		// assert.equal(input.value, '10');
+
+		const button = target.querySelector('button');
+		await button.dispatchEvent(new window.Event('click'));
+
+		assert.equal(input.value, '20');
+		assert.htmlEqual(target.innerHTML, `
+			<button></button>
+			<input type=range min=0 max=20>
+			<p>20 of 20</p>
+		`);
+	},
+};

--- a/test/runtime/samples/binding-input-range-change-with-max/main.svelte
+++ b/test/runtime/samples/binding-input-range-change-with-max/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let value=10;
+	let max=10;
+
+	function change() {
+		value=20;
+		max=20;
+	}
+</script>
+
+<button on:click={change}/>
+<input type=range min=0 max={max} bind:value>
+<p>{value} of {max}</p>


### PR DESCRIPTION
Should fix #3857 

This bug is caused by html input range where setting `value` outside the `min` and `max` will fallback to the nearest valid value. In this case, it will be the `max`.

In `ElementWrapper`, adding bindings happened before adding attributes, which means `value` is updated before `max` when updating at the same cycle. I think the issue can be solved by reordering adding attributes to be first.

However, I can't seem to reproduce the input range behaviour in test. I think there's something missing in input range validation in jsdom, so I put a note there. I hope it's okay.

Really appreciate for your review!