### PR TITLE
disallow simultaneous foo / {foo} / bind:foo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svelte changelog
 
+## Unreleased
+
+* Disallow attribute/prop names from matching two-way-bound names or `{shorthand}` attribute/prop names ([#4325](https://github.com/sveltejs/svelte/issues/4325))
+
 ## 3.18.1
 
 * Fix code generation error with adjacent inline and block comments ([#4312](https://github.com/sveltejs/svelte/issues/4312))

--- a/test/parser/samples/attribute-unique-binding-error/error.json
+++ b/test/parser/samples/attribute-unique-binding-error/error.json
@@ -1,0 +1,10 @@
+{
+	"code": "duplicate-attribute",
+	"message": "Attributes need to be unique",
+	"start": {
+		"line": 1,
+		"column": 17,
+		"character": 17
+	},
+	"pos": 17
+}

--- a/test/parser/samples/attribute-unique-binding-error/input.svelte
+++ b/test/parser/samples/attribute-unique-binding-error/input.svelte
@@ -1,0 +1,1 @@
+<Widget foo={42} bind:foo/>

--- a/test/parser/samples/attribute-unique-shorthand-error/error.json
+++ b/test/parser/samples/attribute-unique-shorthand-error/error.json
@@ -1,0 +1,10 @@
+{
+	"code": "duplicate-attribute",
+	"message": "Attributes need to be unique",
+	"start": {
+		"line": 1,
+		"column": 17,
+		"character": 17
+	},
+	"pos": 17
+}

--- a/test/parser/samples/attribute-unique-shorthand-error/input.svelte
+++ b/test/parser/samples/attribute-unique-shorthand-error/input.svelte
@@ -1,0 +1,1 @@
+<div title='foo' {title}></div>


### PR DESCRIPTION
Fixes #4325 by making such code a compile-time error. `foo`, `{foo}`, and `bind:foo` are now mutually exclusive, on elements or components.

Note that `bind:this` and `this` _are_ allowed to co-exist, as `<svelte:component bind:this={foo} this={bar}/>` is perfectly valid.