### PR TITLE
Await: re-throw error when there is no catch block and promise is rejected 

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -188,7 +188,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 			ctx: #ctx,
 			current: null,
 			token: null,
-			hasCatch: false,
+			hasCatch: ${this.catch.node.start !== null ? 'true' : 'false'},
 			pending: ${this.pending.block.name},
 			then: ${this.then.block.name},
 			catch: ${this.catch.block.name},
@@ -200,12 +200,6 @@ export default class AwaitBlockWrapper extends Wrapper {
 		block.chunks.init.push(b`
 			let ${info} = ${info_props};
 		`);
-
-		if (this.catch.node.start !== null) {
-			block.chunks.init.push(b`
-				${info}.hasCatch = true;
-			`);
-		}
 
 		block.chunks.init.push(b`
 			@handle_promise(${promise} = ${snippet}, ${info});

--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -188,6 +188,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 			ctx: #ctx,
 			current: null,
 			token: null,
+			hasCatch: false,
 			pending: ${this.pending.block.name},
 			then: ${this.then.block.name},
 			catch: ${this.catch.block.name},
@@ -199,6 +200,12 @@ export default class AwaitBlockWrapper extends Wrapper {
 		block.chunks.init.push(b`
 			let ${info} = ${info_props};
 		`);
+
+		if (this.catch.node.start !== null) {
+			block.chunks.init.push(b`
+				${info}.hasCatch = true;
+			`);
+		}
 
 		block.chunks.init.push(b`
 			@handle_promise(${promise} = ${snippet}, ${info});

--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -59,7 +59,6 @@ export function handle_promise(promise, info) {
 			update(info.then, 1, info.value, value);
 			set_current_component(null);
 		}, error => {
-			console.log(info);
 			if (!info.hasCatch) {
 				throw error;
 			}

--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -59,6 +59,10 @@ export function handle_promise(promise, info) {
 			update(info.then, 1, info.value, value);
 			set_current_component(null);
 		}, error => {
+			if (info.current === info.catch && info.error === undefined) {
+				// when no catch block is present
+				throw error;
+			}
 			set_current_component(current_component);
 			update(info.catch, 2, info.error, error);
 			set_current_component(null);

--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -59,8 +59,8 @@ export function handle_promise(promise, info) {
 			update(info.then, 1, info.value, value);
 			set_current_component(null);
 		}, error => {
-			if (info.current === info.catch && info.error === undefined) {
-				// when no catch block is present
+			console.log(info);
+			if (!info.hasCatch) {
 				throw error;
 			}
 			set_current_component(current_component);

--- a/test/runtime/samples/await-without-catch/_config.js
+++ b/test/runtime/samples/await-without-catch/_config.js
@@ -1,0 +1,44 @@
+let fulfil;
+
+let promise = new Promise(f => {
+	fulfil = f;
+});
+
+export default {
+	props: {
+		promise
+	},
+
+	html: `
+		<p>loading...</p>
+	`,
+
+	test({ assert, component, target }) {
+		fulfil(42);
+
+		return promise
+		.then(() => {
+			assert.htmlEqual(target.innerHTML, `
+				<p>loaded</p>
+			`);
+
+			let reject;
+
+			promise = new Promise((f, r) => {
+				reject = r;
+			});
+
+			component.promise = promise;
+
+			assert.htmlEqual(target.innerHTML, `
+				<p>loading...</p>
+			`);
+
+			reject(new Error('this error should be thrown'));
+			return promise;
+		})
+		.catch((err) => {
+			assert.equal(err.message, 'this error should be thrown');
+		});
+	}
+};

--- a/test/runtime/samples/await-without-catch/main.svelte
+++ b/test/runtime/samples/await-without-catch/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	export let promise;
+</script>
+
+{#await promise}
+	<p>loading...</p>
+{:then value}
+	<p>loaded</p>
+{/await}


### PR DESCRIPTION
Fixes #5129 , 

When there is no catch block present in an await, it should throw an error 

The change is done as suggested in the issue. I had to pass the hasCatch field since there was no way I could infer whether a catch block was present or not from existing values (I thought of and tried using `info.error` and similar fields, but they will fail for the case when the catch block has no value or is empty.




### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests with `npm test` or `yarn test`)
