### PR TITLE
WIP: "interface" for exported properties

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -440,9 +440,10 @@ export default function dom(
 				constructor(options) {
 					super();
 
+					this.exportProps = ${prop_names};
 					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(/\\/g, '\\\\')}${options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
 
-					@init(this, { target: this.shadowRoot }, ${definition}, ${has_create_fragment ? 'create_fragment': 'null'}, ${not_equal}, ${prop_names});
+					@init(this, { target: this.shadowRoot }, ${definition}, ${has_create_fragment ? 'create_fragment': 'null'}, ${not_equal}, this.exportProps);
 
 					${dev_props_check}
 
@@ -493,8 +494,9 @@ export default function dom(
 			class ${name} extends ${superclass} {
 				constructor(options) {
 					super(${options.dev && `options`});
+					this.exportProps = ${prop_names};
 					${should_add_css && b`if (!@_document.getElementById("${component.stylesheet.id}-style")) ${add_css}();`}
-					@init(this, options, ${definition}, ${has_create_fragment ? 'create_fragment': 'null'}, ${not_equal}, ${prop_names});
+					@init(this, options, ${definition}, ${has_create_fragment ? 'create_fragment': 'null'}, ${not_equal}, this.exportProps);
 					${options.dev && b`@dispatch_dev("SvelteRegisterComponent", { component: this, tagName: "${name.name}", options, id: create_fragment.name });`}
 
 					${dev_props_check}

--- a/test/js/samples/action-custom-event-handler/expected.js
+++ b/test/js/samples/action-custom-event-handler/expected.js
@@ -57,7 +57,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { bar: 0 });
+		this.exportProps = { bar: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/action/expected.js
+++ b/test/js/samples/action/expected.js
@@ -53,7 +53,8 @@ function link(node) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/bind-online/expected.js
+++ b/test/js/samples/bind-online/expected.js
@@ -43,7 +43,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/bind-open/expected.js
+++ b/test/js/samples/bind-open/expected.js
@@ -59,7 +59,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { open: 0 });
+		this.exportProps = { open: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/bind-width-height/expected.js
+++ b/test/js/samples/bind-width-height/expected.js
@@ -57,7 +57,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { w: 0, h: 0 });
+		this.exportProps = { w: 0, h: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/bindings-readonly-order/expected.js
+++ b/test/js/samples/bindings-readonly-order/expected.js
@@ -76,7 +76,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { files: 0 });
+		this.exportProps = { files: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/capture-inject-dev-only/expected.js
+++ b/test/js/samples/capture-inject-dev-only/expected.js
@@ -69,7 +69,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -58,8 +58,9 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
+		this.exportProps = { foo: 0 };
 		if (!document.getElementById("svelte-1a7i8ec-style")) add_css();
-		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/component-static-array/expected.js
+++ b/test/js/samples/component-static-array/expected.js
@@ -47,7 +47,8 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/component-static-immutable/expected.js
+++ b/test/js/samples/component-static-immutable/expected.js
@@ -47,7 +47,8 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/component-static-immutable2/expected.js
+++ b/test/js/samples/component-static-immutable2/expected.js
@@ -47,7 +47,8 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/component-static-var/expected.js
+++ b/test/js/samples/component-static-var/expected.js
@@ -93,7 +93,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/component-static/expected.js
+++ b/test/js/samples/component-static/expected.js
@@ -47,7 +47,8 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/component-store-access-invalidate/expected.js
+++ b/test/js/samples/component-store-access-invalidate/expected.js
@@ -49,7 +49,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/component-store-file-invalidate/expected.js
+++ b/test/js/samples/component-store-file-invalidate/expected.js
@@ -23,7 +23,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, null, safe_not_equal, { increment: 0 });
+		this.exportProps = { increment: 0 };
+		init(this, options, instance, null, safe_not_equal, this.exportProps);
 	}
 
 	get increment() {

--- a/test/js/samples/component-store-reassign-invalidate/expected.js
+++ b/test/js/samples/component-store-reassign-invalidate/expected.js
@@ -68,7 +68,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -22,7 +22,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, null, safe_not_equal, { x: 0, a: 0, b: 0 });
+		this.exportProps = { x: 0, a: 0, b: 0 };
+		init(this, options, instance, null, safe_not_equal, this.exportProps);
 	}
 
 	get a() {

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -41,8 +41,9 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
+		this.exportProps = {};
 		if (!document.getElementById("svelte-1slhpfn-style")) add_css();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/css-shadow-dom-keyframes/expected.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected.js
@@ -33,8 +33,9 @@ function create_fragment(ctx) {
 class Component extends SvelteElement {
 	constructor(options) {
 		super();
+		this.exportProps = {};
 		this.shadowRoot.innerHTML = `<style>div{animation:foo 1s}@keyframes foo{0%{opacity:0}100%{opacity:1}}</style>`;
-		init(this, { target: this.shadowRoot }, null, create_fragment, safe_not_equal, {});
+		init(this, { target: this.shadowRoot }, null, create_fragment, safe_not_equal, this.exportProps);
 
 		if (options) {
 			if (options.target) {

--- a/test/js/samples/data-attribute/expected.js
+++ b/test/js/samples/data-attribute/expected.js
@@ -57,7 +57,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { bar: 0 });
+		this.exportProps = { bar: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -93,7 +93,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, { name: 0 });
+		this.exportProps = { name: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -194,7 +194,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, { things: 0, foo: 0, bar: 0, baz: 0 });
+		this.exportProps = { things: 0, foo: 0, bar: 0, baz: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -188,7 +188,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, { things: 0, foo: 0 });
+		this.exportProps = { things: 0, foo: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/debug-hoisted/expected.js
+++ b/test/js/samples/debug-hoisted/expected.js
@@ -65,7 +65,8 @@ function instance($$self) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/debug-no-dependencies/expected.js
+++ b/test/js/samples/debug-no-dependencies/expected.js
@@ -134,7 +134,8 @@ function create_fragment(ctx) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -114,7 +114,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { createElement: 0 });
+		this.exportProps = { createElement: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/deconflict-globals/expected.js
+++ b/test/js/samples/deconflict-globals/expected.js
@@ -20,7 +20,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, null, safe_not_equal, { foo: 0 });
+		this.exportProps = { foo: 0 };
+		init(this, options, instance, null, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -97,7 +97,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
+		this.exportProps = { foo: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/dont-invalidate-this/expected.js
+++ b/test/js/samples/dont-invalidate-this/expected.js
@@ -39,7 +39,8 @@ function make_uppercase() {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/dynamic-import/expected.js
+++ b/test/js/samples/dynamic-import/expected.js
@@ -46,7 +46,8 @@ const func = () => import("./Foo.svelte");
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -120,7 +120,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { a: 0, b: 0, c: 0, d: 0, e: 0 });
+		this.exportProps = { a: 0, b: 0, c: 0, d: 0, e: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -165,7 +165,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { comments: 0, elapsed: 0, time: 0, foo: 0 });
+		this.exportProps = { comments: 0, elapsed: 0, time: 0, foo: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -136,7 +136,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { things: 0 });
+		this.exportProps = { things: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -105,7 +105,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { things: 0 });
+		this.exportProps = { things: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/empty-dom/expected.js
+++ b/test/js/samples/empty-dom/expected.js
@@ -9,7 +9,8 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, null, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, null, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/event-handler-dynamic/expected.js
+++ b/test/js/samples/event-handler-dynamic/expected.js
@@ -101,7 +101,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/event-handler-no-passive/expected.js
+++ b/test/js/samples/event-handler-no-passive/expected.js
@@ -40,7 +40,8 @@ const touchstart_handler = e => e.preventDefault();
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/event-modifiers/expected.js
+++ b/test/js/samples/event-modifiers/expected.js
@@ -72,7 +72,8 @@ function handleClick() {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/head-no-whitespace/expected.js
+++ b/test/js/samples/head-no-whitespace/expected.js
@@ -40,7 +40,8 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/hoisted-const/expected.js
+++ b/test/js/samples/hoisted-const/expected.js
@@ -38,7 +38,8 @@ function get_answer() {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/hoisted-let/expected.js
+++ b/test/js/samples/hoisted-let/expected.js
@@ -38,7 +38,8 @@ function get_answer() {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/hydrated-void-element/expected.js
+++ b/test/js/samples/hydrated-void-element/expected.js
@@ -57,7 +57,8 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/if-block-complex/expected.js
+++ b/test/js/samples/if-block-complex/expected.js
@@ -60,7 +60,8 @@ function instance($$self) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -98,7 +98,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
+		this.exportProps = { foo: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -76,7 +76,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
+		this.exportProps = { foo: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -56,7 +56,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { color: 0, x: 0, y: 0 });
+		this.exportProps = { color: 0, x: 0, y: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -47,7 +47,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { data: 0 });
+		this.exportProps = { data: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -47,7 +47,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { color: 0 });
+		this.exportProps = { color: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -66,7 +66,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { style: 0, key: 0, value: 0 });
+		this.exportProps = { style: 0, key: 0, value: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/inline-style-without-updates/expected.js
+++ b/test/js/samples/inline-style-without-updates/expected.js
@@ -35,7 +35,8 @@ let color = "red";
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/input-files/expected.js
+++ b/test/js/samples/input-files/expected.js
@@ -53,7 +53,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { files: 0 });
+		this.exportProps = { files: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/input-no-initial-value/expected.js
+++ b/test/js/samples/input-no-initial-value/expected.js
@@ -77,7 +77,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -64,7 +64,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { value: 0 });
+		this.exportProps = { value: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -57,7 +57,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { foo: 0 });
+		this.exportProps = { foo: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/instrumentation-script-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-script-if-no-block/expected.js
@@ -66,7 +66,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/instrumentation-script-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-script-x-equals-x/expected.js
@@ -68,7 +68,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -66,7 +66,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/instrumentation-template-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-template-x-equals-x/expected.js
@@ -68,7 +68,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/legacy-input-type/expected.js
+++ b/test/js/samples/legacy-input-type/expected.js
@@ -33,7 +33,8 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/loop-protect/expected.js
+++ b/test/js/samples/loop-protect/expected.js
@@ -95,7 +95,8 @@ function instance($$self) {
 class Component extends SvelteComponentDev {
 	constructor(options) {
 		super(options);
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 
 		dispatch_dev("SvelteRegisterComponent", {
 			component: this,

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -167,7 +167,7 @@ class Component extends SvelteComponent {
 	constructor(options) {
 		super();
 
-		init(this, options, instance, create_fragment, safe_not_equal, {
+		this.exportProps = {
 			buffered: 0,
 			seekable: 0,
 			played: 0,
@@ -176,7 +176,9 @@ class Component extends SvelteComponent {
 			paused: 0,
 			volume: 0,
 			playbackRate: 0
-		});
+		};
+
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -57,7 +57,8 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/non-mutable-reference/expected.js
+++ b/test/js/samples/non-mutable-reference/expected.js
@@ -34,7 +34,8 @@ let name = "world";
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/reactive-values-non-topologically-ordered/expected.js
+++ b/test/js/samples/reactive-values-non-topologically-ordered/expected.js
@@ -26,7 +26,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, null, safe_not_equal, { x: 0 });
+		this.exportProps = { x: 0 };
+		init(this, options, instance, null, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/reactive-values-non-writable-dependencies/expected.js
+++ b/test/js/samples/reactive-values-non-writable-dependencies/expected.js
@@ -22,7 +22,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, null, safe_not_equal, { a: 0, b: 0 });
+		this.exportProps = { a: 0, b: 0 };
+		init(this, options, instance, null, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -76,7 +76,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { current: 0 });
+		this.exportProps = { current: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/setup-method/expected.js
+++ b/test/js/samples/setup-method/expected.js
@@ -10,7 +10,8 @@ function foo(bar) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, null, safe_not_equal, { foo: 0 });
+		this.exportProps = { foo: 0 };
+		init(this, options, null, null, safe_not_equal, this.exportProps);
 	}
 
 	get foo() {

--- a/test/js/samples/src-attribute-check/expected.js
+++ b/test/js/samples/src-attribute-check/expected.js
@@ -78,7 +78,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { url: 0, slug: 0 });
+		this.exportProps = { url: 0, slug: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/svg-title/expected.js
+++ b/test/js/samples/svg-title/expected.js
@@ -39,7 +39,8 @@ function create_fragment(ctx) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, null, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, null, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -32,7 +32,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { custom: 0 });
+		this.exportProps = { custom: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/transition-local/expected.js
+++ b/test/js/samples/transition-local/expected.js
@@ -133,7 +133,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { x: 0, y: 0 });
+		this.exportProps = { x: 0, y: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/transition-repeated-outro/expected.js
+++ b/test/js/samples/transition-repeated-outro/expected.js
@@ -110,7 +110,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { num: 0 });
+		this.exportProps = { num: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/unchanged-expression/expected.js
+++ b/test/js/samples/unchanged-expression/expected.js
@@ -85,7 +85,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/unreferenced-state-not-invalidated/expected.js
+++ b/test/js/samples/unreferenced-state-not-invalidated/expected.js
@@ -73,7 +73,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -257,7 +257,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { a: 0, b: 0, c: 0, d: 0, e: 0 });
+		this.exportProps = { a: 0, b: 0, c: 0, d: 0, e: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/window-binding-online/expected.js
+++ b/test/js/samples/window-binding-online/expected.js
@@ -43,7 +43,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, {});
+		this.exportProps = {};
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -82,7 +82,8 @@ function instance($$self, $$props, $$invalidate) {
 class Component extends SvelteComponent {
 	constructor(options) {
 		super();
-		init(this, options, instance, create_fragment, safe_not_equal, { y: 0 });
+		this.exportProps = { y: 0 };
+		init(this, options, instance, create_fragment, safe_not_equal, this.exportProps);
 	}
 }
 


### PR DESCRIPTION
Firstly, this born as a reaction to that PR #3802. 
**Situation:**
I am using ASR routing, this solution put "asr" property into any component and very often I have no reason to use it inside a component. Also, ASR aggregate params from all routing levels and push down it and set as props, and these props also often not needed in my component.
If I remove `export let asr;` I will see a warning in the browser because you will try to set not existent props. But if I keep this export, after #3802 I will see warnings during compile.

**Idea:**
If I would have access to a list of export properties I can decide outside component what exactly I can set. Author of ASR @TehShrike also thought about such a feature. 
But this "interface" provides much more opportunities. Now, you can request and prepare all data what exactly needs for such a component because you will know the public interface of this component. 
Probably it's not needed if you use a component inside another component. 
But looks very helpful for the case when you directly call the constructor. 