### PR TITLE
Fix input with bind:value displaying "undefined"

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -193,7 +193,7 @@ export function set_data(text, data) {
 
 export function set_input_value(input, value) {
 	if (value != null || input.value) {
-		input.value = value;
+		input.value = value || '';
 	}
 }
 


### PR DESCRIPTION
There's a bug where when `<input bind:value={sampleVar} />` and `sampleVar` is updated to undefined (`sampleVar = undefined`), then the input displays "undefined" (despite the input initally showing up correctly empty when initialized to undefined).

This issue has been documented since September 14, 2019 https://github.com/sveltejs/svelte/issues/3569

I'm new to Svelte, but this seems to fix this problem.