### PR TITLE
Move info from FAQ to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ npm install && npm run update
 npm run dev
 ```
 
+### Is svelte.dev down?
+
+Probably not, but it's possible. If you can't seem to access any `.dev` sites, check out [this SuperUser question and answer](https://superuser.com/q/1413402).
 
 ## License
 

--- a/site/content/faq/300-is-svelte-dev-down.md
+++ b/site/content/faq/300-is-svelte-dev-down.md
@@ -1,5 +1,0 @@
----
-question: Is svelte.dev down?
----
-
-Probably not, but it's possible. If you can't seem to access any `.dev` sites, check out [this SuperUser question and answer](https://superuser.com/q/1413402).


### PR DESCRIPTION
It was pointed out in https://github.com/sveltejs/svelte/pull/4823#issuecomment-632147491 that if svelte.dev is down you won't be able to get to the FAQ to get this information, so it should probably live elsewhere