### PR TITLE
fix site broken RSS feed

### DIFF
--- a/site/src/routes/blog/rss.xml.js
+++ b/site/src/routes/blog/rss.xml.js
@@ -8,6 +8,18 @@ function formatPubdate(str) {
 	return `${d} ${months[+m]} ${y} 12:00 +0000`;
 }
 
+function escapeHTML(html) {
+	const chars = {
+		'"' : 'quot',
+		"'": '#39',
+		'&': 'amp',
+		'<' : 'lt',
+		'>' : 'gt'
+	};
+
+	return html.replace(/["'&<>]/g, c => `&${chars[c]};`);
+}
+
 const rss = `
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
@@ -23,9 +35,9 @@ const rss = `
 	</image>
 	${get_posts().filter(post => !post.metadata.draft).map(post => `
 		<item>
-			<title>${post.metadata.title}</title>
+			<title>${escapeHTML(post.metadata.title)}</title>
 			<link>https://svelte.dev/blog/${post.slug}</link>
-			<description>${post.metadata.description}</description>
+			<description>${escapeHTML(post.metadata.description)}</description>
 			<pubDate>${formatPubdate(post.metadata.pubdate)}</pubDate>
 		</item>
 	`).join('')}


### PR DESCRIPTION
Fix #5209  by escaping strings that possibly contain HTML which will break the RSS feed.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
    Currently https://svelte.dev/blog/rss.xml is broken without this fix.
### Tests
-  [x] Run the tests with `npm test` or `yarn test`)
