### PR TITLE
<svelte:element> proposal implementation

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -106,10 +106,11 @@ export default class Element extends Node {
 	children: INode[];
 	namespace: string;
 	needs_manual_style_scoping: boolean;
+	dynamic_tag: boolean;
 
 	constructor(component, parent, scope, info: any) {
 		super(component, parent, scope, info);
-		this.name = info.name;
+		this.name = this.get_element_name(info);
 
 		this.namespace = get_namespace(parent, this, component.namespace);
 
@@ -221,6 +222,26 @@ export default class Element extends Node {
 		this.validate();
 
 		component.stylesheet.apply(this);
+	}
+
+	get_element_name(info: any) {
+		let elementName = info.name;
+
+		if (elementName === 'svelte:element') {
+			const tag_attribute = info.attributes.find(node => node.name === 'tag');
+
+			if (tag_attribute) {
+				const tagValue = tag_attribute.value[0];
+
+				if (tagValue.data) {
+					elementName = tagValue.data;
+				} else {
+					this.dynamic_tag = tagValue.expression.name;
+				}
+			}
+		}
+
+		return elementName;
 	}
 
 	validate() {

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -393,7 +393,7 @@ export default class ElementWrapper extends Wrapper {
 	}
 
 	get_render_statement() {
-		const { name, namespace } = this.node;
+		const { name, namespace, dynamic_tag } = this.node;
 
 		if (namespace === 'http://www.w3.org/2000/svg') {
 			return x`@svg_element("${name}")`;
@@ -406,6 +406,10 @@ export default class ElementWrapper extends Wrapper {
 		const is = this.attributes.find(attr => attr.node.name === 'is');
 		if (is) {
 			return x`@element_is("${name}", ${is.render_chunks().reduce((lhs, rhs) => x`${lhs} + ${rhs}`)});`;
+		}
+
+		if (dynamic_tag) {
+			return x`@element(#ctx.${dynamic_tag} || ${dynamic_tag})`;
 		}
 
 		return x`@element("${name}")`;

--- a/test/parser/samples/error-svelte-selfdestructive/error.json
+++ b/test/parser/samples/error-svelte-selfdestructive/error.json
@@ -1,6 +1,6 @@
 {
 	"code": "invalid-tag-name",
-	"message": "Valid <svelte:...> tag names are svelte:head, svelte:options, svelte:window, svelte:body, svelte:self or svelte:component",
+	"message": "Valid <svelte:...> tag names are svelte:head, svelte:options, svelte:window, svelte:body, svelte:self, svelte:component or svelte:element",
 	"pos": 10,
 	"start": {
 		"character": 10,


### PR DESCRIPTION
An implementation of the proposal described in #2324.

**Problem:**
There's currently no way to dynamically specify a tag for an element. This is problematic if you want the ability to add a `tag` prop to a component and have some or all of that component be wrapped in the tag specified. Workarounds for this issue result in large, incomplete wrapper components such as https://github.com/erzr/jss-svelte/blob/master/packages/jss-svelte/src/components/TagWrapper.svelte that just cover the most commonly used tags.

**Solution:**
A new element named `svelte:element` has been implemented that accepts a single prop `tag`, which could be a string or variable containing the tag name.

Usage:
`<svelte:element tag="h1">This is an h1</svelte:element>`