### PR TITLE
Update writable store tutorial

### DIFF
--- a/site/content/tutorial/08-stores/01-writable-stores/app-a/App.svelte
+++ b/site/content/tutorial/08-stores/01-writable-stores/app-a/App.svelte
@@ -6,7 +6,7 @@
 
 	let count_value;
 
-	const unsubscribe = count.subscribe(value => {
+	const subscribe = count.subscribe(value => {
 		count_value = value;
 	});
 </script>


### PR DESCRIPTION
Rename function `unsubscribe` to `subscribe` in `App.svelte` to match its purpose and avoid confusion among readers
