### PR TITLE
add ssr for group bindings

### DIFF
--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -111,7 +111,7 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 
 		if (name === 'group') {
 			const value_attribute = node.attributes.find(({ name }) => name === 'value');
-			if (value_attribute && value_attribute.chunks.length === 1) {
+			if (value_attribute) {
 				const value = get_attribute_value(value_attribute);
 				const bound = expression.node;
 				renderer.add_expression(x`

--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -110,7 +110,16 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 		}
 
 		if (name === 'group') {
-			// TODO server-render group bindings
+			const value_attribute = node.attributes.find(({ name }) => name === 'value');
+			if (value_attribute && value_attribute.chunks.length === 1) {
+				const value = get_attribute_value(value_attribute);
+				const bound = expression.node;
+				renderer.add_expression(x`
+					${value} === ${bound} || Array.isArray(${bound}) && ${bound}.includes(${value})
+						? @add_attribute("checked", true, 1)
+						: ""
+				`);
+			}
 		} else if (contenteditable && (name === 'textContent' || name === 'innerHTML')) {
 			node_contents = expression.node;
 

--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -1,5 +1,5 @@
 import { is_void } from '../../../utils/names';
-import { get_attribute_value, get_class_attribute_value } from './shared/get_attribute_value';
+import { get_attribute_expression, get_attribute_value, get_class_attribute_value } from './shared/get_attribute_value';
 import { boolean_attributes } from './shared/boolean_attributes';
 import Renderer, { RenderOptions } from '../Renderer';
 import Element from '../../nodes/Element';
@@ -112,13 +112,11 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 		if (name === 'group') {
 			const value_attribute = node.attributes.find(({ name }) => name === 'value');
 			if (value_attribute) {
-				const value = get_attribute_value(value_attribute);
+				const value = get_attribute_expression(value_attribute);
+				const type = node.get_static_attribute_value('type');
 				const bound = expression.node;
-				renderer.add_expression(x`
-					${value} === ${bound} || Array.isArray(${bound}) && ${bound}.includes(${value})
-						? @add_attribute("checked", true, 1)
-						: ""
-				`);
+				const condition = type === 'checkbox' ? x`~${bound}.indexOf(${value})`: x`${value} === ${bound}`;
+				renderer.add_expression(x`${condition} ? @add_attribute("checked", true, 1) : ""`);
 			}
 		} else if (contenteditable && (name === 'textContent' || name === 'innerHTML')) {
 			node_contents = expression.node;

--- a/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.ts
+++ b/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.ts
@@ -26,3 +26,10 @@ export function get_attribute_value(attribute: Attribute): ESTreeExpression {
 		})
 		.reduce((lhs, rhs) => x`${lhs} + ${rhs}`);
 }
+
+export function get_attribute_expression(attribute: Attribute): ESTreeExpression {
+	if (attribute.chunks.length === 1 && attribute.chunks[0].type === 'Expression') {
+		return (attribute.chunks[0] as Expression).node as ESTreeExpression;
+	}
+	return get_attribute_value(attribute);
+}

--- a/test/runtime/samples/attribute-prefer-expression/_config.js
+++ b/test/runtime/samples/attribute-prefer-expression/_config.js
@@ -1,5 +1,4 @@
 export default {
-	skip_if_ssr: true,
 
 	props: {
 		foo: false

--- a/test/runtime/samples/binding-indirect-spread/_config.js
+++ b/test/runtime/samples/binding-indirect-spread/_config.js
@@ -1,5 +1,13 @@
 export default {
-	skip_if_ssr: true,
+	ssrHtml: `
+		<input type="radio" value="radio1">
+		<input type="radio" value="radio2" checked>
+		<input type="radio" value="radio3">
+
+		<input type="checkbox" value="check1">
+		<input type="checkbox" value="check2" checked>
+		<input type="checkbox" value="check3">
+	`,
 	async test({ assert, component, target, window }) {
 		const event = new window.MouseEvent('click');
 

--- a/test/runtime/samples/binding-input-checkbox-group-outside-each/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-group-outside-each/_config.js
@@ -25,6 +25,21 @@ export default {
 
 		<p>Beta</p>`,
 
+	ssrHtml: `
+		<label>
+			<input type="checkbox" value="[object Object]"> Alpha
+		</label>
+
+		<label>
+			<input type="checkbox" value="[object Object]" checked> Beta
+		</label>
+
+		<label>
+			<input type="checkbox" value="[object Object]"> Gamma
+		</label>
+
+		<p>Beta</p>`,
+
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, false);

--- a/test/runtime/samples/binding-input-checkbox-group/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-group/_config.js
@@ -25,6 +25,21 @@ export default {
 
 		<p>Beta</p>`,
 
+	ssrHtml: `
+		<label>
+			<input type="checkbox" value="[object Object]"> Alpha
+		</label>
+
+		<label>
+			<input type="checkbox" value="[object Object]" checked> Beta
+		</label>
+
+		<label>
+			<input type="checkbox" value="[object Object]"> Gamma
+		</label>
+
+		<p>Beta</p>`,
+
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, false);

--- a/test/runtime/samples/binding-input-group-each-1/_config.js
+++ b/test/runtime/samples/binding-input-group-each-1/_config.js
@@ -64,6 +64,54 @@ export default {
 		</div>
 	`,
 
+	ssrHtml: `
+		<div>
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]" checked> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Gamma
+			</label>
+
+			<p>Beta</p>
+		</div>
+		<div>
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Gamma
+			</label>
+
+			<p></p>
+		</div>
+		<div>
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]" checked> Gamma
+			</label>
+
+			<p>Gamma</p>
+		</div>
+	`,
+
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, false);

--- a/test/runtime/samples/binding-input-group-each-2/_config.js
+++ b/test/runtime/samples/binding-input-group-each-2/_config.js
@@ -12,6 +12,19 @@ export default {
 
 		<p>1, 2, 3</p>`,
 
+	ssrHtml: `
+		<label>
+			<input type="checkbox" value="1" checked> 1
+		</label>
+		<label>
+			<input type="checkbox" value="2" checked> 2
+		</label>
+		<label>
+			<input type="checkbox" value="3" checked> 3
+		</label>
+
+		<p>1, 2, 3</p>`,
+
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, true);

--- a/test/runtime/samples/binding-input-group-each-3/_config.js
+++ b/test/runtime/samples/binding-input-group-each-3/_config.js
@@ -63,7 +63,53 @@ export default {
 			<p>Gamma</p>
 		</div>
 	`,
+	ssrHtml: `
+		<div>
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
 
+			<label>
+				<input type="checkbox" value="[object Object]" checked> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Gamma
+			</label>
+
+			<p>Beta</p>
+		</div>
+		<div>
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Gamma
+			</label>
+
+			<p></p>
+		</div>
+		<div>
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]" checked> Gamma
+			</label>
+
+			<p>Gamma</p>
+		</div>
+	`,
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, false);

--- a/test/runtime/samples/binding-input-group-each-4/_config.js
+++ b/test/runtime/samples/binding-input-group-each-4/_config.js
@@ -17,7 +17,24 @@ export default {
 		<label><input type="checkbox" value="3"> 3</label>
 		<p>3</p>
 	`,
-
+	ssrHtml: `
+		<label><input type="checkbox" value="1" checked> 1</label>
+		<label><input type="checkbox" value="2"> 2</label>
+		<label><input type="checkbox" value="3"> 3</label>
+		<p>1</p>
+		<label><input type="checkbox" value="1"> 1</label>
+		<label><input type="checkbox" value="2" checked> 2</label>
+		<label><input type="checkbox" value="3"> 3</label>
+		<p>2</p>
+		<label><input type="checkbox" value="1"> 1</label>
+		<label><input type="checkbox" value="2"> 2</label>
+		<label><input type="checkbox" value="3"> 3</label>
+		<p></p>
+		<label><input type="checkbox" value="1"> 1</label>
+		<label><input type="checkbox" value="2"> 2</label>
+		<label><input type="checkbox" value="3" checked> 3</label>
+		<p>3</p>
+	`,
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, true);

--- a/test/runtime/samples/binding-input-group-each-5/_config.js
+++ b/test/runtime/samples/binding-input-group-each-5/_config.js
@@ -17,7 +17,24 @@ export default {
 		<label><input type="checkbox" value="3"> 3</label>
 		<p>1</p>
 	`,
-
+	ssrHtml: `
+		<label><input type="checkbox" value="1" checked> 1</label>
+		<label><input type="checkbox" value="2"> 2</label>
+		<label><input type="checkbox" value="3"> 3</label>
+		<p>1</p>
+		<label><input type="checkbox" value="1" checked> 1</label>
+		<label><input type="checkbox" value="2" checked> 2</label>
+		<label><input type="checkbox" value="3" checked> 3</label>
+		<p>1, 2, 3</p>
+		<label><input type="checkbox" value="1"> 1</label>
+		<label><input type="checkbox" value="2" checked> 2</label>
+		<label><input type="checkbox" value="3"> 3</label>
+		<p>2</p>
+		<label><input type="checkbox" value="1" checked> 1</label>
+		<label><input type="checkbox" value="2"> 2</label>
+		<label><input type="checkbox" value="3"> 3</label>
+		<p>1</p>
+	`,
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, true);

--- a/test/runtime/samples/binding-input-group-each-6/_config.js
+++ b/test/runtime/samples/binding-input-group-each-6/_config.js
@@ -13,7 +13,6 @@ export default {
 		<label><input type="checkbox" value="z"> z</label>
 		<p></p>
 	`,
-
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, false);

--- a/test/runtime/samples/binding-input-radio-group/_config.js
+++ b/test/runtime/samples/binding-input-radio-group/_config.js
@@ -25,6 +25,21 @@ export default {
 
 		<p>Beta</p>`,
 
+	ssrHtml: `
+		<label>
+			<input type="radio" value="[object Object]"> Alpha
+		</label>
+
+		<label>
+			<input type="radio" value="[object Object]" checked> Beta
+		</label>
+
+		<label>
+			<input type="radio" value="[object Object]"> Gamma
+		</label>
+
+		<p>Beta</p>`,
+
 	async test({ assert, component, target, window }) {
 		const inputs = target.querySelectorAll('input');
 		assert.equal(inputs[0].checked, false);

--- a/test/server-side-rendering/samples/bindings-group/_expected.html
+++ b/test/server-side-rendering/samples/bindings-group/_expected.html
@@ -1,0 +1,5 @@
+<div>Cheese</div>
+<input type="radio" value="Plain" checked>
+<input type="radio" value="Whole wheat">
+<input type="checkbox" value="Beans">
+<input type="checkbox" value="Cheese" checked>

--- a/test/server-side-rendering/samples/bindings-group/main.svelte
+++ b/test/server-side-rendering/samples/bindings-group/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let tortilla = 'Plain';
+	let fillings = ['Cheese'];
+</script>
+
+<div>{fillings.toString()}</div>
+
+<input type="radio" bind:group={tortilla} value="Plain">
+<input type="radio" bind:group={tortilla} value="Whole wheat">
+
+<input type="checkbox" bind:group={fillings} value="Beans">
+<input type="checkbox" bind:group={fillings} value="Cheese">


### PR DESCRIPTION
This PR implements server-rendering for group bindings. I noticed this TODO comment and attempted to add the feature.
https://github.com/sveltejs/svelte/blob/aa3dcc06d6b0fcb079ccd993fa6e3455242a2a96/src/compiler/compile/render_ssr/handlers/Element.ts#L116

This commit covers the following cases
- **group value is a string:** checked if value strict equals group value
- **group value is an array:** checked if value is included in group value array

I didn't see any other data structures for group bindings in docs so I hope this covers everything.