### PR TITLE
Fix perserveComments on ssr (#4730)

### DIFF
--- a/src/compiler/compile/render_ssr/handlers/Comment.ts
+++ b/src/compiler/compile/render_ssr/handlers/Comment.ts
@@ -1,10 +1,8 @@
 import Renderer, { RenderOptions } from '../Renderer';
 import Comment from '../../nodes/Comment';
 
-export default function(_node: Comment, _renderer: Renderer, _options: RenderOptions) {
-	// TODO preserve comments
-
-	// if (options.preserveComments) {
-	// 	renderer.append(`<!--${node.data}-->`);
-	// }
+export default function(node: Comment, renderer: Renderer, options: RenderOptions) {
+	if (options.preserveComments) {
+		renderer.add_string(`<!--${node.data}-->`);
+	}
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -4,7 +4,7 @@ import glob from 'tiny-glob/sync';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as colors from 'kleur';
-export const assert = (assert$1 as unknown) as typeof assert$1 & { htmlEqual: (actual, expected, message?) => void };
+export const assert = (assert$1 as unknown) as typeof assert$1 & { htmlEqual: (actual, expected, message?) => void, htmlEqualWithComments: (actual, expected, message?) => void };
 
 // for coverage purposes, we need to test source files,
 // but for sanity purposes, we need to test dist files
@@ -118,6 +118,9 @@ function cleanChildren(node) {
 				node.removeChild(child);
 				child = previous;
 			}
+		} else if (child.nodeType === 8) {
+			// comment
+			// do nothing
 		} else {
 			cleanChildren(child);
 		}
@@ -137,11 +140,11 @@ function cleanChildren(node) {
 	}
 }
 
-export function normalizeHtml(window, html) {
+export function normalizeHtml(window, html, preserveComments = false) {
 	try {
 		const node = window.document.createElement('div');
 		node.innerHTML = html
-			.replace(/<!--.*?-->/g, '')
+			.replace(/(<!--.*?-->)/g, preserveComments ? '$1' : '')
 			.replace(/>[\s\r\n]+</g, '><')
 			.trim();
 		cleanChildren(node);
@@ -159,6 +162,14 @@ export function setupHtmlEqual() {
 		assert.deepEqual(
 			normalizeHtml(window, actual),
 			normalizeHtml(window, expected),
+			message
+		);
+	};
+	// eslint-disable-next-line no-import-assign
+	assert.htmlEqualWithComments = (actual, expected, message) => {
+		assert.deepEqual(
+			normalizeHtml(window, actual, true),
+			normalizeHtml(window, expected, true),
 			message
 		);
 	};

--- a/test/js/samples/ssr-preserve-comments/expected.js
+++ b/test/js/samples/ssr-preserve-comments/expected.js
@@ -3,7 +3,7 @@ import { create_ssr_component } from "svelte/internal";
 
 const Component = create_ssr_component(($$result, $$props, $$bindings, slots) => {
 	return `<div>content</div>
-
+<!-- comment -->
 <div>more content</div>`;
 });
 

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -81,7 +81,11 @@ describe('ssr', () => {
 				if (css.code) fs.writeFileSync(`${dir}/_actual.css`, css.code);
 
 				try {
-					assert.htmlEqual(html, expectedHtml);
+					if (compileOptions.preserveComments) {
+						assert.equal(html.trim(), expectedHtml.trim());
+					} else {
+						assert.htmlEqual(html, expectedHtml);
+					}
 				} catch (error) {
 					if (shouldUpdateExpected()) {
 						fs.writeFileSync(`${dir}/_expected.html`, html);

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -81,11 +81,9 @@ describe('ssr', () => {
 				if (css.code) fs.writeFileSync(`${dir}/_actual.css`, css.code);
 
 				try {
-					if (compileOptions.preserveComments) {
-						assert.equal(html.trim(), expectedHtml.trim());
-					} else {
-						assert.htmlEqual(html, expectedHtml);
-					}
+					(compileOptions.preserveComments
+						? assert.htmlEqualWithComments
+						: assert.htmlEqual)(html, expectedHtml);
 				} catch (error) {
 					if (shouldUpdateExpected()) {
 						fs.writeFileSync(`${dir}/_expected.html`, html);

--- a/test/server-side-rendering/samples/comment-preserve/_config.js
+++ b/test/server-side-rendering/samples/comment-preserve/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		preserveComments: true
+	}
+};

--- a/test/server-side-rendering/samples/comment-preserve/_expected.html
+++ b/test/server-side-rendering/samples/comment-preserve/_expected.html
@@ -1,0 +1,3 @@
+<p>before</p>
+<!-- a comment -->
+<p>after</p>

--- a/test/server-side-rendering/samples/comment-preserve/main.svelte
+++ b/test/server-side-rendering/samples/comment-preserve/main.svelte
@@ -1,0 +1,3 @@
+<p>before</p>
+<!-- a comment -->
+<p>after</p>


### PR DESCRIPTION
Fixes #4730 

Should I create a test in `server-side-rendering/samples` or the existing one in `js/samples/ssr-preserve-comments` is enough?

Adding the test in server-side-rendering will require an extra config flag to not use `assert.htmlEqual` on that specific test, as it removes comments.