### PR TITLE
fix(5020): skip child content a11y check on html/textContent binding

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -708,8 +708,7 @@ export default class Element extends Node {
 		if (!a11y_required_content.has(this.name)) return;
 		if (
 			this.bindings
-				.map((binding) => binding.name)
-				.some((name) => ['textContent', 'innerHTML'].includes(name))
+				.some((binding) => ['textContent', 'innerHTML'].includes(binding.name))
 		) return;
 
 		if (this.children.length === 0) {

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -706,6 +706,11 @@ export default class Element extends Node {
 
 	validate_content() {
 		if (!a11y_required_content.has(this.name)) return;
+		if (
+			this.bindings
+				.map((binding) => binding.name)
+				.some((name) => ['textContent', 'innerHTML'].includes(name))
+		) return;
 
 		if (this.children.length === 0) {
 			this.component.warn(this, {

--- a/test/validator/samples/a11y-contenteditable-element-without-child/errors.json
+++ b/test/validator/samples/a11y-contenteditable-element-without-child/errors.json
@@ -1,0 +1,17 @@
+[
+	{
+		"code": "missing-contenteditable-attribute",
+		"message": "'contenteditable' attribute is required for textContent and innerHTML two-way bindings",
+		"start": {
+			"line": 6,
+			"column": 3,
+			"character": 157
+		},
+		"end": {
+			"line": 6,
+			"column": 24,
+			"character": 178
+		},
+		"pos": 157
+	}
+]

--- a/test/validator/samples/a11y-contenteditable-element-without-child/input.svelte
+++ b/test/validator/samples/a11y-contenteditable-element-without-child/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let text = 'Hello world';
+</script>
+<p bind:textContent={text} contenteditable="true"></p>
+<p bind:innerHTML={text} contenteditable="true"></p>
+<p bind:innerHTML={text}></p>


### PR DESCRIPTION
Address #5020 as per @Conduitry's comments.