### PR TITLE
fixed sidebar link bounce (Issue #4197)

### DIFF
--- a/site/src/routes/examples/_TableOfContents.svelte
+++ b/site/src/routes/examples/_TableOfContents.svelte
@@ -59,6 +59,7 @@
 		font-size: 1.6rem;
 		align-items: center;
 		justify-content: start;
+		padding: 0;
 	}
 
 	a:hover {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)

This PR relates to Issue #4197. Prior to this change,  anchor tags in the exmaple's Table of Contents would shift or bounce when a link is hovered. This appeared to be caused by a component from @svelte/site-kit, Nav.svelte. Apon hovering, the anchor tags has its padding set to 0, causing all elements below to shift up by 1 pixel. 
All tests still pass and no other elements are effected by this change. 