### PR TITLE
reduce spread code size by passing false to get_spread_update for static attributes

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -676,7 +676,7 @@ export default class ElementWrapper extends Wrapper {
 
 					initial_props.push(snippet);
 
-					updates.push(condition ? x`${condition} && ${snippet}` : snippet);
+					updates.push(condition ? x`${condition} && ${snippet}` : x`false`);
 				} else {
 					const metadata = attr.get_metadata();
 					const name = attr.is_indirectly_bound_value()
@@ -685,17 +685,14 @@ export default class ElementWrapper extends Wrapper {
 					const snippet = x`{ ${name}: ${attr.get_value(block)} }`;
 					initial_props.push(snippet);
 
-					updates.push(condition ? x`${condition} && ${snippet}` : snippet);
+					updates.push(condition ? x`${condition} && ${snippet}` : x`false`);
 				}
 			});
 
 		block.chunks.init.push(b`
 			let ${levels} = [${initial_props}];
 
-			let ${data} = {};
-			for (let #i = 0; #i < ${levels}.length; #i += 1) {
-				${data} = @assign(${data}, ${levels}[#i]);
-			}
+			let ${data} = @get_attributes_for_spread(${levels});
 		`);
 
 		const fn = this.node.namespace === namespaces.svg ? x`@set_svg_attributes` : x`@set_attributes`;

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -252,7 +252,7 @@ export default class InlineComponentWrapper extends Wrapper {
 
 					changes.push(
 						unchanged
-							? x`${levels}[${i}]`
+							? x`false`
 							: condition
 							? x`${condition} && ${change_object}`
 							: change_object
@@ -266,9 +266,7 @@ export default class InlineComponentWrapper extends Wrapper {
 				`);
 
 				statements.push(b`
-					for (let #i = 0; #i < ${levels}.length; #i += 1) {
-						${props} = @assign(${props}, ${levels}[#i]);
-					}
+					${props} = @assign(${props}, @get_attributes_for_spread(${levels}))
 				`);
 
 				if (all_dependencies.size) {

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -223,16 +223,17 @@ export default class InlineComponentWrapper extends Wrapper {
 				const all_dependencies: Set<string> = new Set();
 
 				this.node.attributes.forEach(attr => {
-					add_to_set(all_dependencies, attr.dependencies);
+					add_to_set(all_dependencies, attr.get_dependencies());
 				});
 
-				this.node.attributes.forEach((attr, i) => {
-					const { name, dependencies } = attr;
+				this.node.attributes.forEach((attr) => {
+					const { name } = attr;
+					const dependencies = attr.get_dependencies();
 
-					const condition = dependencies.size > 0 && (dependencies.size !== all_dependencies.size)
+					const condition = dependencies.length > 0 && (dependencies.length !== all_dependencies.size)
 						? renderer.dirty(Array.from(dependencies))
 						: null;
-					const unchanged = dependencies.size === 0;
+					const unchanged = dependencies.length === 0;
 
 					let change_object;
 					if (attr.is_spread) {

--- a/src/runtime/internal/spread.ts
+++ b/src/runtime/internal/spread.ts
@@ -44,9 +44,9 @@ export function get_spread_update(levels, updates) {
 }
 
 export function get_attributes_for_spread(levels) {
-	let attrs = {};
-	for (let i = 0; i < levels.length; i += 1) {
-		attrs = assign(attrs, levels[i]);
+	const attrs = {};
+	for (let i = 0; i < levels.length; i++) {
+		assign(attrs, levels[i++]);
 	}
 	return attrs;
 }

--- a/src/runtime/internal/spread.ts
+++ b/src/runtime/internal/spread.ts
@@ -1,3 +1,5 @@
+import { assign } from "./utils";
+
 export function get_spread_update(levels, updates) {
 	const update = {};
 
@@ -11,7 +13,7 @@ export function get_spread_update(levels, updates) {
 
 		if (n) {
 			for (const key in o) {
-				if (!(key in n)) to_null_out[key] = 1;
+				if (!(key in n) && !accounted_for[key]) to_null_out[key] = 1;
 			}
 
 			for (const key in n) {
@@ -24,6 +26,11 @@ export function get_spread_update(levels, updates) {
 			levels[i] = n;
 		} else {
 			for (const key in o) {
+				// if spreads decides to null out the key
+				// should reset it back for static attribute
+				if (to_null_out[key]) {
+					update[key] = o[key];
+				}
 				accounted_for[key] = 1;
 			}
 		}
@@ -34,6 +41,14 @@ export function get_spread_update(levels, updates) {
 	}
 
 	return update;
+}
+
+export function get_attributes_for_spread(levels) {
+	let attrs = {};
+	for (let i = 0; i < levels.length; i += 1) {
+		attrs = assign(attrs, levels[i]);
+	}
+	return attrs;
 }
 
 export function get_spread_object(spread_props) {

--- a/test/runtime/samples/spread-element-dynamic-non-object/_config.js
+++ b/test/runtime/samples/spread-element-dynamic-non-object/_config.js
@@ -1,0 +1,47 @@
+export default {
+	props: {
+		props: {
+			foo: 'lol',
+			baz: 40 + 2,
+		}
+	},
+
+	html: `
+		<div baz="42" foo="lol" qux="named"></div>
+	`,
+
+	test({ assert, component, target }) {
+		const html = `
+			<div qux="named"></div>
+		`;
+
+		// test undefined
+		component.props = undefined;
+		assert.htmlEqual(target.innerHTML, html);
+
+		// set object props
+		component.props = this.props.props;
+		assert.htmlEqual(target.innerHTML, this.html);
+
+		// test null
+		component.props = null;
+		assert.htmlEqual(target.innerHTML, html);
+
+		// set object props
+		component.props = this.props.props;
+		assert.htmlEqual(target.innerHTML, this.html);
+
+		// test boolean
+		component.props = true;
+		assert.htmlEqual(target.innerHTML, html);
+
+		// set object props
+		component.props = this.props.props;
+		assert.htmlEqual(target.innerHTML, this.html);
+
+		// test number
+		component.props = 123;
+		assert.htmlEqual(target.innerHTML, html);
+
+	}
+};

--- a/test/runtime/samples/spread-element-dynamic-non-object/main.svelte
+++ b/test/runtime/samples/spread-element-dynamic-non-object/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let props;
+</script>
+
+<div {...props} qux="named"/>


### PR DESCRIPTION
Reduce code size by:
1) use `false` for `get_spread_update` for static attributes to reduce codesize

```diff
  set_attributes(div, get_spread_update(div_levels, [
-   { a: "1" },
+   false,
-   { b: "2" },
+   false,
    dirty & /*name*/ 1 && { name: /*name*/ ctx[0] },
-   { a: 1 }
+   false
  ]));
```

2) added `get_attributes_for_spread` util to reuse for initialise attribute data for spread
3) use dynamic dependencies instead of dependencies for spreading attribute, reduce unnecessary code, if the dependencies are not dynamic.


Align the code for spreading in Component and element,

1) apply what https://github.com/sveltejs/svelte/pull/3306 did for Component on element, add check on spreading for element as well.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
