### PR TITLE
Fix current component not being cleared after component update

### DIFF
--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -45,6 +45,7 @@ export function flush() {
 			set_current_component(component);
 			update(component.$$);
 		}
+		set_current_component(null);
 
 		dirty_components.length = 0;
 

--- a/test/runtime/samples/onmount-get-current-component/_config.js
+++ b/test/runtime/samples/onmount-get-current-component/_config.js
@@ -1,0 +1,4 @@
+export default {
+	skip_if_ssr: true,
+	html: `1`,
+};

--- a/test/runtime/samples/onmount-get-current-component/main.svelte
+++ b/test/runtime/samples/onmount-get-current-component/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { onMount } from 'svelte';
+	import { get_current_component } from 'svelte/internal';
+
+	let gotException = 0;
+
+	onMount(() => {
+		try {
+			get_current_component();
+		} catch (error) {
+			gotException++;
+		}
+	});
+</script>
+
+{gotException}


### PR DESCRIPTION
Fixes #4899
Fixes #4259

This PR clears the current component after the update.  This has two effects:
* The lifecycle functions now raise an error when used outside of Svelte code (eg. in a setTimeout handler).  Previously, they operated on the last-updated component, which may not even be in a stable state.
* The lifecycle functions now raise an error when used inside onMount and afterUpdate.  If this is undesirable, we would need to explicitly call set_current_component in flush() again when calling the render callbacks.

This is essentially the same change as #4864, but that PR's unit test did not work correctly and left Svelte in an invalid state, causing many other unit tests to fail.

If any other unit tests or changes are needed, let me know and I'd be happy to work on them.

Closes #5077 (which is a subset of this fix that is more focused to only address #4899).