### PR TITLE
called reactive functions for reassignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add `muted` binding for media elements ([#2998](https://github.com/sveltejs/svelte/issues/2998))
 * Fix let-less `<slot>` with context overflow ([#4624](https://github.com/sveltejs/svelte/issues/4624))
 * Fix `use:` actions being recreated when a keyed `{#each}` is reordered ([#4693](https://github.com/sveltejs/svelte/issues/4693))
+* Fix reactivity when binding directly to `{#each}` context ([#4879](https://github.com/sveltejs/svelte/issues/4879))
 
 ## 3.22.3
 

--- a/src/compiler/compile/nodes/Binding.ts
+++ b/src/compiler/compile/nodes/Binding.ts
@@ -60,7 +60,7 @@ export default class Binding extends Node {
 			scope.dependencies_for_name.get(name).forEach(name => {
 				const variable = component.var_lookup.get(name);
 				if (variable) {
-					variable[this.expression.node.type === 'MemberExpression' ? 'mutated' : 'reassigned'] = true;
+					variable['mutated'] = true;
 				}
 			});
 		} else {

--- a/src/compiler/compile/nodes/Binding.ts
+++ b/src/compiler/compile/nodes/Binding.ts
@@ -60,7 +60,7 @@ export default class Binding extends Node {
 			scope.dependencies_for_name.get(name).forEach(name => {
 				const variable = component.var_lookup.get(name);
 				if (variable) {
-					variable['mutated'] = true;
+					variable.mutated = true;
 				}
 			});
 		} else {

--- a/test/runtime/samples/reactive-function-called-reassigned/_config.js
+++ b/test/runtime/samples/reactive-function-called-reassigned/_config.js
@@ -1,0 +1,27 @@
+let value;
+let called = 0;
+function callback(_value) {
+	called ++;
+	value = _value;
+}
+
+export default {
+	props: {
+		callback,
+	},
+	async test({ assert, component, target, window }) {
+		assert.equal(called, 1);
+
+		const input = target.querySelector('input');
+
+		const event = new window.Event('input');
+		input.value = 'h';
+		await input.dispatchEvent(event);
+
+		assert.equal(called, 2);
+		assert.equal(value.length, 3);
+		assert.equal(value[0], 'h');
+		assert.equal(value[1], '2');
+		assert.equal(value[2], '3');
+	}
+};

--- a/test/runtime/samples/reactive-function-called-reassigned/main.svelte
+++ b/test/runtime/samples/reactive-function-called-reassigned/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	const refs = ['1','2','3']
+	export let callback = () => {};
+
+	$: callback(refs);
+</script>
+
+{#each refs as ref}
+	<input bind:value={ref} />
+{/each}


### PR DESCRIPTION
Fixes: https://github.com/sveltejs/svelte/issues/4879

- when binding to a variable within `{#each}` context, the dependency of the variable is mutated, not reassigned.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [ ] Run the tests tests with `npm test` or `yarn test`)
