### PR TITLE
Fix #4680 - CSS typo in example

### DIFF
--- a/site/content/examples/03-logic/04-keyed-each-blocks/App.svelte
+++ b/site/content/examples/03-logic/04-keyed-each-blocks/App.svelte
@@ -18,7 +18,7 @@
 	Remove first thing
 </button>
 
-<div style="display: grid; grid-template-columns: 1fr 1fr; grip-gap: 1em">
+<div style="display: grid; grid-template-columns: 1fr 1fr; grid-gap: 1em">
 	<div>
 		<h2>Keyed</h2>
 		{#each things as thing (thing.id)}


### PR DESCRIPTION
Change `grip-gap` to the intended `grid-gap`.

Fixes #4680.