### PR TITLE
fix invalidate while update

### DIFF
--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -73,8 +73,9 @@ function update($$) {
 	if ($$.fragment !== null) {
 		$$.update();
 		run_all($$.before_update);
-		$$.fragment && $$.fragment.p($$.ctx, $$.dirty);
+		const dirty = $$.dirty;
 		$$.dirty = [-1];
+		$$.fragment && $$.fragment.p($$.ctx, dirty);
 
 		$$.after_update.forEach(add_render_callback);
 	}

--- a/test/runtime/samples/store-invalidation-while-update-1/_config.js
+++ b/test/runtime/samples/store-invalidation-while-update-1/_config.js
@@ -1,0 +1,44 @@
+export default {
+	html: `
+		<input>
+		<div></div>
+		<div>simple</div>
+		<button>click me</button>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const input = target.querySelector('input');
+		const button = target.querySelector('button');
+
+		const inputEvent = new window.InputEvent('input');
+		const clickEvent = new window.MouseEvent('click');
+
+		input.value = 'foo';
+		await input.dispatchEvent(inputEvent);
+
+		assert.htmlEqual(target.innerHTML, `
+		<input>
+		<div>foo</div>
+		<div>foo</div>
+		<button>click me</button>
+		`);
+		
+		await button.dispatchEvent(clickEvent);
+		assert.htmlEqual(target.innerHTML, `
+		<input>
+		<div>foo</div>
+		<div>clicked</div>
+		<button>click me</button>
+		`);
+
+		input.value = 'bar';
+		await input.dispatchEvent(inputEvent);
+
+		assert.htmlEqual(target.innerHTML, `
+		<input>
+		<div>bar</div>
+		<div>bar</div>
+		<button>click me</button>
+		`);
+	}
+};

--- a/test/runtime/samples/store-invalidation-while-update-1/main.svelte
+++ b/test/runtime/samples/store-invalidation-while-update-1/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	import {writable} from 'svelte/store';
+
+	function action(node, binding) {
+		return {
+			update: (value) => s.set(value),
+		}    
+	}
+	let s = writable("simple");
+	let v = "";
+	
+	function click() {
+		s.set('clicked');
+	}
+</script>
+
+<input bind:value={v} use:action={v}>
+<div>{v}</div>
+<div>{$s}</div>
+<button on:click={click}>click me</button>

--- a/test/runtime/samples/store-invalidation-while-update-2/_config.js
+++ b/test/runtime/samples/store-invalidation-while-update-2/_config.js
@@ -1,0 +1,44 @@
+export default {
+	html: `
+		<div></div>
+		<div>simple</div>
+		<input>
+		<button>click me</button>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const input = target.querySelector('input');
+		const button = target.querySelector('button');
+
+		const inputEvent = new window.InputEvent('input');
+		const clickEvent = new window.MouseEvent('click');
+
+		input.value = 'foo';
+		await input.dispatchEvent(inputEvent);
+
+		assert.htmlEqual(target.innerHTML, `
+		<div>foo</div>
+		<div>foo</div>
+		<input>
+		<button>click me</button>
+		`);
+		
+		await button.dispatchEvent(clickEvent);
+		assert.htmlEqual(target.innerHTML, `
+		<div>foo</div>
+		<div>clicked</div>
+		<input>
+		<button>click me</button>
+		`);
+
+		input.value = 'bar';
+		await input.dispatchEvent(inputEvent);
+
+		assert.htmlEqual(target.innerHTML, `
+		<div>bar</div>
+		<div>bar</div>
+		<input>
+		<button>click me</button>
+		`);
+	}
+};

--- a/test/runtime/samples/store-invalidation-while-update-2/main.svelte
+++ b/test/runtime/samples/store-invalidation-while-update-2/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	import {writable} from 'svelte/store';
+
+	function action(node, binding) {
+		return {
+			update: (value) => s.set(value),
+		}    
+	}
+	let s = writable("simple");
+	let v = "";
+	
+	function click() {
+		s.set('clicked');
+	}
+</script>
+
+<div>{v}</div>
+<div>{$s}</div>
+<input bind:value={v} use:action={v}>
+<button on:click={click}>click me</button>


### PR DESCRIPTION
Fix https://github.com/sveltejs/svelte/issues/4098

the dirty bitmask passed into the `p` function will be a snapshot of the dirty accumulated so far.
reset the dirty bitmask before running `p` function, any `$$invalidate` call within the `p` function will schedule another update function.