### PR TITLE
fix when LHS of a reactive assignment is a member expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Prevent text input cursor jumping in Safari with one-way binding ([#3449](https://github.com/sveltejs/svelte/issues/3449))
 * Expose compiler version in dev events ([#4047](https://github.com/sveltejs/svelte/issues/4047))
+* Do not automatically declare variables in reactive declarations when assigning to a member expression ([#4212](https://github.com/sveltejs/svelte/issues/4212))
 
 ## 3.16.7
 

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -603,6 +603,7 @@ export default class Component {
 
 			const { expression } = node.body;
 			if (expression.type !== 'AssignmentExpression') return;
+			if (expression.left.type === 'MemberExpression') return;
 
 			extract_names(expression.left).forEach(name => {
 				if (!this.var_lookup.has(name) && name[0] !== '$') {

--- a/test/runtime/samples/reactive-values-no-implicit-member-expression/_config.js
+++ b/test/runtime/samples/reactive-values-no-implicit-member-expression/_config.js
@@ -1,0 +1,5 @@
+export default {
+	test({ assert, window }) {
+		assert.equal(window.document.title, 'foo');
+	}
+};

--- a/test/runtime/samples/reactive-values-no-implicit-member-expression/main.svelte
+++ b/test/runtime/samples/reactive-values-no-implicit-member-expression/main.svelte
@@ -1,0 +1,3 @@
+<script>
+	$: document.title = 'foo';
+</script>


### PR DESCRIPTION
Fixes #4212. In DOM mode, we were declaring the variable automatically, which is almost certainly never going to be helpful (and broke stuff like using it to update `document.title`). In SSE mode, we were writing actually invalid code (`let document.title = ...`). This simply skips the automatic declaration of the variable when the LHS of the assignment is a MemberExpression.