### PR TITLE
Programmic slot access/api

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -75,6 +75,8 @@ export default class Block {
 	variables: Map<string, { id: Identifier; init?: Node }> = new Map();
 	get_unique_name: (name: string) => Identifier;
 
+	root_nodes: Identifier[] = [];
+
 	has_update_method = false;
 	autofocus: string;
 
@@ -269,9 +271,14 @@ export default class Block {
 					: this.chunks.hydrate
 			);
 
+			const return_value = this.type === 'slot'
+				? b`return [${this.root_nodes}]`
+				: null;
+
 			properties.create = x`function #create() {
 				${this.chunks.create}
 				${hydrate}
+				${return_value}
 			}`;
 		}
 

--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -59,7 +59,7 @@ export default class Renderer {
 
 		if (component.slots.size > 0) {
 			this.add_to_context('$$scope');
-			this.add_to_context('$$slots');
+			this.add_to_context('#slots');
 		}
 
 		if (this.binding_groups.length > 0) {

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -71,10 +71,16 @@ export default function dom(
 	}
 
 	const uses_slots = component.var_lookup.has('$$slots');
-	let slots = null
+	let slots = null;
+	let slots_update = null;
 
 	if (uses_slots) {
-		slots = b`let { $$slots, update: #update_$$slots } = @create_slots_accessor(#slots, $$scope)`
+		slots = b`let { $$slots, update: #update_$$slots } = @create_slots_accessor(#slots, $$scope)`;
+		slots_update = b`
+			if (${renderer.dirty(['$$scope'], true)}) {
+				#update_$$slots($$scope)
+			}
+		`;
 		renderer.add_to_context('$$scope');
 	}
 
@@ -454,9 +460,7 @@ export default function dom(
 
 				${(reactive_declarations.length > 0 || uses_slots) && b`
 				$$self.$$.update = () => {
-					if (${renderer.dirty(['$$scope'], true)}) {
-						#update_$$slots($$scope)
-					}
+					${slots_update}
 
 					${reactive_declarations}
 				};

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -455,7 +455,7 @@ export default function dom(
 				${(reactive_declarations.length > 0 || uses_slots) && b`
 				$$self.$$.update = () => {
 					if (${renderer.dirty(['$$scope'], true)}) {
-						#update_$$slots($$scope, $$self.$$.dirty)
+						#update_$$slots($$scope)
 					}
 
 					${reactive_declarations}

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -320,6 +320,7 @@ export default class ElementWrapper extends Wrapper {
 				block.chunks.destroy.push(b`@detach(${node});`);
 			}
 		} else {
+			block.root_nodes.push(node);
 			block.chunks.mount.push(b`@insert(#target, ${node}, anchor);`);
 
 			// TODO we eventually need to consider what happens to elements

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -133,6 +133,8 @@ export default class InlineComponentWrapper extends Wrapper {
 
 		const name = this.var;
 
+		if (parent_node === null) block.root_nodes.push(name);
+
 		const component_opts = x`{}` as ObjectExpression;
 
 		const statements: Array<Node | Node[]> = [];

--- a/src/compiler/compile/render_dom/wrappers/Slot.ts
+++ b/src/compiler/compile/render_dom/wrappers/Slot.ts
@@ -128,7 +128,7 @@ export default class SlotWrapper extends Wrapper {
 		const slot_or_fallback = has_fallback ? block.get_unique_name(`${sanitize(slot_name)}_slot_or_fallback`) : slot;
 
 		block.chunks.init.push(b`
-			const ${slot_definition} = ${renderer.reference('$$slots')}.${slot_name};
+			const ${slot_definition} = ${renderer.reference('#slots')}.${slot_name};
 			const ${slot} = @create_slot(${slot_definition}, #ctx, ${renderer.reference('$$scope')}, ${get_slot_context_fn});
 			${has_fallback ? b`const ${slot_or_fallback} = ${slot} || ${this.fallback.name}(#ctx);` : null}
 		`);

--- a/src/compiler/compile/render_dom/wrappers/Text.ts
+++ b/src/compiler/compile/render_dom/wrappers/Text.ts
@@ -44,6 +44,8 @@ export default class TextWrapper extends Wrapper {
 		if (this.skip) return;
 		const use_space = this.use_space();
 
+		if (parent_node === null) block.root_nodes.push(this.var);
+
 		block.add_element(
 			this.var,
 			use_space ? x`@space()` : x`@text("${this.data}")`,

--- a/src/compiler/compile/utils/reserved_keywords.ts
+++ b/src/compiler/compile/utils/reserved_keywords.ts
@@ -1,4 +1,4 @@
-export const reserved_keywords = new Set(["$$props", "$$restProps"]);
+export const reserved_keywords = new Set(["$$props", "$$restProps", "$$slots"]);
 
 export function is_reserved_keyword(name) {
 	return reserved_keywords.has(name);

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -7,7 +7,7 @@ import { transition_in } from './transitions';
 interface Fragment {
 	key: string|null;
 	first: null;
-	/* create  */ c: () => void;
+	/* create  */ c: () => void|any[];
 	/* claim   */ l: (nodes: any) => void;
 	/* hydrate */ h: () => void;
 	/* mount   */ m: (target: HTMLElement, anchor: any) => void;

--- a/src/runtime/internal/index.ts
+++ b/src/runtime/internal/index.ts
@@ -7,6 +7,7 @@ export * from './keyed_each';
 export * from './lifecycle';
 export * from './loop';
 export * from './scheduler';
+export * from './slots';
 export * from './spread';
 export * from './ssr';
 export * from './transitions';

--- a/src/runtime/internal/slots.ts
+++ b/src/runtime/internal/slots.ts
@@ -1,0 +1,69 @@
+import { onDestroy } from './lifecycle';
+import { assign } from './utils'
+
+export function create_slot(definition, ctx, $$scope, fn) {
+	if (definition) {
+		const slot_ctx = get_slot_context(definition, ctx, $$scope, fn);
+		return definition[0](slot_ctx);
+	}
+}
+
+export function get_slot_context(definition, ctx, $$scope, fn) {
+	return definition[1] && fn
+		? assign($$scope.ctx.slice(), definition[1](fn(ctx)))
+		: $$scope.ctx;
+}
+
+export function get_slot_changes(definition, $$scope, dirty, fn) {
+	if (definition[2] && fn) {
+		const lets = definition[2](fn(dirty));
+
+		if ($$scope.dirty === undefined) {
+			return lets;
+		}
+
+		if (typeof lets === 'object') {
+			const merged = [];
+			const len = Math.max($$scope.dirty.length, lets.length);
+			for (let i = 0; i < len; i += 1) {
+				merged[i] = $$scope.dirty[i] | lets[i];
+			}
+
+			return merged;
+		}
+
+		return $$scope.dirty | lets;
+	}
+
+	return $$scope.dirty;
+}
+
+export function create_slots_accessor(slots, scope) {
+	const slot_list = [];
+	function update(scope, dirty) {
+		slot_list.forEach(({ slot, definition }) =>
+			slot.p(
+				get_slot_context(definition, [], scope, null),
+				get_slot_changes(definition, scope, dirty, null)
+			)
+		);
+	}
+
+	const $$slots = {};
+	for (const key in slots) {
+		$$slots[key] = function () {
+			let definition = slots[key];
+			let slot = create_slot(definition, [], scope, null);
+
+			if (slot.d) onDestroy(slot.d);
+			if (slot.p) slot_list.push({ definition, slot });
+
+			return {
+					content: slot.c(),
+					mount: slot.m
+			};
+		};
+	}
+
+	return { $$slots, update };
+}

--- a/src/runtime/internal/slots.ts
+++ b/src/runtime/internal/slots.ts
@@ -1,5 +1,5 @@
 import { onDestroy } from './lifecycle';
-import { assign } from './utils'
+import { assign, noop } from './utils';
 
 export function create_slot(definition, ctx, $$scope, fn) {
 	if (definition) {
@@ -39,28 +39,37 @@ export function get_slot_changes(definition, $$scope, dirty, fn) {
 }
 
 export function create_slots_accessor(slots, scope) {
-	const slot_list = [];
-	function update(scope, dirty) {
-		slot_list.forEach(({ slot, definition }) =>
-			slot.p(
-				get_slot_context(definition, [], scope, null),
-				get_slot_changes(definition, scope, dirty, null)
-			)
-		);
+	const update_list = [];
+	function update(scope) {
+		update_list.forEach(fn => fn(scope));
 	}
 
 	const $$slots = {};
 	for (const key in slots) {
-		$$slots[key] = function () {
-			let definition = slots[key];
-			let slot = create_slot(definition, [], scope, null);
+		$$slots[key] = function (ctx, callback = noop) {
+			const definition = slots[key];
+			const slot = create_slot(definition, null, scope, () => ctx);
+			const content = slot.c();
+
+			function local_update (scope, ctx_fn, dirty_fn) {
+					slot.p(
+						get_slot_context(definition, null, scope, ctx_fn),
+						get_slot_changes(definition, scope, 0, dirty_fn)
+					);
+					callback(content);
+			}
 
 			if (slot.d) onDestroy(slot.d);
-			if (slot.p) slot_list.push({ definition, slot });
+			if (slot.p) update_list.push(local_update);
 
 			return {
-					content: slot.c(),
-					mount: slot.m
+				content,
+				mount: slot.m,
+				update: props => local_update(
+					scope,
+					() => assign(ctx, props),
+					() => Object.keys(props).reduce((o, k) => (o[k] = true, o), {})
+				)
 			};
 		};
 	}

--- a/src/runtime/internal/slots.ts
+++ b/src/runtime/internal/slots.ts
@@ -69,7 +69,12 @@ export function create_slots_accessor(slots, scope) {
 					scope,
 					() => assign(ctx, props),
 					() => Object.keys(props).reduce((o, k) => (o[k] = true, o), {})
-				)
+				),
+				destroy: () => {
+					slot.d();
+					const i = update_list.indexOf(local_update);
+					if (i !== -1) update_list.splice(i, 1);
+				}
 			};
 		};
 	}

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -66,43 +66,6 @@ export function component_subscribe(component, store, callback) {
 	component.$$.on_destroy.push(subscribe(store, callback));
 }
 
-export function create_slot(definition, ctx, $$scope, fn) {
-	if (definition) {
-		const slot_ctx = get_slot_context(definition, ctx, $$scope, fn);
-		return definition[0](slot_ctx);
-	}
-}
-
-export function get_slot_context(definition, ctx, $$scope, fn) {
-	return definition[1] && fn
-		? assign($$scope.ctx.slice(), definition[1](fn(ctx)))
-		: $$scope.ctx;
-}
-
-export function get_slot_changes(definition, $$scope, dirty, fn) {
-	if (definition[2] && fn) {
-		const lets = definition[2](fn(dirty));
-
-		if ($$scope.dirty === undefined) {
-			return lets;
-		}
-
-		if (typeof lets === 'object') {
-			const merged = [];
-			const len = Math.max($$scope.dirty.length, lets.length);
-			for (let i = 0; i < len; i += 1) {
-				merged[i] = $$scope.dirty[i] | lets[i];
-			}
-
-			return merged;
-		}
-
-		return $$scope.dirty | lets;
-	}
-
-	return $$scope.dirty;
-}
-
 export function exclude_internal_props(props) {
 	const result = {};
 	for (const k in props) if (k[0] !== '$') result[k] = props[k];

--- a/test/js/samples/capture-inject-state/expected.js
+++ b/test/js/samples/capture-inject-state/expected.js
@@ -103,6 +103,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$subscribe_prop = () => ($$unsubscribe_prop(), $$unsubscribe_prop = subscribe(prop, $$value => $$invalidate(2, $prop = $$value)), prop);
 
 	$$self.$$.on_destroy.push(() => $$unsubscribe_prop());
+	let { $$slots: slots = {}, $$scope } = $$props;
 	let { prop } = $$props;
 	validate_store(prop, "prop");
 	$$subscribe_prop();
@@ -115,8 +116,7 @@ function instance($$self, $$props, $$invalidate) {
 		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
-	let { $$slots = {}, $$scope } = $$props;
-	validate_slots("Component", $$slots, []);
+	validate_slots("Component", slots, []);
 
 	$$self.$set = $$props => {
 		if ("prop" in $$props) $$subscribe_prop($$invalidate(0, prop = $$props.prop));

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -69,6 +69,7 @@ function create_fragment(ctx) {
 }
 
 function instance($$self, $$props, $$invalidate) {
+	let { $$slots: slots = {}, $$scope } = $$props;
 	let { name } = $$props;
 	const writable_props = ["name"];
 
@@ -76,8 +77,7 @@ function instance($$self, $$props, $$invalidate) {
 		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
-	let { $$slots = {}, $$scope } = $$props;
-	validate_slots("Component", $$slots, []);
+	validate_slots("Component", slots, []);
 
 	$$self.$set = $$props => {
 		if ("name" in $$props) $$invalidate(0, name = $$props.name);

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -170,6 +170,7 @@ function create_fragment(ctx) {
 }
 
 function instance($$self, $$props, $$invalidate) {
+	let { $$slots: slots = {}, $$scope } = $$props;
 	let { things } = $$props;
 	let { foo } = $$props;
 	let { bar } = $$props;
@@ -180,8 +181,7 @@ function instance($$self, $$props, $$invalidate) {
 		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
-	let { $$slots = {}, $$scope } = $$props;
-	validate_slots("Component", $$slots, []);
+	validate_slots("Component", slots, []);
 
 	$$self.$set = $$props => {
 		if ("things" in $$props) $$invalidate(0, things = $$props.things);

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -164,6 +164,7 @@ function create_fragment(ctx) {
 }
 
 function instance($$self, $$props, $$invalidate) {
+	let { $$slots: slots = {}, $$scope } = $$props;
 	let { things } = $$props;
 	let { foo } = $$props;
 	const writable_props = ["things", "foo"];
@@ -172,8 +173,7 @@ function instance($$self, $$props, $$invalidate) {
 		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
-	let { $$slots = {}, $$scope } = $$props;
-	validate_slots("Component", $$slots, []);
+	validate_slots("Component", slots, []);
 
 	$$self.$set = $$props => {
 		if ("things" in $$props) $$invalidate(0, things = $$props.things);

--- a/test/js/samples/debug-hoisted/expected.js
+++ b/test/js/samples/debug-hoisted/expected.js
@@ -49,6 +49,7 @@ function create_fragment(ctx) {
 }
 
 function instance($$self, $$props, $$invalidate) {
+	let { $$slots: slots = {}, $$scope } = $$props;
 	let obj = { x: 5 };
 	let kobzol = 5;
 	const writable_props = [];
@@ -57,8 +58,7 @@ function instance($$self, $$props, $$invalidate) {
 		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
-	let { $$slots = {}, $$scope } = $$props;
-	validate_slots("Component", $$slots, []);
+	validate_slots("Component", slots, []);
 	$$self.$capture_state = () => ({ obj, kobzol });
 
 	$$self.$inject_state = $$props => {

--- a/test/js/samples/debug-no-dependencies/expected.js
+++ b/test/js/samples/debug-no-dependencies/expected.js
@@ -136,14 +136,14 @@ function create_fragment(ctx) {
 }
 
 function instance($$self, $$props) {
+	let { $$slots: slots = {}, $$scope } = $$props;
 	const writable_props = [];
 
 	Object.keys($$props).forEach(key => {
 		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
-	let { $$slots = {}, $$scope } = $$props;
-	validate_slots("Component", $$slots, []);
+	validate_slots("Component", slots, []);
 	return [];
 }
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -65,6 +65,7 @@ function create_fragment(ctx) {
 }
 
 function instance($$self, $$props, $$invalidate) {
+	let { $$slots: slots = {}, $$scope } = $$props;
 	let { foo } = $$props;
 	let bar;
 	const writable_props = ["foo"];
@@ -73,8 +74,7 @@ function instance($$self, $$props, $$invalidate) {
 		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
-	let { $$slots = {}, $$scope } = $$props;
-	validate_slots("Component", $$slots, []);
+	validate_slots("Component", slots, []);
 
 	$$self.$set = $$props => {
 		if ("foo" in $$props) $$invalidate(0, foo = $$props.foo);

--- a/test/js/samples/loop-protect/expected.js
+++ b/test/js/samples/loop-protect/expected.js
@@ -67,6 +67,7 @@ function foo() {
 }
 
 function instance($$self, $$props, $$invalidate) {
+	let { $$slots: slots = {}, $$scope } = $$props;
 	let node;
 
 	{
@@ -111,8 +112,7 @@ function instance($$self, $$props, $$invalidate) {
 		if (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console_1.warn(`<Component> was created with unknown prop '${key}'`);
 	});
 
-	let { $$slots = {}, $$scope } = $$props;
-	validate_slots("Component", $$slots, []);
+	validate_slots("Component", slots, []);
 
 	function div_binding($$value) {
 		binding_callbacks[$$value ? "unshift" : "push"](() => {

--- a/test/runtime/samples/$$slots-let/Child.svelte
+++ b/test/runtime/samples/$$slots-let/Child.svelte
@@ -1,0 +1,8 @@
+<script>
+  const slot = $$slots.default({ value: 'foo' })
+  let target
+  $: target && slot.mount(target)
+</script>
+
+<button on:click={e => slot.update({ value: 'bar' })}>Click me</button>
+<div bind:this={target} />

--- a/test/runtime/samples/$$slots-let/_config.js
+++ b/test/runtime/samples/$$slots-let/_config.js
@@ -1,0 +1,18 @@
+export default {
+	async test({ assert, target, window, }) {
+		assert.htmlEqual(target.innerHTML, `
+			<button>Click me</button>
+			<div>foo</div>
+		`);
+
+		const btn = target.querySelector('button');
+		const clickEvent = new window.MouseEvent('click');
+
+		await btn.dispatchEvent(clickEvent);
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>Click me</button>
+			<div>bar</div>
+		`);
+	}
+};

--- a/test/runtime/samples/$$slots-let/main.svelte
+++ b/test/runtime/samples/$$slots-let/main.svelte
@@ -1,0 +1,7 @@
+<script>
+  import Child from './Child.svelte'
+</script>
+
+<Child let:value>
+  {value}
+</Child>

--- a/test/runtime/samples/$$slots/Child.svelte
+++ b/test/runtime/samples/$$slots/Child.svelte
@@ -1,0 +1,15 @@
+<script>
+  let target;
+
+  const slot = $$slots.default();
+  
+  $: {
+    if (target) {
+      slot.content[0].setAttribute('attr', 'value');
+      slot.content[2].$set({ prop: 'bar' })
+      slot.mount(target);
+    }
+  }
+</script>
+
+<div bind:this={target} />

--- a/test/runtime/samples/$$slots/Component.svelte
+++ b/test/runtime/samples/$$slots/Component.svelte
@@ -1,0 +1,5 @@
+<script>
+  export let prop
+</script>
+
+<p>{prop}</p>

--- a/test/runtime/samples/$$slots/_config.js
+++ b/test/runtime/samples/$$slots/_config.js
@@ -3,7 +3,7 @@ export default {
 		assert.htmlEqual(target.innerHTML, `
 			<button>Click me</button>
 			<div><p attr="value">Value: a</p><p>bar</p></div>
-		`)
+		`);
 
 		const btn = target.querySelector('button');
 		const clickEvent = new window.MouseEvent('click');

--- a/test/runtime/samples/$$slots/_config.js
+++ b/test/runtime/samples/$$slots/_config.js
@@ -1,0 +1,18 @@
+export default {
+	async test({ assert, target, window, }) {
+		assert.htmlEqual(target.innerHTML, `
+			<button>Click me</button>
+			<div><p attr="value">Value: a</p><p>bar</p></div>
+		`)
+
+		const btn = target.querySelector('button');
+		const clickEvent = new window.MouseEvent('click');
+
+		await btn.dispatchEvent(clickEvent);
+
+		assert.htmlEqual(target.innerHTML, `
+			<button>Click me</button>
+			<div><p attr="value">Value: b</p><p>bar</p></div>
+		`);
+	}
+};

--- a/test/runtime/samples/$$slots/main.svelte
+++ b/test/runtime/samples/$$slots/main.svelte
@@ -1,0 +1,12 @@
+<script>
+  import Child from './Child.svelte'
+  import Component from './Component.svelte'
+
+  let value = 'a';
+</script>
+
+<button on:click={e => value = 'b'}>Click me</button>
+<Child>
+  <p>Value: {value}</p>
+  <Component prop="foo" />
+</Child>


### PR DESCRIPTION
This PR implements an alternative approach to consuming slots through the use of a new `$$slots` variable. The need for something like this has been brought up several times see #2106 and to a lesser extent #4036 there's a few more related issues scattered around.

# $$slots

`$$slots` is an object keyed by slot name containing slot constructors of the form `slot_name(ctx?: Object, callback?: Function)`. 

## Parameters

`ctx` is an optional parameter to set the inital context of the slot. Equivalent to passing props to a `<slot />` node.

`callback` is also optional. It's a callback function that will be called when slot content changes. 

## Return value

The constructor returns an object of the form 
```
{
  content: Array<HTMLElement|TextNode|Component>,
  mount: Function(target: HTMLElement, anchor?: HTMLElement),
  update: Function(props: Object),
  destroy: Function
}
```

`content` is an array containing the top level nodes. Some more work is needed to support if, each, and await blocks.

The `mount` function can be called to insert the slot content into the DOM. Note that this isn't required, you could do whatever you want with the content.

You can call `update` to modify the context you initially passed in. This is similar to `Component.$set`.

The `destroy` function removes the content from the dom.

# Examples
Setting a textarea from slot content.
```html
<script>
  export let value = $$slots.default().content[0].data
</script>

<textarea bind:value></textarea>
```

A react style portal component.
```html
<script>
  import { onDestroy } from 'svelte'

  const slot =  $$slots.default()
  slot.mount(document.body)
  onDestroy(slot.destroy)
</script>
```

A nav element that sets the `active` class on child ancher elements.
```html
<script>
  export let path

  $: {
    if (target) {
      const slot = $$slots.default()
      slot.content.forEach(n =>
        n.tagName == 'A'
        && n.getAttribute('href') == path
        && n.classList.add('active')
      )
      slot.mount(target)
    }
  }
</script>
<nav bind:this={target} />
```

