### PR TITLE
Fix separate bind:group with one array

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -124,6 +124,7 @@ export function xlink_attr(node, attribute, value) {
 	node.setAttributeNS('http://www.w3.org/1999/xlink', attribute, value);
 }
 
+// To force uncheck repeated group, need to store old value
 let oldValue: Set<unknown> = new Set();
 
 export function get_binding_group_value(group) {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -125,7 +125,7 @@ export function xlink_attr(node, attribute, value) {
 }
 
 // To force uncheck repeated group, need to store old value for each group
-let groups = new Map();
+const groups = new Map();
 
 export function get_binding_group_value(group) {
 	const value = new Set();

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -129,17 +129,15 @@ const groups = new Map();
 
 export function get_binding_group_value(group) {
 	const value = new Set();
-	const force = [];
+	const force = new Set();
 	for (let i = 0; i < group.length; i += 1) {
 		if (group[i].checked) {
 			value.add(group[i].__value);
 		} else if (groups.get(group) && groups.get(group).has(group[i].__value)) {
-			force.push(group[i].__value);
+			force.add(group[i].__value);
 		}
 	}
-	for (let i = 0; i < force.length; i += 1) {
-		value.delete(force[i]);
-	}
+	force.forEach((key) => value.delete(key));
 	groups.set(group, value);
 	return Array.from(value);
 }

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -124,8 +124,8 @@ export function xlink_attr(node, attribute, value) {
 	node.setAttributeNS('http://www.w3.org/1999/xlink', attribute, value);
 }
 
-// To force uncheck repeated group, need to store old value
-let oldValue: Set<unknown> = new Set();
+// To force uncheck repeated group, need to store old value for each group
+let groups = new Map();
 
 export function get_binding_group_value(group) {
 	const value = new Set();
@@ -133,14 +133,14 @@ export function get_binding_group_value(group) {
 	for (let i = 0; i < group.length; i += 1) {
 		if (group[i].checked) {
 			value.add(group[i].__value);
-		} else if (oldValue.has(group[i].__value)) {
+		} else if (groups.get(group) && groups.get(group).has(group[i].__value)) {
 			force.push(group[i].__value);
 		}
 	}
 	for (let i = 0; i < force.length; i += 1) {
 		value.delete(force[i]);
 	}
-	oldValue = value;
+	groups.set(group, value);
 	return Array.from(value);
 }
 

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -124,12 +124,23 @@ export function xlink_attr(node, attribute, value) {
 	node.setAttributeNS('http://www.w3.org/1999/xlink', attribute, value);
 }
 
+let oldValue: Set<unknown> = new Set();
+
 export function get_binding_group_value(group) {
-	const value = [];
+	const value = new Set();
+	const force = [];
 	for (let i = 0; i < group.length; i += 1) {
-		if (group[i].checked) value.push(group[i].__value);
+		if (group[i].checked) {
+			value.add(group[i].__value);
+		} else if (oldValue.has(group[i].__value)) {
+			force.push(group[i].__value);
+		}
 	}
-	return value;
+	for (let i = 0; i < force.length; i += 1) {
+		value.delete(force[i]);
+	}
+	oldValue = value;
+	return Array.from(value);
 }
 
 export function to_number(value) {

--- a/test/runtime/samples/binding-input-checkbox-group-repeated-with-other/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-group-repeated-with-other/_config.js
@@ -1,0 +1,91 @@
+const values = [
+	"a",
+	"b",
+];
+
+export default {
+	props: {
+		values,
+		selected: [],
+		selected2: []
+	},
+
+	async test({ assert, target, window }) {
+		const inputs = target.querySelectorAll('input');
+		assert.equal(inputs[0].checked, false);
+		assert.equal(inputs[1].checked, false);
+		assert.equal(inputs[2].checked, false);
+		assert.equal(inputs[3].checked, false);
+		assert.equal(inputs[4].checked, false);
+		assert.equal(inputs[5].checked, false);
+
+		const event = new window.Event('change');
+
+		inputs[5].checked = true;
+		await inputs[5].dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<label>
+				<input type="checkbox" value="a"> a
+			</label>
+
+			<label>
+				<input type="checkbox" value="b"> b
+			</label>
+
+			<label>
+				<input type="checkbox" value="a"> a
+			</label>
+
+			<label>
+				<input type="checkbox" value="b"> b
+			</label>
+
+			<p></p>
+
+			<label>
+				<input type="checkbox" value="a"> a
+			</label>
+
+			<label>
+				<input type="checkbox" value="b"> b
+			</label>
+
+			<p>b</p>
+		`);
+
+		inputs[3].checked = true;
+		await inputs[3].dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<label>
+				<input type="checkbox" value="a"> a
+			</label>
+
+			<label>
+				<input type="checkbox" value="b"> b
+			</label>
+
+			<label>
+				<input type="checkbox" value="a"> a
+			</label>
+
+			<label>
+				<input type="checkbox" value="b"> b
+			</label>
+
+			<p>b</p>
+
+			<label>
+				<input type="checkbox" value="a"> a
+			</label>
+
+			<label>
+				<input type="checkbox" value="b"> b
+			</label>
+
+			<p>b</p>
+		`);
+
+	}
+};

--- a/test/runtime/samples/binding-input-checkbox-group-repeated-with-other/main.svelte
+++ b/test/runtime/samples/binding-input-checkbox-group-repeated-with-other/main.svelte
@@ -1,0 +1,33 @@
+<script>
+	export let selected;
+	export let selected2;
+	export let values;
+</script>
+
+<label>
+	<input type="checkbox" value="{values[0]}" bind:group={selected} /> {values[0]}
+</label>
+
+<label>
+	<input type="checkbox" value="{values[1]}" bind:group={selected} /> {values[1]}
+</label>
+
+<label>
+	<input type="checkbox" value="{values[0]}" bind:group={selected} /> {values[0]}
+</label>
+
+<label>
+	<input type="checkbox" value="{values[1]}" bind:group={selected} /> {values[1]}
+</label>
+
+<p>{selected.join(', ')}</p>
+
+<label>
+	<input type="checkbox" value="{values[0]}" bind:group={selected2} /> {values[0]}
+</label>
+
+<label>
+	<input type="checkbox" value="{values[1]}" bind:group={selected2} /> {values[1]}
+</label>
+
+<p>{selected2.join( ', ' ) }</p>

--- a/test/runtime/samples/binding-input-checkbox-group-repeated/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-group-repeated/_config.js
@@ -1,0 +1,113 @@
+const values = [
+	{ name: 'Alpha' },
+	{ name: 'Beta' },
+	{ name: 'Gamma' }
+];
+
+export default {
+	props: {
+		values,
+		selected: [values[1]]
+	},
+
+	html: `
+		<label>
+			<input type="checkbox" value="[object Object]"> Alpha
+		</label>
+
+		<label>
+			<input type="checkbox" value="[object Object]"> Beta
+		</label>
+
+		<label>
+			<input type="checkbox" value="[object Object]"> Alpha
+		</label>
+
+		<label>
+			<input type="checkbox" value="[object Object]"> Beta
+		</label>
+
+		<p>Beta</p>`,
+
+	async test({ assert, component, target, window }) {
+		const inputs = target.querySelectorAll('input');
+		assert.equal(inputs[0].checked, false);
+		assert.equal(inputs[1].checked, true);
+		assert.equal(inputs[2].checked, false);
+		assert.equal(inputs[3].checked, true);
+
+		const event = new window.Event('change');
+
+		inputs[0].checked = true;
+		await inputs[0].dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<p>Alpha, Beta</p>
+		`);
+
+		inputs[1].checked = false;
+		await inputs[1].dispatchEvent(event);
+
+		assert.htmlEqual(target.innerHTML, `
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<p>Alpha</p>
+		`);
+
+		component.selected = [values[0], values[1]];
+		assert.equal(inputs[0].checked, true);
+		assert.equal(inputs[1].checked, true);
+		assert.equal(inputs[0].checked, true);
+		assert.equal(inputs[1].checked, true);
+
+		assert.htmlEqual(target.innerHTML, `
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Alpha
+			</label>
+
+			<label>
+				<input type="checkbox" value="[object Object]"> Beta
+			</label>
+
+			<p>Alpha, Beta</p>
+		`);
+	}
+};

--- a/test/runtime/samples/binding-input-checkbox-group-repeated/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-group-repeated/_config.js
@@ -1,7 +1,6 @@
 const values = [
 	{ name: 'Alpha' },
-	{ name: 'Beta' },
-	{ name: 'Gamma' }
+	{ name: 'Beta' }
 ];
 
 export default {

--- a/test/runtime/samples/binding-input-checkbox-group-repeated/main.svelte
+++ b/test/runtime/samples/binding-input-checkbox-group-repeated/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	export let selected;
+	export let values;
+</script>
+
+<label>
+	<input type="checkbox" value="{values[0]}" bind:group={selected} /> {values[0].name}
+</label>
+
+<label>
+	<input type="checkbox" value="{values[1]}" bind:group={selected} /> {values[1].name}
+</label>
+
+<label>
+	<input type="checkbox" value="{values[0]}" bind:group={selected} /> {values[0].name}
+</label>
+
+<label>
+	<input type="checkbox" value="{values[1]}" bind:group={selected} /> {values[1].name}
+</label>
+
+<p>{selected.map( function ( value ) { return value.name; }).join( ', ' ) }</p>


### PR DESCRIPTION
Fix #4397 

This is two issues:
- push to array add duplicated values, i use Set
- unchecked values need to compare to previous values, so need store old values for each group, i use Map

Add two tests:
- one check what check\uncheck work with binded array
- another: identical values in other group does not affect the first
