### PR TITLE
Mention "import type" in TypeScript FAQ

### DIFF
--- a/site/content/faq/500-what-about-typescript-support.md
+++ b/site/content/faq/500-what-about-typescript-support.md
@@ -11,4 +11,4 @@ let x: number;
 $: x = count + 1;
 ```
 
-Also, to import an interface please use [TypeScript's `import type` syntax](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export).
+To `import` a type or interface make sure to use [TypeScript's `type` modifier](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export):

--- a/site/content/faq/500-what-about-typescript-support.md
+++ b/site/content/faq/500-what-about-typescript-support.md
@@ -12,3 +12,7 @@ $: x = count + 1;
 ```
 
 To `import` a type or interface make sure to use [TypeScript's `type` modifier](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export):
+
+```
+import type { SomeInterface } from './SomeFile';
+```

--- a/site/content/faq/500-what-about-typescript-support.md
+++ b/site/content/faq/500-what-about-typescript-support.md
@@ -10,3 +10,5 @@ To declare the type of a reactive variable in a Svelte template, you should use 
 let x: number;
 $: x = count + 1;
 ```
+
+Also, to import an interface please use [TypeScript's `import type` syntax](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export).

--- a/site/content/faq/500-what-about-typescript-support.md
+++ b/site/content/faq/500-what-about-typescript-support.md
@@ -11,8 +11,10 @@ let x: number;
 $: x = count + 1;
 ```
 
-To `import` a type or interface make sure to use [TypeScript's `type` modifier](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export):
+To import a type or interface make sure to use [TypeScript's `type` modifier](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export):
 
 ```
 import type { SomeInterface } from './SomeFile';
 ```
+
+You must use the `type` modifier because `svelte-preprocess` doesn't know whether an import is a type or a value — it only transpiles one file at a time without knowledge of the other files and therefore can't safely erase imports which only contain types without this modifier present.


### PR DESCRIPTION
This gets asked a lot. I'm not quite sure why Svelte has this additional restriction over normal TypeScript, but it'd be good to mention it up front