### PR TITLE
move `it` to the correct spot

### DIFF
--- a/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
+++ b/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
@@ -18,4 +18,4 @@ function handleClick() {
 }
 ```
 
-Svelte 'instruments' this assignment with some code that tells it the DOM will need to be updated.
+Svelte 'instruments' this assignment with some code that tells the DOM it will need to be updated.


### PR DESCRIPTION
Was annoyed by the grammar.

Svelte 'instruments' this assignment with some code that tells `it` the DOM will need to be updated.

`it` would either be the code or the assignment. But nobody is telling the code or the assignment anything.

The code is telling the DOM that IT will need to be updated.

so: `Svelte 'instruments' this assignment with some code that tells the DOM it will need to be updated.`