### PR TITLE
Fix use-directives called multiple times

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -295,7 +295,7 @@ export default class Block {
 		if (this.chunks.mount.length === 0) {
 			properties.mount = noop;
 		} else if (this.event_listeners.length === 0) {
-			properties.mount = x`function #mount(#target, #anchor) {
+			properties.mount = x`function #mount(#target, #anchor, #remount) {
 				${this.chunks.mount}
 			}`;
 		} else {

--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -205,7 +205,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 		const has_transitions = this.pending.block.has_intro_method || this.pending.block.has_outro_method;
 
 		block.chunks.mount.push(b`
-			${info}.block.m(${initial_mount_node}, ${info}.anchor = ${anchor_node});
+			${info}.block.m(${initial_mount_node}, ${info}.anchor = ${anchor_node}, #remount);
 			${info}.mount = () => ${update_mount_node};
 			${info}.anchor = ${anchor};
 		`);

--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -294,7 +294,7 @@ export default class EachBlockWrapper extends Wrapper {
 
 			block.chunks.mount.push(b`
 				if (${each_block_else}) {
-					${each_block_else}.m(${initial_mount_node}, ${initial_anchor_node});
+					${each_block_else}.m(${initial_mount_node}, ${initial_anchor_node}, #remount);
 				}
 			`);
 
@@ -417,7 +417,7 @@ export default class EachBlockWrapper extends Wrapper {
 
 		block.chunks.mount.push(b`
 			for (let #i = 0; #i < ${view_length}; #i += 1) {
-				${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node});
+				${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node}, #remount);
 			}
 		`);
 
@@ -509,7 +509,7 @@ export default class EachBlockWrapper extends Wrapper {
 
 		block.chunks.mount.push(b`
 			for (let #i = 0; #i < ${view_length}; #i += 1) {
-				${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node});
+				${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node}, #remount);
 			}
 		`);
 

--- a/src/compiler/compile/render_dom/wrappers/IfBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/IfBlock.ts
@@ -297,11 +297,11 @@ export default class IfBlockWrapper extends Wrapper {
 
 		if (if_exists_condition) {
 			block.chunks.mount.push(
-				b`if (${if_exists_condition}) ${name}.m(${initial_mount_node}, ${anchor_node});`
+				b`if (${if_exists_condition}) ${name}.m(${initial_mount_node}, ${anchor_node}, #remount);`
 			);
 		} else {
 			block.chunks.mount.push(
-				b`${name}.m(${initial_mount_node}, ${anchor_node});`
+				b`${name}.m(${initial_mount_node}, ${anchor_node}, #remount);`
 			);
 		}
 
