### PR TITLE
Fixes #5153 - Wrapping of buttons in REPL (.app-controls)

### DIFF
--- a/site/src/routes/repl/[id]/_components/AppControls/index.svelte
+++ b/site/src/routes/repl/[id]/_components/AppControls/index.svelte
@@ -227,6 +227,7 @@ export default app;` });
 		padding: .6rem var(--side-nav);
 		background-color: var(--second);
 		color: white;
+		white-space: nowrap;
 	}
 
 	.icon {


### PR DESCRIPTION
Fixes the issue mentioned in #5153 about the wrapping of controls in Safari Mobile.