### PR TITLE
feat: export more store type definitions (#4834)

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -1,19 +1,19 @@
 import { run_all, subscribe, noop, safe_not_equal, is_function, get_store_value } from 'svelte/internal';
 
 /** Callback to inform of a value updates. */
-type Subscriber<T> = (value: T) => void;
+export type Subscriber<T> = (value: T) => void;
 
 /** Unsubscribes from value updates. */
-type Unsubscriber = () => void;
+export type Unsubscriber = () => void;
 
 /** Callback to update a value. */
-type Updater<T> = (value: T) => T;
+export type Updater<T> = (value: T) => T;
 
 /** Cleanup logic callback. */
-type Invalidator<T> = (value?: T) => void;
+export type Invalidator<T> = (value?: T) => void;
 
 /** Start and stop notification callbacks. */
-type StartStopNotifier<T> = (set: Subscriber<T>) => Unsubscriber | void;
+export type StartStopNotifier<T> = (set: Subscriber<T>) => Unsubscriber | void;
 
 /** Readable interface for subscribing. */
 export interface Readable<T> {


### PR DESCRIPTION
**Export more store type definitions**

See this issue for a more detailed description: #4834 

I am building a custom svelte store to simplify the usage of IntersectionObserver with TypeScript.
I need to overwrite the subscribe method, because I need to unobserve the observed element, when `store.unsubscribe` is called.

Since I'm using TypeScript, I want to type my custom `subscribe` correctly and reuse Svelte's type definitions:

```ts
subscribe(run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
```

The types `Subscriber`, `Invalidator` and `Unsubscriber` are however not exported from "svelte/store".