### PR TITLE
[site] Remove WIP message, but still reference the chat room.

### DIFF
--- a/site/content/docs/00-introduction.md
+++ b/site/content/docs/00-introduction.md
@@ -2,8 +2,8 @@
 title: Before we begin
 ---
 
-> Temporary note: This document is a work-in-progress. Please forgive any missing or misleading parts, and don't be shy about asking for help in the [Discord chatroom](chat). The [tutorial](tutorial) is more complete; start there.
-
 This page contains detailed API reference documentation. It's intended to be a resource for people who already have some familiarity with Svelte.
 
 If that's not you (yet), you may prefer to visit the [interactive tutorial](tutorial) or the [examples](examples) before consulting this reference.
+
+Don't be shy about asking for help in the [Discord chatroom](chat).


### PR DESCRIPTION
As noted on the Discord chat, the docs are more complete now.

So I removed the WIP message, but I kept the reference to Discord, since it's important to lead people to the chat for an active community.

Signed-off-by: Wolfr <johan.ronsse@gmail.com>
