### PR TITLE
Issue 4240

### DIFF
--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -25,14 +25,7 @@ export function spread(args, classes_to_add) {
 		else if (boolean_attributes.has(name.toLowerCase())) {
 			if (value) str += " " + name;
 		} else if (value != null) {
-			str +=
-				' ' +
-				name +
-				'="' +
-				String(value)
-					.replace(/"/g, '&#34;')
-					.replace(/'/g, '&#39;') +
-				'"';
+			str += ` ${name}="${String(value).replace(/"/g, '&#34;').replace(/'/g, '&#39;')}"`;
 		}
 	});
 

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -25,9 +25,14 @@ export function spread(args, classes_to_add) {
 		else if (boolean_attributes.has(name.toLowerCase())) {
 			if (value) str += " " + name;
 		} else if (value != null) {
-			str += " " + name + "=" + JSON.stringify(String(value)
-				.replace(/"/g, '&#34;')
-				.replace(/'/g, '&#39;'));
+			str +=
+				' ' +
+				name +
+				'="' +
+				String(value)
+					.replace(/"/g, '&#34;')
+					.replace(/'/g, '&#39;') +
+				'"';
 		}
 	});
 

--- a/test/server-side-rendering/samples/spread-attributes-white-space/_expected.html
+++ b/test/server-side-rendering/samples/spread-attributes-white-space/_expected.html
@@ -1,3 +1,8 @@
 <input value="
-    bar
-" />
+	bar
+">
+
+<input class="
+	white
+	space
+">

--- a/test/server-side-rendering/samples/spread-attributes-white-space/_expected.html
+++ b/test/server-side-rendering/samples/spread-attributes-white-space/_expected.html
@@ -1,0 +1,3 @@
+<input value="
+    bar
+" />

--- a/test/server-side-rendering/samples/spread-attributes-white-space/main.svelte
+++ b/test/server-side-rendering/samples/spread-attributes-white-space/main.svelte
@@ -5,3 +5,8 @@
 </script>
 
 <input {...props} />
+
+<input class="
+	white
+	space
+" {...({})}>

--- a/test/server-side-rendering/samples/spread-attributes-white-space/main.svelte
+++ b/test/server-side-rendering/samples/spread-attributes-white-space/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let props = {
+		value: '\n\tbar\n',
+	};
+</script>
+
+<input {...props} />


### PR DESCRIPTION
Fixes #4240.

In `ssr.ts`, `JSON.stringify` was being used to encode the values of attributes. This was causing actual JavaScript/JSON escape values to be written into the HTML. This fix changes it so it concatenates double quotes before and after `String(value)` instead.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [X] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [X] Run the tests tests with `npm test` or `yarn test`)
