### PR TITLE
Fix `slide` behavior in safari when element is transitioning

### DIFF
--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -128,7 +128,12 @@ export function slide(node: Element, {
 			`margin-top: ${t * margin_top}px;` +
 			`margin-bottom: ${t * margin_bottom}px;` +
 			`border-top-width: ${t * border_top_width}px;` +
-			`border-bottom-width: ${t * border_bottom_width}px;`
+			`border-bottom-width: ${t * border_bottom_width}px;` +
+			// fixes #4712
+			// Safari has bug that when element is transitioning, it'll ignore overflow: hidden property,
+			// adding this property seems to work. see https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
+			// for more details. 
+			`-webkit-mask-image: -webkit-radial-gradient(white, black);`,
 	};
 }
 

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -131,8 +131,8 @@ export function slide(node: Element, {
 			`border-bottom-width: ${t * border_bottom_width}px;` +
 			// fixes #4712
 			// Safari has bug that when element is transitioning, it'll ignore overflow: hidden property,
-			// adding this property seems to work. see https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
-			// for more details. 
+			// adding this property seems to work.
+			// see https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
 			`-webkit-mask-image: -webkit-radial-gradient(white, black);`,
 	};
 }


### PR DESCRIPTION
fixes #4712 

## Summary

While I'm not sure if it's what svelte wants to deal with, it looks like safari has a bug that it'll ignore element `overflow: hidden;` when it's transitioning. I found this [solution](https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b), which adds a css property to element itself and it works as expected.

[repl](https://svelte.dev/repl/f0a579625c9f4d69978e3e87911a5ac9?version=3.21.0) (from #4712)


## Screenshot

### iOS Safari (simulator)
![transition1](https://user-images.githubusercontent.com/6581081/80313976-55a2f100-8829-11ea-923a-f0e644ad3dae.gif)

### Safari
![transition2](https://user-images.githubusercontent.com/6581081/80313978-5d629580-8829-11ea-959a-1f21286bd600.gif)