### PR TITLE
site: remove BLM filter, but leave banner

### DIFF
--- a/site/src/routes/_layout.svelte
+++ b/site/src/routes/_layout.svelte
@@ -101,9 +101,6 @@
 	.BLM a {
 		white-space: nowrap;
 	}
-	:global(header){
-		filter: grayscale(100%) /* BLM */
-	}
 	main {
 		position: relative;
 		margin: 0 auto;
@@ -126,9 +123,5 @@
 		main {
 			padding-bottom: 75px; /* BLM */
 		}
-	}
-
-	main > :global(*) {
-		filter: grayscale(100%) /* BLM */
 	}
 </style>


### PR DESCRIPTION
This removes the Black Lives Matter grayscale filter while leaving the banner, as discussed.