### PR TITLE
fix hydration of <title>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix updating a `<slot>` inside an `{#if}` or other block ([#4292](https://github.com/sveltejs/svelte/issues/4292))
 * Fix using RxJS observables in `derived` stores ([#4298](https://github.com/sveltejs/svelte/issues/4298))
 * Add dev mode check to disallow duplicate keys in a keyed `{#each}` ([#4301](https://github.com/sveltejs/svelte/issues/4301))
+* Fix hydration of `<title>` when starting from SSR-generated code with `hydratable: true` ([#4310](https://github.com/sveltejs/svelte/issues/4310))
 
 ## 3.17.2
 

--- a/src/compiler/compile/render_ssr/handlers/Title.ts
+++ b/src/compiler/compile/render_ssr/handlers/Title.ts
@@ -5,11 +5,7 @@ import { x } from 'code-red';
 export default function(node: Title, renderer: Renderer, options: RenderOptions) {
 	renderer.push();
 
-	renderer.add_string('<title');
-	if (options.hydratable && options.head_id) {
-		renderer.add_string(` data-svelte="${options.head_id}"`);
-	}
-	renderer.add_string('>');
+	renderer.add_string(`<title>`);
 
 	renderer.render(node.children, options);
 

--- a/test/hydration/samples/head-meta-hydrate-duplicate/_before_head.html
+++ b/test/hydration/samples/head-meta-hydrate-duplicate/_before_head.html
@@ -1,4 +1,4 @@
-<title data-svelte="svelte-1s8aodm">Some Title</title>
+<title>Some Title</title>
 <link rel="canonical" href="/" data-svelte="svelte-1s8aodm">
 <meta name="description" content="some description" data-svelte="svelte-1s8aodm">
 <meta name="keywords" content="some keywords" data-svelte="svelte-1s8aodm">

--- a/test/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected-head.html
+++ b/test/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected-head.html
@@ -1,4 +1,4 @@
-<title data-svelte="svelte-1s8aodm">Some Title</title>
+<title>Some Title</title>
 <link rel="canonical" href="/" data-svelte="svelte-1s8aodm">
 <meta name="description" content="some description" data-svelte="svelte-1s8aodm">
 <meta name="keywords" content="some keywords" data-svelte="svelte-1s8aodm">


### PR DESCRIPTION
Fixes #4310. Tested with the repro in that ticket. No new unit test though because I couldn't get the existing `head-meta-hydrate-duplicate` test to acknowledge that the `<title>` was currently getting removed. Possibly a JSDOM limitation, but I didn't look into it too hard.