### PR TITLE
Fix markdown

### DIFF
--- a/site/content/tutorial/01-introduction/03-dynamic-attributes/app-b/App.svelte
+++ b/site/content/tutorial/01-introduction/03-dynamic-attributes/app-b/App.svelte
@@ -3,4 +3,4 @@
 	let name = 'Rick Astley';
 </script>
 
-<img {src} alt="{name} dances.">
+<img src={src} alt="{name} dances.">

--- a/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
+++ b/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
@@ -7,29 +7,27 @@ Just like you can use curly braces to control text, you can use them to control 
 Our image is missing a `src` — let's add one:
 
 ```html
-<img src={src}>
+<img src="{src}" />
 ```
 
 That's better. But Svelte is giving us a warning:
 
 > A11y: &lt;img&gt; element should have an alt attribute
 
-When building web apps, it's important to make sure that they're *accessible* to the broadest possible userbase, including people with (for example) impaired vision or motion, or people without powerful hardware or good internet connections. Accessibility (shortened to a11y) isn't always easy to get right, but Svelte will help by warning you if you write inaccessible markup.
+When building web apps, it's important to make sure that they're _accessible_ to the broadest possible userbase, including people with (for example) impaired vision or motion, or people without powerful hardware or good internet connections. Accessibility (shortened to a11y) isn't always easy to get right, but Svelte will help by warning you if you write inaccessible markup.
 
 In this case, we're missing the `alt` attribute that describes the image for people using screenreaders, or people with slow or flaky internet connections that can't download the image. Let's add one:
 
 ```html
-<img src={src} alt="A man dances.">
+<img src="{src}" alt="A man dances." />
 ```
 
-We can use curly braces *inside* attributes. Try changing it to `"{name} dances."` — remember to declare a `name` variable in the `<script>` block.
-
+We can use curly braces _inside_ attributes. Try changing it to `"{name} dances."` — remember to declare a `name` variable in the `<script>` block.
 
 ## Shorthand attributes
 
 It's not uncommon to have an attribute where the name and value are the same, like `src={src}`. Svelte gives us a convenient shorthand for these cases:
 
 ```html
-<img {src} alt="A man dances.">
+<img src="{src}" alt="A man dances." />
 ```
-


### PR DESCRIPTION
In the tutorial, image tag has src={src} for the entire beginning of tutorial, until right here at the end of part 3. It then changes to only {src} which still works, but it is not explained why. 

I've changed it to be src={src} so as not to confuse anyone.