### PR TITLE
optimise style attribute for template literal

### DIFF
--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -7,34 +7,53 @@ import {
 	insert,
 	noop,
 	safe_not_equal,
-	set_style
+	set_style,
+	space
 } from "svelte/internal";
 
 function create_fragment(ctx) {
-	let div;
+	let div0;
+	let t;
+	let div1;
 
 	return {
 		c() {
-			div = element("div");
-			set_style(div, "color", /*color*/ ctx[0]);
-			set_style(div, "transform", "translate(" + /*x*/ ctx[1] + "px," + /*y*/ ctx[2] + "px)");
+			div0 = element("div");
+			t = space();
+			div1 = element("div");
+			set_style(div0, "color", /*color*/ ctx[0]);
+			set_style(div0, "transform", "translate(" + /*x*/ ctx[1] + "px," + /*y*/ ctx[2] + "px)");
+			set_style(div1, "color", /*color*/ ctx[0]);
+			set_style(div1, "transform", "translate(" + /*x*/ ctx[1] + "px," + /*y*/ ctx[2] + "px)");
 		},
 		m(target, anchor) {
-			insert(target, div, anchor);
+			insert(target, div0, anchor);
+			insert(target, t, anchor);
+			insert(target, div1, anchor);
 		},
 		p(ctx, [dirty]) {
 			if (dirty & /*color*/ 1) {
-				set_style(div, "color", /*color*/ ctx[0]);
+				set_style(div0, "color", /*color*/ ctx[0]);
 			}
 
 			if (dirty & /*x, y*/ 6) {
-				set_style(div, "transform", "translate(" + /*x*/ ctx[1] + "px," + /*y*/ ctx[2] + "px)");
+				set_style(div0, "transform", "translate(" + /*x*/ ctx[1] + "px," + /*y*/ ctx[2] + "px)");
+			}
+
+			if (dirty & /*color*/ 1) {
+				set_style(div1, "color", /*color*/ ctx[0]);
+			}
+
+			if (dirty & /*x, y*/ 6) {
+				set_style(div1, "transform", "translate(" + /*x*/ ctx[1] + "px," + /*y*/ ctx[2] + "px)");
 			}
 		},
 		i: noop,
 		o: noop,
 		d(detaching) {
-			if (detaching) detach(div);
+			if (detaching) detach(div0);
+			if (detaching) detach(t);
+			if (detaching) detach(div1);
 		}
 	};
 }

--- a/test/js/samples/inline-style-optimized-multiple/input.svelte
+++ b/test/js/samples/inline-style-optimized-multiple/input.svelte
@@ -5,3 +5,4 @@
 </script>
 
 <div style='color: {color}; transform: translate({x}px,{y}px);'></div>
+<div style={`color: ${color}; transform: translate(${x}px,${y}px);`}></div>

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -7,29 +7,43 @@ import {
 	insert,
 	noop,
 	safe_not_equal,
-	set_style
+	set_style,
+	space
 } from "svelte/internal";
 
 function create_fragment(ctx) {
-	let div;
+	let div0;
+	let t;
+	let div1;
 
 	return {
 		c() {
-			div = element("div");
-			set_style(div, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
+			div0 = element("div");
+			t = space();
+			div1 = element("div");
+			set_style(div0, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
+			set_style(div1, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
 		},
 		m(target, anchor) {
-			insert(target, div, anchor);
+			insert(target, div0, anchor);
+			insert(target, t, anchor);
+			insert(target, div1, anchor);
 		},
 		p(ctx, [dirty]) {
 			if (dirty & /*data*/ 1) {
-				set_style(div, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
+				set_style(div0, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
+			}
+
+			if (dirty & /*data*/ 1) {
+				set_style(div1, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
 			}
 		},
 		i: noop,
 		o: noop,
 		d(detaching) {
-			if (detaching) detach(div);
+			if (detaching) detach(div0);
+			if (detaching) detach(t);
+			if (detaching) detach(div1);
 		}
 	};
 }

--- a/test/js/samples/inline-style-optimized-url/input.svelte
+++ b/test/js/samples/inline-style-optimized-url/input.svelte
@@ -3,3 +3,4 @@
 </script>
 
 <div style='background: url(data:image/png;base64,{data})'></div>
+<div style={`background: url(data:image/png;base64,${data})`}></div>

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -7,29 +7,43 @@ import {
 	insert,
 	noop,
 	safe_not_equal,
-	set_style
+	set_style,
+	space
 } from "svelte/internal";
 
 function create_fragment(ctx) {
-	let div;
+	let div0;
+	let t;
+	let div1;
 
 	return {
 		c() {
-			div = element("div");
-			set_style(div, "color", /*color*/ ctx[0]);
+			div0 = element("div");
+			t = space();
+			div1 = element("div");
+			set_style(div0, "color", /*color*/ ctx[0]);
+			set_style(div1, "color", /*color*/ ctx[0]);
 		},
 		m(target, anchor) {
-			insert(target, div, anchor);
+			insert(target, div0, anchor);
+			insert(target, t, anchor);
+			insert(target, div1, anchor);
 		},
 		p(ctx, [dirty]) {
 			if (dirty & /*color*/ 1) {
-				set_style(div, "color", /*color*/ ctx[0]);
+				set_style(div0, "color", /*color*/ ctx[0]);
+			}
+
+			if (dirty & /*color*/ 1) {
+				set_style(div1, "color", /*color*/ ctx[0]);
 			}
 		},
 		i: noop,
 		o: noop,
 		d(detaching) {
-			if (detaching) detach(div);
+			if (detaching) detach(div0);
+			if (detaching) detach(t);
+			if (detaching) detach(div1);
 		}
 	};
 }

--- a/test/js/samples/inline-style-optimized/input.svelte
+++ b/test/js/samples/inline-style-optimized/input.svelte
@@ -3,3 +3,4 @@
 </script>
 
 <div style='color: {color}'></div>
+<div style={`color: ${color}`}></div>


### PR DESCRIPTION
Tangentially related to https://github.com/sveltejs/svelte/issues/5204, i noticed that there's no optimisation for

```svelte
<div style={`color: ${color}`}></div>
```

which should be similar to 

```svelte
<div style='color: {color}'></div>
```

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests with `npm test` or `yarn test`)
