### PR TITLE
Derived stores composition + tiny optimizations

### DIFF
--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -1,3 +1,5 @@
+import { Store, Unsubscriber } from '../store';
+
 export function noop() {}
 
 export const identity = x => x;
@@ -14,7 +16,7 @@ export function is_promise<T = any>(value: any): value is PromiseLike<T> {
 
 export function add_location(element, file, line, column, char) {
 	element.__svelte_meta = {
-		loc: { file, line, column, char }
+		loc: { file, line, column, char },
 	};
 }
 
@@ -35,7 +37,7 @@ export function is_function(thing: any): thing is Function {
 }
 
 export function safe_not_equal(a, b) {
-	return a != a ? b == b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
+	return a != a ? b == b : a !== b || (a && typeof a === 'object') || typeof a === 'function';
 }
 
 export function not_equal(a, b) {
@@ -48,17 +50,16 @@ export function validate_store(store, name) {
 	}
 }
 
-export function subscribe(store, ...callbacks) {
-	if (store == null) {
-		return noop;
-	}
+export function subscribe<T>(store: Store<T>, ...callbacks: Parameters<Store<T>['subscribe']>): Unsubscriber {
+	if (store == null) return noop;
 	const unsub = store.subscribe(...callbacks);
+	// @ts-ignore
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 
 export function get_store_value(store) {
 	let value;
-	subscribe(store, _ => value = _)();
+	subscribe(store, _ => (value = _))();
 	return value;
 }
 
@@ -74,9 +75,7 @@ export function create_slot(definition, ctx, $$scope, fn) {
 }
 
 export function get_slot_context(definition, ctx, $$scope, fn) {
-	return definition[1] && fn
-		? assign($$scope.ctx.slice(), definition[1](fn(ctx)))
-		: $$scope.ctx;
+	return definition[1] && fn ? assign($$scope.ctx.slice(), definition[1](fn(ctx))) : $$scope.ctx;
 }
 
 export function get_slot_changes(definition, $$scope, dirty, fn) {
@@ -118,7 +117,7 @@ export function compute_rest_props(props, keys) {
 
 export function once(fn) {
 	let ran = false;
-	return function(this: any, ...args) {
+	return function (this: any, ...args) {
 		if (ran) return;
 		ran = true;
 		fn.call(this, ...args);

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -90,8 +90,8 @@ export function writable<T>(value: T, start: StartStopNotifier<T> = noop): Writa
 		invalidate: Invalidator<T> = noop
 	): Unsubscriber {
 		const subscriber: SubscribeInvalidateTuple<T> = [run, invalidate];
-		if (!subscribers.length) stop = start(set) || noop;
 		subscribers.push(subscriber);
+		if (subscribers.length === 1) stop = start(set) || noop;
 		run(value);
 		return () => {
 			const index = subscribers.indexOf(subscriber);

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -168,6 +168,7 @@ function auto(fn): DeriverController {
 		update(payload, set) {
 			set(fn(payload));
 		},
+		cleanup: noop,
 	};
 }
 function manual(fn): DeriverController {

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -135,11 +135,7 @@ export function derived<S extends SingleStore | ArrayStore, F extends Deriver<S,
 
 /** DERIVING LOGIC */
 
-/**
- * derived from a single store
- *
- * derived store StartStopNotifier function when given a single store
- * */
+/** derived StartStopNotifier when given a single store */
 const single = <T>(store: SingleStore, controller: DeriverController): StartStopNotifier<T> => set => {
 	const unsub = subscribe(store, value => controller.update(value, set));
 	return function stop() {
@@ -147,7 +143,7 @@ const single = <T>(store: SingleStore, controller: DeriverController): StartStop
 	};
 };
 
-/** derived store StartStopNotifier function when given an array of stores */
+/** derived StartStopNotifier when given an array of stores */
 const multiple = <T>(stores: ArrayStore, controller: DeriverController): StartStopNotifier<T> => set => {
 	const values = new Array(stores.length);
 	let pending = 1 << stores.length;
@@ -178,9 +174,7 @@ const multiple = <T>(stores: ArrayStore, controller: DeriverController): StartSt
 
 /**
  *  mode "auto" : function has <2 arguments
- *
- *  derived value = value returned by the function
- *
+ *  the derived value is the value returned by the function
  */
 const auto = (fn: AutoDeriver<any, any>): DeriverController => ({
 	update(payload, set) {
@@ -191,11 +185,10 @@ const auto = (fn: AutoDeriver<any, any>): DeriverController => ({
 
 /**
  *  mode "manual" : function has >1 arguments
+ *  [(...args) does not count as an argument]
  *
- *  derived value = value set manually
- *  before each update => callback returned by the function
- *
- *  note :  [(...args) does not count as an argument]
+ *  derived value is a value set() manually
+ *  if a callback is returned it is called on next update
  */
 const manual = (fn: ManualDeriver<any, any>): DeriverController => ({
 	update(payload, set) {


### PR DESCRIPTION
I made some tweaks to svelte stores in a standalone for another project and thought it might be worth a PR

The current `derived` store function performs unnecessary work by merging 4 runtimes into a single one. It can either have one or multiple stores and `set` is either called automatically through a returned value or manually where the returned value becomes an optional cleanup. I rewrote it to compose from 2 pairs of functions instead. 

It gives derived stores a clear structure that makes the logic behind it easily understandable. While I did not change any logic or introduce any new behavior, I do find the modularity of that design to be very inspiring.

Also did tiny changes in `writable`, removed some variables & added some types