### PR TITLE
Component custom prefix option

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -29,6 +29,7 @@ import add_to_set from './utils/add_to_set';
 import check_graph_for_cycles from './utils/check_graph_for_cycles';
 import { print, x, b } from 'code-red';
 import { is_reserved_keyword } from './utils/reserved_keywords';
+import get_prefix from './utils/get_prefix';
 
 interface ComponentOptions {
 	namespace?: string;
@@ -133,7 +134,8 @@ export default class Component {
 			source,
 			ast,
 			compile_options.filename,
-			compile_options.dev
+			compile_options.dev,
+			get_prefix(compile_options.prefix),
 		);
 		this.stylesheet.validate(this);
 

--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -291,14 +291,14 @@ export default class Stylesheet {
 
 	nodes_with_css_class: Set<CssNode> = new Set();
 
-	constructor(source: string, ast: Ast, filename: string, dev: boolean) {
+	constructor(source: string, ast: Ast, filename: string, dev: boolean, prefix: string) {
 		this.source = source;
 		this.ast = ast;
 		this.filename = filename;
 		this.dev = dev;
 
 		if (ast.css && ast.css.children.length) {
-			this.id = `svelte-${hash(ast.css.content.styles)}`;
+			this.id = `${prefix}${hash(ast.css.content.styles)}`;
 
 			this.has_styles = true;
 

--- a/src/compiler/compile/index.ts
+++ b/src/compiler/compile/index.ts
@@ -26,7 +26,8 @@ const valid_options = [
 	'css',
 	'loopGuardTimeout',
 	'preserveComments',
-	'preserveWhitespace'
+	'preserveWhitespace',
+	'prefix',
 ];
 
 function validate_options(options: CompileOptions, warnings: Warning[]) {

--- a/src/compiler/compile/nodes/Head.ts
+++ b/src/compiler/compile/nodes/Head.ts
@@ -1,6 +1,7 @@
 import Node from './shared/Node';
 import map_children from './shared/map_children';
 import hash from '../utils/hash';
+import get_prefix from '../utils/get_prefix';
 
 export default class Head extends Node {
 	type: 'Head';
@@ -22,7 +23,7 @@ export default class Head extends Node {
 		}));
 
 		if (this.children.length > 0) {
-			this.id = `svelte-${hash(this.component.source.slice(this.start, this.end))}`;
+			this.id = `${get_prefix(this.component.compile_options.prefix)}${hash(this.component.source.slice(this.start, this.end))}`;
 		}
 	}
 }

--- a/src/compiler/compile/utils/get_prefix.ts
+++ b/src/compiler/compile/utils/get_prefix.ts
@@ -1,0 +1,9 @@
+export default function get_prefix(str?: string): string {
+    const standard_prefix = 'svelte-';
+    if (!str
+        || typeof str !== 'string') return standard_prefix;
+    str = str.replace(/^[^_-a-z]+|[^_-a-z0-9]/gi, '');
+    return str.length
+        ? str
+        : standard_prefix;
+}

--- a/src/compiler/compile/utils/get_prefix.ts
+++ b/src/compiler/compile/utils/get_prefix.ts
@@ -2,7 +2,7 @@ export default function get_prefix(str?: string): string {
     const standard_prefix = 'svelte-';
     if (!str
         || typeof str !== 'string') return standard_prefix;
-    str = str.replace(/^[^_-a-z]+|[^_-a-z0-9]/gi, '');
+    str = str.replace(/^[^_\-a-z]+|[^_\-a-z0-9]/gi, '');
     return str.length
         ? str
         : standard_prefix;

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -123,6 +123,7 @@ export interface CompileOptions {
 	tag?: string;
 	css?: boolean;
 	loopGuardTimeout?: number;
+	prefix?: string;
 
 	preserveComments?: boolean;
 	preserveWhitespace?: boolean;

--- a/test/css/samples/custom-prefix-has-only-disallowed-characters/_config.js
+++ b/test/css/samples/custom-prefix-has-only-disallowed-characters/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		prefix: ' $!*'
+	}
+};

--- a/test/css/samples/custom-prefix-has-only-disallowed-characters/expected.css
+++ b/test/css/samples/custom-prefix-has-only-disallowed-characters/expected.css
@@ -1,0 +1,1 @@
+div.svelte-xyz{color:blue}

--- a/test/css/samples/custom-prefix-has-only-disallowed-characters/expected.css
+++ b/test/css/samples/custom-prefix-has-only-disallowed-characters/expected.css
@@ -1,1 +1,1 @@
-div.svelte-xyz{color:blue}
+div.svelte-1tjtw78{color:blue}

--- a/test/css/samples/custom-prefix-has-only-disallowed-characters/expected.css
+++ b/test/css/samples/custom-prefix-has-only-disallowed-characters/expected.css
@@ -1,1 +1,1 @@
-div.svelte-1tjtw78{color:blue}
+div.svelte-xyz{color:blue}

--- a/test/css/samples/custom-prefix-has-only-disallowed-characters/input.svelte
+++ b/test/css/samples/custom-prefix-has-only-disallowed-characters/input.svelte
@@ -1,0 +1,7 @@
+<div></div>
+
+<style>
+	div {
+		color: blue;
+	}
+</style>

--- a/test/css/samples/custom-prefix-has-special-character/_config.js
+++ b/test/css/samples/custom-prefix-has-special-character/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		prefix: 'me$-'
+	}
+};

--- a/test/css/samples/custom-prefix-has-special-character/expected.css
+++ b/test/css/samples/custom-prefix-has-special-character/expected.css
@@ -1,1 +1,1 @@
-div.me-xyz{color:blue}
+div.me-1tjtw78{color:blue}

--- a/test/css/samples/custom-prefix-has-special-character/expected.css
+++ b/test/css/samples/custom-prefix-has-special-character/expected.css
@@ -1,0 +1,1 @@
+div.me-xyz{color:blue}

--- a/test/css/samples/custom-prefix-has-special-character/input.svelte
+++ b/test/css/samples/custom-prefix-has-special-character/input.svelte
@@ -1,0 +1,7 @@
+<div></div>
+
+<style>
+	div {
+		color: blue;
+	}
+</style>

--- a/test/css/samples/custom-prefix-has-whitespace/_config.js
+++ b/test/css/samples/custom-prefix-has-whitespace/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		prefix: 'me -'
+	}
+};

