### PR TITLE
docs: selectable npx degit link

### DIFF
--- a/site/src/routes/index.svelte
+++ b/site/src/routes/index.svelte
@@ -85,7 +85,7 @@
 
 	<div style="grid-area: start; display: flex; flex-direction: column; min-width: 0" slot="how">
 		<pre class="language-bash" style="margin: 0 0 1em 0; min-width: 0; min-height: 0">
-npx degit <a href="https://github.com/sveltejs/template">sveltejs/template</a> my-svelte-project
+npx degit <a href="https://github.com/sveltejs/template" style="user-select: initial;">sveltejs/template</a> my-svelte-project
 <span class="token comment"># or download and extract <a href="https://github.com/sveltejs/template/archive/master.zip">this .zip file</a></span>
 cd my-svelte-project
 


### PR DESCRIPTION
With 691211aeba94c2cefaebc059c432a6ca20b51192, it isn't possible anymore to copy paste the npx degit link:

![image](https://user-images.githubusercontent.com/28659384/70846294-34340080-1e58-11ea-950d-5b0864b18902.png)


