### PR TITLE
Fix: input type number warning in browsers

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -133,7 +133,7 @@ export function get_binding_group_value(group) {
 }
 
 export function to_number(value) {
-	return value === '' ? undefined : +value;
+	return value === '' ? null : +value;
 }
 
 export function time_ranges_to_array(ranges) {

--- a/test/runtime/samples/binding-input-number/_config.js
+++ b/test/runtime/samples/binding-input-number/_config.js
@@ -35,14 +35,14 @@ export default {
 			<p>number 44</p>
 		`);
 
-		// empty string should be treated as undefined
+		// empty string should be treated as null
 		input.value = '';
 		await input.dispatchEvent(event);
 
-		assert.equal(component.count, undefined);
+		assert.equal(component.count, null);
 		assert.htmlEqual(target.innerHTML, `
 			<input type='number'>
-			<p>undefined undefined</p>
+			<p>object null</p>
 		`);
 	},
 };


### PR DESCRIPTION
Fix #1701

Redo tests, but this case it cant be direct tested, only warning in browsers.
You can check this warnings in browser via [REPL](https://svelte.dev/repl/442cfd6a0b144afa92df765357c0911f?version=3.22.1)
If you set string or undefined to input-type-number binded variable browser show warning in devtools console. You need set number and then other "wrong" value to repeat warning
To check usecase, check [REPL](https://svelte.dev/repl/922cb0532c56400a94d95e8d4536e322) from 1701 issue, but look not to repl console, but browser console.
