### PR TITLE
CI: tests: validator: add support for customElement compile option + test cases

### DIFF
--- a/test/validator/index.js
+++ b/test/validator/index.js
@@ -28,7 +28,7 @@ describe("validate", () => {
 					dev: config.dev,
 					legacy: config.legacy,
 					generate: false,
-					customElement : config.customElement || false
+					customElement: config.customElement
 				});
 
 				assert.deepEqual(warnings.map(w => ({

--- a/test/validator/index.js
+++ b/test/validator/index.js
@@ -27,7 +27,8 @@ describe("validate", () => {
 				const { warnings } = svelte.compile(input, {
 					dev: config.dev,
 					legacy: config.legacy,
-					generate: false
+					generate: false,
+					customElement : config.customElement || false
 				});
 
 				assert.deepEqual(warnings.map(w => ({

--- a/test/validator/samples/tag-custom-element-options-missing/input.svelte
+++ b/test/validator/samples/tag-custom-element-options-missing/input.svelte
@@ -1,0 +1,1 @@
+<svelte:options tag="custom-element"/>

--- a/test/validator/samples/tag-custom-element-options-missing/warnings.json
+++ b/test/validator/samples/tag-custom-element-options-missing/warnings.json
@@ -1,15 +1,15 @@
 [{
-    "code": "missing-custom-element-compile-options",
-    "message": "The 'tag' option is used when generating a custom element. Did you forget the 'customElement: true' compile option?",
-    "start": {
-        "line": 1,
-        "column": 16,
-        "character": 16
-    },
-    "end": {
-        "line": 1,
-        "column": 36,
-        "character": 36
-    },
-    "pos": 16
+		"code": "missing-custom-element-compile-options",
+		"message": "The 'tag' option is used when generating a custom element. Did you forget the 'customElement: true' compile option?",
+		"start": {
+				"line": 1,
+				"column": 16,
+				"character": 16
+		},
+		"end": {
+				"line": 1,
+				"column": 36,
+				"character": 36
+		},
+		"pos": 16
 }]

--- a/test/validator/samples/tag-custom-element-options-missing/warnings.json
+++ b/test/validator/samples/tag-custom-element-options-missing/warnings.json
@@ -1,0 +1,15 @@
+[{
+    "code": "missing-custom-element-compile-options",
+    "message": "The 'tag' option is used when generating a custom element. Did you forget the 'customElement: true' compile option?",
+    "start": {
+        "line": 1,
+        "column": 16,
+        "character": 16
+    },
+    "end": {
+        "line": 1,
+        "column": 36,
+        "character": 36
+    },
+    "pos": 16
+}]

--- a/test/validator/samples/tag-custom-element-options-true/_config.js
+++ b/test/validator/samples/tag-custom-element-options-true/_config.js
@@ -1,3 +1,3 @@
 export default {
-    customElement: true,
+	customElement: true
 };

--- a/test/validator/samples/tag-custom-element-options-true/_config.js
+++ b/test/validator/samples/tag-custom-element-options-true/_config.js
@@ -1,0 +1,3 @@
+export default {
+    customElement: true,
+};

--- a/test/validator/samples/tag-custom-element-options-true/input.svelte
+++ b/test/validator/samples/tag-custom-element-options-true/input.svelte
@@ -1,0 +1,1 @@
+<svelte:options tag="custom-element"/>


### PR DESCRIPTION
This PR updates the validator test harness to allow config to control `customElement` .

This enables newly added test cases to exercise both code paths during component compile:
1. `<svelte:options tag='custom-element'>` is present and `customElement` is false (or missing).
2. `<svelte:options tag='custom-element'>` is present and `customElement` is true.

See this issue for more information: #4132.