### PR TITLE
Skip JS globals for InlineComponent nodes in warn_if_undefined.

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -1289,7 +1289,7 @@ export default class Component {
 
 		if (this.var_lookup.has(name) && !this.var_lookup.get(name).global) return;
 		if (template_scope && template_scope.names.has(name)) return;
-		if (globals.has(name)) return;
+		if (globals.has(name) && node.type != 'InlineComponent') return;
 
 		let message = `'${name}' is not defined`;
 		if (!this.ast.instance)

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -1289,7 +1289,7 @@ export default class Component {
 
 		if (this.var_lookup.has(name) && !this.var_lookup.get(name).global) return;
 		if (template_scope && template_scope.names.has(name)) return;
-		if (globals.has(name) && node.type != 'InlineComponent') return;
+		if (globals.has(name) && node.type !== 'InlineComponent') return;
 
 		let message = `'${name}' is not defined`;
 		if (!this.ast.instance)

--- a/test/validator/samples/missing-component-global/input.svelte
+++ b/test/validator/samples/missing-component-global/input.svelte
@@ -1,0 +1,3 @@
+<div>
+	<String/>
+</div>

--- a/test/validator/samples/missing-component-global/warnings.json
+++ b/test/validator/samples/missing-component-global/warnings.json
@@ -1,0 +1,15 @@
+[{
+	"code": "missing-declaration",
+	"message": "'String' is not defined. Consider adding a <script> block with 'export let String' to declare a prop",
+	"start": {
+		"line": 2,
+		"column": 1,
+		"character": 7
+	},
+	"end": {
+		"line": 2,
+		"column": 10,
+		"character": 16
+	},
+	"pos": 7
+}]


### PR DESCRIPTION
Fixes #4070.

Currently `<String/>` compiles and results in a runtime error.

Do not check in globals for definitions of `InlineComponent` nodes in `warn_if_undefined`:
```javascript
if (globals.has(name) && node.type != 'InlineComponent') return;
```