### PR TITLE
Do not null blocks on await outros

### DIFF
--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -1,4 +1,4 @@
-import { is_promise } from './utils';
+import { is_promise, noop } from './utils';
 import { check_outros, group_outros, transition_in, transition_out } from './transitions';
 import { flush } from './scheduler';
 import { get_current_component, set_current_component } from './lifecycle';
@@ -27,9 +27,7 @@ export function handle_promise(promise, info) {
 				info.blocks.forEach((block, i) => {
 					if (i !== index && block) {
 						group_outros();
-						transition_out(block, 1, 1, () => {
-							info.blocks[i] = null;
-						});
+						transition_out(block, 1, 1, noop);
 						check_outros();
 					}
 				});


### PR DESCRIPTION
### Description
Do not null blocks after out transition in await block.

### Motivation
If the `then` block has `out` transition, it takes some time for it to "disappear". After the update of `pending` block, `then` block is being transitioned out. If the promise is then resolved, `then` block is updated and `pending` block is transitioned out and `then` block set as current. Only after that, the `then`'s transition out (triggered by the update of `pending` block) finishes and the corresponding block info is being nulled. 

That results in a situation where await block is in `then` state, but `then` entry in `blocks` field is null. Therefore it is not transitioned out during the next `pending` block update.

### Caveats
I found the original commit which introduced nulling out the transitioned blocks. It's almost 2 years ago by @Rich-Harris in [1d3b1284eaecf2d09557d883b0db3adbab48f633](https://github.com/sveltejs/svelte/commit/1d3b1284eaecf2d09557d883b0db3adbab48f633) but I don't know what was the original motivation, so I am afraid this change/revert might break something :(

### Related issue
Fixes #1591 

### Tests
- All the tests are passing.
- I tried to write a test, but was not successful.
