### PR TITLE
fix binding to module-level variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix binding to module-level variables ([#4086](https://github.com/sveltejs/svelte/issues/4086))
 * Disallow attribute/prop names from matching two-way-bound names or `{shorthand}` attribute/prop names ([#4325](https://github.com/sveltejs/svelte/issues/4325))
 
 ## 3.18.1

--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -161,11 +161,14 @@ export default class Renderer {
 		}
 
 		if (
-			variable &&
-			!variable.referenced &&
-			!variable.is_reactive_dependency &&
-			!variable.export_name &&
-			!name.startsWith('$$')
+			variable && (
+				variable.module || (
+					!variable.referenced &&
+					!variable.is_reactive_dependency &&
+					!variable.export_name &&
+					!name.startsWith('$$')
+				)
+			)
 		) {
 			return value || name;
 		}

--- a/test/runtime/samples/module-context-bind/_config.js
+++ b/test/runtime/samples/module-context-bind/_config.js
@@ -1,0 +1,4 @@
+export default {
+	skip_if_ssr: true,
+	html: '<div>object</div>'
+};

--- a/test/runtime/samples/module-context-bind/main.svelte
+++ b/test/runtime/samples/module-context-bind/main.svelte
@@ -1,0 +1,11 @@
+<script context='module'>
+	let foo;
+</script>
+
+<script>
+	import { onMount } from 'svelte';
+	let bar;
+	onMount(() => bar = foo);
+</script>
+
+<div bind:this={foo}>{typeof bar}</div>


### PR DESCRIPTION
Fixes #4086. I looked a bit into the other optimizations I mentioned in that issue, but I don't think they're worth the effort for now, especially since binding to module-level variables is kind of a weird and niche thing to be doing anyway.