### PR TITLE
add updating guard to binding callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Prevent duplicate invalidation with certain two-way component bindings ([#3180](https://github.com/sveltejs/svelte/issues/3180), [#5117](https://github.com/sveltejs/svelte/issues/5117), [#5144](https://github.com/sveltejs/svelte/issues/5144))
 * Fix reactivity when passing `$$props` to a `<slot>` ([#3364](https://github.com/sveltejs/svelte/issues/3364))
 * Fix unneeded invalidation of `$$props` and `$$restProps` ([#4993](https://github.com/sveltejs/svelte/issues/4993), [#5118](https://github.com/sveltejs/svelte/issues/5118))
 

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -86,7 +86,6 @@ export default function dom(
 	const set = (uses_props || uses_rest || writable_props.length > 0 || component.slots.size > 0)
 		? x`
 			${$$props} => {
-				${(uses_props || uses_rest) && b`if (@is_empty(${$$props})) return;`}
 				${uses_props && renderer.invalidate('$$props', x`$$props = @assign(@assign({}, $$props), @exclude_internal_props($$new_props))`)}
 				${uses_rest && !uses_props && x`$$props = @assign(@assign({}, $$props), @exclude_internal_props($$new_props))`}
 				${uses_rest && renderer.invalidate('$$restProps', x`$$restProps = ${compute_rest}`)}
@@ -421,7 +420,7 @@ export default function dom(
 
 				${component.partly_hoisted}
 
-				${set && b`$$self.$set = ${set};`}
+				${set && b`$$self.$$set = ${set};`}
 
 				${capture_state && b`$$self.$capture_state = ${capture_state};`}
 

--- a/test/js/samples/action-custom-event-handler/expected.js
+++ b/test/js/samples/action-custom-event-handler/expected.js
@@ -55,7 +55,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { bar } = $$props;
 	const foo_function = () => handleFoo(bar);
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("bar" in $$props) $$invalidate(0, bar = $$props.bar);
 	};
 

--- a/test/js/samples/bind-open/expected.js
+++ b/test/js/samples/bind-open/expected.js
@@ -52,7 +52,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(0, open);
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("open" in $$props) $$invalidate(0, open = $$props.open);
 	};
 

--- a/test/js/samples/bind-width-height/expected.js
+++ b/test/js/samples/bind-width-height/expected.js
@@ -46,7 +46,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(1, h);
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("w" in $$props) $$invalidate(0, w = $$props.w);
 		if ("h" in $$props) $$invalidate(1, h = $$props.h);
 	};

--- a/test/js/samples/bindings-readonly-order/expected.js
+++ b/test/js/samples/bindings-readonly-order/expected.js
@@ -68,7 +68,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(0, files);
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("files" in $$props) $$invalidate(0, files = $$props.files);
 	};
 

--- a/test/js/samples/capture-inject-state/expected.js
+++ b/test/js/samples/capture-inject-state/expected.js
@@ -118,7 +118,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { $$slots = {}, $$scope } = $$props;
 	validate_slots("Component", $$slots, []);
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("prop" in $$props) $$subscribe_prop($$invalidate(0, prop = $$props.prop));
 		if ("alias" in $$props) $$invalidate(1, realName = $$props.alias);
 	};

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -48,7 +48,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { foo = 42 } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("foo" in $$props) $$invalidate(0, foo = $$props.foo);
 	};
 

--- a/test/js/samples/computed-collapsed-if/expected.js
+++ b/test/js/samples/computed-collapsed-if/expected.js
@@ -12,7 +12,7 @@ function instance($$self, $$props, $$invalidate) {
 		return x * 3;
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("x" in $$props) $$invalidate(0, x = $$props.x);
 	};
 

--- a/test/js/samples/data-attribute/expected.js
+++ b/test/js/samples/data-attribute/expected.js
@@ -47,7 +47,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { bar } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("bar" in $$props) $$invalidate(0, bar = $$props.bar);
 	};
 

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -79,7 +79,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { $$slots = {}, $$scope } = $$props;
 	validate_slots("Component", $$slots, []);
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("name" in $$props) $$invalidate(0, name = $$props.name);
 	};
 

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -183,7 +183,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { $$slots = {}, $$scope } = $$props;
 	validate_slots("Component", $$slots, []);
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("things" in $$props) $$invalidate(0, things = $$props.things);
 		if ("foo" in $$props) $$invalidate(1, foo = $$props.foo);
 		if ("bar" in $$props) $$invalidate(2, bar = $$props.bar);

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -175,7 +175,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { $$slots = {}, $$scope } = $$props;
 	validate_slots("Component", $$slots, []);
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("things" in $$props) $$invalidate(0, things = $$props.things);
 		if ("foo" in $$props) $$invalidate(1, foo = $$props.foo);
 	};

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -104,7 +104,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { createElement } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("createElement" in $$props) $$invalidate(0, createElement = $$props.createElement);
 	};
 

--- a/test/js/samples/deconflict-globals/expected.js
+++ b/test/js/samples/deconflict-globals/expected.js
@@ -10,7 +10,7 @@ function instance($$self, $$props, $$invalidate) {
 		alert(JSON.stringify(data()));
 	});
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("foo" in $$props) $$invalidate(0, foo = $$props.foo);
 	};
 

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -76,7 +76,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { $$slots = {}, $$scope } = $$props;
 	validate_slots("Component", $$slots, []);
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("foo" in $$props) $$invalidate(0, foo = $$props.foo);
 	};
 

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -106,7 +106,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { d } = $$props;
 	let { e } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("a" in $$props) $$invalidate(0, a = $$props.a);
 		if ("b" in $$props) $$invalidate(1, b = $$props.b);
 		if ("c" in $$props) $$invalidate(2, c = $$props.c);

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -152,7 +152,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { time } = $$props;
 	let { foo } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("comments" in $$props) $$invalidate(0, comments = $$props.comments);
 		if ("elapsed" in $$props) $$invalidate(1, elapsed = $$props.elapsed);
 		if ("time" in $$props) $$invalidate(2, time = $$props.time);

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -128,7 +128,7 @@ function foo(node, animation, params) {
 function instance($$self, $$props, $$invalidate) {
 	let { things } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("things" in $$props) $$invalidate(0, things = $$props.things);
 	};
 

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -97,7 +97,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { things } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("things" in $$props) $$invalidate(0, things = $$props.things);
 	};
 

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -88,7 +88,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { foo } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("foo" in $$props) $$invalidate(0, foo = $$props.foo);
 	};
 

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -66,7 +66,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { foo } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("foo" in $$props) $$invalidate(0, foo = $$props.foo);
 	};
 

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -44,7 +44,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { x } = $$props;
 	let { y } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("color" in $$props) $$invalidate(0, color = $$props.color);
 		if ("x" in $$props) $$invalidate(1, x = $$props.x);
 		if ("y" in $$props) $$invalidate(2, y = $$props.y);

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -37,7 +37,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { data } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("data" in $$props) $$invalidate(0, data = $$props.data);
 	};
 

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -37,7 +37,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { color } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("color" in $$props) $$invalidate(0, color = $$props.color);
 	};
 

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -54,7 +54,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { key } = $$props;
 	let { value } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("style" in $$props) $$invalidate(0, style = $$props.style);
 		if ("key" in $$props) $$invalidate(1, key = $$props.key);
 		if ("value" in $$props) $$invalidate(2, value = $$props.value);

--- a/test/js/samples/input-files/expected.js
+++ b/test/js/samples/input-files/expected.js
@@ -49,7 +49,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(0, files);
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("files" in $$props) $$invalidate(0, files = $$props.files);
 	};
 

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -60,7 +60,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(0, value);
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("value" in $$props) $$invalidate(0, value = $$props.value);
 	};
 

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -53,7 +53,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(0, foo);
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("foo" in $$props) $$invalidate(0, foo = $$props.foo);
 	};
 

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -173,7 +173,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(10, ended);
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("buffered" in $$props) $$invalidate(0, buffered = $$props.buffered);
 		if ("seekable" in $$props) $$invalidate(1, seekable = $$props.seekable);
 		if ("played" in $$props) $$invalidate(2, played = $$props.played);

--- a/test/js/samples/optional-chaining/expected.js
+++ b/test/js/samples/optional-chaining/expected.js
@@ -167,7 +167,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { f } = $$props;
 	let Component;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("a" in $$props) $$invalidate(0, a = $$props.a);
 		if ("b" in $$props) $$invalidate(1, b = $$props.b);
 		if ("c" in $$props) $$invalidate(2, c = $$props.c);

--- a/test/js/samples/reactive-values-non-topologically-ordered/expected.js
+++ b/test/js/samples/reactive-values-non-topologically-ordered/expected.js
@@ -6,7 +6,7 @@ function instance($$self, $$props, $$invalidate) {
 	let a;
 	let b;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("x" in $$props) $$invalidate(0, x = $$props.x);
 	};
 

--- a/test/js/samples/reactive-values-non-writable-dependencies/expected.js
+++ b/test/js/samples/reactive-values-non-writable-dependencies/expected.js
@@ -5,7 +5,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { a = 1 } = $$props;
 	let { b = 2 } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("a" in $$props) $$invalidate(0, a = $$props.a);
 		if ("b" in $$props) $$invalidate(1, b = $$props.b);
 	};

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -50,7 +50,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { current } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("current" in $$props) $$invalidate(0, current = $$props.current);
 	};
 

--- a/test/js/samples/src-attribute-check/expected.js
+++ b/test/js/samples/src-attribute-check/expected.js
@@ -67,7 +67,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { url } = $$props;
 	let { slug } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("url" in $$props) $$invalidate(0, url = $$props.url);
 		if ("slug" in $$props) $$invalidate(1, slug = $$props.slug);
 	};

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -22,7 +22,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { custom } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("custom" in $$props) $$invalidate(0, custom = $$props.custom);
 	};
 

--- a/test/js/samples/transition-local/expected.js
+++ b/test/js/samples/transition-local/expected.js
@@ -124,7 +124,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { x } = $$props;
 	let { y } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("x" in $$props) $$invalidate(0, x = $$props.x);
 		if ("y" in $$props) $$invalidate(1, y = $$props.y);
 	};

--- a/test/js/samples/transition-repeated-outro/expected.js
+++ b/test/js/samples/transition-repeated-outro/expected.js
@@ -102,7 +102,7 @@ function create_fragment(ctx) {
 function instance($$self, $$props, $$invalidate) {
 	let { num = 1 } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("num" in $$props) $$invalidate(0, num = $$props.num);
 	};
 

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -243,7 +243,7 @@ function instance($$self, $$props, $$invalidate) {
 	let { d } = $$props;
 	let { e } = $$props;
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("a" in $$props) $$invalidate(0, a = $$props.a);
 		if ("b" in $$props) $$invalidate(1, b = $$props.b);
 		if ("c" in $$props) $$invalidate(2, c = $$props.c);

--- a/test/js/samples/video-bindings/expected.js
+++ b/test/js/samples/video-bindings/expected.js
@@ -93,7 +93,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(3, offsetWidth);
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("currentTime" in $$props) $$invalidate(0, currentTime = $$props.currentTime);
 		if ("videoHeight" in $$props) $$invalidate(1, videoHeight = $$props.videoHeight);
 		if ("videoWidth" in $$props) $$invalidate(2, videoWidth = $$props.videoWidth);

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -78,7 +78,7 @@ function instance($$self, $$props, $$invalidate) {
 		$$invalidate(0, y = window.pageYOffset)
 	}
 
-	$$self.$set = $$props => {
+	$$self.$$set = $$props => {
 		if ("y" in $$props) $$invalidate(0, y = $$props.y);
 	};
 

--- a/test/runtime/samples/component-binding-store/Input.svelte
+++ b/test/runtime/samples/component-binding-store/Input.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let value = '';
+</script>
+
+<input bind:value />

--- a/test/runtime/samples/component-binding-store/_config.js
+++ b/test/runtime/samples/component-binding-store/_config.js
@@ -1,0 +1,61 @@
+export default {
+	html: `
+		<input />
+		<input />
+		<div></div>
+	`,
+
+	async test({ assert, component, target, window }) {
+		let count = 0;
+		component.callback = () => {
+			count++;
+		};
+
+		const [input1, input2] = target.querySelectorAll("input");
+
+		input1.value = "1";
+		await input1.dispatchEvent(new window.Event("input"));
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<input />
+				<input />
+				<div>1</div>
+			`
+		);
+		assert.equal(input1.value, "1");
+		assert.equal(input2.value, "1");
+		assert.equal(count, 1);
+
+		input2.value = "123";
+		await input2.dispatchEvent(new window.Event("input"));
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<input />
+				<input />
+				<div>123</div>
+			`
+		);
+		assert.equal(input1.value, "123");
+		assert.equal(input2.value, "123");
+		assert.equal(count, 2);
+
+		input1.value = "456";
+		await input1.dispatchEvent(new window.Event("input"));
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<input />
+				<input />
+				<div>456</div>
+			`
+		);
+		assert.equal(input1.value, "456");
+		assert.equal(input2.value, "456");
+		assert.equal(count, 3);
+	},
+};

--- a/test/runtime/samples/component-binding-store/main.svelte
+++ b/test/runtime/samples/component-binding-store/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	import { writable } from 'svelte/store';
+	import Input from './Input.svelte';
+
+	let value = writable({ value: '' });
+
+	export let callback = () => {};
+
+	value.subscribe(() => {
+		callback();
+	})
+</script>
+
+<input bind:value={$value.value} />
+
+<Input bind:value={$value.value}/>
+
+<div>{$value.value}</div>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/3180
Fixes https://github.com/sveltejs/svelte/issues/5117

binding callback should be called only when changes happen internally.

similar with `<input bind:value>`, the on input only call when typing into the input, but not when programmatically set the `input.value`.

a brief description of the bug:
- we have a `<Component bind:value />` and when we `$$invalidate(value)` from outside,
- `component.$set({ value })` which internally calls `$$invalidate(value_internal)`
- which then calls the binding callback `$$.bound[value]()`
- in the binding callback, we call the `$$invalidate(value)`
- which again calls the `component.$set({ value })` which internally calls `$$invalidate(value_internal)`
- only this time round, the `!safe_not_equal(value, value_internal)`, so the binding callback, `$$.bound[value]()`, did not get called.

as you can see from the sequence of steps, `$$invalidate(value)` get called twice.

Also, it seemed like it will add quite some bytes into the compiled code, should we rename the variable to a shorter name?
or use `1` / `0` instead of `true` / `false`?

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests with `npm test` or `yarn test`)
