### PR TITLE
✏️ outdated logotype on svg-transition example

### DIFF
--- a/site/content/examples/12-svg/05-svg-transitions/App.svelte
+++ b/site/content/examples/12-svg/05-svg-transitions/App.svelte
@@ -33,7 +33,7 @@
 		font-family: 'Overpass';
 		letter-spacing: 0.12em;
 		color: #676778;
-		font-weight: 100;
+		font-weight: 600;
 	}
 
 	.centered span {

--- a/site/content/examples/12-svg/05-svg-transitions/App.svelte
+++ b/site/content/examples/12-svg/05-svg-transitions/App.svelte
@@ -33,7 +33,7 @@
 		font-family: 'Overpass';
 		letter-spacing: 0.12em;
 		color: #676778;
-		font-weight: 600;
+		font-weight: 400;
 	}
 
 	.centered span {
@@ -71,4 +71,4 @@
 	toggle me
 </label>
 
-<link href="https://fonts.googleapis.com/css?family=Overpass:100" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Overpass:100,400" rel="stylesheet">


### PR DESCRIPTION
solves #2467

It was quite a simple fix. Decided to take a stab at it while going around the issues.
The new logotype uses a semi-bold `Overpass` font-weight while the old one used to use the light version by means of a `font-weight: 100`.
