### PR TITLE
fix: if inside bind await block contextual dependencies

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -71,6 +71,8 @@ export default class AwaitBlockWrapper extends Wrapper {
 		this.not_static_content();
 
 		block.add_dependencies(this.node.expression.dependencies);
+		if (this.node.value) block.renderer.add_to_context(this.node.value, true);
+		if (this.node.error) block.renderer.add_to_context(this.node.error, true);
 
 		let is_dynamic = false;
 		let has_intros = false;
@@ -118,9 +120,6 @@ export default class AwaitBlockWrapper extends Wrapper {
 		if (has_outros) {
 			block.add_outro();
 		}
-
-		if (this.node.value) block.renderer.add_to_context(this.node.value, true);
-		if (this.node.error) block.renderer.add_to_context(this.node.error, true);
 	}
 
 	render(

--- a/test/runtime/samples/await-then-if/_config.js
+++ b/test/runtime/samples/await-then-if/_config.js
@@ -1,0 +1,25 @@
+let fulfil;
+
+const thePromise = new Promise(f => {
+	fulfil = f;
+});
+
+export default {
+	props: {
+		thePromise
+	},
+
+	html: `
+		loading...
+	`,
+
+	async test({ assert, component, target }) {
+		fulfil([]);
+
+		await thePromise;
+		
+		assert.htmlEqual(target.innerHTML, `
+			<p>promise array is empty</p>
+		`);
+	}
+};

--- a/test/runtime/samples/await-then-if/main.svelte
+++ b/test/runtime/samples/await-then-if/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	export let thePromise;
+</script>
+
+{#await thePromise}
+	loading...
+{:then r}
+	{#if r.length < 1}
+		<p>promise array is empty</p>
+	{:else}
+		<p>promise array is not empty</p>
+	{/if}
+{/await}


### PR DESCRIPTION
Fix https://github.com/sveltejs/svelte/issues/4044

in `IfBlockBranch` will call `expression.manipulate(block)` in the `constructor`. which is called before adding the `value` and `error` into context dependencies.