--- a/test/css/samples/custom-prefix-has-whitespace/expected.css
+++ b/test/css/samples/custom-prefix-has-whitespace/expected.css
@@ -1,1 +1,1 @@
-div.me-xyz{color:blue}
+div.me-1tjtw78{color:blue}

--- a/test/css/samples/custom-prefix-has-whitespace/expected.css
+++ b/test/css/samples/custom-prefix-has-whitespace/expected.css
@@ -1,0 +1,1 @@
+div.me-xyz{color:blue}

--- a/test/css/samples/custom-prefix-has-whitespace/input.svelte
+++ b/test/css/samples/custom-prefix-has-whitespace/input.svelte
@@ -1,0 +1,7 @@
+<div></div>
+
+<style>
+	div {
+		color: blue;
+	}
+</style>

--- a/test/css/samples/custom-prefix-no-string/_config.js
+++ b/test/css/samples/custom-prefix-no-string/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		prefix: true
+	}
+};

--- a/test/css/samples/custom-prefix-no-string/expected.css
+++ b/test/css/samples/custom-prefix-no-string/expected.css
@@ -1,0 +1,1 @@
+div.svelte-xyz{color:blue}

--- a/test/css/samples/custom-prefix-no-string/expected.css
+++ b/test/css/samples/custom-prefix-no-string/expected.css
@@ -1,1 +1,1 @@
-div.svelte-xyz{color:blue}
+div.svelte-1tjtw78{color:blue}

