### PR TITLE
fix(5019): check if mapbox key is added before generating the production build.

### DIFF
--- a/site/rollup.config.js
+++ b/site/rollup.config.js
@@ -14,7 +14,7 @@ const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
 if (!dev && !process.env.MAPBOX_ACCESS_TOKEN) {
-	throw Error('MAPBOX Access Token is missing. Please add the token in the .env file to generate the production build.');
+	throw new Error('MAPBOX_ACCESS_TOKEN is missing. Please add the token in the .env file before generating the production build.');
 }
 
 const onwarn = (warning, onwarn) => (warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message)) || onwarn(warning);

--- a/site/rollup.config.js
+++ b/site/rollup.config.js
@@ -13,6 +13,10 @@ const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
+if (!dev && !process.env.MAPBOX_ACCESS_TOKEN) {
+	throw Error('MAPBOX Access Token is missing. Please add the token in the .env file to generate the production build.');
+}
+
 const onwarn = (warning, onwarn) => (warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message)) || onwarn(warning);
 const dedupe = importee => importee === 'svelte' || importee.startsWith('svelte/');
 


### PR DESCRIPTION
Fixes #5056 

Adding a check in the rollup config to see if the Mapbox access token is present when generating a production build.

# Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests tests with `npm test` or `yarn test`)
