### PR TITLE
WIP fix for #4731: preserveWhitespace in SSR

### DIFF
--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -12,7 +12,11 @@ export default function(node: Element, renderer: Renderer, options: RenderOption
 	slot_scopes: Map<any, any>;
 }) {
 
-	const children = remove_whitespace_children(node.children, node.next);
+	const children = (
+		options.preserveWhitespace
+			? node.children
+			: remove_whitespace_children(node.children, node.next)
+	);
 
 	// awkward special case
 	let node_contents;

--- a/src/compiler/compile/render_ssr/handlers/InlineComponent.ts
+++ b/src/compiler/compile/render_ssr/handlers/InlineComponent.ts
@@ -68,7 +68,11 @@ export default function(node: InlineComponent, renderer: Renderer, options: Rend
 
 	const slot_fns = [];
 
-	const children = remove_whitespace_children(node.children, node.next);
+	const children = (
+		options.preserveWhitespace
+			? node.children
+			: remove_whitespace_children(node.children, node.next)
+	);
 
 	if (children.length) {
 		const slot_scopes = new Map();

--- a/src/compiler/compile/render_ssr/index.ts
+++ b/src/compiler/compile/render_ssr/index.ts
@@ -18,8 +18,14 @@ export default function ssr(
 
 	const { name } = component;
 
+	const children = (
+		options.preserveWhitespace
+			? component.fragment.children
+			: trim(component.fragment.children)
+	);
+
 	// create $$render function
-	renderer.render(trim(component.fragment.children), Object.assign({
+	renderer.render(children, Object.assign({
 		locate: component.locate
 	}, options));
 

--- a/test/server-side-rendering/index.js
+++ b/test/server-side-rendering/index.js
@@ -76,7 +76,11 @@ describe("ssr", () => {
 				if (css.code) fs.writeFileSync(`${dir}/_actual.css`, css.code);
 
 				try {
-					assert.htmlEqual(html, expectedHtml);
+					if (compileOptions.preserveWhitespace) {
+						assert.equal(html, expectedHtml);
+					} else {
+						assert.htmlEqual(html, expectedHtml);
+					}
 				} catch (error) {
 					if (shouldUpdateExpected()) {
 						fs.writeFileSync(`${dir}/_expected.html`, html);

--- a/test/server-side-rendering/samples/preserve-whitespace/_config.js
+++ b/test/server-side-rendering/samples/preserve-whitespace/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		preserveWhitespace: true
+	}
+};

--- a/test/server-side-rendering/samples/preserve-whitespace/_expected.html
+++ b/test/server-side-rendering/samples/preserve-whitespace/_expected.html
@@ -1,0 +1,11 @@
+
+<div>
+    <div>
+        <p> Some text </p>
+    </div>
+    <select>
+        <option value="1">1</option>
+        <option value="2">2</option>
+    </select>
+</div>
+

--- a/test/server-side-rendering/samples/preserve-whitespace/main.svelte
+++ b/test/server-side-rendering/samples/preserve-whitespace/main.svelte
@@ -4,8 +4,9 @@
         <p> Some text </p>
     </div>
     <select>
-        <option value="1">1</option>
-        <option value="2">2</option>
+{#each [1, 2] as value}
+        <option>{value}</option>
+{/each}
     </select>
 </div>
 

--- a/test/server-side-rendering/samples/preserve-whitespace/main.svelte
+++ b/test/server-side-rendering/samples/preserve-whitespace/main.svelte
@@ -1,0 +1,11 @@
+
+<div>
+    <div>
+        <p> Some text </p>
+    </div>
+    <select>
+        <option value="1">1</option>
+        <option value="2">2</option>
+    </select>
+</div>
+


### PR DESCRIPTION
WIP fix for #4731.

Why this is still work in progress:
- [x] ~the test works, but don't currently fail, because `htmlEqual` [uses `normalizeHtml` which strips spaces & comments](https://github.com/sveltejs/svelte/blob/e3fef0f740fa788bba68a29f5561ad439475edbb/test/helpers.js#L143-L145) (same problem as #4736), any advise?~
***Update:** solved by [updating the testing code in #f2e0479](https://github.com/bwbroersma/svelte/commit/f2e047922b333fa53e3aa91b990e611f155fdc7b#diff-a3d48d9bec58270d822587f7c0987c52)*
- [ ] trailing newlines are not generated in the `_actual.html`, but are in working with full samples, what am I missing?
- [ ] `option` in `{#each}`-loop still don't preserve whitespace (was looking at `should_skip` in [`src/compiler/compile/render_dom/wrappers/Text.ts`](https://github.com/sveltejs/svelte/blob/e3fef0f740fa788bba68a29f5561ad439475edbb/src/compiler/compile/render_dom/wrappers/Text.ts#L23))

*Update: both open issues seem to be related to `should_skip` in `src/compiler/compile/nodes/Text.ts`, for some reason this check doesn't work (`preserveWhitespace` seems to be false):*
```ts
		return parent_element.namespace
			|| elements_without_text.has(parent_element.name)
			&& (this.component.compile_options.preserveWhitespace
				|| this.component.component_options.preserveWhitespace);
```
