### PR TITLE
fix(5018): compare wholeText instead of data

### DIFF
--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -73,7 +73,7 @@ export function dataset_dev(node: HTMLElement, property: string, value?: any) {
 
 export function set_data_dev(text, data) {
 	data = '' + data;
-	if (text.data === data) return;
+	if (text.wholeText === data) return;
 
 	dispatch_dev("SvelteDOMSetData", { node: text, data });
 	text.data = data;

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -193,7 +193,7 @@ export function claim_space(nodes) {
 
 export function set_data(text, data) {
 	data = '' + data;
-	if (text.data !== data) text.data = data;
+	if (text.wholeText !== data) text.data = data;
 }
 
 export function set_input_value(input, value) {

--- a/test/runtime/samples/component-event-handler-contenteditable/_config.js
+++ b/test/runtime/samples/component-event-handler-contenteditable/_config.js
@@ -1,0 +1,15 @@
+export default {
+	html: `
+		<div contenteditable=""></div>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const div = target.querySelector('div');
+		const text =  window.document.createTextNode('a');
+		div.insertBefore(text, null);
+		const event = new window.InputEvent('input');
+		await div.dispatchEvent(event);
+
+		assert.equal(div.textContent, 'a');
+	}
+};

--- a/test/runtime/samples/component-event-handler-contenteditable/main.svelte
+++ b/test/runtime/samples/component-event-handler-contenteditable/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let text = '';
+	const updater = (event) => {text = event.target.textContent}
+</script>
+
+<div contenteditable on:input={updater}>{text}</div>


### PR DESCRIPTION
This PR addresses #5018.
Instead of comparing the input with data property on the Text Node, I've changed it to wholeText.