### PR TITLE
don't treat $$-names as stores during invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Do not treat modifications to `$$props` as updates to a store called `$props` ([#4368](https://github.com/sveltejs/svelte/issues/4368))
 * Deconflict `value` parameter name used in contextual bindings ([#4445](https://github.com/sveltejs/svelte/issues/4445))
 * Fix dev mode validation of `{#each}` blocks using strings ([#4450](https://github.com/sveltejs/svelte/issues/4450))
 

--- a/src/compiler/compile/render_dom/invalidate.ts
+++ b/src/compiler/compile/render_dom/invalidate.ts
@@ -43,7 +43,7 @@ export function invalidate(renderer: Renderer, scope: Scope, node: Node, names: 
 		if (node.type === 'AssignmentExpression' && node.operator === '=' && nodes_match(node.left, node.right) && tail.length === 0) {
 			return get_invalidated(head, node);
 		} else {
-			const is_store_value = head.name[0] === '$';
+			const is_store_value = head.name[0] === '$' && head.name[1] !== '$';
 			const extra_args = tail.map(variable => get_invalidated(variable));
 
 			const pass_value = (


### PR DESCRIPTION
Fixes #4368. No tests, and I think I want to kick the can on what actually should happen when writing to `$$props` (should it be a compile-time error?). At the very least, treating it as a subscription to `$props` was definitely wrong.