### PR TITLE
fix extract names from ThisExpression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svelte changelog
 
+## Unreleased
+
+* Fix handling of `this` in inline function expressions in the template ([#5033](https://github.com/sveltejs/svelte/issues/5033))
+
 ## 3.23.2
 
 * Fix `bind:group` inside `{#each}` ([#3243](https://github.com/sveltejs/svelte/issues/3243))

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -120,12 +120,9 @@ export default class Expression {
 				if (function_expression) {
 					if (node.type === 'AssignmentExpression') {
 						deep = node.left.type === 'MemberExpression';
-						names = deep
-							? [get_object(node.left).name]
-							: extract_names(node.left);
+						names = extract_names(deep ? get_object(node.left) : node.left);
 					} else if (node.type === 'UpdateExpression') {
-						const { name } = get_object(node.argument);
-						names = [name];
+						names = extract_names(get_object(node.argument));
 					}
 				}
 

--- a/test/runtime/samples/this-in-function-expressions/_config.js
+++ b/test/runtime/samples/this-in-function-expressions/_config.js
@@ -1,0 +1,10 @@
+export default {
+	async test({ assert, component, target, window, raf }) {
+		const [_, btn] = target.querySelectorAll("button");
+		const clickEvent = new window.MouseEvent("click");
+
+		await btn.dispatchEvent(clickEvent);
+
+		assert.equal(btn.x, 1);
+	},
+};

--- a/test/runtime/samples/this-in-function-expressions/main.svelte
+++ b/test/runtime/samples/this-in-function-expressions/main.svelte
@@ -1,0 +1,2 @@
+<button on:click="{() => { this.x = 1; }}" />
+<button on:click="{function () { this.x = 1; }}" />


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/5033

We assumed object of `MemberExpression` to be `Identifier` only, `ThisExpression` does not have `.name`, causing `.name[0]` to be `accessing property 0 of undefined`

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
