### PR TITLE
Adds a markup parameter to Preprocessors.

### DIFF
--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -17,6 +17,7 @@ export type Preprocessor = (options: {
 	content: string;
 	attributes: Record<string, string | boolean>;
 	filename?: string;
+	markup: string;
 }) => Processed | Promise<Processed>;
 
 function parse_attributes(str: string) {
@@ -103,7 +104,8 @@ export default async function preprocess(
 				const processed = await fn({
 					content,
 					attributes: parse_attributes(attributes),
-					filename
+					filename,
+					markup: source
 				});
 				if (processed && processed.dependencies) dependencies.push(...processed.dependencies);
 				return processed ? `<script${attributes}>${processed.code}</script>` : match;
@@ -122,7 +124,8 @@ export default async function preprocess(
 				const processed: Processed = await fn({
 					content,
 					attributes: parse_attributes(attributes),
-					filename
+					filename,
+					markup: source
 				});
 				if (processed && processed.dependencies) dependencies.push(...processed.dependencies);
 				return processed ? `<style${attributes}>${processed.code}</style>` : match;

--- a/test/preprocess/samples/script-markup/_config.js
+++ b/test/preprocess/samples/script-markup/_config.js
@@ -1,0 +1,12 @@
+export default {
+	preprocess: {
+		script: ({ content, markup }) => {
+			return {
+				code: content.replace(
+					"__HASDIVTAG__",
+					markup && /<div\/>/g.test(markup) ? "'yes'" : "'no'"
+				),
+			};
+		},
+	},
+};

--- a/test/preprocess/samples/script-markup/input.svelte
+++ b/test/preprocess/samples/script-markup/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	console.log(__HASDIVTAG__);
+</script>
+
+<div/>

--- a/test/preprocess/samples/script-markup/output.svelte
+++ b/test/preprocess/samples/script-markup/output.svelte
@@ -1,0 +1,5 @@
+<script>
+	console.log('yes');
+</script>
+
+<div/>


### PR DESCRIPTION
This parameter will hold the entire processed source file up until the
current preprocessor. This enables the script and style preprocessors to use context information from the entire file.

Fixes #4912

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
