### PR TITLE
Preprocess self closing style

### DIFF
--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -114,8 +114,8 @@ export default async function preprocess(
 	for (const fn of style) {
 		source = await replace_async(
 			source,
-			/<!--[^]*?-->|<style(\s[^]*?)?>([^]*?)<\/style>/gi,
-			async (match, attributes = '', content) => {
+			/<!--[^]*?-->|<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gi,
+			async (match, attributes = '', content = '') => {
 				if (!attributes && !content) {
 					return match;
 				}

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -94,8 +94,8 @@ export default async function preprocess(
 	for (const fn of script) {
 		source = await replace_async(
 			source,
-			/<!--[^]*?-->|<script(\s[^]*?)?>([^]*?)<\/script>/gi,
-			async (match, attributes = '', content) => {
+			/<!--[^]*?-->|<script(\s[^]*?)?(?:>([^]*?)<\/script>|\/>)/gi,
+			async (match, attributes = '', content = '') => {
 				if (!attributes && !content) {
 					return match;
 				}

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -95,7 +95,7 @@ export default async function preprocess(
 		source = await replace_async(
 			source,
 			/<!--[^]*?-->|<script(\s[^]*?)?(?:>([^]*?)<\/script>|\/>)/gi,
-			async (match, attributes = '', content) => {
+			async (match, attributes = '', content = '') => {
 				if (!attributes && !content) {
 					return match;
 				}
@@ -115,7 +115,7 @@ export default async function preprocess(
 		source = await replace_async(
 			source,
 			/<!--[^]*?-->|<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gi,
-			async (match, attributes = '', content) => {
+			async (match, attributes = '', content = '') => {
 				if (!attributes && !content) {
 					return match;
 				}

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -95,7 +95,7 @@ export default async function preprocess(
 		source = await replace_async(
 			source,
 			/<!--[^]*?-->|<script(\s[^]*?)?(?:>([^]*?)<\/script>|\/>)/gi,
-			async (match, attributes = '', content = '') => {
+			async (match, attributes = '', content) => {
 				if (!attributes && !content) {
 					return match;
 				}
@@ -115,7 +115,7 @@ export default async function preprocess(
 		source = await replace_async(
 			source,
 			/<!--[^]*?-->|<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gi,
-			async (match, attributes = '', content = '') => {
+			async (match, attributes = '', content) => {
 				if (!attributes && !content) {
 					return match;
 				}

--- a/test/preprocess/samples/script-self-closing/_config.js
+++ b/test/preprocess/samples/script-self-closing/_config.js
@@ -1,0 +1,12 @@
+import * as assert from "assert";
+
+export default {
+	preprocess: {
+		script: ({ content, attributes }) => {
+			assert.equal(content, "");
+			return {
+				code: `console.log("${attributes["the-answer"]}");`
+			};
+		}
+	}
+};

--- a/test/preprocess/samples/script-self-closing/_config.js
+++ b/test/preprocess/samples/script-self-closing/_config.js
@@ -3,7 +3,7 @@ import * as assert from "assert";
 export default {
 	preprocess: {
 		script: ({ content, attributes }) => {
-			assert.equal(content, undefined);
+			assert.equal(content, "");
 			return {
 				code: `console.log("${attributes["the-answer"]}");`
 			};

--- a/test/preprocess/samples/script-self-closing/_config.js
+++ b/test/preprocess/samples/script-self-closing/_config.js
@@ -3,7 +3,7 @@ import * as assert from "assert";
 export default {
 	preprocess: {
 		script: ({ content, attributes }) => {
-			assert.equal(content, "");
+			assert.equal(content, undefined);
 			return {
 				code: `console.log("${attributes["the-answer"]}");`
 			};

--- a/test/preprocess/samples/script-self-closing/input.svelte
+++ b/test/preprocess/samples/script-self-closing/input.svelte
@@ -1,0 +1,1 @@
+<script the-answer="42"/>

--- a/test/preprocess/samples/script-self-closing/output.svelte
+++ b/test/preprocess/samples/script-self-closing/output.svelte
@@ -1,0 +1,1 @@
+<script the-answer="42">console.log("42");</script>

--- a/test/preprocess/samples/style-self-closing/_config.js
+++ b/test/preprocess/samples/style-self-closing/_config.js
@@ -1,0 +1,12 @@
+import * as assert from "assert";
+
+export default {
+	preprocess: {
+		style: ({ content, attributes: { color } }) => {
+			assert.equal(content, "");
+			return {
+				code: `div { color: ${color}; }`
+			};
+		}
+	}
+};

--- a/test/preprocess/samples/style-self-closing/_config.js
+++ b/test/preprocess/samples/style-self-closing/_config.js
@@ -3,7 +3,7 @@ import * as assert from "assert";
 export default {
 	preprocess: {
 		style: ({ content, attributes: { color } }) => {
-			assert.equal(content, undefined);
+			assert.equal(content, "");
 			return {
 				code: `div { color: ${color}; }`
 			};

--- a/test/preprocess/samples/style-self-closing/_config.js
+++ b/test/preprocess/samples/style-self-closing/_config.js
@@ -3,7 +3,7 @@ import * as assert from "assert";
 export default {
 	preprocess: {
 		style: ({ content, attributes: { color } }) => {
-			assert.equal(content, "");
+			assert.equal(content, undefined);
 			return {
 				code: `div { color: ${color}; }`
 			};

--- a/test/preprocess/samples/style-self-closing/input.svelte
+++ b/test/preprocess/samples/style-self-closing/input.svelte
@@ -1,0 +1,3 @@
+<div class='brand-color'>$brand</div>
+
+<style color="red"/>

--- a/test/preprocess/samples/style-self-closing/output.svelte
+++ b/test/preprocess/samples/style-self-closing/output.svelte
@@ -1,0 +1,3 @@
+<div class='brand-color'>$brand</div>
+
+<style color="red">div { color: red; }</style>


### PR DESCRIPTION
Implements #5080

- Extends the regex that is used to identify `script` / `style` tags during preprocessing
- Added two tests: One with a self-closing `script` tag and one with a self-closing `style` tag
- If a self-closing tag doesn't have any attributes it will still be ignored


### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [X] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [X] Run the tests with `npm test` or `yarn test`)