### PR TITLE
Opt out of loop protection if inside generator

### DIFF
--- a/test/runtime/samples/loop-protect-generator-opt-out/_config.js
+++ b/test/runtime/samples/loop-protect-generator-opt-out/_config.js
@@ -1,0 +1,6 @@
+export default {
+	compileOptions: {
+		dev: true,
+		loopGuardTimeout: 1,
+	},
+};

--- a/test/runtime/samples/loop-protect-generator-opt-out/main.svelte
+++ b/test/runtime/samples/loop-protect-generator-opt-out/main.svelte
@@ -1,0 +1,14 @@
+<script>
+  let it = gen();
+  it.next();
+  
+  setTimeout(() => {
+    it.next();
+  }, 20)
+
+  function* gen() {
+    while (true) {
+      yield;
+    }
+  }
+</script>

--- a/test/runtime/samples/loop-protect-generator-opt-out/main.svelte
+++ b/test/runtime/samples/loop-protect-generator-opt-out/main.svelte
@@ -1,14 +1,14 @@
 <script>
-  let it = gen();
-  it.next();
-  
-  setTimeout(() => {
-    it.next();
-  }, 20)
+	const it = gen();
+	it.next();
 
-  function* gen() {
-    while (true) {
-      yield;
-    }
-  }
+	setTimeout(() => {
+		it.next();
+	}, 20)
+
+	function* gen() {
+		while (true) {
+			yield;
+		}
+	}
 </script>


### PR DESCRIPTION
Fixes #4698

This PR will allow us to use loops within generator functions in the REPL without it throwing an incorrect "Infinite loop" error. This is done by opting out of `loop_protect` if the loop is inside a generator function

I have used `generator_count` rather than a simple boolean to make sure it works for nested generators also

I'm very new to both ASTs and the Svelte codebase so if there's a better way to do this I'd love to hear it!

Thanks
