### PR TITLE
fix(820): label has associated control

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -61,6 +61,17 @@ const a11y_no_onchange = new Set([
 	'option'
 ]);
 
+const a11y_labelable = new Set([
+	"button",
+	"input",
+	"keygen",
+	"meter",
+	"output",
+	"progress",
+	"select",
+	"textarea"
+]);
+
 const invisible_elements = new Set(['meta', 'html', 'script', 'style']);
 
 const valid_modifiers = new Set([
@@ -508,7 +519,7 @@ export default class Element extends Node {
 		}
 
 		if (this.name === 'label') {
-			const has_input_child = this.children.some(i => (i instanceof Element && i.name === 'input' ));
+			const has_input_child = this.children.some(i => (i instanceof Element && a11y_labelable.has(i.name) ));
 			if (!attribute_map.has('for') && !has_input_child) {
 				component.warn(this, {
 					code: `a11y-label-has-associated-control`,

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -507,6 +507,16 @@ export default class Element extends Node {
 			}
 		}
 
+		if (this.name === 'label') {
+			const has_input_child = this.children.some(i => (i instanceof Element && i.name === 'input' ));
+			if (!attribute_map.has('for') && !has_input_child) {
+				component.warn(this, {
+					code: `a11y-label-has-associated-control`,
+					message: `A11y: A form label must be associated with a control.`
+				});
+			}
+		}
+
 		if (a11y_no_onchange.has(this.name)) {
 			if (handlers_map.has('change') && !handlers_map.has('blur')) {
 				component.warn(this, {

--- a/test/validator/samples/a11y-label-has-associated-control/input.svelte
+++ b/test/validator/samples/a11y-label-has-associated-control/input.svelte
@@ -1,0 +1,5 @@
+<label>A</label>
+<label for="id">B</label>
+
+<label>C <input type="text" /></label>
+<label>D <span></span></label>

--- a/test/validator/samples/a11y-label-has-associated-control/input.svelte
+++ b/test/validator/samples/a11y-label-has-associated-control/input.svelte
@@ -2,4 +2,5 @@
 <label for="id">B</label>
 
 <label>C <input type="text" /></label>
-<label>D <span></span></label>
+<label>D <button>D</button></label>
+<label>E <span></span></label>

--- a/test/validator/samples/a11y-label-has-associated-control/warnings.json
+++ b/test/validator/samples/a11y-label-has-associated-control/warnings.json
@@ -1,32 +1,32 @@
 [
-	{
-		"code": "a11y-label-has-associated-control",
-		"end": {
-			"character": 16,
-			"column": 16,
-			"line": 1
-		},
-		"message": "A11y: A form label must be associated with a control.",
-		"pos": 0,
-		"start": {
-			"character": 0,
-			"column": 0,
-			"line": 1
-		}
-	},
-	{
-		"code": "a11y-label-has-associated-control",
-		"end": {
-			"character": 113,
-			"column": 30,
-			"line": 5
-		},
-		"message": "A11y: A form label must be associated with a control.",
-		"pos": 83,
-		"start": {
-			"character": 83,
-			"column": 0,
-			"line": 5
-		}
-	}
+  {
+    "code": "a11y-label-has-associated-control",
+    "end": {
+      "character": 16,
+      "column": 16,
+      "line": 1
+    },
+    "message": "A11y: A form label must be associated with a control.",
+    "pos": 0,
+    "start": {
+      "character": 0,
+      "column": 0,
+      "line": 1
+    }
+  },
+  {
+    "code": "a11y-label-has-associated-control",
+    "end": {
+      "character": 149,
+      "column": 30,
+      "line": 6
+    },
+    "message": "A11y: A form label must be associated with a control.",
+    "pos": 119,
+    "start": {
+      "character": 119,
+      "column": 0,
+      "line": 6
+    }
+  }
 ]

--- a/test/validator/samples/a11y-label-has-associated-control/warnings.json
+++ b/test/validator/samples/a11y-label-has-associated-control/warnings.json
@@ -1,0 +1,32 @@
+[
+	{
+		"code": "a11y-label-has-associated-control",
+		"end": {
+			"character": 16,
+			"column": 16,
+			"line": 1
+		},
+		"message": "A11y: A form label must be associated with a control.",
+		"pos": 0,
+		"start": {
+			"character": 0,
+			"column": 0,
+			"line": 1
+		}
+	},
+	{
+		"code": "a11y-label-has-associated-control",
+		"end": {
+			"character": 113,
+			"column": 30,
+			"line": 5
+		},
+		"message": "A11y: A form label must be associated with a control.",
+		"pos": 83,
+		"start": {
+			"character": 83,
+			"column": 0,
+			"line": 5
+		}
+	}
+]


### PR DESCRIPTION
For #820  
Because [label-has-for](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) has been deprecated I have instead implemented [label-has-associated-control](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md).

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests with `npm test` or `yarn test`)
