### PR TITLE
simplifies code contributions by fully automating the dev setup

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+RUN sudo apt-get update && \
+    sudo apt-get install -yq chromium-browser && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,20 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: >
+      cd site &&
+      npm install &&
+      sed -ri "s/http:\/\/\\\$\\{window\.location\.hostname\\}:\\\$\\{port\\}\/__sapper__/$(gp url 10000 | sed "s_/_\\\\/_g")\/__sapper__/" ./node_modules/sapper/sapper-dev-client.js &&
+      npm run update 
+    command: npm run dev
+  - init: npm install
+    command: npm run dev
+ports:
+  - port: 3000
+    onOpen: open-preview
+  - port: 10000
+    onOpen: ignore
+
+vscode:
+  extensions:
+    - JamesBirtles.svelte-vscode@0.4.0:aicIqbjKmEBw3n8OhIUmwA==

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svelte changelog
 
+## 3.20.1
+
+* Fix compiler regression with slots ([#4562](https://github.com/sveltejs/svelte/issues/4562))
+
 ## 3.20.0
 
 * Allow destructuring in `{#await}` blocks ([#1851](https://github.com/sveltejs/svelte/issues/1851))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,16 @@ When [opening a new issue](https://github.com/sveltejs/svelte/issues/new/choose)
 1. After cloning the repository, run `npm install` in the root of the repository.
 1. To start a development server, run `npm run dev`.
 
+## Online one-click setup for contributing
+
+You can use Gitpod (a free online VS Code like-IDE) for contributing. With a single click it will launch a workspace and automatically:
+
+- clone the svelte repo.
+- install the dependencies.
+- run `npm run dev` in `/` and `/site`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/sveltejs/svelte)
+
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 	<img alt="Cybernetically enhanced web apps: Svelte" src="https://sveltejs.github.io/assets/banner.png">
   </a>
 
+  <a href="https://gitpod.io/#https://github.com/sveltejs/svelte">
+	<img alt="Gitpod Ready-to-Code" src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod">
+  </a>
+
   <a href="https://www.npmjs.com/package/svelte">
     <img src="https://img.shields.io/npm/v/svelte.svg" alt="npm version">
   </a>
@@ -50,6 +54,16 @@ To watch for changes and continually rebuild the package (this is useful if you'
 ```bash
 npm run dev
 ```
+
+### Online setup with one-click
+
+You can use Gitpod (a free online VS Code like-IDE) for the online setup. With a single click it will launch a workspace and automatically:
+
+- clone the svelte repo.
+- install the dependencies.
+- run `npm run dev` in `/` and `/site`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/sveltejs/svelte)
 
 The compiler is written in [TypeScript](https://www.typescriptlang.org/), but don't let that put you off — it's basically just JavaScript with type annotations. You'll pick it up in no time. If you're using an editor other than [Visual Studio Code](https://code.visualstudio.com/) you may need to install a plugin in order to get syntax highlighting and code hints etc.
 


### PR DESCRIPTION
Hi! :slightly_smiling_face: 

This Pr simplifies code contributions by fully automating the setup with Gitpod (A free online VS Code-like IDE) with a single click it will launch a workspace and automatically:

- clone the svelte repo.
- install the dependencies.
- run `npm run dev` in `/` and `/site`.

So that anyone interested in contributing can start straight away.

It seems to work well :) You can give it a try on my fork via the link below:

https://gitpod.io/#https://github.com/nisarhassan12/svelte/tree/gitpod-setup

![image](https://user-images.githubusercontent.com/46004116/72590554-d6477c80-391f-11ea-869e-90d6df66e907.png)

