### PR TITLE
Add more globals

### DIFF
--- a/src/compiler/utils/names.ts
+++ b/src/compiler/utils/names.ts
@@ -5,6 +5,8 @@ export const globals = new Set([
 	'alert',
 	'Array',
 	'Boolean',
+	'clearInterval',
+	'clearTimeout',
 	'confirm',
 	'console',
 	'Date',
@@ -16,6 +18,9 @@ export const globals = new Set([
 	'Error',
 	'EvalError',
 	'Event',
+	'fetch',
+	'global',
+	'globalThis',
 	'history',
 	'Infinity',
 	'InternalError',
@@ -41,11 +46,14 @@ export const globals = new Set([
 	'RegExp',
 	'sessionStorage',
 	'Set',
+	'setInterval',
+	'setTimeout',
 	'String',
 	'SyntaxError',
 	'TypeError',
 	'undefined',
 	'URIError',
+	'URL',
 	'window'
 ]);
 


### PR DESCRIPTION
It came up in discord that `setTimeout` used outside of `script` triggers a warning; e.g. `<button on:click={() => setTimeout(...)}>`. I also added `setInterval` and a couple of other common globals.