### PR TITLE
[WIP] Allow custom elements to be rendered to light dom or shadow dom (open, closed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/compiler/compile/index.ts
+++ b/src/compiler/compile/index.ts
@@ -22,6 +22,7 @@ const valid_options = [
 	'hydratable',
 	'legacy',
 	'customElement',
+	'shadowDom',
 	'tag',
 	'css',
 	'loopGuardTimeout',

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -426,14 +426,19 @@ export default function dom(
 	}
 
 	if (options.customElement) {
+		const lightDom = options.shadowDom === 'none';
 		const declaration = b`
 			class ${name} extends @SvelteElement {
 				constructor(options) {
 					super();
+					
+					${!lightDom && b`
+						this.attachShadow({ mode: '${options.shadowDom}' });
+					`}
 
 					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(/\\/g, '\\\\')}${options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
 
-					@init(this, { target: this.shadowRoot }, ${definition}, ${has_create_fragment ? 'create_fragment': 'null'}, ${not_equal}, ${prop_indexes}, ${dirty});
+					@init(this, { target: ${lightDom ? 'this' : 'this.shadowRoot'} }, ${definition}, ${has_create_fragment ? 'create_fragment': 'null'}, ${not_equal}, ${prop_indexes}, ${dirty});
 
 					${dev_props_check}
 

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -119,6 +119,7 @@ export interface CompileOptions {
 	hydratable?: boolean;
 	legacy?: boolean;
 	customElement?: boolean;
+	shadowDom?: ShadowDomMode;
 	tag?: string;
 	css?: boolean;
 	loopGuardTimeout?: number;
@@ -161,3 +162,7 @@ export interface Var {
 	subscribable?: boolean;
 	is_reactive_dependency?: boolean;
 }
+
+export type ShadowDomMode = 'none'
+	| 'open'
+	| 'closed'

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -166,7 +166,6 @@ if (typeof HTMLElement === 'function') {
 		$$: T$$;
 		constructor() {
 			super();
-			this.attachShadow({ mode: 'open' });
 		}
 
 		connectedCallback() {


### PR DESCRIPTION
Hi peeps,

We're in the middle of choosing a JS component wrapper for our design system. Svelte looks really good, best developer experience so far. Custom elements are an important part of this process because it allows teams to consume individual components in their own projects, which may then use React (even though it has known issues with custom elements, this library sorts them out for us https://github.com/BBKolton/reactify-wc/), Vue, Angular, Svelte, etc.

However, there are a couple of issues with the way it handles custom elements (https://github.com/sveltejs/svelte/issues/1748)

It's important to be able to render elements directly on the lightdom due to accessibility issues.

These small changes solve that specific issue:

<img width="331" alt="Screenshot 2019-12-09 21 02 26" src="https://user-images.githubusercontent.com/844181/70426668-80351d00-1ac7-11ea-915a-2b94b91738e7.png">
<img width="290" alt="Screenshot 2019-12-09 21 02 21" src="https://user-images.githubusercontent.com/844181/70426670-80cdb380-1ac7-11ea-8913-3506997026fc.png">

But before looking deeper into this issue, I have a question that's more around what's the philosophy for Svelte:

Safari does not support extending built-in elements (e.g. `<p is="my-svelte-component">`). There is a (small) [polyfill](https://github.com/ungap/custom-elements-builtin) for Safari which is used in the [heresy project](https://github.com/WebReflection/heresy).

Libraries like Stencil have no intention of adding polyfills for it, so I'm wondering; what's Svelte's stance on this?

Similarly to the point above, it's really important because it allows us to be able to progressively enhance a small component (such as an anchor or a paragraph) while keeping all the default attributes (like the aria- attributes) without having to re-implement them on each component.

If I'm completely missing something that already exists, or what I'm saying makes no sense at all, I'm also happy to be corrected.

Thanks.
