### PR TITLE
Fixed text.md

### DIFF
--- a/site/content/tutorial/01-introduction/01-basics/text.md
+++ b/site/content/tutorial/01-introduction/01-basics/text.md
@@ -29,4 +29,4 @@ Each tutorial chapter will have a 'Show me' button that you can click if you get
 
 ## Understanding components
 
-In Svelte, an application is composed from one or more *components*. A component is a reusable self-contained block of code that encapsulates HTML, CSS and JavaScript that belong together, written into a `.svelte` file. The 'hello world' example in the code editor is a simple component.
+In Svelte, an application is composed of one or more *components*. A component is a reusable self-contained block of code that encapsulates HTML, CSS and JavaScript that belong together, written into a `.svelte` file. The 'hello world' example in the code editor is a simple component.


### PR DESCRIPTION
Corrected the typo "composed from" and replaced it with "composed of" in the `text.md` introduction tutorial.



### Before submitting the PR, please make sure you do the following
- [x] No issue referenced. Instead, this is just a fix of a typo I spotted in Svelte tutorial docs.
- [x] The original text reads "an application is composed from..." instead of "an application is composed of..." .
- [x] No tests required.
### Tests
-  [x] Run the tests with `npm test` or `yarn test`)
