### PR TITLE
Custom element dispatch event

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -268,6 +268,9 @@ export function toggle_class(element, name, toggle) {
 }
 
 export function custom_event<T=any>(type: string, detail?: T) {
+        // is compile target customElement?
+        // is event not a Svelte event?
+        // use new CustomEvent with bubbles/composed = true for non, svelte event
 	const e: CustomEvent<T> = document.createEvent('CustomEvent');
 	e.initCustomEvent(type, false, false, detail);
 	return e;

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -268,9 +268,6 @@ export function toggle_class(element, name, toggle) {
 }
 
 export function custom_event<T=any>(type: string, detail?: T) {
-        // is compile target customElement?
-        // is event not a Svelte event?
-        // use new CustomEvent with bubbles/composed = true for non, svelte event
 	const e: CustomEvent<T> = document.createEvent('CustomEvent');
 	e.initCustomEvent(type, false, false, detail);
 	return e;

--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -28,6 +28,8 @@ export function onDestroy(fn) {
 }
 
 export function createEventDispatcher() {
+        // is compile target customElement?
+        // always dispatch!
 	const component = get_current_component();
 
 	return (type: string, detail?: any) => {

--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -28,8 +28,6 @@ export function onDestroy(fn) {
 }
 
 export function createEventDispatcher() {
-        // is compile target customElement?
-        // always dispatch!
 	const component = get_current_component();
 
 	return (type: string, detail?: any) => {
@@ -42,6 +40,11 @@ export function createEventDispatcher() {
 			callbacks.slice().forEach(fn => {
 				fn.call(component, event);
 			});
+		}
+
+		if (component.shadowRoot) {
+			const event = custom_event(type, detail);
+			component.dispatchEvent(event);
 		}
 	};
 }

--- a/test/custom-elements/samples/dispatch/main.svelte
+++ b/test/custom-elements/samples/dispatch/main.svelte
@@ -3,12 +3,14 @@
 
 	const dispatch = createEventDispatcher();
 
-	const handleChange = evt => {
-		dispatch('change', evt);
+	const sayHello = () => {
+		dispatch('message', {
+      text: 'Hello!'
+    });
 	};
 </script>
 
 <svelte:options tag="custom-element" />
-<label>
-	<input type="checkbox" on:change={handleChange} />
-</label>
+<button on:click={sayHello}>
+	Click to say hello
+</button>

--- a/test/custom-elements/samples/dispatch/main.svelte
+++ b/test/custom-elements/samples/dispatch/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+
+	const handleChange = evt => {
+		dispatch('change', evt);
+	};
+</script>
+
+<svelte:options tag="custom-element" />
+<label>
+	<input type="checkbox" on:change={handleChange} />
+</label>

--- a/test/custom-elements/samples/dispatch/test.js
+++ b/test/custom-elements/samples/dispatch/test.js
@@ -1,23 +1,24 @@
 import * as assert from 'assert';
 import './main.svelte';
 
-console.log('console.log');
-
 export default async function(target) {
 	target.innerHTML = '<custom-element></custom-element>';
 	const el = target.querySelector('custom-element');
-	const label = el.shadowRoot.querySelector('label');
-	const input = el.shadowRoot.querySelector('input');
+	const button = el.shadowRoot.querySelector('button');
 
-	return new Promise(resolve => {
-		el.addEventListener('change', function changeHandler(evt) {
-			el.removeEventListener('change', changeHandler);
+	return new Promise((resolve, reject) => {
+		el.addEventListener('message', function changeHandler(evt) {
+			el.removeEventListener('message', changeHandler);
 
-			assert.equal(evt.target, el);
-			assert.equal(input.checked, true);
-			resolve();
+      try {
+        assert.equal(evt.target, el);
+        assert.equal(evt.detail.text, 'Hello!');
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
 		});
 
-		label.dispatchEvent(new MouseEvent('click'));
+		button.dispatchEvent(new MouseEvent('click'));
 	});
 }

--- a/test/custom-elements/samples/dispatch/test.js
+++ b/test/custom-elements/samples/dispatch/test.js
@@ -1,0 +1,23 @@
+import * as assert from 'assert';
+import './main.svelte';
+
+console.log('console.log');
+
+export default async function(target) {
+	target.innerHTML = '<custom-element></custom-element>';
+	const el = target.querySelector('custom-element');
+	const label = el.shadowRoot.querySelector('label');
+	const input = el.shadowRoot.querySelector('input');
+
+	return new Promise(resolve => {
+		el.addEventListener('change', function changeHandler(evt) {
+			el.removeEventListener('change', changeHandler);
+
+			assert.equal(evt.target, el);
+			assert.equal(input.checked, true);
+			resolve();
+		});
+
+		label.dispatchEvent(new MouseEvent('click'));
+	});
+}


### PR DESCRIPTION
Possible solution to #3712, #3119 and #2611.

Enables event dispatching for custom elements. As it is now, no events are dispatched from a custom element because `component.$$.callbacks[type]` is always falsy.

When compile target is custom element, always dispatch event.
Atm checking this by `component.shadowRoot` - perhaps there is a safer/better way?