### PR TITLE
Change resize listener destruction ordering

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -585,7 +585,7 @@ export default class ElementWrapper extends Wrapper {
 						b`${resize_listener} = @add_resize_listener(${this.var}, ${callee}.bind(${this.var}));`
 					);
 
-					block.chunks.destroy.push(
+					block.chunks.destroy.unshift(
 						b`${resize_listener}();`
 					);
 				} else {

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -484,7 +484,7 @@ export default class InlineComponentWrapper extends Wrapper {
 				b`if (${name}) @transition_out(${name}.$$.fragment, #local);`
 			);
 
-			block.chunks.destroy.push(b`if (${name}) @destroy_component(${name}, ${parent_node ? null : 'detaching'});`);
+			block.chunks.destroy.splice(-1, 0, b`if (${name}) @destroy_component(${name}, ${parent_node ? null : 'detaching'});`);
 		} else {
 			const expression = this.node.name === 'svelte:self'
 				? component.name
@@ -523,7 +523,7 @@ export default class InlineComponentWrapper extends Wrapper {
 				`);
 			}
 
-			block.chunks.destroy.push(b`
+			block.chunks.destroy.splice(-1, 0, b`
 				@destroy_component(${name}, ${parent_node ? null : 'detaching'});
 			`);
 

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -287,8 +287,8 @@ export function add_resize_listener(node: HTMLElement, fn: () => void) {
 	append(node, iframe);
 
 	return () => {
-		detach(iframe);
 		if (unsubscribe) unsubscribe();
+		detach(iframe);
 	};
 }
 

--- a/test/js/samples/bind-width-height/expected.js
+++ b/test/js/samples/bind-width-height/expected.js
@@ -29,8 +29,8 @@ function create_fragment(ctx) {
 		i: noop,
 		o: noop,
 		d(detaching) {
-			if (detaching) detach(div);
 			div_resize_listener();
+			if (detaching) detach(div);
 		}
 	};
 }

--- a/test/js/samples/component-static-var/expected.js
+++ b/test/js/samples/component-static-var/expected.js
@@ -69,8 +69,8 @@ function create_fragment(ctx) {
 		},
 		d(detaching) {
 			destroy_component(foo, detaching);
-			if (detaching) detach(t0);
 			destroy_component(bar, detaching);
+			if (detaching) detach(t0);
 			if (detaching) detach(t1);
 			if (detaching) detach(input);
 			dispose();

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -48,8 +48,8 @@ function create_fragment(ctx) {
 		},
 		d(detaching) {
 			destroy_component(imported, detaching);
-			if (detaching) detach(t);
 			destroy_component(nonimported, detaching);
+			if (detaching) detach(t);
 		}
 	};
 }

--- a/test/js/samples/video-bindings/expected.js
+++ b/test/js/samples/video-bindings/expected.js
@@ -58,8 +58,8 @@ function create_fragment(ctx) {
 		i: noop,
 		o: noop,
 		d(detaching) {
-			if (detaching) detach(video);
 			video_resize_listener();
+			if (detaching) detach(video);
 			run_all(dispose);
 		}
 	};


### PR DESCRIPTION
Fixes #4752 

This swaps the order on the destruction of the resize listening `<iframe>` that is created whenever you use `bind:width`, `bind:height`, etc.

The `<iframe>` is now destroyed before the element being bound to, and the `resize` event listener is now removed from the `<iframe>` before it is detached from the DOM. This works around an issue in older versions of WebKit where once the `<iframe>` is detached its `.contentWindow` property is gone and the unsubscription throws errors.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
- [x] Run the tests tests with `npm test` or `yarn test`

**NOTE**

I ran the tests, but since I'm on windows the results were drowned out in `\r\n` vs `\n` noise. Is there a doc somewhere about the right way to fix that for this repo?
