### PR TITLE
Avoid using shift in flush

### DIFF
--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -37,11 +37,13 @@ export function flush() {
 	do {
 		// first, call beforeUpdate functions
 		// and update components
-		while (dirty_components.length) {
-			const component = dirty_components.shift();
+		for (let i = 0; i < dirty_components.length; i += 1) {
+			const component = dirty_components[i];
 			set_current_component(component);
 			update(component.$$);
 		}
+		
+		dirty_components.length = 0;
 
 		while (binding_callbacks.length) binding_callbacks.pop()();
 

--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -31,8 +31,11 @@ export function add_flush_callback(fn) {
 	flush_callbacks.push(fn);
 }
 
+let flushing = false;
 const seen_callbacks = new Set();
 export function flush() {
+	if (flushing) return;
+	flushing = true;
 
 	do {
 		// first, call beforeUpdate functions
@@ -42,7 +45,7 @@ export function flush() {
 			set_current_component(component);
 			update(component.$$);
 		}
-		
+
 		dirty_components.length = 0;
 
 		while (binding_callbacks.length) binding_callbacks.pop()();
@@ -69,6 +72,7 @@ export function flush() {
 	}
 
 	update_scheduled = false;
+	flushing = false;
 	seen_callbacks.clear();
 }
 


### PR DESCRIPTION
We noticed that there was a large amount of memory being created as part of the flush method, which seems to be due to some array optimizations in old JS engines. This seems to be easily fixed by changing to a simple for loop instead of a while loop that modifies the array during iteration. This is the same pattern that is used for the `render_callbacks`.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
