### PR TITLE
Docs: Accurately name function

### DIFF
--- a/site/content/tutorial/02-reactivity/01-reactive-assignments/app-b/App.svelte
+++ b/site/content/tutorial/02-reactivity/01-reactive-assignments/app-b/App.svelte
@@ -1,11 +1,11 @@
 <script>
 	let count = 0;
 
-	function handleClick() {
+	function incrementCount() {
 		count += 1;
 	}
 </script>
 
-<button on:click={handleClick}>
+<button on:click={incrementCount}>
 	Clicked {count} {count === 1 ? 'time' : 'times'}
 </button>

--- a/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
+++ b/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
@@ -7,13 +7,13 @@ At the heart of Svelte is a powerful system of *reactivity* for keeping the DOM 
 To demonstrate it, we first need to wire up an event handler. Replace line 9 with this:
 
 ```html
-<button on:click={handleClick}>
+<button on:click={incrementCount}>
 ```
 
 Inside the `handleClick` function, all we need to do is change the value of `count`:
 
 ```js
-function handleClick() {
+function incrementCount() {
 	count += 1;
 }
 ```

--- a/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
+++ b/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
@@ -10,7 +10,7 @@ To demonstrate it, we first need to wire up an event handler. Replace line 9 wit
 <button on:click={incrementCount}>
 ```
 
-Inside the `handleClick` function, all we need to do is change the value of `count`:
+Inside the `incrementCount` function, all we need to do is change the value of `count`:
 
 ```js
 function incrementCount() {


### PR DESCRIPTION
Replacing "handleX" with a more specific name that describes what the function does. This is to follow the "clean coding" best practice of naming functions by what they do.  In this case "incrementCount". It is much cleaner to know what a function does, and not relevant to know what triggered it to run.

For example, if later on I want another method to trigger this function

```js
function verifyIncrementAndSubmitCount () {
  ensureCountIsAccurate();
  handleClick();
  submitCount();
}
```

In this case `handleClick` is confusing. It's telling me the original event that it was written to be called by, but now it is being called from two places. It would be easier to understand had it always had a descriptive name to begin with.

```js
function verifyIncrementAndSubmitCount () {
  ensureCountIsAccurate();
  incrementCount();
  submitCount();
}
```

This is a problem I've seen a lot in the React community. Fortunately the Vue community has been much better about it. I'd like to see the Svelte community be steered away from this unhelpful crutch of "handle" + event name.

* * *

**Edit 1:**

*This change is small, why not fix all of the documentation?*

Logically my change should be as small and specific as possible, or should be as wide and complete as possible.

*Why is the description so long then?*

This is my first PR/interaction with this repo. I'm unfamiliar with the maintainers and the community. I have no basis to go on for how they will react to this suggestion. It is better to have a description that is thorough and detailed to cover all edge cases and reasoning, to prevent bike-shedding.

*Then why not be as "wide and complete" as possible for the PR too?*

This PR acts as a place for the community to discuss things such as:

* How important clean code is to the community, this documentation, and the project source code.
  * Perhaps the answer is "none", and the community is hostile towards these ideas. Then I would have only spent enough time to find that out, instead of converting the entire documentation and code base to have it rejected.
  * Perhaps the answer is "we care, but disagree with the reasoning in the description". Then a clearer picture would be painted as to how the code could be improved stylistically to have better readability based on the community/maintainers input.

If I made the PR larger, then focus would be placed on every line, rather than the bigger concept. Once these bigger ideas are validated or corrected, then follow-up PR's can be made.

> Why can't it just be renamed to `verifyAndIncrementCount`?
> I think `BeforeSubmitting` doesn't fit here.
> Or it can be `verifyAndIncrementAndSubmitCount`

Valid points. These changes are not in the PR, and were only given names to illustrate the point of why `handleX` is a poor naming convention to default to. I have changed this function's name to be more concise. In actual code I would prefer the function name to have some context as to *why* we are verifying, incrementing, and submitting a count.