### PR TITLE
Link to list of community preprocessors

### DIFF
--- a/site/content/docs/04-compile-time.md
+++ b/site/content/docs/04-compile-time.md
@@ -183,6 +183,10 @@ const ast = svelte.parse(source, { filename: 'App.svelte' });
 
 ### `svelte.preprocess`
 
+A number of [community-maintained preprocessing plugins](https://github.com/sveltejs/integrations#preprocessors) are available to allow you to use Svelte with tools like TypeScript, PostCSS, SCSS, and Less.
+
+You can write your own preprocessor using the `svelte.preprocess` API.
+
 ```js
 result: {
 	code: string,


### PR DESCRIPTION
Partially addresses https://github.com/sveltejs/svelte/issues/4816

If you Google 'svelte typescript' you're taken to closed issues without much explanation as to the current state of TypeScript support. It's nearly impossible to figure out and took me a couple days of research. I included the text "TypeScript" in the hope that people can find it using Ctrl+F and that it comes up first on Google. PostCSS, SCSS, and Less are also widely used enough that it seemed worth a singular mention in the docs. I tried to mirror the existing reference to "webpack" that appears earlier in the docs for consistency

Note that this depends on https://github.com/sveltejs/integrations/pull/33 being merged first