### PR TITLE
Update old `.technology` links in the Sapper intro blog post

### DIFF
--- a/site/content/blog/2017-12-31-sapper-towards-the-ideal-web-app-framework.md
+++ b/site/content/blog/2017-12-31-sapper-towards-the-ideal-web-app-framework.md
@@ -5,7 +5,7 @@ author: Rich Harris
 authorURL: https://twitter.com/Rich_Harris
 ---
 
-> Quickstart for the impatient: [the Sapper docs](https://sapper.svelte.technology), and the [starter template](https://github.com/sveltejs/sapper-template)
+> Quickstart for the impatient: [the Sapper docs](https://sapper.svelte.dev), and the [starter template](https://github.com/sveltejs/sapper-template)
 
 If you had to list the characteristics of the perfect Node.js web application framework, you'd probably come up with something like this:
 
@@ -47,9 +47,9 @@ What happens if we use the new model as a starting point?
 
 ## Introducing Sapper
 
-<aside><p>The <a href="https://sapper.svelte.technology/docs#why-the-name-">name comes from</a> the term for combat engineers, and is also short for Svelte app maker</p></aside>
+<aside><p>The <a href="https://sapper.svelte.dev/docs#Why_the_name">name comes from</a> the term for combat engineers, and is also short for Svelte app maker</p></aside>
 
-[Sapper](https://sapper.svelte.technology) is the answer to that question. **Sapper is a Next.js-style framework that aims to meet the eleven criteria at the top of this article while dramatically reducing the amount of code that gets sent to the browser.** It's implemented as Express-compatible middleware, meaning it's easy to understand and customise.
+[Sapper](https://sapper.svelte.dev) is the answer to that question. **Sapper is a Next.js-style framework that aims to meet the eleven criteria at the top of this article while dramatically reducing the amount of code that gets sent to the browser.** It's implemented as Express-compatible middleware, meaning it's easy to understand and customise.
 
 The same 'hello world' app that took 204kb with React and Next weighs just 7kb with Sapper. That number is likely to fall further in the future as we explore the space of optimisation possibilities, such as not shipping any JavaScript *at all* for pages that aren't interactive, beyond the tiny Sapper runtime that handles client-side routing.
 


### PR DESCRIPTION
`sapper.svelte.technology` has moved to `sapper.svelte.dev`. The old URLs redirect to the `.dev` site, but updating the links will avoid the need for each browser to follow a redirect before getting to the site. Additionally, the fragment id in the link to the description of the Sapper name has changed from `#why-the-name-` to `#Why_the_name`. I've updated that as well, so that following the link will scroll to the appropriate section of the page.