### PR TITLE
Reset current component after call to flush()

### DIFF
--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -14,7 +14,10 @@ let update_scheduled = false;
 export function schedule_update() {
 	if (!update_scheduled) {
 		update_scheduled = true;
-		resolved_promise.then(flush);
+		resolved_promise.then(() => {
+			flush();
+			set_current_component(null);
+		});
 	}
 }
 


### PR DESCRIPTION
Fixes #4899

This is a version of #4909 that fixes fewer problems—it doesn't fix the behaviour of onMount or onAfterUpdate, but only fixes the bug that the current component is set in to some completely random component in (non-Svelte) event handlers and tasks.

Since this is a rather pressing issue for my library (the only workaround is [really awful](https://github.com/rdb/svelte-meteor-data/blob/11baf981ee6c087defc938b191b4992a8d8e7f90/subscribe.js#L10-L17)), and #4909 appears blocked waiting to fully understand the consequences, I figured I would make a PR that fixes the most pressing aspect of the bug while having fewer consequences.  If there is worry about side-effects of #4909, this one could first be accepted into a bug-fix release to be potentially replaced with #4909 in a more major release.

The only place where this PR resets the current component is after `flush()` is called from a `Promise.resolve().then(...)` in `scheduler.ts`, so only when called from the microtask queue, not from other Svelte code.  In seemingly every other location (eg. await_block.ts), Svelte is resetting the current component at the end of a microtask, so this seems like a clear oversight.

Thank you so much for maintaining this great library!  If there is anything I can do to help the process along, please don't hesitate to ask.