### PR TITLE
repl: multiple dots in filename not supported when reloading a saved project in REPL

### DIFF
--- a/site/src/routes/repl/[id]/index.svelte
+++ b/site/src/routes/repl/[id]/index.svelte
@@ -57,7 +57,10 @@
 					is_relaxed_gist = data.relaxed;
 
 					const components = data.files.map(file => {
-						let [name, type] = file.name.split('.');
+						const dot = file.name.lastIndexOf(".");
+						let name = file.name.slice(0, dot);
+						let type = file.name.slice(dot + 1);
+
 						if (type === 'html') type = 'svelte'; // TODO do this on the server
 						return { name, type, source: file.source };
 					});


### PR DESCRIPTION
When reloading a saved project in the REPL with a file containing multiple dots (like `example.store.js`), the file will be reload with an uncomplete name (=> `example.store`) and imports will break.

Example REPL generating this error : https://svelte.dev/repl/e16ae6e77ec94412b296dc7af897ac85?version=3.18.2 

This error can be fix by using the last dot in filename for splitting (`lastIndexOf('.')`)  instead of `let [name, type] = file.name.split('.');` :blush: 
