### PR TITLE
work around childKeys collision with Block comments and css

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -43,6 +43,7 @@ interface ComponentOptions {
 childKeys.EachBlock = childKeys.IfBlock = ['children', 'else'];
 childKeys.Attribute = ['value'];
 childKeys.ExportNamedDeclaration = ['declaration', 'specifiers'];
+childKeys.Block = ['children'];
 
 export default class Component {
 	stats: Stats;


### PR DESCRIPTION
Fixes #3977. Thanks to @mrkishi for helping track this down. It was a bit of a nightmare.

I believe though that the proper solution to this and doubtless future bizarre bugs will be to stop caching child keys in estree-walker at all. It's a cute idea but holy hell is it a huge headache sometimes.