### PR TITLE
add '.vscode' to .gitignore (#4594)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .DS_Store
 .nyc_output
+.vscode
 node_modules
 *.map
 /src/compiler/compile/internal_exports.ts


### PR DESCRIPTION

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [X] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [X] Run the tests tests with `npm test` or `yarn test`)

fixed #4594 

When I saved some files, it was changed automatically due to vscode setting.
vscode default setting value of typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions is true
And I use this setting value all of my workspaces.

But it seems like svelte project is using false.
I want to try to join this project, but I couldn't change default settings for only this project.
Because my other projects are using true.
So I set some setting values and don't want to commit, because other people don't need this value.

I thought I would commit my `.vscode/settings.json`, but you might not want it.
So I commit only `.gitignore` 😃