### PR TITLE
[Tutorial] Make the instruction of default values more clear

### DIFF
--- a/site/content/tutorial/03-props/02-default-values/text.md
+++ b/site/content/tutorial/03-props/02-default-values/text.md
@@ -2,7 +2,7 @@
 title: Default values
 ---
 
-We can easily specify default values for props inside Nested.svelte:
+We can easily specify default values for props in `Nested.svelte`:
 
 ```html
 <script>

--- a/site/content/tutorial/03-props/02-default-values/text.md
+++ b/site/content/tutorial/03-props/02-default-values/text.md
@@ -2,7 +2,7 @@
 title: Default values
 ---
 
-We can easily specify default values for props:
+We can easily specify default values for props inside Nested.svelte:
 
 ```html
 <script>


### PR DESCRIPTION
Target page: https://svelte.dev/tutorial/default-values
I was stuck by this instruction for a while, and I think maybe we can make it more clear.

Related issue: #4521