### PR TITLE
add generic type for SvelteComponentDev props

### DIFF
--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -98,18 +98,18 @@ export function validate_slots(name, slot, keys) {
 }
 
 type Props = Record<string, any>;
-export interface SvelteComponentDev {
-	$set(props?: Props): void;
+export interface SvelteComponentDev<P = Props> {
+	$set(props?: P): void;
 	$on<T = any>(event: string, callback: (event: CustomEvent<T>) => void): () => void;
 	$destroy(): void;
 	[accessor: string]: any;
 }
 
-export class SvelteComponentDev extends SvelteComponent {
+export class SvelteComponentDev<P = Props> extends SvelteComponent {
 	constructor(options: {
 		target: Element;
 		anchor?: Element;
-		props?: Props;
+		props?: P;
 		hydrate?: boolean;
 		intro?: boolean;
 		$$inline?: boolean;


### PR DESCRIPTION
For using it as follows in TS:

```jsx
SvelteComponentDev<MyProps>
```

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
