### PR TITLE
fix $$invalidate getting confused by an undefined third argument (#4170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Prevent text input cursor jumping in Safari with one-way binding ([#3449](https://github.com/sveltejs/svelte/issues/3449))
 * Expose compiler version in dev events ([#4047](https://github.com/sveltejs/svelte/issues/4047))
+* Fix reactive assignments with destructuring and stores where the destructured value should be undefined ([#4170](https://github.com/sveltejs/svelte/issues/4170))
 * Do not automatically declare variables in reactive declarations when assigning to a member expression ([#4212](https://github.com/sveltejs/svelte/issues/4212))
 
 ## 3.16.7

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -127,7 +127,8 @@ export function init(component, options, instance, create_fragment, not_equal, p
 	let ready = false;
 
 	$$.ctx = instance
-		? instance(component, prop_values, (i, ret, value = ret) => {
+		? instance(component, prop_values, (i, ret, ...rest) => {
+			const value = rest.length ? rest[0] : ret;
 			if ($$.ctx && not_equal($$.ctx[i], $$.ctx[i] = value)) {
 				if ($$.bound[i]) $$.bound[i](value);
 				if (ready) make_dirty(component, i);

--- a/test/runtime/samples/reactive-values-store-destructured-undefined/_config.js
+++ b/test/runtime/samples/reactive-values-store-destructured-undefined/_config.js
@@ -1,0 +1,6 @@
+export default {
+	html: `
+		<p>undefined</p>
+		<p>undefined</p>
+	`
+};

--- a/test/runtime/samples/reactive-values-store-destructured-undefined/main.svelte
+++ b/test/runtime/samples/reactive-values-store-destructured-undefined/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { writable } from 'svelte/store';
+	const store = writable([]);
+	$: ({ foo1 } = $store);
+	$: [foo2] = $store;
+</script>
+
+<p>{foo1}</p>
+<p>{foo2}</p>


### PR DESCRIPTION
Fixes #4170. I investigated swapping the second and third arguments to `$$invalidate` but that ran into complications because the `ret` argument actually contains the assignment, and needs to be evaluated before the `value` argument. So, ultimately, I just used a `...rest` argument, and `value` is getting manually set to `rest.length ? rest[0] : ret`.