### PR TITLE
Updated instruction for jetbrains IDEs

### DIFF
--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -60,7 +60,7 @@ To treat `*.svelte` files as HTML, add the following lines to your `settings.jso
 
 ## JetBrains WebStorm
 
-To get Svelte integration in WebStorm or other Jetbrains IDEs, you can use [Svelte framework plugin](https://plugins.jetbrains.com/plugin/12375-svelte/). Visit WebStorm [plugin installation guide](https://www.jetbrains.com/help/webstorm/managing-plugins.html) for more details.
+The [Svelte Framework Integration](https://plugins.jetbrains.com/plugin/12375-svelte/) can be used to add support for Svelte to WebStorm, or other Jetbrains IDEs. Consult the [WebStorm plugin installation guide](https://www.jetbrains.com/help/webstorm/managing-plugins.html) on the JetBrains website for more details.
 
 ## Sublime Text 3
 

--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -60,7 +60,7 @@ To treat `*.svelte` files as HTML, add the following lines to your `settings.jso
 
 ## JetBrains WebStorm
 
-To treat `*.svelte` files as HTML in WebStorm, you need to create a new file type association. Please refer to the [JetBrains website](https://www.jetbrains.com/help/webstorm/creating-and-registering-file-types.html) to see how.
+To get Svelte integration in WebStorm or other Jetbrains IDEs, you can use [Svelte framework plugin](https://plugins.jetbrains.com/plugin/12375-svelte/). Visit WebStorm [plugin installation guide](https://www.jetbrains.com/help/webstorm/managing-plugins.html) for more details.
 
 ## Sublime Text 3
 


### PR DESCRIPTION
Added instruction to use plugins instead of treating svelte as html since a language plugin is available now.

Plugin URL: https://plugins.jetbrains.com/plugin/12375-svelte/