### PR TITLE
fix dirtybit

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -1,7 +1,7 @@
 import Renderer from './Renderer';
 import Wrapper from './wrappers/shared/Wrapper';
 import { b, x } from 'code-red';
-import { Node, Identifier, ArrayPattern } from 'estree';
+import { Node, Identifier } from 'estree';
 import { is_head } from './wrappers/shared/is_head';
 
 export interface BlockOptions {
@@ -301,9 +301,7 @@ export default class Block {
 			} else {
 				const ctx = this.maintain_context ? x`#new_ctx` : x`#ctx`;
 
-				let dirty: Identifier | ArrayPattern = { type: 'Identifier', name: '#dirty' };
-
-				properties.update = x`function #update(${ctx}, ${dirty}) {
+				properties.update = x`function #update(${ctx}, #dirty) {
 					${this.maintain_context && b`#ctx = ${ctx};`}
 					${this.chunks.update}
 				}`;

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -302,9 +302,6 @@ export default class Block {
 				const ctx = this.maintain_context ? x`#new_ctx` : x`#ctx`;
 
 				let dirty: Identifier | ArrayPattern = { type: 'Identifier', name: '#dirty' };
-				if (!this.renderer.context_overflow && !this.parent) {
-					dirty = { type: 'ArrayPattern', elements: [dirty] };
-				}
 
 				properties.update = x`function #update(${ctx}, ${dirty}) {
 					${this.maintain_context && b`#ctx = ${ctx};`}

--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -248,7 +248,7 @@ export default class Renderer {
 						.reduce((lhs, rhs) => x`${lhs} | ${rhs}`);
 				}
 
-				return x`${dirty} & /*${names.join(', ')}*/ ${bitmask[0].n}` as BinaryExpression;
+				return x`${dirty}[0] & /*${names.join(', ')}*/ ${bitmask[0].n}` as BinaryExpression;
 			}
 		} as any;
 	}

