### PR TITLE
doc on assignment updated (01-component-format.md)

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -119,7 +119,9 @@ Any top-level statement (i.e. not inside a block or a function) can be made reac
 
 	// this will update `document.title` whenever
 	// the `title` prop changes
-	$: document.title = title;
+	$: {
+    document.title = title;
+  }
 
 	$: {
 		console.log(`multiple statements can be combined`);


### PR DESCRIPTION
The single-line assignment declaration does not work to set the document.title (see https://github.com/sveltejs/svelte/issues/2510). I'm not able to fix it, so instead, let's just update the documentation :-)

