### PR TITLE
Use event.key instead of event.which

### DIFF
--- a/site/content/examples/06-lifecycle/02-update/App.svelte
+++ b/site/content/examples/06-lifecycle/02-update/App.svelte
@@ -20,7 +20,7 @@
 	];
 
 	function handleKeydown(event) {
-		if (event.which === 13) {
+		if (event.key === 'Enter') {
 			const text = event.target.value;
 			if (!text) return;
 

--- a/site/content/examples/06-lifecycle/03-tick/App.svelte
+++ b/site/content/examples/06-lifecycle/03-tick/App.svelte
@@ -4,7 +4,7 @@
 	let text = `Select some text and hit the tab key to toggle uppercase`;
 
 	async function handleKeydown(event) {
-		if (event.which !== 9) return;
+		if (event.key !== 'Tab') return;
 
 		event.preventDefault();
 

--- a/site/content/examples/10-animations/00-animate/App.svelte
+++ b/site/content/examples/10-animations/00-animate/App.svelte
@@ -112,7 +112,7 @@
 	<input
 		class="new-todo"
 		placeholder="what needs to be done?"
-		on:keydown="{event => event.which === 13 && add(event.target)}"
+		on:keydown="{event => event.key === 'Enter' && add(event.target)}"
 	>
 
 	<div class='left'>

--- a/site/content/tutorial/07-lifecycle/03-update/app-a/App.svelte
+++ b/site/content/tutorial/07-lifecycle/03-update/app-a/App.svelte
@@ -20,7 +20,7 @@
 	];
 
 	function handleKeydown(event) {
-		if (event.which === 13) {
+		if (event.key === 'Enter') {
 			const text = event.target.value;
 			if (!text) return;
 

--- a/site/content/tutorial/07-lifecycle/03-update/app-b/App.svelte
+++ b/site/content/tutorial/07-lifecycle/03-update/app-b/App.svelte
@@ -20,7 +20,7 @@
 	];
 
 	function handleKeydown(event) {
-		if (event.which === 13) {
+		if (event.key === 'Enter') {
 			const text = event.target.value;
 			if (!text) return;
 

--- a/site/content/tutorial/07-lifecycle/04-tick/app-a/App.svelte
+++ b/site/content/tutorial/07-lifecycle/04-tick/app-a/App.svelte
@@ -2,7 +2,7 @@
 	let text = `Select some text and hit the tab key to toggle uppercase`;
 
 	async function handleKeydown(event) {
-		if (event.which !== 9) return;
+		if (event.key !== 'Tab') return;
 
 		event.preventDefault();
 

--- a/site/content/tutorial/07-lifecycle/04-tick/app-b/App.svelte
+++ b/site/content/tutorial/07-lifecycle/04-tick/app-b/App.svelte
@@ -4,7 +4,7 @@
 	let text = `Select some text and hit the tab key to toggle uppercase`;
 
 	async function handleKeydown(event) {
-		if (event.which !== 9) return;
+		if (event.key !== 'Tab') return;
 
 		event.preventDefault();
 

--- a/site/content/tutorial/10-transitions/08-deferred-transitions/app-a/App.svelte
+++ b/site/content/tutorial/10-transitions/08-deferred-transitions/app-a/App.svelte
@@ -56,7 +56,7 @@
 <div class='board'>
 	<input
 		placeholder="what needs to be done?"
-		on:keydown={e => e.which === 13 && add(e.target)}
+		on:keydown={e => e.key === 'Enter' && add(e.target)}
 	>
 
 	<div class='left'>

--- a/site/content/tutorial/10-transitions/08-deferred-transitions/app-b/App.svelte
+++ b/site/content/tutorial/10-transitions/08-deferred-transitions/app-b/App.svelte
@@ -56,7 +56,7 @@
 <div class='board'>
 	<input
 		placeholder="what needs to be done?"
-		on:keydown={e => e.which === 13 && add(e.target)}
+		on:keydown={e => e.key === 'Enter' && add(e.target)}
 	>
 
 	<div class='left'>

--- a/site/content/tutorial/11-animations/01-animate/app-a/App.svelte
+++ b/site/content/tutorial/11-animations/01-animate/app-a/App.svelte
@@ -56,7 +56,7 @@
 <div class='board'>
 	<input
 		placeholder="what needs to be done?"
-		on:keydown={e => e.which === 13 && add(e.target)}
+		on:keydown={e => e.key === 'Enter' && add(e.target)}
 	>
 
 	<div class='left'>

--- a/site/content/tutorial/11-animations/01-animate/app-b/App.svelte
+++ b/site/content/tutorial/11-animations/01-animate/app-b/App.svelte
@@ -57,7 +57,7 @@
 <div class='board'>
 	<input
 		placeholder="what needs to be done?"
-		on:keydown={e => e.which === 13 && add(e.target)}
+		on:keydown={e => e.key === 'Enter' && add(e.target)}
 	>
 
 	<div class='left'>

--- a/site/src/routes/repl/[id]/_components/AppControls/index.svelte
+++ b/site/src/routes/repl/[id]/_components/AppControls/index.svelte
@@ -30,7 +30,7 @@
 	$: canSave = $session.user && gist && gist.owner === $session.user.uid;
 
 	function handleKeydown(event) {
-		if (event.which === 83 && (isMac ? event.metaKey : event.ctrlKey)) {
+		if (event.key === 's' && (isMac ? event.metaKey : event.ctrlKey)) {
 			event.preventDefault();
 			save();
 		}

--- a/test/runtime/samples/action-custom-event-handler-this/_config.js
+++ b/test/runtime/samples/action-custom-event-handler-this/_config.js
@@ -4,7 +4,7 @@ export default {
 	test({ assert, component, target, window }) {
 		const input = target.querySelector('input');
 		const event = new window.KeyboardEvent('keydown', {
-			which: 13
+			key: 'Enter'
 		});
 
 		let blurred = false;

--- a/test/runtime/samples/action-custom-event-handler-this/main.svelte
+++ b/test/runtime/samples/action-custom-event-handler-this/main.svelte
@@ -1,7 +1,7 @@
 <script>
 	function enter(node, callback) {
 		function handleKeydown(event) {
-			if (event.which === 13) {
+			if (event.key === 'Enter') {
 				callback(event);
 			}
 		}

--- a/test/runtime/samples/window-event-custom/_config.js
+++ b/test/runtime/samples/window-event-custom/_config.js
@@ -3,7 +3,7 @@ export default {
 
 	async test({ assert, component, target, window }) {
 		const event = new window.KeyboardEvent('keydown', {
-			which: 27
+			key: 'Escape'
 		});
 
 		await window.dispatchEvent(event);

--- a/test/runtime/samples/window-event-custom/main.svelte
+++ b/test/runtime/samples/window-event-custom/main.svelte
@@ -3,7 +3,7 @@
 
 	function esc(node, callback) {
 		function onKeyDown(event) {
-			if (event.which === 27) callback(event);
+			if (event.key === 'Escape') callback(event);
 		}
 		node.addEventListener('keydown', onKeyDown);
 		return {


### PR DESCRIPTION
Fixes #4755 -- Tutorials use `event.which`, which is deprecated in favor of `event.key`.

I also converted the other instances of event.which: two tests and one line in the REPL code. I tested the REPL by adding a temporary console.log inside the key handler and checking that it triggered when I pressed Cmd+s.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [NA] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [X] Run the tests tests with `npm test` or `yarn test`)
