### PR TITLE
REPL share title should use the repl title

### DIFF
--- a/site/src/routes/repl/[id]/index.svelte
+++ b/site/src/routes/repl/[id]/index.svelte
@@ -187,7 +187,7 @@
 <svelte:head>
 	<title>{name} • REPL • Svelte</title>
 
-	<meta name="twitter:title" content="Svelte REPL">
+	<meta name="twitter:title" content="{name} | Svelte REPL">
 	<meta name="twitter:description" content="Cybernetically enhanced web apps">
 	<meta name="Description" content="Interactive Svelte playground">
 </svelte:head>


### PR DESCRIPTION
Partially fix for https://github.com/sveltejs/svelte/issues/4045#issue-531999258

not sure what would be the alternative share image.