### PR TITLE
Fixes #5165 REPL on iOS: Input/output toggle is only visible after awk…

### DIFF
--- a/site/src/components/Repl/InputOutputToggle.svelte
+++ b/site/src/components/Repl/InputOutputToggle.svelte
@@ -5,8 +5,8 @@
 <style>
 	.input-output-toggle {
 		display: grid;
-		position: absolute;
 		user-select: none;
+		flex: 0;
 		grid-template-columns: 1fr 40px 1fr;
 		grid-gap: 0.5em;
 		align-items: center;

--- a/site/src/components/Repl/ReplWidget.svelte
+++ b/site/src/components/Repl/ReplWidget.svelte
@@ -89,6 +89,8 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
+		display: flex;
+		flex-direction: column;
 		background-color: var(--back);
 		overflow: hidden;
 		box-sizing: border-box;
@@ -98,6 +100,7 @@
 	.viewport {
 		width: 100%;
 		height: 100%;
+		flex: 1;
 	}
 
 	.mobile .viewport {

--- a/site/src/routes/_layout.svelte
+++ b/site/src/routes/_layout.svelte
@@ -62,6 +62,7 @@
 
 <style>
 	main {
+		height: 100%;
 		position: relative;
 		margin: 0 auto;
 		/* padding: var(--nav-h) var(--side-nav) 0 var(--side-nav); */

--- a/site/src/routes/repl/[id]/_components/AppControls/index.svelte
+++ b/site/src/routes/repl/[id]/_components/AppControls/index.svelte
@@ -228,6 +228,7 @@ export default app;` });
 		background-color: var(--second);
 		color: white;
 		white-space: nowrap;
+		flex: 0;
 	}
 
 	.icon {

--- a/site/src/routes/repl/[id]/index.svelte
+++ b/site/src/routes/repl/[id]/index.svelte
@@ -117,7 +117,7 @@
 <style>
 	.repl-outer {
 		position: relative;
-		height: calc(100vh - var(--nav-h));
+		height: 100%;
 		--app-controls-h: 5.6rem;
 		--pane-controls-h: 4.2rem;
 		overflow: hidden;
@@ -125,6 +125,8 @@
 		padding: var(--app-controls-h) 0 0 0;
 		/* margin: 0 calc(var(--side-nav) * -1); */
 		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
 	}
 
 	.viewport {
@@ -136,6 +138,7 @@
 		width: 200%;
 		height: calc(100% - 42px);
 		transition: transform 0.3s;
+		flex: 1;
 	}
 
 	.mobile .offset {

--- a/site/src/routes/repl/embed.svelte
+++ b/site/src/routes/repl/embed.svelte
@@ -27,6 +27,8 @@
 		overflow: hidden;
 		box-sizing: border-box;
 		--pane-controls-h: 4.2rem;
+		display: flex;
+		flex-direction: column;
 	}
 </style>
 


### PR DESCRIPTION
Fixes #5165  REPL on iOS: Input/output toggle is only visible after awkward scroll.

By giving `main` a height of 100%, we can now treat the `.outer-repl` div as a flex container. I removed the absolute positioning from the `.input-output-toggle` and gave the 3 divs within the `outer-repl` their proper flex growth logic: `flex: 0`(don't grow)  for the bars (top bar and bottom bar) and `flex: 1;` (grow) for the content area.

This in turn gives a good scroll result in Safari on iOS13 (tested in simulator).

I then tested for any regressions to the main layout in Firefox, Safari and Chrome and all looked fine.

<img width="529" alt="Screenshot 2020-07-21 at 14 28 39" src="https://user-images.githubusercontent.com/12690/88054956-7e076680-cb5e-11ea-8fdb-1621bdadc2ca.png">

Signed-off-by: Wolfr <johan.ronsse@gmail.com>

