### PR TITLE
Separate the identification and removal of attributes

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -155,13 +155,15 @@ export function claim_element(nodes, name, attributes, svg) {
 		const node = nodes[i];
 		if (node.nodeName === name) {
 			let j = 0;
+			const remove = [];
 			while (j < node.attributes.length) {
-				const attribute = node.attributes[j];
-				if (attributes[attribute.name]) {
-					j++;
-				} else {
-					node.removeAttribute(attribute.name);
+				const attribute = node.attributes[j++];
+				if (!attributes[attribute.name]) {
+					remove.push(attribute.name);
 				}
+			}
+			for (let k = 0; k < remove.length; k++) {
+				node.removeAttribute(remove[k]);
 			}
 			return nodes.splice(i, 1)[0];
 		}


### PR DESCRIPTION
Because EdgeHTML does not actually remove the `value` attribute from an `HTMLInputElement`, the prior implementation would generate an infinite loop. By making this two passes, we are a bit less memory efficient but avoid the nasty edge cases when DOM elements don't fully respect the API.

I believe the existing tests, if they were to run against Edge, would suffer from this case. I was unable to do so as the harness is not configured in a way to make that easy, however, it does fix the case I discovered this with in situ.
