### PR TITLE
Readable props dev warning

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -365,11 +365,11 @@ export default function dom(
 		});
 
 		let unknown_props_check;
-		if (component.compile_options.dev && !component.var_lookup.has('$$props') && writable_props.length) {
+		if (component.compile_options.dev && !component.var_lookup.has('$$props') && props.length) {
 			unknown_props_check = b`
-				const writable_props = [${writable_props.map(prop => x`'${prop.export_name}'`)}];
+				const props = [${props.map(prop => x`'${prop.export_name}'`)}];
 				@_Object.keys($$props).forEach(key => {
-					if (!~writable_props.indexOf(key) && key.slice(0, 2) !== '$$') @_console.warn(\`<${component.tag}> was created with unknown prop '\${key}'\`);
+					if (!~props.indexOf(key) && key.slice(0, 2) !== '$$') @_console.warn(\`<${component.tag}> was created with unknown prop '\${key}'\`);
 				});
 			`;
 		}

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -69,10 +69,10 @@ function create_fragment(ctx) {
 
 function instance($$self, $$props, $$invalidate) {
 	let { name } = $$props;
-	const writable_props = ["name"];
+	const props = ["name"];
 
 	Object.keys($$props).forEach(key => {
-		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
+		if (!~props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
 	$$self.$set = $$props => {

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -164,10 +164,10 @@ function instance($$self, $$props, $$invalidate) {
 	let { foo } = $$props;
 	let { bar } = $$props;
 	let { baz } = $$props;
-	const writable_props = ["things", "foo", "bar", "baz"];
+	const props = ["things", "foo", "bar", "baz"];
 
 	Object.keys($$props).forEach(key => {
-		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
+		if (!~props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
 	$$self.$set = $$props => {

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -162,10 +162,10 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { things } = $$props;
 	let { foo } = $$props;
-	const writable_props = ["things", "foo"];
+	const props = ["things", "foo"];
 
 	Object.keys($$props).forEach(key => {
-		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
+		if (!~props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
 	$$self.$set = $$props => {

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -66,10 +66,10 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { foo } = $$props;
 	let bar;
-	const writable_props = ["foo"];
+	const props = ["foo"];
 
 	Object.keys($$props).forEach(key => {
-		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
+		if (!~props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
 	$$self.$set = $$props => {

--- a/test/runtime/samples/dev-warning-unknown-props-uses-readable/Foo.svelte
+++ b/test/runtime/samples/dev-warning-unknown-props-uses-readable/Foo.svelte
@@ -1,5 +1,5 @@
 <script>
-	export const foo = undefined;
+	export function foo() {}
 </script>
 
 <div>{foo}</div>

--- a/test/runtime/samples/dev-warning-unknown-props-uses-readable/Foo.svelte
+++ b/test/runtime/samples/dev-warning-unknown-props-uses-readable/Foo.svelte
@@ -1,0 +1,5 @@
+<script>
+	export const foo = undefined;
+</script>
+
+<div>{foo}</div>

--- a/test/runtime/samples/dev-warning-unknown-props-uses-readable/_config.js
+++ b/test/runtime/samples/dev-warning-unknown-props-uses-readable/_config.js
@@ -1,0 +1,7 @@
+export default {
+	compileOptions: {
+		dev: true
+	},
+
+	warnings: []
+};

--- a/test/runtime/samples/dev-warning-unknown-props-uses-readable/main.svelte
+++ b/test/runtime/samples/dev-warning-unknown-props-uses-readable/main.svelte
@@ -2,4 +2,4 @@
 	import Foo from './Foo.svelte';
 </script>
 
-<Foo foo="sho"/>
+<Foo foo={false}/>

--- a/test/runtime/samples/dev-warning-unknown-props-uses-readable/main.svelte
+++ b/test/runtime/samples/dev-warning-unknown-props-uses-readable/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Foo from './Foo.svelte';
+</script>
+
+<Foo foo="sho"/>


### PR DESCRIPTION
This makes it so that the the unknown prop dev warning checks all props not just writable_props.
This helps with the new dev warning which recommends external only props be made const by preventing the unknown prop warning when they are bound too.

### Before submitting the PR, please make sure you do the following
- [] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [X] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [X] Run the tests tests with `npm test` or `yarn test`)
