### PR TITLE
Adds a FAQ entry for how to document a svelte component

### DIFF
--- a/site/content/faq/401-how-do-i-document-my-components.md
+++ b/site/content/faq/401-how-do-i-document-my-components.md
@@ -1,0 +1,32 @@
+---
+question: How do I document my .svelte files?
+---
+
+In editors which use the Svelte Language Server you can document Components, functions and exports using specially formatted comments.
+
+````svelte
+<script>
+	/** What should we call the user? */
+	export let name = 'world';
+</script>
+
+<!--
+@component
+Here's some documentation for this component. It will show up
+on hover.
+
+- You can use markdown here.
+- You can also use code blocks here.
+- Usage:
+  ```tsx
+  <main name="Arethra">
+  ```
+-->
+<main>
+	<h1>
+		Hello, {name}
+	</h1>
+</main>
+````
+
+Note: The `@component` is necessary in the HTML comment which describes your component.

--- a/site/content/faq/450-how-do-i-document-my-components.md
+++ b/site/content/faq/450-how-do-i-document-my-components.md
@@ -12,8 +12,8 @@ In editors which use the Svelte Language Server you can document Components, fun
 
 <!--
 @component
-Here's some documentation for this component. It will show up
-on hover.
+Here's some documentation for this component.
+It will show up on hover.
 
 - You can use markdown here.
 - You can also use code blocks here.

--- a/site/content/faq/450-how-do-i-document-my-components.md
+++ b/site/content/faq/450-how-do-i-document-my-components.md
@@ -1,5 +1,5 @@
 ---
-question: How do I document my .svelte files?
+question: How do I document my components?
 ---
 
 In editors which use the Svelte Language Server you can document Components, functions and exports using specially formatted comments.


### PR DESCRIPTION
Adds a FAQ entry on how to write documentation for your components: Both at component and JS level. Works in both JS/TS, so long as you have an editor with the LSP that was released in the last week.

Based on @fnune's work in the language tools

- https://github.com/sveltejs/language-tools/pull/282
- https://github.com/sveltejs/language-tools/pull/285