### PR TITLE
fix select bind:value when option value change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix handling of `this` in inline function expressions in the template ([#5033](https://github.com/sveltejs/svelte/issues/5033))
+* Update `<select>` with one-way `value` binding when the available `<option>`s change ([#5051](https://github.com/sveltejs/svelte/issues/5051))
 
 ## 3.23.2
 

--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -10,6 +10,7 @@ import flatten_reference from '../../../utils/flatten_reference';
 import { Node, Identifier } from 'estree';
 import add_to_set from '../../../utils/add_to_set';
 import mark_each_block_bindings from '../shared/mark_each_block_bindings';
+import handle_select_value_binding from './handle_select_value_binding';
 
 export default class BindingWrapper {
 	node: Binding;
@@ -35,12 +36,8 @@ export default class BindingWrapper {
 		block.add_dependencies(dependencies);
 
 		// TODO does this also apply to e.g. `<input type='checkbox' bind:group='foo'>`?
-		if (parent.node.name === 'select') {
-			(parent as ElementWrapper).select_binding_dependencies = dependencies;
-			dependencies.forEach((prop: string) => {
-				parent.renderer.component.indirect_dependencies.set(prop, new Set());
-			});
-		}
+
+		handle_select_value_binding(this, dependencies);
 
 		if (node.is_contextual) {
 			mark_each_block_bindings(this.parent, this.node);

--- a/src/compiler/compile/render_dom/wrappers/Element/handle_select_value_binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/handle_select_value_binding.ts
@@ -1,0 +1,16 @@
+import AttributeWrapper from "./Attribute";
+import BindingWrapper from "./Binding";
+import ElementWrapper from "./index";
+
+export default function handle_select_value_binding(
+	attr: AttributeWrapper | BindingWrapper,
+	dependencies: Set<string>
+) {
+	const { parent } = attr;
+	if (parent.node.name === "select") {
+		(parent as ElementWrapper).select_binding_dependencies = dependencies;
+		dependencies.forEach((prop: string) => {
+			parent.renderer.component.indirect_dependencies.set(prop, new Set());
+		});
+	}
+}

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -15,7 +15,6 @@ function create_fragment(ctx) {
 	let select;
 	let option0;
 	let option1;
-	let select_value_value;
 
 	return {
 		c() {
@@ -33,12 +32,11 @@ function create_fragment(ctx) {
 			insert(target, select, anchor);
 			append(select, option0);
 			append(select, option1);
-			select_value_value = /*current*/ ctx[0];
-			select_option(select, select_value_value);
+			select_option(select, /*current*/ ctx[0]);
 		},
 		p(ctx, [dirty]) {
-			if (dirty & /*current*/ 1 && select_value_value !== (select_value_value = /*current*/ ctx[0])) {
-				select_option(select, select_value_value);
+			if (dirty & /*current*/ 1) {
+				select_option(select, /*current*/ ctx[0]);
 			}
 		},
 		i: noop,

--- a/test/runtime/samples/binding-select-late-3/_config.js
+++ b/test/runtime/samples/binding-select-late-3/_config.js
@@ -1,0 +1,34 @@
+export default {
+	props: {
+		items: [],
+		selected: 'two'
+	},
+
+	html: `
+		<select></select>
+		<p>selected: two</p>
+	`,
+
+	ssrHtml: `
+		<select value="two"></select>
+		<p>selected: two</p>
+	`,
+
+	test({ assert, component, target }) {
+		component.items = [ 'one', 'two', 'three' ];
+
+		const options = target.querySelectorAll('option');
+		assert.ok(!options[0].selected);
+		assert.ok(options[1].selected);
+		assert.ok(!options[2].selected);
+
+		assert.htmlEqual(target.innerHTML, `
+			<select>
+				<option value='one'>one</option>
+				<option value='two'>two</option>
+				<option value='three'>three</option>
+			</select>
+			<p>selected: two</p>
+		`);
+	}
+};

--- a/test/runtime/samples/binding-select-late-3/main.svelte
+++ b/test/runtime/samples/binding-select-late-3/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	export let selected;
+	export let items;
+</script>
+
+<select value={selected} on:blur={e => selected = e.target.value}>
+	{#each items as item}
+		<option>{item}</option>
+	{/each}
+</select>
+
+<p>selected: {selected || 'nothing'}</p>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/5051

port the same logic from `bind:value` to `value={value}`

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
