### PR TITLE
fix dynamic event handler for bind variables

### DIFF
--- a/test/runtime/samples/event-handler-dynamic-bound-var/Nested.svelte
+++ b/test/runtime/samples/event-handler-dynamic-bound-var/Nested.svelte
@@ -1,0 +1,7 @@
+<script>
+  let text = 'Hello World';
+  export function updateText() {
+    text = 'Bye World';
+  }
+</script>
+{text}

--- a/test/runtime/samples/event-handler-dynamic-bound-var/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-bound-var/_config.js
@@ -1,0 +1,20 @@
+export default {
+	html: `
+		<button>Click Me</button>
+		Hello World
+	`,
+	async test({ assert, component, target, window }) {
+		const button = target.querySelector('button');
+
+		const event = new window.MouseEvent('click');
+
+		await button.dispatchEvent(event);
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>Click Me</button>
+				Bye World
+			`
+		);
+	},
+};

--- a/test/runtime/samples/event-handler-dynamic-bound-var/main.svelte
+++ b/test/runtime/samples/event-handler-dynamic-bound-var/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Nested from './Nested.svelte';
+	let nested;
+</script>
+
+<button on:click={nested && nested.updateText}>Click Me</button>
+
+<Nested bind:this={nested} />


### PR DESCRIPTION
in `EventHandler` we are setting the `reassigned` in `constructor`, which may run first before other template components set the `reassigned` property for the dependencies variable.

- the `reassigned` should be evaluated during "render", after template traversal.