### PR TITLE
Fix: bind:this in each with objects\array

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/shared/bind_this.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/bind_this.ts
@@ -54,6 +54,9 @@ export default function bind_this(component: Component, block: Block, binding: B
 
 		const args = [];
 		for (const id of contextual_dependencies) {
+			if (block.variables.has(id.name)) {
+				if (block.renderer.context_lookup.get(id.name).is_contextual) continue;
+			}
 			args.push(id);
 			block.add_variable(id, block.renderer.reference(id.name));
 		}

--- a/src/compiler/compile/render_dom/wrappers/shared/bind_this.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/bind_this.ts
@@ -54,10 +54,10 @@ export default function bind_this(component: Component, block: Block, binding: B
 
 		const args = [];
 		for (const id of contextual_dependencies) {
+			args.push(id);
 			if (block.variables.has(id.name)) {
 				if (block.renderer.context_lookup.get(id.name).is_contextual) continue;
 			}
-			args.push(id);
 			block.add_variable(id, block.renderer.reference(id.name));
 		}
 

--- a/test/runtime/samples/binding-this-each-object-props/_config.js
+++ b/test/runtime/samples/binding-this-each-object-props/_config.js
@@ -1,0 +1,14 @@
+export default {
+	html: ``,
+
+	async test({ assert, component, target }) {
+		component.visible = true;
+		assert.htmlEqual(target.innerHTML, `
+			<div>b</div><div>b</div><div>c</div><div>c</div>
+		`);
+		assert.equal(component.items1[1], target.querySelector('div'));
+		assert.equal(component.items2[1], target.querySelector('div:nth-child(2)'));
+		assert.equal(component.items1[2], target.querySelector('div:nth-child(3)'));
+		assert.equal(component.items2[2], target.querySelector('div:last-child'));
+	}
+};

--- a/test/runtime/samples/binding-this-each-object-props/main.svelte
+++ b/test/runtime/samples/binding-this-each-object-props/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	export const items1 = {};
+	export const items2 = {};
+	export let data = [
+		{id: 1, text: "b"},
+		{id: 2, text: "c"},
+	];
+</script>
+
+{#each data as item (item.id)}
+	<div bind:this={items1[item.id]}>{item.text}</div>
+	<div bind:this={items2[item.id]}>{item.text}</div>
+{/each}

--- a/test/runtime/samples/binding-this-each-object-spread/_config.js
+++ b/test/runtime/samples/binding-this-each-object-spread/_config.js
@@ -1,0 +1,14 @@
+export default {
+	html: ``,
+
+	async test({ assert, component, target }) {
+		component.visible = true;
+		assert.htmlEqual(target.innerHTML, `
+			<div>a</div><div>a</div><div>b</div><div>b</div>
+		`);
+		assert.equal(component.items1[1], target.querySelector('div'));
+		assert.equal(component.items2[1], target.querySelector('div:nth-child(2)'));
+		assert.equal(component.items1[2], target.querySelector('div:nth-child(3)'));
+		assert.equal(component.items2[2], target.querySelector('div:last-child'));
+	}
+};

--- a/test/runtime/samples/binding-this-each-object-spread/main.svelte
+++ b/test/runtime/samples/binding-this-each-object-spread/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	export const items1 = {};
+	export const items2 = {};
+	var data = [
+		{id: 1, text: "a"},
+		{id: 2, text: "b"},
+	];
+</script>
+
+{#each data as {id, text} (id)}
+	<div bind:this={items1[id]}>{text}</div>
+	<div bind:this={items2[id]}>{text}</div>
+{/each}


### PR DESCRIPTION
Fix #4686

Code from issue
```
{#each entries as { itemId, entry } (itemId)}
	<div bind:this={items1[itemId]} />
	<div bind:this={items2[itemId]} />
{/each}
```

Adding dependecies only use single variable name (`itemId`), but it can be too hard to detect what array `items1[itemId]` and `items2[itemId]` are different.
If you use it carefully, there will be no problems. Also, detecting different variable names can be bypassed by using variable reference (something like `let items1 = []; let items2 = items1;`)

Also i add two tests (one with object props, and one with spread)

PS: also i look to issue #4636, but this is another issue that is not directly related to this one