### PR TITLE
a11y: add mouse-events-have-key-events rule

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -515,6 +515,20 @@ export default class Element extends Node {
 				});
 			}
 		}
+
+		if (handlers_map.has('mouseover') && !handlers_map.has('focus')) {
+			component.warn(this, {
+				code: `a11y-mouse-events-have-key-events`,
+				message: `A11y: on:mouseover must be accompanied by on:focus for accessibility`
+			});
+		}
+
+		if (handlers_map.has('mouseout') && !handlers_map.has('blur')) {
+			component.warn(this, {
+				code: `a11y-mouse-events-have-key-events`,
+				message: `A11y: on:mouseout must be accompanied by on:blur for accessibility`
+			});
+		}
 	}
 
 	validate_bindings() {

--- a/test/validator/samples/a11y-mouse-events-have-key-events/input.svelte
+++ b/test/validator/samples/a11y-mouse-events-have-key-events/input.svelte
@@ -1,0 +1,14 @@
+<script>
+    function noop() {}
+</script>
+
+<!-- should warn -->
+<div on:mouseover={noop} />
+<div on:mouseout={noop} />
+<div on:mouseover={noop} on:blur={noop} />
+<div on:mouseout={noop} on:focus={noop} />
+
+<!-- should not warn -->
+<div on:mouseover={noop} on:focus={noop} />
+<div on:mouseout={noop} on:blur={noop} />
+<div on:mouseover={noop} on:mouseout={noop} on:blur={noop} on:focus={noop}/>

--- a/test/validator/samples/a11y-mouse-events-have-key-events/warnings.json
+++ b/test/validator/samples/a11y-mouse-events-have-key-events/warnings.json
@@ -1,0 +1,62 @@
+[
+	{
+		"code": "a11y-mouse-events-have-key-events",
+		"message": "A11y: on:mouseover must be accompanied by on:focus for accessibility",
+		"end": {
+			"character": 91,
+			"column": 27,
+			"line": 6
+		},
+		"start": {
+			"character": 64,
+			"column": 0,
+			"line": 6
+		},
+		"pos": 64
+	},
+	{
+		"code": "a11y-mouse-events-have-key-events",
+		"message": "A11y: on:mouseout must be accompanied by on:blur for accessibility",
+		"end": {
+			"character": 118,
+			"column": 26,
+			"line": 7
+		},
+		"start": {
+			"character": 92,
+			"column": 0,
+			"line": 7
+		},
+		"pos": 92
+	},
+	{
+		"code": "a11y-mouse-events-have-key-events",
+		"message": "A11y: on:mouseover must be accompanied by on:focus for accessibility",
+		"end": {
+			"character": 161,
+			"column": 42,
+			"line": 8
+		},
+		"start": {
+			"character": 119,
+			"column": 0,
+			"line": 8
+		},
+		"pos": 119
+	},
+	{
+		"code": "a11y-mouse-events-have-key-events",
+		"message": "A11y: on:mouseout must be accompanied by on:blur for accessibility",
+		"end": {
+			"character": 204,
+			"column": 42,
+			"line": 9
+		},
+		"start": {
+			"character": 162,
+			"column": 0,
+			"line": 9
+		},
+		"pos": 162
+	}
+]


### PR DESCRIPTION
Implements [mouse-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md) a11y warning from #820 

Different error message for each combination (but the same warning code - is that okay?)
