### PR TITLE
fix deriving from RxJS observables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svelte changelog
 
+## Unreleased
+
+* Fix using RxJS observables in `derived` stores ([#4298](https://github.com/sveltejs/svelte/issues/4298))
+
 ## 3.17.2
 
 * Fix removing attributes during hydration ([#1733](https://github.com/sveltejs/svelte/issues/1733))

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -48,8 +48,8 @@ export function validate_store(store, name) {
 	}
 }
 
-export function subscribe(store, callback) {
-	const unsub = store.subscribe(callback);
+export function subscribe(store, ...args) {
+	const unsub = store.subscribe(...args);
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -48,8 +48,8 @@ export function validate_store(store, name) {
 	}
 }
 
-export function subscribe(store, ...args) {
-	const unsub = store.subscribe(...args);
+export function subscribe(store, ...callbacks) {
+	const unsub = store.subscribe(...callbacks);
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -1,4 +1,4 @@
-import { run_all, noop, safe_not_equal, is_function, get_store_value } from 'svelte/internal';
+import { run_all, subscribe, noop, safe_not_equal, is_function, get_store_value } from 'svelte/internal';
 
 /** Callback to inform of a value updates. */
 type Subscriber<T> = (value: T) => void;
@@ -173,7 +173,8 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 			}
 		};
 
-		const unsubscribers = stores_array.map((store, i) => store.subscribe(
+		const unsubscribers = stores_array.map((store, i) => subscribe(
+			store,
 			(value) => {
 				values[i] = value;
 				pending &= ~(1 << i);

--- a/test/store/index.js
+++ b/test/store/index.js
@@ -116,6 +116,15 @@ describe('store', () => {
 		});
 	});
 
+	const fake_observable = {
+		subscribe(fn) {
+			fn(42);
+			return {
+				unsubscribe: () => {}
+			};
+		}
+	};
+
 	describe('derived', () => {
 		it('maps a single store', () => {
 			const a = writable(1);
@@ -346,6 +355,11 @@ describe('store', () => {
 			b.set(2);
 			assert.deepEqual(get(c), 'two 2');
 		});
+
+		it('works with RxJS-style observables', () => {
+			const d = derived(fake_observable, _ => _);
+			assert.equal(get(d), 42);
+		});
 	});
 
 	describe('get', () => {
@@ -355,16 +369,7 @@ describe('store', () => {
 		});
 
 		it('works with RxJS-style observables', () => {
-			const observable = {
-				subscribe(fn) {
-					fn(42);
-					return {
-						unsubscribe: () => {}
-					};
-				}
-			};
-
-			assert.equal(get(observable), 42);
+			assert.equal(get(fake_observable), 42);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #4298. I'm not convinced this is the best way to handle this though. Making the `subscribe` helper accept a `...` rest param might not be worth it just to make the code slightly more DRY.