### PR TITLE
Use raf's time for smoother transitions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,8 @@ module.exports = {
 			}
 		],
 		'@typescript-eslint/no-object-literal-type-assertion': 'off',
-		'@typescript-eslint/no-unused-vars': 'off'
+		'@typescript-eslint/no-unused-vars': 'off',
+		'@typescript-eslint/prefer-interface': 'off'
 	},
 	globals: {
 		globalThis: false

--- a/test/runtime/index.js
+++ b/test/runtime/index.js
@@ -107,7 +107,7 @@ describe("runtime", () => {
 					set_raf(cb => {
 						raf.callback = () => {
 							raf.callback = null;
-							cb();
+							cb(raf.time);
 							flush();
 						};
 					});


### PR DESCRIPTION
`requestAnimationFrame`'s argument is better suited to time animations since browsers can account for the frame's actual rendering time.

There's been a lot of movement in browsers so I haven't kept up with which one's _do_ pass in the time the frame's going to be rendered or not, but the worst they could do is just pass the current time, which would be the same behavior as the current one.