### PR TITLE
Typings for createEventDispatcher

### DIFF
--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -27,7 +27,9 @@ export function onDestroy(fn) {
 	get_current_component().$$.on_destroy.push(fn);
 }
 
-export function createEventDispatcher() {
+export function createEventDispatcher<
+	EventMap extends {} = any
+>(): <EventKey extends Extract<keyof EventMap, string>>(type: EventKey, detail?: EventMap[EventKey]) => void {
 	const component = get_current_component();
 
 	return (type: string, detail?: any) => {


### PR DESCRIPTION
Makes it possible to explicitly type which events can be dispatched like so:

```ts
const bla2 = createEventDispatcher<{click: boolean}>();
bla2('click', ''); // error, type string not assignable to type boolean
bla2('qwd', true); // error, "qwd" not assignable to "click"
```

#5211