### PR TITLE
fix destructuring in slot let binding

### DIFF
--- a/test/runtime/samples/component-slot-let-destructured-2/Nested.svelte
+++ b/test/runtime/samples/component-slot-let-destructured-2/Nested.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let props;
+</script>
+
+<slot value={props} data={Array.isArray(props) ? props[0] : props.a} />

--- a/test/runtime/samples/component-slot-let-destructured-2/_config.js
+++ b/test/runtime/samples/component-slot-let-destructured-2/_config.js
@@ -1,0 +1,68 @@
+export default {
+	html: `
+		<div>
+			hello world 0 hello
+			<button>Increment</button>
+		</div>
+		<div>
+			hello world 0 hello
+			<button>Increment</button>
+		</div>
+		<div>
+			hello world 0 hello
+			<button>Increment</button>
+		</div>
+	`,
+	async test({ assert, component, target, window }) {
+		const [button1, button2, button3] = target.querySelectorAll('button');
+		const event = new window.MouseEvent('click');
+
+		await button1.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<div>
+				hello world 1 hello
+				<button>Increment</button>
+			</div>
+			<div>
+				hello world 0 hello
+				<button>Increment</button>
+			</div>
+			<div>
+				hello world 0 hello
+				<button>Increment</button>
+			</div>
+		`);
+
+		await button2.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<div>
+				hello world 1 hello
+				<button>Increment</button>
+			</div>
+			<div>
+				hello world 1 hello
+				<button>Increment</button>
+			</div>
+			<div>
+				hello world 0 hello
+				<button>Increment</button>
+			</div>
+		`);
+
+		await button3.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<div>
+				hello world 1 hello
+				<button>Increment</button>
+			</div>
+			<div>
+				hello world 1 hello
+				<button>Increment</button>
+			</div>
+			<div>
+				hello world 1 hello
+				<button>Increment</button>
+			</div>
+		`);
+	}
+};

--- a/test/runtime/samples/component-slot-let-destructured-2/main.svelte
+++ b/test/runtime/samples/component-slot-let-destructured-2/main.svelte
@@ -1,0 +1,28 @@
+<script>
+	import Nested from "./Nested.svelte";
+	let c = 0, d = 0, e = 0;
+</script>
+
+<div>
+	<Nested props={['hello', 'world']} let:value={pair} let:data={foo}>
+		{pair[0]} {pair[1]} {c} {foo}
+	</Nested>
+
+	<button on:click={() => { c += 1; }}>Increment</button>
+</div>
+
+<div>
+	<Nested props={['hello', 'world']} let:value={[a, b]} let:data={foo}>
+		{a} {b} {d} {foo}
+	</Nested>
+
+	<button on:click={() => { d += 1; }}>Increment</button>
+</div>
+
+<div>
+	<Nested props={{ a: 'hello', b: 'world' }} let:value={{ a, b }} let:data={foo}>
+		{a} {b} {e} {foo}
+	</Nested>
+
+	<button on:click={() => { e += 1; }}>Increment</button>
+</div>


### PR DESCRIPTION
Fix https://github.com/sveltejs/svelte/issues/2751

- in the `get_slot_changes` fn, the dirty bit is passed in, so destructuring it will cause bug.
- object destructuring is still okay, because it would be accessing property on `number`, but array destructuring will have error, because `number` is not iterable.

so, i changed the slot_change function from this:
```js
({ value: [a, b], data: foo }) => (a ? 64 : 0) | (b ? 128 : 0) | (foo ? 256 : 0)
```

into this:
```js
({ value: a_b$, data: foo }) => (a_b$ ? 64 : 0) | (a_b$ ? 128 : 0) | (foo ? 256 : 0)
```