### PR TITLE
Split </script> to prevent inadvertantly closing an enclosing inline script tag (#4980)

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -275,7 +275,7 @@ export function add_resize_listener(node: HTMLElement, fn: () => void) {
 	let unsubscribe: () => void;
 
 	if (crossorigin) {
-		iframe.src = `data:text/html,<script>onresize=function(){parent.postMessage(0,'*')}</script>`;
+		iframe.src = `data:text/html,<script>onresize=function(){parent.postMessage(0,'*')}<` + `/script>`;
 		unsubscribe = listen(window, 'message', (event: MessageEvent) => {
 			if (event.source === iframe.contentWindow) fn();
 		});


### PR DESCRIPTION
I haven't tried to unit test this functionality as I'm not sure how it would be done and whether it is worth it in this case.
