### PR TITLE
fix context export not working if conflicts with instance variable

### DIFF
--- a/test/runtime/samples/module-context-export/Foo.svelte
+++ b/test/runtime/samples/module-context-export/Foo.svelte
@@ -1,0 +1,7 @@
+<script context="module">
+	export const foo = 42;
+</script>
+<script>
+  let foo = 100;
+  console.log(foo);
+</script>

--- a/test/runtime/samples/module-context-export/_config.js
+++ b/test/runtime/samples/module-context-export/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<p>(42)(99)</p>`
+};

--- a/test/runtime/samples/module-context-export/main.svelte
+++ b/test/runtime/samples/module-context-export/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { foo } from './Foo.svelte';
+	export let bar = 99;
+</script>
+
+<p>({foo})({bar})</p>


### PR DESCRIPTION
sorry, my bad for causing this regression bug.

Fix https://github.com/sveltejs/svelte/issues/3983

unknowingly, `module_js` and `instance_js` uses the same `var_lookup`. and `instance_js` var will overwrite `module_js` after traversing it's ast.

previously it works because, the module_js ast is traversed and extract exports. before traversing instance ast (which overwrites the module_js's vars)