### PR TITLE
Fix for :global(...) styles in custom elements. Close #2969

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -442,7 +442,7 @@ export default function dom(
 				constructor(options) {
 					super();
 
-					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(/\\/g, '\\\\')}${options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
+					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(/\\/g, '\\\\').replace(/:global\(([-.\w]+)\)/g, '$1')}${options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
 
 					@init(this, { target: this.shadowRoot }, ${definition}, ${has_create_fragment ? 'create_fragment': 'null'}, ${not_equal}, ${prop_indexes}, ${dirty});
 

--- a/test/custom-elements/samples/global-styles/main.svelte
+++ b/test/custom-elements/samples/global-styles/main.svelte
@@ -1,0 +1,9 @@
+<svelte:options tag="custom-element"/>
+
+<style>
+:global(p.active) {
+	color:rgb(128, 128, 128);
+}
+</style>
+
+<p></p>

--- a/test/custom-elements/samples/global-styles/test.js
+++ b/test/custom-elements/samples/global-styles/test.js
@@ -1,0 +1,12 @@
+import * as assert from 'assert';
+import CustomElement from './main.svelte';
+
+export default function (target) {
+	new CustomElement({
+		target
+	});
+
+	const style = target.querySelector('custom-element').shadowRoot.querySelector('style');
+
+	assert.equal(style.textContent, 'p.active{color:rgb(128, 128, 128)}');
+}


### PR DESCRIPTION
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)

I tried to find a way to fix it on Stylesheet render/transform layer, but the changeset for that case seems would be much bigger.

This is a little in-place  fix, but it closes [the old issue](https://github.com/sveltejs/svelte/issues/2969) with global styles in web-components and opens the way to use svelte as a wrapper for many 3d-party js frameworks





