### PR TITLE
fix: Parameters with default values are optional

### DIFF
--- a/src/runtime/animate/index.ts
+++ b/src/runtime/animate/index.ts
@@ -11,9 +11,9 @@ export interface AnimationConfig {
 }
 
 interface FlipParams {
-	delay: number;
-	duration: number | ((len: number) => number);
-	easing: (t: number) => number;
+	delay?: number;
+	duration?: number | ((len: number) => number);
+	easing?: (t: number) => number;
 }
 
 export function flip(node: Element, animation: { from: DOMRect; to: DOMRect }, params: FlipParams): AnimationConfig {

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -12,11 +12,11 @@ export interface TransitionConfig {
 }
 
 interface BlurParams {
-	delay: number;
-	duration: number;
+	delay?: number;
+	duration?: number;
 	easing?: EasingFunction;
-	amount: number;
-	opacity: number;
+	amount?: number;
+	opacity?: number;
 }
 
 export function blur(node: Element, {
@@ -41,9 +41,9 @@ export function blur(node: Element, {
 }
 
 interface FadeParams {
-	delay: number;
-	duration: number;
-	easing: EasingFunction;
+	delay?: number;
+	duration?: number;
+	easing?: EasingFunction;
 }
 
 export function fade(node: Element, {
@@ -62,12 +62,12 @@ export function fade(node: Element, {
 }
 
 interface FlyParams {
-	delay: number;
-	duration: number;
-	easing: EasingFunction;
-	x: number;
-	y: number;
-	opacity: number;
+	delay?: number;
+	duration?: number;
+	easing?: EasingFunction;
+	x?: number;
+	y?: number;
+	opacity?: number;
 }
 
 export function fly(node: Element, {
@@ -95,9 +95,9 @@ export function fly(node: Element, {
 }
 
 interface SlideParams {
-	delay: number;
-	duration: number;
-	easing: EasingFunction;
+	delay?: number;
+	duration?: number;
+	easing?: EasingFunction;
 }
 
 export function slide(node: Element, {
@@ -133,11 +133,11 @@ export function slide(node: Element, {
 }
 
 interface ScaleParams {
-	delay: number;
-	duration: number;
-	easing: EasingFunction;
-	start: number;
-	opacity: number;
+	delay?: number;
+	duration?: number;
+	easing?: EasingFunction;
+	start?: number;
+	opacity?: number;
 }
 
 export function scale(node: Element, {
@@ -166,10 +166,10 @@ export function scale(node: Element, {
 }
 
 interface DrawParams {
-	delay: number;
-	speed: number;
-	duration: number | ((len: number) => number);
-	easing: EasingFunction;
+	delay?: number;
+	speed?: number;
+	duration?: number | ((len: number) => number);
+	easing?: EasingFunction;
 }
 
 export function draw(node: SVGElement & { getTotalLength(): number }, {
@@ -199,9 +199,9 @@ export function draw(node: SVGElement & { getTotalLength(): number }, {
 }
 
 interface CrossfadeParams {
-	delay: number;
-	duration: number | ((len: number) => number);
-	easing: EasingFunction;
+	delay?: number;
+	duration?: number | ((len: number) => number);
+	easing?: EasingFunction;
 }
 
 type ClientRectMap = Map<any, { rect: ClientRect }>;


### PR DESCRIPTION
I've marked the properties of parameters that have default values as optional (`x: number` to `x?: number`)

The current situation marks the properties of the interface as required, which cause errors when properties are omitted:
<img width="850" alt="screenshot" src="https://user-images.githubusercontent.com/207248/85951592-527ccc00-b964-11ea-9064-fc67687cde7c.png">
> Argument of type '{ x: number; }' is not assignable to parameter of type 'FlyParams'.
  Type '{ x: number; }' is missing the following properties from type 'FlyParams': delay, duration, easing, y, opacity
