### PR TITLE
feat: instant-set for zero duration

### DIFF
--- a/src/runtime/motion/tweened.ts
+++ b/src/runtime/motion/tweened.ts
@@ -93,6 +93,11 @@ export function tweened<T>(value?: T, defaults: Options<T> = {}): Tweened<T> {
 			interpolate = get_interpolator
 		} = assign(assign({}, defaults), opts);
 
+		if (duration === 0) {
+			store.set(target_value);
+			return Promise.resolve();
+		}
+
 		const start = now() + delay;
 		let fn;
 

--- a/test/motion/index.js
+++ b/test/motion/index.js
@@ -19,5 +19,12 @@ describe('motion', () => {
 			size.set(100);
 			assert.equal(get(size), 100);
 		});
+
+		it('sets immediately when duration is 0', () => {
+			const size = tweened(0);
+
+			size.set(100, { duration : 0 });
+			assert.equal(get(size), 100);
+		});
 	});
 });


### PR DESCRIPTION
Fixes #4399

This is something I recently needed again, I wanted to immediately set the store to a new value from the authoritative source and then start a tween based on the given rate of change of the value towards the min/max (depending on direction of change). I was getting weird numbers using the `{ duration : 1 }` hack until I made the tweened `.set()` call live in a rAF which just seemed silly.

Now, if you call `.set(<value>, { duration : 0 })` it'll just set immediately and as a bonus do way less work! Added a test that fails w/o this PR (though it fails due to node not having `requestAnimationFrame`, *not* due to the value not setting instantly).

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
