### PR TITLE
fix binding out of sync on reactive update

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -300,7 +300,9 @@ export default class InlineComponentWrapper extends Wrapper {
 
 			updates.push(b`
 				if (!${updating} && ${changed(Array.from(binding.expression.dependencies))}) {
+					${updating} = true;
 					${name_changes}.${binding.name} = ${snippet};
+					@add_flush_callback(() => ${updating} = false);
 				}
 			`);
 
@@ -337,8 +339,6 @@ export default class InlineComponentWrapper extends Wrapper {
 				block.chunks.init.push(b`
 					function ${id}(${value}) {
 						#ctx.${id}.call(null, ${value}, #ctx);
-						${updating} = true;
-						@add_flush_callback(() => ${updating} = false);
 					}
 				`);
 
@@ -347,8 +347,6 @@ export default class InlineComponentWrapper extends Wrapper {
 				block.chunks.init.push(b`
 					function ${id}(${value}) {
 						#ctx.${id}.call(null, ${value});
-						${updating} = true;
-						@add_flush_callback(() => ${updating} = false);
 					}
 				`);
 			}

--- a/test/runtime/samples/component-binding-reactive-statement/Button.svelte
+++ b/test/runtime/samples/component-binding-reactive-statement/Button.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let count
+	
+	function handleClick() {
+		count += 1;
+	}
+</script>
+
+<button on:click={handleClick}>
+	button {count}
+</button>

--- a/test/runtime/samples/component-binding-reactive-statement/_config.js
+++ b/test/runtime/samples/component-binding-reactive-statement/_config.js
@@ -1,0 +1,38 @@
+export default {
+	html: `
+		<button>main 0</button>
+		<button>button 0</button>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const event = new window.MouseEvent('click');
+
+		const buttons = target.querySelectorAll('button');
+
+		await buttons[0].dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>main 1</button>
+			<button>button 1</button>
+		`);
+
+		await buttons[1].dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>main 2</button>
+			<button>button 2</button>
+		`);
+
+		// reactive update, reset to 2
+		await buttons[0].dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>main 2</button>
+			<button>button 2</button>
+		`);
+
+		// bound to main, reset to 2
+		await buttons[1].dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>main 2</button>
+			<button>button 2</button>
+		`);
+	}
+};

--- a/test/runtime/samples/component-binding-reactive-statement/main.svelte
+++ b/test/runtime/samples/component-binding-reactive-statement/main.svelte
@@ -1,0 +1,19 @@
+<script>
+	import Button from './Button.svelte';
+	
+	let count = 0;
+
+	$: if (count > 2) {
+		count = 2;
+	}
+
+	function handleClick() {
+		count += 1;
+	}
+</script>
+
+<button on:click={handleClick}>
+	main {count}
+</button>
+
+<Button bind:count />


### PR DESCRIPTION
Should fix #3382 

The bug is caused by `updating_count` in `App` being set to `true` on bound after `RefactoredButton` click . When `count` is updated reactively in `App`, `updating_count` is still `true` (because it has not been flushed yet), hence setting the final value of `count` back to `RefactoredButton` is skipped.

This solution is to move setting `updating_count` (and flush callback) from binding to `p`. The reason is, I believe, *updating in binding* does not entirely represent *updating of a component* i.e. the way parent updates and passes the props to its children is only through `p` and it should also be considered updating.

I hope my understanding is correct and this change does not create any unexpected behaviours. I have also added a new test case for this.

Thanks and appreciate for your review!