### PR TITLE
Doc (#4172): Fixing the unclear slot with fallback content example

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1202,14 +1202,16 @@ The content is exposed in the child component using the `<slot>` element, which 
 
 ```html
 <!-- App.svelte -->
+<Widget></Widget>
+
 <Widget>
-	<p>this is some child content</p>
+	<p>this is some child content that will overwrite the default slot content</p>
 </Widget>
 
 <!-- Widget.svelte -->
 <div>
 	<slot>
-		this will be rendered if someone does <Widget/>
+		this fallback content will be rendered when no content is provided, like in the first example
 	</slot>
 </div>
 ```


### PR DESCRIPTION
fix #4172

The API documentation about `<slot>` contains the following example that does not work.

```
<!-- App.svelte -->
<Widget>
	<p>this is some child content</p>
</Widget>

<!-- Widget.svelte -->
<div>
	<slot>
		this will be rendered if someone does <Widget/>
	</slot>
</div>
```

This fix, as explained by @antony, makes the example more verbose but more clear.