### PR TITLE
fix(examples): hide "undefined" domain in HN example

### DIFF
--- a/site/content/examples/21-miscellaneous/01-hacker-news/Item.svelte
+++ b/site/content/examples/21-miscellaneous/01-hacker-news/Item.svelte
@@ -26,7 +26,9 @@
 <article>
 	<a href="{item.url}">
 		<h1>{item.title}</h1>
-		<small>{item.domain}</small>
+		{#if item.domain != null}
+			<small>{item.domain}</small>
+		{/if}
 	</a>
 
 	<p class="meta">submitted by {item.user} {item.time_ago}

--- a/site/content/examples/21-miscellaneous/01-hacker-news/Item.svelte
+++ b/site/content/examples/21-miscellaneous/01-hacker-news/Item.svelte
@@ -26,7 +26,7 @@
 <article>
 	<a href="{item.url}">
 		<h1>{item.title}</h1>
-		{#if item.domain != null}
+		{#if item.domain}
 			<small>{item.domain}</small>
 		{/if}
 	</a>


### PR DESCRIPTION
This commit introduces a null-undefined check against the domain of the HN items in the Hacker News example.

### Before
![Screenshot 2020-04-06 at 16 02 33](https://user-images.githubusercontent.com/22741774/78567206-9e661c00-7820-11ea-8b5e-3c87ffbd28e0.png)

---
### After
![Screenshot 2020-04-06 at 16 02 20](https://user-images.githubusercontent.com/22741774/78567199-9d34ef00-7820-11ea-90f9-3172dd98c258.png)

Note that it still works fine on items with correct domain

![Screenshot 2020-04-06 at 16 07 42](https://user-images.githubusercontent.com/22741774/78567358-d79e8c00-7820-11ea-92bf-733cff1df64d.png)

---

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
