### PR TITLE
a11y: warn about href="javascript:void(0)"

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -428,7 +428,7 @@ export default class Element extends Node {
 			if (attribute) {
 				const value = attribute.get_static_value();
 
-				if (value === '' || value === '#' || /^\W*javascript:/.test(value)) {
+				if (value === '' || value === '#' || /^\W*javascript:/i.test(value)) {
 					component.warn(attribute, {
 						code: `a11y-invalid-attribute`,
 						message: `A11y: '${value}' is not a valid ${attribute.name} attribute`

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -428,7 +428,7 @@ export default class Element extends Node {
 			if (attribute) {
 				const value = attribute.get_static_value();
 
-				if (value === '' || value === '#' || /^\W*?javascript/.test(value)) {
+				if (value === '' || value === '#' || /^\W*javascript:/.test(value)) {
 					component.warn(attribute, {
 						code: `a11y-invalid-attribute`,
 						message: `A11y: '${value}' is not a valid ${attribute.name} attribute`

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -428,7 +428,7 @@ export default class Element extends Node {
 			if (attribute) {
 				const value = attribute.get_static_value();
 
-				if (value === '' || value === '#') {
+				if (value === '' || value === '#' || /^\W*?javascript/.test(value)) {
 					component.warn(attribute, {
 						code: `a11y-invalid-attribute`,
 						message: `A11y: '${value}' is not a valid ${attribute.name} attribute`

--- a/test/validator/samples/a11y-anchor-is-valid/input.svelte
+++ b/test/validator/samples/a11y-anchor-is-valid/input.svelte
@@ -1,3 +1,4 @@
 <a>not actually a link</a>
 <a href=''>invalid</a>
 <a href='#'>invalid</a>
+<a href="javascript:void(0)">invalid</a>

--- a/test/validator/samples/a11y-anchor-is-valid/warnings.json
+++ b/test/validator/samples/a11y-anchor-is-valid/warnings.json
@@ -43,5 +43,20 @@
 			"character": 61
 		},
 		"pos": 53
+	},
+	{
+		"code": "a11y-invalid-attribute",
+		"message": "A11y: 'javascript:void(0)' is not a valid href attribute",
+		"start": {
+			"line": 4,
+			"column": 3,
+			"character": 77
+		},
+		"end": {
+			"line": 4,
+			"column": 28,
+			"character": 102
+		},
+		"pos": 77
 	}
 ]


### PR DESCRIPTION
## Summary

`href="javascript:void(0)"` is not recommended for a11y and maybe it would be great if svelte can warn about it.

## Note

Besides, would it be great to warn about something like:

```svelte
<a href={null}></a>
<a href={undefined}></a>
<a href={`javascript:void(0)`}></a>
```
as well? If so I'm willing to help or have an issue about this.

### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
