### PR TITLE
Use IE-compatible js to check for unknown prop warnings

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -247,7 +247,7 @@ export default function dom(
 			function create_fragment(#ctx) {
 				${block.get_contents()}
 			}
-		`);	
+		`);
 	}
 
 	body.push(b`
@@ -369,7 +369,7 @@ export default function dom(
 			unknown_props_check = b`
 				const writable_props = [${writable_props.map(prop => x`'${prop.export_name}'`)}];
 				@_Object.keys($$props).forEach(key => {
-					if (!writable_props.includes(key) && !key.startsWith('$$')) @_console.warn(\`<${component.tag}> was created with unknown prop '\${key}'\`);
+					if (!~writable_props.indexOf(key) && key.slice(0, 2) !== '$$') @_console.warn(\`<${component.tag}> was created with unknown prop '\${key}'\`);
 				});
 			`;
 		}

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -72,7 +72,7 @@ function instance($$self, $$props, $$invalidate) {
 	const writable_props = ["name"];
 
 	Object.keys($$props).forEach(key => {
-		if (!writable_props.includes(key) && !key.startsWith("$$")) console.warn(`<Component> was created with unknown prop '${key}'`);
+		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
 	$$self.$set = $$props => {

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -167,7 +167,7 @@ function instance($$self, $$props, $$invalidate) {
 	const writable_props = ["things", "foo", "bar", "baz"];
 
 	Object.keys($$props).forEach(key => {
-		if (!writable_props.includes(key) && !key.startsWith("$$")) console.warn(`<Component> was created with unknown prop '${key}'`);
+		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
 	$$self.$set = $$props => {

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -165,7 +165,7 @@ function instance($$self, $$props, $$invalidate) {
 	const writable_props = ["things", "foo"];
 
 	Object.keys($$props).forEach(key => {
-		if (!writable_props.includes(key) && !key.startsWith("$$")) console.warn(`<Component> was created with unknown prop '${key}'`);
+		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
 	$$self.$set = $$props => {

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -69,7 +69,7 @@ function instance($$self, $$props, $$invalidate) {
 	const writable_props = ["foo"];
 
 	Object.keys($$props).forEach(key => {
-		if (!writable_props.includes(key) && !key.startsWith("$$")) console.warn(`<Component> was created with unknown prop '${key}'`);
+		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
 	$$self.$set = $$props => {


### PR DESCRIPTION
Fixes #3914. We can't use `.includes` or `.startsWith`, because those need to be polyfilled on IE.