### PR TITLE
exclude global variables from $capture_state

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -167,7 +167,7 @@ export default function dom(
 			`;
 		}
 
-		const capturable_vars = component.vars.filter(v => !v.internal && !v.name.startsWith('$$'));
+		const capturable_vars = component.vars.filter(v => !v.internal && !v.global && !v.name.startsWith('$$'));
 
 		if (capturable_vars.length > 0) {
 			capture_state = x`() => ({ ${capturable_vars.map(prop => p`${prop.name}`)} })`;

--- a/test/js/samples/loop-protect/expected.js
+++ b/test/js/samples/loop-protect/expected.js
@@ -108,7 +108,7 @@ function instance($$self, $$props, $$invalidate) {
 		});
 	}
 
-	$$self.$capture_state = () => ({ node, foo, console });
+	$$self.$capture_state = () => ({ node, foo });
 
 	$$self.$inject_state = $$props => {
 		if ("node" in $$props) $$invalidate(0, node = $$props.node);


### PR DESCRIPTION
Fixes #4463. As luck would have it, we already have an unrelated test that contains a global (`console`), and so captures the behaviour. I suppose this is good enough for this?