### PR TITLE
Clarify noun regarding svelte-self example

### DIFF
--- a/site/content/tutorial/16-special-elements/01-svelte-self/text.md
+++ b/site/content/tutorial/16-special-elements/01-svelte-self/text.md
@@ -14,7 +14,7 @@ It's useful for things like this folder tree view, where folders can contain *ot
 {/if}
 ```
 
-...but that's impossible, because a component can't import itself. Instead, we use `<svelte:self>`:
+...but that's impossible, because a module can't import itself. Instead, we use `<svelte:self>`:
 
 ```html
 {#if file.type === 'folder'}

--- a/site/content/tutorial/16-special-elements/01-svelte-self/text.md
+++ b/site/content/tutorial/16-special-elements/01-svelte-self/text.md
@@ -14,7 +14,7 @@ It's useful for things like this folder tree view, where folders can contain *ot
 {/if}
 ```
 
-...but that's impossible, because a file can't import itself. Instead, we use `<svelte:self>`:
+...but that's impossible, because a component can't import itself. Instead, we use `<svelte:self>`:
 
 ```html
 {#if file.type === 'folder'}


### PR DESCRIPTION
Hey! This is a small documentation change which I feel helps make super clear that "file" is really referencing to the `Folder.svelte` component file, not the `<File/>` component.