### PR TITLE
fix: ensure spring animation does not have negative start offset

### DIFF
--- a/src/runtime/motion/spring.ts
+++ b/src/runtime/motion/spring.ts
@@ -1,5 +1,5 @@
 import { Readable, writable } from 'svelte/store';
-import { loop, now, Task } from 'svelte/internal';
+import { loop, Task } from 'svelte/internal';
 import { is_date } from './utils';
 
 interface TickContext<T> {
@@ -85,7 +85,7 @@ export function spring<T=any>(value?: T, opts: SpringOpts = {}): Spring<T> {
 
 		if (value == null || opts.hard || (spring.stiffness >= 1 && spring.damping >= 1)) {
 			cancel_task = true; // cancel any running animation
-			last_time = now();
+			last_time = null;
 			last_value = new_value;
 			store.set(value = target_value);
 			return Promise.resolve();
@@ -96,10 +96,12 @@ export function spring<T=any>(value?: T, opts: SpringOpts = {}): Spring<T> {
 		}
 
 		if (!task) {
-			last_time = now();
+			last_time = null;
 			cancel_task = false;
 
 			task = loop(now => {
+
+				if (last_time === null) last_time = now;
 
 				if (cancel_task) {
 					cancel_task = false;


### PR DESCRIPTION
fixes https://github.com/sveltejs/svelte/issues/4468

In some situations animating a spring causes the spring value to animate in the wrong direction for the first tick.

For example, animating `100` to `0`, logging the value inside the spring function shows:

```
100.1 -> 98 -> 87 -> 80 -> all good
```

That `100.1` is problematic, it causes a slight jump at the start of the animation.

### 

As stated in the referenced issue I wasn't able to reproduce this with a test or on the REPL, this PR did solve the issue in my project.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. **Haven’t included a test as I don’t know what causes the issue.**
- [x] Remember to `npm run lint`!

### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`