### PR TITLE
Fix: make condition check height in addition to width

### DIFF
--- a/site/scripts/get-example-thumbnails/index.js
+++ b/site/scripts/get-example-thumbnails/index.js
@@ -45,7 +45,7 @@ async function main() {
 			image.autocrop();
 			// image.scale(0.25);
 
-			if (image.bitmap.width > 200 || image.bitmap.width > 200) {
+			if (image.bitmap.width > 200 || image.bitmap.height > 200) {
 				const scale = Math.min(
 					200 / image.bitmap.width,
 					200 / image.bitmap.height


### PR DESCRIPTION
The `if` conditional was checking the same condition twice. The code
appears to intend to check both the height and width. I found this alert
on LGTM.com:
https://lgtm.com/projects/g/sveltejs/svelte/alerts/?mode=list
