### PR TITLE
Pass compiler version in dev events

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,6 +60,9 @@ export default [
 			],
 			external,
 			plugins: [
+				replace({
+					__VERSION__: pkg.version
+				}),
 				ts_plugin,
 				{
 					writeBundle(bundle) {

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -2,7 +2,7 @@ import { custom_event, append, insert, detach, listen, attr } from './dom';
 import { SvelteComponent } from './Component';
 
 export function dispatch_dev<T=any>(type: string, detail?: T) {
-	document.dispatchEvent(custom_event(type, detail));
+	document.dispatchEvent(custom_event(type, { version: '__VERSION__', ...detail }));
 }
 
 export function append_dev(target: Node, node: Node) {


### PR DESCRIPTION
Includes the compiler version in all dev events. As the compiler internals change having the version number to test against should make things much simpler.

fixes #4047 