### PR TITLE
fix dev mode each block validation when using strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svelte changelog
 
+## Unreleased
+
+* Fix dev mode validation of `{#each}` blocks using strings ([#4450](https://github.com/sveltejs/svelte/issues/4450))
+
 ## 3.19.0
 
 * Fix indirect bindings involving elements with spreads ([#3680](https://github.com/sveltejs/svelte/issues/3680))

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -80,7 +80,7 @@ export function set_data_dev(text, data) {
 }
 
 export function validate_each_argument(arg) {
-	if (!arg || !('length' in arg)) {
+	if (typeof arg !== 'string' && !(arg && typeof arg === 'object' && 'length' in arg)) {
 		let msg = '{#each} only iterates over array-like objects.';
 		if (typeof Symbol === 'function' && arg && Symbol.iterator in arg) {
 			msg += ' You can use a spread to convert this iterable into an array.';

--- a/test/runtime/samples/each-block-string/_config.js
+++ b/test/runtime/samples/each-block-string/_config.js
@@ -1,0 +1,10 @@
+export default {
+	compileOptions: {
+		dev: true
+	},
+	html: `
+		<div>f</div>
+		<div>o</div>
+		<div>o</div>
+	`
+};

--- a/test/runtime/samples/each-block-string/main.svelte
+++ b/test/runtime/samples/each-block-string/main.svelte
@@ -1,0 +1,3 @@
+{#each 'foo' as c}
+	<div>{c}</div>
+{/each}


### PR DESCRIPTION
Fixes #4450. `'length' in str` is a runtime error, so we now check whether it's a string _or_ a truthy object with a `length` key. I can't think of a case where we might want to allow another value type, like `function` for example.