### PR TITLE
Fix listen_dev argument order

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/EventHandler.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/EventHandler.ts
@@ -54,8 +54,8 @@ export default class EventHandlerWrapper {
 		}
 
 		if (block.renderer.options.dev) {
-			args.push(this.node.modifiers.has('stopPropagation') ? TRUE : FALSE);
 			args.push(this.node.modifiers.has('preventDefault') ? TRUE : FALSE);
+			args.push(this.node.modifiers.has('stopPropagation') ? TRUE : FALSE);
 		}
 
 		block.event_listeners.push(


### PR DESCRIPTION
Somehow the order of the `stopPropagation` and `preventDefault` arguments to the `listen_dev` function got reversed.