### PR TITLE
make autosubscribing to a nullish store a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Make autosubscribing to a nullish store a no-op ([#2181](https://github.com/sveltejs/svelte/issues/2181))
 * Fix updating a `<slot>` inside an `{#if}` or other block ([#4292](https://github.com/sveltejs/svelte/issues/4292))
 * Fix using RxJS observables in `derived` stores ([#4298](https://github.com/sveltejs/svelte/issues/4298))
 * Add dev mode check to disallow duplicate keys in a keyed `{#each}` ([#4301](https://github.com/sveltejs/svelte/issues/4301))

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -43,12 +43,15 @@ export function not_equal(a, b) {
 }
 
 export function validate_store(store, name) {
-	if (!store || typeof store.subscribe !== 'function') {
+	if (store != null && typeof store.subscribe !== 'function') {
 		throw new Error(`'${name}' is not a store with a 'subscribe' method`);
 	}
 }
 
 export function subscribe(store, ...callbacks) {
+	if (store == null) {
+		return noop;
+	}
 	const unsub = store.subscribe(...callbacks);
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }

--- a/test/runtime/samples/store-auto-subscribe-nullish/_config.js
+++ b/test/runtime/samples/store-auto-subscribe-nullish/_config.js
@@ -1,0 +1,13 @@
+import { writable } from '../../../../store';
+
+export default {
+	html: `
+		<p>undefined</p>
+	`,
+	async test({ assert, component, target }) {
+		component.store = writable('foo');
+		assert.htmlEqual(target.innerHTML, `
+			<p>foo</p>
+		`);
+	}
+};

--- a/test/runtime/samples/store-auto-subscribe-nullish/main.svelte
+++ b/test/runtime/samples/store-auto-subscribe-nullish/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let store;
+</script>
+
+<p>{$store}</p>


### PR DESCRIPTION
Resolves #2181.

This adds a _very_ slight cost in terms of per-app bytes (and adds an extra `== null` test each time we subscribe to a component via the `subscribe()` helper) - and it's possible that this will mask genuine bugs or logic errors in components - but I still think we're better off with this.

With this PR, you're allowed to have autosubscribed stores that don't immediately have values, which, in addition to what's described in #2181, also lets you more easily use a series of reactive declarations to grab something from nested stores.

If this is merged, we should probably also document the new behavior somewhere beyond the changelog, but I'm not sure where.