### PR TITLE
Compiler: add $$self to reserved_keywords

### DIFF
--- a/src/compiler/compile/utils/reserved_keywords.ts
+++ b/src/compiler/compile/utils/reserved_keywords.ts
@@ -1,4 +1,4 @@
-export const reserved_keywords = new Set(["$$props", "$$restProps"]);
+export const reserved_keywords = new Set(["$$props", "$$restProps", "$$self"]);
 
 export function is_reserved_keyword(name) {
 	return reserved_keywords.has(name);


### PR DESCRIPTION
Currently, the only way to get a reference to a component itself is to bind it using `bind:this` from a parent component, so this PR makes it possible to directly access `$$self` from the component itself.

I will confess – I'm not sure if this was an omission on purpose or whether it was just not something that anybody has needed. I'm using the `bind:this` trick above and an `onDestroy` closure to clean up the reference after the fact, but it's imperfect – ideally, I'd be able to do the binding in `onMount`.