### PR TITLE
fix(5019): imported stores can be identified as reactive store subscr…

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -1152,7 +1152,7 @@ export default class Component {
 			for (const specifier of specifiers) {
 				const variable = var_lookup.get(specifier.local.name);
 
-				if (!variable.mutated || var_lookup.get(`$${specifier.local.name}`)) {
+				if (!variable.mutated || variable.subscribable) {
 					variable.hoistable = true;
 				}
 			}

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -632,7 +632,6 @@ export default class Component {
 			this.add_var({
 				name,
 				initialised: instance_scope.initialised_declarations.has(name),
-				hoistable: true,
 				writable
 			});
 
@@ -1153,7 +1152,9 @@ export default class Component {
 			for (const specifier of specifiers) {
 				const variable = var_lookup.get(specifier.local.name);
 
-				if (!variable.mutated) variable.hoistable = true;
+				if (!variable.mutated || var_lookup.get(`$${specifier.local.name}`)) {
+					variable.hoistable = true;
+				}
 			}
 		}
 	}

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -632,6 +632,7 @@ export default class Component {
 			this.add_var({
 				name,
 				initialised: instance_scope.initialised_declarations.has(name),
+				hoistable: true,
 				writable
 			});
 

--- a/test/runtime/samples/store-imports-hoisted/_config.js
+++ b/test/runtime/samples/store-imports-hoisted/_config.js
@@ -1,0 +1,7 @@
+export default {
+	compileOptions: { dev: true }, // tests `@validate_store` code generation
+
+	html: `
+		<p>42</p>
+	`
+};

--- a/test/runtime/samples/store-imports-hoisted/foo.js
+++ b/test/runtime/samples/store-imports-hoisted/foo.js
@@ -1,0 +1,3 @@
+import { writable } from '../../../../store';
+
+export default writable(42);

--- a/test/runtime/samples/store-imports-hoisted/main.svelte
+++ b/test/runtime/samples/store-imports-hoisted/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import foo from './foo.js';
+	foo.bar = 'baz';
+	const answer = $foo;
+</script>
+
+<p>{answer}</p>


### PR DESCRIPTION
This PR address the issue #5019.
The way stores are filtered it is expected variable to be hoistable.
https://github.com/sveltejs/svelte/blob/master/src/compiler/compile/render_dom/index.ts#L320
```js
const reactive_store_subscriptions = reactive_stores
    .filter(store => {
        const variable = component.var_lookup.get(store.name.slice(1));
        return !variable || variable.hoistable;
    })
    .map(({ name }) => b`
        ${component.compile_options.dev && b`@validate_store(${name.slice(1)}, '${name.slice(1)}');`}
        @component_subscribe($$self, ${name.slice(1)}, $$value => $$invalidate(${renderer.context_lookup.get(name).index}, ${name} = $$value));
    `);
```
Since `imports` are by their nature hoistable, I have explicitly set that.
