### PR TITLE
Remove unused method parameter

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/RawMustacheTag.ts
+++ b/src/compiler/compile/render_dom/wrappers/RawMustacheTag.ts
@@ -22,7 +22,7 @@ export default class RawMustacheTagWrapper extends Tag {
 		this.not_static_content();
 	}
 
-	render(block: Block, parent_node: Identifier, _parent_nodes: Identifier) {
+	render(block: Block, parent_node: Identifier) {
 		const in_head = is_head(parent_node);
 
 		const can_use_innerhtml = !in_head && parent_node && !this.prev && !this.next;


### PR DESCRIPTION
I'm new to Svelte and still trying to wrap my head around the codebase, which is a bit tricky to understand as a newcomer, so please let me know if I'm missing something or there's something special that an underscore prefix means in Svelte. All the tests pass with this change though