### PR TITLE
skip comments for preprocessors

### DIFF
--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -94,8 +94,12 @@ export default async function preprocess(
 	for (const fn of script) {
 		source = await replace_async(
 			source,
-			/<script(\s[^]*?)?>([^]*?)<\/script>/gi,
+			/<!--[^]*?-->|<script(\s[^]*?)?>([^]*?)<\/script>/gi,
 			async (match, attributes = '', content) => {
+				if (!attributes && !content) {
+					return match;
+				}
+				attributes = attributes || '';
 				const processed = await fn({
 					content,
 					attributes: parse_attributes(attributes),
@@ -110,8 +114,11 @@ export default async function preprocess(
 	for (const fn of style) {
 		source = await replace_async(
 			source,
-			/<style(\s[^]*?)?>([^]*?)<\/style>/gi,
+			/<!--[^]*?-->|<style(\s[^]*?)?>([^]*?)<\/style>/gi,
 			async (match, attributes = '', content) => {
+				if (!attributes && !content) {
+					return match;
+				}
 				const processed: Processed = await fn({
 					content,
 					attributes: parse_attributes(attributes),

--- a/test/preprocess/samples/comments/_config.js
+++ b/test/preprocess/samples/comments/_config.js
@@ -1,0 +1,8 @@
+export default {
+	preprocess: [
+		{
+			script: ({ content }) => ({ code: content.replace(/one/g, 'two') }),
+			style: ({ content }) => ({ code: content.replace(/one/g, 'three') }),
+		},
+	],
+};

--- a/test/preprocess/samples/comments/input.svelte
+++ b/test/preprocess/samples/comments/input.svelte
@@ -1,0 +1,25 @@
+<style>
+	one
+</style>
+
+<script>
+	one
+</script>
+
+<!-- <style>
+	one
+</style> -->
+
+<!-- <script>
+	one
+</script> -->
+
+<style>
+<!-- one -->
+</style>
+
+<script>
+<!-- one -->
+</script>
+
+

--- a/test/preprocess/samples/comments/output.svelte
+++ b/test/preprocess/samples/comments/output.svelte
@@ -1,0 +1,25 @@
+<style>
+	three
+</style>
+
+<script>
+	two
+</script>
+
+<!-- <style>
+	one
+</style> -->
+
+<!-- <script>
+	one
+</script> -->
+
+<style>
+<!-- three -->
+</style>
+
+<script>
+<!-- two -->
+</script>
+
+


### PR DESCRIPTION
Fix https://github.com/sveltejs/svelte/issues/3047#issuecomment-552340079

need to skip html comments when `regexp`ing `<script>` and `<style>` tag.