### PR TITLE
fix undefined class with scoped-css

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -617,7 +617,7 @@ export default class ElementWrapper extends Wrapper {
 					const snippet = x`{ ${
 						(metadata && metadata.property_name) ||
 						fix_attribute_casing(attr.node.name)
-					}: ${attr.node.get_value(block)} }`;
+					}: ${attr.get_value(block)} }`;
 					initial_props.push(snippet);
 
 					updates.push(condition ? x`${condition} && ${snippet}` : snippet);

--- a/test/css/samples/undefined-with-scope/expected.css
+++ b/test/css/samples/undefined-with-scope/expected.css
@@ -1,0 +1,1 @@
+p.svelte-xyz{color:red}

--- a/test/css/samples/undefined-with-scope/expected.html
+++ b/test/css/samples/undefined-with-scope/expected.html
@@ -1,0 +1,1 @@
+<p class=" svelte-xyz">Foo</p>

--- a/test/css/samples/undefined-with-scope/input.svelte
+++ b/test/css/samples/undefined-with-scope/input.svelte
@@ -1,0 +1,3 @@
+<style>p { color: red; }</style>
+
+<p class={undefined}>Foo</p>


### PR DESCRIPTION
Fixed https://github.com/sveltejs/svelte/issues/3067#issuecomment-515207718 where scoped css causes a string concatenation and ended up with `undefined` class name.

- I've combined the computation of `value` in both `(dependencies.length > 0)` if and else case, to make them consistent. for example, this bug was fixed in the `if (dependencies.length > 0)` case but not the `else` case. [see repl](https://svelte.dev/repl/48755756aa5d42b58d584cac73429262?version=3.12.1)
- I've tried to moved the `get_value(block)` of `src/compiler/compile/nodes/Attribute.ts` to `src/compiler/compile/render_dom/wrappers/Element/Attribute.ts`, but apparently is still being used by `InlineCompiler`, which would take a bigger change, and I don't want to touch it for now.