### PR TITLE
svelte syntax highlighting via prism

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -8,7 +8,7 @@ Components are the building blocks of Svelte applications. They are written into
 
 All three sections — script, styles and markup — are optional.
 
-```html
+```sv
 <script>
 	// logic goes here
 </script>
@@ -30,7 +30,7 @@ A `<script>` block contains JavaScript that runs when a component instance is cr
 
 Svelte uses the `export` keyword to mark a variable declaration as a *property* or *prop*, which means it becomes accessible to consumers of the component (see the section on [attributes and props](docs#Attributes_and_props) for more information).
 
-```html
+```sv
 <script>
 	export let foo;
 
@@ -46,7 +46,7 @@ You can specify a default initial value for a prop. It will be used if the compo
 
 In development mode (see the [compiler options](docs#svelte_compile)), a warning will be printed if no default initial value is provided and the consumer does not specify a value. To squelch this warning, ensure that a default initial value is specified, even if it is `undefined`.
 
-```html
+```sv
 <script>
 	export let bar = 'optional default initial value';
 	export let baz = undefined;
@@ -57,7 +57,7 @@ In development mode (see the [compiler options](docs#svelte_compile)), a warning
 
 If you export a `const`, `class` or `function`, it is readonly from outside the component. Function *expressions* are valid props, however.
 
-```html
+```sv
 <script>
 	// these are readonly
 	export const thisIs = 'readonly';
@@ -75,7 +75,7 @@ If you export a `const`, `class` or `function`, it is readonly from outside the 
 
 You can use reserved words as prop names.
 
-```html
+```sv
 <script>
 	let className;
 
@@ -95,7 +95,7 @@ Update expressions (`count += 1`) and property assignments (`obj.x = y`) have th
 
 Because Svelte's reactivity is based on assignments, using array methods like `.push()` and `.splice()` won't automatically trigger updates. Options for getting around this can be found in the [tutorial](tutorial/updating-arrays-and-objects).
 
-```html
+```sv
 <script>
 	let count = 0;
 
@@ -113,7 +113,7 @@ Because Svelte's reactivity is based on assignments, using array methods like `.
 
 Any top-level statement (i.e. not inside a block or a function) can be made reactive by prefixing it with the `$:` [JS label syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label). Reactive statements run immediately before the component updates, whenever the values that they depend on have changed.
 
-```html
+```sv
 <script>
 	export let title;
 
@@ -132,7 +132,7 @@ Any top-level statement (i.e. not inside a block or a function) can be made reac
 
 If a statement consists entirely of an assignment to an undeclared variable, Svelte will inject a `let` declaration on your behalf.
 
-```html
+```sv
 <script>
 	export let num;
 
@@ -157,7 +157,7 @@ Note that the store must be declared at the top level of the component — not i
 
 Local variables (that do not represent store values) must *not* have a `$` prefix.
 
-```html
+```sv
 <script>
 	import { writable } from 'svelte/store';
 
@@ -199,7 +199,7 @@ You cannot `export default`, since the default export is the component itself.
 
 > Variables defined in `module` scripts are not reactive — reassigning them will not trigger a rerender even though the variable itself will update. For values shared between multiple components, consider using a [store](docs#svelte_store).
 
-```html
+```sv
 <script context="module">
 	let totalComponents = 0;
 
@@ -225,7 +225,7 @@ CSS inside a `<style>` block will be scoped to that component.
 
 This works by adding a class to affected elements, which is based on a hash of the component styles (e.g. `svelte-123xyz`).
 
-```html
+```sv
 <style>
 	p {
 		/* this will only affect <p> elements in this component */
@@ -238,7 +238,7 @@ This works by adding a class to affected elements, which is based on a hash of t
 
 To apply styles to a selector globally, use the `:global(...)` modifier.
 
-```html
+```sv
 <style>
 	:global(body) {
 		/* this will apply to <body> */

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -9,7 +9,7 @@ title: Template syntax
 
 A lowercase tag, like `<div>`, denotes a regular HTML element. A capitalised tag, such as `<Widget>` or `<Namespace.Widget>`, indicates a *component*.
 
-```html
+```sv
 <script>
 	import Widget from './Widget.svelte';
 </script>
@@ -26,7 +26,7 @@ A lowercase tag, like `<div>`, denotes a regular HTML element. A capitalised tag
 
 By default, attributes work exactly like their HTML counterparts.
 
-```html
+```sv
 <div class="foo">
 	<button disabled>can't touch this</button>
 </div>
@@ -36,7 +36,7 @@ By default, attributes work exactly like their HTML counterparts.
 
 As in HTML, values may be unquoted.
 
-```html
+```sv
 <input type=checkbox>
 ```
 
@@ -44,7 +44,7 @@ As in HTML, values may be unquoted.
 
 Attribute values can contain JavaScript expressions.
 
-```html
+```sv
 <a href="page/{p}">page {p}</a>
 ```
 
@@ -52,7 +52,7 @@ Attribute values can contain JavaScript expressions.
 
 Or they can *be* JavaScript expressions.
 
-```html
+```sv
 <button disabled={!clickable}>...</button>
 ```
 
@@ -71,7 +71,7 @@ All other attributes are included unless their value is [nullish](https://develo
 
 An expression might include characters that would cause syntax highlighting to fail in regular HTML, so quoting the value is permitted. The quotes do not affect how the value is parsed:
 
-```html
+```sv
 <button disabled="{number !== 42}">...</button>
 ```
 
@@ -79,7 +79,7 @@ An expression might include characters that would cause syntax highlighting to f
 
 When the attribute name and value match (`name={name}`), they can be replaced with `{name}`.
 
-```html
+```sv
 <!-- These are equivalent -->
 <button disabled={disabled}>...</button>
 <button {disabled}>...</button>
@@ -91,7 +91,7 @@ By convention, values passed to components are referred to as *properties* or *p
 
 As with elements, `name={name}` can be replaced with the `{name}` shorthand.
 
-```html
+```sv
 <Widget foo={bar} answer={42} text="hello"/>
 ```
 
@@ -101,7 +101,7 @@ As with elements, `name={name}` can be replaced with the `{name}` shorthand.
 
 An element or component can have multiple spread attributes, interspersed with regular ones.
 
-```html
+```sv
 <Widget {...things}/>
 ```
 
@@ -109,7 +109,7 @@ An element or component can have multiple spread attributes, interspersed with r
 
 *`$$props`* references all props that are passed to a component – including ones that are not declared with `export`. It is useful in rare cases, but not generally recommended, as it is difficult for Svelte to optimise.
 
-```html
+```sv
 <Widget {...$$props}/>
 ```
 
@@ -133,7 +133,7 @@ An element or component can have multiple spread attributes, interspersed with r
 
 Text can also contain JavaScript expressions:
 
-```html
+```sv
 <h1>Hello {name}!</h1>
 <p>{a} + {b} = {a + b}.</p>
 ```
@@ -145,7 +145,7 @@ Text can also contain JavaScript expressions:
 
 You can use HTML comments inside components.
 
-```html
+```sv
 <!-- this is a comment! -->
 <h1>Hello world</h1>
 ```
@@ -154,7 +154,7 @@ You can use HTML comments inside components.
 
 Comments beginning with `svelte-ignore` disable warnings for the next block of markup. Usually these are accessibility warnings; make sure that you're disabling them for a good reason.
 
-```html
+```sv
 <!-- svelte-ignore a11y-autofocus -->
 <input bind:value={name} autofocus>
 ```
@@ -176,7 +176,7 @@ Comments beginning with `svelte-ignore` disable warnings for the next block of m
 
 Content that is conditionally rendered can be wrapped in an if block.
 
-```html
+```sv
 {#if answer === 42}
 	<p>what was the question?</p>
 {/if}
@@ -186,7 +186,7 @@ Content that is conditionally rendered can be wrapped in an if block.
 
 Additional conditions can be added with `{:else if expression}`, optionally ending in an `{:else}` clause.
 
-```html
+```sv
 {#if porridge.temperature > 100}
 	<p>too hot!</p>
 {:else if 80 > porridge.temperature}
@@ -219,7 +219,7 @@ Additional conditions can be added with `{:else if expression}`, optionally endi
 
 Iterating over lists of values can be done with an each block.
 
-```html
+```sv
 <h1>Shopping list</h1>
 <ul>
 	{#each items as item}
@@ -234,7 +234,7 @@ You can use each blocks to iterate over any array or array-like value — that i
 
 An each block can also specify an *index*, equivalent to the second argument in an `array.map(...)` callback:
 
-```html
+```sv
 {#each items as item, i}
 	<li>{i + 1}: {item.name} x {item.qty}</li>
 {/each}
@@ -244,7 +244,7 @@ An each block can also specify an *index*, equivalent to the second argument in 
 
 If a *key* expression is provided — which must uniquely identify each list item — Svelte will use it to diff the list when data changes, rather than adding or removing items at the end. The key can be any object, but strings and numbers are recommended since they allow identity to persist when the objects themselves change.
 
-```html
+```sv
 {#each items as item (item.id)}
 	<li>{item.name} x {item.qty}</li>
 {/each}
@@ -259,7 +259,7 @@ If a *key* expression is provided — which must uniquely identify each list ite
 
 You can freely use destructuring and rest patterns in each blocks.
 
-```html
+```sv
 {#each items as { id, name, qty }, i (id)}
 	<li>{i + 1}: {name} x {qty}</li>
 {/each}
@@ -277,7 +277,7 @@ You can freely use destructuring and rest patterns in each blocks.
 
 An each block can also have an `{:else}` clause, which is rendered if the list is empty.
 
-```html
+```sv
 {#each todos as todo}
 	<p>{todo.text}</p>
 {:else}
@@ -302,7 +302,7 @@ An each block can also have an `{:else}` clause, which is rendered if the list i
 
 Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected.
 
-```html
+```sv
 {#await promise}
 	<!-- promise is pending -->
 	<p>waiting for the promise to resolve...</p>
@@ -319,7 +319,7 @@ Await blocks allow you to branch on the three possible states of a Promise — p
 
 The `catch` block can be omitted if you don't need to render anything when the promise rejects (or no error is possible).
 
-```html
+```sv
 {#await promise}
 	<!-- promise is pending -->
 	<p>waiting for the promise to resolve...</p>
@@ -333,7 +333,7 @@ The `catch` block can be omitted if you don't need to render anything when the p
 
 If you don't care about the pending state, you can also omit the initial block.
 
-```html
+```sv
 {#await promise then value}
 	<p>The value is {value}</p>
 {/await}
@@ -354,7 +354,7 @@ The expression should be valid standalone HTML — `{@html "<div>"}content{@html
 
 > Svelte does not sanitize expressions before injecting HTML. If the data comes from an untrusted source, you must sanitize it, or you are exposing your users to an XSS vulnerability.
 
-```html
+```sv
 <div class="blog-post">
 	<h1>{post.title}</h1>
 	{@html post.content}
@@ -377,7 +377,7 @@ The `{@debug ...}` tag offers an alternative to `console.log(...)`. It logs the 
 
 It accepts a comma-separated list of variable names (not arbitrary expressions).
 
-```html
+```sv
 <script>
 	let user = {
 		firstname: 'Ada',
@@ -394,7 +394,7 @@ It accepts a comma-separated list of variable names (not arbitrary expressions).
 
 `{@debug ...}` accepts a comma-separated list of variable names (not arbitrary expressions).
 
-```html
+```sv
 <!-- Compiles -->
 {@debug user}
 {@debug user1, user2, user3}
@@ -428,7 +428,7 @@ on:eventname|modifiers={handler}
 
 Use the `on:` directive to listen to DOM events.
 
-```html
+```sv
 <script>
 	let count = 0;
 
@@ -446,7 +446,7 @@ Use the `on:` directive to listen to DOM events.
 
 Handlers can be declared inline with no performance penalty. As with attributes, directive values may be quoted for the sake of syntax highlighters.
 
-```html
+```sv
 <button on:click="{() => count += 1}">
 	count: {count}
 </button>
@@ -456,7 +456,7 @@ Handlers can be declared inline with no performance penalty. As with attributes,
 
 Add *modifiers* to DOM events with the `|` character.
 
-```html
+```sv
 <form on:submit|preventDefault={handleSubmit}>
 	<!-- the `submit` event's default is prevented,
 	     so the page won't reload -->
@@ -478,7 +478,7 @@ Modifiers can be chained together, e.g. `on:click|once|capture={...}`.
 
 If the `on:` directive is used without a value, the component will *forward* the event, meaning that a consumer of the component can listen for it.
 
-```html
+```sv
 <button on:click>
 	The component itself will emit the click event
 </button>
@@ -488,7 +488,7 @@ If the `on:` directive is used without a value, the component will *forward* the
 
 It's possible to have multiple event listeners for the same event:
 
-```html
+```sv
 <script>
 	let counter = 0;
 	function increment() {
@@ -515,7 +515,7 @@ Data ordinarily flows down, from parent to child. The `bind:` directive allows d
 
 The simplest bindings reflect the value of a property, such as `input.value`.
 
-```html
+```sv
 <input bind:value={name}>
 <textarea bind:value={text}></textarea>
 
@@ -526,7 +526,7 @@ The simplest bindings reflect the value of a property, such as `input.value`.
 
 If the name matches the value, you can use a shorthand.
 
-```html
+```sv
 <!-- These are equivalent -->
 <input bind:value={value}>
 <input bind:value>
@@ -536,7 +536,7 @@ If the name matches the value, you can use a shorthand.
 
 Numeric input values are coerced; even though `input.value` is a string as far as the DOM is concerned, Svelte will treat it as a number. If the input is empty or invalid (in the case of `type="number"`), the value is `undefined`.
 
-```html
+```sv
 <input type="number" bind:value={num}>
 <input type="range" bind:value={num}>
 ```
@@ -548,7 +548,7 @@ Numeric input values are coerced; even though `input.value` is a string as far a
 
 A `<select>` value binding corresponds to the `value` property on the selected `<option>`, which can be any value (not just strings, as is normally the case in the DOM).
 
-```html
+```sv
 <select bind:value={selected}>
 	<option value={a}>a</option>
 	<option value={b}>b</option>
@@ -560,7 +560,7 @@ A `<select>` value binding corresponds to the `value` property on the selected `
 
 A `<select multiple>` element behaves similarly to a checkbox group.
 
-```html
+```sv
 <select multiple bind:value={fillings}>
 	<option value="Rice">Rice</option>
 	<option value="Beans">Beans</option>
@@ -573,7 +573,7 @@ A `<select multiple>` element behaves similarly to a checkbox group.
 
 When the value of an `<option>` matches its text content, the attribute can be omitted.
 
-```html
+```sv
 <select multiple bind:value={fillings}>
 	<option>Rice</option>
 	<option>Beans</option>
@@ -586,7 +586,7 @@ When the value of an `<option>` matches its text content, the attribute can be o
 
 Elements with the `contenteditable` attribute support `innerHTML` and `textContent` bindings.
 
-```html
+```sv
 <div contenteditable="true" bind:innerHTML={html}></div>
 ```
 
@@ -612,7 +612,7 @@ Media elements (`<audio>` and `<video>`) have their own set of bindings — six 
 
 Videos additionally have readonly `videoWidth` and `videoHeight` bindings.
 
-```html
+```sv
 <video
 	src={clip}
 	bind:duration
@@ -640,7 +640,7 @@ Block-level elements have 4 readonly bindings, measured using a technique simila
 * `offsetWidth`
 * `offsetHeight`
 
-```html
+```sv
 <div
 	bind:offsetWidth={width}
 	bind:offsetHeight={height}
@@ -659,7 +659,7 @@ bind:group={variable}
 
 Inputs that work together can use `bind:group`.
 
-```html
+```sv
 <script>
 	let tortilla = 'Plain';
 	let fillings = [];
@@ -687,7 +687,7 @@ bind:this={dom_node}
 
 To get a reference to a DOM node, use `bind:this`.
 
-```html
+```sv
 <script>
 	import { onMount } from 'svelte';
 
@@ -716,7 +716,7 @@ class:name
 
 A `class:` directive provides a shorter way of toggling a class on an element.
 
-```html
+```sv
 <!-- These are equivalent -->
 <div class="{active ? 'active' : ''}">...</div>
 <div class:active={active}>...</div>
@@ -749,7 +749,7 @@ action = (node: HTMLElement, parameters: any) => {
 
 Actions are functions that are called when an element is created. They can return an object with a `destroy` method that is called after the element is unmounted:
 
-```html
+```sv
 <script>
 	function foo(node) {
 		// the node has been mounted in the DOM
@@ -771,7 +771,7 @@ An action can have parameters. If the returned value has an `update` method, it 
 
 > Don't worry about the fact that we're redeclaring the `foo` function for every component instance — Svelte will hoist any functions that don't depend on local state out of the component definition.
 
-```html
+```sv
 <script>
 	export let bar;
 
@@ -828,7 +828,7 @@ When a block is transitioning out, all elements inside the block, including thos
 
 The `transition:` directive indicates a *bidirectional* transition, which means it can be smoothly reversed while the transition is in progress.
 
-```html
+```sv
 {#if visible}
 	<div transition:fade>
 		fades in and out
@@ -846,7 +846,7 @@ Like actions, transitions can have parameters.
 
 (The double `{{curlies}}` aren't a special syntax; this is an object literal inside an expression tag.)
 
-```html
+```sv
 {#if visible}
 	<div transition:fade="{{ duration: 2000 }}">
 		flies in, fades out over two seconds
@@ -864,7 +864,7 @@ The `t` argument passed to `css` is a value between `0` and `1` after the `easin
 
 The function is called repeatedly *before* the transition begins, with different `t` and `u` arguments.
 
-```html
+```sv
 <script>
 	import { elasticOut } from 'svelte/easing';
 
@@ -895,7 +895,7 @@ A custom transition function can also return a `tick` function, which is called 
 
 > If it's possible to use `css` instead of `tick`, do so — CSS animations can run off the main thread, preventing jank on slower devices.
 
-```html
+```sv
 <script>
 	export let visible = false;
 
@@ -941,7 +941,7 @@ An element with transitions will dispatch the following events in addition to an
 * `outrostart`
 * `outroend`
 
-```html
+```sv
 {#if visible}
 	<p
 		transition:fly="{{ y: 200, duration: 2000 }}"
@@ -959,7 +959,7 @@ An element with transitions will dispatch the following events in addition to an
 
 Local transitions only play when the block they belong to is created or destroyed, *not* when parent blocks are created or destroyed.
 
-```html
+```sv
 {#if x}
 	{#if y}
 		<p transition:fade>
@@ -1008,7 +1008,7 @@ Similar to `transition:`, but only applies to elements entering (`in:`) or leavi
 
 Unlike with `transition:`, transitions applied with `in:` and `out:` are not bidirectional — an in transition will continue to 'play' alongside the out transition, rather than reversing, if the block is outroed while the transition is in progress. If an out transition is aborted, transitions will restart from scratch.
 
-```html
+```sv
 {#if visible}
 	<div in:fly out:fade>
 		flies in, fades out
@@ -1057,7 +1057,7 @@ An animation is triggered when the contents of a [keyed each block](docs#each) a
 
 Animations can be used with Svelte's [built-in animation functions](docs#svelte_animate) or [custom animation functions](docs#Custom_animation_functions).
 
-```html
+```sv
 <!-- When `list` is reordered the animation will run-->
 {#each list as item, index (item)}
 	<li animate:flip>{item}</li>
@@ -1072,7 +1072,7 @@ As with actions and transitions, animations can have parameters.
 
 (The double `{{curlies}}` aren't a special syntax; this is an object literal inside an expression tag.)
 
-```html
+```sv
 {#each list as item, index (item)}
 	<li animate:flip="{{ delay: 500 }}">{item}</li>
 {/each}
@@ -1091,7 +1091,7 @@ The `t` argument passed to `css` is a value that goes from `0` and `1` after the
 The function is called repeatedly *before* the animation begins, with different `t` and `u` arguments.
 
 
-```html
+```sv
 <script>
 	import { cubicOut } from 'svelte/easing';
 
@@ -1124,7 +1124,7 @@ A custom animation function can also return a `tick` function, which is called *
 
 > If it's possible to use `css` instead of `tick`, do so — CSS animations can run off the main thread, preventing jank on slower devices.
 
-```html
+```sv
 <script>
 	import { cubicOut } from 'svelte/easing';
 
@@ -1164,7 +1164,7 @@ on:eventname={handler}
 
 Components can emit events using [createEventDispatcher](docs#createEventDispatcher), or by forwarding DOM events. Listening for component events looks the same as listening for DOM events:
 
-```html
+```sv
 <SomeComponent on:whatever={handler}/>
 ```
 
@@ -1172,7 +1172,7 @@ Components can emit events using [createEventDispatcher](docs#createEventDispatc
 
 As with DOM events, if the `on:` directive is used without a value, the component will *forward* the event, meaning that a consumer of the component can listen for it.
 
-```html
+```sv
 <SomeComponent on:whatever/>
 ```
 
@@ -1187,7 +1187,7 @@ bind:property={variable}
 
 You can bind to component props using the same syntax as for elements.
 
-```html
+```sv
 <Keypad bind:value={pin}/>
 ```
 
@@ -1203,7 +1203,7 @@ Components also support `bind:this`, allowing you to interact with component ins
 
 > Note that we can't do `{cart.empty}` since `cart` is `undefined` when the button is first rendered and throws an error.
 
-```html
+```sv
 <ShoppingCart bind:this={cart}/>
 
 <button on:click={() => cart.empty()}>
@@ -1231,7 +1231,7 @@ Components can have child content, in the same way that elements can.
 
 The content is exposed in the child component using the `<slot>` element, which can contain fallback content that is rendered if no children are provided.
 
-```html
+```sv
 <!-- App.svelte -->
 <Widget></Widget>
 
@@ -1253,7 +1253,7 @@ The content is exposed in the child component using the `<slot>` element, which 
 
 Named slots allow consumers to target specific areas. They can also have fallback content.
 
-```html
+```sv
 <!-- App.svelte -->
 <Widget>
 	<h1 slot="header">Hello</h1>
@@ -1276,7 +1276,7 @@ Slots can be rendered zero or more times, and can pass values *back* to the pare
 
 The usual shorthand rules apply — `let:item` is equivalent to `let:item={item}`, and `<slot {item}>` is equivalent to `<slot item={item}>`.
 
-```html
+```sv
 <!-- App.svelte -->
 <FancyList {items} let:prop={thing}>
 	<div>{thing.text}</div>
@@ -1296,7 +1296,7 @@ The usual shorthand rules apply — `let:item` is equivalent to `let:item={item}
 
 Named slots can also expose values. The `let:` directive goes on the element with the `slot` attribute.
 
-```html
+```sv
 <!-- App.svelte -->
 <FancyList {items}>
 	<div slot="item" let:item>{item.text}</div>
@@ -1324,7 +1324,7 @@ The `<svelte:self>` element allows a component to include itself, recursively.
 
 It cannot appear at the top level of your markup; it must be inside an if or each block to prevent an infinite loop.
 
-```html
+```sv
 <script>
 	export let count;
 </script>
@@ -1349,7 +1349,7 @@ The `<svelte:component>` element renders a component dynamically, using the comp
 
 If `this` is falsy, no component is rendered.
 
-```html
+```sv
 <svelte:component this={currentSelection.component} foo={bar}/>
 ```
 
@@ -1367,7 +1367,7 @@ If `this` is falsy, no component is rendered.
 
 The `<svelte:window>` element allows you to add event listeners to the `window` object without worrying about removing them when the component is destroyed, or checking for the existence of `window` when server-side rendering.
 
-```html
+```sv
 <script>
 	function handleKeydown(event) {
 		alert(`pressed the ${event.key} key`);
@@ -1391,7 +1391,7 @@ You can also bind to the following properties:
 
 All except `scrollX` and `scrollY` are readonly.
 
-```html
+```sv
 <svelte:window bind:scrollY={y}/>
 ```
 
@@ -1406,7 +1406,7 @@ All except `scrollX` and `scrollY` are readonly.
 
 As with `<svelte:window>`, this element allows you to add listeners to events on `document.body`, such as `mouseenter` and `mouseleave` which don't fire on `window`.
 
-```html
+```sv
 <svelte:body
 	on:mouseenter={handleMouseenter}
 	on:mouseleave={handleMouseleave}
@@ -1424,7 +1424,7 @@ As with `<svelte:window>`, this element allows you to add listeners to events on
 
 This element makes it possible to insert elements into `document.head`. During server-side rendering, `head` content is exposed separately to the main `html` content.
 
-```html
+```sv
 <svelte:head>
 	<link rel="stylesheet" href="tutorial/dark-theme.css">
 </svelte:head>
@@ -1448,6 +1448,6 @@ The `<svelte:options>` element provides a place to specify per-component compile
 * `namespace="..."` — the namespace where this component will be used, most commonly "svg"
 * `tag="..."` — the name to use when compiling this component as a custom element
 
-```html
+```sv
 <svelte:options tag="my-custom-element"/>
 ```

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -22,7 +22,7 @@ The `onMount` function schedules a callback to run as soon as the component has 
 
 `onMount` does not run inside a [server-side component](docs#Server-side_component_API).
 
-```html
+```sv
 <script>
 	import { onMount } from 'svelte';
 
@@ -36,7 +36,7 @@ The `onMount` function schedules a callback to run as soon as the component has 
 
 If a function is returned from `onMount`, it will be called when the component is unmounted.
 
-```html
+```sv
 <script>
 	import { onMount } from 'svelte';
 
@@ -62,7 +62,7 @@ Schedules a callback to run immediately before the component is updated after an
 
 > The first time the callback runs will be before the initial `onMount`
 
-```html
+```sv
 <script>
 	import { beforeUpdate } from 'svelte';
 
@@ -82,7 +82,7 @@ afterUpdate(callback: () => void)
 
 Schedules a callback to run immediately after the component has been updated.
 
-```html
+```sv
 <script>
 	import { afterUpdate } from 'svelte';
 
@@ -104,7 +104,7 @@ Schedules a callback to run once the component is unmounted.
 
 Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the only one that runs inside a server-side component.
 
-```html
+```sv
 <script>
 	import { onDestroy } from 'svelte';
 
@@ -124,7 +124,7 @@ promise: Promise = tick()
 
 Returns a promise that resolves once any pending state changes have been applied, or in the next microtask if there are none.
 
-```html
+```sv
 <script>
 	import { beforeUpdate, tick } from 'svelte';
 
@@ -148,7 +148,7 @@ Associates an arbitrary `context` object with the current component and the spec
 
 Like lifecycle functions, this must be called during component initialisation.
 
-```html
+```sv
 <script>
 	import { setContext } from 'svelte';
 
@@ -168,7 +168,7 @@ context: any = getContext(key: any)
 
 Retrieves the context that belongs to the closest parent component with the specified `key`. Must be called during component initialisation.
 
-```html
+```sv
 <script>
 	import { getContext } from 'svelte';
 
@@ -188,7 +188,7 @@ Creates an event dispatcher that can be used to dispatch [component events](docs
 
 Component events created with `createEventDispatcher` create a [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent). These events do not [bubble](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture) and are not cancellable with `event.preventDefault()`. The `detail` argument corresponds to the [CustomEvent.detail](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail) property and can contain any type of data.
 
-```html
+```sv
 <script>
 	import { createEventDispatcher } from 'svelte';
 
@@ -202,7 +202,7 @@ Component events created with `createEventDispatcher` create a [CustomEvent](htt
 
 Events dispatched from child components can be listened to in their parent. Any data provided when the event was dispatched is available on the `detail` property of the event object.
 
-```html
+```sv
 <script>
 	function callbackFunction(event) {
 		console.log(`Notify fired! Detail: ${event.detail}`)
@@ -413,7 +413,7 @@ Both functions return a Promise that resolves when the tween completes. If the t
 
 Out of the box, Svelte will interpolate between two numbers, two arrays or two objects (as long as the arrays and objects are the same 'shape', and their 'leaf' properties are also numbers).
 
-```html
+```sv
 <script>
 	import { tweened } from 'svelte/motion';
 	import { cubicOut } from 'svelte/easing';
@@ -452,7 +452,7 @@ $: $size = big ? 100 : 10;
 
 The `interpolate` option allows you to tween between *any* arbitrary values. It must be an `(a, b) => t => value` function, where `a` is the starting value, `b` is the target value, `t` is a number between 0 and 1, and `value` is the result. For example, we can use the [d3-interpolate](https://github.com/d3/d3-interpolate) package to smoothly interpolate between two colours.
 
-```html
+```sv
 <script>
 	import { interpolateLab } from 'd3-interpolate';
 	import { tweened } from 'svelte/motion';
@@ -499,7 +499,7 @@ Both `set` and `update` can take a second argument — an object with `hard` or 
 
 [See a full example on the spring tutorial.](tutorial/spring)
 
-```html
+```sv
 <script>
 	import { spring } from 'svelte/motion';
 
@@ -546,7 +546,7 @@ Animates the opacity of an element from 0 to the current opacity for `in` transi
 
 You can see the `fade` transition in action in the [transition tutorial](tutorial/transition).
 
-```html
+```sv
 <script>
 	import { fade } from 'svelte/transition';
 </script>
@@ -582,7 +582,7 @@ Animates a `blur` filter alongside an element's opacity.
 * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
 * `amount` (`number`, default 5) - the size of the blur in pixels
 
-```html
+```sv
 <script>
 	import { blur } from 'svelte/transition';
 </script>
@@ -621,7 +621,7 @@ Animates the x and y positions and the opacity of an element. `in` transitions a
 
 You can see the `fly` transition in action in the [transition tutorial](tutorial/adding-parameters-to-transitions).
 
-```html
+```sv
 <script>
 	import { fly } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
@@ -656,7 +656,7 @@ Slides an element in and out.
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicOut`) — an [easing function](docs#svelte_easing)
 
-```html
+```sv
 <script>
 	import { slide } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
@@ -693,7 +693,7 @@ Animates the opacity and scale of an element. `in` transitions animate from an e
 * `start` (`number`, default 0) - the scale value to animate out to and in from
 * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
 
-```html
+```sv
 <script>
 	import { scale } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
@@ -731,7 +731,7 @@ Animates the stroke of an SVG element, like a snake in a tube. `in` transitions 
 
 The `speed` parameter is a means of setting the duration of the transition relative to the path's length. It is modifier that is applied to the length of the path: `duration = length / speed`. A path that is 1000 pixels with a speed of 1 will have a duration of `1000ms`, setting the speed to `0.5` will double that duration and setting it to `2` will halve it.
 
-```html
+```sv
 <script>
 	import { draw } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
@@ -785,7 +785,7 @@ The `flip` function calculates the start and end position of an element and anim
 You can see a full example on the [animations tutorial](tutorial/animate)
 
 
-```html
+```sv
 <script>
 	import { flip } from 'svelte/animate';
 	import { quintOut } from 'svelte/easing';
@@ -973,7 +973,7 @@ app.count += 1;
 
 Svelte components can also be compiled to custom elements (aka web components) using the `customElement: true` compiler option. You should specify a tag name for the component using the `<svelte:options>` [element](docs#svelte_options).
 
-```html
+```sv
 <svelte:options tag="my-element" />
 
 <script>

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1281,9 +1281,9 @@
       }
     },
     "@sveltejs/site-kit": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/site-kit/-/site-kit-1.1.4.tgz",
-      "integrity": "sha512-PsFUX1C/fhV0ODdCJaEQ8OwzgmaPJVmdefiSYA+i6zttBeV19d/ow+l7SPMXxBkux+vUIl5can4BwValCukCsw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@sveltejs/site-kit/-/site-kit-1.1.5.tgz",
+      "integrity": "sha512-Rs2quQ/H00DAN/ZTFa+unLefL335UW3Yo4I2rTocW5JwW73Kvi5++d7BcY8LsjhMCbG1PkwQmJE2RVrIIxQcOw==",
       "dev": true,
       "requires": {
         "@sindresorhus/slugify": "^0.9.1",
@@ -3163,6 +3163,11 @@
       "requires": {
         "xtend": "^4.0.0"
       }
+    },
+    "prism-svelte": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/prism-svelte/-/prism-svelte-0.4.3.tgz",
+      "integrity": "sha512-plS7uY0WWiTBwWZs9KM3M88ZxHWKbrbMUDf52CPum6BqAxiLmKROmaTnmhXtv0krQ0l0HRLcFS8JDwOFyPt/OQ=="
     },
     "prismjs": {
       "version": "1.17.1",

--- a/site/package.json
+++ b/site/package.json
@@ -24,6 +24,7 @@
     "marked": "^0.7.0",
     "pg": "^7.12.1",
     "polka": "^1.0.0-next.9",
+    "prism-svelte": "^0.4.3",
     "prismjs": "^1.17.1",
     "sirv": "^1.0.0-next.2",
     "yootils": "0.0.16"
@@ -35,7 +36,7 @@
     "@babel/preset-env": "^7.6.0",
     "@babel/runtime": "^7.6.0",
     "@sindresorhus/slugify": "^0.9.1",
-    "@sveltejs/site-kit": "^1.1.4",
+    "@sveltejs/site-kit": "^1.1.5",
     "@sveltejs/svelte-repl": "^0.1.19",
     "degit": "^2.1.4",
     "dotenv": "^8.1.0",

--- a/site/src/utils/highlight.js
+++ b/site/src/utils/highlight.js
@@ -1,6 +1,7 @@
 import { langs } from '@sveltejs/site-kit/utils/markdown.js';
 import PrismJS from 'prismjs';
 import 'prismjs/components/prism-bash';
+import 'prism-svelte';
 
 export function highlight(source, lang) {
 	const plang = langs[lang] || '';


### PR DESCRIPTION
This PR adds proper syntax highlighting to svelte code blocks via [prism-svelte](https://github.com/pngwn/prism-svelte).

It works for big old code blocks like this:
<img width="773" alt="Screenshot 2020-05-17 at 16 13 42" src="https://user-images.githubusercontent.com/12937446/82152517-ae2e4280-9859-11ea-8517-7fbe4030d478.png">

And also for those signatures we have like this:
<img width="463" alt="Screenshot 2020-05-17 at 16 14 38" src="https://user-images.githubusercontent.com/12937446/82152526-be462200-9859-11ea-9705-48e0241b9477.png">

If some helpful folk could take a look over the svelte blocks to make sure nothing is amiss, that would be great.

The svelte grammar extends the markup grammar so the addition of a new `sv` tag wasn't strictly necessary (all valid HTML should be highlighted correctly too) but I felt it was better to be explicit.