### PR TITLE
move destructuring to the beginning of await block updates

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -60,7 +60,7 @@ class AwaitBlockBranch extends Wrapper {
 
 			this.block.chunks.declarations.push(b`(${node.pattern} = #ctx[${index}])`);
 			if (this.block.has_update_method) {
-				this.block.chunks.update.push(b`(${node.pattern} = #ctx[${index}])`);
+				this.block.chunks.update.unshift(b`(${node.pattern} = #ctx[${index}])`);
 			}
 		}
 	}

--- a/test/runtime/samples/await-then-destruct-if/_config.js
+++ b/test/runtime/samples/await-then-destruct-if/_config.js
@@ -1,0 +1,15 @@
+export default {
+	async test({ assert, target, component }) {
+		await Promise.resolve();
+
+		component.fail = 'wrong';
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			correct
+			correct
+			`
+		);
+	}
+};

--- a/test/runtime/samples/await-then-destruct-if/main.svelte
+++ b/test/runtime/samples/await-then-destruct-if/main.svelte
@@ -1,0 +1,24 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	export let fail = 'incorrect'
+
+	const object = writable(Promise.resolve({ result: true }))
+	const array = writable(Promise.resolve([true]))
+</script>
+
+{#await $object then { result }}
+	{#if result}
+		correct
+	{:else}
+		{fail}
+	{/if}
+{/await}
+
+{#await $array then [result]}
+	{#if result}
+		correct
+	{:else}
+		{fail}
+	{/if}
+{/await}


### PR DESCRIPTION
Resubmitted because the previous PR wasn't clear to people.

The issue happened when a dynamic await branch with destructuring depended on one of its destructured values in an if/else block branching decision. Because the destructuring happened at the end of the update function after the if block determined its branch, the depended value was always `undefined`. Moving the destructuring to the start of the function fixes the bug.

Issue is illustrated in the attached test. It fails in the current version of svelte, passes in this one.