### PR TITLE
fix: Don't attempt to unsub if the iframe is destroyed

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -270,9 +270,11 @@ export function add_resize_listener(node: HTMLElement, fn: () => void) {
 	iframe.setAttribute('aria-hidden', 'true');
 	iframe.tabIndex = -1;
 
+	const crossorigin = is_crossorigin();
+
 	let unsubscribe: () => void;
 
-	if (is_crossorigin()) {
+	if (crossorigin) {
 		iframe.src = `data:text/html,<script>onresize=function(){parent.postMessage(0,'*')}</script>`;
 		unsubscribe = listen(window, 'message', (event: MessageEvent) => {
 			if (event.source === iframe.contentWindow) fn();
@@ -287,8 +289,13 @@ export function add_resize_listener(node: HTMLElement, fn: () => void) {
 	append(node, iframe);
 
 	return () => {
+		if (crossorigin) {
+			unsubscribe();
+		} else if (unsubscribe && iframe.contentWindow) {
+			unsubscribe();
+		}
+		
 		detach(iframe);
-		if (unsubscribe) unsubscribe();
 	};
 }
 


### PR DESCRIPTION
Fixes #4752 by not attempting to call `.removeEventListener` if the `iframe.contentWindow` no longer exists.

Also now calls `unsubscribe()` w/o checking in the cross-origin case because it is set synchronously for that codepath.

I wasn't able to write a test for this, unfortunately, but it does work in our svelte app in Chrome as well as our goofy custom browser that exhibited the issue from #4752.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
