### PR TITLE
chore(site): bump polka deps

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1256,19 +1256,19 @@
       }
     },
     "@polka/redirect": {
-      "version": "1.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@polka/redirect/-/redirect-1.0.0-next.0.tgz",
-      "integrity": "sha512-ym6ooqMr09+cV+y52p5kszJ0jYcX+nJfm8POrQb7QYowvpPPuneZ71EclHrQSB7a50lcytgR/xtL6AUFdvyEkg=="
+      "version": "1.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/@polka/redirect/-/redirect-1.0.0-next.7.tgz",
+      "integrity": "sha512-sHh1oVy9VBVhn41fOlrUdlxFkcbKrYdBcqePTSxvf2NqKu7UcMPZse/wDeQZk17A8cqDArKsR4m0MXd+3/Q83g=="
     },
     "@polka/send": {
-      "version": "1.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/@polka/send/-/send-1.0.0-next.6.tgz",
-      "integrity": "sha512-4ON4Yf/QcP9I6HmFvn8rspRdBQ6NupSkUvAkUKo4gT2SSSWrrHMqDVQJsvDr4BRGRIVZSg+gr6W3M9Xj3V3JSQ=="
+      "version": "1.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/@polka/send/-/send-1.0.0-next.7.tgz",
+      "integrity": "sha512-X/7sxWMfzuHuMXSls3SuOgfwcoNakuaNWciVS/KX3RML8NIPKQYgbhpqYPCujtXK9Z/KvW3/gzr2TUpabIJRMg=="
     },
     "@polka/url": {
-      "version": "1.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.3.tgz",
-      "integrity": "sha512-Uom7l6OeP6vcf85lMImelYu5WKVWjXyhkpi9WsRdRzlJFJFPVhjBtBCktgDUj7dk1N5FURUdegSZ5XOjxf8JZg=="
+      "version": "1.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.9.tgz",
+      "integrity": "sha512-VZqSaulg2kVQYMulmuZcvapPwH5/y81YHANiFIKz1GNZoG/F4o1JSeLlrvXJ8tC+RPUjxdrebfT3Qn+bnMi0bA=="
     },
     "@sindresorhus/slugify": {
       "version": "0.9.1",
@@ -2517,9 +2517,9 @@
       }
     },
     "mime": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
-      "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -3126,11 +3126,11 @@
       "dev": true
     },
     "polka": {
-      "version": "1.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/polka/-/polka-1.0.0-next.6.tgz",
-      "integrity": "sha512-e3vZm2cMmPPrgn+0J5DO0rrSTfsCHGyh+YS6jjrqYP8BHJkPq8nCVSDxHkaiEN4f0c2dtR6FB+snDmLE/sRz7A==",
+      "version": "1.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/polka/-/polka-1.0.0-next.9.tgz",
+      "integrity": "sha512-oAWH5O3CIPTzPKNx9KF9NDfy3KRyy9NtUhDEJGmMRCDT6s3CZaGDm7xafcKtm0uK6g0CBiNtoeGWpPFSLUXeaw==",
       "requires": {
-        "@polka/url": "^1.0.0-next.3",
+        "@polka/url": "^1.0.0-next.9",
         "trouter": "^3.1.0"
       }
     },
@@ -3583,19 +3583,13 @@
       "dev": true
     },
     "sirv": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-0.4.2.tgz",
-      "integrity": "sha512-dQbZnsMaIiTQPZmbGmktz+c74zt/hyrJEB4tdp2Jj0RNv9J6B/OWR5RyrZEvIn9fyh9Zlg2OlE2XzKz6wMKGAw==",
+      "version": "1.0.0-next.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.0-next.2.tgz",
+      "integrity": "sha512-hWp0todr4jSb1BFBiANRmqYRXzX02l36/X4tyHPYKqMZ+e1hrDZKUjIIXrAOBRWlAE/G5cGImUciMrUcU8DeOg==",
       "requires": {
-        "@polka/url": "^0.5.0",
-        "mime": "^2.3.1"
-      },
-      "dependencies": {
-        "@polka/url": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
-          "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw=="
-        }
+        "@polka/url": "^1.0.0-next.9",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
       }
     },
     "source-map": {
@@ -3831,6 +3825,11 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
+    },
+    "totalist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.0.1.tgz",
+      "integrity": "sha512-HuAt9bWDCdLkebrIQr+i63NgQSvjeD2VTNUIEBqof/4pG4Gb6omuBOMUX0vF371cbfImXQzmb4Ue/0c9MUWGew=="
     },
     "trim-right": {
       "version": "1.0.1",

--- a/site/package.json
+++ b/site/package.json
@@ -13,8 +13,8 @@
     "deploy": "make deploy"
   },
   "dependencies": {
-    "@polka/redirect": "^1.0.0-next.0",
-    "@polka/send": "^1.0.0-next.6",
+    "@polka/redirect": "^1.0.0-next.7",
+    "@polka/send": "^1.0.0-next.7",
     "cookie": "^0.4.0",
     "devalue": "^2.0.0",
     "do-not-zip": "^1.0.0",
@@ -23,9 +23,9 @@
     "jsonwebtoken": "^8.5.1",
     "marked": "^0.7.0",
     "pg": "^7.12.1",
-    "polka": "^1.0.0-next.6",
+    "polka": "^1.0.0-next.9",
     "prismjs": "^1.17.1",
-    "sirv": "^0.4.2",
+    "sirv": "^1.0.0-next.2",
     "yootils": "0.0.16"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #3968

Needed a PR because we install from package-lock file.

Also bumped to `sirv@next` because
A) we were using two different `@polka/url` versions
B) upcoming `sirv` has some of its own fixes
