### PR TITLE
site: explain how to use `site-kit` and `site-repl`

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -54,13 +54,22 @@ To build the website, run `npm run sapper`. The output can be found in `__sapper
 Tests can be run using `npm run test`.
 
 
-## Working With Components
+## Linking `@sveltejs/site-kit` and `@sveltejs/site-repl`
 
-svelte.dev uses the package [`@sveltejs/site-kit`](https://github.com/sveltejs/site-kit) to import it's UI components
+This site depends on `@sveltejs/site-kit`, a collection of styles, components and icons used in common by *.svelte.dev websites, and `@sveltejs/site-repl`.
 
-clone [`@sveltejs/site-kit`](https://github.com/sveltejs/site-kit) locally
+In order to work on features that depend on those packages, you need to [link](https://docs.npmjs.com/cli/link) their repositories:
 
-[`npm-link`](https://docs.npmjs.com/cli/link) your local site-kit to `svelte/site` to see your component changes reflected locally.
+- `cd <somewhere>`
+- `git clone https://github.com/sveltejs/site-kit`
+- `git clone https://github.com/sveltejs/svelte-repl`
+- `cd <somewhere>/site-kit`
+- `npm link`
+- `cd <somewhere>/svelte-repl`
+- `npm link`
+- `cd <svelte-repo>/site`
+- `npm link @sveltejs/site-kit`
+- `npm link @sveltejs/svelte-repl`
  
 
 

--- a/site/README.md
+++ b/site/README.md
@@ -53,6 +53,17 @@ To build the website, run `npm run sapper`. The output can be found in `__sapper
 
 Tests can be run using `npm run test`.
 
+
+## Working With Components
+
+svelte.dev uses the package [`@sveltejs/site-kit`](https://github.com/sveltejs/site-kit) to import it's UI components
+
+clone [`@sveltejs/site-kit`](https://github.com/sveltejs/site-kit) locally
+
+[`npm-link`](https://docs.npmjs.com/cli/link) your local site-kit to `svelte/site` to see your component changes reflected locally.
+ 
+
+
 ## Translating the API docs
 
 Anchors are automatically generated using headings in the documentation and by default (for the english language) they are latinised to make sure the URL is always conforming to RFC3986.


### PR DESCRIPTION
Updates README with steps for working with and updating site-kit components. 

