### PR TITLE
[internals] Inline helpers + tweaks

### DIFF
--- a/src/compiler/compile/index.ts
+++ b/src/compiler/compile/index.ts
@@ -1,4 +1,3 @@
-import { assign } from '../../runtime/internal/utils';
 import Stats from '../Stats';
 import parse from '../parse/index';
 import render_dom from './render_dom/index';
@@ -68,7 +67,7 @@ function validate_options(options: CompileOptions, warnings: Warning[]) {
 }
 
 export default function compile(source: string, options: CompileOptions = {}) {
-	options = assign({ generate: 'dom', dev: false }, options);
+	options = { generate: 'dom', dev: false, ...options };
 
 	const stats = new Stats();
 	const warnings = [];

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -469,7 +469,7 @@ export default class Block {
 				const listener = this.get_unique_name(`${sanitize_name((node.arguments[1] as Literal).value)}_listener`);
 				this.add_variable(listener);
 				mount.push(b`${listener} = ${node};`);
-				destroy.push(b`${listener}();`)
+				destroy.push(b`${listener}();`);
 			} else if (
 				node.type === "AssignmentExpression" &&
 				node.left.type === "Identifier" &&
@@ -477,7 +477,7 @@ export default class Block {
 			) {
 				// b`identifier = use_action(args);`
 				mount.push(node);
-				destroy.push(b`if (${node.left} && typeof ${node.left}.destroy === "function") ${node.left}.destroy();`)
+				destroy.push(b`if (${node.left} && typeof ${node.left}.destroy === "function") ${node.left}.destroy();`);
 			} else {
 				throw new Error(`Forgot to specify logic for event_listener handling`);
 			}
@@ -498,4 +498,4 @@ export default class Block {
 	}
 }
 
-const isCallExpression = (node): node is CallExpression => node.type === "CallExpression"
+const isCallExpression = (node): node is CallExpression => node.type === "CallExpression";

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -3,6 +3,7 @@ import Wrapper from './wrappers/shared/Wrapper';
 import { b, x } from 'code-red';
 import { Node, Identifier, ArrayPattern, Literal, CallExpression } from 'estree';
 import { is_head } from './wrappers/shared/is_head';
+import { sanitize_name } from '../utils/stringify';
 
 export interface BlockOptions {
 	parent?: Block;
@@ -465,14 +466,14 @@ export default class Block {
 				node.callee.name === "@listen"
 			) {
 				// b`@listen(ref, "type", args);`
-				const listener = this.get_unique_name(`${(node.arguments[1] as Literal).value}_listener`);
+				const listener = this.get_unique_name(`${sanitize_name((node.arguments[1] as Literal).value)}_listener`);
 				this.add_variable(listener);
 				mount.push(b`${listener} = ${node};`);
 				destroy.push(b`${listener}();`)
 			} else if (
 				node.type === "AssignmentExpression" &&
 				node.left.type === "Identifier" &&
-				node.left.name.endsWith("_action")
+				node.left.name.includes("_action")
 			) {
 				// b`identifier = use_action(args);`
 				mount.push(node);

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -486,7 +486,7 @@ export default class Block {
 				`);
 
 				this.chunks.destroy.push(
-					b`@run_all(${dispose});`
+					b`${dispose}.forEach((#v) => #v());`
 				);
 			}
 		}

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -111,7 +111,7 @@ export default function dom(
 	}`
 	: null;
 			
-	const k = set ? b`let #k;` : null
+	const k = uses_$$ ? b`let #k;` : null
 	const accessors = [];
 
 	const not_equal = component.component_options.immutable ? x`@not_equal` : x`@safe_not_equal`;

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -77,10 +77,8 @@ export default function dom(
 	const props = component.vars.filter(variable => !variable.module && variable.export_name);
 	const writable_props = props.filter(variable => variable.writable);
 
-	const omit_props_names = component.get_unique_name('omit_props_names');
-
 	const rest = uses_rest ? b`
-		const ${omit_props_names.name} = [${props.map(prop => `"${prop.export_name}"`)}];
+		const #keys = new Set([${props.map(prop => `"${prop.export_name}"`).join()}]);
 		const $$restProps = {}; 
 		for (#k in $$props) { 
 			if (!#keys.has(#k) && #k[0] !== '$') { 
@@ -405,13 +403,12 @@ export default function dom(
 				const i = renderer.context_lookup.get($name).index;
 
 				return b`
-				let ${$name}, 
-					${unsubscribe} = @noop,
-					${subscribe} = () => { 
-						${unsubscribe}();
-						${unsubscribe} = @subscribe(${name}, (#value) => { $$invalidate(${i}, (${$name} = #value)); });
-						return ${name};
-					};`;
+				let ${$name}, ${unsubscribe} = @noop;
+				const ${subscribe} = () => { 
+					${unsubscribe}();
+					${unsubscribe} = @subscribe(${name}, (#value) => { $$invalidate(${i}, (${$name} = #value)); });
+					return ${name};
+				};`;
 			}
 
 			return b`let ${$name};`;

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -448,7 +448,8 @@ export default function dom(
 
 				${unknown_props_check}
 
-				${component.slots.size || component.compile_options.dev ? b`let { $$slots = {}, $$scope } = $$props;` : null}
+				${component.slots.size || component.compile_options.dev ? b`let { $$slots = {} } = $$props;` : null}
+				${component.slots.size ? b`let { $$scope } = $$props;` : null}
 				${component.compile_options.dev && b`@validate_slots('${component.tag}', $$slots, [${[...component.slots.keys()].map(key => `'${key}'`).join(',')}]);`}
 
 				${renderer.binding_groups.length > 0 && b`const $$binding_groups = [${renderer.binding_groups.map(_ => x`[]`)}];`}

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -101,7 +101,7 @@ export default function dom(
 		}
 		${uses_props && renderer.invalidate("$$props")}
 		${uses_rest && renderer.invalidate("$$restProps")}
-	`
+	`;
 	
 	const set = (uses_$$ || writable_props.length > 0 || component.slots.size > 0)
 	? x`${$$props} => {
@@ -111,7 +111,7 @@ export default function dom(
 	}`
 	: null;
 			
-	const k = uses_$$ ? b`let #k;` : null
+	const k = uses_$$ ? b`let #k;` : null;
 	const accessors = [];
 
 	const not_equal = component.component_options.immutable ? x`@not_equal` : x`@safe_not_equal`;

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -267,7 +267,7 @@ export default function dom(
 
 			const insert = (reassigned || export_name)
 				? b`${`$$subscribe_${name}`}()`
-				: b`$$self.$$.on_destroy.push(@subscribe(${name}, #value => {$$invalidate(${i}, (${value} = #value));})`;
+				: b`$$self.$$.on_destroy.push(@subscribe(${name}, #value => {$$invalidate(${i}, ${value} = #value);}))`;
 
 			if (component.compile_options.dev) {
 				return b`@validate_store(${name}, '${name}'); ${insert}`;

--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -604,6 +604,9 @@ export default class EachBlockWrapper extends Wrapper {
 			`);
 		}
 
-		block.chunks.destroy.push(b`@destroy_each(${iterations}, detaching);`);
+		block.chunks.destroy.push(b`
+		for (let #i = 0; #i < ${iterations}.length; #i += 1) {
+			if (${iterations}[#i]) ${iterations}[#i].d(detaching);
+		}`);
 	}
 }

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -215,7 +215,7 @@ export default class AttributeWrapper {
 
 		if (scoped_css && rendered.length === 2) {
 			// we have a situation like class={possiblyUndefined}
-			rendered[0] = x`@null_to_empty(${rendered[0]})`;
+			rendered[0] = x`null != ${rendered[0]} ? ${rendered[0]} : ""`;
 		}
 
 		return rendered.reduce((lhs, rhs) => x`${lhs} + ${rhs}`);

--- a/src/compiler/compile/render_dom/wrappers/Element/EventHandler.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/EventHandler.ts
@@ -31,7 +31,7 @@ export default class EventHandlerWrapper {
 
 		if (this.node.reassigned) {
 			block.maintain_context = true;
-			return x`function () { if (@is_function(${snippet})) ${snippet}.apply(this, arguments); }`;
+			return x`function () { if ("function" === typeof (${snippet})) ${snippet}.apply(this, arguments); }`;
 		}
 		return snippet;
 	}

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -690,11 +690,10 @@ export default class ElementWrapper extends Wrapper {
 			});
 
 		block.chunks.init.push(b`
-			let ${levels} = [${initial_props}];
-
-			let ${data} = {};
-			for (let #i = 0; #i < ${levels}.length; #i += 1) {
-				${data} = @assign(${data}, ${levels}[#i]);
+			const ${levels} = [${initial_props}];
+			let ${data} = ${levels}[0] || {};
+			for (let i = 1; i < ${levels}.length; i++) {
+				${data} = { ...${data}, ...${levels}[i] };
 			}
 		`);
 

--- a/src/compiler/compile/render_dom/wrappers/Head.ts
+++ b/src/compiler/compile/render_dom/wrappers/Head.ts
@@ -36,7 +36,7 @@ export default class HeadWrapper extends Wrapper {
 		let nodes;
 		if (this.renderer.options.hydratable && this.fragment.nodes.length) {
 			nodes = block.get_unique_name('head_nodes');
-			block.chunks.claim.push(b`const ${nodes} = @query_selector_all('[data-svelte="${this.node.id}"]', @_document.head);`);
+			block.chunks.claim.push(b`const ${nodes} = Array.from(( @_document.head || @_document.body ).querySelectorAll('[data-svelte="${this.node.id}"]'));`);
 		}
 
 		this.fragment.render(block, x`@_document.head` as unknown as Identifier, nodes);

--- a/src/compiler/compile/render_dom/wrappers/Head.ts
+++ b/src/compiler/compile/render_dom/wrappers/Head.ts
@@ -43,7 +43,7 @@ export default class HeadWrapper extends Wrapper {
 
 		if (nodes && this.renderer.options.hydratable) {
 			block.chunks.claim.push(
-				b`${nodes}.forEach(@detach);`
+				b`for(let #i = 0;#i < ${nodes}.length; #i++) @detach(${nodes}[#i]);`
 			);
 		}
 	}

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -426,7 +426,7 @@ export default class InlineComponentWrapper extends Wrapper {
 
 			if (parent_nodes && this.renderer.options.hydratable) {
 				block.chunks.claim.push(
-					b`if (${name}) @claim_component(${name}.$$.fragment, ${parent_nodes});`
+					b`if (${name} && ${name}.$$.fragment) ${name}.$$.fragment.l(${parent_nodes});`
 				);
 			}
 

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -241,7 +241,7 @@ export default class InlineComponentWrapper extends Wrapper {
 
 						let value_object = value;
 						if (attr.expression.node.type !== 'ObjectExpression') {
-							value_object = x`typeof (#buffer = ${value}) === 'object' && #buffer !== null ? #buffer : {}`
+							value_object = x`typeof (#buffer = ${value}) === 'object' && #buffer !== null ? #buffer : {}`;
 						}
 						change_object = value_object;
 					} else {

--- a/src/compiler/compile/render_dom/wrappers/Slot.ts
+++ b/src/compiler/compile/render_dom/wrappers/Slot.ts
@@ -126,10 +126,15 @@ export default class SlotWrapper extends Wrapper {
 		const slot = block.get_unique_name(`${sanitize(slot_name)}_slot`);
 		const slot_definition = block.get_unique_name(`${sanitize(slot_name)}_slot_template`);
 		const slot_or_fallback = has_fallback ? block.get_unique_name(`${sanitize(slot_name)}_slot_or_fallback`) : slot;
+		const $$scope = renderer.reference('$$scope');
+		const context = x`
+			${slot_definition}[1] && ${get_slot_context_fn} 
+			? @_Object.assign(${$$scope}.ctx.slice(), ${slot_definition}[1](${get_slot_context_fn}(#ctx))) 
+			: ${$$scope}.ctx`;
 
 		block.chunks.init.push(b`
 			const ${slot_definition} = ${renderer.reference('$$slots')}.${slot_name};
-			const ${slot} = @create_slot(${slot_definition}, #ctx, ${renderer.reference('$$scope')}, ${get_slot_context_fn});
+			const ${slot} = ${slot_definition} && ${slot_definition}[0](${context});
 			${has_fallback ? b`const ${slot_or_fallback} = ${slot} || ${this.fallback.name}(#ctx);` : null}
 		`);
 
@@ -172,7 +177,8 @@ export default class SlotWrapper extends Wrapper {
 
 		const slot_update = b`
 			if (${slot}.p && ${renderer.dirty(dynamic_dependencies)}) {
-				@update_slot(${slot}, ${slot_definition}, #ctx, ${renderer.reference('$$scope')}, #dirty, ${get_slot_changes_fn}, ${get_slot_context_fn});
+				const #changes = @get_slot_changes(${slot_definition}, ${$$scope}, #dirty, ${get_slot_changes_fn})
+				if (#changes) ${slot}.p(${context}, #changes);
 			}
 		`;
 		const fallback_update = has_fallback && fallback_dynamic_dependencies.length > 0 && b`

--- a/src/compiler/compile/render_dom/wrappers/shared/add_actions.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/add_actions.ts
@@ -29,11 +29,11 @@ export function add_action(block: Block, target: string, action: Action) {
 	const fn = block.renderer.reference(action.name);
 
 	block.event_listeners.push(
-		x`@action_destroyer(${id} = ${fn}.call(null, ${target}, ${snippet}))`
+		x`(${id} = ${fn}.call(null, ${target}, ${snippet})) && 'function' === typeof ${id}.destroy ? ${id}.destroy : @noop`
 	);
 
 	if (dependencies && dependencies.length > 0) {
-		let condition = x`${id} && @is_function(${id}.update)`;
+		let condition = x`${id} && "function" === typeof ${id}.update`;
 
 		if (dependencies.length > 0) {
 			condition = x`${condition} && ${block.renderer.dirty(dependencies)}`;

--- a/src/compiler/compile/render_dom/wrappers/shared/add_actions.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/add_actions.ts
@@ -1,6 +1,7 @@
 import { b, x } from 'code-red';
 import Block from '../../Block';
 import Action from '../../../nodes/Action';
+import { sanitize_name } from '../../../utils/stringify';
 export default function add_actions(
 	block: Block,
 	target: string,
@@ -18,7 +19,7 @@ export function add_action(block: Block, target: string, action: Action) {
 		dependencies = expression.dynamic_dependencies();
 	}
 
-	const id = block.get_unique_name(`${action.name.replace(/[^a-zA-Z0-9_$]/g, '_')}_action`);
+	const id = block.get_unique_name(`${sanitize_name(action.name)}_action`);
 	block.add_variable(id);
 
 	const fn = block.renderer.reference(action.name);

--- a/src/compiler/compile/render_dom/wrappers/shared/add_actions.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/add_actions.ts
@@ -1,7 +1,6 @@
 import { b, x } from 'code-red';
 import Block from '../../Block';
 import Action from '../../../nodes/Action';
-
 export default function add_actions(
 	block: Block,
 	target: string,
@@ -9,7 +8,6 @@ export default function add_actions(
 ) {
 	actions.forEach(action => add_action(block, target, action));
 }
-
 export function add_action(block: Block, target: string, action: Action) {
 	const { expression } = action;
 	let snippet;
@@ -20,23 +18,20 @@ export function add_action(block: Block, target: string, action: Action) {
 		dependencies = expression.dynamic_dependencies();
 	}
 
-	const id = block.get_unique_name(
-		`${action.name.replace(/[^a-zA-Z0-9_$]/g, '_')}_action`
-	);
-
+	const id = block.get_unique_name(`${action.name.replace(/[^a-zA-Z0-9_$]/g, '_')}_action`);
 	block.add_variable(id);
 
 	const fn = block.renderer.reference(action.name);
 
-	block.event_listeners.push(
-		x`(${id} = ${fn}.call(null, ${target}, ${snippet})) && 'function' === typeof ${id}.destroy ? ${id}.destroy : @noop`
-	);
+	const subscriber = x`${id} = ${fn}.call(null, ${target}, ${snippet})`;
+
+	block.event_listeners.push(subscriber);
 
 	if (dependencies && dependencies.length > 0) {
 		let condition = x`${id} && "function" === typeof ${id}.update`;
 
 		if (dependencies.length > 0) {
-			condition = x`${condition} && ${block.renderer.dirty(dependencies)}`;
+			condition = x`${block.renderer.dirty(dependencies)} && ${condition}`;
 		}
 
 		block.chunks.update.push(

--- a/src/compiler/compile/render_ssr/handlers/AwaitBlock.ts
+++ b/src/compiler/compile/render_ssr/handlers/AwaitBlock.ts
@@ -13,7 +13,7 @@ export default function(node: AwaitBlock, renderer: Renderer, options: RenderOpt
 
 	renderer.add_expression(x`
 		function(__value) {
-			if (@is_promise(__value)) return ${pending};
+			if (__value && typeof __value === 'object' && typeof __value.then === 'function') return ${pending};
 			return (function(${node.then_node ? node.then_node : ''}) { return ${then}; }(__value));
 		}(${node.expression.node})
 	`);

--- a/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.ts
+++ b/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.ts
@@ -9,7 +9,7 @@ export function get_class_attribute_value(attribute: Attribute): ESTreeExpressio
 	// handle special case — `class={possiblyUndefined}` with scoped CSS
 	if (attribute.chunks.length === 2 && (attribute.chunks[1] as Text).synthetic) {
 		const value = (attribute.chunks[0] as Expression).node;
-		return x`@escape(@null_to_empty(${value})) + "${(attribute.chunks[1] as Text).data}"`;
+		return x`(${x`${value} != null ? @escape(${value}) : ""`}) + "${(attribute.chunks[1] as Text).data}"`;
 	}
 
 	return get_attribute_value(attribute);

--- a/src/compiler/compile/render_ssr/index.ts
+++ b/src/compiler/compile/render_ssr/index.ts
@@ -36,7 +36,7 @@ export default function ssr(
 	const rest = uses_rest
 		? b`
 		let #k;
-		const #keys = new Set([${props.map(prop => `"${prop.export_name}"`)}]);
+		const #keys = new Set([${props.map(prop => `"${prop.export_name}"`).join()}]);
 		let $$restProps = {};
 		for (#k in $$props){ if (!#keys.has(#k) && #k[0] !== '$'){ $$restProps[#k] = $$props[#k];}}`
 		: null;
@@ -59,7 +59,7 @@ export default function ssr(
 	component.rewrite_props(
 		({ name }) =>
 			b`
-			${component.compile_options.dev && b`@validate_store_dev(${name}, '${name}');`}
+			${component.compile_options.dev && b`@validate_store(${name}, '${name}');`}
 			@subscribe(${name}, (#v) => { ${`$${name}`} = #v; })();`
 	);
 

--- a/src/compiler/compile/render_ssr/index.ts
+++ b/src/compiler/compile/render_ssr/index.ts
@@ -142,7 +142,7 @@ export default function ssr(
 			const store = component.var_lookup.get(store_name);
 				return b`
 			let ${name}; 
-			${store && store.hoistable && b`@subscribe(${store_name},(#v) => { ${name}=#v; })();`}`;
+			${store && store.hoistable && b`@subscribe(${store_name},(#v) => { ${name} = #v; })();`}`;
 		}),
 
 		instance_javascript,

--- a/src/compiler/compile/utils/stringify.ts
+++ b/src/compiler/compile/utils/stringify.ts
@@ -5,6 +5,10 @@ export function string_literal(data: string) {
 	};
 }
 
+export function sanitize_name(str){
+	return str.replace(/[^a-zA-Z0-9_$]/g, '_')
+}
+
 export function escape(data: string, { only_escape_at_symbol = false } = {}) {
 	return data.replace(only_escape_at_symbol ? /@+/g : /(@+|#+)/g, (match: string) => {
 		return match + match[0];

--- a/src/compiler/compile/utils/stringify.ts
+++ b/src/compiler/compile/utils/stringify.ts
@@ -5,8 +5,8 @@ export function string_literal(data: string) {
 	};
 }
 
-export function sanitize_name(str){
-	return str.replace(/[^a-zA-Z0-9_$]/g, '_')
+export function sanitize_name(str) {
+	return str.replace(/[^a-zA-Z0-9_$]/g, '_');
 }
 
 export function escape(data: string, { only_escape_at_symbol = false } = {}) {

--- a/src/runtime/animate/index.ts
+++ b/src/runtime/animate/index.ts
@@ -1,5 +1,4 @@
 import { cubicOut } from 'svelte/easing';
-import { is_function } from 'svelte/internal';
 
 // todo: same as Transition, should it be shared?
 export interface AnimationConfig {
@@ -35,7 +34,7 @@ export function flip(node: Element, animation: { from: DOMRect; to: DOMRect }, p
 
 	return {
 		delay,
-		duration: is_function(duration) ? duration(d) : duration,
+		duration: typeof duration === "function" ? duration(d) : duration,
 		easing,
 		css: (_t, u) => `transform: ${transform} translate(${u * dx}px, ${u * dy}px);`
 	};

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -57,12 +57,12 @@ export function mount_component(component, target, anchor) {
 		} else {
 			// Edge case - component was destroyed immediately,
 			// most likely as a result of a binding initialising
-			new_on_destroy.forEach(v => v());
+			for (let i = 0; i < new_on_destroy.length; i++) new_on_destroy[i]();
 		}
 		component.$$.on_mount = [];
 	});
 
-	after_update.forEach(add_render_callback);
+	for (let i = 0; i < after_update.length; i++) add_render_callback(after_update);
 }
 
 export function destroy_component(component, detaching) {

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -44,14 +44,6 @@ export function bind(component, name, callback) {
 	}
 }
 
-export function create_component(block) {
-	block && block.c();
-}
-
-export function claim_component(block, parent_nodes) {
-	block && block.l(parent_nodes);
-}
-
 export function mount_component(component, target, anchor) {
 	const { fragment, on_mount, on_destroy, after_update } = component.$$;
 
@@ -139,7 +131,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 
 	$$.update();
 	ready = true;
-	$$.before_update.forEach(v => v());
+	for (let i = 0, { before_update } = $$; i < before_update.length; i++) before_update[i]();
 
 	// `false` as a special case of no DOM component
 	$$.fragment = create_fragment ? create_fragment($$.ctx) : false;

--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -1,4 +1,3 @@
-import { is_promise } from './utils';
 import { check_outros, group_outros, transition_in, transition_out } from './transitions';
 import { flush } from './scheduler';
 import { get_current_component, set_current_component } from './lifecycle';
@@ -52,7 +51,7 @@ export function handle_promise(promise, info) {
 		}
 	}
 
-	if (is_promise(promise)) {
+	if (promise && typeof promise === 'object' && typeof promise.then === 'function') {
 		const current_component = get_current_component();
 		promise.then(value => {
 			set_current_component(current_component);

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -152,16 +152,13 @@ export function children(element) {
 }
 
 export function claim_element(nodes, name, attributes, svg) {
-	for (let i = 0; i < nodes.length; i += 1) {
-		const node = nodes[i];
-		if (node.nodeName === name) {
-			let j = 0;
+	for (let i = 0, j = 0, node, attr; i < nodes.length; i += 1) {
+		if ((node = nodes[i]).nodeName === name) {
 			while (j < node.attributes.length) {
-				const attribute = node.attributes[j];
-				if (attributes[attribute.name]) {
+				if (attributes[attr = node.attributes[j].name]) {
 					j++;
 				} else {
-					node.removeAttribute(attribute.name);
+					node.removeAttribute(attr);
 				}
 			}
 			return nodes.splice(i, 1)[0];
@@ -172,14 +169,12 @@ export function claim_element(nodes, name, attributes, svg) {
 }
 
 export function claim_text(nodes, data) {
-	for (let i = 0; i < nodes.length; i += 1) {
-		const node = nodes[i];
-		if (node.nodeType === 3) {
+	for (let i = 0, node; i < nodes.length; i += 1) {
+		if ((node = nodes[i]).nodeType === 3) {
 			node.data = '' + data;
 			return nodes.splice(i, 1)[0];
 		}
 	}
-
 	return text(data);
 }
 
@@ -209,10 +204,8 @@ export function set_style(node, key, value, important) {
 }
 
 export function select_option(select, value) {
-	for (let i = 0; i < select.options.length; i += 1) {
-		const option = select.options[i];
-
-		if (option.__value === value) {
+	for (let i = 0, option; i < select.options.length; i += 1) {
+		if ((option = select.options[i]).__value === value) {
 			option.selected = true;
 			return;
 		}
@@ -220,15 +213,13 @@ export function select_option(select, value) {
 }
 
 export function select_options(select, value) {
-	for (let i = 0; i < select.options.length; i += 1) {
-		const option = select.options[i];
-		option.selected = ~value.indexOf(option.__value);
+	for (let i = 0, option; i < select.options.length; i += 1) {
+		(option = select.options[i]).selected = ~value.indexOf(option.__value);
 	}
 }
 
 export function select_value(select) {
-	const selected_option = select.querySelector(':checked') || select.options[0];
-	return selected_option && selected_option.__value;
+	return (select = select.querySelector(':checked') || select.options[0]) && select.__value;
 }
 
 export function select_multiple_value(select) {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -1,5 +1,3 @@
-import { has_prop } from "./utils";
-
 export function append(target: Node, node: Node) {
 	target.appendChild(node);
 }
@@ -26,18 +24,10 @@ export function element_is<K extends keyof HTMLElementTagNameMap>(name: K, is: s
 	return document.createElement<K>(name, { is });
 }
 
-export function object_without_properties<T, K extends keyof T>(obj: T, exclude: K[]) {
-	const target = {} as Pick<T, Exclude<keyof T, K>>;
-	for (const k in obj) {
-		if (
-			has_prop(obj, k)
-			// @ts-ignore
-			&& exclude.indexOf(k) === -1
-		) {
-			// @ts-ignore
-			target[k] = obj[k];
-		}
-	}
+export function object_without_properties<T, K extends string[]>(obj: T, excluded: K) {
+	const target = {} as Pick<T, Exclude<keyof T, keyof K>>;
+	let key;
+	for (key in obj) if (!~excluded.indexOf(key)) target[key] = obj[key];
 	return target;
 }
 
@@ -82,6 +72,15 @@ export function self(fn) {
 	return function(event) {
 		// @ts-ignore
 		if (event.target === this) fn.call(this, event);
+	};
+}
+
+export function once(fn) {
+	let ran = false;
+	return function(this: any, ...args) {
+		if (ran) return;
+		ran = true;
+		fn.call(this, ...args);
 	};
 }
 
@@ -307,10 +306,6 @@ export function custom_event<T=any>(type: string, detail?: T) {
 	const e: CustomEvent<T> = document.createEvent('CustomEvent');
 	e.initCustomEvent(type, false, false, detail);
 	return e;
-}
-
-export function query_selector_all(selector: string, parent: HTMLElement = document.body) {
-	return Array.from(parent.querySelectorAll(selector));
 }
 
 export class HtmlTag {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -1,3 +1,5 @@
+import { has_prop } from "./utils";
+
 export function append(target: Node, node: Node) {
 	target.appendChild(node);
 }
@@ -27,7 +29,7 @@ export function element_is<K extends keyof HTMLElementTagNameMap>(name: K, is: s
 export function object_without_properties<T, K extends string[]>(obj: T, excluded: K) {
 	const target = {} as Pick<T, Exclude<keyof T, keyof K>>;
 	let key;
-	for (key in obj) if (!~excluded.indexOf(key)) target[key] = obj[key];
+	for (key in obj) if (has_prop(obj, key) && !~excluded.indexOf(key)) target[key] = obj[key];
 	return target;
 }
 

--- a/src/runtime/internal/keyed_each.ts
+++ b/src/runtime/internal/keyed_each.ts
@@ -107,14 +107,3 @@ export function update_keyed_each(old_blocks, dirty, get_key, dynamic, ctx, list
 
 	return new_blocks;
 }
-
-export function validate_each_keys(ctx, list, get_context, get_key) {
-	const keys = new Set();
-	for (let i = 0; i < list.length; i++) {
-		const key = get_key(get_context(ctx, list, i));
-		if (keys.has(key)) {
-			throw new Error(`Cannot have duplicate keys in a keyed each`);
-		}
-		keys.add(key);
-	}
-}

--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -42,7 +42,7 @@ export function flush() {
 		for (let i = 0; i < dirty_components.length; i += 1) {
 			const component = dirty_components[i];
 			set_current_component(component);
-			const { $$ } = component
+			const { $$ } = component;
 			if ($$.fragment !== null) {
 				$$.update();
 				$$.before_update.forEach(v => v());

--- a/src/runtime/internal/spread.ts
+++ b/src/runtime/internal/spread.ts
@@ -35,7 +35,3 @@ export function get_spread_update(levels, updates) {
 
 	return update;
 }
-
-export function get_spread_object(spread_props) {
-	return typeof spread_props === 'object' && spread_props !== null ? spread_props : {};
-}

--- a/src/runtime/internal/spread.ts
+++ b/src/runtime/internal/spread.ts
@@ -4,9 +4,9 @@ export function get_spread_update(levels, updates) {
 	const to_null_out = {};
 	const accounted_for = { $$scope: 1 };
 
-	let i = levels.length,
-		key,
-		n;
+	let i = levels.length;
+	let	key;
+	let	n;
 	while (i--) {
 		if (n = updates[i]) {
 			for (key in levels[i]) {

--- a/src/runtime/internal/spread.ts
+++ b/src/runtime/internal/spread.ts
@@ -4,17 +4,16 @@ export function get_spread_update(levels, updates) {
 	const to_null_out = {};
 	const accounted_for = { $$scope: 1 };
 
-	let i = levels.length;
+	let i = levels.length,
+		key,
+		n;
 	while (i--) {
-		const o = levels[i];
-		const n = updates[i];
-
-		if (n) {
-			for (const key in o) {
+		if (n = updates[i]) {
+			for (key in levels[i]) {
 				if (!(key in n)) to_null_out[key] = 1;
 			}
 
-			for (const key in n) {
+			for (key in n) {
 				if (!accounted_for[key]) {
 					update[key] = n[key];
 					accounted_for[key] = 1;
@@ -23,13 +22,13 @@ export function get_spread_update(levels, updates) {
 
 			levels[i] = n;
 		} else {
-			for (const key in o) {
+			for (key in levels[i]) {
 				accounted_for[key] = 1;
 			}
 		}
 	}
 
-	for (const key in to_null_out) {
+	for ( key in to_null_out) {
 		if (!(key in update)) update[key] = undefined;
 	}
 

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -101,7 +101,7 @@ export function create_ssr_component(fn) {
 
 			const html = $$render(result, props, {}, options);
 
-			on_destroy.forEach(v => v());
+			for (let i = 0; i < on_destroy.length; i++) on_destroy[i]();
 
 			return {
 				html,

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -1,5 +1,4 @@
 import { set_current_component, current_component } from './lifecycle';
-import { run_all, blank_object } from './utils';
 import { boolean_attributes } from '../../compiler/compile/render_ssr/handlers/shared/boolean_attributes';
 
 export const invalid_attribute_name_character = /[\s'">/=\u{FDD0}-\u{FDEF}\u{FFFE}\u{FFFF}\u{1FFFE}\u{1FFFF}\u{2FFFE}\u{2FFFF}\u{3FFFE}\u{3FFFF}\u{4FFFE}\u{4FFFF}\u{5FFFE}\u{5FFFF}\u{6FFFE}\u{6FFFF}\u{7FFFE}\u{7FFFF}\u{8FFFE}\u{8FFFF}\u{9FFFE}\u{9FFFF}\u{AFFFE}\u{AFFFF}\u{BFFFE}\u{BFFFF}\u{CFFFE}\u{CFFFF}\u{DFFFE}\u{DFFFF}\u{EFFFE}\u{EFFFF}\u{FFFFE}\u{FFFFF}\u{10FFFE}\u{10FFFF}]/u;
@@ -56,15 +55,6 @@ export const missing_component = {
 	$$render: () => ''
 };
 
-export function validate_component(component, name) {
-	if (!component || !component.$$render) {
-		if (name === 'svelte:component') name += ' this={...}';
-		throw new Error(`<${name}> is not a valid SSR component. You may need to review your build config to ensure that dependencies are compiled, rather than imported as pre-compiled modules`);
-	}
-
-	return component;
-}
-
 export function debug(file, line, column, values) {
 	console.log(`{@debug} ${file ? file + ' ' : ''}(${line}:${column})`); // eslint-disable-line no-console
 	console.log(values); // eslint-disable-line no-console
@@ -85,7 +75,7 @@ export function create_ssr_component(fn) {
 			on_mount: [],
 			before_update: [],
 			after_update: [],
-			callbacks: blank_object()
+			callbacks: Object.create(null)
 		};
 
 		set_current_component({ $$ });
@@ -111,7 +101,7 @@ export function create_ssr_component(fn) {
 
 			const html = $$render(result, props, {}, options);
 
-			run_all(on_destroy);
+			on_destroy.forEach(v => v());
 
 			return {
 				html,

--- a/src/runtime/internal/transitions.ts
+++ b/src/runtime/internal/transitions.ts
@@ -1,4 +1,4 @@
-import { identity as linear, is_function, noop, run_all } from './utils';
+import { identity as linear, noop } from './utils';
 import { now } from "./environment";
 import { loop } from './loop';
 import { create_rule, delete_rule } from './style_manager';
@@ -36,7 +36,7 @@ export function group_outros() {
 
 export function check_outros() {
 	if (!outros.r) {
-		run_all(outros.c);
+		outros.c.forEach(v => v());
 	}
 	outros = outros.p;
 }
@@ -129,7 +129,8 @@ export function create_in_transition(node: Element & ElementCSSInlineStyle, fn: 
 
 			delete_rule(node);
 
-			if (is_function(config)) {
+			if (typeof config === "function") {
+				//@ts-ignore
 				config = config();
 				wait().then(go);
 			} else {
@@ -185,7 +186,7 @@ export function create_out_transition(node: Element & ElementCSSInlineStyle, fn:
 					if (!--group.r) {
 						// this will result in `end()` being called,
 						// so we don't need to clean up here
-						run_all(group.c);
+						group.c.forEach(v => v());
 					}
 
 					return false;
@@ -201,7 +202,7 @@ export function create_out_transition(node: Element & ElementCSSInlineStyle, fn:
 		});
 	}
 
-	if (is_function(config)) {
+	if (typeof config === "function") {
 		wait().then(() => {
 			// @ts-ignore
 			config = config();
@@ -313,7 +314,7 @@ export function create_bidirectional_transition(node: Element & ElementCSSInline
 								clear_animation();
 							} else {
 								// outro — needs to be coordinated
-								if (!--running_program.group.r) run_all(running_program.group.c);
+								if (!--running_program.group.r) running_program.group.c.forEach(v => v());
 							}
 						}
 
@@ -334,7 +335,7 @@ export function create_bidirectional_transition(node: Element & ElementCSSInline
 
 	return {
 		run(b) {
-			if (is_function(config)) {
+			if (typeof config === "function") {
 				wait().then(() => {
 					// @ts-ignore
 					config = config();

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -2,38 +2,6 @@ export function noop() {}
 
 export const identity = x => x;
 
-export function assign<T, S>(tar: T, src: S): T & S {
-	// @ts-ignore
-	for (const k in src) tar[k] = src[k];
-	return tar as T & S;
-}
-
-export function is_promise<T = any>(value: any): value is PromiseLike<T> {
-	return value && typeof value === 'object' && typeof value.then === 'function';
-}
-
-export function add_location(element, file, line, column, char) {
-	element.__svelte_meta = {
-		loc: { file, line, column, char }
-	};
-}
-
-export function run(fn) {
-	return fn();
-}
-
-export function blank_object() {
-	return Object.create(null);
-}
-
-export function run_all(fns) {
-	fns.forEach(run);
-}
-
-export function is_function(thing: any): thing is Function {
-	return typeof thing === 'function';
-}
-
 export function safe_not_equal(a, b) {
 	return a != a ? b == b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
 }
@@ -42,10 +10,15 @@ export function not_equal(a, b) {
 	return a != a ? b == b : a !== b;
 }
 
-export function validate_store(store, name) {
-	if (store != null && typeof store.subscribe !== 'function') {
-		throw new Error(`'${name}' is not a store with a 'subscribe' method`);
-	}
+export function get_slot_changes(definition, $$scope, dirty, fn) {
+	if (!definition[2] || !fn) return $$scope.dirty;
+	const lets = definition[2](fn(dirty));
+	if ($$scope.dirty === void 0) return lets;
+	else if (typeof lets === 'object') {
+		const merged = new Array(Math.max($$scope.dirty.length, lets.length));
+		for (let i = 0; i < merged.length; i += 1) merged[i] = $$scope.dirty[i] | lets[i];
+		return merged;
+	} else return $$scope.dirty | lets;
 }
 
 export function subscribe(store, ...callbacks) {
@@ -56,94 +29,7 @@ export function subscribe(store, ...callbacks) {
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 
-export function get_store_value(store) {
-	let value;
-	subscribe(store, _ => value = _)();
-	return value;
-}
-
-export function component_subscribe(component, store, callback) {
-	component.$$.on_destroy.push(subscribe(store, callback));
-}
-
-export function create_slot(definition, ctx, $$scope, fn) {
-	if (definition) {
-		const slot_ctx = get_slot_context(definition, ctx, $$scope, fn);
-		return definition[0](slot_ctx);
-	}
-}
-
-export function get_slot_context(definition, ctx, $$scope, fn) {
-	return definition[1] && fn
-		? assign($$scope.ctx.slice(), definition[1](fn(ctx)))
-		: $$scope.ctx;
-}
-
-export function get_slot_changes(definition, $$scope, dirty, fn) {
-	if (definition[2] && fn) {
-		const lets = definition[2](fn(dirty));
-
-		if ($$scope.dirty === undefined) {
-			return lets;
-		}
-
-		if (typeof lets === 'object') {
-			const merged = [];
-			const len = Math.max($$scope.dirty.length, lets.length);
-			for (let i = 0; i < len; i += 1) {
-				merged[i] = $$scope.dirty[i] | lets[i];
-			}
-
-			return merged;
-		}
-
-		return $$scope.dirty | lets;
-	}
-
-	return $$scope.dirty;
-}
-
-export function update_slot(slot, slot_definition, ctx, $$scope, dirty, get_slot_changes_fn, get_slot_context_fn) {
-	const slot_changes = get_slot_changes(slot_definition, $$scope, dirty, get_slot_changes_fn);
-	if (slot_changes) {
-		const slot_context = get_slot_context(slot_definition, ctx, $$scope, get_slot_context_fn);
-		slot.p(slot_context, slot_changes);
-	}
-}
-
-export function exclude_internal_props(props) {
-	const result = {};
-	for (const k in props) if (k[0] !== '$') result[k] = props[k];
-	return result;
-}
-
-export function compute_rest_props(props, keys) {
-	const rest = {};
-	keys = new Set(keys);
-	for (const k in props) if (!keys.has(k) && k[0] !== '$') rest[k] = props[k];
-	return rest;
-}
-
-export function once(fn) {
-	let ran = false;
-	return function(this: any, ...args) {
-		if (ran) return;
-		ran = true;
-		fn.call(this, ...args);
-	};
-}
-
-export function null_to_empty(value) {
-	return value == null ? '' : value;
-}
-
 export function set_store_value(store, ret, value = ret) {
 	store.set(value);
 	return ret;
-}
-
-export const has_prop = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
-
-export function action_destroyer(action_result) {
-	return action_result && is_function(action_result.destroy) ? action_result.destroy : noop;
 }

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -33,3 +33,5 @@ export function set_store_value(store, ret, value = ret) {
 	store.set(value);
 	return ret;
 }
+
+export const has_prop = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);

--- a/src/runtime/motion/tweened.ts
+++ b/src/runtime/motion/tweened.ts
@@ -1,5 +1,5 @@
 import { Readable, writable } from 'svelte/store';
-import { assign, loop, now, Task } from 'svelte/internal';
+import { loop, now, Task } from 'svelte/internal';
 import { linear } from 'svelte/easing';
 import { is_date } from './utils';
 
@@ -91,7 +91,7 @@ export function tweened<T>(value?: T, defaults: Options<T> = {}): Tweened<T> {
 			duration = 400,
 			easing = linear,
 			interpolate = get_interpolator
-		} = assign(assign({}, defaults), opts);
+		} = { ...defaults, ...opts };
 
 		if (duration === 0) {
 			if (previous_task) {

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -1,4 +1,4 @@
-import { run_all, subscribe, noop, safe_not_equal, is_function, get_store_value } from 'svelte/internal';
+import { subscribe, noop, safe_not_equal } from 'svelte/internal';
 
 /** Callback to inform of a value updates. */
 type Subscriber<T> = (value: T) => void;
@@ -169,7 +169,7 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 			if (auto) {
 				set(result as T);
 			} else {
-				cleanup = is_function(result) ? result as Unsubscriber : noop;
+				cleanup = "function" === typeof result ? result as Unsubscriber : noop;
 			}
 		};
 
@@ -191,7 +191,7 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 		sync();
 
 		return function stop() {
-			run_all(unsubscribers);
+			unsubscribers.forEach(v => v());
 			cleanup();
 		};
 	});
@@ -201,4 +201,8 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
  * Get the current value from a store by subscribing and immediately unsubscribing.
  * @param store readable
  */
-export { get_store_value as get };
+export function get(store) {
+	let value;
+	subscribe(store, _ => value = _)();
+	return value;
+}

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -1,5 +1,4 @@
 import { cubicOut, cubicInOut, linear } from 'svelte/easing';
-import { assign, is_function } from 'svelte/internal';
 
 type EasingFunction = (t: number) => number;
 
@@ -217,7 +216,8 @@ export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
 			delay = 0,
 			duration = d => Math.sqrt(d) * 30,
 			easing = cubicOut
-		} = assign(assign({}, defaults), params);
+			//@ts-ignore
+		} = {...defaults, params};
 
 		const to = node.getBoundingClientRect();
 		const dx = from.left - to.left;
@@ -232,7 +232,7 @@ export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
 
 		return {
 			delay,
-			duration: is_function(duration) ? duration(d) : duration,
+			duration: typeof duration === "function" ? duration(d) : duration,
 			easing,
 			css: (t, u) => `
 				opacity: ${t * opacity};


### PR DESCRIPTION
#### `$$restProps` & `$$slots` 
* inline all helpers but `get_slot_changes`
* removed unused `$$scope` declaration variable in dev mode

#### `render_listeners`
* following domnodes pattern, each listener now gets its own variable
* avoid declaring an extra variable for action.destroy

#### `other helpers inlined at compile time`
* **destroy_each( arr, detaching )**
   * `for ( ... ) if ( each_value ) each_value.d( detaching )`
* **query_selector_all( id, document.head )**
   * `Array.from((document.head || document.body ).querySelectorAll( id ))`
* **create_component** / **claim_component** **(component.$$.fragment)**
   * `if ( component.$$.fragment ) component.$$.fragment` `.c()` / `.l()` 
* **component_subscribe( $$self, store, callback )**
   * `$$self.$$.on_destroy.push(subscribe(store, callback))`
* **null_to_empty**
   * `null != value ? value : ""`
* **is_function**
   * `"function" === typeof value`
* **is_promise**
   * `value && "object" === typeof value && "function" === typeof value.then`
* **assign**
   * `{ ...a, ...b }`
* **blank_object**
  * `Object.create( null )`
* **get_spread_object**
  * `typeof props === "object" && props !== null ? props : {}`
* **run** / **run_all**
   * `for( ... ) each_value();`
* **foo = get_store_value( store )**
  * `subscribe(store, (v) => foo = v)()`

#### `src/runtime`

* inlined components `update` function 
* moved all dev functions to `dev.ts`
* predeclared loop variables & removed the unnecessary consts in `dom.ts` and `spread.ts`
* moved `once` modifier from `utils.ts` to `dom.ts`
* converted some `.forEach` into for loops


Those changes naturally require updating expected test results. I intentionally did not commit those so as to give maintainers an opportunity to test the #4914 script, but all test are passing.