### PR TITLE
docs: Fix simple typo, specificy -> specify

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -804,7 +804,7 @@ You can see a full example on the [animations tutorial](tutorial/animate)
 
 ### `svelte/easing`
 
-Easing functions specificy the rate of change over time and are useful when working with Svelte's built-in transitions and animations as well as the tweened and spring utilities. `svelte/easing` contains 31 named exports, a `linear` ease and 3 variants of 10 different easing functions: `in`, `out` and `inOut`.
+Easing functions specify the rate of change over time and are useful when working with Svelte's built-in transitions and animations as well as the tweened and spring utilities. `svelte/easing` contains 31 named exports, a `linear` ease and 3 variants of 10 different easing functions: `in`, `out` and `inOut`.
 
 You can explore the various eases using the [ease visualiser](examples#easing) in the [examples section](examples).
 


### PR DESCRIPTION
There is a small typo in site/content/docs/03-run-time.md.

Should read `specify` rather than `specificy`.

