### PR TITLE
Remove CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@
     <img src="https://img.shields.io/npm/v/svelte.svg" alt="npm version">
   </a>
 
-  <a href="https://github.com/sveltejs/svelte/actions">
-    <img src="https://github.com/sveltejs/svelte/workflows/CI/badge.svg?branch=master"
-         alt="build status">
-  </a>
-
   <a href="https://github.com/sveltejs/svelte/blob/master/LICENSE">
     <img src="https://img.shields.io/npm/l/svelte.svg" alt="license">
   </a>


### PR DESCRIPTION
https://twitter.com/SankarSanjay/status/1230793772159488000

I'm not sure it adds anything, but it does have the ability to make people think the code isn't solid. Particularly when it's right next to the npm badge, it kinda looks like the current version didn't pass CI