### PR TITLE
fix dynamic event handler expression

### DIFF
--- a/src/compiler/compile/nodes/EventHandler.ts
+++ b/src/compiler/compile/nodes/EventHandler.ts
@@ -44,6 +44,8 @@ export default class EventHandler extends Node {
 
 					this.reassigned = component.var_lookup.get(info.expression.name).reassigned;
 				}
+			} else if (this.expression.dynamic_dependencies().length > 0) {
+				this.reassigned = true;
 			}
 		} else {
 			this.handler_name = component.get_unique_name(`${sanitize(this.name)}_handler`);

--- a/test/runtime/samples/event-handler-dynamic-expression/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-expression/_config.js
@@ -1,0 +1,20 @@
+export default {
+	html: `<button>bar</button>`,
+
+	async test({ assert, component, target, window }) {
+		const [button] = target.querySelectorAll(
+			'button'
+		);
+
+		const event = new window.MouseEvent('click');
+
+		await button.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `<button>foo</button>`);
+		
+		await button.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `<button>bar</button>`);
+		
+		await button.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `<button>foo</button>`);
+	},
+};

--- a/test/runtime/samples/event-handler-dynamic-expression/main.svelte
+++ b/test/runtime/samples/event-handler-dynamic-expression/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let name = 'bar';
+	function foo() {
+		name = 'foo';
+	}
+	function bar() {
+		name = 'bar';
+	}
+	
+</script>
+
+<button on:click={name === 'bar' ? foo : bar}>{name}</button>


### PR DESCRIPTION
https://github.com/sveltejs/svelte/pull/3836 fixed the case if the event handler is an Identifier expression.

but it doesn't work for cases like

```html
<button on:click={foo ? bar : baz} />
```

This PR will fix this.