### PR TITLE
fix bitmask overflow when using slotted components

### DIFF
--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -220,7 +220,11 @@ export default class Renderer {
 				const i = (value / 31) | 0;
 				const n = 1 << (value % 31);
 
-				if (!bitmask[i]) bitmask[i] = { n: 0, names: [] };
+				if (bitmask.length <= i) {
+					for (let j = bitmask.length; j <= i; j++) {
+						bitmask[j] = { n: 0, names: [] };
+					}
+				}
 
 				bitmask[i].n |= n;
 				bitmask[i].names.push(name);

--- a/test/runtime/samples/bitmask-overflow-3/_config.js
+++ b/test/runtime/samples/bitmask-overflow-3/_config.js
@@ -1,0 +1,3 @@
+export default {
+	error: `A is not defined`,
+};

--- a/test/runtime/samples/bitmask-overflow-3/main.svelte
+++ b/test/runtime/samples/bitmask-overflow-3/main.svelte
@@ -1,0 +1,4 @@
+<script>
+	let x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31;
+</script>
+<A>foo</A>


### PR DESCRIPTION
Fixes #4077. I'm not positive that this isn't actually covering up a bug elsewhere, but it does seem to make some sort of sense that we'd want to fill in any skipped entries in the `bitmask` array, which is what this does.