### PR TITLE
Add type param to setContext and getContext

### DIFF
--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -44,11 +44,11 @@ export function createEventDispatcher() {
 	};
 }
 
-export function setContext(key, context) {
+export function setContext<T>(key, context: T) {
 	get_current_component().$$.context.set(key, context);
 }
 
-export function getContext(key) {
+export function getContext<T>(key): T {
 	return get_current_component().$$.context.get(key);
 }
 


### PR DESCRIPTION
Adds a type parameter to `setContext` and `getContext` to make it easier to type context values.

Given an interface:

```ts
interface ContextValue {
  register: (args: {
    id: number;
    name: string;
    content: string;
    type: string;
  }) => void;
  active: Writable<boolean | number>;
}
```

This becomes possible:

```ts
setContext<ContextValue>(key, {
  register: ({ id, name, content, type }) => {
    files.update((s) => s.set(id, { name, content, type }));
    if (!$active) active.set(id);
  },
  active,
});
```

and this

```ts
const ctx = getContext<ContextValue>(key)
```