### PR TITLE
Add accessible-emoji a11y check

### DIFF
--- a/test/validator/samples/a11y-accessible-emoji/input.svelte
+++ b/test/validator/samples/a11y-accessible-emoji/input.svelte
@@ -1,0 +1,5 @@
+<span>🐼</span>
+<i role="img" aria-label="Panda">🐼</i>
+
+<!-- this one won't have a warning -->
+<span role="img" aria-label="Panda">🐼</span>

--- a/test/validator/samples/a11y-accessible-emoji/warnings.json
+++ b/test/validator/samples/a11y-accessible-emoji/warnings.json
@@ -1,0 +1,33 @@
+[
+	{
+		"code": "a11y-accessible-emoji",
+		"message": "A11y: emojis should be wrapped in a <span>, with role=\"img\", and have a description using aria-label or aria-labelledby",
+		"start": {
+			"line": 1,
+			"column": 6,
+			"character": 6
+		},
+		"end": {
+			"line": 1,
+			"column": 8,
+			"character": 8
+		},
+		"pos": 6
+	},
+
+	{
+		"code": "a11y-accessible-emoji",
+		"message": "A11y: emojis should be wrapped in a <span>, with role=\"img\", and have a description using aria-label or aria-labelledby",
+		"start": {
+			"line": 2,
+			"column": 33,
+			"character": 49
+		},
+		"end": {
+			"line": 2,
+			"column": 35,
+			"character": 51
+		},
+		"pos": 49
+	}
+]


### PR DESCRIPTION
Warns if an emoji isn't accessible i.e. not wrapped in a `<span>` with `role="img"` and `aria-label`. [More info](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md)

Part of the list in #820 
