### PR TITLE
Added typings to `get_store_value`

### DIFF
--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -62,7 +62,7 @@ export function subscribe(store, ...callbacks) {
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 
-export function get_store_value<T, S extends Readable<T>>(store: S): T { {
+export function get_store_value<T, S extends Readable<T>>(store: S): T {
 	let value;
 	subscribe(store, _ => value = _)();
 	return value;

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -1,3 +1,5 @@
+import { Readable } from "../store";
+
 export function noop() {}
 
 export const identity = x => x;
@@ -60,7 +62,7 @@ export function subscribe(store, ...callbacks) {
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 
-export function get_store_value(store) {
+export function get_store_value<T, S extends Readable<T>>(store: S): T { {
 	let value;
 	subscribe(store, _ => value = _)();
 	return value;


### PR DESCRIPTION
I'm using the `get` method frequently to get authentication data from a svelte-store outside of svelte-components. To make that work within TypeScript files, I added typings. 