### PR TITLE
Suggest not using the word "outroing"

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -795,7 +795,7 @@ transition = (node: HTMLElement, params: any) => {
 
 A transition is triggered by an element entering or leaving the DOM as a result of a state change.
 
-Elements inside an *outroing* block are kept in the DOM until all current transitions have completed.
+When a block is transitioning out, elements inside the block are kept in the DOM until all current transitions have completed.
 
 The `transition:` directive indicates a *bidirectional* transition, which means it can be smoothly reversed while the transition is in progress.
 


### PR DESCRIPTION
I've rewritten a sentence to avoid using the word "outroing". I came here thinking it was a typo of "outgoing", but discovered it is a term used internally with Svelte. I think the term is confusing and does not help people to learn Svelte.

Thanks!



### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
