### PR TITLE
Document $: in the tutorial

### DIFF
--- a/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
+++ b/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
@@ -11,7 +11,7 @@ let count = 0;
 $: doubled = count * 2;
 ```
 
-> Don't worry if this looks unfamiliar. It's valid JavaScript, which Svelte interprets to mean 're-run this code whenever any of the referenced values change'. Once you get used to it, there's no going back. For those that are curious, `$:` is [label syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label).
+> Don't worry if this looks a little alien. It's [valid](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label) (if unconventional) JavaScript, which Svelte interprets to mean 're-run this code whenever any of the referenced values change'. Once you get used to it, there's no going back.
 
 Let's use `doubled` in our markup:
 

--- a/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
+++ b/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
@@ -11,7 +11,7 @@ let count = 0;
 $: doubled = count * 2;
 ```
 
-> Don't worry if this looks a little alien. It's valid (if unconventional) JavaScript, which Svelte interprets to mean 're-run this code whenever any of the referenced values change'. Once you get used to it, there's no going back.
+> Don't worry if this looks unfamiliar. It's valid JavaScript, which Svelte interprets to mean 're-run this code whenever any of the referenced values change'. Once you get used to it, there's no going back. For those that are curious, `$:` is [label syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label).
 
 Let's use `doubled` in our markup:
 


### PR DESCRIPTION
This change re-words some of the prose so that the label syntax is spoken of in _unfamiliar_ terms rather than _alien_ as it is valid syntax and not some svelte-specific feature/functionality. IMO this clarifies what `$:` is with a little note for those that are curious, given that labels are rarely used in the JavaScript ecosystem.


### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)