### PR TITLE
Remove unnecessary double quotes in tutorial

### DIFF
--- a/site/content/tutorial/05-events/02-inline-handlers/app-b/App.svelte
+++ b/site/content/tutorial/05-events/02-inline-handlers/app-b/App.svelte
@@ -6,6 +6,6 @@
 	div { width: 100%; height: 100%; }
 </style>
 
-<div on:mousemove="{e => m = { x: e.clientX, y: e.clientY }}">
+<div on:mousemove={e => m = { x: e.clientX, y: e.clientY }}>
 	The mouse position is {m.x} x {m.y}
 </div>


### PR DESCRIPTION
The double quotes caused a bit of confusion for me when I first encountered it (because the rest of the tutorial doesn't care to use quotes even when the value is a string. )

And generally, it feels weird to put javascript code in a "string".

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
