### PR TITLE
Use SSR rendered as initial html for runtime hydration test

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -232,12 +232,7 @@ export default class ElementWrapper extends Wrapper {
 	render(block: Block, parent_node: Identifier, parent_nodes: Identifier) {
 		const { renderer } = this;
 
-		if (this.node.name === 'noscript') {
-			if (renderer.options.hydratable) {
-				block.chunks.claim.push(b`@claim_noscript(${parent_nodes});`);
-			}
-			return;
-		}
+		if (this.node.name === 'noscript') return;
 
 		const node = this.var;
 		const nodes = parent_nodes && block.get_unique_name(`${this.var.name}_nodes`); // if we're in unclaimable territory, i.e. <head>, parent_nodes is null

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -232,7 +232,12 @@ export default class ElementWrapper extends Wrapper {
 	render(block: Block, parent_node: Identifier, parent_nodes: Identifier) {
 		const { renderer } = this;
 
-		if (this.node.name === 'noscript') return;
+		if (this.node.name === 'noscript') {
+			if (renderer.options.hydratable) {
+				block.chunks.claim.push(b`@claim_noscript(${parent_nodes});`);
+			}
+			return;
+		}
 
 		const node = this.var;
 		const nodes = parent_nodes && block.get_unique_name(`${this.var.name}_nodes`); // if we're in unclaimable territory, i.e. <head>, parent_nodes is null

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -374,7 +374,7 @@ export default class ElementWrapper extends Wrapper {
 	get_claim_statement(nodes: Identifier) {
 		const attributes = this.attributes
 			.filter((attr) => !(attr instanceof SpreadAttributeWrapper) && !attr.property_name)
-			.map((attr) => p`${fix_attribute_casing(attr.node.name)}: true`);
+			.map((attr) => p`${attr.name}: true`);
 
 		const name = this.node.namespace
 			? this.node.name

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -374,7 +374,7 @@ export default class ElementWrapper extends Wrapper {
 	get_claim_statement(nodes: Identifier) {
 		const attributes = this.node.attributes
 			.filter((attr) => attr.type === 'Attribute')
-			.map((attr) => p`${attr.name}: true`);
+			.map((attr) => p`${fix_attribute_casing(attr.name)}: true`);
 
 		const name = this.node.namespace
 			? this.node.name

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -374,7 +374,7 @@ export default class ElementWrapper extends Wrapper {
 	get_claim_statement(nodes: Identifier) {
 		const attributes = this.attributes
 			.filter((attr) => !(attr instanceof SpreadAttributeWrapper) && !attr.property_name)
-			.map((attr) => p`${attr.name}: true`);
+			.map((attr) => p`${(attr as StyleAttributeWrapper | AttributeWrapper).name}: true`);
 
 		const name = this.node.namespace
 			? this.node.name

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -372,9 +372,9 @@ export default class ElementWrapper extends Wrapper {
 	}
 
 	get_claim_statement(nodes: Identifier) {
-		const attributes = this.node.attributes
-			.filter((attr) => attr.type === 'Attribute')
-			.map((attr) => p`${fix_attribute_casing(attr.name)}: true`);
+		const attributes = this.attributes
+			.filter((attr) => attr.node.type === 'Attribute' && !attr.get_property_name())
+			.map((attr) => p`${fix_attribute_casing(attr.node.name)}: true`);
 
 		const name = this.node.namespace
 			? this.node.name

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -373,7 +373,7 @@ export default class ElementWrapper extends Wrapper {
 
 	get_claim_statement(nodes: Identifier) {
 		const attributes = this.attributes
-			.filter((attr) => attr.node.type === 'Attribute' && !attr.get_property_name())
+			.filter((attr) => !(attr instanceof SpreadAttributeWrapper) && !attr.property_name)
 			.map((attr) => p`${fix_attribute_casing(attr.node.name)}: true`);
 
 		const name = this.node.namespace

--- a/src/compiler/compile/render_dom/wrappers/RawMustacheTag.ts
+++ b/src/compiler/compile/render_dom/wrappers/RawMustacheTag.ts
@@ -51,8 +51,11 @@ export default class RawMustacheTagWrapper extends Tag {
 
 			const update_anchor = needs_anchor ? html_anchor : this.next ? this.next.var : 'null';
 
-			block.chunks.hydrate.push(b`${html_tag} = new @HtmlTag(${update_anchor});`);
-			block.chunks.mount.push(b`${html_tag}.m(${init}, ${parent_node || '#target'}, ${parent_node ? null : '#anchor'});`);
+			block.chunks.create.push(b`${html_tag} = new @HtmlTag(${update_anchor});`);
+			if (this.renderer.options.hydratable) {
+				block.chunks.claim.push(b`${html_tag} = @claim_html_tag(${update_anchor}, ${_parent_nodes});`);
+			}
+			block.chunks.mount.push(b`${html_tag}.m(${init}, ${parent_node || '#target'}, ${parent_node ? null : 'anchor'});`);
 
 			if (needs_anchor) {
 				block.add_element(html_anchor, x`@empty()`, x`@empty()`, parent_node);

--- a/src/compiler/compile/render_dom/wrappers/RawMustacheTag.ts
+++ b/src/compiler/compile/render_dom/wrappers/RawMustacheTag.ts
@@ -51,11 +51,12 @@ export default class RawMustacheTagWrapper extends Tag {
 
 			const update_anchor = needs_anchor ? html_anchor : this.next ? this.next.var : 'null';
 
-			block.chunks.create.push(b`${html_tag} = new @HtmlTag(${update_anchor});`);
+			block.chunks.create.push(b`${html_tag} = new @HtmlTag();`);
 			if (this.renderer.options.hydratable) {
-				block.chunks.claim.push(b`${html_tag} = @claim_html_tag(${update_anchor}, ${_parent_nodes});`);
+				block.chunks.claim.push(b`${html_tag} = @claim_html_tag(${_parent_nodes});`);
 			}
-			block.chunks.mount.push(b`${html_tag}.m(${init}, ${parent_node || '#target'}, ${parent_node ? null : 'anchor'});`);
+			block.chunks.hydrate.push(b`${html_tag}.a = ${update_anchor};`);
+			block.chunks.mount.push(b`${html_tag}.m(${init}, ${parent_node || '#target'}, ${parent_node ? null : '#anchor'});`);
 
 			if (needs_anchor) {
 				block.add_element(html_anchor, x`@empty()`, x`@empty()`, parent_node);

--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -7,6 +7,7 @@ import { x } from 'code-red';
 import Expression from '../../nodes/shared/Expression';
 import remove_whitespace_children from './utils/remove_whitespace_children';
 import fix_attribute_casing from '../../render_dom/wrappers/Element/fix_attribute_casing';
+import { namespaces } from '../../../utils/namespaces';
 
 export default function(node: Element, renderer: Renderer, options: RenderOptions) {
 
@@ -42,20 +43,21 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 			if (attribute.is_spread) {
 				args.push(attribute.expression.node);
 			} else {
+				const attr_name = node.namespace === namespaces.foreign ? attribute.name : fix_attribute_casing(attribute.name);
 				const name = attribute.name.toLowerCase();
 				if (name === 'value' && node.name.toLowerCase() === 'textarea') {
 					node_contents = get_attribute_value(attribute);
 				} else if (attribute.is_true) {
-					args.push(x`{ ${fix_attribute_casing(attribute.name)}: true }`);
+					args.push(x`{ ${attr_name}: true }`);
 				} else if (
 					boolean_attributes.has(name) &&
 					attribute.chunks.length === 1 &&
 					attribute.chunks[0].type !== 'Text'
 				) {
 					// a boolean attribute with one non-Text chunk
-					args.push(x`{ ${fix_attribute_casing(attribute.name)}: ${(attribute.chunks[0] as Expression).node} || null }`);
+					args.push(x`{ ${attr_name}: ${(attribute.chunks[0] as Expression).node} || null }`);
 				} else {
-					args.push(x`{ ${fix_attribute_casing(attribute.name)}: ${get_attribute_value(attribute)} }`);
+					args.push(x`{ ${attr_name}: ${get_attribute_value(attribute)} }`);
 				}
 			}
 		});
@@ -65,10 +67,11 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 		let add_class_attribute = !!class_expression;
 		node.attributes.forEach(attribute => {
 			const name = attribute.name.toLowerCase();
+			const attr_name = node.namespace === namespaces.foreign ? attribute.name : fix_attribute_casing(attribute.name);
 			if (name === 'value' && node.name.toLowerCase() === 'textarea') {
 				node_contents = get_attribute_value(attribute);
 			} else if (attribute.is_true) {
-				renderer.add_string(` ${fix_attribute_casing(attribute.name)}`);
+				renderer.add_string(` ${attr_name}`);
 			} else if (
 				boolean_attributes.has(name) &&
 				attribute.chunks.length === 1 &&
@@ -76,17 +79,17 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 			) {
 				// a boolean attribute with one non-Text chunk
 				renderer.add_string(' ');
-				renderer.add_expression(x`${(attribute.chunks[0] as Expression).node} ? "${fix_attribute_casing(attribute.name)}" : ""`);
+				renderer.add_expression(x`${(attribute.chunks[0] as Expression).node} ? "${attr_name}" : ""`);
 			} else if (name === 'class' && class_expression) {
 				add_class_attribute = false;
-				renderer.add_string(` ${fix_attribute_casing(attribute.name)}="`);
+				renderer.add_string(` ${attr_name}="`);
 				renderer.add_expression(x`[${get_class_attribute_value(attribute)}, ${class_expression}].join(' ').trim()`);
 				renderer.add_string('"');
 			} else if (attribute.chunks.length === 1 && attribute.chunks[0].type !== 'Text') {
 				const snippet = (attribute.chunks[0] as Expression).node;
-				renderer.add_expression(x`@add_attribute("${fix_attribute_casing(attribute.name)}", ${snippet}, ${boolean_attributes.has(name) ? 1 : 0})`);
+				renderer.add_expression(x`@add_attribute("${attr_name}", ${snippet}, ${boolean_attributes.has(name) ? 1 : 0})`);
 			} else {
-				renderer.add_string(` ${fix_attribute_casing(attribute.name)}="`);
+				renderer.add_string(` ${attr_name}="`);
 				renderer.add_expression((name === 'class' ? get_class_attribute_value : get_attribute_value)(attribute));
 				renderer.add_string('"');
 			}

--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -6,6 +6,7 @@ import Element from '../../nodes/Element';
 import { x } from 'code-red';
 import Expression from '../../nodes/shared/Expression';
 import remove_whitespace_children from './utils/remove_whitespace_children';
+import fix_attribute_casing from '../../render_dom/wrappers/Element/fix_attribute_casing';
 
 export default function(node: Element, renderer: Renderer, options: RenderOptions) {
 
@@ -45,16 +46,16 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 				if (name === 'value' && node.name.toLowerCase() === 'textarea') {
 					node_contents = get_attribute_value(attribute);
 				} else if (attribute.is_true) {
-					args.push(x`{ ${attribute.name}: true }`);
+					args.push(x`{ ${fix_attribute_casing(attribute.name)}: true }`);
 				} else if (
 					boolean_attributes.has(name) &&
 					attribute.chunks.length === 1 &&
 					attribute.chunks[0].type !== 'Text'
 				) {
 					// a boolean attribute with one non-Text chunk
-					args.push(x`{ ${attribute.name}: ${(attribute.chunks[0] as Expression).node} || null }`);
+					args.push(x`{ ${fix_attribute_casing(attribute.name)}: ${(attribute.chunks[0] as Expression).node} || null }`);
 				} else {
-					args.push(x`{ ${attribute.name}: ${get_attribute_value(attribute)} }`);
+					args.push(x`{ ${fix_attribute_casing(attribute.name)}: ${get_attribute_value(attribute)} }`);
 				}
 			}
 		});
@@ -67,7 +68,7 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 			if (name === 'value' && node.name.toLowerCase() === 'textarea') {
 				node_contents = get_attribute_value(attribute);
 			} else if (attribute.is_true) {
-				renderer.add_string(` ${attribute.name}`);
+				renderer.add_string(` ${fix_attribute_casing(attribute.name)}`);
 			} else if (
 				boolean_attributes.has(name) &&
 				attribute.chunks.length === 1 &&
@@ -75,17 +76,17 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 			) {
 				// a boolean attribute with one non-Text chunk
 				renderer.add_string(' ');
-				renderer.add_expression(x`${(attribute.chunks[0] as Expression).node} ? "${attribute.name}" : ""`);
+				renderer.add_expression(x`${(attribute.chunks[0] as Expression).node} ? "${fix_attribute_casing(attribute.name)}" : ""`);
 			} else if (name === 'class' && class_expression) {
 				add_class_attribute = false;
-				renderer.add_string(` ${attribute.name}="`);
+				renderer.add_string(` ${fix_attribute_casing(attribute.name)}="`);
 				renderer.add_expression(x`[${get_class_attribute_value(attribute)}, ${class_expression}].join(' ').trim()`);
 				renderer.add_string('"');
 			} else if (attribute.chunks.length === 1 && attribute.chunks[0].type !== 'Text') {
 				const snippet = (attribute.chunks[0] as Expression).node;
-				renderer.add_expression(x`@add_attribute("${attribute.name}", ${snippet}, ${boolean_attributes.has(name) ? 1 : 0})`);
+				renderer.add_expression(x`@add_attribute("${fix_attribute_casing(attribute.name)}", ${snippet}, ${boolean_attributes.has(name) ? 1 : 0})`);
 			} else {
-				renderer.add_string(` ${attribute.name}="`);
+				renderer.add_string(` ${fix_attribute_casing(attribute.name)}="`);
 				renderer.add_expression((name === 'class' ? get_class_attribute_value : get_attribute_value)(attribute));
 				renderer.add_string('"');
 			}

--- a/src/compiler/compile/render_ssr/handlers/HtmlTag.ts
+++ b/src/compiler/compile/render_ssr/handlers/HtmlTag.ts
@@ -3,7 +3,7 @@ import RawMustacheTag from '../../nodes/RawMustacheTag';
 import { Expression } from 'estree';
 
 export default function(node: RawMustacheTag, renderer: Renderer, _options: RenderOptions) {
-	renderer.add_string('<!-- HTML_TAG_START -->');
+	if (options.hydratable) renderer.add_string('<!-- HTML_TAG_START -->');
 	renderer.add_expression(node.expression.node as Expression);
-	renderer.add_string('<!-- HTML_TAG_END -->');
+	if (options.hydratable) renderer.add_string('<!-- HTML_TAG_END -->');
 }

--- a/src/compiler/compile/render_ssr/handlers/HtmlTag.ts
+++ b/src/compiler/compile/render_ssr/handlers/HtmlTag.ts
@@ -3,5 +3,7 @@ import RawMustacheTag from '../../nodes/RawMustacheTag';
 import { Expression } from 'estree';
 
 export default function(node: RawMustacheTag, renderer: Renderer, _options: RenderOptions) {
+	renderer.add_string('<!-- HTML_TAG_START -->');
 	renderer.add_expression(node.expression.node as Expression);
+	renderer.add_string('<!-- HTML_TAG_END -->');
 }

--- a/src/compiler/compile/render_ssr/handlers/HtmlTag.ts
+++ b/src/compiler/compile/render_ssr/handlers/HtmlTag.ts
@@ -2,7 +2,7 @@ import Renderer, { RenderOptions } from '../Renderer';
 import RawMustacheTag from '../../nodes/RawMustacheTag';
 import { Expression } from 'estree';
 
-export default function(node: RawMustacheTag, renderer: Renderer, _options: RenderOptions) {
+export default function(node: RawMustacheTag, renderer: Renderer, options: RenderOptions) {
 	if (options.hydratable) renderer.add_string('<!-- HTML_TAG_START -->');
 	renderer.add_expression(node.expression.node as Expression);
 	if (options.hydratable) renderer.add_string('<!-- HTML_TAG_END -->');

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -201,17 +201,17 @@ function find_comment(nodes, text, start) {
 	return nodes.length;
 }
 
-export function claim_html_tag(update_anchor, nodes) {
+export function claim_html_tag(nodes) {
 	// find html opening tag
 	const start_index = find_comment(nodes, 'HTML_TAG_START', 0);
 	const end_index = find_comment(nodes, 'HTML_TAG_END', start_index);
 	if (start_index === end_index) {
-		return new HtmlTag(update_anchor);
+		return new HtmlTag();
 	}
 	const html_tag_nodes = nodes.splice(start_index, end_index + 1);
 	detach(html_tag_nodes[0]);
 	detach(html_tag_nodes[html_tag_nodes.length - 1]);
-	return new HtmlTag(update_anchor, html_tag_nodes.slice(1, html_tag_nodes.length - 1));
+	return new HtmlTag(html_tag_nodes.slice(1, html_tag_nodes.length - 1));
 }
 
 export function set_data(text, data) {
@@ -352,8 +352,7 @@ export class HtmlTag {
 	// anchor
 	a: HTMLElement;
 
-	constructor(anchor: HTMLElement = null, claimed_nodes?: ChildNode[]) {
-		this.a = anchor;
+	constructor(claimed_nodes?: ChildNode[]) {
 		this.e = this.n = null;
 		this.l = claimed_nodes;
 	}

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -191,10 +191,6 @@ export function claim_space(nodes) {
 	return claim_text(nodes, ' ');
 }
 
-export function claim_noscript(nodes) {
-	detach(claim_element(nodes, 'NOSCRIPT', {}, false));
-}
-
 function find_comment(nodes, text, start) {
 	for (let i = start; i < nodes.length; i += 1) {
 		const node = nodes[i];

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -191,6 +191,33 @@ export function claim_space(nodes) {
 	return claim_text(nodes, ' ');
 }
 
+export function claim_noscript(nodes) {
+	detach(claim_element(nodes, 'NOSCRIPT', {}, false));
+}
+
+function find_comment(nodes, text, start) {
+	for (let i = start; i < nodes.length; i += 1) {
+		const node = nodes[i];
+		if (node.nodeType === 8 /* comment node */ && node.textContent.trim() === text) {
+			return i;
+		}
+	}
+	return nodes.length;
+}
+
+export function claim_html_tag(update_anchor, nodes) {
+	// find html opening tag
+	const start_index = find_comment(nodes, 'HTML_TAG_START', 0);
+	const end_index = find_comment(nodes, 'HTML_TAG_END', start_index);
+	if (start_index === end_index) {
+		return new HtmlTag(update_anchor);
+	}
+	const html_tag_nodes = nodes.splice(start_index, end_index + 1);
+	detach(html_tag_nodes[0]);
+	detach(html_tag_nodes[html_tag_nodes.length - 1]);
+	return new HtmlTag(update_anchor, html_tag_nodes.slice(1, html_tag_nodes.length - 1));
+}
+
 export function set_data(text, data) {
 	data = '' + data;
 	if (text.wholeText !== data) text.data = data;
@@ -318,27 +345,38 @@ export function query_selector_all(selector: string, parent: HTMLElement = docum
 }
 
 export class HtmlTag {
+	// parent for creating node
 	e: HTMLElement;
+	// html tag nodes
 	n: ChildNode[];
+	// hydration claimed nodes
+	l: ChildNode[] | void;
+	// target
 	t: HTMLElement;
+	// anchor
 	a: HTMLElement;
 
-	constructor(anchor: HTMLElement = null) {
+	constructor(anchor: HTMLElement = null, claimed_nodes?: ChildNode[]) {
 		this.a = anchor;
 		this.e = this.n = null;
+		this.l = claimed_nodes;
 	}
 
 	m(html: string, target: HTMLElement, anchor: HTMLElement = null) {
 		if (!this.e) {
 			this.e = element(target.nodeName as keyof HTMLElementTagNameMap);
 			this.t = target;
-			this.h(html);
+			if (this.l) {
+				this.n = this.l;
+			} else {
+				this.h(html);
+			}
 		}
 
 		this.i(anchor);
 	}
 
-	h(html) {
+	h(html: string) {
 		this.e.innerHTML = html;
 		this.n = Array.from(this.e.childNodes);
 	}

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -52,9 +52,9 @@ function create_each_block(ctx) {
 			t4 = text(t4_value);
 			t5 = text(" ago:");
 			t6 = space();
-			html_tag = new HtmlTag(raw_value);
+			html_tag = new HtmlTag();
 			attr(span, "class", "meta");
-			html_tag = new HtmlTag(null);
+			html_tag.a = null;
 			attr(div, "class", "comment");
 		},
 		m(target, anchor) {

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -52,6 +52,7 @@ function create_each_block(ctx) {
 			t4 = text(t4_value);
 			t5 = text(" ago:");
 			t6 = space();
+			html_tag = new HtmlTag(raw_value);
 			attr(span, "class", "meta");
 			html_tag = new HtmlTag(null);
 			attr(div, "class", "comment");

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -49,7 +49,7 @@ describe('runtime', () => {
 
 	const failed = new Set();
 
-	function runTest(dir, hydrate) {
+	function runTest(dir, hydrate, from_ssr_html) {
 		if (dir[0] === '.') return;
 
 		const config = loadConfig(`${__dirname}/samples/${dir}/_config.js`);
@@ -61,7 +61,8 @@ describe('runtime', () => {
 			throw new Error('Forgot to remove `solo: true` from test');
 		}
 
-		(config.skip ? it.skip : solo ? it.only : it)(`${dir} ${hydrate ? '(with hydration)' : ''}`, () => {
+		const testName = `${dir} ${hydrate ? `(with hydration ${from_ssr_html ? 'from ssr rendered html' : ''})` : ''}`;
+		(config.skip ? it.skip : solo ? it.only : it)(testName, () => {
 			if (failed.has(dir)) {
 				// this makes debugging easier, by only printing compiled output once
 				throw new Error('skipping test, already failed');
@@ -151,7 +152,7 @@ describe('runtime', () => {
 
 					const target = window.document.querySelector('main');
 
-					if (hydrate) {
+					if (hydrate && from_ssr_html) {
 						// ssr into target
 						compileOptions.generate = 'ssr';
 						cleanRequireCache();
@@ -255,7 +256,8 @@ describe('runtime', () => {
 
 	fs.readdirSync(`${__dirname}/samples`).forEach(dir => {
 		runTest(dir, false);
-		runTest(dir, true);
+		runTest(dir, true, false);
+		runTest(dir, true, true);
 	});
 
 	async function create_component(src = '<div></div>') {

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -153,6 +153,17 @@ describe('runtime', () => {
 
 					const target = window.document.querySelector('main');
 
+					if (hydrate) {
+						// ssr into target
+						compileOptions.generate = 'ssr';
+						cleanRequireCache();
+						const SsrSvelteComponent = require(`./samples/${dir}/main.svelte`).default;
+						const { html } = SsrSvelteComponent.render(config.props);
+						target.innerHTML = html;
+
+						delete compileOptions.generate;
+					}
+
 					const warnings = [];
 					const warn = console.warn;
 					console.warn = warning => {
@@ -182,7 +193,9 @@ describe('runtime', () => {
 						throw new Error('Received unexpected warnings');
 					}
 
-					if (config.html) {
+					if (hydrate && config.ssrHtml) {
+						assert.htmlEqual(target.innerHTML, config.ssrHtml);
+					} else if (config.html) {
 						assert.htmlEqual(target.innerHTML, config.html);
 					}
 

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -56,6 +56,7 @@ describe('runtime', () => {
 		const solo = config.solo || /\.solo/.test(dir);
 
 		if (hydrate && config.skip_if_hydrate) return;
+		if (hydrate && from_ssr_html && config.skip_if_hydrate_from_ssr) return;
 
 		if (solo && process.env.CI) {
 			throw new Error('Forgot to remove `solo: true` from test');
@@ -160,6 +161,8 @@ describe('runtime', () => {
 						const { html } = SsrSvelteComponent.render(config.props);
 						target.innerHTML = html;
 						delete compileOptions.generate;
+					} else {
+						target.innerHTML = '';
 					}
 
 					if (config.before_test) config.before_test();

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -62,7 +62,7 @@ describe('runtime', () => {
 			throw new Error('Forgot to remove `solo: true` from test');
 		}
 
-		const testName = `${dir} ${hydrate ? `(with hydration ${from_ssr_html ? 'from ssr rendered html' : ''})` : ''}`;
+		const testName = `${dir} ${hydrate ? `(with hydration${from_ssr_html ? ' from ssr rendered html' : ''})` : ''}`;
 		(config.skip ? it.skip : solo ? it.only : it)(testName, () => {
 			if (failed.has(dir)) {
 				// this makes debugging easier, by only printing compiled output once

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -146,8 +146,6 @@ describe('runtime', () => {
 						throw err;
 					}
 
-					if (config.before_test) config.before_test();
-
 					// Put things we need on window for testing
 					window.SvelteComponent = SvelteComponent;
 
@@ -160,9 +158,10 @@ describe('runtime', () => {
 						const SsrSvelteComponent = require(`./samples/${dir}/main.svelte`).default;
 						const { html } = SsrSvelteComponent.render(config.props);
 						target.innerHTML = html;
-
 						delete compileOptions.generate;
 					}
+
+					if (config.before_test) config.before_test();
 
 					const warnings = [];
 					const warn = console.warn;
@@ -193,9 +192,7 @@ describe('runtime', () => {
 						throw new Error('Received unexpected warnings');
 					}
 
-					if (hydrate && config.ssrHtml) {
-						assert.htmlEqual(target.innerHTML, config.ssrHtml);
-					} else if (config.html) {
+					if (config.html) {
 						assert.htmlEqual(target.innerHTML, config.html);
 					}
 

--- a/test/runtime/samples/attribute-boolean-indeterminate/_config.js
+++ b/test/runtime/samples/attribute-boolean-indeterminate/_config.js
@@ -7,13 +7,11 @@ export default {
 		indeterminate: true
 	},
 
-	html: `
-		<input type='checkbox'>
-	`,
+	html: '<input type=\'checkbox\'>',
 
 	// somehow ssr will render indeterminate=""
 	// the hydrated html will still contain that attribute
-	ssrHtml: `<input type='checkbox' indeterminate="">`,
+	ssrHtml: '<input type=\'checkbox\' indeterminate="">',
 
 	test({ assert, component, target }) {
 		const input = target.querySelector('input');

--- a/test/runtime/samples/attribute-boolean-indeterminate/_config.js
+++ b/test/runtime/samples/attribute-boolean-indeterminate/_config.js
@@ -11,6 +11,10 @@ export default {
 		<input type='checkbox'>
 	`,
 
+	// somehow ssr will render indeterminate=""
+	// the hydrated html will still contain that attribute
+	ssrHtml: `<input type='checkbox' indeterminate="">`,
+
 	test({ assert, component, target }) {
 		const input = target.querySelector('input');
 

--- a/test/runtime/samples/attribute-boolean-indeterminate/_config.js
+++ b/test/runtime/samples/attribute-boolean-indeterminate/_config.js
@@ -7,11 +7,11 @@ export default {
 		indeterminate: true
 	},
 
-	html: '<input type=\'checkbox\'>',
+	html: "<input type='checkbox'>",
 
 	// somehow ssr will render indeterminate=""
 	// the hydrated html will still contain that attribute
-	ssrHtml: '<input type=\'checkbox\' indeterminate="">',
+	ssrHtml: "<input type='checkbox' indeterminate=''>",
 
 	test({ assert, component, target }) {
 		const input = target.querySelector('input');

--- a/test/runtime/samples/attribute-casing-foreign-namespace-compiler-option/_config.js
+++ b/test/runtime/samples/attribute-casing-foreign-namespace-compiler-option/_config.js
@@ -11,6 +11,7 @@ export default {
 	options: {
 		hydrate: false // Hydration test will fail as case sensitivity is only handled for svg elements.
 	},
+	skip_if_hydrate_from_ssr: true,
 	compileOptions: {
 		namespace: 'foreign'
 	},

--- a/test/runtime/samples/attribute-casing-foreign-namespace/_config.js
+++ b/test/runtime/samples/attribute-casing-foreign-namespace/_config.js
@@ -9,6 +9,7 @@ export default {
 	options: {
 		hydrate: false // Hydration test will fail as case sensitivity is only handled for svg elements.
 	},
+	skip_if_hydrate_from_ssr: true,
 
 	test({ assert, target }) {
 		const attr = sel => target.querySelector(sel).attributes[0].name;

--- a/test/runtime/samples/attribute-dynamic-type/_config.js
+++ b/test/runtime/samples/attribute-dynamic-type/_config.js
@@ -1,12 +1,11 @@
 export default {
-	skip_if_ssr: true,
-
 	props: {
 		inputType: 'text',
 		inputValue: 42
 	},
 
 	html: '<input type="text">',
+	ssrHtml: '<input type="text" value="42">',
 
 	test({ assert, component, target }) {
 		const input = target.querySelector('input');

--- a/test/runtime/samples/binding-this-each-block-property-2/_config.js
+++ b/test/runtime/samples/binding-this-each-block-property-2/_config.js
@@ -7,7 +7,7 @@ export default {
 	props: {
 		callback
 	},
-	after_test() {
+	before_test() {
 		calls = [];
 	},
 	async test({ assert, component, target }) {

--- a/test/runtime/samples/component-namespaced/_config.js
+++ b/test/runtime/samples/component-namespaced/_config.js
@@ -9,10 +9,6 @@ export default {
 		<p>foo 1</p>
 	`,
 
-	before_test() {
-		delete require.cache[path.resolve(__dirname, 'components.js')];
-	},
-
 	test({ assert, component, target }) {
 		component.a = 2;
 		assert.htmlEqual(target.innerHTML, `

--- a/test/runtime/samples/component-namespaced/_config.js
+++ b/test/runtime/samples/component-namespaced/_config.js
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 export default {
 	props: {
 		a: 1

--- a/test/runtime/samples/component-namespaced/components.js
+++ b/test/runtime/samples/component-namespaced/components.js
@@ -1,3 +1,0 @@
-import Foo from './Foo.svelte';
-
-export default { Foo };

--- a/test/runtime/samples/component-namespaced/components.svelte
+++ b/test/runtime/samples/component-namespaced/components.svelte
@@ -1,0 +1,5 @@
+<script context="module">
+  import Foo from './Foo.svelte';
+
+  export const Components = { Foo };
+</script>

--- a/test/runtime/samples/component-namespaced/main.svelte
+++ b/test/runtime/samples/component-namespaced/main.svelte
@@ -1,5 +1,5 @@
 <script>
-	import Components from './components.js';
+	import { Components } from './components.svelte';
 
 	export let a;
 </script>

--- a/test/runtime/samples/deconflict-builtins-2/_config.js
+++ b/test/runtime/samples/deconflict-builtins-2/_config.js
@@ -1,4 +1,4 @@
 export default {
-	html: '<text>hello world</text>',
+	html: '<svg><text>hello world</text></svg>',
 	preserveIdentifiers: true
 };

--- a/test/runtime/samples/deconflict-builtins-2/main.svelte
+++ b/test/runtime/samples/deconflict-builtins-2/main.svelte
@@ -1,5 +1,6 @@
 <script>
 	let foo = 'hello world'
 </script>
-
-<text>{foo}</text>
+<svg>
+	<text>{foo}</text>
+</svg>

--- a/test/runtime/samples/each-block-keyed-dyanmic-key/_config.js
+++ b/test/runtime/samples/each-block-keyed-dyanmic-key/_config.js
@@ -9,6 +9,10 @@ export default {
 		}
 	},
 
+	before_test() {
+		count = 0;
+	},
+
 	html: `
 		<div>foo</div>
 		<div>foo</div>

--- a/test/runtime/samples/if-block-conservative-update/_config.js
+++ b/test/runtime/samples/if-block-conservative-update/_config.js
@@ -11,6 +11,9 @@ export default {
 
 	html: '<p>potato</p>',
 
+	before_test() {
+		count = 0;
+	},
 	test({ assert, component, target }) {
 		assert.equal(count, 1);
 

--- a/test/runtime/samples/if-block-else-conservative-update/_config.js
+++ b/test/runtime/samples/if-block-else-conservative-update/_config.js
@@ -17,6 +17,11 @@ export default {
 
 	html: '<p>potato</p>',
 
+	before_test() {
+		count_a = 0;
+		count_b = 0;
+	},
+
 	test({ assert, component, target }) {
 		assert.equal(count_a, 1);
 		assert.equal(count_b, 0);

--- a/test/runtime/samples/lifecycle-render-order-for-children/_config.js
+++ b/test/runtime/samples/lifecycle-render-order-for-children/_config.js
@@ -2,7 +2,9 @@ import order from './order.js';
 
 export default {
 	skip_if_ssr: true,
-
+	before_test() {
+		order.length = 0;
+	},
 	test({ assert, component, target, compileOptions }) {
 		if (compileOptions.hydratable) {
 			assert.deepEqual(order, [
@@ -43,7 +45,5 @@ export default {
 				'0: afterUpdate'
 			]);
 		}
-
-		order.length = 0;
 	}
 };

--- a/test/runtime/samples/lifecycle-render-order/_config.js
+++ b/test/runtime/samples/lifecycle-render-order/_config.js
@@ -3,6 +3,9 @@ import order from './order.js';
 export default {
 	skip_if_ssr: true,
 
+	before_test() {
+		order.length = 0;
+	},
 	test({ assert }) {
 		assert.deepEqual(order, [
 			'beforeUpdate',
@@ -10,7 +13,5 @@ export default {
 			'onMount',
 			'afterUpdate'
 		]);
-
-		order.length = 0;
 	}
 };

--- a/test/runtime/samples/noscript-removal/_config.js
+++ b/test/runtime/samples/noscript-removal/_config.js
@@ -1,9 +1,14 @@
 export default {
-	skip_if_ssr: true,
-
 	html: `
 	<div>foo</div>
 
 	<div>foo<div>foo</div></div>
-`
+	`,
+	ssrHtml: `
+	<noscript>foo</noscript>
+
+	<div>foo<noscript>foo</noscript></div>
+
+	<div>foo<div>foo<noscript>foo</noscript></div></div>
+	`
 };

--- a/test/runtime/samples/noscript-removal/_config.js
+++ b/test/runtime/samples/noscript-removal/_config.js
@@ -1,14 +1,33 @@
 export default {
-	html: `
-	<div>foo</div>
-
-	<div>foo<div>foo</div></div>
-	`,
 	ssrHtml: `
 	<noscript>foo</noscript>
 
 	<div>foo<noscript>foo</noscript></div>
 
 	<div>foo<div>foo<noscript>foo</noscript></div></div>
-	`
+	`,
+	test({ assert, target, compileOptions }) {
+		// if created on client side, should not build noscript
+		if (!compileOptions.hydratable) {
+			assert.equal(target.querySelectorAll('noscript').length, 0);
+		}
+
+		// it's okay not to remove the node during hydration
+		// will not be seen by user anyway
+		removeNoScript(target);
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<div>foo</div>
+				<div>foo<div>foo</div></div>
+			`
+		);
+	}
 };
+
+function removeNoScript(target) {
+	target.querySelectorAll('noscript').forEach(elem => {
+		elem.parentNode.removeChild(elem);
+	});
+}

--- a/test/runtime/samples/ondestroy-deep/_config.js
+++ b/test/runtime/samples/ondestroy-deep/_config.js
@@ -2,6 +2,9 @@ import { destroyed, reset } from './destroyed.js';
 
 export default {
 	test({ assert, component }) {
+		// for hydration, ssr may have pushed to `destroyed`
+		reset();
+
 		component.visible = false;
 		assert.deepEqual(destroyed, ['A', 'B', 'C']);
 

--- a/test/runtime/samples/raw-anchor-first-child/_config.js
+++ b/test/runtime/samples/raw-anchor-first-child/_config.js
@@ -8,5 +8,6 @@ export default {
 		assert.ok(!span.previousSibling);
 
 		component.raw = '<span>bar</span>';
+		assert.htmlEqual(target.innerHTML, '<div><span>bar</span></div>');
 	}
 };

--- a/test/runtime/samples/raw-mustaches/_config.js
+++ b/test/runtime/samples/raw-mustaches/_config.js
@@ -1,5 +1,4 @@
 export default {
-	skip_if_ssr: true,
 
 	props: {
 		raw: '<span><em>raw html!!!\\o/</span></em>'

--- a/test/runtime/samples/reactive-function-called-reassigned/_config.js
+++ b/test/runtime/samples/reactive-function-called-reassigned/_config.js
@@ -9,6 +9,9 @@ export default {
 	props: {
 		callback
 	},
+	before_test() {
+		called = 0;
+	},
 	async test({ assert, component, target, window }) {
 		assert.equal(called, 1);
 

--- a/test/runtime/samples/store-unreferenced/_config.js
+++ b/test/runtime/samples/store-unreferenced/_config.js
@@ -3,11 +3,13 @@ import { count } from './store.js';
 export default {
 	html: '<p>count: 0</p>',
 
+	before_test() {
+		count.set(0);
+	},
+
 	async test({ assert, component, target }) {
 		await component.increment();
 
 		assert.htmlEqual(target.innerHTML, '<p>count: 1</p>');
-
-		count.set(0);
 	}
 };


### PR DESCRIPTION
When running runtime (hydration) test, we are expecting the component to create the DOM while failing to claim elements from HTML.

This may fail to surface bugs such as hydrated DOM different from client rendered DOM.

Fixes:
- claiming `HtmlTag` element
- hydrating extra attributes from SSR

Not fixed for now:
- claiming `HtmlTag` in head