### PR TITLE
make builds time out after a reasonable period

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   Tests:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 6
     strategy:
       matrix:
         node-version: [8, 10, 12, 14]
@@ -18,12 +19,14 @@ jobs:
         CI: true
   Lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
     - run: 'npm i && npm run lint'
   Unit:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 3
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]


### PR DESCRIPTION
Not sure if we pay any bills for CI, but some builds get stuck for half a day. This will stop that.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests with `npm test` or `yarn test`)
