### PR TITLE
docs: `value` can not be set via spread attribute when using bind:group

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -677,6 +677,27 @@ Inputs that work together can use `bind:group`.
 <input type="checkbox" bind:group={fillings} value="Guac (extra)">
 ```
 
+---
+
+The Svelte compiler must be able to detect the `value` attribute for `bind:group` to work properly.
+
+This example uses spread attributes to set the `value` of each checkbox, but it will *not* work since the compiler can not see the `value` attribute.
+
+```sv
+<script>
+	let tortilla = 'Plain';
+	let tortillaInputs = [
+		{ value: 'Plain',  style: 'color:silver' },
+		{ value: 'Whole wheat',  style: 'color:wheat' },
+		{ value: 'Spinach',  style: 'color:lightgreen' },
+	];
+</script>
+
+{#each tortillaInputs as props}
+	<input type="radio" bind:group={tortilla} {...props}>
+{/each}
+```
+
 #### [bind:this](bind_element)
 
 ```sv

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -121,6 +121,9 @@ An element or component can have multiple spread attributes, interspersed with r
 <input {...$$restProps}>
 ```
 
+
+> The `value` attribute of an `input` element or its children `option` elements must  not be set with spread attributes when using `bind:group` or `bind:checked`. Svelte needs to see the element's `value` directly in the markup in this case so that it can link it to the bound variable.
+
 ---
 
 ### Text expressions
@@ -675,27 +678,6 @@ Inputs that work together can use `bind:group`.
 <input type="checkbox" bind:group={fillings} value="Beans">
 <input type="checkbox" bind:group={fillings} value="Cheese">
 <input type="checkbox" bind:group={fillings} value="Guac (extra)">
-```
-
----
-
-The Svelte compiler must be able to detect the `value` attribute for `bind:group` to work properly.
-
-This example uses spread attributes to set the `value` of each checkbox, but it will *not* work since the compiler can not see the `value` attribute.
-
-```sv
-<script>
-	let tortilla = 'Plain';
-	let tortillaInputs = [
-		{ value: 'Plain',  style: 'color:silver' },
-		{ value: 'Whole wheat',  style: 'color:wheat' },
-		{ value: 'Spinach',  style: 'color:lightgreen' },
-	];
-</script>
-
-{#each tortillaInputs as props}
-	<input type="radio" bind:group={tortilla} {...props}>
-{/each}
 ```
 
 #### [bind:this](bind_element)

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -122,7 +122,7 @@ An element or component can have multiple spread attributes, interspersed with r
 ```
 
 
-> The `value` attribute of an `input` element or its children `option` elements must  not be set with spread attributes when using `bind:group` or `bind:checked`. Svelte needs to see the element's `value` directly in the markup in this case so that it can link it to the bound variable.
+> The `value` attribute of an `input` element or its children `option` elements must not be set with spread attributes when using `bind:group` or `bind:checked`. Svelte needs to be able to see the element's `value` directly in the markup in these cases so that it can link it to the bound variable.
 
 ---
 


### PR DESCRIPTION
Fixes #4808

Note that when using `bind:group`, setting `value` via spread attributes doesn't work. 

e.g.  `<input type="radio" bind:group={v} {...props}>` 

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.

![image](https://user-images.githubusercontent.com/1369558/81968383-09d9a100-95b8-11ea-9292-e91fa9b5b98f.png)
