### PR TITLE
Small tweaks to readable store example

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -288,7 +288,8 @@ The second argument to `readable` is the same as the second argument to `writabl
 import { readable } from 'svelte/store';
 
 const time = readable(null, set => {
-  set(new Date());
+	set(new Date());
+
 	const interval = setInterval(() => {
 		set(new Date());
 	}, 1000);

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -287,7 +287,8 @@ The second argument to `readable` is the same as the second argument to `writabl
 ```js
 import { readable } from 'svelte/store';
 
-const time = readable(new Date(), set => {
+const time = readable(null, set => {
+  set(new Date());
 	const interval = setInterval(() => {
 		set(new Date());
 	}, 1000);


### PR DESCRIPTION
The current time should be stored by the callback when the first subscriber comes, and not when the readable is first created