### PR TITLE
fix event handlers that are dynamic via reactive declarations or stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Permit reserved keywords as destructuring keys in `{#each}` ([#4372](https://github.com/sveltejs/svelte/issues/4372))
 * Disallow reserved keywords in `{expressions}` ([#4372](https://github.com/sveltejs/svelte/issues/4372))
 * Fix code generation error with precedence of arrow functions ([#4384](https://github.com/sveltejs/svelte/issues/4384))
+* Fix event handlers that are dynamic via reactive declarations or stores ([#4388](https://github.com/sveltejs/svelte/issues/4388))
 
 ## 3.18.1
 

--- a/src/compiler/compile/nodes/EventHandler.ts
+++ b/src/compiler/compile/nodes/EventHandler.ts
@@ -53,13 +53,6 @@ export default class EventHandler extends Node {
 		}
 		const node = this.expression.node;
 
-		if (node.type === 'Identifier') {
-			return (
-				this.component.node_for_declaration.get(node.name) &&
-				this.component.var_lookup.get(node.name).reassigned
-			);
-		}
-
 		if (/FunctionExpression/.test(node.type)) {
 			return false;
 		}

--- a/test/runtime/samples/event-handler-dynamic-2/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-2/_config.js
@@ -1,0 +1,54 @@
+export default {
+	html: `
+		<button>toggle</button>
+		<p>0</p>
+		<button>handler_a</button>
+		<button>handler_b</button>
+	`,
+
+	async test({ assert, target, window }) {
+		const [toggle, handler_a, handler_b] = target.querySelectorAll(
+			'button'
+		);
+
+		const event = new window.MouseEvent('click');
+
+		await handler_a.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>toggle</button>
+			<p>1</p>
+			<button>handler_a</button>
+			<button>handler_b</button>
+		`);
+
+		await toggle.dispatchEvent(event);
+
+		await handler_a.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>toggle</button>
+			<p>2</p>
+			<button>handler_a</button>
+			<button>handler_b</button>
+		`);
+
+		await toggle.dispatchEvent(event);
+
+		await handler_b.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>toggle</button>
+			<p>1</p>
+			<button>handler_a</button>
+			<button>handler_b</button>
+		`);
+
+		await toggle.dispatchEvent(event);
+
+		await handler_b.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>toggle</button>
+			<p>2</p>
+			<button>handler_a</button>
+			<button>handler_b</button>
+		`);
+	},
+};

--- a/test/runtime/samples/event-handler-dynamic-2/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-2/_config.js
@@ -7,48 +7,27 @@ export default {
 	`,
 
 	async test({ assert, target, window }) {
-		const [toggle, handler_a, handler_b] = target.querySelectorAll(
-			'button'
-		);
+		const [toggle, handler_a, handler_b] = target.querySelectorAll('button');
+		const p = target.querySelector('p');
 
 		const event = new window.MouseEvent('click');
 
 		await handler_a.dispatchEvent(event);
-		assert.htmlEqual(target.innerHTML, `
-			<button>toggle</button>
-			<p>1</p>
-			<button>handler_a</button>
-			<button>handler_b</button>
-		`);
+		assert.equal(p.innerHTML, '1');
 
 		await toggle.dispatchEvent(event);
 
 		await handler_a.dispatchEvent(event);
-		assert.htmlEqual(target.innerHTML, `
-			<button>toggle</button>
-			<p>2</p>
-			<button>handler_a</button>
-			<button>handler_b</button>
-		`);
+		assert.equal(p.innerHTML, '2');
 
 		await toggle.dispatchEvent(event);
 
 		await handler_b.dispatchEvent(event);
-		assert.htmlEqual(target.innerHTML, `
-			<button>toggle</button>
-			<p>1</p>
-			<button>handler_a</button>
-			<button>handler_b</button>
-		`);
+		assert.equal(p.innerHTML, '1');
 
 		await toggle.dispatchEvent(event);
 
 		await handler_b.dispatchEvent(event);
-		assert.htmlEqual(target.innerHTML, `
-			<button>toggle</button>
-			<p>2</p>
-			<button>handler_a</button>
-			<button>handler_b</button>
-		`);
+		assert.equal(p.innerHTML, '2');
 	},
 };

--- a/test/runtime/samples/event-handler-dynamic-2/main.svelte
+++ b/test/runtime/samples/event-handler-dynamic-2/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	let number = 0;
+	const handler_1 = () => number = 1;
+	const handler_2 = () => number = 2;
+
+	let flag = true;
+
+	$: handler_a = flag ? handler_1 : handler_2;
+	const handler_b = writable();
+	$: handler_b.set(flag ? handler_1 : handler_2);
+</script>
+
+<button on:click={() => flag = !flag}>toggle</button>
+
+<p>{number}</p>
+
+<button on:click={handler_a}>handler_a</button>
+<button on:click={$handler_b}>handler_b</button>


### PR DESCRIPTION
Fixes #4388. The existing `EventHandler#reassigned` logic was buggy because there would be no `node_for_declaration` for automatically declared reactive assignments (or for store autosubscriptions).

I initially changed it to checking `this.component.var_lookup.get(node.name)`, but this didn't work for stores. I added a special case for `node.name[0] === '$'`, and that did work.

But then I realized we probably didn't need this logic at all, and that we could just use the `this.expression.dynamic_dependencies().length > 0` check for everything that wasn't a function, regardless of whether it was an identifier. This seemed to work, and didn't break any existing tests, and was simpler as a bonus.