### PR TITLE
Blog: Update default shell to use on Windows

### DIFF
--- a/site/content/blog/2019-04-16-svelte-for-new-developers.md
+++ b/site/content/blog/2019-04-16-svelte-for-new-developers.md
@@ -14,7 +14,7 @@ If you get stuck at any point following this guide, the best place to ask for he
 
 ## First things first
 
-You'll be using the *command line*, also known as the terminal. On Windows, you can access it by running **Command Prompt** from the Start menu; on a Mac, hit `Cmd` and `Space` together to bring up **Spotlight**, then start typing `Terminal.app`. On most Linux systems, `Ctrl-Alt-T` brings up the command line.
+You'll be using the *command line*, also known as the terminal. On Windows, you can access it by running **PowerShell** from the Start menu (or **Command Prompt** if you have a version of Windows lower than 7, but in this case you will have to adjust the following commands); on a Mac, hit `Cmd` and `Space` together to bring up **Spotlight**, then start typing `Terminal.app`. On most Linux systems, `Ctrl-Alt-T` brings up the command line.
 
 The command line is a way to interact with your computer (or another computer! but that's a topic for another time) with more power and control than the GUI (graphical user interface) that most people use day-to-day.
 

--- a/site/content/blog/2019-04-16-svelte-for-new-developers.md
+++ b/site/content/blog/2019-04-16-svelte-for-new-developers.md
@@ -14,11 +14,11 @@ If you get stuck at any point following this guide, the best place to ask for he
 
 ## First things first
 
-You'll be using the *command line*, also known as the terminal. On Windows, you can access it by running **PowerShell** from the Start menu (or **Command Prompt** if you have a version of Windows lower than 7, but in this case you will have to adjust the following commands); on a Mac, hit `Cmd` and `Space` together to bring up **Spotlight**, then start typing `Terminal.app`. On most Linux systems, `Ctrl-Alt-T` brings up the command line.
+You'll be using the *command line*, also known as the terminal. On Windows, you can access it by running **Command Prompt** from the Start menu; on a Mac, hit `Cmd` and `Space` together to bring up **Spotlight**, then start typing `Terminal.app`. On most Linux systems, `Ctrl-Alt-T` brings up the command line.
 
 The command line is a way to interact with your computer (or another computer! but that's a topic for another time) with more power and control than the GUI (graphical user interface) that most people use day-to-day.
 
-Once on the command line, you can navigate the filesystem using `ls` to list the contents of your current directory, and `cd` to change the current directory. For example, if you had a `Development` directory of your projects inside your home directory, you would type
+Once on the command line, you can navigate the filesystem using `ls` (`dir` on Windows) to list the contents of your current directory, and `cd` to change the current directory. For example, if you had a `Development` directory of your projects inside your home directory, you would type
 
 ```bash
 cd Development
@@ -34,7 +34,7 @@ cd svelte-projects
 A full introduction to the command line is out of the scope of this guide, but here are a few more useful commands:
 
 * `cd ..` — navigates to the parent of the current directory
-* `cat my-file.txt` — on Mac/Linux, lists the contents of `my-file.txt`
+* `cat my-file.txt` — on Mac/Linux (`type my-file.txt` on Windows), lists the contents of `my-file.txt`
 * `open .` (or `start .` on Windows) — opens the current directory in Finder or File Explorer
 
 


### PR DESCRIPTION
The commands used in the tutorial can't work on Windows with the command prompt, so I specify PowerShell instead of it
