### PR TITLE
fix(site): add padding-bottom for banner space

### DIFF
--- a/site/src/routes/_layout.svelte
+++ b/site/src/routes/_layout.svelte
@@ -109,7 +109,23 @@
 		margin: 0 auto;
 		/* padding: var(--nav-h) var(--side-nav) 0 var(--side-nav); */
 		padding: var(--nav-h) 0 0 0;
+		padding-bottom: 64px; /* BLM */
 		overflow-x: hidden;
+	}
+
+	@media screen and (max-width: 769px) {
+		main {
+			padding-bottom: 90px; /* BLM */
+		}
+	}
+
+	@media screen and (max-width: 377px) {
+		.BLM {
+			font-size: 85%;
+		}
+		main {
+			padding-bottom: 75px; /* BLM */
+		}
 	}
 
 	main > :global(*) {


### PR DESCRIPTION
The BLM banner is fixed and currently doesn't allow the `main` to offset its contents.

The PR adds manual `padding-bottom` offsets so that no content is lost/hidden behind the banner.
