### PR TITLE
Recomputes css hash id when unused selectors are present

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -170,6 +170,8 @@ export default class Component {
 
 		this.walk_instance_js_post_template();
 
+		this.stylesheet.recompute_stylesheet_hash(this);
+
 		if (!compile_options.customElement) this.stylesheet.reify();
 
 		this.stylesheet.warn_on_unused_selectors(this);

--- a/test/runtime/samples/css-style-hashing/Component1.svelte
+++ b/test/runtime/samples/css-style-hashing/Component1.svelte
@@ -1,0 +1,10 @@
+<div class="component-1 red"> Red </div>
+
+<style>
+	.red {
+		background: red;
+	}
+	.yellow {
+		background: yellow;
+	}
+</style>

--- a/test/runtime/samples/css-style-hashing/Component2.svelte
+++ b/test/runtime/samples/css-style-hashing/Component2.svelte
@@ -1,0 +1,11 @@
+<div class="component-2 red"> Red </div>
+<div class="component-2 yellow"> Yellow </div>
+
+<style>
+	.red {
+		background: red;
+	}
+	.yellow {
+		background: yellow;
+	}
+</style>

--- a/test/runtime/samples/css-style-hashing/_config.js
+++ b/test/runtime/samples/css-style-hashing/_config.js
@@ -1,0 +1,10 @@
+export default {
+	test({ assert, component, target, window }) {
+		const [component_one_red] = target.querySelectorAll('.component-1');
+		const [component_two_red, component_two_yellow] = target.querySelectorAll('.component-2');
+
+		assert.equal(window.getComputedStyle(component_one_red).background, 'red');
+		assert.equal(window.getComputedStyle(component_two_red).background, 'red');
+		assert.equal(window.getComputedStyle(component_two_yellow).background, 'yellow');
+	}
+};

--- a/test/runtime/samples/css-style-hashing/main.svelte
+++ b/test/runtime/samples/css-style-hashing/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Component1 from './Component1.svelte'
+	import Component2 from './Component2.svelte'
+</script>
+
+<Component1 />
+<Component2 />


### PR DESCRIPTION
This is an attempt to fix #4313 which demonstrates that incorrect css can be produced when two components have the same style rules and the first component to be included has unused selectors.