### PR TITLE
[Internals] Improve unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
     - run: 'npm i && npm run lint'
+  Unit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+    - run: 'npm i && npm run test:unit'

--- a/src/compiler/compile/utils/__test__.ts
+++ b/src/compiler/compile/utils/__test__.ts
@@ -10,7 +10,7 @@ describe('get_name_from_filename', () => {
 		assert.equal(get_name_from_filename('path/to/Widget/index.svelte'), 'Widget');
 	});
 
-	it('handles unusual filenames', () => {
-		assert.equal(get_name_from_filename('path/to/[...parts].svelte'), 'Parts');
+	it('handles Windows filenames', () => {
+		assert.equal(get_name_from_filename('path\\to\\Widget.svelte'), 'Widget');
 	});
 });


### PR DESCRIPTION
While implementing #3311 (and adding some unit tests for some new util functions I wrote), I noticed that the existing unit tests:
- are broken (specifically this case).
- are never run on CI / anywhere.

This ticket fixes the first item by making the test more valuable and testing the real case that it was meant to catch (for Windows filenames -- see https://github.com/sveltejs/svelte/pull/3862).

It addresses the second issue by adding unit testing to the CI tasks. Not sure if this is actually something we want seeing as we're only testing one module (for now). 

I hope that this encourages more unit testing in the future (although I think the integration/other tests are probably solid enough already). In general I think unit tests are pretty cheap, but one thing they are good for (especially in a large OS project) is for documenting how code works, making it easier for folks new to the project to understand. 👍 

Resolves #4261 