### PR TITLE
docs: correct build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
     <img src="https://packagephobia.now.sh/badge?p=svelte" alt="install size">
   </a>
 
-  <a href="https://travis-ci.org/sveltejs/svelte">
-    <img src="https://api.travis-ci.org/sveltejs/svelte.svg?branch=master"
+  <a href="https://github.com/sveltejs/svelte/actions">
+    <img src="https://github.com/sveltejs/svelte/workflows/CI/badge.svg"
          alt="build status">
   </a>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </a>
 
   <a href="https://github.com/sveltejs/svelte/actions">
-    <img src="https://github.com/sveltejs/svelte/workflows/CI/badge.svg"
+    <img src="https://github.com/sveltejs/svelte/workflows/CI/badge.svg?branch=master"
          alt="build status">
   </a>
 


### PR DESCRIPTION
Currently Travis CI is not used, so I replaced it with the Github Actions badge.