### PR TITLE
chore: save compiled output for test suites

### DIFF
--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -45,12 +45,6 @@ export function tryToReadFile(file) {
 	}
 }
 
-export function cleanRequireCache() {
-	Object.keys(require.cache)
-		.filter(x => x.endsWith('.svelte'))
-		.forEach(file => delete require.cache[file]);
-}
-
 const virtualConsole = new jsdom.VirtualConsole();
 virtualConsole.sendTo(console);
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,5 @@
 import * as assert$1 from 'assert';
 import * as jsdom from 'jsdom';
-import glob from 'tiny-glob/sync';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as colors from 'kleur';
@@ -204,27 +203,6 @@ export function addLineNumbers(code) {
 			);
 		})
 		.join('\n');
-}
-
-export function showOutput(cwd, options = {}, compile = svelte.compile) {
-	glob('**/*.svelte', { cwd }).forEach(file => {
-		if (file[0] === '_') return;
-
-		try {
-			const { js } = compile(
-				fs.readFileSync(`${cwd}/${file}`, 'utf-8'),
-				Object.assign(options, {
-					filename: file
-				})
-			);
-
-			console.log( // eslint-disable-line no-console
-				`\n>> ${colors.cyan().bold(file)}\n${addLineNumbers(js.code)}\n<< ${colors.cyan().bold(file)}`
-			);
-		} catch (err) {
-			console.log(`failed to generate output: ${err.message}`);
-		}
-	});
 }
 
 export function shouldUpdateExpected() {

--- a/test/register.ts
+++ b/test/register.ts
@@ -1,0 +1,77 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { mkdirp } from './helpers';
+import * as svelte from 'svelte/compiler';
+
+type Compile = typeof svelte.compile;
+type CompileOptions = Parameters<Compile>[1];
+
+const extensions = ['.svelte', '.html'];
+let compileOptions = {};
+let compile;
+let folderName = 'normal';
+
+const sveltePath = process.cwd().split('\\').join('/');
+
+function capitalise(name: string) {
+	return name[0].toUpperCase() + name.slice(1);
+}
+
+export function setCompileOptions(_compileOptions: CompileOptions) {
+	compileOptions = _compileOptions;
+}
+
+export function setCompile(_compile: Compile) {
+	compile = _compile;
+}
+
+export function setOutputFolderName(_folderName: string) {
+	folderName = _folderName;
+}
+
+export function clearRequireCache() {
+	Object.keys(require.cache)
+		.filter(x => x.endsWith('.svelte'))
+		.forEach(file => {
+			delete require.cache[file];
+		});
+}
+
+function registerExtension(extension: string) {
+	require.extensions[extension] = function(module, filename) {
+		const name = path
+			.parse(filename)
+			.name.replace(/^\d/, '_$&')
+			.replace(/[^a-zA-Z0-9_$]/g, '');
+
+		const options = Object.assign({}, compileOptions, {
+			filename,
+			sveltePath,
+			name: capitalise(name),
+			format: 'cjs'
+		});
+
+		const {
+			js: { code }
+		} = compile(fs.readFileSync(filename, 'utf-8'), options);
+
+		if (!process.env.CI) {
+			saveGeneratedOutput(code, filename);
+		}
+
+		return module._compile(code, filename);
+	};
+}
+
+function saveGeneratedOutput(code: string, filename: string) {
+	filename = filename.split('\\').join('/');
+	filename = filename.replace(
+		/samples\/([^/]+)\/(.*)\.svelte$/,
+		`samples/$1/_output/${folderName}/$2.js`
+	);
+
+	mkdirp(path.dirname(filename));
+	fs.writeFileSync(filename, code, 'utf8');
+}
+
+extensions.forEach(registerExtension);

--- a/test/register.ts
+++ b/test/register.ts
@@ -53,7 +53,7 @@ function registerExtension(extension: string) {
 
 		const {
 			js: { code }
-		} = compile(fs.readFileSync(filename, 'utf-8'), options);
+		} = compile(fs.readFileSync(filename, 'utf-8').replace(/\r/g, ''), options);
 
 		if (!process.env.CI) {
 			saveGeneratedOutputToCache(code, filename);

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -48,7 +48,7 @@ describe('runtime', () => {
 		}
 
 		const testName = `${dir} ${hydrate ? `(with hydration${from_ssr_html ? ' from ssr rendered html' : ''})` : ''}`;
-		(config.skip ? it.skip : solo ? it.only : it)(testName, (done) => {
+		(config.skip ? it.skip : solo ? it.only : it)(testName, () => {
 			if (failed.has(dir)) {
 				// this makes debugging easier, by only printing compiled output once
 				throw new Error('skipping test, already failed');
@@ -196,14 +196,12 @@ describe('runtime', () => {
 				.catch(err => {
 					// print a clickable link to open the directory
 					err.stack += `\n\ncmd-click: ${path.relative(process.cwd(), cwd)}/main.svelte`;
-					done(err);
 					throw err;
 				})
 				.then(() => {
 					flush();
 
 					if (config.after_test) config.after_test();
-					done();
 				});
 		});
 	}

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -65,6 +65,7 @@ describe('runtime', () => {
 				accessors: 'accessors' in config ? config.accessors : true
 			};
 
+			register.clearCompileOutputCache();
 			register.clearRequireCache();
 			register.setCompile((config.preserveIdentifiers ? svelte : svelte$).compile);
 			register.setCompileOptions(compileOptions);
@@ -191,11 +192,10 @@ describe('runtime', () => {
 					}
 				}).catch(err => {
 					failed.add(dir);
-					throw err;
-				})
-				.catch(err => {
 					// print a clickable link to open the directory
 					err.stack += `\n\ncmd-click: ${path.relative(process.cwd(), cwd)}/main.svelte`;
+					// saves the compiled output into file system
+					register.writeCompileOutputCacheToFile();
 					throw err;
 				})
 				.then(() => {

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -57,20 +57,13 @@ describe('runtime', () => {
 			unhandled_rejection = null;
 
 			const cwd = path.resolve(`${__dirname}/samples/${dir}`);
-			
+
 			const compileOptions = {
 				...config.compileOptions,
 				hydratable: hydrate,
 				immutable: config.immutable,
 				accessors: 'accessors' in config ? config.accessors : true
 			};
-
-			register.clearCompileOutputCache();
-			register.clearRequireCache();
-			register.setCompile((config.preserveIdentifiers ? svelte : svelte$).compile);
-			register.setCompileOptions(compileOptions);
-			register.setOutputFolderName(hydrate ? 'hydratable' : 'normal');
-
 			let mod;
 			let SvelteComponent;
 
@@ -99,7 +92,13 @@ describe('runtime', () => {
 							flush();
 						};
 					});
-
+		
+					register.clearCompileOutputCache();
+					register.clearRequireCache();
+					register.setCompile((config.preserveIdentifiers ? svelte : svelte$).compile);
+					register.setCompileOptions(compileOptions);
+					register.setOutputFolderName(hydrate ? 'hydratable' : 'normal');
+		
 					mod = require(`./samples/${dir}/main.svelte`);
 					SvelteComponent = mod.default;
 

--- a/test/runtime/samples/constructor-pass-context/_config.js
+++ b/test/runtime/samples/constructor-pass-context/_config.js
@@ -1,5 +1,5 @@
 export default {
-	async test({ assert, target, window }) {
+	async test({ assert, target, window, require }) {
 		const Component = require('./Component.svelte').default;
 
 		const called = [];
@@ -19,7 +19,7 @@ export default {
 
 		component.$destroy();
 	},
-	test_ssr({ assert }) {
+	test_ssr({ assert, require }) {
 		const Component = require('./Component.svelte').default;
 
 		const called = [];

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -142,7 +142,7 @@ describe('ssr', () => {
 
 	// duplicate client-side tests, as far as possible
 	runRuntimeSamples('runtime');
-	// runRuntimeSamples('runtime-puppeteer');
+	runRuntimeSamples('runtime-puppeteer');
 
 	function runRuntimeSamples(suite) {
 		fs.readdirSync(`test/${suite}/samples`).forEach(dir => {

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -188,7 +188,18 @@ describe('ssr', () => {
 						}
 
 						if (config.test_ssr) {
-							config.test_ssr({ assert });
+							config.test_ssr({
+								assert,
+								require: function require_for_ssr(module: string) {
+									register.clearRequireCache();
+									register.setCompileOptions({
+										sveltePath,
+										generate: 'ssr',
+										format: 'cjs'
+									});
+									return require(path.join(__dirname, `../${suite}/samples/${dir}`, module));
+								}
+							});
 						}
 
 						if (config.after_test) config.after_test();


### PR DESCRIPTION
Unifying the test helper to save the compiled output for:
- ssr
- runtime
- hydration

use the `register.extension` to also save the compiled output to filesystem.

-----

Updated 2022-10-14

- the output will only be saved when the test fails.
  - when compiling with `register.extension` in the test, we will record the compiled output in a cache
  - only write cache into the file when the test fails
  - will clear the cache for each test
