### PR TITLE
Mechanism for bubbling all events

### DIFF
--- a/src/compiler/compile/nodes/EventHandler.ts
+++ b/src/compiler/compile/nodes/EventHandler.ts
@@ -1,7 +1,6 @@
 import Node from './shared/Node';
 import Expression from './shared/Expression';
 import Component from '../Component';
-import { sanitize } from '../../utils/names';
 import { Identifier } from 'estree';
 
 export default class EventHandler extends Node {
@@ -42,8 +41,6 @@ export default class EventHandler extends Node {
 					}
 				}
 			}
-		} else {
-			this.handler_name = component.get_unique_name(`${sanitize(this.name)}_handler`);
 		}
 	}
 

--- a/src/compiler/compile/render_dom/wrappers/Element/EventHandler.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/EventHandler.ts
@@ -28,7 +28,7 @@ export default class EventHandlerWrapper {
 
 	render(block: Block, target: string | Expression) {
 		if (!this.node.expression) {
-			if (this.node.name === "*")
+			if (this.node.name === '*')
 				block.chunks.bubble.push(b`local_dispose.push(@listen(${target}, type, callback))`);
 			else
 				block.chunks.bubble.push(b`if (type === "${this.node.name}") local_dispose.push(@listen(${target}, "${this.node.name}", callback));`);

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -392,7 +392,7 @@ export default class InlineComponentWrapper extends Wrapper {
 			.filter(handler => {
 				if (handler.expression) return true;
 
-				if (handler.name === "*")
+				if (handler.name === '*')
 					block.chunks.bubble.push(b`local_dispose.push(${name}.$on(type, callback))`);
 				else
 					block.chunks.bubble.push(b`if (type === "${handler.name}") local_dispose.push(${name}.$on("${handler.name}", callback));`);

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -11,6 +11,7 @@ interface Fragment {
 	/* claim   */ l: (nodes: any) => void;
 	/* hydrate */ h: () => void;
 	/* mount   */ m: (target: HTMLElement, anchor: any) => void;
+	/* bubble  */ b?: (type: string, callback: Function) => Function;
 	/* update  */ p: (ctx: any, dirty: any) => void;
 	/* measure */ r: () => void;
 	/* fix     */ f: () => void;
@@ -222,10 +223,15 @@ export class SvelteComponent {
 	}
 
 	$on(type, callback) {
+		const dispose = this.$$.fragment
+			&& this.$$.fragment.b
+			&& this.$$.fragment.b(type, callback)
+			|| noop;
 		const callbacks = (this.$$.callbacks[type] || (this.$$.callbacks[type] = []));
 		callbacks.push(callback);
 
 		return () => {
+			dispose();
 			const index = callbacks.indexOf(callback);
 			if (index !== -1) callbacks.splice(index, 1);
 		};

--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -53,14 +53,3 @@ export function setContext<T>(key, context: T) {
 export function getContext<T>(key): T {
 	return get_current_component().$$.context.get(key);
 }
-
-// TODO figure out if we still want to support
-// shorthand events, or if we want to implement
-// a real bubbling mechanism
-export function bubble(component, event) {
-	const callbacks = component.$$.callbacks[event.type];
-
-	if (callbacks) {
-		callbacks.slice().forEach(fn => fn(event));
-	}
-}

--- a/test/runtime/samples/event-handler-bubble-all-component/Widget.svelte
+++ b/test/runtime/samples/event-handler-bubble-all-component/Widget.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+</script>
+
+<button on:click='{() => dispatch("foo", { answer: 42 })}'>click me</button>

--- a/test/runtime/samples/event-handler-bubble-all-component/_config.js
+++ b/test/runtime/samples/event-handler-bubble-all-component/_config.js
@@ -1,0 +1,18 @@
+export default {
+	html: `
+		<button>click me</button>
+	`,
+
+	test({ assert, component, target, window }) {
+		const button = target.querySelector('button');
+		const event = new window.MouseEvent('click');
+
+		let answer;
+		component.$on('foo', event => {
+			answer = event.detail.answer;
+		});
+
+		button.dispatchEvent(event);
+		assert.equal(answer, 42);
+	}
+};

--- a/test/runtime/samples/event-handler-bubble-all-component/main.svelte
+++ b/test/runtime/samples/event-handler-bubble-all-component/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Widget from './Widget.svelte';
+</script>
+
+<Widget on:*/>

--- a/test/runtime/samples/event-handler-bubble-all/Button.svelte
+++ b/test/runtime/samples/event-handler-bubble-all/Button.svelte
@@ -1,0 +1,1 @@
+<button on:*>toggle</button>

--- a/test/runtime/samples/event-handler-bubble-all/_config.js
+++ b/test/runtime/samples/event-handler-bubble-all/_config.js
@@ -1,0 +1,21 @@
+export default {
+	html: `
+		<button>toggle</button>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const button = target.querySelector('button');
+		const event = new window.MouseEvent('click');
+
+		await button.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>toggle</button>
+			<p>hello!</p>
+		`);
+
+		await button.dispatchEvent(event);
+		assert.htmlEqual(target.innerHTML, `
+			<button>toggle</button>
+		`);
+	}
+};

--- a/test/runtime/samples/event-handler-bubble-all/main.svelte
+++ b/test/runtime/samples/event-handler-bubble-all/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import Button from './Button.svelte'
+
+	export let visible;
+</script>
+
+<Button on:click='{() => visible = !visible}'>toggle</Button>
+
+{#if visible}
+	<p>hello!</p>
+{/if}


### PR DESCRIPTION
This PR enables the use of the `on:*` directive to bubble all events to the parent. See #2837. I removed the bubble utility function and instead the `Component.$on` function delegates to `Fragment.b` which connects the appropriate listeners directly or does so after the component mounts. This has an advantage over the previous approach as it doesn't require adding an event listener to the element when no bubbled events are listened to.