### PR TITLE
Fixes typo in Tutorial DOM Events - issue #4023

### DIFF
--- a/site/content/tutorial/05-events/01-dom-events/text.md
+++ b/site/content/tutorial/05-events/01-dom-events/text.md
@@ -5,7 +5,7 @@ title: DOM events
 As we've briefly seen already, you can listen to any event on an element with the `on:` directive:
 
 ```html
-<div on:mousemove={handleMousemove}>
+<div on:mousemover={handleMousemove}>
 	The mouse position is {m.x} x {m.y}
 </div>
 ```


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/4023

Testing:
- "mouseove" does not work when used in tutorial.
- "mouseover" works when used in tutorial

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
