### PR TITLE
React to array mutation in each block with static content

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -96,6 +96,19 @@ export default class EachBlockWrapper extends Wrapper {
 			bindings: new Map(block.bindings)
 		});
 
+		const reassigned_deps: Set<string> = new Set();
+
+		block.dependencies.forEach(dep => {
+			const info = renderer.context_lookup.get(dep);
+			if (info && info.variable.reassigned) {
+				reassigned_deps.add(dep);
+			}
+		});
+
+		if (reassigned_deps.size) {
+			this.block.add_dependencies(reassigned_deps);
+		}
+
 		// TODO this seems messy
 		this.block.has_animation = this.node.has_animation;
 

--- a/test/runtime/samples/each-block-static-update/_config.js
+++ b/test/runtime/samples/each-block-static-update/_config.js
@@ -1,0 +1,7 @@
+export default {
+	html: ``,
+
+	test({ assert, target }) {
+		assert.htmlEqual(target.innerHTML, `staticstatic`);
+	}
+};

--- a/test/runtime/samples/each-block-static-update/main.svelte
+++ b/test/runtime/samples/each-block-static-update/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { onMount } from 'svelte';
+	let arr = [1];
+	
+	onMount(() => {
+		arr.push(arr.length + 1);
+		arr = arr;
+	});
+</script>
+
+{#each arr as num}
+	static
+{/each}


### PR DESCRIPTION
Potentially fixes #4804 

@dimfeld mentions [here](https://github.com/sveltejs/svelte/issues/4804#issuecomment-626095834) that there is an optimisation for unkeyed each blocks in place, and I'm not sure if this fix opts out of that too eagerly