--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -26,7 +26,6 @@ export default class Renderer {
 
 	context: ContextMember[] = [];
 	context_lookup: Map<string, ContextMember> = new Map();
-	context_overflow: boolean;
 	blocks: Array<Block | Node | Node[]> = [];
 	readonly: Set<string> = new Set();
 	meta_bindings: Array<Node | Node[]> = []; // initial values for e.g. window.innerWidth, if there's a <svelte:window> meta tag
@@ -96,8 +95,6 @@ export default class Renderer {
 		this.block.assign_variable_names();
 
 		this.fragment.render(this.block, null, x`#nodes` as Identifier);
-
-		this.context_overflow = this.context.length > 31;
 
 		this.context.forEach(member => {
 			const { variable } = member;
@@ -240,15 +237,11 @@ export default class Renderer {
 					return x`${dirty} & /*${names.join(', ')}*/ 0` as BinaryExpression;
 				}
 
-				if (renderer.context_overflow) {
-					return bitmask
-						.map((b, i) => ({ b, i }))
-						.filter(({ b }) => b)
-						.map(({ b, i }) => x`${dirty}[${i}] & /*${b.names.join(', ')}*/ ${b.n}`)
-						.reduce((lhs, rhs) => x`${lhs} | ${rhs}`);
-				}
-
-				return x`${dirty}[0] & /*${names.join(', ')}*/ ${bitmask[0].n}` as BinaryExpression;
+				return bitmask
+					.map((b, i) => ({ b, i }))
+					.filter(({ b }) => b)
+					.map(({ b, i }) => x`${dirty}[${i}] & /*${b.names.join(', ')}*/ ${b.n}`)
+					.reduce((lhs, rhs) => x`${lhs} | ${rhs}`);
 			}
 		} as any;
 	}

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -429,7 +429,7 @@ export default function dom(
 	}` as ObjectExpression;
 
 	let dirty;
-	if (renderer.context_overflow) {
+	if (renderer.context.length > 31) {
 		dirty = x`[]`;
 		for (let i = 0; i < renderer.context.length; i += 31) {
 			dirty.elements.push(x`-1`);

--- a/src/compiler/compile/render_dom/wrappers/shared/get_slot_definition.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/get_slot_definition.ts
@@ -2,7 +2,6 @@ import Let from '../../../nodes/Let';
 import { x, p } from 'code-red';
 import Block from '../../Block';
 import TemplateScope from '../../../nodes/shared/TemplateScope';
-import { BinaryExpression } from 'estree';
 
 export function get_slot_definition(block: Block, scope: TemplateScope, lets: Let[]) {
 	if (lets.length === 0) return { block, scope };
@@ -36,39 +35,30 @@ export function get_slot_definition(block: Block, scope: TemplateScope, lets: Le
 	const changes = {
 		type: 'ParenthesizedExpression',
 		get expression() {
-			if (block.renderer.context_overflow) {
-				const grouped = [];
+			const grouped = [];
 
-				Array.from(names).forEach(name => {
-					const i = context_lookup.get(name).index.value as number;
-					const g = Math.floor(i / 31);
+			Array.from(names).forEach(name => {
+				const i = context_lookup.get(name).index.value as number;
+				const g = Math.floor(i / 31);
 
-					if (!grouped[g]) grouped[g] = [];
-					grouped[g].push({ name, n: i % 31 });
-				});
+				if (!grouped[g]) grouped[g] = [];
+				grouped[g].push({ name, n: i % 31 });
+			});
 
-				const elements = [];
+			const elements = [];
 
-				for (let g = 0; g < grouped.length; g += 1) {
-					elements[g] = grouped[g]
-						? grouped[g]
-							.map(({ name, n }) => x`${name} ? ${1 << n} : 0`)
-							.reduce((lhs, rhs) => x`${lhs} | ${rhs}`)
-						: x`0`;
-				}
-
-				return {
-					type: 'ArrayExpression',
-					elements
-				};
+			for (let g = 0; g < grouped.length; g += 1) {
+				elements[g] = grouped[g]
+					? grouped[g]
+						.map(({ name, n }) => x`${name} ? ${1 << n} : 0`)
+						.reduce((lhs, rhs) => x`${lhs} | ${rhs}`)
+					: x`0`;
 			}
 
-			return Array.from(names)
-				.map(name => {
-					const i = context_lookup.get(name).index.value as number;
-					return x`${name} ? ${1 << i} : 0`;
-				})
-				.reduce((lhs, rhs) => x`${lhs} | ${rhs}`) as BinaryExpression;
+			return {
+				type: 'ArrayExpression',
+				elements
+			};
 		}
 	};
 

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -80,17 +80,16 @@ export function get_slot_changes(definition, $$scope, dirty, fn) {
 	if (definition[2] && fn) {
 		const lets = definition[2](fn(dirty));
 
-		if (typeof $$scope.dirty === 'object') {
+		if ($$scope.dirty) {
 			const merged = [];
 			const len = Math.max($$scope.dirty.length, lets.length);
 			for (let i = 0; i < len; i += 1) {
 				merged[i] = $$scope.dirty[i] | lets[i];
 			}
-
 			return merged;
 		}
 
-		return $$scope.dirty | lets;
+		return lets;
 	}
 
 	return $$scope.dirty;

--- a/test/js/samples/action-custom-event-handler/expected.js
+++ b/test/js/samples/action-custom-event-handler/expected.js
@@ -23,8 +23,8 @@ function create_fragment(ctx) {
 			insert(target, button, anchor);
 			foo_action = foo.call(null, button, /*foo_function*/ ctx[1]) || ({});
 		},
-		p(ctx, [dirty]) {
-			if (is_function(foo_action.update) && dirty & /*bar*/ 1) foo_action.update.call(null, /*foo_function*/ ctx[1]);
+		p(ctx, dirty) {
+			if (is_function(foo_action.update) && dirty[0] & /*bar*/ 1) foo_action.update.call(null, /*foo_function*/ ctx[1]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/bind-open/expected.js
+++ b/test/js/samples/bind-open/expected.js
@@ -27,8 +27,8 @@ function create_fragment(ctx) {
 			insert(target, details, anchor);
 			details.open = /*open*/ ctx[0];
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*open*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*open*/ 1) {
 				details.open = /*open*/ ctx[0];
 			}
 		},

--- a/test/js/samples/capture-inject-dev-only/expected.js
+++ b/test/js/samples/capture-inject-dev-only/expected.js
@@ -37,10 +37,10 @@ function create_fragment(ctx) {
 			insert(target, input, anchor);
 			set_input_value(input, /*foo*/ ctx[0]);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*foo*/ 1) set_data(t0, /*foo*/ ctx[0]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*foo*/ 1) set_data(t0, /*foo*/ ctx[0]);
 
-			if (dirty & /*foo*/ 1 && input.value !== /*foo*/ ctx[0]) {
+			if (dirty[0] & /*foo*/ 1 && input.value !== /*foo*/ ctx[0]) {
 				set_input_value(input, /*foo*/ ctx[0]);
 			}
 		},

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -34,8 +34,8 @@ function create_fragment(ctx) {
 			insert(target, p, anchor);
 			append(p, t);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*foo*/ 1) set_data(t, /*foo*/ ctx[0]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*foo*/ 1) set_data(t, /*foo*/ ctx[0]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/component-static-var/expected.js
+++ b/test/js/samples/component-static-var/expected.js
@@ -46,12 +46,12 @@ function create_fragment(ctx) {
 			set_input_value(input, /*z*/ ctx[0]);
 			current = true;
 		},
-		p(ctx, [dirty]) {
+		p(ctx, dirty) {
 			const bar_changes = {};
-			if (dirty & /*z*/ 1) bar_changes.x = /*z*/ ctx[0];
+			if (dirty[0] & /*z*/ 1) bar_changes.x = /*z*/ ctx[0];
 			bar.$set(bar_changes);
 
-			if (dirty & /*z*/ 1 && input.value !== /*z*/ ctx[0]) {
+			if (dirty[0] & /*z*/ 1 && input.value !== /*z*/ ctx[0]) {
 				set_input_value(input, /*z*/ ctx[0]);
 			}
 		},

--- a/test/js/samples/component-store-access-invalidate/expected.js
+++ b/test/js/samples/component-store-access-invalidate/expected.js
@@ -28,8 +28,8 @@ function create_fragment(ctx) {
 			insert(target, h1, anchor);
 			append(h1, t);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*$foo*/ 1) set_data(t, /*$foo*/ ctx[0]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*$foo*/ 1) set_data(t, /*$foo*/ ctx[0]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/component-store-reassign-invalidate/expected.js
+++ b/test/js/samples/component-store-reassign-invalidate/expected.js
@@ -39,8 +39,8 @@ function create_fragment(ctx) {
 			insert(target, t1, anchor);
 			insert(target, button, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*$foo*/ 2) set_data(t0, /*$foo*/ ctx[1]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*$foo*/ 2) set_data(t0, /*$foo*/ ctx[1]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/data-attribute/expected.js
+++ b/test/js/samples/data-attribute/expected.js
@@ -29,8 +29,8 @@ function create_fragment(ctx) {
 			insert(target, t, anchor);
 			insert(target, div1, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*bar*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*bar*/ 1) {
 				attr(div1, "data-foo", /*bar*/ ctx[0]);
 			}
 		},

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -44,8 +44,8 @@ function create_fragment(ctx) {
 			append_dev(h1, t2);
 			insert_dev(target, t3, anchor);
 		},
-		p: function update(ctx, [dirty]) {
-			if (dirty & /*name*/ 1) set_data_dev(t1, /*name*/ ctx[0]);
+		p: function update(ctx, dirty) {
+			if (dirty[0] & /*name*/ 1) set_data_dev(t1, /*name*/ ctx[0]);
 			debugger;
 		},
 		i: noop,

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -54,9 +54,9 @@ function create_each_block(ctx) {
 			insert_dev(target, t1, anchor);
 		},
 		p: function update(ctx, dirty) {
-			if (dirty & /*things*/ 1 && t0_value !== (t0_value = /*thing*/ ctx[4].name + "")) set_data_dev(t0, t0_value);
+			if (dirty[0] & /*things*/ 1 && t0_value !== (t0_value = /*thing*/ ctx[4].name + "")) set_data_dev(t0, t0_value);
 
-			if (dirty & /*foo, bar, baz, things*/ 15) {
+			if (dirty[0] & /*foo, bar, baz, things*/ 15) {
 				const foo = /*foo*/ ctx[1];
 				const bar = /*bar*/ ctx[2];
 				const baz = /*baz*/ ctx[3];
@@ -119,8 +119,8 @@ function create_fragment(ctx) {
 			append_dev(p, t1);
 			append_dev(p, t2);
 		},
-		p: function update(ctx, [dirty]) {
-			if (dirty & /*things*/ 1) {
+		p: function update(ctx, dirty) {
+			if (dirty[0] & /*things*/ 1) {
 				each_value = /*things*/ ctx[0];
 				let i;
 
@@ -143,7 +143,7 @@ function create_fragment(ctx) {
 				each_blocks.length = each_value.length;
 			}
 
-			if (dirty & /*foo*/ 2) set_data_dev(t2, /*foo*/ ctx[1]);
+			if (dirty[0] & /*foo*/ 2) set_data_dev(t2, /*foo*/ ctx[1]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -51,9 +51,9 @@ function create_each_block(ctx) {
 			insert_dev(target, t1, anchor);
 		},
 		p: function update(ctx, dirty) {
-			if (dirty & /*things*/ 1 && t0_value !== (t0_value = /*thing*/ ctx[2].name + "")) set_data_dev(t0, t0_value);
+			if (dirty[0] & /*things*/ 1 && t0_value !== (t0_value = /*thing*/ ctx[2].name + "")) set_data_dev(t0, t0_value);
 
-			if (dirty & /*foo*/ 2) {
+			if (dirty[0] & /*foo*/ 2) {
 				const foo = /*foo*/ ctx[1];
 				console.log({ foo });
 				debugger;
@@ -113,8 +113,8 @@ function create_fragment(ctx) {
 			append_dev(p, t1);
 			append_dev(p, t2);
 		},
-		p: function update(ctx, [dirty]) {
-			if (dirty & /*things*/ 1) {
+		p: function update(ctx, dirty) {
+			if (dirty[0] & /*things*/ 1) {
 				each_value = /*things*/ ctx[0];
 				let i;
 
@@ -137,7 +137,7 @@ function create_fragment(ctx) {
 				each_blocks.length = each_value.length;
 			}
 
-			if (dirty & /*foo*/ 2) set_data_dev(t2, /*foo*/ ctx[1]);
+			if (dirty[0] & /*foo*/ 2) set_data_dev(t2, /*foo*/ ctx[1]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/debug-hoisted/expected.js
+++ b/test/js/samples/debug-hoisted/expected.js
@@ -23,8 +23,8 @@ function create_fragment(ctx) {
 			throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		},
 		m: noop,
-		p: function update(ctx, [dirty]) {
-			if (dirty & /*obj, kobzol*/ 3) {
+		p: function update(ctx, dirty) {
+			if (dirty[0] & /*obj, kobzol*/ 3) {
 				const obj = /*obj*/ ctx[0];
 				const kobzol = /*kobzol*/ ctx[1];
 				console.log({ obj, kobzol });

--- a/test/js/samples/debug-no-dependencies/expected.js
+++ b/test/js/samples/debug-no-dependencies/expected.js
@@ -88,7 +88,7 @@ function create_fragment(ctx) {
 
 			insert_dev(target, each_1_anchor, anchor);
 		},
-		p: function update(ctx, [dirty]) {
+		p: function update(ctx, dirty) {
 			if (dirty & /*things*/ 0) {
 				each_value = things;
 				let i;

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -36,7 +36,7 @@ function create_each_block(ctx) {
 			append(span, t);
 		},
 		p(ctx, dirty) {
-			if (dirty & /*createElement*/ 1 && t_value !== (t_value = /*node*/ ctx[1] + "")) set_data(t, t_value);
+			if (dirty[0] & /*createElement*/ 1 && t_value !== (t_value = /*node*/ ctx[1] + "")) set_data(t, t_value);
 		},
 		d(detaching) {
 			if (detaching) detach(span);
@@ -68,8 +68,8 @@ function create_fragment(ctx) {
 
 			insert(target, each_1_anchor, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*createElement*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*createElement*/ 1) {
 				each_value = /*createElement*/ ctx[0];
 				let i;
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -41,9 +41,9 @@ function create_fragment(ctx) {
 			append_dev(p, t1);
 			append_dev(p, t2);
 		},
-		p: function update(ctx, [dirty]) {
-			if (dirty & /*foo*/ 1 && t0_value !== (t0_value = Math.max(0, /*foo*/ ctx[0]) + "")) set_data_dev(t0, t0_value);
-			if (dirty & /*bar*/ 2) set_data_dev(t2, /*bar*/ ctx[1]);
+		p: function update(ctx, dirty) {
+			if (dirty[0] & /*foo*/ 1 && t0_value !== (t0_value = Math.max(0, /*foo*/ ctx[0]) + "")) set_data_dev(t0, t0_value);
+			if (dirty[0] & /*bar*/ 2) set_data_dev(t2, /*bar*/ ctx[1]);
 		},
 		i: noop,
 		o: noop,
@@ -86,7 +86,7 @@ function instance($$self, $$props, $$invalidate) {
 	};
 
 	$$self.$$.update = () => {
-		if ($$self.$$.dirty & /*foo*/ 1) {
+		if ($$self.$$.dirty[0] & /*foo*/ 1) {
 			$: $$invalidate(1, bar = foo * 2);
 		}
 	};

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -36,7 +36,7 @@ function create_each_block(ctx) {
 			append(span, t);
 		},
 		p(ctx, dirty) {
-			if (dirty & /*a, b, c, d, e*/ 31 && t_value !== (t_value = /*num*/ ctx[5] + "")) set_data(t, t_value);
+			if (dirty[0] & /*a, b, c, d, e*/ 31 && t_value !== (t_value = /*num*/ ctx[5] + "")) set_data(t, t_value);
 		},
 		d(detaching) {
 			if (detaching) detach(span);
@@ -68,8 +68,8 @@ function create_fragment(ctx) {
 
 			insert(target, each_1_anchor, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*a, b, c, d, e*/ 31) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*a, b, c, d, e*/ 31) {
 				each_value = [/*a*/ ctx[0], /*b*/ ctx[1], /*c*/ ctx[2], /*d*/ ctx[3], /*e*/ ctx[4]];
 				let i;
 

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -70,9 +70,9 @@ function create_each_block(ctx) {
 			html_tag.m(div);
 		},
 		p(ctx, dirty) {
-			if (dirty & /*comments*/ 1 && t2_value !== (t2_value = /*comment*/ ctx[4].author + "")) set_data(t2, t2_value);
-			if (dirty & /*elapsed, comments, time*/ 7 && t4_value !== (t4_value = /*elapsed*/ ctx[1](/*comment*/ ctx[4].time, /*time*/ ctx[2]) + "")) set_data(t4, t4_value);
-			if (dirty & /*comments*/ 1 && raw_value !== (raw_value = /*comment*/ ctx[4].html + "")) html_tag.p(raw_value);
+			if (dirty[0] & /*comments*/ 1 && t2_value !== (t2_value = /*comment*/ ctx[4].author + "")) set_data(t2, t2_value);
+			if (dirty[0] & /*elapsed, comments, time*/ 7 && t4_value !== (t4_value = /*elapsed*/ ctx[1](/*comment*/ ctx[4].time, /*time*/ ctx[2]) + "")) set_data(t4, t4_value);
+			if (dirty[0] & /*comments*/ 1 && raw_value !== (raw_value = /*comment*/ ctx[4].html + "")) html_tag.p(raw_value);
 		},
 		d(detaching) {
 			if (detaching) detach(div);
@@ -110,8 +110,8 @@ function create_fragment(ctx) {
 			insert(target, p, anchor);
 			append(p, t1);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*comments, elapsed, time*/ 7) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*comments, elapsed, time*/ 7) {
 				each_value = /*comments*/ ctx[0];
 				let i;
 
@@ -134,7 +134,7 @@ function create_fragment(ctx) {
 				each_blocks.length = each_value.length;
 			}
 
-			if (dirty & /*foo*/ 8) set_data(t1, /*foo*/ ctx[3]);
+			if (dirty[0] & /*foo*/ 8) set_data(t1, /*foo*/ ctx[3]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -44,7 +44,7 @@ function create_each_block(key_1, ctx) {
 			append(div, t);
 		},
 		p(ctx, dirty) {
-			if (dirty & /*things*/ 1 && t_value !== (t_value = /*thing*/ ctx[1].name + "")) set_data(t, t_value);
+			if (dirty[0] & /*things*/ 1 && t_value !== (t_value = /*thing*/ ctx[1].name + "")) set_data(t, t_value);
 		},
 		r() {
 			rect = div.getBoundingClientRect();
@@ -91,7 +91,7 @@ function create_fragment(ctx) {
 
 			insert(target, each_1_anchor, anchor);
 		},
-		p(ctx, [dirty]) {
+		p(ctx, dirty) {
 			const each_value = /*things*/ ctx[0];
 			for (let i = 0; i < each_blocks.length; i += 1) each_blocks[i].r();
 			each_blocks = update_keyed_each(each_blocks, dirty, get_key, 1, ctx, each_value, each_1_lookup, each_1_anchor.parentNode, fix_and_destroy_block, create_each_block, each_1_anchor, get_each_context);

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -40,7 +40,7 @@ function create_each_block(key_1, ctx) {
 			append(div, t);
 		},
 		p(ctx, dirty) {
-			if (dirty & /*things*/ 1 && t_value !== (t_value = /*thing*/ ctx[1].name + "")) set_data(t, t_value);
+			if (dirty[0] & /*things*/ 1 && t_value !== (t_value = /*thing*/ ctx[1].name + "")) set_data(t, t_value);
 		},
 		d(detaching) {
 			if (detaching) detach(div);
@@ -76,7 +76,7 @@ function create_fragment(ctx) {
 
 			insert(target, each_1_anchor, anchor);
 		},
-		p(ctx, [dirty]) {
+		p(ctx, dirty) {
 			const each_value = /*things*/ ctx[0];
 			each_blocks = update_keyed_each(each_blocks, dirty, get_key, 1, ctx, each_value, each_1_lookup, each_1_anchor.parentNode, destroy_block, create_each_block, each_1_anchor, get_each_context);
 		},

--- a/test/js/samples/event-handler-dynamic/expected.js
+++ b/test/js/samples/event-handler-dynamic/expected.js
@@ -61,9 +61,9 @@ function create_fragment(ctx) {
 			insert(target, t5, anchor);
 			insert(target, button2, anchor);
 		},
-		p(new_ctx, [dirty]) {
+		p(new_ctx, dirty) {
 			ctx = new_ctx;
-			if (dirty & /*number*/ 2) set_data(t4, /*number*/ ctx[1]);
+			if (dirty[0] & /*number*/ 2) set_data(t4, /*number*/ ctx[1]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -65,7 +65,7 @@ function create_fragment(ctx) {
 			if_block.m(target, anchor);
 			insert(target, if_block_anchor, anchor);
 		},
-		p(ctx, [dirty]) {
+		p(ctx, dirty) {
 			if (current_block_type !== (current_block_type = select_block_type(ctx, dirty))) {
 				if_block.d(1);
 				if_block = current_block_type(ctx);

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -40,7 +40,7 @@ function create_fragment(ctx) {
 			if (if_block) if_block.m(target, anchor);
 			insert(target, if_block_anchor, anchor);
 		},
-		p(ctx, [dirty]) {
+		p(ctx, dirty) {
 			if (/*foo*/ ctx[0]) {
 				if (!if_block) {
 					if_block = create_if_block(ctx);

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -22,12 +22,12 @@ function create_fragment(ctx) {
 		m(target, anchor) {
 			insert(target, div, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*color*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*color*/ 1) {
 				set_style(div, "color", /*color*/ ctx[0]);
 			}
 
-			if (dirty & /*x, y*/ 6) {
+			if (dirty[0] & /*x, y*/ 6) {
 				set_style(div, "transform", "translate(" + /*x*/ ctx[1] + "px," + /*y*/ ctx[2] + "px)");
 			}
 		},

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -21,8 +21,8 @@ function create_fragment(ctx) {
 		m(target, anchor) {
 			insert(target, div, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*data*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*data*/ 1) {
 				set_style(div, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
 			}
 		},

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -21,8 +21,8 @@ function create_fragment(ctx) {
 		m(target, anchor) {
 			insert(target, div, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*color*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*color*/ 1) {
 				set_style(div, "color", /*color*/ ctx[0]);
 			}
 		},

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -30,12 +30,12 @@ function create_fragment(ctx) {
 			insert(target, t, anchor);
 			insert(target, div1, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*style*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*style*/ 1) {
 				attr(div0, "style", /*style*/ ctx[0]);
 			}
 
-			if (dirty & /*key, value*/ 6 && div1_style_value !== (div1_style_value = "" + (/*key*/ ctx[1] + ": " + /*value*/ ctx[2]))) {
+			if (dirty[0] & /*key, value*/ 6 && div1_style_value !== (div1_style_value = "" + (/*key*/ ctx[1] + ": " + /*value*/ ctx[2]))) {
 				attr(div1, "style", div1_style_value);
 			}
 		},

--- a/test/js/samples/input-no-initial-value/expected.js
+++ b/test/js/samples/input-no-initial-value/expected.js
@@ -44,8 +44,8 @@ function create_fragment(ctx) {
 			append(form, t0);
 			append(form, button);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*test*/ 1 && input.value !== /*test*/ ctx[0]) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*test*/ 1 && input.value !== /*test*/ ctx[0]) {
 				set_input_value(input, /*test*/ ctx[0]);
 			}
 		},

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -32,8 +32,8 @@ function create_fragment(ctx) {
 			insert(target, input, anchor);
 			set_input_value(input, /*value*/ ctx[0]);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*value*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*value*/ 1) {
 				set_input_value(input, /*value*/ ctx[0]);
 			}
 		},

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -25,8 +25,8 @@ function create_fragment(ctx) {
 			insert(target, input, anchor);
 			input.checked = /*foo*/ ctx[0];
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*foo*/ 1) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*foo*/ 1) {
 				input.checked = /*foo*/ ctx[0];
 			}
 		},

--- a/test/js/samples/instrumentation-script-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-script-if-no-block/expected.js
@@ -39,8 +39,8 @@ function create_fragment(ctx) {
 			append(p, t2);
 			append(p, t3);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*x*/ 1) set_data(t3, /*x*/ ctx[0]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*x*/ 1) set_data(t3, /*x*/ ctx[0]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/instrumentation-script-main-block/expected.js
+++ b/test/js/samples/instrumentation-script-main-block/expected.js
@@ -28,8 +28,8 @@ function create_fragment(ctx) {
 			append(p, t0);
 			append(p, t1);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*x*/ 1) set_data(t1, /*x*/ ctx[0]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*x*/ 1) set_data(t1, /*x*/ ctx[0]);
 		},
 		i: noop,
 		o: noop,
@@ -57,7 +57,7 @@ function instance($$self, $$props, $$invalidate) {
 	);
 
 	$$self.$$.update = () => {
-		if ($$self.$$.dirty & /*x, y*/ 3) {
+		if ($$self.$$.dirty[0] & /*x, y*/ 3) {
 			$: $$invalidate(0, x += y);
 		}
 	};

--- a/test/js/samples/instrumentation-script-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-script-x-equals-x/expected.js
@@ -40,8 +40,8 @@ function create_fragment(ctx) {
 			append(p, t2);
 			append(p, t3);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*things*/ 1 && t3_value !== (t3_value = /*things*/ ctx[0].length + "")) set_data(t3, t3_value);
+		p(ctx, dirty) {
+			if (dirty[0] & /*things*/ 1 && t3_value !== (t3_value = /*things*/ ctx[0].length + "")) set_data(t3, t3_value);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -39,8 +39,8 @@ function create_fragment(ctx) {
 			append(p, t2);
 			append(p, t3);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*x*/ 1) set_data(t3, /*x*/ ctx[0]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*x*/ 1) set_data(t3, /*x*/ ctx[0]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/instrumentation-template-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-template-x-equals-x/expected.js
@@ -40,8 +40,8 @@ function create_fragment(ctx) {
 			append(p, t2);
 			append(p, t3);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*things*/ 1 && t3_value !== (t3_value = /*things*/ ctx[0].length + "")) set_data(t3, t3_value);
+		p(ctx, dirty) {
+			if (dirty[0] & /*things*/ 1 && t3_value !== (t3_value = /*things*/ ctx[0].length + "")) set_data(t3, t3_value);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -67,20 +67,20 @@ function create_fragment(ctx) {
 				audio.playbackRate = /*playbackRate*/ ctx[7];
 			}
 		},
-		p(ctx, [dirty]) {
-			if (!audio_updating && dirty & /*currentTime*/ 8 && !isNaN(/*currentTime*/ ctx[3])) {
+		p(ctx, dirty) {
+			if (!audio_updating && dirty[0] & /*currentTime*/ 8 && !isNaN(/*currentTime*/ ctx[3])) {
 				audio.currentTime = /*currentTime*/ ctx[3];
 			}
 
-			if (dirty & /*paused*/ 32 && audio_is_paused !== (audio_is_paused = /*paused*/ ctx[5])) {
+			if (dirty[0] & /*paused*/ 32 && audio_is_paused !== (audio_is_paused = /*paused*/ ctx[5])) {
 				audio[audio_is_paused ? "pause" : "play"]();
 			}
 
-			if (dirty & /*volume*/ 64 && !isNaN(/*volume*/ ctx[6])) {
+			if (dirty[0] & /*volume*/ 64 && !isNaN(/*volume*/ ctx[6])) {
 				audio.volume = /*volume*/ ctx[6];
 			}
 
-			if (dirty & /*playbackRate*/ 128 && !isNaN(/*playbackRate*/ ctx[7])) {
+			if (dirty[0] & /*playbackRate*/ 128 && !isNaN(/*playbackRate*/ ctx[7])) {
 				audio.playbackRate = /*playbackRate*/ ctx[7];
 			}
 

--- a/test/js/samples/reactive-values-non-topologically-ordered/expected.js
+++ b/test/js/samples/reactive-values-non-topologically-ordered/expected.js
@@ -11,11 +11,11 @@ function instance($$self, $$props, $$invalidate) {
 	};
 
 	$$self.$$.update = () => {
-		if ($$self.$$.dirty & /*x*/ 1) {
+		if ($$self.$$.dirty[0] & /*x*/ 1) {
 			$: $$invalidate(2, b = x);
 		}
 
-		if ($$self.$$.dirty & /*b*/ 4) {
+		if ($$self.$$.dirty[0] & /*b*/ 4) {
 			$: a = b;
 		}
 	};

--- a/test/js/samples/reactive-values-non-writable-dependencies/expected.js
+++ b/test/js/samples/reactive-values-non-writable-dependencies/expected.js
@@ -11,7 +11,7 @@ function instance($$self, $$props, $$invalidate) {
 	};
 
 	$$self.$$.update = () => {
-		if ($$self.$$.dirty & /*a, b*/ 3) {
+		if ($$self.$$.dirty[0] & /*a, b*/ 3) {
 			$: console.log("max", Math.max(a, b));
 		}
 	};

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -43,8 +43,8 @@ function create_fragment(ctx) {
 				}
 			}
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*current*/ 1 && select_value_value !== (select_value_value = /*current*/ ctx[0])) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*current*/ 1 && select_value_value !== (select_value_value = /*current*/ ctx[0])) {
 				for (var i = 0; i < select.options.length; i += 1) {
 					var option = select.options[i];
 

--- a/test/js/samples/src-attribute-check/expected.js
+++ b/test/js/samples/src-attribute-check/expected.js
@@ -44,12 +44,12 @@ function create_fragment(ctx) {
 			insert(target, t, anchor);
 			insert(target, img1, anchor);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*url*/ 1 && img0.src !== (img0_src_value = /*url*/ ctx[0])) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*url*/ 1 && img0.src !== (img0_src_value = /*url*/ ctx[0])) {
 				attr(img0, "src", img0_src_value);
 			}
 
-			if (dirty & /*slug*/ 2 && img1.src !== (img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"))) {
+			if (dirty[0] & /*slug*/ 2 && img1.src !== (img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"))) {
 				attr(img1, "src", img1_src_value);
 			}
 		},

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -8,8 +8,8 @@ function create_fragment(ctx) {
 	return {
 		c: noop,
 		m: noop,
-		p(ctx, [dirty]) {
-			if (dirty & /*custom*/ 1 && title_value !== (title_value = "a " + /*custom*/ ctx[0] + " title")) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*custom*/ 1 && title_value !== (title_value = "a " + /*custom*/ ctx[0] + " title")) {
 				document.title = title_value;
 			}
 		},

--- a/test/js/samples/transition-local/expected.js
+++ b/test/js/samples/transition-local/expected.js
@@ -91,7 +91,7 @@ function create_fragment(ctx) {
 			if (if_block) if_block.m(target, anchor);
 			insert(target, if_block_anchor, anchor);
 		},
-		p(ctx, [dirty]) {
+		p(ctx, dirty) {
 			if (/*x*/ ctx[0]) {
 				if (if_block) {
 					if_block.p(ctx, dirty);

--- a/test/js/samples/transition-repeated-outro/expected.js
+++ b/test/js/samples/transition-repeated-outro/expected.js
@@ -61,7 +61,7 @@ function create_fragment(ctx) {
 			insert(target, if_block_anchor, anchor);
 			current = true;
 		},
-		p(ctx, [dirty]) {
+		p(ctx, dirty) {
 			if (/*num*/ ctx[0] < 5) {
 				if (!if_block) {
 					if_block = create_if_block(ctx);

--- a/test/js/samples/unchanged-expression/expected.js
+++ b/test/js/samples/unchanged-expression/expected.js
@@ -56,8 +56,8 @@ function create_fragment(ctx) {
 			append(p3, t8);
 			append(p3, t9);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*world3*/ 1) set_data(t9, /*world3*/ ctx[0]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*world3*/ 1) set_data(t9, /*world3*/ ctx[0]);
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/unreferenced-state-not-invalidated/expected.js
+++ b/test/js/samples/unreferenced-state-not-invalidated/expected.js
@@ -27,8 +27,8 @@ function create_fragment(ctx) {
 			insert(target, p, anchor);
 			append(p, t);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*y*/ 1) set_data(t, /*y*/ ctx[0]);
+		p(ctx, dirty) {
+			if (dirty[0] & /*y*/ 1) set_data(t, /*y*/ ctx[0]);
 		},
 		i: noop,
 		o: noop,
@@ -58,7 +58,7 @@ function instance($$self, $$props, $$invalidate) {
 	let y;
 
 	$$self.$$.update = () => {
-		if ($$self.$$.dirty & /*b*/ 2) {
+		if ($$self.$$.dirty[0] & /*b*/ 2) {
 			$: $$invalidate(0, y = b * 2);
 		}
 	};

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -155,7 +155,7 @@ function create_fragment(ctx) {
 			if (if_block4) if_block4.m(target, anchor);
 			insert(target, if_block4_anchor, anchor);
 		},
-		p(ctx, [dirty]) {
+		p(ctx, dirty) {
 			if (/*a*/ ctx[0]) {
 				if (!if_block0) {
 					if_block0 = create_if_block_4(ctx);

--- a/test/js/samples/video-bindings/expected.js
+++ b/test/js/samples/video-bindings/expected.js
@@ -47,8 +47,8 @@ function create_fragment(ctx) {
 			insert(target, video, anchor);
 			video_resize_listener = add_resize_listener(video, /*video_elementresize_handler*/ ctx[4].bind(video));
 		},
-		p(ctx, [dirty]) {
-			if (!video_updating && dirty & /*currentTime*/ 1 && !isNaN(/*currentTime*/ ctx[0])) {
+		p(ctx, dirty) {
+			if (!video_updating && dirty[0] & /*currentTime*/ 1 && !isNaN(/*currentTime*/ ctx[0])) {
 				video.currentTime = /*currentTime*/ ctx[0];
 			}
 

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -46,15 +46,15 @@ function create_fragment(ctx) {
 			append(p, t0);
 			append(p, t1);
 		},
-		p(ctx, [dirty]) {
-			if (dirty & /*y*/ 1 && !scrolling) {
+		p(ctx, dirty) {
+			if (dirty[0] & /*y*/ 1 && !scrolling) {
 				scrolling = true;
 				clearTimeout(scrolling_timeout);
 				scrollTo(window.pageXOffset, /*y*/ ctx[0]);
 				scrolling_timeout = setTimeout(clear_scrolling, 100);
 			}
 
-			if (dirty & /*y*/ 1) set_data(t1, /*y*/ ctx[0]);
+			if (dirty[0] & /*y*/ 1) set_data(t1, /*y*/ ctx[0]);
 		},
 		i: noop,
 		o: noop,

--- a/test/runtime/samples/store-auto-subscribe-event-callback/_config.js
+++ b/test/runtime/samples/store-auto-subscribe-event-callback/_config.js
@@ -1,0 +1,22 @@
+export default {
+	html: `
+	<input class="input" placeholder="Type here" type="text">
+	Dirty: false
+	Valid: false
+	`,
+
+	async test({ assert, component, target, window }) {
+		const input = target.querySelector('input');
+
+		input.value = 'foo';
+		const inputEvent = new window.InputEvent('input');
+		
+		await input.dispatchEvent(inputEvent);
+		
+		assert.htmlEqual(target.innerHTML, `
+		<input class="input" placeholder="Type here" type="text">
+		Dirty: true
+		Valid: true
+		`);
+	},
+};

--- a/test/runtime/samples/store-auto-subscribe-event-callback/_config.js
+++ b/test/runtime/samples/store-auto-subscribe-event-callback/_config.js
@@ -5,14 +5,14 @@ export default {
 	Valid: false
 	`,
 
-	async test({ assert, component, target, window }) {
+	async test({ assert, target, window }) {
 		const input = target.querySelector('input');
 
 		input.value = 'foo';
 		const inputEvent = new window.InputEvent('input');
-		
+
 		await input.dispatchEvent(inputEvent);
-		
+
 		assert.htmlEqual(target.innerHTML, `
 		<input class="input" placeholder="Type here" type="text">
 		Dirty: true

--- a/test/runtime/samples/store-auto-subscribe-event-callback/main.svelte
+++ b/test/runtime/samples/store-auto-subscribe-event-callback/main.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { writable } from 'svelte/store'
+
+	export function createValidator () {
+		const { subscribe, set } = writable({ dirty: false, valid: false })
+
+		function action (node, binding) {
+			return {
+				update (value) {
+					set({ dirty: true, valid: value !== '' })
+				}
+			}
+		}
+
+		return [ { subscribe }, action ]
+	}
+  const [ validity, validate ] = createValidator();
+	let email = null
+</script>
+
+<input class="input"
+	type="text"
+	bind:value={email}
+	placeholder="Type here"
+	use:validate={email}
+	/>
+
+Dirty: {$validity.dirty}
+Valid: {$validity.valid}

--- a/test/runtime/samples/store-auto-subscribe-event-callback/main.svelte
+++ b/test/runtime/samples/store-auto-subscribe-event-callback/main.svelte
@@ -1,21 +1,21 @@
 <script>
-  import { writable } from 'svelte/store'
+	import { writable } from 'svelte/store';
 
-	export function createValidator () {
-		const { subscribe, set } = writable({ dirty: false, valid: false })
+	export function createValidator() {
+		const { subscribe, set } = writable({ dirty: false, valid: false });
 
-		function action (node, binding) {
+		function action(node, binding) {
 			return {
-				update (value) {
-					set({ dirty: true, valid: value !== '' })
+				update(value) {
+					set({ dirty: true, valid: value !== '' });
 				}
-			}
+			};
 		}
 
-		return [ { subscribe }, action ]
+		return [{ subscribe }, action];
 	}
-  const [ validity, validate ] = createValidator();
-	let email = null
+	const [validity, validate] = createValidator();
+	let email = null;
 </script>
 
 <input class="input"
@@ -23,7 +23,7 @@
 	bind:value={email}
 	placeholder="Type here"
 	use:validate={email}
-	/>
+/>
 
 Dirty: {$validity.dirty}
 Valid: {$validity.valid}


### PR DESCRIPTION
Fix https://github.com/sveltejs/svelte/issues/4094

Found the problem is that we destructure the dirty bits array if it doesnt overflow.
but problem is, it is a number, instead of an object.

The `change` map can still be updated within the `p` function. and previously is ok, because it is an object.
Now, although the `dirty` bitmap array is updated, the `dirty` is not updated, because we eagerly destructure it into a number.

so after this change, `dirty` is an array, whether or not it is overflowed.