### PR TITLE
Clearer documentation of store contract

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -186,22 +186,11 @@ You can create your own stores without relying on [`svelte/store`](docs#svelte_s
 
 const subscriptions = [];
 
-let lastHash;
-
-const callSubscriptions = () => {
-	if (location.hash !== lastHash) {
-		lastHash = location.hash;
-		for (const subscription of subscriptions) {
-			subscription(location.hash);
-		}
-	}
-};
-
-window.addEventListener('hashchange', callSubscriptions);
+let storeValue = location.hash; // Set initial value
 
 const hashStore = {
 	subscribe(subscription) {
-		subscription(location.hash); // Call subscription with current value
+		subscription(storeValue); // Call subscription with current value
 		subscriptions.push(subscription); // Subscribe to future values
 		return () => { // Return an "unsubscribe" function
 			const index = subscriptions.indexOf(subscription);
@@ -211,10 +200,21 @@ const hashStore = {
 		};
 	},
 	set(hash) {
-		location.hash = hash; // Set the value
-		callSubscriptions(); // Synchronously notify all subscriptions
+		storeValue = hash; // Set the value
+		location.hash = hash; // Update location.hash
+		for (const subscription of subscriptions) {
+			// Call all subscriptions
+			subscription(storeValue);
+		}
 	}
 };
+
+// Event listener to stay in sync with external changes
+window.addEventListener('hashchange', () => {
+	if (location.hash !== storeValue) {
+		hashStore.set(location.hash);
+	}
+});
 
 
 ```

--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -172,58 +172,17 @@ Local variables (that do not represent store values) must *not* have a `$` prefi
 </script>
 ```
 
----
-
 ##### Store contract
 
 ```js
 store = { subscribe: (subscription: (value: any) => void) => () => void, set?: (value: any) => void }
 ```
 
----
-
 You can create your own stores without relying on [`svelte/store`](docs#svelte_store), by implementing the *store contract*:
 
 1. A store must contain a `.subscribe` method, which must accept as its argument a subscription function. This subscription function must be immediately and synchronously called with the store's current value upon calling `.subscribe`. All of a store's active subscription functions must later be synchronously called whenever the store's value changes.
 2. The `.subscribe` method must return an unsubscribe function. Calling an unsubscribe function must stop its subscription, and its corresponding subscription function must not be called again by the store.
 3. A store may *optionally* contain a `.set` method, which must accept as its argument a new value for the store, and which synchronously calls all of the store's active subscription functions. Such a store is called a *writable store*.
-
-```js
-
-/* Example: a custom writable store for `location.hash` */
-
-let storeValue = location.hash; // Set initial value
-
-const subscriptions = new Set();
-
-const hashStore = {
-	subscribe(subscription) {
-		subscription(storeValue); // Call subscription with current value
-		const item = {subscription};
-		subscriptions.add(item); // Subscribe to future values
-		return () => { // Return an "unsubscribe" function
-			subscriptions.delete(item); // Remove the subscription
-		};
-	},
-	set(hash) {
-		location.hash = hash; // Update location.hash
-		storeValue = location.hash; // Set the value
-		for (const {subscription} of subscriptions) {
-			// Call all subscriptions
-			subscription(storeValue);
-		}
-	}
-};
-
-window.addEventListener('hashchange', () => {
-	// Keep the store in sync with external changes
-	if (location.hash !== storeValue) {
-		hashStore.set(location.hash);
-	}
-});
-
-
-```
 
 
 ### &lt;script context="module"&gt;

--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -174,7 +174,15 @@ Local variables (that do not represent store values) must *not* have a `$` prefi
 
 ---
 
-You can create your own stores without relying on [`svelte/store`](docs#svelte_store), by implementing the **store contract**:
+##### Store contract
+
+```js
+store = { subscribe: (subscription: (value: any) => void) => () => void, set?: (value: any) => void }
+```
+
+---
+
+You can create your own stores without relying on [`svelte/store`](docs#svelte_store), by implementing the *store contract*:
 
 1. A store must contain a `.subscribe` method, which must accept as its argument a subscription function. This subscription function must be immediately and synchronously called with the store's current value upon calling `.subscribe`. All of a store's active subscription functions must later be synchronously called whenever the store's value changes.
 2. The `.subscribe` method must return an unsubscribe function. Calling an unsubscribe function must stop its subscription, and its corresponding subscription function must not be called again by the store.

--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -147,24 +147,7 @@ If a statement consists entirely of an assignment to an undeclared variable, Sve
 
 ---
 
-A *store* is any object that allows reactive access to a value via a simple *store contract*.
-
-The [`svelte/store` module](docs#svelte_store) contains minimal store implementations which fulfil this contract. You can use these as the basis for your own stores, or you can implement your stores from scratch.
-
-A store must contain a `.subscribe` method, which must accept as its argument a subscription function. This subscription function must be immediately and synchronously called with the store's current value upon calling `.subscribe`. All of a store's active subscription functions must later be synchronously called whenever the store's value changes. The `.subscribe` method must also return an unsubscription function. Calling an unsubscription function must stop its subscription, and its corresponding subscription function must not be called again by the store.
-
-A store may optionally contain a `.set` method, which must accept as its argument a new value for the store, and which synchronously calls all of the store's active subscription functions. Such a store is called a *writable store*.
-
-```js
-const unsubscribe = store.subscribe(value => {
-	console.log(value);
-}); // logs `value`
-
-// later...
-unsubscribe();
-```
-
----
+A *store* is an object that allows reactive access to a value via a simple *store contract*. The [`svelte/store` module](docs#svelte_store) contains minimal store implementations which fulfil this contract.
 
 Any time you have a reference to a store, you can access its value inside a component by prefixing it with the `$` character. This causes Svelte to declare the prefixed variable, and set up a store subscription that will be unsubscribed when appropriate.
 
@@ -187,6 +170,53 @@ Local variables (that do not represent store values) must *not* have a `$` prefi
 	$count = 2;
 	console.log($count); // logs 2
 </script>
+```
+
+---
+
+You can create your own stores without relying on [`svelte/store`](docs#svelte_store), by implementing the **store contract**:
+
+1) A store must contain a `.subscribe` method, which must accept as its argument a subscription function. This subscription function must be immediately and synchronously called with the store's current value upon calling `.subscribe`. All of a store's active subscription functions must later be synchronously called whenever the store's value changes.
+2) The `.subscribe` method must return an unsubscribe function. Calling an unsubscribe function must stop its subscription, and its corresponding subscription function must not be called again by the store.
+3) A store may *optionally* contain a `.set` method, which must accept as its argument a new value for the store, and which synchronously calls all of the store's active subscription functions. Such a store is called a *writable store*.
+
+```js
+
+/* Example: a custom writable store for `location.hash` */
+
+const subscriptions = [];
+
+let lastHash;
+
+const callSubscriptions = () => {
+	if (location.hash !== lastHash) {
+		lastHash = location.hash;
+		for (const subscription of subscriptions) {
+			subscription(location.hash);
+		}
+	}
+};
+
+window.addEventListener('hashchange', callSubscriptions);
+
+const hashStore = {
+	subscribe(subscription) {
+		subscription(location.hash); // Call subscription with current value
+		subscriptions.push(subscription); // Subscribe to future values
+		return () => { // Return an "unsubscribe" function
+			const index = subscriptions.indexOf(subscription);
+			if (index !== -1) {
+				subscriptions.splice(index, 1); // Remove the subscription
+			}
+		};
+	},
+	set(hash) {
+		location.hash = hash; // Set the value
+		callSubscriptions(); // Synchronously notify all subscriptions
+	}
+};
+
+
 ```
 
 

--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -176,9 +176,9 @@ Local variables (that do not represent store values) must *not* have a `$` prefi
 
 You can create your own stores without relying on [`svelte/store`](docs#svelte_store), by implementing the **store contract**:
 
-1) A store must contain a `.subscribe` method, which must accept as its argument a subscription function. This subscription function must be immediately and synchronously called with the store's current value upon calling `.subscribe`. All of a store's active subscription functions must later be synchronously called whenever the store's value changes.
-2) The `.subscribe` method must return an unsubscribe function. Calling an unsubscribe function must stop its subscription, and its corresponding subscription function must not be called again by the store.
-3) A store may *optionally* contain a `.set` method, which must accept as its argument a new value for the store, and which synchronously calls all of the store's active subscription functions. Such a store is called a *writable store*.
+1. A store must contain a `.subscribe` method, which must accept as its argument a subscription function. This subscription function must be immediately and synchronously called with the store's current value upon calling `.subscribe`. All of a store's active subscription functions must later be synchronously called whenever the store's value changes.
+2. The `.subscribe` method must return an unsubscribe function. Calling an unsubscribe function must stop its subscription, and its corresponding subscription function must not be called again by the store.
+3. A store may *optionally* contain a `.set` method, which must accept as its argument a new value for the store, and which synchronously calls all of the store's active subscription functions. Such a store is called a *writable store*.
 
 ```js
 

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -216,7 +216,7 @@ Events dispatched from child components can be listened to in their parent. Any 
 
 The `svelte/store` module exports functions for creating [readable](docs#readable), [writable](docs#writable) and [derived](docs#derived) stores.
 
-Keep in mind that you don't *have* to use these functions to enjoy the [reactive `$store` syntax](docs#4_Prefix_stores_with_$_to_access_their_values) in your components. Any object that correctly implements `subscribe`/`unsubscribe` and (optionally) `set` is a valid store, and will work both with the special syntax, and with Svelte's built in [`derived` stores](docs#derived).
+Keep in mind that you don't *have* to use these functions to enjoy the [reactive `$store` syntax](docs#4_Prefix_stores_with_$_to_access_their_values) in your components. Any object that correctly implements `.subscribe`, unsubscribe, and (optionally) `.set` is a valid store, and will work both with the special syntax, and with Svelte's built-in [`derived` stores](docs#derived).
 
 This makes it possible to wrap almost any other reactive state handling library for use in Svelte. Read more about the [store contract](docs#4_Prefix_stores_with_$_to_access_their_values) to see what a correct implementation looks like.
 

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -218,7 +218,7 @@ The `svelte/store` module exports functions for creating [readable](docs#readabl
 
 Keep in mind that you don't *have* to use these functions to enjoy the [reactive `$store` syntax](docs#4_Prefix_stores_with_$_to_access_their_values) in your components. Any object that correctly implements `.subscribe`, unsubscribe, and (optionally) `.set` is a valid store, and will work both with the special syntax, and with Svelte's built-in [`derived` stores](docs#derived).
 
-This makes it possible to wrap almost any other reactive state handling library for use in Svelte. Read more about the [store contract](docs#4_Prefix_stores_with_$_to_access_their_values) to see what a correct implementation looks like.
+This makes it possible to wrap almost any other reactive state handling library for use in Svelte. Read more about the [store contract](docs#Store_contract) to see what a correct implementation looks like.
 
 #### `writable`
 

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -214,7 +214,11 @@ Events dispatched from child components can be listened to in their parent. Any 
 
 ### `svelte/store`
 
-The `svelte/store` module exports functions for creating [stores](docs#4_Prefix_stores_with_$_to_access_their_values).
+The `svelte/store` module exports functions for creating [readable](docs#readable), [writable](docs#writable) and [derived](docs#derived) stores.
+
+Keep in mind that you don't *have* to use these functions to enjoy the [reactive `$store` syntax](docs#4_Prefix_stores_with_$_to_access_their_values) in your components. Any object that correctly implements `subscribe`/`unsubscribe` and (optionally) `set` is a valid store, and will work both with the special syntax, and with Svelte's built in [`derived` stores](docs#derived).
+
+This makes it possible to wrap almost any other reactive state handling library for use in Svelte. Read more about the [store contract](docs#4_Prefix_stores_with_$_to_access_their_values) to see what a correct implementation looks like.
 
 #### `writable`
 


### PR DESCRIPTION
I've been scratching my head trying to understand the ins and outs of the store contract, and how to implement custom stores. This PR is a suggestion for how to improve the documentation.

1. I've expanded the `svelte/store` intro to be much more explicit about the store contract documentation.
2. I've reorganized the section in `01-component-format.md` to describe the syntax first (which is what the headline promises) and the contract second.
3. I put the specifics of what you need to fulfil to implement a store in a numbered list, to make it super clear.
4. I've added a tiny example of how to wrap `location.hash` and the `hashchange` event in a custom store. I'm not sure if this is the best example, but it is small. It might be better to include an example of, say, RxJS, but I'm probably not the right person to write it.