@@ -427,7 +427,7 @@ export default class IfBlockWrapper extends Wrapper {
 
 		block.chunks.mount.push(
 			if_current_block_type_index(
-				b`${if_blocks}[${current_block_type_index}].m(${initial_mount_node}, ${anchor_node});`
+				b`${if_blocks}[${current_block_type_index}].m(${initial_mount_node}, ${anchor_node}, #remount);`
 			)
 		);
 
@@ -522,7 +522,7 @@ export default class IfBlockWrapper extends Wrapper {
 		const anchor_node = parent_node ? 'null' : '#anchor';
 
 		block.chunks.mount.push(
-			b`if (${name}) ${name}.m(${initial_mount_node}, ${anchor_node});`
+			b`if (${name}) ${name}.m(${initial_mount_node}, ${anchor_node}, #remount);`
 		);
 
 		if (branch.dependencies.length > 0) {

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -435,7 +435,7 @@ export default class InlineComponentWrapper extends Wrapper {
 
 			block.chunks.mount.push(b`
 				if (${name}) {
-					@mount_component(${name}, ${parent_node || '#target'}, ${parent_node ? 'null' : '#anchor'});
+					@mount_component(${name}, ${parent_node || '#target'}, ${parent_node ? 'null' : '#anchor'}, #remount);
 				}
 			`);
 
@@ -509,7 +509,7 @@ export default class InlineComponentWrapper extends Wrapper {
 			}
 
 			block.chunks.mount.push(
-				b`@mount_component(${name}, ${parent_node || '#target'}, ${parent_node ? 'null' : '#anchor'});`
+				b`@mount_component(${name}, ${parent_node || '#target'}, ${parent_node ? 'null' : '#anchor'}, #remount);`
 			);
 
 			block.chunks.intro.push(b`

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -52,10 +52,10 @@ export function claim_component(block, parent_nodes) {
 	block && block.l(parent_nodes);
 }
 
-export function mount_component(component, target, anchor) {
+export function mount_component(component, target, anchor, remount=false) {
 	const { fragment, on_mount, on_destroy, after_update } = component.$$;
 
-	fragment && fragment.m(target, anchor);
+	fragment && fragment.m(target, anchor, remount);
 
 	// onMount happens before the initial afterUpdate
 	add_render_callback(() => {

--- a/test/js/samples/bind-width-height/expected.js
+++ b/test/js/samples/bind-width-height/expected.js
@@ -21,7 +21,7 @@ function create_fragment(ctx) {
 			div.textContent = "some content";
 			add_render_callback(() => /*div_elementresize_handler*/ ctx[2].call(div));
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 			div_resize_listener = add_resize_listener(div, /*div_elementresize_handler*/ ctx[2].bind(div));
 		},

--- a/test/js/samples/capture-inject-state/expected.js
+++ b/test/js/samples/capture-inject-state/expected.js
@@ -53,7 +53,7 @@ function create_fragment(ctx) {
 		l: function claim(nodes) {
 			throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			insert_dev(target, p, anchor);
 			append_dev(p, t0);
 			append_dev(p, t1);

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -30,7 +30,7 @@ function create_fragment(ctx) {
 			t = text(/*foo*/ ctx[0]);
 			attr(p, "class", "svelte-1a7i8ec");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 			append(p, t);
 		},

--- a/test/js/samples/component-static-array/expected.js
+++ b/test/js/samples/component-static-array/expected.js
@@ -19,8 +19,8 @@ function create_fragment(ctx) {
 		c() {
 			create_component(nested.$$.fragment);
 		},
-		m(target, anchor) {
-			mount_component(nested, target, anchor);
+		m(target, anchor, remount) {
+			mount_component(nested, target, anchor, remount);
 			current = true;
 		},
 		p: noop,

--- a/test/js/samples/component-static-immutable/expected.js
+++ b/test/js/samples/component-static-immutable/expected.js
@@ -19,8 +19,8 @@ function create_fragment(ctx) {
 		c() {
 			create_component(nested.$$.fragment);
 		},
-		m(target, anchor) {
-			mount_component(nested, target, anchor);
+		m(target, anchor, remount) {
+			mount_component(nested, target, anchor, remount);
 			current = true;
 		},
 		p: noop,

--- a/test/js/samples/component-static-immutable2/expected.js
+++ b/test/js/samples/component-static-immutable2/expected.js
@@ -19,8 +19,8 @@ function create_fragment(ctx) {
 		c() {
 			create_component(nested.$$.fragment);
 		},
-		m(target, anchor) {
-			mount_component(nested, target, anchor);
+		m(target, anchor, remount) {
+			mount_component(nested, target, anchor, remount);
 			current = true;
 		},
 		p: noop,

--- a/test/js/samples/component-static-var/expected.js
+++ b/test/js/samples/component-static-var/expected.js
@@ -37,9 +37,9 @@ function create_fragment(ctx) {
 			input = element("input");
 		},
 		m(target, anchor, remount) {
-			mount_component(foo, target, anchor);
+			mount_component(foo, target, anchor, remount);
 			insert(target, t0, anchor);
-			mount_component(bar, target, anchor);
+			mount_component(bar, target, anchor, remount);
 			insert(target, t1, anchor);
 			insert(target, input, anchor);
 			set_input_value(input, /*z*/ ctx[0]);

--- a/test/js/samples/component-static/expected.js
+++ b/test/js/samples/component-static/expected.js
@@ -19,8 +19,8 @@ function create_fragment(ctx) {
 		c() {
 			create_component(nested.$$.fragment);
 		},
-		m(target, anchor) {
-			mount_component(nested, target, anchor);
+		m(target, anchor, remount) {
+			mount_component(nested, target, anchor, remount);
 			current = true;
 		},
 		p: noop,

--- a/test/js/samples/component-store-access-invalidate/expected.js
+++ b/test/js/samples/component-store-access-invalidate/expected.js
@@ -24,7 +24,7 @@ function create_fragment(ctx) {
 			h1 = element("h1");
 			t = text(/*$foo*/ ctx[0]);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, h1, anchor);
 			append(h1, t);
 		},

--- a/test/js/samples/css-media-query/expected.js
+++ b/test/js/samples/css-media-query/expected.js
@@ -26,7 +26,7 @@ function create_fragment(ctx) {
 			div = element("div");
 			attr(div, "class", "svelte-1slhpfn");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 		},
 		p: noop,

--- a/test/js/samples/css-shadow-dom-keyframes/expected.js
+++ b/test/js/samples/css-shadow-dom-keyframes/expected.js
@@ -18,7 +18,7 @@ function create_fragment(ctx) {
 			div.textContent = "fades in";
 			this.c = noop;
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 		},
 		p: noop,

--- a/test/js/samples/data-attribute/expected.js
+++ b/test/js/samples/data-attribute/expected.js
@@ -24,7 +24,7 @@ function create_fragment(ctx) {
 			attr(div0, "data-foo", "bar");
 			attr(div1, "data-foo", /*bar*/ ctx[0]);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div0, anchor);
 			insert(target, t, anchor);
 			insert(target, div1, anchor);

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -38,7 +38,7 @@ function create_fragment(ctx) {
 		l: function claim(nodes) {
 			throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			insert_dev(target, h1, anchor);
 			append_dev(h1, t0);
 			append_dev(h1, t1);

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -50,7 +50,7 @@ function create_each_block(ctx) {
 
 			add_location(span, file, 8, 1, 116);
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			insert_dev(target, span, anchor);
 			append_dev(span, t0);
 			insert_dev(target, t1, anchor);
@@ -112,9 +112,9 @@ function create_fragment(ctx) {
 		l: function claim(nodes) {
 			throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				each_blocks[i].m(target, anchor, remount);
 			}
 
 			insert_dev(target, t0, anchor);

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -47,7 +47,7 @@ function create_each_block(ctx) {
 
 			add_location(span, file, 6, 1, 82);
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			insert_dev(target, span, anchor);
 			append_dev(span, t0);
 			insert_dev(target, t1, anchor);
@@ -106,9 +106,9 @@ function create_fragment(ctx) {
 		l: function claim(nodes) {
 			throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				each_blocks[i].m(target, anchor, remount);
 			}
 
 			insert_dev(target, t0, anchor);

--- a/test/js/samples/debug-no-dependencies/expected.js
+++ b/test/js/samples/debug-no-dependencies/expected.js
@@ -41,7 +41,7 @@ function create_each_block(ctx) {
 			t0 = space();
 			t1 = text(t1_value);
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			insert_dev(target, t0, anchor);
 			insert_dev(target, t1, anchor);
 		},
@@ -84,9 +84,9 @@ function create_fragment(ctx) {
 		l: function claim(nodes) {
 			throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				each_blocks[i].m(target, anchor, remount);
 			}
 
 			insert_dev(target, each_1_anchor, anchor);

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -31,7 +31,7 @@ function create_each_block(ctx) {
 			span = element("span");
 			t = text(t_value);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, span, anchor);
 			append(span, t);
 		},
@@ -61,9 +61,9 @@ function create_fragment(ctx) {
 
 			each_1_anchor = empty();
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				each_blocks[i].m(target, anchor, remount);
 			}
 
 			insert(target, each_1_anchor, anchor);

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -36,7 +36,7 @@ function create_fragment(ctx) {
 		l: function claim(nodes) {
 			throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			insert_dev(target, p, anchor);
 			append_dev(p, t0);
 			append_dev(p, t1);

--- a/test/js/samples/dynamic-import/expected.js
+++ b/test/js/samples/dynamic-import/expected.js
@@ -21,8 +21,8 @@ function create_fragment(ctx) {
 		c() {
 			create_component(lazyload.$$.fragment);
 		},
-		m(target, anchor) {
-			mount_component(lazyload, target, anchor);
+		m(target, anchor, remount) {
+			mount_component(lazyload, target, anchor, remount);
 			current = true;
 		},
 		p: noop,

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -31,7 +31,7 @@ function create_each_block(ctx) {
 			span = element("span");
 			t = text(t_value);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, span, anchor);
 			append(span, t);
 		},
@@ -61,9 +61,9 @@ function create_fragment(ctx) {
 
 			each_1_anchor = empty();
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			for (let i = 0; i < 5; i += 1) {
-				each_blocks[i].m(target, anchor);
+				each_blocks[i].m(target, anchor, remount);
 			}
 
 			insert(target, each_1_anchor, anchor);

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -56,7 +56,7 @@ function create_each_block(ctx) {
 			html_tag = new HtmlTag(raw_value, null);
 			attr(div, "class", "comment");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 			append(div, strong);
 			append(strong, t0);
@@ -101,9 +101,9 @@ function create_fragment(ctx) {
 			p = element("p");
 			t1 = text(/*foo*/ ctx[3]);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				each_blocks[i].m(target, anchor, remount);
 			}
 
 			insert(target, t0, anchor);

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -39,7 +39,7 @@ function create_each_block(key_1, ctx) {
 			t = text(t_value);
 			this.first = div;
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 			append(div, t);
 		},
@@ -84,9 +84,9 @@ function create_fragment(ctx) {
 
 			each_1_anchor = empty();
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				each_blocks[i].m(target, anchor, remount);
 			}
 
 			insert(target, each_1_anchor, anchor);

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -35,7 +35,7 @@ function create_each_block(key_1, ctx) {
 			t = text(t_value);
 			this.first = div;
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 			append(div, t);
 		},
@@ -69,9 +69,9 @@ function create_fragment(ctx) {
 
 			each_1_anchor = empty();
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				each_blocks[i].m(target, anchor, remount);
 			}
 
 			insert(target, each_1_anchor, anchor);

--- a/test/js/samples/head-no-whitespace/expected.js
+++ b/test/js/samples/head-no-whitespace/expected.js
@@ -23,7 +23,7 @@ function create_fragment(ctx) {
 			attr(meta1, "name", "twitter:title");
 			attr(meta1, "content", "Svelte");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			append(document.head, meta0);
 			append(document.head, meta1);
 		},

--- a/test/js/samples/hoisted-const/expected.js
+++ b/test/js/samples/hoisted-const/expected.js
@@ -17,7 +17,7 @@ function create_fragment(ctx) {
 			b = element("b");
 			b.textContent = `${get_answer()}`;
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, b, anchor);
 		},
 		p: noop,

--- a/test/js/samples/hoisted-let/expected.js
+++ b/test/js/samples/hoisted-let/expected.js
@@ -17,7 +17,7 @@ function create_fragment(ctx) {
 			b = element("b");
 			b.textContent = `${get_answer()}`;
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, b, anchor);
 		},
 		p: noop,

--- a/test/js/samples/hydrated-void-element/expected.js
+++ b/test/js/samples/hydrated-void-element/expected.js
@@ -38,7 +38,7 @@ function create_fragment(ctx) {
 			if (img.src !== (img_src_value = "donuts.jpg")) attr(img, "src", img_src_value);
 			attr(img, "alt", "donuts");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, img, anchor);
 			insert(target, t, anchor);
 			insert(target, div, anchor);

--- a/test/js/samples/if-block-complex/expected.js
+++ b/test/js/samples/if-block-complex/expected.js
@@ -19,7 +19,7 @@ function create_if_block(ctx) {
 			div = element("div");
 			attr(div, "class", "divider");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 		},
 		d(detaching) {
@@ -38,8 +38,8 @@ function create_fragment(ctx) {
 			if (if_block) if_block.c();
 			if_block_anchor = empty();
 		},
-		m(target, anchor) {
-			if (if_block) if_block.m(target, anchor);
+		m(target, anchor, remount) {
+			if (if_block) if_block.m(target, anchor, remount);
 			insert(target, if_block_anchor, anchor);
 		},
 		p: noop,

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -18,7 +18,7 @@ function create_else_block(ctx) {
 			p = element("p");
 			p.textContent = "not foo!";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 		},
 		d(detaching) {
@@ -36,7 +36,7 @@ function create_if_block(ctx) {
 			p = element("p");
 			p.textContent = "foo!";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 		},
 		d(detaching) {
@@ -61,8 +61,8 @@ function create_fragment(ctx) {
 			if_block.c();
 			if_block_anchor = empty();
 		},
-		m(target, anchor) {
-			if_block.m(target, anchor);
+		m(target, anchor, remount) {
+			if_block.m(target, anchor, remount);
 			insert(target, if_block_anchor, anchor);
 		},
 		p(ctx, [dirty]) {

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -18,7 +18,7 @@ function create_if_block(ctx) {
 			p = element("p");
 			p.textContent = "foo!";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 		},
 		d(detaching) {
@@ -36,14 +36,14 @@ function create_fragment(ctx) {
 			if (if_block) if_block.c();
 			if_block_anchor = empty();
 		},
-		m(target, anchor) {
-			if (if_block) if_block.m(target, anchor);
+		m(target, anchor, remount) {
+			if (if_block) if_block.m(target, anchor, remount);
 			insert(target, if_block_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
 			if (/*foo*/ ctx[0]) {
 				if (if_block) {
-					
+
 				} else {
 					if_block = create_if_block(ctx);
 					if_block.c();

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -19,7 +19,7 @@ function create_fragment(ctx) {
 			set_style(div, "color", /*color*/ ctx[0]);
 			set_style(div, "transform", "translate(" + /*x*/ ctx[1] + "px," + /*y*/ ctx[2] + "px)");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 		},
 		p(ctx, [dirty]) {

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -18,7 +18,7 @@ function create_fragment(ctx) {
 			div = element("div");
 			set_style(div, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 		},
 		p(ctx, [dirty]) {

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -18,7 +18,7 @@ function create_fragment(ctx) {
 			div = element("div");
 			set_style(div, "color", /*color*/ ctx[0]);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 		},
 		p(ctx, [dirty]) {

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -25,7 +25,7 @@ function create_fragment(ctx) {
 			attr(div0, "style", /*style*/ ctx[0]);
 			attr(div1, "style", div1_style_value = "" + (/*key*/ ctx[1] + ": " + /*value*/ ctx[2]));
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div0, anchor);
 			insert(target, t, anchor);
 			insert(target, div1, anchor);

--- a/test/js/samples/inline-style-without-updates/expected.js
+++ b/test/js/samples/inline-style-without-updates/expected.js
@@ -18,7 +18,7 @@ function create_fragment(ctx) {
 			div = element("div");
 			set_style(div, "color", color);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 		},
 		p: noop,

--- a/test/js/samples/instrumentation-script-main-block/expected.js
+++ b/test/js/samples/instrumentation-script-main-block/expected.js
@@ -23,7 +23,7 @@ function create_fragment(ctx) {
 			t0 = text("x: ");
 			t1 = text(/*x*/ ctx[0]);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 			append(p, t0);
 			append(p, t1);

--- a/test/js/samples/legacy-input-type/expected.js
+++ b/test/js/samples/legacy-input-type/expected.js
@@ -18,7 +18,7 @@ function create_fragment(ctx) {
 			input = element("input");
 			set_input_type(input, "search");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, input, anchor);
 		},
 		p: noop,

--- a/test/js/samples/loop-protect/expected.js
+++ b/test/js/samples/loop-protect/expected.js
@@ -29,7 +29,7 @@ function create_fragment(ctx) {
 		l: function claim(nodes) {
 			throw new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");
 		},
-		m: function mount(target, anchor) {
+		m: function mount(target, anchor, remount) {
 			insert_dev(target, div, anchor);
 			/*div_binding*/ ctx[1](div);
 		},

--- a/test/js/samples/non-imported-component/expected.js
+++ b/test/js/samples/non-imported-component/expected.js
@@ -28,10 +28,10 @@ function create_fragment(ctx) {
 			t = space();
 			create_component(nonimported.$$.fragment);
 		},
-		m(target, anchor) {
-			mount_component(imported, target, anchor);
+		m(target, anchor, remount) {
+			mount_component(imported, target, anchor, remount);
 			insert(target, t, anchor);
-			mount_component(nonimported, target, anchor);
+			mount_component(nonimported, target, anchor, remount);
 			current = true;
 		},
 		p: noop,

--- a/test/js/samples/non-mutable-reference/expected.js
+++ b/test/js/samples/non-mutable-reference/expected.js
@@ -17,7 +17,7 @@ function create_fragment(ctx) {
 			h1 = element("h1");
 			h1.textContent = `Hello ${name}!`;
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, h1, anchor);
 		},
 		p: noop,

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -28,7 +28,7 @@ function create_fragment(ctx) {
 			option1.__value = "2";
 			option1.value = option1.__value;
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, select, anchor);
 			append(select, option0);
 			append(select, option1);

--- a/test/js/samples/src-attribute-check/expected.js
+++ b/test/js/samples/src-attribute-check/expected.js
@@ -39,7 +39,7 @@ function create_fragment(ctx) {
 			attr(img1, "alt", "potato");
 			if (img1.src !== (img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"))) attr(img1, "src", img1_src_value);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, img0, anchor);
 			insert(target, t, anchor);
 			insert(target, img1, anchor);

--- a/test/js/samples/svg-title/expected.js
+++ b/test/js/samples/svg-title/expected.js
@@ -22,7 +22,7 @@ function create_fragment(ctx) {
 			title = svg_element("title");
 			t = text("a title");
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, svg, anchor);
 			append(svg, title);
 			append(title, t);

--- a/test/js/samples/transition-local/expected.js
+++ b/test/js/samples/transition-local/expected.js
@@ -22,8 +22,8 @@ function create_if_block(ctx) {
 			if (if_block) if_block.c();
 			if_block_anchor = empty();
 		},
-		m(target, anchor) {
-			if (if_block) if_block.m(target, anchor);
+		m(target, anchor, remount) {
+			if (if_block) if_block.m(target, anchor, remount);
 			insert(target, if_block_anchor, anchor);
 		},
 		p(ctx, dirty) {
@@ -60,7 +60,7 @@ function create_if_block_1(ctx) {
 			div = element("div");
 			div.textContent = "...";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 		},
 		i(local) {
@@ -89,8 +89,8 @@ function create_fragment(ctx) {
 			if (if_block) if_block.c();
 			if_block_anchor = empty();
 		},
-		m(target, anchor) {
-			if (if_block) if_block.m(target, anchor);
+		m(target, anchor, remount) {
+			if (if_block) if_block.m(target, anchor, remount);
 			insert(target, if_block_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
@@ -117,7 +117,7 @@ function create_fragment(ctx) {
 }
 
 function foo() {
-	
+
 }
 
 function instance($$self, $$props, $$invalidate) {

--- a/test/js/samples/transition-repeated-outro/expected.js
+++ b/test/js/samples/transition-repeated-outro/expected.js
@@ -26,7 +26,7 @@ function create_if_block(ctx) {
 			div = element("div");
 			div.innerHTML = `<p>wheeee</p>`;
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
 			current = true;
 		},
@@ -56,8 +56,8 @@ function create_fragment(ctx) {
 			if (if_block) if_block.c();
 			if_block_anchor = empty();
 		},
-		m(target, anchor) {
-			if (if_block) if_block.m(target, anchor);
+		m(target, anchor, remount) {
+			if (if_block) if_block.m(target, anchor, remount);
 			insert(target, if_block_anchor, anchor);
 			current = true;
 		},

--- a/test/js/samples/unchanged-expression/expected.js
+++ b/test/js/samples/unchanged-expression/expected.js
@@ -43,7 +43,7 @@ function create_fragment(ctx) {
 			t8 = text("Hello ");
 			t9 = text(/*world3*/ ctx[0]);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div0, anchor);
 			append(div0, p0);
 			append(div0, t1);

--- a/test/js/samples/unreferenced-state-not-invalidated/expected.js
+++ b/test/js/samples/unreferenced-state-not-invalidated/expected.js
@@ -23,7 +23,7 @@ function create_fragment(ctx) {
 			p = element("p");
 			t = text(/*y*/ ctx[0]);
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 			append(p, t);
 		},

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -20,7 +20,7 @@ function create_if_block_4(ctx) {
 			p = element("p");
 			p.textContent = "a";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 		},
 		d(detaching) {
@@ -38,7 +38,7 @@ function create_if_block_3(ctx) {
 			p = element("p");
 			p.textContent = "b";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 		},
 		d(detaching) {
@@ -56,7 +56,7 @@ function create_if_block_2(ctx) {
 			p = element("p");
 			p.textContent = "c";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 		},
 		d(detaching) {
@@ -74,7 +74,7 @@ function create_if_block_1(ctx) {
 			p = element("p");
 			p.textContent = "d";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 		},
 		d(detaching) {
@@ -92,7 +92,7 @@ function create_if_block(ctx) {
 			p = element("p");
 			p.textContent = "e";
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, p, anchor);
 		},
 		d(detaching) {
@@ -138,27 +138,27 @@ function create_fragment(ctx) {
 			if (if_block4) if_block4.c();
 			if_block4_anchor = empty();
 		},
-		m(target, anchor) {
+		m(target, anchor, remount) {
 			insert(target, div, anchor);
-			if (if_block0) if_block0.m(div, null);
+			if (if_block0) if_block0.m(div, null, remount);
 			append(div, t0);
 			append(div, p0);
 			append(div, t2);
-			if (if_block1) if_block1.m(div, null);
+			if (if_block1) if_block1.m(div, null, remount);
 			append(div, t3);
-			if (if_block2) if_block2.m(div, null);
+			if (if_block2) if_block2.m(div, null, remount);
 			append(div, t4);
 			append(div, p1);
 			append(div, t6);
-			if (if_block3) if_block3.m(div, null);
+			if (if_block3) if_block3.m(div, null, remount);
 			insert(target, t7, anchor);
-			if (if_block4) if_block4.m(target, anchor);
+			if (if_block4) if_block4.m(target, anchor, remount);
 			insert(target, if_block4_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
 			if (/*a*/ ctx[0]) {
 				if (if_block0) {
-					
+
 				} else {
 					if_block0 = create_if_block_4(ctx);
 					if_block0.c();
@@ -171,7 +171,7 @@ function create_fragment(ctx) {
 
 			if (/*b*/ ctx[1]) {
 				if (if_block1) {
-					
+
 				} else {
 					if_block1 = create_if_block_3(ctx);
 					if_block1.c();
@@ -184,7 +184,7 @@ function create_fragment(ctx) {
 
 			if (/*c*/ ctx[2]) {
 				if (if_block2) {
-					
+
 				} else {
 					if_block2 = create_if_block_2(ctx);
 					if_block2.c();
@@ -197,7 +197,7 @@ function create_fragment(ctx) {
 
 			if (/*d*/ ctx[3]) {
 				if (if_block3) {
-					
+
 				} else {
 					if_block3 = create_if_block_1(ctx);
 					if_block3.c();
@@ -210,7 +210,7 @@ function create_fragment(ctx) {
 
 			if (/*e*/ ctx[4]) {
 				if (if_block4) {
-					
+
 				} else {
 					if_block4 = create_if_block(ctx);
 					if_block4.c();

--- a/test/runtime/samples/each-block-keyed-component-action/Component.svelte
+++ b/test/runtime/samples/each-block-keyed-component-action/Component.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let action;
+</script>
+
+<div use:action />

--- a/test/runtime/samples/each-block-keyed-component-action/_config.js
+++ b/test/runtime/samples/each-block-keyed-component-action/_config.js
@@ -1,0 +1,21 @@
+export default {
+	test({ assert, component, raf }) {
+		assert.equal(component.count, 0);
+
+		component.arr = ["2"];
+
+		assert.equal(component.count, 1);
+
+		component.arr = ["1", "2"];
+
+		assert.equal(component.count, 2);
+
+		component.arr = ["2", "1"];
+
+		assert.equal(component.count, 2);
+
+		component.arr = [];
+
+		assert.equal(component.count, 0);
+	},
+};

--- a/test/runtime/samples/each-block-keyed-component-action/main.svelte
+++ b/test/runtime/samples/each-block-keyed-component-action/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	import Component from "./Component.svelte";
+	export let arr = [];
+	export let count = 0;
+	function action(node, params) {
+		count += 1;
+		return {
+			destroy() {
+				count -= 1;
+			}
+		};
+	}
+</script>
+
+{#each arr as item (item)}
+	<Component {action} />
+{/each}


### PR DESCRIPTION
Fixes #4693.

**Additional remarks:** 

As far as I can tell, the fix seems to be working fine. I added a new test which covers the problem (thanks @pushkine !) and also thoroughly tested this version in a rather large scale app. 

But, as already discussed in the issue, I think @pushkine has a valid point that this should be considered more of a a short-term remedy to address the (potentially huge) memory leak caused by mounting directives over and over. A more thorough approach would be in order in the long run.