### PR TITLE
Create .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+	"quoteProps": "consistent",
+	"arrowParens": "avoid",
+	"jsxBracketSameLine": true,
+	"jsxSingleQuote": true,
+	"singleQuote": true,
+	"printWidth": 120,
+	"useTabs": true,
+	"semi": true
+}


### PR DESCRIPTION
This file is used in case you have the prettier extension installed and you format the file you're working on
https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
I'm not asking to reformat the whole thing, or to have those options precisely, I just want a preset common to the project, so as to make it consistent looking

The options as is are compatible with the linting, I'd like the `semi` linting rule removed however, doesn't make much sense to keep it enabled
`one-var` also, but that might be more touchy I guess