### PR TITLE
Site: add editor file association instructions

### DIFF
--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -58,7 +58,11 @@ To treat `*.svelte` files as HTML, add the following lines to your `settings.jso
 
 ## JetBrains WebStorm
 
-To treat `*.svelte` files as HTML in WebStorm, you need to create a new file type association. 
-Please refer to the [JetBrains website](https://www.jetbrains.com/help/webstorm/creating-and-registering-file-types.html) to see how.
+To treat `*.svelte` files as HTML in WebStorm, you need to create a new file type association. Please refer to the [JetBrains website](https://www.jetbrains.com/help/webstorm/creating-and-registering-file-types.html) to see how.
+
+## Sublime Text 3
+
+Open any `.svelte` file.  
+Go to *__View →  Syntax → Open all with current extension__* and choose `HTML` from an option list.
 
 

--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -6,7 +6,8 @@ authorURL: https://twitter.com/Rich_Harris
 draft: true
 ---
 
-*__Coming soon__*  
+*__Coming soon__*
+
 This post will walk you through setting up your editor so that recognises Svelte files:
 
 * eslint-plugin-svelte3
@@ -63,7 +64,6 @@ To treat `*.svelte` files as HTML in WebStorm, you need to create a new file typ
 
 ## Sublime Text 3
 
-Open any `.svelte` file.  
-Go to *__View →  Syntax → Open all with current extension__* and choose "HTML" from an option list.
+Open any `.svelte` file.
 
-
+Go to *__View → Syntax → Open all with current extension as... → HTML__*.

--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -6,7 +6,8 @@ authorURL: https://twitter.com/Rich_Harris
 draft: true
 ---
 
-*Coming soon* This post will walk you through setting up your editor so that recognises Svelte files:
+*__Coming soon__*  
+This post will walk you through setting up your editor so that recognises Svelte files:
 
 * eslint-plugin-svelte3
 * svelte-vscode
@@ -14,7 +15,7 @@ draft: true
 
 ## Atom
 
-To treat `*.svelte` files as HTML, open Edit → Config... and add the following lines to your `core` section:
+To treat `*.svelte` files as HTML, open *__Edit → Config...__* and add the following lines to your `core` section:
 
 ```cson
 "*":
@@ -63,6 +64,6 @@ To treat `*.svelte` files as HTML in WebStorm, you need to create a new file typ
 ## Sublime Text 3
 
 Open any `.svelte` file.  
-Go to *__View →  Syntax → Open all with current extension__* and choose `HTML` from an option list.
+Go to *__View →  Syntax → Open all with current extension__* and choose "HTML" from an option list.
 
 

--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -55,3 +55,10 @@ To treat `*.svelte` files as HTML, add the following lines to your `settings.jso
     "*.svelte": "html"
   }
 ```
+
+## JetBrains WebStorm
+
+To treat `*.svelte` files as HTML in WebStorm, you need to create a new file type association. 
+Please refer to the [JetBrains website](https://www.jetbrains.com/help/webstorm/creating-and-registering-file-types.html) to see how.
+
+

--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -45,3 +45,13 @@ To set the filetype for a single file, use a [modeline](https://vim.fandom.com/w
 ```
 <!-- vim: set ft=html :-->
 ```
+
+## Visual Studio Code
+
+To treat `*.svelte` files as HTML, add the following lines to your `settings.json` file:
+
+```cson
+  "files.associations": {
+    "*.svelte": "html"
+  }
+```


### PR DESCRIPTION
Issue #3889

Added instructions on how to associate `.svelte` files with HTML in VSCode, WebStorm and Sublime Text 3.

Also made some small tweaks like separating "Coming soon" to the other line and highlighting it.
