### PR TITLE
adds link to REPL from example page.

### DIFF
--- a/site/src/routes/examples/_TableOfContents.svelte
+++ b/site/src/routes/examples/_TableOfContents.svelte
@@ -29,13 +29,33 @@
 		font-weight: 700;
 	}
 
+	div {
+		display: flex;
+		flex-direction: row;
+		padding: 0.2rem 3rem;
+		margin: 0 -3rem;
+	}
+
+	div.active {
+		background: rgba(0, 0, 0, 0.15) calc(100% - 3rem) 47% no-repeat
+			url(/icons/arrow-right.svg);
+		background-size: 1em 1em;
+		color: white;
+	}
+
+	div.active.loading {
+		background: rgba(0, 0, 0, 0.1) calc(100% - 3rem) 47% no-repeat
+			url(/icons/loading.svg);
+		background-size: 1em 1em;
+		color: white;
+	}
+
 	a {
 		display: flex;
+		flex: 1 1 auto;
 		position: relative;
 		color: var(--sidebar-text);
 		border-bottom: none;
-		padding: 0.2rem 3rem;
-		margin: 0 -3rem;
 		font-size: 1.6rem;
 		align-items: center;
 		justify-content: start;
@@ -45,18 +65,11 @@
 		color: white;
 	}
 
-	a.active {
-		background: rgba(0, 0, 0, 0.15) calc(100% - 3rem) 50% no-repeat
-			url(/icons/arrow-right.svg);
-		background-size: 1em 1em;
-		color: white;
-	}
-
-	a.active.loading {
-		background: rgba(0, 0, 0, 0.1) calc(100% - 3rem) 50% no-repeat
-			url(/icons/loading.svg);
-		background-size: 1em 1em;
-		color: white;
+	.repl-link {
+		flex: 0 1 auto;
+		font-size: 1.2rem;
+		font-weight: 700;
+		margin-right: 2.5rem;
 	}
 
 	.thumbnail {
@@ -72,27 +85,31 @@
 
 <ul class="examples-toc">
 	{#each sections as section}
-	<li>
-		<span class="section-title">
-			{section.title}
-		</span>
+		<li>
+			<span class="section-title">{section.title}</span>
 
-		{#each section.examples as example}
-		<a
-			href="examples#{example.slug}"
-			class="row"
-			class:active="{example.slug === active_section}"
-			class:loading="{isLoading}"
-		>
-			<img
-				class="thumbnail"
-				alt="{example.title} thumbnail"
-				src="examples/thumbnails/{example.slug}.jpg"
-			/>
+			{#each section.examples as example}
+				<div
+					class="row"
+					class:active={example.slug === active_section}
+					class:loading={isLoading}>
+					<a
+						href="examples#{example.slug}"
+						class="row"
+						class:active={example.slug === active_section}
+						class:loading={isLoading}>
+						<img
+							class="thumbnail"
+							alt="{example.title} thumbnail"
+							src="examples/thumbnails/{example.slug}.jpg" />
 
-			<span>{example.title}</span>
-		</a>
-		{/each}
-	</li>
+						<span>{example.title}</span>
+					</a>
+					{#if example.slug === active_section}
+						<a href="repl/{example.slug}" class="repl-link">REPL</a>
+					{/if}
+				</div>
+			{/each}
+		</li>
 	{/each}
 </ul>


### PR DESCRIPTION
This PR adds a link to the REPL from the examples page to the left of the arrow in the list. I couldn't find anything in the issues list, I might have missed it though.

This is how it looks:
<img width="362" alt="Screenshot 2019-12-18 at 09 04 18" src="https://user-images.githubusercontent.com/534488/71067770-6e154780-2175-11ea-8519-390490d3e11a.png">
