### PR TITLE
feat: add scoping css prefix option in compiler

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -132,7 +132,8 @@ export default class Component {
 			source,
 			ast,
 			compile_options.filename,
-			compile_options.dev
+			compile_options.dev,
+			compile_options.cssPrefix
 		);
 		this.stylesheet.validate(this);
 

--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -291,14 +291,14 @@ export default class Stylesheet {
 
 	nodes_with_css_class: Set<CssNode> = new Set();
 
-	constructor(source: string, ast: Ast, filename: string, dev: boolean) {
+	constructor(source: string, ast: Ast, filename: string, dev: boolean, cssPrefix: string) {
 		this.source = source;
 		this.ast = ast;
 		this.filename = filename;
 		this.dev = dev;
 
 		if (ast.css && ast.css.children.length) {
-			this.id = `svelte-${hash(ast.css.content.styles)}`;
+			this.id = `${cssPrefix}-${hash(ast.css.content.styles)}`;
 
 			this.has_styles = true;
 

--- a/src/compiler/compile/index.ts
+++ b/src/compiler/compile/index.ts
@@ -26,7 +26,8 @@ const valid_options = [
 	'css',
 	'loopGuardTimeout',
 	'preserveComments',
-	'preserveWhitespace'
+	'preserveWhitespace',
+	'cssPrefix'
 ];
 
 function validate_options(options: CompileOptions, warnings: Warning[]) {
@@ -68,7 +69,7 @@ function validate_options(options: CompileOptions, warnings: Warning[]) {
 }
 
 export default function compile(source: string, options: CompileOptions = {}) {
-	options = assign({ generate: 'dom', dev: false }, options);
+	options = assign({ generate: 'dom', dev: false, cssPrefix: 'svelte' }, options);
 
 	const stats = new Stats();
 	const warnings = [];

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -126,6 +126,7 @@ export interface CompileOptions {
 
 	preserveComments?: boolean;
 	preserveWhitespace?: boolean;
+	cssPrefix?: string;
 }
 
 export interface ParserOptions {

--- a/test/css/index.js
+++ b/test/css/index.js
@@ -84,7 +84,9 @@ describe('css', () => {
 				css: read(`${__dirname}/samples/${dir}/expected.css`)
 			};
 
-			const actual_css = dom.css.code.replace(/svelte(-ref)?-[a-z0-9]+/g, (m, $1) => $1 ? m : 'svelte-xyz');
+			const cssPrefix = config.compileOptions && config.compileOptions.cssPrefix || 'svelte';
+			const regexp = new RegExp(`${cssPrefix}(-ref)?-[a-z0-9]+`, 'g');
+			const actual_css = dom.css.code.replace(regexp, (m, $1) => $1 ? m : 'svelte-xyz');
 			try {
 				assert.equal(actual_css, expected.css);
 			} catch (error) {

--- a/test/css/samples/custom-css-prefix/_config.js
+++ b/test/css/samples/custom-css-prefix/_config.js
@@ -1,0 +1,5 @@
+export default {
+    compileOptions: {
+        cssPrefix: 'sv'
+    }
+};

--- a/test/css/samples/custom-css-prefix/expected.css
+++ b/test/css/samples/custom-css-prefix/expected.css
@@ -1,0 +1,1 @@
+div.svelte-xyz{color:red}

--- a/test/css/samples/custom-css-prefix/input.svelte
+++ b/test/css/samples/custom-css-prefix/input.svelte
@@ -1,0 +1,7 @@
+<div>red</div>
+
+<style>
+	div {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
Add an option in the compiler to change the scoped css class name prefix, partially addresses #570

Super simple, not a callback, just a string. Has a simple test to check if the option works.

Let me know if I should go ahead and extend this if I'm on the right track.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
