### PR TITLE
transition in custom element

### DIFF
--- a/test/custom-elements/index.ts
+++ b/test/custom-elements/index.ts
@@ -63,7 +63,9 @@ describe('custom-elements', function() {
 
 		const solo = /\.solo$/.test(dir);
 		const skip = /\.skip$/.test(dir);
+		const easing = path.resolve('easing/index.mjs');
 		const internal = path.resolve('internal/index.mjs');
+		const transition = path.resolve('transition/index.mjs');
 		const index = path.resolve('index.mjs');
 		const warnings = [];
 
@@ -76,8 +78,16 @@ describe('custom-elements', function() {
 				plugins: [
 					{
 						resolveId(importee) {
-							if (importee === 'svelte/internal' || importee === './internal') {
+							if (importee === '../easing') {
+								return easing;
+							}
+
+							if (importee === 'svelte/internal' || importee === './internal' || importee === '../internal') {
 								return internal;
+							}
+
+							if (importee === 'svelte/transition' || importee === './transition') {
+								return transition;
 							}
 
 							if (importee === 'svelte') {

--- a/test/custom-elements/samples/transition/main.svelte
+++ b/test/custom-elements/samples/transition/main.svelte
@@ -1,0 +1,18 @@
+<svelte:options tag="custom-element"/>
+
+<script>
+	import { onMount } from 'svelte';
+	import { fade } from 'svelte/transition';
+
+	let show = false;
+
+	onMount(() => {
+		show = true;
+	});
+</script>
+
+{#if show}
+	<p transition:fade>
+		Fades in and out
+	</p>
+{/if}

--- a/test/custom-elements/samples/transition/test.js
+++ b/test/custom-elements/samples/transition/test.js
@@ -1,0 +1,18 @@
+import * as assert from 'assert';
+import './main.svelte';
+
+export default async function (target) {
+	target.innerHTML = '<custom-element></custom-element>';
+
+	// wait one tick in order for styles to be applied
+	await Promise.resolve();
+
+	const el = target.querySelector('custom-element');
+	const style = el.shadowRoot.querySelector('style');
+
+	assert.ok(style);
+	assert.ok(style.sheet);
+	assert.equal(style, el.shadowRoot.firstElementChild);
+	assert.equal(style.sheet.cssRules.length, 1);
+	assert.equal(el.shadowRoot.__svelte_stylesheet, style.sheet);
+}


### PR DESCRIPTION
fixes #1825

### The problem
The style-element containing the transition CSS is appended to the head-element which is unseeable from within the shadow dom.

### The fix
This fixes that by adding the style element to the shadow DOM (for custom elements).