### PR TITLE
fix child context in await blocks with no `then` variable

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -206,7 +206,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 
 					} else {
 						const #child_ctx = #ctx.slice();
-						#child_ctx[${value_index}] = ${info}.resolved;
+						${this.node.value && x`#child_ctx[${value_index}] = ${info}.resolved;`}
 						${info}.block.p(#child_ctx, #dirty);
 					}
 				`);
@@ -220,7 +220,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 				block.chunks.update.push(b`
 					{
 						const #child_ctx = #ctx.slice();
-						#child_ctx[${value_index}] = ${info}.resolved;
+						${this.node.value && x`#child_ctx[${value_index}] = ${info}.resolved;`}
 						${info}.block.p(#child_ctx, #dirty);
 					}
 				`);

--- a/test/runtime/samples/await-then-no-context/main.svelte
+++ b/test/runtime/samples/await-then-no-context/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	const promise = new Promise(() => {});
+	const test = [1, 2, 3];
+</script>
+
+{#await promise}
+	<div>waiting</div>
+{:then}
+	{#each test as t}
+		<div>t</div>
+	{/each}
+{/await}


### PR DESCRIPTION
Fixes #4022. It seems the most correct to me to just not generate the `#child_ctx[${value_index}] = ${info}.resolved;` lines when we don't have a `then` variable.