### PR TITLE
ctx to local name map (fixes #4041)

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -372,6 +372,14 @@ export default function dom(
 			}) as Expression)
 		};
 
+		const ctx_names = component.compile_options.dev && {
+			type: 'ArrayExpression',
+			elements: initial_context.map(member => ({
+				type: 'Literal',
+				value: member.name
+			}) as Expression)
+		};
+
 		body.push(b`
 			function ${definition}(${args}) {
 				${reactive_store_declarations}
@@ -407,6 +415,8 @@ export default function dom(
 				${fixed_reactive_declarations}
 
 				${uses_props && b`$$props = @exclude_internal_props($$props);`}
+
+				${ctx_names && x`$$self.ctx_names = ${ctx_names};`}
 
 				return ${return_value};
 			}

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -416,7 +416,7 @@ export default function dom(
 
 				${uses_props && b`$$props = @exclude_internal_props($$props);`}
 
-				${ctx_names && x`$$self.ctx_names = ${ctx_names};`}
+				${ctx_names && x`$$self.$$.ctx_names = ${ctx_names};`}
 
 				return ${return_value};
 			}

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -87,6 +87,7 @@ function instance($$self, $$props, $$invalidate) {
 		if ("name" in $$props) $$invalidate(0, name = $$props.name);
 	};
 
+	$$self.ctx_names = ["name"];
 	return [name];
 }
 

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -87,7 +87,7 @@ function instance($$self, $$props, $$invalidate) {
 		if ("name" in $$props) $$invalidate(0, name = $$props.name);
 	};
 
-	$$self.ctx_names = ["name"];
+	$$self.$$.ctx_names = ["name"];
 	return [name];
 }
 

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -194,6 +194,7 @@ function instance($$self, $$props, $$invalidate) {
 		if ("baz" in $$props) $$invalidate(3, baz = $$props.baz);
 	};
 
+	$$self.ctx_names = ["things", "foo", "bar", "baz"];
 	return [things, foo, bar, baz];
 }
 

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -194,7 +194,7 @@ function instance($$self, $$props, $$invalidate) {
 		if ("baz" in $$props) $$invalidate(3, baz = $$props.baz);
 	};
 
-	$$self.ctx_names = ["things", "foo", "bar", "baz"];
+	$$self.$$.ctx_names = ["things", "foo", "bar", "baz"];
 	return [things, foo, bar, baz];
 }
 

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -182,6 +182,7 @@ function instance($$self, $$props, $$invalidate) {
 		if ("foo" in $$props) $$invalidate(1, foo = $$props.foo);
 	};
 
+	$$self.ctx_names = ["things", "foo"];
 	return [things, foo];
 }
 

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -182,7 +182,7 @@ function instance($$self, $$props, $$invalidate) {
 		if ("foo" in $$props) $$invalidate(1, foo = $$props.foo);
 	};
 
-	$$self.ctx_names = ["things", "foo"];
+	$$self.$$.ctx_names = ["things", "foo"];
 	return [things, foo];
 }
 

--- a/test/js/samples/debug-hoisted/expected.js
+++ b/test/js/samples/debug-hoisted/expected.js
@@ -60,6 +60,7 @@ function instance($$self) {
 		if ("kobzol" in $$props) $$invalidate(1, kobzol = $$props.kobzol);
 	};
 
+	$$self.ctx_names = ["obj", "kobzol"];
 	return [obj, kobzol];
 }
 

--- a/test/js/samples/debug-hoisted/expected.js
+++ b/test/js/samples/debug-hoisted/expected.js
@@ -60,7 +60,7 @@ function instance($$self) {
 		if ("kobzol" in $$props) $$invalidate(1, kobzol = $$props.kobzol);
 	};
 
-	$$self.ctx_names = ["obj", "kobzol"];
+	$$self.$$.ctx_names = ["obj", "kobzol"];
 	return [obj, kobzol];
 }
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -91,6 +91,7 @@ function instance($$self, $$props, $$invalidate) {
 		}
 	};
 
+	$$self.ctx_names = ["foo", "bar"];
 	return [foo, bar];
 }
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -91,7 +91,7 @@ function instance($$self, $$props, $$invalidate) {
 		}
 	};
 
-	$$self.ctx_names = ["foo", "bar"];
+	$$self.$$.ctx_names = ["foo", "bar"];
 	return [foo, bar];
 }
 

--- a/test/js/samples/loop-protect/expected.js
+++ b/test/js/samples/loop-protect/expected.js
@@ -89,7 +89,7 @@ function instance($$self) {
 		} while (true);
 	}
 
-	$$self.ctx_names = [];
+	$$self.$$.ctx_names = [];
 	return [];
 }
 

--- a/test/js/samples/loop-protect/expected.js
+++ b/test/js/samples/loop-protect/expected.js
@@ -89,6 +89,7 @@ function instance($$self) {
 		} while (true);
 	}
 
+	$$self.ctx_names = [];
 	return [];
 }
 


### PR DESCRIPTION
Adds a `ctx_names` property to component instances in dev mode. It mirrors the `ctx` property providing names instead of values. This solves #4041.