### PR TITLE
npm audit fix related to https-proxy-agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1682,9 +1682,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",


### PR DESCRIPTION
`npm audit` lists two high vulnerabilities related to _https-proxy-agent_ during install (of this repo). 

```
npm install
...
found 2 high severity vulnerabilities
```

`npm audit fix` updates https-proxy-agent from version 2.2.2 to 2.2.4.

```
npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm update https-proxy-agent --depth 3  to resolve 2 vulnerabilities
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Machine-In-The-Middle                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ https-proxy-agent                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ codecov [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ codecov > teeny-request > https-proxy-agent                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1184                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Machine-In-The-Middle                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ https-proxy-agent                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ puppeteer [dev]                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ puppeteer > https-proxy-agent                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1184                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

Running ```npm test``` results in 

```
  2720 passing (46s)
  24 pending
```

There seems to be no open issue related to this - and since this was quickly fixed, I decided to rather create directly create a PR. Hope this is ok. 