### PR TITLE
Fix else-block update in keyed each-block

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -423,7 +423,7 @@ export default class EachBlockWrapper extends Wrapper {
 		if (all_dependencies.size) {
 			block.chunks.update.push(b`
 				if (${block.renderer.dirty(Array.from(all_dependencies))}) {
-					const ${this.vars.each_block_value} = ${snippet};
+					${this.vars.each_block_value} = ${snippet};
 					${this.renderer.options.dev && b`@validate_each_argument(${this.vars.each_block_value});`}
 
 					${this.block.has_outros && b`@group_outros();`}

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -93,7 +93,7 @@ function create_fragment(ctx) {
 		},
 		p(ctx, [dirty]) {
 			if (dirty & /*things*/ 1) {
-				const each_value = /*things*/ ctx[0];
+				each_value = /*things*/ ctx[0];
 				for (let i = 0; i < each_blocks.length; i += 1) each_blocks[i].r();
 				each_blocks = update_keyed_each(each_blocks, dirty, get_key, 1, ctx, each_value, each_1_lookup, each_1_anchor.parentNode, fix_and_destroy_block, create_each_block, each_1_anchor, get_each_context);
 				for (let i = 0; i < each_blocks.length; i += 1) each_blocks[i].a();

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -78,7 +78,7 @@ function create_fragment(ctx) {
 		},
 		p(ctx, [dirty]) {
 			if (dirty & /*things*/ 1) {
-				const each_value = /*things*/ ctx[0];
+				each_value = /*things*/ ctx[0];
 				each_blocks = update_keyed_each(each_blocks, dirty, get_key, 1, ctx, each_value, each_1_lookup, each_1_anchor.parentNode, destroy_block, create_each_block, each_1_anchor, get_each_context);
 			}
 		},

--- a/test/runtime/samples/each-block-keyed-else/_config.js
+++ b/test/runtime/samples/each-block-keyed-else/_config.js
@@ -1,0 +1,37 @@
+export default {
+	props: {
+		animals: ['alpaca', 'baboon', 'capybara'],
+		foo: 'something else'
+	},
+
+	html: `
+		before
+		<p>alpaca</p>
+		<p>baboon</p>
+		<p>capybara</p>
+		after
+	`,
+
+	test({ assert, component, target }) {
+		component.animals = [];
+		assert.htmlEqual(target.innerHTML, `
+			before
+			<p>no animals, but rather something else</p>
+			after
+		`);
+
+		component.foo = 'something other';
+		assert.htmlEqual(target.innerHTML, `
+			before
+			<p>no animals, but rather something other</p>
+			after
+		`);
+
+		component.animals = ['wombat'];
+		assert.htmlEqual(target.innerHTML, `
+			before
+			<p>wombat</p>
+			after
+		`);
+	}
+};

--- a/test/runtime/samples/each-block-keyed-else/main.svelte
+++ b/test/runtime/samples/each-block-keyed-else/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	export let animals;
+	export let foo;
+</script>
+
+before
+{#each animals as animal (animal)}
+	<p>{animal}</p>
+{:else}
+	<p>no animals, but rather {foo}</p>
+{/each}
+after


### PR DESCRIPTION
This fixes #4536 and fixes #4549.
The value of the updated array was in scope only in the each block and not in the else block.
The bug was likely introduced in #4413.
I've chosen to remove the shadowing of the `this.vars.each_block_value` variable to keep the behavior of the unkeyed case i.e. the let binding in the fragment initialization is updated during the update.

Thanks to @bwbroersma for the help and test case.