--- a/test/css/samples/custom-prefix-no-string/expected.css
+++ b/test/css/samples/custom-prefix-no-string/expected.css
@@ -1,1 +1,1 @@
-div.svelte-1tjtw78{color:blue}
+div.svelte-xyz{color:blue}

--- a/test/css/samples/custom-prefix-no-string/input.svelte
+++ b/test/css/samples/custom-prefix-no-string/input.svelte
@@ -1,0 +1,7 @@
+<div></div>
+
+<style>
+	div {
+		color: blue;
+	}
+</style>

--- a/test/css/samples/custom-prefix-starts-with-number/_config.js
+++ b/test/css/samples/custom-prefix-starts-with-number/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		prefix: '0me-'
+	}
+};

--- a/test/css/samples/custom-prefix-starts-with-number/expected.css
+++ b/test/css/samples/custom-prefix-starts-with-number/expected.css
@@ -1,1 +1,1 @@
-div.me-xyz{color:blue}
+div.me-1tjtw78{color:blue}

--- a/test/css/samples/custom-prefix-starts-with-number/expected.css
+++ b/test/css/samples/custom-prefix-starts-with-number/expected.css
@@ -1,0 +1,1 @@
+div.me-xyz{color:blue}

--- a/test/css/samples/custom-prefix-starts-with-number/input.svelte
+++ b/test/css/samples/custom-prefix-starts-with-number/input.svelte
@@ -1,0 +1,7 @@
+<div></div>
+
+<style>
+	div {
+		color: blue;
+	}
+</style>

--- a/test/css/samples/custom-prefix-starts-with-whitespace/_config.js
+++ b/test/css/samples/custom-prefix-starts-with-whitespace/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		prefix: ' me-'
+	}
+};

--- a/test/css/samples/custom-prefix-starts-with-whitespace/expected.css
+++ b/test/css/samples/custom-prefix-starts-with-whitespace/expected.css
@@ -1,1 +1,1 @@
-div.me-xyz{color:blue}
+div.me-1tjtw78{color:blue}

--- a/test/css/samples/custom-prefix-starts-with-whitespace/expected.css
+++ b/test/css/samples/custom-prefix-starts-with-whitespace/expected.css
@@ -1,0 +1,1 @@
+div.me-xyz{color:blue}

--- a/test/css/samples/custom-prefix-starts-with-whitespace/input.svelte
+++ b/test/css/samples/custom-prefix-starts-with-whitespace/input.svelte
@@ -1,0 +1,7 @@
+<div></div>
+
+<style>
+	div {
+		color: blue;
+	}
+</style>

--- a/test/css/samples/custom-prefix/_config.js
+++ b/test/css/samples/custom-prefix/_config.js
@@ -1,0 +1,5 @@
+export default {
+	compileOptions: {
+		prefix: 'me-'
+	}
+};

--- a/test/css/samples/custom-prefix/expected.css
+++ b/test/css/samples/custom-prefix/expected.css
@@ -1,1 +1,1 @@
-div.me-xyz{color:blue}
+div.me-1tjtw78{color:blue}

--- a/test/css/samples/custom-prefix/expected.css
+++ b/test/css/samples/custom-prefix/expected.css
@@ -1,0 +1,1 @@
+div.me-xyz{color:blue}

--- a/test/css/samples/custom-prefix/input.svelte
+++ b/test/css/samples/custom-prefix/input.svelte
@@ -1,0 +1,7 @@
+<div></div>
+
+<style>
+	div {
+		color: blue;
+	}
+</style>


### PR DESCRIPTION
Add the option to pass a custom prefix to the compiler.
- Fallback will be `svelte-`
- prefix is checked for validity as a class selector

Tests were run:
`npm run test -- -g css` with .solo on the newly added tests
![test](https://user-images.githubusercontent.com/30938967/80547152-c24bf600-89b7-11ea-986d-e1b4ead522d2.png)
