### PR TITLE
Fixes a11y warning in 06-select-bindings tutorial

### DIFF
--- a/site/content/tutorial/06-bindings/06-select-bindings/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/06-select-bindings/app-a/App.svelte
@@ -21,7 +21,7 @@
 <h2>Insecurity questions</h2>
 
 <form on:submit|preventDefault={handleSubmit}>
-	<select value={selected} on:change="{() => answer = ''}">
+	<select value={selected} on:blur="{() => answer = ''}">
 		{#each questions as question}
 			<option value={question}>
 				{question.text}

--- a/site/content/tutorial/06-bindings/06-select-bindings/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/06-select-bindings/app-b/App.svelte
@@ -21,7 +21,7 @@
 <h2>Insecurity questions</h2>
 
 <form on:submit|preventDefault={handleSubmit}>
-	<select bind:value={selected} on:change="{() => answer = ''}">
+	<select bind:value={selected} on:blur="{() => answer = ''}">
 		{#each questions as question}
 			<option value={question}>
 				{question.text}

--- a/site/content/tutorial/06-bindings/06-select-bindings/text.md
+++ b/site/content/tutorial/06-bindings/06-select-bindings/text.md
@@ -5,7 +5,7 @@ title: Select bindings
 We can also use `bind:value` with `<select>` elements. Update line 24:
 
 ```html
-<select bind:value={selected} on:change="{() => answer = ''}">
+<select bind:value={selected} on:blur="{() => answer = ''}">
 ```
 
 Note that the `<option>` values are objects rather than strings. Svelte doesn't mind.


### PR DESCRIPTION
The Select Bindings examples shows an accessibility warning:

`A11y: on:blur must be used instead of on:change, unless absolutely necessary and it causes no negative consequences for keyboard only or screen reader users. (24:1)`