### PR TITLE
fix: preserve property case for custom elements

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -82,10 +82,12 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 		const element = this.parent;
 		const { name, property_name, should_cache, is_indirectly_bound_value } = this;
 
+		const is_custom_element = /-/.test(element.node.name);
+
 		// xlink is a special case... we could maybe extend this to generic
 		// namespaced attributes but I'm not sure that's applicable in
 		// HTML5?
-		const method = /-/.test(element.node.name)
+		const method = is_custom_element
 			? '@set_custom_element_data'
 			: name.slice(0, 6) === 'xlink:'
 				? '@xlink_attr'
@@ -130,10 +132,12 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 				? b`@prop_dev(${element.var}, "${property_name}", ${should_cache ? this.last : value});`
 				: b`${element.var}.${property_name} = ${should_cache ? this.last : value};`;
 		} else {
+			// use this.node.name when the element is a custom element to preserve property case-sensitivity
+			const custom_element_aware_name = is_custom_element ? this.node.name : name;
 			block.chunks.hydrate.push(
-				b`${method}(${element.var}, "${name}", ${init});`
+				b`${method}(${element.var}, "${custom_element_aware_name}", ${init});`
 			);
-			updater = b`${method}(${element.var}, "${name}", ${should_cache ? this.last : value});`;
+			updater = b`${method}(${element.var}, "${custom_element_aware_name}", ${should_cache ? this.last : value});`;
 		}
 
 		if (is_indirectly_bound_value) {

--- a/test/custom-elements/samples/props/main.svelte
+++ b/test/custom-elements/samples/props/main.svelte
@@ -6,4 +6,4 @@
 	export let items = ['a', 'b', 'c'];
 </script>
 
-<my-widget class="foo" {items}/>
+<my-widget class="foo" widgetItems={items}/>

--- a/test/custom-elements/samples/props/my-widget.svelte
+++ b/test/custom-elements/samples/props/my-widget.svelte
@@ -1,8 +1,8 @@
 <svelte:options tag="my-widget"/>
 
 <script>
-	export let items = [];
+	export let widgetItems = [];
 </script>
 
-<p>{items.length} items</p>
-<p>{items.join(', ')}</p>
+<p>{widgetItems.length} items</p>
+<p>{widgetItems.join(', ')}</p>


### PR DESCRIPTION
Fixes #5184

Heuristics used to determine whether a custom element's property or attribute should be set doesn't support properties that include uppercase characters. This PR preserves property casing when dealing with custom elements.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

  The updated test fails without the change, works with the change included.

### Tests
-  [x] Run the tests with `npm test` or `yarn test`)
