### PR TITLE
fix handle marking global variable as dependency

### DIFF
--- a/src/compiler/compile/nodes/Binding.ts
+++ b/src/compiler/compile/nodes/Binding.ts
@@ -52,7 +52,9 @@ export default class Binding extends Node {
 		} else if (this.is_contextual) {
 			scope.dependencies_for_name.get(name).forEach(name => {
 				const variable = component.var_lookup.get(name);
-				variable[this.expression.node.type === 'MemberExpression' ? 'mutated' : 'reassigned'] = true;
+				if (variable) {
+					variable[this.expression.node.type === 'MemberExpression' ? 'mutated' : 'reassigned'] = true;
+				}
 			});
 		} else {
 			const variable = component.var_lookup.get(name);

--- a/test/runtime/samples/bindings-global-dependency/_config.js
+++ b/test/runtime/samples/bindings-global-dependency/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: '<input type="text">'
+};

--- a/test/runtime/samples/bindings-global-dependency/main.svelte
+++ b/test/runtime/samples/bindings-global-dependency/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let data = {
+		a: {value:''}
+	}
+</script>
+
+{#each Object.values(data) as object}
+	<input type="text" bind:value={object.value} />
+{/each}


### PR DESCRIPTION
Fix https://github.com/sveltejs/svelte/issues/3992

Since @Conduitry changes in https://github.com/sveltejs/svelte/pull/3746/files, we don't skip marking known global as dependencies. Meaning, known globals could be a dependency.

In Binding, we mark dependency variable as mutated, and because it was never defined within the component, we get setting 'mutated' of undefined error

In this change, we skip over setting 'mutated' for variable that we cannot find.

