### PR TITLE
fix bitmask overflow when using slotted components

### DIFF
--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -86,8 +86,6 @@ export default class Renderer {
 			null
 		);
 
-		this.context_overflow = this.context.length > 31;
-
 		// TODO messy
 		this.blocks.forEach(block => {
 			if (block instanceof Block) {
@@ -98,6 +96,8 @@ export default class Renderer {
 		this.block.assign_variable_names();
 
 		this.fragment.render(this.block, null, x`#nodes` as Identifier);
+
+		this.context_overflow = this.context.length > 31;
 
 		this.context.forEach(member => {
 			const { variable } = member;

--- a/test/runtime/samples/bitmask-overflow-3/_config.js
+++ b/test/runtime/samples/bitmask-overflow-3/_config.js
@@ -1,0 +1,3 @@
+export default {
+	error: `A is not defined`,
+};

--- a/test/runtime/samples/bitmask-overflow-3/main.svelte
+++ b/test/runtime/samples/bitmask-overflow-3/main.svelte
@@ -1,0 +1,4 @@
+<script>
+	let x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31;
+</script>
+<A>foo</A>


### PR DESCRIPTION
Fixes #4077. I had intended to just reopen #4084, but apparently if you force-push a branch while a PR is closed, you can't do that. This moves down the computation of `context_overflow` as discussed, and adds a test.