### PR TITLE
Provide parser error when :global appears without selector in CSS

### DIFF
--- a/src/compiler/parse/read/style.ts
+++ b/src/compiler/parse/read/style.ts
@@ -54,6 +54,13 @@ export default function read_style(parser: Parser, start: number, attributes: No
 				}, node.start);
 			}
 
+			if (node.type === 'PseudoClassSelector' && node.name === 'global' && node.children === null) {
+				parser.error({
+					code: `css-global-without-selector`,
+					message: `:global() must contain a selector, cannot be used on its own`
+				}, node.loc.start.offset);
+			}
+
 			if (node.loc) {
 				node.start = node.loc.start.offset;
 				node.end = node.loc.end.offset;

--- a/src/compiler/parse/read/style.ts
+++ b/src/compiler/parse/read/style.ts
@@ -56,8 +56,8 @@ export default function read_style(parser: Parser, start: number, attributes: No
 
 			if (node.type === 'PseudoClassSelector' && node.name === 'global' && node.children === null) {
 				parser.error({
-					code: `css-global-without-selector`,
-					message: `:global() must contain a selector, cannot be used on its own`
+					code: `css-syntax-error`,
+					message: `:global() must contain a selector`
 				}, node.loc.start.offset);
 			}
 

--- a/test/parser/samples/error-css-global-without-selector/error.json
+++ b/test/parser/samples/error-css-global-without-selector/error.json
@@ -1,6 +1,6 @@
 {
-	"code": "css-global-without-selector",
-	"message": ":global() must contain a selector, cannot be used on its own",
+	"code": "css-syntax-error",
+	"message": ":global() must contain a selector",
 	"start": {
 		"line": 2,
 		"column": 1,

--- a/test/parser/samples/error-css-global-without-selector/error.json
+++ b/test/parser/samples/error-css-global-without-selector/error.json
@@ -1,0 +1,10 @@
+{
+	"code": "css-global-without-selector",
+	"message": ":global() must contain a selector, cannot be used on its own",
+	"start": {
+		"line": 2,
+		"column": 1,
+		"character": 9
+	},
+	"pos": 9
+}

--- a/test/parser/samples/error-css-global-without-selector/input.svelte
+++ b/test/parser/samples/error-css-global-without-selector/input.svelte
@@ -1,0 +1,3 @@
+<style>
+	:global {}
+</style>


### PR DESCRIPTION
Fixes #4930 

Prevent a compiler crash when `:global` appears by itself in a CSS selector by adding an extra check when walking the style AST. If a node meets the following conditions:

- `type` is `'PseudoClassSelector'`,
- `name` is `'global'`, and
- `children` is `null`,

then the parser reports an error: `:global() must contain a selector, cannot be used on its own`.

Long-time user, first-time contributor -- please forgive any naive errors in putting together this PR. In particular, I wasn't quite sure of the right way to report the location of the error. In the file I touched, `src/compiler/parse/read/style.ts`, one of the existing checks uses the node's `loc.start.offset` property, while the other uses the `start` property. The former seemed to make the most sense with the test case I wrote, so I went with that -- but happy to correct if I was wrong.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
