### PR TITLE
compiler: text util: preserve space after svg <tspan> tags

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Text.ts
+++ b/src/compiler/compile/render_dom/wrappers/Text.ts
@@ -27,6 +27,11 @@ function should_skip(node: Text) {
 	if (parent_element.type === 'Head') return true;
 	if (parent_element.type === 'InlineComponent') return parent_element.children.length === 1 && node === parent_element.children[0];
 
+	// svg namespace exclusions
+	if (/svg$/.test(parent_element.namespace)) {
+		if (node.prev && node.prev.type === "Element" && node.prev.name === "tspan") return false;
+	}
+
 	return parent_element.namespace || elements_without_text.has(parent_element.name);
 }
 

--- a/test/runtime/samples/svg-tspan-preserve-space/_config.js
+++ b/test/runtime/samples/svg-tspan-preserve-space/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<svg><text x=0 y=50><tspan>foo</tspan> bar<tspan>foo</tspan> bar</text></svg>`,
+};

--- a/test/runtime/samples/svg-tspan-preserve-space/main.svelte
+++ b/test/runtime/samples/svg-tspan-preserve-space/main.svelte
@@ -1,0 +1,1 @@
+<svg><text x=0 y=50><tspan>foo</tspan> {"bar"}<tspan>foo</tspan> bar</text></svg>


### PR DESCRIPTION
Fixes #3998 and adds a run-time test to make sure it stays fixed.

Note that I chose to nest the `if` statements because I have a feeling we'll need to fix other svg stuff in the future.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
