### PR TITLE
fix: cache value & cancel tween for instant-set

### DIFF
--- a/src/runtime/motion/tweened.ts
+++ b/src/runtime/motion/tweened.ts
@@ -94,7 +94,12 @@ export function tweened<T>(value?: T, defaults: Options<T> = {}): Tweened<T> {
 		} = assign(assign({}, defaults), opts);
 
 		if (duration === 0) {
-			store.set(target_value);
+			if (previous_task) {
+				previous_task.abort();
+				previous_task = null;
+			}
+			
+			store.set(value = target_value);
 			return Promise.resolve();
 		}
 


### PR DESCRIPTION
Fixes #4846

Now when the early-out branch is taken for a `duration` of 0 it will do two things that were missing in the first implementation:

1. It will cancel any tweens that are in-progress so the value doesn't keep changing after snapping to the specified value.
2. It will cache off the `value` correctly, so that later tweens use the correct starting point.

Is there a better way to test this within the current suite? The mocha tests don't have access to any browser globals so you can't actually test any tweens and given how broken this was after #4766 the lack of test coverage makes me nervous.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
