### PR TITLE
docs: make event forwarding example work initially

### DIFF
--- a/site/content/tutorial/05-events/05-event-forwarding/app-a/Outer.svelte
+++ b/site/content/tutorial/05-events/05-event-forwarding/app-a/Outer.svelte
@@ -1,5 +1,12 @@
 <script>
 	import Inner from './Inner.svelte';
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+
+	function forward(event) {
+		dispatch('message', event.detail);
+	}
 </script>
 
-<Inner/>
+<Inner on:message={forward}/>


### PR DESCRIPTION
Currently, on the [events forwarding](https://svelte.dev/tutorial/event-forwarding) tutorial page the button in the demo does not work initially which is a little bit confusing. Better flow is to have the code that works initially, and then gets refactored by clicking the `show me` button. Which is the whole point of that particular tutorial.