### PR TITLE
fix misaligned line number in sourcemap (#3906)

### DIFF
--- a/src/compiler/parse/read/script.ts
+++ b/src/compiler/parse/read/script.ts
@@ -31,13 +31,16 @@ function get_context(parser: Parser, attributes: any[], start: number): string {
 export default function read_script(parser: Parser, start: number, attributes: Node[]): Script {
 	const script_start = parser.index;
 	const script_end = parser.template.indexOf(script_closing_tag, script_start);
+	const script_start_line = parser.template.slice(0, script_start).split('\n').length - 1;
 
 	if (script_end === -1) parser.error({
 		code: `unclosed-script`,
 		message: `<script> must have a closing tag`
 	});
 
-	const source = ' '.repeat(script_start) + parser.template.slice(script_start, script_end);
+	const source = '\n'.repeat(script_start_line) + ' '.repeat(script_start - script_start_line) +
+		parser.template.slice(script_start, script_end);
+
 	parser.index = script_end + script_closing_tag.length;
 
 	let ast: Program;

--- a/src/compiler/parse/read/script.ts
+++ b/src/compiler/parse/read/script.ts
@@ -31,16 +31,14 @@ function get_context(parser: Parser, attributes: any[], start: number): string {
 export default function read_script(parser: Parser, start: number, attributes: Node[]): Script {
 	const script_start = parser.index;
 	const script_end = parser.template.indexOf(script_closing_tag, script_start);
-	const script_start_line = parser.template.slice(0, script_start).split('\n').length - 1;
 
 	if (script_end === -1) parser.error({
 		code: `unclosed-script`,
 		message: `<script> must have a closing tag`
 	});
 
-	const source = '\n'.repeat(script_start_line) + ' '.repeat(script_start - script_start_line) +
+	const source = parser.template.slice(0, script_start).replace(/[^\n]/g, ' ') +
 		parser.template.slice(script_start, script_end);
-
 	parser.index = script_end + script_closing_tag.length;
 
 	let ast: Program;

--- a/test/sourcemaps/samples/script-after-comment/input.svelte
+++ b/test/sourcemaps/samples/script-after-comment/input.svelte
@@ -1,0 +1,9 @@
+<!--
+	Multiline
+	comment
+-->
+<script>
+	function assertThisLine() {}
+</script>
+
+{foo.bar.baz}

--- a/test/sourcemaps/samples/script-after-comment/test.js
+++ b/test/sourcemaps/samples/script-after-comment/test.js
@@ -1,0 +1,16 @@
+export function test({ assert, smc, locateInSource, locateInGenerated }) {
+	const expected = locateInSource( 'assertThisLine' );
+	const start = locateInGenerated( 'assertThisLine' );
+
+	const actual = smc.originalPositionFor({
+		line: start.line + 1,
+		column: start.column
+	});
+
+	assert.deepEqual( actual, {
+		source: 'input.svelte',
+		name: null,
+		line: expected.line + 1,
+		column: expected.column
+	});
+}

--- a/test/sourcemaps/samples/two-scripts/input.svelte
+++ b/test/sourcemaps/samples/two-scripts/input.svelte
@@ -1,0 +1,9 @@
+<script context="module">
+	export let first;
+</script>
+
+<script>
+	function assertThisLine() {}
+</script>
+
+{foo.bar.baz}

--- a/test/sourcemaps/samples/two-scripts/test.js
+++ b/test/sourcemaps/samples/two-scripts/test.js
@@ -1,0 +1,16 @@
+export function test({ assert, smc, locateInSource, locateInGenerated }) {
+	const expected = locateInSource( 'assertThisLine' );
+	const start = locateInGenerated( 'assertThisLine' );
+
+	const actual = smc.originalPositionFor({
+		line: start.line + 1,
+		column: start.column
+	});
+
+	assert.deepEqual( actual, {
+		source: 'input.svelte',
+		name: null,
+		line: expected.line + 1,
+		column: expected.column
+	});
+}


### PR DESCRIPTION
Fixes issue #3906.  Sourcemaps line numbers for every `<script>` start at line 1, even when the script is lower in the file.  E.g.

```
<!-- Some comment
and more
and more details -->
<script>
  ...
</script>
```

and

```
<script context="module">
  // correct sourcemap
  ...
</script>
<script>
  // incorrect sourcemap
  ...
</script>
```

The two examples above are (approximately) the two tests included in this PR.  Both tests fail prior to applying the fix and pass afterwards.
 