### PR TITLE
docs: fix store contract type signature

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -175,7 +175,7 @@ Local variables (that do not represent store values) must *not* have a `$` prefi
 ##### Store contract
 
 ```js
-store = { subscribe: (subscription: (value: any) => void) => () => void, set?: (value: any) => void }
+store = { subscribe: (subscription: (value: any) => void) => (() => void), set?: (value: any) => void }
 ```
 
 You can create your own stores without relying on [`svelte/store`](docs#svelte_store), by implementing the *store contract*:


### PR DESCRIPTION
The store contract documentation states that the subscribe method "must return an unsubscribe function", but its signature suggested that it instead took a second, unit argument then returned `void`. This PR adds parentheses to reflect the intended meaning. 

I haven't given a name to the unit argument to the unsubscribe function.