### PR TITLE
WIP: adding multi class by separator feature

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -1357,7 +1357,7 @@ function process_component_options(component: Component, nodes) {
 						if (typeof value !== 'string' && value !== null)
 							component.error(attribute, { code, message });
 
-						if (value === 'tag') {
+						if (name === 'tag') {
 							if (value && !/^[a-zA-Z][a-zA-Z0-9]*-[a-zA-Z0-9-]+$/.test(value)) {
 								component.error(attribute, {
 									code: `invalid-tag-property`,

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -1348,29 +1348,32 @@ function process_component_options(component: Component, nodes) {
 				const { name } = attribute;
 
 				switch (name) {
+					case 'classSeparator':
 					case 'tag': {
 						const code = 'invalid-tag-attribute';
-						const message = `'tag' must be a string literal`;
-						const tag = get_value(attribute, code, message);
+						const message = `'${name}' must be a string literal`;
+						const value = get_value(attribute, code, message);
 
-						if (typeof tag !== 'string' && tag !== null)
+						if (typeof value !== 'string' && value !== null)
 							component.error(attribute, { code, message });
 
-						if (tag && !/^[a-zA-Z][a-zA-Z0-9]*-[a-zA-Z0-9-]+$/.test(tag)) {
-							component.error(attribute, {
-								code: `invalid-tag-property`,
-								message: `tag name must be two or more words joined by the '-' character`,
-							});
+						if (value === 'tag') {
+							if (value && !/^[a-zA-Z][a-zA-Z0-9]*-[a-zA-Z0-9-]+$/.test(value)) {
+								component.error(attribute, {
+									code: `invalid-tag-property`,
+									message: `tag name must be two or more words joined by the '-' character`,
+								});
+							}
+
+							if (value && !component.compile_options.customElement) {
+								component.warn(attribute, {
+									code: 'missing-custom-element-compile-options',
+									message: `The 'tag' option is used when generating a custom element. Did you forget the 'customElement: true' compile option?`
+								});
+							}
 						}
 
-						if (tag && !component.compile_options.customElement) {
-							component.warn(attribute, {
-								code: 'missing-custom-element-compile-options',
-								message: `The 'tag' option is used when generating a custom element. Did you forget the 'customElement: true' compile option?`
-							});
-						}
-
-						component_options.tag = tag;
+						component_options[name] = value;
 						break;
 					}
 

--- a/src/compiler/compile/index.ts
+++ b/src/compiler/compile/index.ts
@@ -26,7 +26,8 @@ const valid_options = [
 	'css',
 	'loopGuardTimeout',
 	'preserveComments',
-	'preserveWhitespace'
+	'preserveWhitespace',
+	'classSeparator'
 ];
 
 function validate_options(options: CompileOptions, warnings: Warning[]) {

--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -30,8 +30,22 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 
 	const class_expression_list = node.classes.map(class_directive => {
 		const { expression, name } = class_directive;
-		const snippet = expression ? expression.node : x`#ctx.${name}`; // TODO is this right?
-		return x`${snippet} ? "${name}" : ""`;
+
+		const name_has_separator = name.includes(options.classSeparator);
+
+		let parsed_name = name;
+		if (name_has_separator) {
+			parsed_name = `"${name.split(",").join(' ')}"`;
+		}
+
+		if (name_has_separator && expression) {
+			// TODO: we have a wrong scenario here, "class:one,two". We should treat this case, showing error?
+			return parsed_name;
+		}
+
+		const snippet = expression ? expression.node : x`#ctx.${name}`;
+
+		return x`${snippet} ? "${parsed_name}" : ""`;
 	});
 	if (node.needs_manual_style_scoping) {
 		class_expression_list.push(x`"${node.component.stylesheet.id}"`);

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -126,6 +126,8 @@ export interface CompileOptions {
 
 	preserveComments?: boolean;
 	preserveWhitespace?: boolean;
+
+	classSeparator?: string;
 }
 
 export interface ParserOptions {

--- a/test/runtime/index.js
+++ b/test/runtime/index.js
@@ -79,6 +79,7 @@ describe("runtime", () => {
 			compileOptions.hydratable = hydrate;
 			compileOptions.immutable = config.immutable;
 			compileOptions.accessors = 'accessors' in config ? config.accessors : true;
+			compileOptions.classSeparator = 'classSeparator' in config ? config.classSeparator : undefined;
 
 			cleanRequireCache();
 

--- a/test/runtime/samples/class-separation-boolean/_config.js
+++ b/test/runtime/samples/class-separation-boolean/_config.js
@@ -1,0 +1,6 @@
+export default {
+	classSeparator: ',',
+	skip_if_ssr: true,
+
+	html: `<div class="one two"></div>`,
+};

--- a/test/runtime/samples/class-separation-boolean/main.svelte
+++ b/test/runtime/samples/class-separation-boolean/main.svelte
@@ -1,0 +1,1 @@
+<div class:one,two={true} />


### PR DESCRIPTION
Related to:
https://github.com/sveltejs/svelte/pull/3419

This is a WIP feature I want to collect feedbacks about it. We already have a small discussion about how to implement that feature, and that's one of the solutions.

Basically, we can use an option to set the class separator for the svelte compiler, so we can use something like (let's suppose the classSeparator is settled to `,`):

`<div class:one,two={condition}>`

Markup (when condition is true):
`<div class="one two">`
