### PR TITLE
remove unneeded fragment block

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -419,8 +419,8 @@ export default class Block {
 		return body;
 	}
 
-	has_content() {
-		return this.first ||
+	has_content(): boolean {
+		return !!this.first ||
 			this.event_listeners.length > 0 ||
 			this.chunks.intro.length > 0 ||
 			this.chunks.outro.length > 0  ||

--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -284,4 +284,8 @@ export default class Renderer {
 
 		return node;
 	}
+
+	remove_block(block: Block | Node | Node[]) {
+		this.blocks.splice(this.blocks.indexOf(block), 1);
+	}
 }

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -155,6 +155,7 @@ export default class InlineComponentWrapper extends Wrapper {
 		// removing empty slot
 		for (const slot of this.slots.keys()) {
 			if (!this.slots.get(slot).block.has_content()) {
+				this.renderer.remove_block(this.slots.get(slot).block);
 				this.slots.delete(slot);
 			}
 		}


### PR DESCRIPTION
- remove slot template fragment block
  - in https://github.com/sveltejs/svelte/pull/4500 we do not use the fragment block if it is empty, but we still render the fragment block code.
- remove empty slot fallback block
  - if the slot fallback has no content, remove it.