### PR TITLE
fix(examples): use correct URL for Ask HN posts

### DIFF
--- a/site/content/examples/21-miscellaneous/01-hacker-news/Item.svelte
+++ b/site/content/examples/21-miscellaneous/01-hacker-news/Item.svelte
@@ -3,6 +3,8 @@
 
 	export let item;
 	export let returnTo;
+
+	$: url = !item.domain ? `https://news.ycombinator.com/${item.url}` : item.url;
 </script>
 
 <style>
@@ -24,7 +26,7 @@
 <a href={returnTo}>&laquo; back</a>
 
 <article>
-	<a href="{item.url}">
+	<a href="{url}">
 		<h1>{item.title}</h1>
 		<small>{item.domain}</small>
 	</a>

--- a/site/content/examples/21-miscellaneous/01-hacker-news/Summary.svelte
+++ b/site/content/examples/21-miscellaneous/01-hacker-news/Summary.svelte
@@ -7,14 +7,8 @@
 		const c = item.comments_count;
 		return `${c} ${c === 1 ? 'comment' : 'comments'}`;
 	}
-	
-	function item_url() {
-		const { url, type } = item;
-		if (type === "ask") {
-			return `https://news.ycombinator.com/${url}`;
-		}
-		return url;
-	}
+
+	$: url = item.type === "ask" ? `https://news.ycombinator.com/${item.url}` : item.url;
 </script>
 
 <style>
@@ -41,6 +35,6 @@
 
 <article>
 	<span>{i + offset + 1}</span>
-	<h2><a target="_blank" href={item_url()}>{item.title}</a></h2>
+	<h2><a target="_blank" href={url}>{item.title}</a></h2>
 	<p class="meta"><a href="#/item/{item.id}">{comment_text()}</a> by {item.user} {item.time_ago}</p>
 </article>

--- a/site/content/examples/21-miscellaneous/01-hacker-news/Summary.svelte
+++ b/site/content/examples/21-miscellaneous/01-hacker-news/Summary.svelte
@@ -7,6 +7,14 @@
 		const c = item.comments_count;
 		return `${c} ${c === 1 ? 'comment' : 'comments'}`;
 	}
+	
+	function item_url() {
+		const { url, type } = item;
+		if (type === "ask") {
+			return `https://news.ycombinator.com/${url}`;
+		}
+		return url;
+	}
 </script>
 
 <style>
@@ -33,6 +41,6 @@
 
 <article>
 	<span>{i + offset + 1}</span>
-	<h2><a target="_blank" href={item.url}>{item.title}</a></h2>
+	<h2><a target="_blank" href={item_url()}>{item.title}</a></h2>
 	<p class="meta"><a href="#/item/{item.id}">{comment_text()}</a> by {item.user} {item.time_ago}</p>
 </article>


### PR DESCRIPTION
Before, the link for items of type `ask` would be `https://svelte.dev/item?id=22792829` (which returns a 404), and with this change, the correct URL `https://news.ycombinator.com/item?id=22792829` is generated.



### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
