### PR TITLE
fix lint warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,8 +144,8 @@
       }
     },
     "@sveltejs/eslint-config": {
-      "version": "github:sveltejs/eslint-config#e8a9b27cd3f7aa66388474412b1a5c11c5a44ade",
-      "from": "github:sveltejs/eslint-config#v0.0.1",
+      "version": "github:sveltejs/eslint-config#848ce6464a9ae9c2f3a3095474701dfe9ab851df",
+      "from": "github:sveltejs/eslint-config#v5.0.0",
       "dev": true
     },
     "@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@rollup/plugin-sucrase": "^3.0.0",
     "@rollup/plugin-typescript": "^2.0.1",
     "@rollup/plugin-virtual": "^2.0.0",
-    "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v0.0.1",
+    "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.0.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^8.10.53",
     "@typescript-eslint/eslint-plugin": "^3.0.2",

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -8,7 +8,7 @@ import {
 	create_scopes,
 	extract_names,
 	Scope,
-	extract_identifiers,
+	extract_identifiers
 } from './utils/scope';
 import Stylesheet from './css/Stylesheet';
 import { test } from '../config';
@@ -155,7 +155,7 @@ export default class Component {
 				) || { start: 0, end: 0 };
 				this.warn(svelteOptions, {
 					code: 'custom-element-no-tag',
-					message: `No custom element 'tag' option was specified. To automatically register a custom element, specify a name with a hyphen in it, e.g. <svelte:options tag="my-thing"/>. To hide this warning, use <svelte:options tag={null}/>`,
+					message: `No custom element 'tag' option was specified. To automatically register a custom element, specify a name with a hyphen in it, e.g. <svelte:options tag="my-thing"/>. To hide this warning, use <svelte:options tag={null}/>`
 				});
 			}
 			this.tag = this.component_options.tag || compile_options.tag;
@@ -190,7 +190,7 @@ export default class Component {
 			this.add_var({
 				name,
 				injected: true,
-				referenced: true,
+				referenced: true
 			});
 		} else if (name[0] === '$') {
 			this.add_var({
@@ -198,7 +198,7 @@ export default class Component {
 				injected: true,
 				referenced: true,
 				mutated: true,
-				writable: true,
+				writable: true
 			});
 
 			const subscribable_name = name.slice(1);
@@ -289,7 +289,7 @@ export default class Component {
 			}
 			const imported_helpers = Array.from(this.helpers, ([name, alias]) => ({
 				name,
-				alias,
+				alias
 			}));
 
 			create_module(
@@ -305,7 +305,7 @@ export default class Component {
 					.filter(variable => variable.module && variable.export_name)
 					.map(variable => ({
 						name: variable.name,
-						as: variable.export_name,
+						as: variable.export_name
 					}))
 			);
 
@@ -342,9 +342,9 @@ export default class Component {
 					reassigned: v.reassigned || false,
 					referenced: v.referenced || false,
 					writable: v.writable || false,
-					referenced_from_script: v.referenced_from_script || false,
+					referenced_from_script: v.referenced_from_script || false
 				})),
-			stats: this.stats.render(),
+			stats: this.stats.render()
 		};
 	}
 
@@ -409,7 +409,7 @@ export default class Component {
 			source: this.source,
 			start: pos.start,
 			end: pos.end,
-			filename: this.compile_options.filename,
+			filename: this.compile_options.filename
 		});
 	}
 
@@ -441,7 +441,7 @@ export default class Component {
 			pos: pos.start,
 			filename: this.compile_options.filename,
 			toString: () =>
-				`${warning.message} (${start.line}:${start.column})\n${frame}`,
+				`${warning.message} (${start.line}:${start.column})\n${frame}`
 		});
 	}
 
@@ -453,7 +453,7 @@ export default class Component {
 		if (node.type === 'ExportDefaultDeclaration') {
 			this.error(node, {
 				code: `default-export`,
-				message: `A component cannot have a default export`,
+				message: `A component cannot have a default export`
 			});
 		}
 
@@ -461,7 +461,7 @@ export default class Component {
 			if (node.source) {
 				this.error(node, {
 					code: `not-implemented`,
-					message: `A component currently cannot have an export ... from`,
+					message: `A component currently cannot have an export ... from`
 				});
 			}
 			if (node.declaration) {
@@ -531,10 +531,10 @@ export default class Component {
 				if (node.type === 'LabeledStatement' && node.label.name === '$') {
 					component.warn(node as any, {
 						code: 'module-script-reactive-declaration',
-						message: '$: has no effect in a module script',
+						message: '$: has no effect in a module script'
 					});
 				}
-			},
+			}
 		});
 
 		const { scope, globals } = create_scopes(script.content);
@@ -544,7 +544,7 @@ export default class Component {
 			if (name[0] === '$') {
 				this.error(node as any, {
 					code: 'illegal-declaration',
-					message: `The $ prefix is reserved, and cannot be used for variable and import names`,
+					message: `The $ prefix is reserved, and cannot be used for variable and import names`
 				});
 			}
 
@@ -562,7 +562,7 @@ export default class Component {
 			if (name[0] === '$') {
 				this.error(node as any, {
 					code: 'illegal-subscription',
-					message: `Cannot reference store value inside <script context="module">`,
+					message: `Cannot reference store value inside <script context="module">`
 				});
 			} else {
 				this.add_var({
@@ -623,7 +623,7 @@ export default class Component {
 			if (name[0] === '$') {
 				this.error(node as any, {
 					code: 'illegal-declaration',
-					message: `The $ prefix is reserved, and cannot be used for variable and import names`,
+					message: `The $ prefix is reserved, and cannot be used for variable and import names`
 				});
 			}
 
@@ -647,12 +647,12 @@ export default class Component {
 					injected: true,
 					writable: true,
 					reassigned: true,
-					initialised: true,
+					initialised: true
 				});
 			} else if (is_reserved_keyword(name)) {
 				this.add_var({
 					name,
-					injected: true,
+					injected: true
 				});
 			} else if (name[0] === '$') {
 				if (name === '$' || name[1] === '$') {
@@ -666,7 +666,7 @@ export default class Component {
 					name,
 					injected: true,
 					mutated: true,
-					writable: true,
+					writable: true
 				});
 
 				this.add_reference(name.slice(1));
@@ -764,7 +764,7 @@ export default class Component {
 				if (map.has(node)) {
 					scope = scope.parent;
 				}
-			},
+			}
 		});
 
 		for (const [parent, prop, index] of to_remove) {
@@ -832,7 +832,7 @@ export default class Component {
 				if (map.has(node)) {
 					scope = scope.parent;
 				}
-			},
+			}
 		});
 	}
 
@@ -844,7 +844,7 @@ export default class Component {
 		) {
 			this.warn(node as any, {
 				code: 'non-top-level-reactive-declaration',
-				message: '$: has no effect outside of the top-level',
+				message: '$: has no effect outside of the top-level'
 			});
 		}
 
@@ -881,7 +881,7 @@ export default class Component {
 			if (node.body.type !== 'BlockStatement') {
 				node.body = {
 					type: 'BlockStatement',
-					body: [node.body],
+					body: [node.body]
 				};
 			}
 			node.body.body.push(inside[0]);
@@ -890,8 +890,8 @@ export default class Component {
 				type: 'BlockStatement',
 				body: [
 					before[0],
-					node,
-				],
+					node
+				]
 			};
 		}
 		return null;
@@ -927,7 +927,7 @@ export default class Component {
 										// TODO is this still true post-#3539?
 										component.error(declarator as any, {
 											code: 'destructured-prop',
-											message: `Cannot declare props in destructured declaration`,
+											message: `Cannot declare props in destructured declaration`
 										});
 									}
 
@@ -990,7 +990,7 @@ export default class Component {
 				if (node.type === 'ExportNamedDeclaration' && node.declaration) {
 					(parent as Program).body[index] = node.declaration;
 				}
-			},
+			}
 		});
 	}
 
@@ -1004,7 +1004,7 @@ export default class Component {
 			hoistable_nodes,
 			var_lookup,
 			injected_reactive_declaration_vars,
-			imports,
+			imports
 		} = this;
 
 		const top_level_function_declarations = new Map();
@@ -1136,7 +1136,7 @@ export default class Component {
 					if (map.has(node)) {
 						scope = scope.parent;
 					}
-				},
+				}
 			});
 
 			checked.add(fn_declaration);
@@ -1229,7 +1229,7 @@ export default class Component {
 						if (map.has(node)) {
 							scope = scope.parent;
 						}
-					},
+					}
 				});
 
 				const { expression } = node.body as ExpressionStatement;
@@ -1239,7 +1239,7 @@ export default class Component {
 					assignees,
 					dependencies,
 					node,
-					declaration,
+					declaration
 				});
 			}
 		});
@@ -1320,7 +1320,7 @@ export default class Component {
 
 		this.warn(node, {
 			code: 'missing-declaration',
-			message,
+			message
 		});
 	}
 
@@ -1343,7 +1343,7 @@ function process_component_options(component: Component, nodes) {
 			'accessors' in component.compile_options
 				? component.compile_options.accessors
 				: !!component.compile_options.customElement,
-		preserveWhitespace: !!component.compile_options.preserveWhitespace,
+		preserveWhitespace: !!component.compile_options.preserveWhitespace
 	};
 
 	const node = nodes.find(node => node.name === 'svelte:options');
@@ -1384,7 +1384,7 @@ function process_component_options(component: Component, nodes) {
 						if (tag && !/^[a-zA-Z][a-zA-Z0-9]*-[a-zA-Z0-9-]+$/.test(tag)) {
 							component.error(attribute, {
 								code: `invalid-tag-property`,
-								message: `tag name must be two or more words joined by the '-' character`,
+								message: `tag name must be two or more words joined by the '-' character`
 							});
 						}
 
@@ -1412,12 +1412,12 @@ function process_component_options(component: Component, nodes) {
 							if (match) {
 								component.error(attribute, {
 									code: `invalid-namespace-property`,
-									message: `Invalid namespace '${ns}' (did you mean '${match}'?)`,
+									message: `Invalid namespace '${ns}' (did you mean '${match}'?)`
 								});
 							} else {
 								component.error(attribute, {
 									code: `invalid-namespace-property`,
-									message: `Invalid namespace '${ns}'`,
+									message: `Invalid namespace '${ns}'`
 								});
 							}
 						}
@@ -1443,13 +1443,13 @@ function process_component_options(component: Component, nodes) {
 					default:
 						component.error(attribute, {
 							code: `invalid-options-attribute`,
-							message: `<svelte:options> unknown attribute`,
+							message: `<svelte:options> unknown attribute`
 						});
 				}
 			} else {
 				component.error(attribute, {
 					code: `invalid-options-attribute`,
-					message: `<svelte:options> can only have static 'tag', 'namespace', 'accessors', 'immutable' and 'preserveWhitespace' attributes`,
+					message: `<svelte:options> can only have static 'tag', 'namespace', 'accessors', 'immutable' and 'preserveWhitespace' attributes`
 				});
 			}
 		});

--- a/src/compiler/compile/index.ts
+++ b/src/compiler/compile/index.ts
@@ -52,7 +52,7 @@ function validate_options(options: CompileOptions, warnings: Warning[]) {
 			code: `options-lowercase-name`,
 			message,
 			filename,
-			toString: () => message,
+			toString: () => message
 		});
 	}
 
@@ -62,7 +62,7 @@ function validate_options(options: CompileOptions, warnings: Warning[]) {
 			code: `options-loop-guard-timeout`,
 			message,
 			filename,
-			toString: () => message,
+			toString: () => message
 		});
 	}
 }

--- a/src/compiler/compile/nodes/Binding.ts
+++ b/src/compiler/compile/nodes/Binding.ts
@@ -76,7 +76,7 @@ export default class Binding extends Node {
 
 			if (info.expression.type === 'Identifier' && !variable.writable) component.error(this.expression.node, {
 				code: 'invalid-binding',
-				message: 'Cannot bind to a variable which is not writable',
+				message: 'Cannot bind to a variable which is not writable'
 			});
 		}
 

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -399,7 +399,7 @@ export default class Element extends Node {
 			if (/(^[0-9-.])|[\^$@%&#?!|()[\]{}^*+~;]/.test(name)) {
 				component.error(attribute, {
 					code: `illegal-attribute`,
-					message: `'${name}' is not a valid attribute name`,
+					message: `'${name}' is not a valid attribute name`
 				});
 			}
 
@@ -423,7 +423,7 @@ export default class Element extends Node {
 				if (!(parent.type === 'InlineComponent' || within_custom_element(parent))) {
 					component.error(attribute, {
 						code: `invalid-slotted-content`,
-						message: `Element with a slot='...' attribute must be a child of a component or a descendant of a custom element`,
+						message: `Element with a slot='...' attribute must be a child of a component or a descendant of a custom element`
 					});
 				}
 			}

--- a/src/compiler/compile/nodes/Text.ts
+++ b/src/compiler/compile/nodes/Text.ts
@@ -12,7 +12,7 @@ const elements_without_text = new Set([
 	'dl',
 	'optgroup',
 	'select',
-	'video',
+	'video'
 ]);
 
 export default class Text extends Node {

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -106,7 +106,7 @@ export default class Block {
 			intro: [],
 			update: [],
 			outro: [],
-			destroy: [],
+			destroy: []
 		};
 
 		this.has_animation = false;

--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -76,7 +76,7 @@ export default class Renderer {
 
 			bindings: new Map(),
 
-			dependencies: new Set(),
+			dependencies: new Set()
 		});
 
 		this.block.has_update_method = true;

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -307,8 +307,8 @@ const attribute_lookup = {
 			'optgroup',
 			'option',
 			'select',
-			'textarea',
-		],
+			'textarea'
+		]
 	},
 	formnovalidate: { property_name: 'formNoValidate', applies_to: ['button', 'input'] },
 	hidden: {},
@@ -335,9 +335,9 @@ const attribute_lookup = {
 			'progress',
 			'param',
 			'select',
-			'textarea',
-		],
-	},
+			'textarea'
+		]
+	}
 };
 
 Object.keys(attribute_lookup).forEach(name => {

--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -302,7 +302,7 @@ function get_binding_group(renderer: Renderer, value: Binding, block: Block) {
 			},
 			is_context: contexts.length > 0,
 			contexts,
-			index,
+			index
 		});
 	}
 
@@ -355,7 +355,7 @@ function get_event_handler(
 		uses_context: binding.node.is_contextual || binding.node.expression.uses_context, // TODO this is messy
 		mutation,
 		contextual_dependencies,
-		lhs,
+		lhs
 	};
 }
 

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -132,7 +132,7 @@ const events = [
 		event_names: ['toggle'],
 		filter: (node: Element, _name: string) =>
 			node.name === 'details'
-	},
+	}
 ];
 
 export default class ElementWrapper extends Wrapper {

--- a/src/compiler/compile/render_dom/wrappers/IfBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/IfBlock.ts
@@ -603,7 +603,7 @@ export default class IfBlockWrapper extends Wrapper {
 			// as -1
 			operator: val.operator,
 			prefix: val.prefix,
-			argument: val.argument,
+			argument: val.argument
 		};
 	}
 }

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -112,7 +112,7 @@ export default class InlineComponentWrapper extends Wrapper {
 		if (variable.reassigned || variable.export_name || variable.is_reactive_dependency) {
 			this.renderer.component.warn(this.node, {
 				code: 'reactive-component',
-				message: `<${name}/> will not be reactive if ${name} changes. Use <svelte:component this={${name}}/> if you want this reactivity.`,
+				message: `<${name}/> will not be reactive if ${name} changes. Use <svelte:component this={${name}}/> if you want this reactivity.`
 			});
 		}
 	}

--- a/src/compiler/compile/render_dom/wrappers/Window.ts
+++ b/src/compiler/compile/render_dom/wrappers/Window.ts
@@ -16,7 +16,7 @@ const associated_events = {
 	outerHeight: 'resize',
 
 	scrollX: 'scroll',
-	scrollY: 'scroll',
+	scrollY: 'scroll'
 };
 
 const properties = {
@@ -29,7 +29,7 @@ const readonly = new Set([
 	'innerHeight',
 	'outerWidth',
 	'outerHeight',
-	'online',
+	'online'
 ]);
 
 export default class WindowWrapper extends Wrapper {

--- a/src/compiler/compile/render_dom/wrappers/shared/get_slot_definition.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/get_slot_definition.ts
@@ -34,13 +34,13 @@ export function get_slot_definition(block: Block, scope: TemplateScope, lets: Le
 			type: 'Property',
 			kind: 'init',
 			key: l.name,
-			value,
+			value
 		});
 	});
 
 	const changes_input = {
 		type: 'ObjectPattern',
-		properties,
+		properties
 	};
 
 	const names: Set<string> = new Set();

--- a/src/compiler/compile/utils/string_to_member_expression.ts
+++ b/src/compiler/compile/utils/string_to_member_expression.ts
@@ -4,13 +4,13 @@ export function string_to_member_expression(name: string) {
 	const parts = name.split(".");
 	let node: MemberExpression | Identifier = {
 		type: "Identifier",
-		name: parts[0],
+		name: parts[0]
 	};
 	for (let i = 1; i < parts.length; i++) {
 		node = {
 			type: "MemberExpression",
 			object: node,
-			property: { type: "Identifier", name: parts[i] },
+			property: { type: "Identifier", name: parts[i] }
 		} as MemberExpression;
 	}
 	return node;

--- a/src/compiler/compile/utils/stringify.ts
+++ b/src/compiler/compile/utils/stringify.ts
@@ -16,7 +16,7 @@ const escaped = {
   "'": '&#39;',
 	'&': '&amp;',
 	'<': '&lt;',
-	'>': '&gt;',
+	'>': '&gt;'
 };
 
 export function escape_html(html) {

--- a/src/compiler/parse/index.ts
+++ b/src/compiler/parse/index.ts
@@ -41,7 +41,7 @@ export class Parser {
 			start: null,
 			end: null,
 			type: 'Fragment',
-			children: [],
+			children: []
 		};
 
 		this.stack.push(this.html);

--- a/src/compiler/parse/read/script.ts
+++ b/src/compiler/parse/read/script.ts
@@ -57,6 +57,6 @@ export default function read_script(parser: Parser, start: number, attributes: N
 		start,
 		end: parser.index,
 		context: get_context(parser, attributes, start),
-		content: ast,
+		content: ast
 	};
 }

--- a/src/compiler/parse/read/style.ts
+++ b/src/compiler/parse/read/style.ts
@@ -14,7 +14,7 @@ export default function read_style(parser: Parser, start: number, attributes: No
 	try {
 		ast = parse(styles, {
 			positions: true,
-			offset: content_start,
+			offset: content_start
 		});
 	} catch (err) {
 		if (err.name === 'CssSyntaxError') {

--- a/src/compiler/parse/state/mustache.ts
+++ b/src/compiler/parse/state/mustache.ts
@@ -134,9 +134,9 @@ export default function mustache(parser: Parser) {
 						type: 'IfBlock',
 						elseif: true,
 						expression,
-						children: [],
-					},
-				],
+						children: []
+					}
+				]
 			};
 
 			parser.stack.push(block.else.children[0]);
@@ -161,7 +161,7 @@ export default function mustache(parser: Parser) {
 				start: parser.index,
 				end: null,
 				type: 'ElseBlock',
-				children: [],
+				children: []
 			};
 
 			parser.stack.push(block.else);
@@ -260,14 +260,14 @@ export default function mustache(parser: Parser) {
 					type: 'CatchBlock',
 					children: [],
 					skip: true
-				},
+				}
 			} :
 			{
 				start,
 				end: null,
 				type,
 				expression,
-				children: [],
+				children: []
 			};
 
 		parser.allow_whitespace();
@@ -350,7 +350,7 @@ export default function mustache(parser: Parser) {
 			start,
 			end: parser.index,
 			type: 'RawMustacheTag',
-			expression,
+			expression
 		});
 	} else if (parser.eat('@debug')) {
 		let identifiers;
@@ -394,7 +394,7 @@ export default function mustache(parser: Parser) {
 			start,
 			end: parser.index,
 			type: 'MustacheTag',
-			expression,
+			expression
 		});
 	}
 }

--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -25,16 +25,16 @@ const specials = new Map([
 		'script',
 		{
 			read: read_script,
-			property: 'js',
-		},
+			property: 'js'
+		}
 	],
 	[
 		'style',
 		{
 			read: read_style,
-			property: 'css',
-		},
-	],
+			property: 'css'
+		}
+	]
 ]);
 
 const SELF = /^svelte:self(?=[\s/>])/;
@@ -63,7 +63,7 @@ export default function tag(parser: Parser) {
 			start,
 			end: parser.index,
 			type: 'Comment',
-			data,
+			data
 		});
 
 		return;
@@ -116,7 +116,7 @@ export default function tag(parser: Parser) {
 		type,
 		name,
 		attributes: [],
-		children: [],
+		children: []
 	};
 
 	parser.allow_whitespace();
@@ -163,7 +163,7 @@ export default function tag(parser: Parser) {
 		parser.last_auto_closed_tag = {
 			tag: parent.name,
 			reason: name,
-			depth: parser.stack.length,
+			depth: parser.stack.length
 		};
 	}
 
@@ -437,7 +437,7 @@ function read_attribute(parser: Parser, unique_names: Set<string>) {
 		end,
 		type: 'Attribute',
 		name,
-		value,
+		value
 	};
 }
 
@@ -504,7 +504,7 @@ function read_sequence(parser: Parser, done: () => boolean): TemplateNode[] {
 				start: index,
 				end: parser.index,
 				type: 'MustacheTag',
-				expression,
+				expression
 			});
 
 			current_chunk = {

--- a/src/compiler/parse/state/text.ts
+++ b/src/compiler/parse/state/text.ts
@@ -19,7 +19,7 @@ export default function text(parser: Parser) {
 		end: parser.index,
 		type: 'Text',
 		raw: data,
-		data: decode_character_references(data),
+		data: decode_character_references(data)
 	};
 
 	parser.current().children.push(node);

--- a/src/compiler/parse/utils/entities.ts
+++ b/src/compiler/parse/utils/entities.ts
@@ -2030,5 +2030,5 @@ export default {
 	sc: 8827,
 	wp: 8472,
 	wr: 8768,
-	xi: 958,
+	xi: 958
 };

--- a/src/compiler/parse/utils/html.ts
+++ b/src/compiler/parse/utils/html.ts
@@ -32,7 +32,7 @@ const windows_1252 = [
 	339,
 	157,
 	382,
-	376,
+	376
 ];
 
 const entity_pattern = new RegExp(
@@ -124,7 +124,7 @@ const disallowed_contents = new Map([
 			'address article aside blockquote div dl fieldset footer form h1 h2 h3 h4 h5 h6 header hgroup hr main menu nav ol p pre section table ul'.split(
 				' '
 			)
-		),
+		)
 	],
 	['rt', new Set(['rt', 'rp'])],
 	['rp', new Set(['rt', 'rp'])],
@@ -135,7 +135,7 @@ const disallowed_contents = new Map([
 	['tfoot', new Set(['tbody'])],
 	['tr', new Set(['tr', 'tbody'])],
 	['td', new Set(['td', 'th', 'tr'])],
-	['th', new Set(['td', 'th', 'tr'])],
+	['th', new Set(['td', 'th', 'tr'])]
 ]);
 
 // can this be a child of the parent element, or does it implicitly

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -49,7 +49,7 @@ async function replace_async(str: string, re: RegExp, func: (...any) => Promise<
 					({
 						offset: args[args.length - 2],
 						length: args[0].length,
-						replacement: res,
+						replacement: res
 					}) as Replacement
 			)
 		);

--- a/src/compiler/utils/fuzzymatch.ts
+++ b/src/compiler/utils/fuzzymatch.ts
@@ -206,7 +206,7 @@ class FuzzySet {
 			match_score = matches[match_index];
 			results.push([
 				match_score / (vector_normal * items[match_index][0]),
-				items[match_index][1],
+				items[match_index][1]
 			]);
 		}
 
@@ -218,7 +218,7 @@ class FuzzySet {
 		for (let i = 0; i < end_index; ++i) {
 			new_results.push([
 				_distance(results[i][1], normalized_value),
-				results[i][1],
+				results[i][1]
 			]);
 		}
 		results = new_results;

--- a/src/compiler/utils/names.ts
+++ b/src/compiler/utils/names.ts
@@ -105,7 +105,7 @@ export const reserved = new Set([
 	'void',
 	'while',
 	'with',
-	'yield',
+	'yield'
 ]);
 
 const void_element_names = /^(?:area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/;

--- a/src/compiler/utils/namespaces.ts
+++ b/src/compiler/utils/namespaces.ts
@@ -17,7 +17,7 @@ export const valid_namespaces = [
 	svg,
 	xlink,
 	xml,
-	xmlns,
+	xmlns
 ];
 
 export const namespaces: Record<string, string> = { html, mathml, svg, xlink, xml, xmlns };

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -52,7 +52,7 @@ const subscriber_queue = [];
  */
 export function readable<T>(value: T, start: StartStopNotifier<T>): Readable<T> {
 	return {
-		subscribe: writable(value, start).subscribe,
+		subscribe: writable(value, start).subscribe
 	};
 }
 
@@ -184,7 +184,7 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 			},
 			() => {
 				pending |= (1 << i);
-			}),
+			})
 		);
 
 		inited = true;

--- a/test/css/samples/unused-selector-string-concat/_config.js
+++ b/test/css/samples/unused-selector-string-concat/_config.js
@@ -12,7 +12,7 @@ export default {
 				13:   .foocc {color: red;}`,
 			start: { line: 11, column: 2, character: 206 },
 			end: { line: 11, column: 8, character: 212 },
-			pos: 206,
+			pos: 206
 		},
 		{
 			code: 'css-unused-selector',
@@ -26,7 +26,7 @@ export default {
 				14:   .foodd {color: red;}`,
 			start: { line: 12, column: 2, character: 229 },
 			end: { line: 12, column: 8, character: 235 },
-			pos: 229,
+			pos: 229
 		},
 		{
 			code: 'css-unused-selector',
@@ -40,7 +40,7 @@ export default {
 				16:   .bb {color: red;}`,
 			start: { line: 14, column: 2, character: 275 },
 			end: { line: 14, column: 8, character: 281 },
-			pos: 275,
+			pos: 275
 		},
 		{
 			code: 'css-unused-selector',
@@ -54,7 +54,7 @@ export default {
 				22:   .ddbar {color: red;}`,
 			start: { line: 20, column: 2, character: 401 },
 			end: { line: 20, column: 8, character: 407 },
-			pos: 401,
+			pos: 401
 		},
 		{
 			code: 'css-unused-selector',
@@ -68,7 +68,7 @@ export default {
 				23:   .fooaabar {color: red;}`,
 			start: { line: 21, column: 2, character: 424 },
 			end: { line: 21, column: 8, character: 430 },
-			pos: 424,
+			pos: 424
 		},
 		{
 			code: 'css-unused-selector',
@@ -82,7 +82,7 @@ export default {
 				24:   .foobbbar {color: red;}`,
 			start: { line: 22, column: 2, character: 447 },
 			end: { line: 22, column: 8, character: 453 },
-			pos: 447,
+			pos: 447
 		},
 		{
 			code: 'css-unused-selector',
@@ -96,7 +96,7 @@ export default {
 				25:   .fooccbar {color: red;}`,
 			start: { line: 23, column: 2, character: 470 },
 			end: { line: 23, column: 11, character: 479 },
-			pos: 470,
+			pos: 470
 		},
 		{
 			code: 'css-unused-selector',
@@ -110,7 +110,7 @@ export default {
 				26:   .fooddbar {color: red;}`,
 			start: { line: 24, column: 2, character: 496 },
 			end: { line: 24, column: 11, character: 505 },
-			pos: 496,
+			pos: 496
 		},
 		{
 			code: 'css-unused-selector',
@@ -124,7 +124,7 @@ export default {
 				27:   .baz {color: red;}`,
 			start: { line: 25, column: 2, character: 522 },
 			end: { line: 25, column: 11, character: 531 },
-			pos: 522,
+			pos: 522
 		},
 		{
 			code: 'css-unused-selector',
@@ -137,7 +137,7 @@ export default {
 				29: </style>`,
 			start: { line: 28, column: 2, character: 595 },
 			end: { line: 28, column: 9, character: 602 },
-			pos: 595,
-		},
-	],
+			pos: 595
+		}
+	]
 };

--- a/test/css/samples/unused-selector-ternary-bailed/_config.js
+++ b/test/css/samples/unused-selector-ternary-bailed/_config.js
@@ -1,3 +1,3 @@
 export default {
-	warnings: [],
+	warnings: []
 };

--- a/test/css/samples/unused-selector-ternary-concat/_config.js
+++ b/test/css/samples/unused-selector-ternary-concat/_config.js
@@ -5,7 +5,7 @@ export default {
 			end: {
 				character: 205,
 				column: 9,
-				line: 14,
+				line: 14
 			},
 			frame: `
 				12:   .thing.active {color: blue;}
@@ -18,8 +18,8 @@ export default {
 			start: {
 				character: 198,
 				column: 2,
-				line: 14,
-			},
-		},
-	],
+				line: 14
+			}
+		}
+	]
 };

--- a/test/css/samples/unused-selector-ternary-nested/_config.js
+++ b/test/css/samples/unused-selector-ternary-nested/_config.js
@@ -12,7 +12,7 @@ export default {
 				17:   .unused {color: blue;}`,
 			start: { line: 15, column: 2, character: 261 },
 			end: { line: 15, column: 15, character: 274 },
-			pos: 261,
+			pos: 261
 		},
 		{
 			code: 'css-unused-selector',
@@ -25,7 +25,7 @@ export default {
 				18: </style>`,
 			start: { line: 17, column: 2, character: 295 },
 			end: { line: 17, column: 9, character: 302 },
-			pos: 295,
-		},
-	],
+			pos: 295
+		}
+	]
 };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -153,6 +153,7 @@ export function normalizeHtml(window, html) {
 export function setupHtmlEqual() {
 	const window = env();
 
+	// eslint-disable-next-line no-import-assign
 	assert.htmlEqual = (actual, expected, message) => {
 		assert.deepEqual(
 			normalizeHtml(window, actual),

--- a/test/hydration/samples/dynamic-text-nil/_config.js
+++ b/test/hydration/samples/dynamic-text-nil/_config.js
@@ -7,7 +7,7 @@ export default {
 
 		return {
 			nullText,
-			undefinedText,
+			undefinedText
 		};
 	},
 
@@ -17,5 +17,5 @@ export default {
 
 		assert.equal(nullText, snapshot.nullText);
 		assert.equal(undefinedText, snapshot.undefinedText);
-	},
+	}
 };

--- a/test/hydration/samples/element-ref/_config.js
+++ b/test/hydration/samples/element-ref/_config.js
@@ -3,7 +3,7 @@ export default {
 		const h1 = target.querySelector('h1');
 
 		return {
-			h1,
+			h1
 		};
 	},
 

--- a/test/js/samples/loop-protect/_config.js
+++ b/test/js/samples/loop-protect/_config.js
@@ -1,6 +1,6 @@
 export default {
 	options: {
 		dev: true,
-		loopGuardTimeout: 100,
-	},
+		loopGuardTimeout: 100
+	}
 };

--- a/test/preprocess/samples/comments/_config.js
+++ b/test/preprocess/samples/comments/_config.js
@@ -2,7 +2,7 @@ export default {
 	preprocess: [
 		{
 			script: ({ content }) => ({ code: content.replace(/one/g, 'two') }),
-			style: ({ content }) => ({ code: content.replace(/one/g, 'three') }),
-		},
-	],
+			style: ({ content }) => ({ code: content.replace(/one/g, 'three') })
+		}
+	]
 };

--- a/test/runtime/samples/$$rest-without-props/_config.js
+++ b/test/runtime/samples/$$rest-without-props/_config.js
@@ -11,7 +11,7 @@ export default {
 		<div d="4" e="5" foo="1"></div>
 		<button></button><button></button><button></button><button></button>
 	`,
-	async test({ assert, target, window, }) {
+	async test({ assert, target, window }) {
 		const [btn1, btn2, btn3, btn4] = target.querySelectorAll('button');
 		const clickEvent = new window.MouseEvent('click');
 

--- a/test/runtime/samples/$$rest/_config.js
+++ b/test/runtime/samples/$$rest/_config.js
@@ -13,7 +13,7 @@ export default {
 		<button></button><button></button><button></button><button></button>
 	`,
 
-	async test({ assert, target, window, }) {
+	async test({ assert, target, window }) {
 		const [btn1, btn2, btn3, btn4] = target.querySelectorAll('button');
 		const clickEvent = new window.MouseEvent('click');
 

--- a/test/runtime/samples/action-custom-event-handler-this/_config.js
+++ b/test/runtime/samples/action-custom-event-handler-this/_config.js
@@ -18,5 +18,5 @@ export default {
 		input.dispatchEvent(event);
 
 		assert.ok(blurred);
-	},
+	}
 };

--- a/test/runtime/samples/action-ternary-template/_config.js
+++ b/test/runtime/samples/action-ternary-template/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		target: 'World!',
-		display: true,
+		display: true
 	},
 
 	html: `
@@ -16,5 +16,5 @@ export default {
 		assert.htmlEqual(target.innerHTML, `
 			<h1>Hello World!</h1>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/action-this/_config.js
+++ b/test/runtime/samples/action-this/_config.js
@@ -7,5 +7,5 @@ export default {
 		await button.dispatchEvent(click);
 		await Promise.resolve();
 		assert.htmlEqual(target.innerHTML, `<button>2</button>`);
-	},
+	}
 };

--- a/test/runtime/samples/apply-directives-in-order-2/_config.js
+++ b/test/runtime/samples/apply-directives-in-order-2/_config.js
@@ -1,7 +1,7 @@
 const value = [];
 export default {
 	props: {
-		value,
+		value
 	},
 
 	async test({ assert, component, target, window }) {
@@ -32,7 +32,7 @@ export default {
 			'15',
 			'16',
 			'17',
-			'18',
+			'18'
 		]);
-	},
+	}
 };

--- a/test/runtime/samples/apply-directives-in-order/_config.js
+++ b/test/runtime/samples/apply-directives-in-order/_config.js
@@ -33,5 +33,5 @@ export default {
 			<input>
 			<p>HE</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/attribute-boolean-false/_config.js
+++ b/test/runtime/samples/attribute-boolean-false/_config.js
@@ -3,5 +3,5 @@ export default {
 	test({ assert, component, target }) {
 		const textarea = target.querySelector('textarea');
 		assert.ok(textarea.readOnly === false);
-	},
+	}
 };

--- a/test/runtime/samples/attribute-boolean-true/_config.js
+++ b/test/runtime/samples/attribute-boolean-true/_config.js
@@ -3,5 +3,5 @@ export default {
 	test({ assert, component, target }) {
 		const textarea = target.querySelector('textarea');
 		assert.ok(textarea.readOnly);
-	},
+	}
 };

--- a/test/runtime/samples/attribute-dataset-without-value/_config.js
+++ b/test/runtime/samples/attribute-dataset-without-value/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: '<div data-potato=""></div>',
+	html: '<div data-potato=""></div>'
 };

--- a/test/runtime/samples/attribute-dynamic-no-dependencies/_config.js
+++ b/test/runtime/samples/attribute-dynamic-no-dependencies/_config.js
@@ -1,5 +1,5 @@
 export default {
 	html: `
 		<div><div title='foo'>bar</div></div>
-	`,
+	`
 };

--- a/test/runtime/samples/attribute-false/_config.js
+++ b/test/runtime/samples/attribute-false/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: `<div class="false"></div>`,
+	html: `<div class="false"></div>`
 };

--- a/test/runtime/samples/attribute-null-classnames-no-style/_config.js
+++ b/test/runtime/samples/attribute-null-classnames-no-style/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		testName1: "test1",
-		testName2: "test2",
+		testName2: "test2"
 	},
 
 	html: `<div class="test1test2"></div>`,

--- a/test/runtime/samples/attribute-null-classnames-with-style/_config.js
+++ b/test/runtime/samples/attribute-null-classnames-with-style/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		testName1: "test1",
-		testName2: "test2",
+		testName2: "test2"
 	},
 
 	html: `<div class="test1test2 svelte-x1o6ra"></div>`,

--- a/test/runtime/samples/attribute-null-func-classnames-no-style/_config.js
+++ b/test/runtime/samples/attribute-null-func-classnames-no-style/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		testName1: "test1",
-		testName2: "test2",
+		testName2: "test2"
 	},
 
 	html: `<div class="test1test2"></div>`,

--- a/test/runtime/samples/attribute-null-func-classnames-with-style/_config.js
+++ b/test/runtime/samples/attribute-null-func-classnames-with-style/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		testName1: "test1",
-		testName2: "test2",
+		testName2: "test2"
 	},
 
 	html: `<div class="test1test2 svelte-x1o6ra"></div>`,

--- a/test/runtime/samples/attribute-null/_config.js
+++ b/test/runtime/samples/attribute-null/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: `<div></div>`,
+	html: `<div></div>`
 };

--- a/test/runtime/samples/attribute-prefer-expression/_config.js
+++ b/test/runtime/samples/attribute-prefer-expression/_config.js
@@ -2,7 +2,7 @@ export default {
 	skip_if_ssr: true,
 
 	props: {
-		foo: false,
+		foo: false
 	},
 
 	test({ assert, component, target }) {
@@ -15,5 +15,5 @@ export default {
 
 		assert.ok(!inputs[0].checked);
 		assert.ok(inputs[1].checked);
-	},
+	}
 };

--- a/test/runtime/samples/attribute-undefined/_config.js
+++ b/test/runtime/samples/attribute-undefined/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: `<div></div>`,
+	html: `<div></div>`
 };

--- a/test/runtime/samples/await-with-update-2/_config.js
+++ b/test/runtime/samples/await-with-update-2/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		thePromise: new Promise((_) => {}),
-		count: 0,
+		count: 0
 	},
 
 	html: `
@@ -60,5 +60,5 @@ export default {
 			</div>
 			`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/await-with-update/_config.js
+++ b/test/runtime/samples/await-with-update/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		thePromise: new Promise((_) => {}),
-		count: 0,
+		count: 0
 	},
 
 	html: `
@@ -56,5 +56,5 @@ export default {
 			</div>
 			`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/binding-contenteditable-html-initial/_config.js
+++ b/test/runtime/samples/binding-contenteditable-html-initial/_config.js
@@ -36,5 +36,5 @@ export default {
 			<editor contenteditable="true">good<span>bye</span></editor>
 			<p>hello good<span>bye</span></p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-contenteditable-html/_config.js
+++ b/test/runtime/samples/binding-contenteditable-html/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		name: '<b>world</b>',
+		name: '<b>world</b>'
 	},
 
 	html: `
@@ -34,5 +34,5 @@ export default {
 			<editor contenteditable="true">good<span>bye</span></editor>
 			<p>hello good<span>bye</span></p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-contenteditable-text-initial/_config.js
+++ b/test/runtime/samples/binding-contenteditable-text-initial/_config.js
@@ -30,5 +30,5 @@ export default {
 			<editor contenteditable="true">goodbye</editor>
 			<p>hello goodbye</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-contenteditable-text/_config.js
+++ b/test/runtime/samples/binding-contenteditable-text/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		name: 'world',
+		name: 'world'
 	},
 
 	html: `
@@ -28,5 +28,5 @@ export default {
 			<editor contenteditable="true">goodbye</editor>
 			<p>hello goodbye</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-checkbox-indeterminate/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-indeterminate/_config.js
@@ -2,7 +2,7 @@ export default {
 	skip_if_ssr: true,
 
 	props: {
-		indeterminate: true,
+		indeterminate: true
 	},
 
 	html: `
@@ -38,5 +38,5 @@ export default {
 			<p>checked? true</p>
 			<p>indeterminate? true</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-checkbox-with-event-in-each/_config.js
+++ b/test/runtime/samples/binding-input-checkbox-with-event-in-each/_config.js
@@ -3,13 +3,13 @@ export default {
 		cats: [
 			{
 				name: "cat 0",
-				checked: false,
+				checked: false
 			},
 			{
 				name: "cat 1",
-				checked: false,
-			},
-		],
+				checked: false
+			}
+		]
 	},
 
 	html: `
@@ -22,7 +22,7 @@ export default {
 		const newCats = cats.slice();
 		newCats.push({
 			name: "cat " + cats.length,
-			checked: false,
+			checked: false
 		});
 		component.cats = newCats;
 

--- a/test/runtime/samples/binding-input-group-duplicate-value/_config.js
+++ b/test/runtime/samples/binding-input-group-duplicate-value/_config.js
@@ -77,5 +77,5 @@ export default {
 		assert.equal(inputs[5].checked, false);
 		assert.equal(inputs[6].checked, false);
 		assert.equal(inputs[7].checked, true);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-group-each-1/_config.js
+++ b/test/runtime/samples/binding-input-group-each-1/_config.js
@@ -7,13 +7,13 @@ const values = [
 const selected_array = [
 	[values[1]],
 	[],
-	[values[2]],
+	[values[2]]
 ];
 
 export default {
 	props: {
 		values,
-		selected_array,
+		selected_array
 	},
 
 	html: `

--- a/test/runtime/samples/binding-input-group-each-3/_config.js
+++ b/test/runtime/samples/binding-input-group-each-3/_config.js
@@ -7,13 +7,13 @@ const values = [
 const selected_array = [
 	[values[1]],
 	[],
-	[values[2]],
+	[values[2]]
 ];
 
 export default {
 	props: {
 		values,
-		selected_array,
+		selected_array
 	},
 
 	html: `

--- a/test/runtime/samples/binding-input-number-2/_config.js
+++ b/test/runtime/samples/binding-input-number-2/_config.js
@@ -27,5 +27,5 @@ export default {
 		component.value = 1;
 		assert.equal(component.value, 1);
 		assert.equal(input.value, "1");
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-number/_config.js
+++ b/test/runtime/samples/binding-input-number/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		count: 42,
+		count: 42
 	},
 
 	html: `
@@ -44,5 +44,5 @@ export default {
 			<input type='number'>
 			<p>undefined undefined</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-range-change-with-max/_config.js
+++ b/test/runtime/samples/binding-input-range-change-with-max/_config.js
@@ -29,5 +29,5 @@ export default {
 			<input type=range min=0 max=20>
 			<p>20 of 20</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-range-change/_config.js
+++ b/test/runtime/samples/binding-input-range-change/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		count: 42,
+		count: 42
 	},
 
 	html: `
@@ -34,5 +34,5 @@ export default {
 			<input type='range'>
 			<p>number 44</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-range/_config.js
+++ b/test/runtime/samples/binding-input-range/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		count: 42,
+		count: 42
 	},
 
 	html: `
@@ -34,5 +34,5 @@ export default {
 			<input type='range'>
 			<p>number 44</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-contextual-deconflicted/_config.js
+++ b/test/runtime/samples/binding-input-text-contextual-deconflicted/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		foo: 'a',
-		items: ['x'],
+		items: ['x']
 	},
 
 	html: `
@@ -32,5 +32,5 @@ export default {
 			<div><input><p>b</p></div>
 			<div><input><p>y</p></div>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-contextual-reactive/_config.js
+++ b/test/runtime/samples/binding-input-text-contextual-reactive/_config.js
@@ -121,5 +121,5 @@ export default {
 
 			<p>done:one / done:two / remaining:four</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-contextual/_config.js
+++ b/test/runtime/samples/binding-input-text-contextual/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		items: ['one', 'two', 'three'],
+		items: ['one', 'two', 'three']
 	},
 
 	html: `
@@ -65,5 +65,5 @@ export default {
 				<input><p>five</p>
 			</div>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-deconflicted/_config.js
+++ b/test/runtime/samples/binding-input-text-deconflicted/_config.js
@@ -1,8 +1,8 @@
 export default {
 	props: {
 		component: {
-			name: 'world',
-		},
+			name: 'world'
+		}
 	},
 
 	html: `
@@ -36,5 +36,5 @@ export default {
 			<h1>Hello goodbye!</h1>
 			<input>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-deep-computed-dynamic/_config.js
+++ b/test/runtime/samples/binding-input-text-deep-computed-dynamic/_config.js
@@ -4,8 +4,8 @@ export default {
 		obj: {
 			foo: 'a',
 			bar: 'b',
-			baz: 'c',
-		},
+			baz: 'c'
+		}
 	},
 
 	html: `
@@ -56,5 +56,5 @@ export default {
 			<input>
 			<pre>{"foo":"d","bar":"e","baz":"f"}</pre>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-deep-computed/_config.js
+++ b/test/runtime/samples/binding-input-text-deep-computed/_config.js
@@ -2,8 +2,8 @@ export default {
 	props: {
 		prop: 'name',
 		user: {
-			name: 'alice',
-		},
+			name: 'alice'
+		}
 	},
 
 	html: `
@@ -40,5 +40,5 @@ export default {
 			<input>
 			<p>hello carol</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-deep-contextual-computed-dynamic/_config.js
+++ b/test/runtime/samples/binding-input-text-deep-contextual-computed-dynamic/_config.js
@@ -5,9 +5,9 @@ export default {
 			{
 				foo: 'a',
 				bar: 'b',
-				baz: 'c',
-			},
-		],
+				baz: 'c'
+			}
+		]
 	},
 
 	html: `
@@ -58,5 +58,5 @@ export default {
 			<input>
 			<pre>{"foo":"d","bar":"e","baz":"f"}</pre>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-deep-contextual/_config.js
+++ b/test/runtime/samples/binding-input-text-deep-contextual/_config.js
@@ -3,8 +3,8 @@ export default {
 		items: [
 			{ description: 'one' },
 			{ description: 'two' },
-			{ description: 'three' },
-		],
+			{ description: 'three' }
+		]
 	},
 
 	html: `
@@ -45,5 +45,5 @@ export default {
 			<div><input><p>four</p></div>
 			<div><input><p>five</p></div>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-deep/_config.js
+++ b/test/runtime/samples/binding-input-text-deep/_config.js
@@ -1,8 +1,8 @@
 export default {
 	props: {
 		user: {
-			name: 'alice',
-		},
+			name: 'alice'
+		}
 	},
 
 	html: `
@@ -39,5 +39,5 @@ export default {
 			<input>
 			<p>hello carol</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text-undefined/_config.js
+++ b/test/runtime/samples/binding-input-text-undefined/_config.js
@@ -26,5 +26,5 @@ export default {
 
 		component.x = undefined;
 		assert.equal(input.value, '');
-	},
+	}
 };

--- a/test/runtime/samples/binding-input-text/_config.js
+++ b/test/runtime/samples/binding-input-text/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		name: 'world',
+		name: 'world'
 	},
 
 	html: `
@@ -33,5 +33,5 @@ export default {
 			<input>
 			<p>hello goodbye</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-select-initial-value/_config.js
+++ b/test/runtime/samples/binding-select-initial-value/_config.js
@@ -24,7 +24,7 @@ export default {
 	`,
 
 	props: {
-		selected: 'b',
+		selected: 'b'
 	},
 
 	test({ assert, component, target }) {
@@ -33,5 +33,5 @@ export default {
 
 		assert.equal(select.value, 'b');
 		assert.ok(options[1].selected);
-	},
+	}
 };

--- a/test/runtime/samples/binding-select-optgroup/_config.js
+++ b/test/runtime/samples/binding-select-optgroup/_config.js
@@ -45,5 +45,5 @@ export default {
 				</optgroup>
 			</select>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-select/_config.js
+++ b/test/runtime/samples/binding-select/_config.js
@@ -24,7 +24,7 @@ export default {
 	`,
 
 	props: {
-		selected: 'one',
+		selected: 'one'
 	},
 
 	async test({ assert, component, target, window }) {
@@ -53,5 +53,5 @@ export default {
 		`);
 
 		component.selected = 'three';
-	},
+	}
 };

--- a/test/runtime/samples/binding-store-deep/_config.js
+++ b/test/runtime/samples/binding-store-deep/_config.js
@@ -37,5 +37,5 @@ export default {
 
 		assert.deepEqual(names, ['world', 'everybody', 'goodbye']);
 		unsubscribe();
-	},
+	}
 };

--- a/test/runtime/samples/binding-store/_config.js
+++ b/test/runtime/samples/binding-store/_config.js
@@ -37,5 +37,5 @@ export default {
 
 		assert.deepEqual(names, ['world', 'everybody', 'goodbye']);
 		unsubscribe();
-	},
+	}
 };

--- a/test/runtime/samples/binding-textarea/_config.js
+++ b/test/runtime/samples/binding-textarea/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		value: 'some text',
+		value: 'some text'
 	},
 
 	html: `
@@ -33,5 +33,5 @@ export default {
 			<textarea></textarea>
 			<p>goodbye</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/binding-this-each-block-property-2/_config.js
+++ b/test/runtime/samples/binding-this-each-block-property-2/_config.js
@@ -5,7 +5,7 @@ function callback(refs) {
 export default {
 	html: ``,
 	props: {
-		callback,
+		callback
 	},
 	after_test() {
 		calls = [];
@@ -49,5 +49,5 @@ export default {
 		assert.equal(calls[6][0].ref, divs[0]);
 		assert.equal(calls[6][1].ref, divs[1]);
 		assert.equal(calls[6][2].ref, divs[2]);
-	},
+	}
 };

--- a/test/runtime/samples/bitmask-overflow-2/_config.js
+++ b/test/runtime/samples/bitmask-overflow-2/_config.js
@@ -1,3 +1,3 @@
 export default {
-	error: `potato is not defined`,
+	error: `potato is not defined`
 };

--- a/test/runtime/samples/bitmask-overflow-3/_config.js
+++ b/test/runtime/samples/bitmask-overflow-3/_config.js
@@ -1,3 +1,3 @@
 export default {
-	error: `A is not defined`,
+	error: `A is not defined`
 };

--- a/test/runtime/samples/bitmask-overflow-slot-2/_config.js
+++ b/test/runtime/samples/bitmask-overflow-slot-2/_config.js
@@ -90,7 +90,7 @@ export default {
 
 		assert.deepEqual(component.reads, {
 			_0: 2,
-			_1: 2,
+			_1: 2
 		});
 	}
 };

--- a/test/runtime/samples/class-with-spread-and-bind/_config.js
+++ b/test/runtime/samples/class-with-spread-and-bind/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		primary: true,
+		primary: true
 	},
 
 	html: `<div class="test-class primary" role="button"></div>`,
@@ -14,5 +14,5 @@ export default {
 			<div class="test-class primary" role="button"></div>
 		`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/component-binding-deep/_config.js
+++ b/test/runtime/samples/component-binding-deep/_config.js
@@ -21,5 +21,5 @@ export default {
 			<input>
 			<p>blah</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/component-binding-store/_config.js
+++ b/test/runtime/samples/component-binding-store/_config.js
@@ -57,5 +57,5 @@ export default {
 		assert.equal(input1.value, "456");
 		assert.equal(input2.value, "456");
 		assert.equal(count, 3);
-	},
+	}
 };

--- a/test/runtime/samples/component-event-not-stale/_config.js
+++ b/test/runtime/samples/component-event-not-stale/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		value: 1,
+		value: 1
 	},
 
 	test({ assert, component, target, window }) {
@@ -26,5 +26,5 @@ export default {
 			{ value: 2 },
 			{ value: 2 }
 		]);
-	},
+	}
 };

--- a/test/runtime/samples/component-events-console/_config.js
+++ b/test/runtime/samples/component-events-console/_config.js
@@ -21,5 +21,5 @@ export default {
 		}
 
 		console.log = log;
-	},
+	}
 };

--- a/test/runtime/samples/component-shorthand-import/_config.js
+++ b/test/runtime/samples/component-shorthand-import/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: `<p>This is the widget.</p>`,
+	html: `<p>This is the widget.</p>`
 };

--- a/test/runtime/samples/component-slot-fallback-3/_config.js
+++ b/test/runtime/samples/component-slot-fallback-3/_config.js
@@ -2,5 +2,5 @@ export default {
 	html: `
 	<div>Hello World</div>
 	<div>Hello</div><div>world</div><div>Bye</div><div>World</div>
-	`,
+	`
 };

--- a/test/runtime/samples/component-slot-fallback-4/_config.js
+++ b/test/runtime/samples/component-slot-fallback-4/_config.js
@@ -1,5 +1,5 @@
 export default {
 	html: `
 	foobar
-	`,
+	`
 };

--- a/test/runtime/samples/component-slot-let-in-slot/_config.js
+++ b/test/runtime/samples/component-slot-let-in-slot/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		prop: 'a',
+		prop: 'a'
 	},
 
 	html: 'a',

--- a/test/runtime/samples/component-slot-nested-if/_config.js
+++ b/test/runtime/samples/component-slot-nested-if/_config.js
@@ -26,5 +26,5 @@ export default {
 			Display: abc
 		`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/deconflict-builtins-2/_config.js
+++ b/test/runtime/samples/deconflict-builtins-2/_config.js
@@ -1,4 +1,4 @@
 export default {
 	html: `<text>hello world</text>`,
-	preserveIdentifiers: true,
+	preserveIdentifiers: true
 };

--- a/test/runtime/samples/dev-warning-missing-data-each/_config.js
+++ b/test/runtime/samples/dev-warning-missing-data-each/_config.js
@@ -7,18 +7,18 @@ export default {
 		letters: [
 			{
 				id: 1,
-				char: 'a',
+				char: 'a'
 			},
 			{
 				id: 2,
-				char: 'b',
+				char: 'b'
 			},
 			{
 				id: 3,
-				char: 'c',
-			},
-		],
+				char: 'c'
+			}
+		]
 	},
 
-	warnings: [],
+	warnings: []
 };

--- a/test/runtime/samples/document-event/_config.js
+++ b/test/runtime/samples/document-event/_config.js
@@ -9,5 +9,5 @@ export default {
 		const event2 = new window.Event('mouseleave');
 		window.document.body.dispatchEvent(event2);
 		assert.deepEqual(component.events, ['enter', 'leave']);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-array-literal/_config.js
+++ b/test/runtime/samples/each-block-array-literal/_config.js
@@ -15,5 +15,5 @@ export default {
 
 		button.dispatchEvent(event);
 		assert.equal(component.clicked, 'racoon');
-	},
+	}
 };

--- a/test/runtime/samples/each-block-destructured-array-sparse/_config.js
+++ b/test/runtime/samples/each-block-destructured-array-sparse/_config.js
@@ -16,5 +16,5 @@ export default {
 		assert.htmlEqual( target.innerHTML, `
 			<p>bar</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-destructured-array/_config.js
+++ b/test/runtime/samples/each-block-destructured-array/_config.js
@@ -16,5 +16,5 @@ export default {
 		assert.htmlEqual( target.innerHTML, `
 			<p>foo: bar</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-destructured-default/_config.js
+++ b/test/runtime/samples/each-block-destructured-default/_config.js
@@ -18,5 +18,5 @@ export default {
 		assert.htmlEqual(target.innerHTML, `
 			<p class="mammal">cow - ‎B. taurus - 50kg</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-destructured-object-binding/_config.js
+++ b/test/runtime/samples/each-block-destructured-object-binding/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		people: [{ name: { first: 'Doctor', last: 'Who' } }],
+		people: [{ name: { first: 'Doctor', last: 'Who' } }]
 	},
 
 	html: `
@@ -41,5 +41,5 @@ export default {
 			<input>
 			<p>Frank Oz</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-destructured-object-rest/_config.js
+++ b/test/runtime/samples/each-block-destructured-object-rest/_config.js
@@ -16,5 +16,5 @@ export default {
 		assert.htmlEqual(target.innerHTML, `
 			<p class="mammal">cow</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-destructured-object/_config.js
+++ b/test/runtime/samples/each-block-destructured-object/_config.js
@@ -16,5 +16,5 @@ export default {
 		assert.htmlEqual( target.innerHTML, `
 			<p>cow: hooves</p>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-else-mount-or-intro/_config.js
+++ b/test/runtime/samples/each-block-else-mount-or-intro/_config.js
@@ -1,4 +1,4 @@
 export default {
 	props: { items: [] },
-	html: `No items.`,
+	html: `No items.`
 };

--- a/test/runtime/samples/each-block-in-if-block/_config.js
+++ b/test/runtime/samples/each-block-in-if-block/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		dummy: false,
-		fruits: ['Apple', 'Banana', 'Tomato'],
+		fruits: ['Apple', 'Banana', 'Tomato']
 	},
 
 	html: '<div><div>Apple</div><div>Banana</div><div>Tomato</div></div>',

--- a/test/runtime/samples/each-block-keyed-component-action/_config.js
+++ b/test/runtime/samples/each-block-keyed-component-action/_config.js
@@ -17,5 +17,5 @@ export default {
 		component.arr = [];
 
 		assert.equal(component.count, 0);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-keyed-empty/_config.js
+++ b/test/runtime/samples/each-block-keyed-empty/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		x: [{ z: 1 }, { z: 2 }],
+		x: [{ z: 1 }, { z: 2 }]
 	},
 
 	html: ``

--- a/test/runtime/samples/each-block-keyed-non-prop/_config.js
+++ b/test/runtime/samples/each-block-keyed-non-prop/_config.js
@@ -25,5 +25,5 @@ export default {
 
 		assert.equal(p1, p4, 'first <p> element should be retained');
 		assert.equal(p3, p5, 'last <p> element should be retained');
-	},
+	}
 };

--- a/test/runtime/samples/each-block-keyed-random-permute/_config.js
+++ b/test/runtime/samples/each-block-keyed-random-permute/_config.js
@@ -19,7 +19,7 @@ function permute() {
 
 export default {
 	props: {
-		values: toObjects('abc'),
+		values: toObjects('abc')
 	},
 
 	html: `(a)(b)(c)`,

--- a/test/runtime/samples/each-block-keyed-shift/_config.js
+++ b/test/runtime/samples/each-block-keyed-shift/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		titles: [{ name: 'a', }, { name: 'b' }, { name: 'c' }]
+		titles: [{ name: 'a' }, { name: 'b' }, { name: 'c' }]
 	},
 
 	html: `

--- a/test/runtime/samples/each-block-keyed-siblings/_config.js
+++ b/test/runtime/samples/each-block-keyed-siblings/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		ones: [{ text: '1' }],
-		twos: [{ text: '2' }],
+		twos: [{ text: '2' }]
 	},
 
 	html: `
@@ -16,5 +16,5 @@ export default {
 			<div>11</div>
 			<div>2</div>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-keyed-static/_config.js
+++ b/test/runtime/samples/each-block-keyed-static/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		x: [{ z: 1 }, { z: 2 }],
+		x: [{ z: 1 }, { z: 2 }]
 	},
 
 	html: `

--- a/test/runtime/samples/each-block-scope-shadow-bind-2/_config.js
+++ b/test/runtime/samples/each-block-scope-shadow-bind-2/_config.js
@@ -19,5 +19,5 @@ export default {
         <input />
       `
 		);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-scope-shadow-bind-3/_config.js
+++ b/test/runtime/samples/each-block-scope-shadow-bind-3/_config.js
@@ -101,5 +101,5 @@ export default {
 				</div>
 			`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-scope-shadow-bind-4/_config.js
+++ b/test/runtime/samples/each-block-scope-shadow-bind-4/_config.js
@@ -60,5 +60,5 @@ export default {
 				<button>Button</button>
       `
 		);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-scope-shadow-bind/_config.js
+++ b/test/runtime/samples/each-block-scope-shadow-bind/_config.js
@@ -19,5 +19,5 @@ export default {
         <input />
       `
 		);
-	},
+	}
 };

--- a/test/runtime/samples/each-block-scope-shadow-self/_config.js
+++ b/test/runtime/samples/each-block-scope-shadow-self/_config.js
@@ -9,5 +9,5 @@ export default {
 		assert.equal(target.querySelectorAll('input').length, 3);
 		assert.deepEqual(component.data, { a: 'svelte', b: 'B', c: 'C' });
 		assert.deepEqual(component.x, ['a', 'b', 'c']);
-	},
+	}
 };

--- a/test/runtime/samples/each-blocks-assignment-2/_config.js
+++ b/test/runtime/samples/each-blocks-assignment-2/_config.js
@@ -16,5 +16,5 @@ export default {
 			<button>Test</button>
 		`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/each-blocks-assignment/_config.js
+++ b/test/runtime/samples/each-blocks-assignment/_config.js
@@ -93,5 +93,5 @@ export default {
 			<button>Test</button>
 		`
 		);		
-	},
+	}
 };

--- a/test/runtime/samples/empty-dom/_config.js
+++ b/test/runtime/samples/empty-dom/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: '',
+	html: ''
 };

--- a/test/runtime/samples/empty-style-block/_config.js
+++ b/test/runtime/samples/empty-style-block/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: '',
+	html: ''
 };

--- a/test/runtime/samples/escape-template-literals/_config.js
+++ b/test/runtime/samples/escape-template-literals/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: '<code>`${foo}\\n`</code>\n<div title="`${foo}\\n`">foo</div>\n<div>`${foo}\\n`</div>',
+	html: '<code>`${foo}\\n`</code>\n<div title="`${foo}\\n`">foo</div>\n<div>`${foo}\\n`</div>'
 };

--- a/test/runtime/samples/event-handler-async/_config.js
+++ b/test/runtime/samples/event-handler-async/_config.js
@@ -1,5 +1,5 @@
 export default {
 	html: `
 		<button>nothing</button>
-	`,
+	`
 };

--- a/test/runtime/samples/event-handler-dynamic-2/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-2/_config.js
@@ -29,5 +29,5 @@ export default {
 
 		await handler_b.dispatchEvent(event);
 		assert.equal(p.innerHTML, '2');
-	},
+	}
 };

--- a/test/runtime/samples/event-handler-dynamic-bound-var/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-bound-var/_config.js
@@ -16,5 +16,5 @@ export default {
 				Bye World
 			`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/event-handler-dynamic-expression/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-expression/_config.js
@@ -16,5 +16,5 @@ export default {
 		
 		await button.dispatchEvent(event);
 		assert.htmlEqual(target.innerHTML, `<button>foo</button>`);
-	},
+	}
 };

--- a/test/runtime/samples/event-handler-dynamic-hash/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-hash/_config.js
@@ -52,5 +52,5 @@ export default {
 			<p>2</p>
 			<button>click</button>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/event-handler-dynamic-invalid/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-invalid/_config.js
@@ -24,5 +24,5 @@ export default {
 
 		await buttonInvalid.dispatchEvent(event);
 		assert.equal(err, "", err);
-	},
+	}
 };

--- a/test/runtime/samples/event-handler-dynamic-modifier-self/_config.js
+++ b/test/runtime/samples/event-handler-dynamic-modifier-self/_config.js
@@ -12,5 +12,5 @@ export default {
 		await button.dispatchEvent(event);
 
 		assert.ok(!component.inner_clicked);
-	},
+	}
 };

--- a/test/runtime/samples/event-handler-dynamic/_config.js
+++ b/test/runtime/samples/event-handler-dynamic/_config.js
@@ -52,5 +52,5 @@ export default {
 			<p>2</p>
 			<button>click</button>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/event-handler-each-this/_config.js
+++ b/test/runtime/samples/event-handler-each-this/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		items: ['foo', 'bar', 'baz'],
+		items: ['foo', 'bar', 'baz']
 	},
 
 	html: `

--- a/test/runtime/samples/event-handler-modifier-self/_config.js
+++ b/test/runtime/samples/event-handler-modifier-self/_config.js
@@ -12,5 +12,5 @@ export default {
 		await button.dispatchEvent(event);
 
 		assert.ok(!component.inner_clicked);
-	},
+	}
 };

--- a/test/runtime/samples/globals-not-overwritten-by-bindings/_config.js
+++ b/test/runtime/samples/globals-not-overwritten-by-bindings/_config.js
@@ -37,17 +37,17 @@ export default {
 		todos: {
 			first: {
 				description: 'Buy some milk',
-				done: true,
+				done: true
 			},
 			second: {
 				description: 'Do the laundry',
-				done: true,
+				done: true
 			},
 			third: {
 				description: "Find life's true purpose",
-				done: false,
-			},
-		},
+				done: false
+			}
+		}
 	},
 
 	async test({ assert, component, target, window }) {
@@ -74,5 +74,5 @@ export default {
 				<input type="text">
 			</div>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/globals-shadowed-by-each-binding/_config.js
+++ b/test/runtime/samples/globals-shadowed-by-each-binding/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: '<p>Alert1</p><p>Alert2</p>',
+	html: '<p>Alert1</p><p>Alert2</p>'
 };

--- a/test/runtime/samples/if-block-component-store-function-conditionals/_config.js
+++ b/test/runtime/samples/if-block-component-store-function-conditionals/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: '<p>OK</p>',
+	html: '<p>OK</p>'
 };

--- a/test/runtime/samples/if-block-component-without-outro/_config.js
+++ b/test/runtime/samples/if-block-component-without-outro/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		foo: true,
+		foo: true
 	},
 
 	html: '<div>A wild component appears</div>',
@@ -8,5 +8,5 @@ export default {
 	test({ assert, component, target }) {
 		component.foo = false;
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/if-block-else-in-each/_config.js
+++ b/test/runtime/samples/if-block-else-in-each/_config.js
@@ -1,9 +1,9 @@
 export default {
 	props: {
-		array: [true, false],
+		array: [true, false]
 	},
 	html: `
 		<div>foo</div>
 		<div>bar</div>
-	`,
+	`
 };

--- a/test/runtime/samples/if-block-else-partial-outro/_config.js
+++ b/test/runtime/samples/if-block-else-partial-outro/_config.js
@@ -1,7 +1,7 @@
 export default {
 	props: {
 		x: 1,
-		y: false,
+		y: false
 	},
 
 	html: `
@@ -13,5 +13,5 @@ export default {
 		assert.htmlEqual(target.innerHTML, `
 			<span>2</span>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/if-block-no-outro-else-with-outro/_config.js
+++ b/test/runtime/samples/if-block-no-outro-else-with-outro/_config.js
@@ -18,5 +18,5 @@ export default {
 			<p>y</p>
 			<input type=text>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/if-block-outro-unique-select-block-type/_config.js
+++ b/test/runtime/samples/if-block-outro-unique-select-block-type/_config.js
@@ -2,5 +2,5 @@ export default {
 	html: `
 		<div></div>
 		<div></div>
-	`,
+	`
 };

--- a/test/runtime/samples/initial-state-assign/_config.js
+++ b/test/runtime/samples/initial-state-assign/_config.js
@@ -3,5 +3,5 @@ export default {
 	html: `
 		"foo"
 		"bar"
-	`,
+	`
 };

--- a/test/runtime/samples/lifecycle-render-order-for-children/_config.js
+++ b/test/runtime/samples/lifecycle-render-order-for-children/_config.js
@@ -21,7 +21,7 @@ export default {
 				'3: onMount',
 				'3: afterUpdate',
 				'0: onMount',
-				'0: afterUpdate',
+				'0: afterUpdate'
 			]);
 		} else {
 			assert.deepEqual(order, [
@@ -40,10 +40,10 @@ export default {
 				'3: onMount',
 				'3: afterUpdate',
 				'0: onMount',
-				'0: afterUpdate',
+				'0: afterUpdate'
 			]);
 		}
 
 		order.length = 0;
-	},
+	}
 };

--- a/test/runtime/samples/loop-protect-generator-opt-out/_config.js
+++ b/test/runtime/samples/loop-protect-generator-opt-out/_config.js
@@ -1,6 +1,6 @@
 export default {
 	compileOptions: {
 		dev: true,
-		loopGuardTimeout: 1,
-	},
+		loopGuardTimeout: 1
+	}
 };

--- a/test/runtime/samples/loop-protect-inner-function/_config.js
+++ b/test/runtime/samples/loop-protect-inner-function/_config.js
@@ -2,6 +2,6 @@ export default {
 	html: '<div></div>',
 	compileOptions: {
 		dev: true,
-		loopGuardTimeout: 100,
+		loopGuardTimeout: 100
 	}
 };

--- a/test/runtime/samples/loop-protect/_config.js
+++ b/test/runtime/samples/loop-protect/_config.js
@@ -2,6 +2,6 @@ export default {
 	error: 'Infinite loop detected',
 	compileOptions: {
 		dev: true,
-		loopGuardTimeout: 100,
+		loopGuardTimeout: 100
 	}
 };

--- a/test/runtime/samples/nested-transition-detach-each/_config.js
+++ b/test/runtime/samples/nested-transition-detach-each/_config.js
@@ -35,5 +35,5 @@ export default {
 		raf.tick(0);
 		raf.tick(100);
 		assert.htmlEqual(target.innerHTML, ``);
-	},
+	}
 };

--- a/test/runtime/samples/nested-transition-detach-if-false/_config.js
+++ b/test/runtime/samples/nested-transition-detach-if-false/_config.js
@@ -20,5 +20,5 @@ export default {
 				<span>a</span>
 			</li>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/nested-transition-if-block-not-remounted/_config.js
+++ b/test/runtime/samples/nested-transition-if-block-not-remounted/_config.js
@@ -20,5 +20,5 @@ export default {
 		};
 
 		component.value = 'two';
-	},
+	}
 };

--- a/test/runtime/samples/noscript-removal/_config.js
+++ b/test/runtime/samples/noscript-removal/_config.js
@@ -5,5 +5,5 @@ export default {
 	<div>foo</div>
 
 	<div>foo<div>foo</div></div>
-`,
+`
 };

--- a/test/runtime/samples/paren-wrapped-expressions/_config.js
+++ b/test/runtime/samples/paren-wrapped-expressions/_config.js
@@ -2,7 +2,7 @@ export default {
 	props: {
 		a: 'foo',
 		b: true,
-		c: [ 1, 2, 3 ],
+		c: [ 1, 2, 3 ]
 	},
 
 	html: `

--- a/test/runtime/samples/prop-exports/_config.js
+++ b/test/runtime/samples/prop-exports/_config.js
@@ -10,7 +10,7 @@ export default {
 		a2: 4,
 		a6: writable(29),
 		for: 'loop',
-		continue: '...',
+		continue: '...'
 	},
 
 	html: `

--- a/test/runtime/samples/props-reactive-only-with-change/_config.js
+++ b/test/runtime/samples/props-reactive-only-with-change/_config.js
@@ -4,7 +4,7 @@ export default {
 	props: {
 		callback: (value) => callbacks.push(value),
 		val1: "1",
-		val2: "2",
+		val2: "2"
 	},
 
 	before_test() {
@@ -26,5 +26,5 @@ export default {
 		component.val2 = "5";
 		assert.equal(callbacks.length, 5);
 		assert.equal(JSON.stringify(callbacks), '["1","2","1","1","2"]');
-	},
+	}
 };

--- a/test/runtime/samples/props-reactive-slot/_config.js
+++ b/test/runtime/samples/props-reactive-slot/_config.js
@@ -17,5 +17,5 @@ export default {
 			<button>Change</button>
 		`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/raw-mustache-as-root/_config.js
+++ b/test/runtime/samples/raw-mustache-as-root/_config.js
@@ -29,5 +29,5 @@ export default {
 				<p>This line should be last.</p>
 			`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/raw-mustache-inside-head/_config.js
+++ b/test/runtime/samples/raw-mustache-inside-head/_config.js
@@ -12,5 +12,5 @@ export default {
 		await btn.dispatchEvent(clickEvent);
 
 		assert.equal(window.document.head.innerHTML.includes('<style>body { color: blue; }</style><style>body { color: green; }</style>'), true);
-	},
+	}
 };

--- a/test/runtime/samples/raw-mustache-inside-slot/_config.js
+++ b/test/runtime/samples/raw-mustache-inside-slot/_config.js
@@ -29,5 +29,5 @@ export default {
 				<p>This line should be last.</p>
 			`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/raw-mustaches-td-tr/_config.js
+++ b/test/runtime/samples/raw-mustaches-td-tr/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		raw: "<tr><td>1</td><td>2</td></tr>",
+		raw: "<tr><td>1</td><td>2</td></tr>"
 	},
 
 	html: `
@@ -14,5 +14,5 @@ export default {
 				</tr>
 			</tbody>
 		</table>
-	`,
+	`
 };

--- a/test/runtime/samples/reactive-function-called-reassigned/_config.js
+++ b/test/runtime/samples/reactive-function-called-reassigned/_config.js
@@ -7,7 +7,7 @@ function callback(_value) {
 
 export default {
 	props: {
-		callback,
+		callback
 	},
 	async test({ assert, component, target, window }) {
 		assert.equal(called, 1);

--- a/test/runtime/samples/reactive-import-statement/_config.js
+++ b/test/runtime/samples/reactive-import-statement/_config.js
@@ -11,7 +11,7 @@ export default {
 	before_test() {
 		delete require.cache[path.resolve(__dirname, 'data.js')];
 	},
-	async test({ assert, target, window, }) {
+	async test({ assert, target, window }) {
 		const btn = target.querySelector('button');
 		const clickEvent = new window.MouseEvent('click');
 

--- a/test/runtime/samples/reactive-value-assign-property/_config.js
+++ b/test/runtime/samples/reactive-value-assign-property/_config.js
@@ -1,5 +1,5 @@
 export default {
 	html: `
 		<h1>Hello world!</h1>
-	`,
+	`
 };

--- a/test/runtime/samples/self-reference-component/_config.js
+++ b/test/runtime/samples/self-reference-component/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: '5 4 3 2 1 0',
+	html: '5 4 3 2 1 0'
 };

--- a/test/runtime/samples/set-undefined-attr/_config.js
+++ b/test/runtime/samples/set-undefined-attr/_config.js
@@ -1,5 +1,5 @@
 export default {
 	html: `<div draggable='false'></div>`,
 
-	ssrHtml: `<div foo='1' draggable='false'></div>`,
+	ssrHtml: `<div foo='1' draggable='false'></div>`
 };

--- a/test/runtime/samples/sigil-component-prop/_config.js
+++ b/test/runtime/samples/sigil-component-prop/_config.js
@@ -3,5 +3,5 @@ export default {
 		dev: true
 	},
 	props: { foo: 'foo' },
-	html: `<div>foo @ foo # foo</div>`,
+	html: `<div>foo @ foo # foo</div>`
 };

--- a/test/runtime/samples/slot-if-block-update-no-anchor/_config.js
+++ b/test/runtime/samples/slot-if-block-update-no-anchor/_config.js
@@ -3,5 +3,5 @@ export default {
 		assert.htmlEqual(target.innerHTML, `<span></span>`);
 		component.enabled = true;
 		assert.htmlEqual(target.innerHTML, `<span>enabled</span>`);
-	},
+	}
 };

--- a/test/runtime/samples/spread-component-2/_config.js
+++ b/test/runtime/samples/spread-component-2/_config.js
@@ -10,7 +10,7 @@ export default {
 			baz: 50 + 2,
 			qux: 1,
 			quux: 'quuxx'
-		}],
+		}]
 	},
 
 	html: `

--- a/test/runtime/samples/spread-component-dynamic-non-object-multiple-dependencies/_config.js
+++ b/test/runtime/samples/spread-component-dynamic-non-object-multiple-dependencies/_config.js
@@ -2,7 +2,7 @@ export default {
 	props: {
 		props: {
 			foo: 'lol',
-			baz: 40 + 2,
+			baz: 40 + 2
 		}
 	},
 

--- a/test/runtime/samples/spread-component-dynamic-non-object/_config.js
+++ b/test/runtime/samples/spread-component-dynamic-non-object/_config.js
@@ -2,7 +2,7 @@ export default {
 	props: {
 		props: {
 			foo: 'lol',
-			baz: 40 + 2,
+			baz: 40 + 2
 		}
 	},
 

--- a/test/runtime/samples/spread-component-dynamic-undefined/_config.js
+++ b/test/runtime/samples/spread-component-dynamic-undefined/_config.js
@@ -1,17 +1,17 @@
 export default {
 	props: {
 		props: {
-			a: 1,
-		},
+			a: 1
+		}
 	},
 
 	html: ``,
 
 	test({ assert, component, target }) {
 		component.props = {
-			a: 2,
+			a: 2
 		};
 
 		assert.htmlEqual(target.innerHTML, ``);
-	},
+	}
 };

--- a/test/runtime/samples/spread-component-dynamic/_config.js
+++ b/test/runtime/samples/spread-component-dynamic/_config.js
@@ -1,8 +1,8 @@
 export default {
 	props: {
 		props: {
-			a: 1,
-		},
+			a: 1
+		}
 	},
 
 	html: `
@@ -11,9 +11,9 @@ export default {
 
 	test({ assert, component, target }) {
 		component.props = {
-			a: 2,
+			a: 2
 		};
 
 		assert.htmlEqual(target.innerHTML, `<p>a: 2</p>`);
-	},
+	}
 };

--- a/test/runtime/samples/spread-component-multiple-dependencies/_config.js
+++ b/test/runtime/samples/spread-component-multiple-dependencies/_config.js
@@ -6,5 +6,5 @@ export default {
 			target.innerHTML,
 			`a baz`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/spread-each-component/_config.js
+++ b/test/runtime/samples/spread-each-component/_config.js
@@ -20,5 +20,5 @@ export default {
 			<div data-a="3" data-b="4"></div>
 			<div data-a="1" data-b="2"></div>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/spread-each-element/_config.js
+++ b/test/runtime/samples/spread-each-element/_config.js
@@ -20,5 +20,5 @@ export default {
 			<div data-c="3" data-d="4"></div>
 			<div data-a="1" data-b="2"></div>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/spread-element-boolean/_config.js
+++ b/test/runtime/samples/spread-element-boolean/_config.js
@@ -21,5 +21,5 @@ export default {
 			`<button>click me</button>`
 		);
 		assert.ok(!button.disabled);
-	},
+	}
 };

--- a/test/runtime/samples/spread-element-input-value/_config.js
+++ b/test/runtime/samples/spread-element-input-value/_config.js
@@ -35,7 +35,7 @@ export default {
 		spy2.reset();
 		component.val2 = '56789';
 		assert.ok(spy2.isSetCalled());
-	},
+	}
 };
 
 function spyOnValueSetter(input, initialValue) {
@@ -48,7 +48,7 @@ function spyOnValueSetter(input, initialValue) {
 		set(_value) {
 			value = _value;
 			isSet = true;
-		},
+		}
 	});
 
 	return {
@@ -57,6 +57,6 @@ function spyOnValueSetter(input, initialValue) {
 		},
 		reset() {
 			isSet = false;
-		},
+		}
 	};
 }

--- a/test/runtime/samples/spread-element-multiple-dependencies/_config.js
+++ b/test/runtime/samples/spread-element-multiple-dependencies/_config.js
@@ -6,5 +6,5 @@ export default {
 			target.innerHTML,
 			`<div class='a' title='baz'></div>`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/spread-element-multiple/_config.js
+++ b/test/runtime/samples/spread-element-multiple/_config.js
@@ -2,12 +2,12 @@ export default {
 	props: {
 		a: {
 			'data-one': 1,
-			'data-two': 2,
+			'data-two': 2
 		},
 		c: {
-			'data-b': 'overridden',
+			'data-b': 'overridden'
 		},
-		d: 'deeeeee',
+		d: 'deeeeee'
 	},
 
 	html: `
@@ -27,5 +27,5 @@ export default {
 			target.innerHTML,
 			`<div data-one="10" data-b="b" data-c="new" data-d="DEEEEEE" >test</div>`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/store-auto-subscribe-event-callback/_config.js
+++ b/test/runtime/samples/store-auto-subscribe-event-callback/_config.js
@@ -18,5 +18,5 @@ export default {
 		Dirty: true
 		Valid: true
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/store-resubscribe-b/_config.js
+++ b/test/runtime/samples/store-resubscribe-b/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: `42`,
+	html: `42`
 };

--- a/test/runtime/samples/store-resubscribe-export/_config.js
+++ b/test/runtime/samples/store-resubscribe-export/_config.js
@@ -6,14 +6,14 @@ const fakeStore = val => ({
 		return {
 			unsubscribe: () => {
 				subscribeCalled = true;
-			},
+			}
 		};
-	},
+	}
 });
 
 export default {
 	props: {
-		foo: fakeStore(1),
+		foo: fakeStore(1)
 	},
 	html: `
 		<h1>1</h1>
@@ -23,5 +23,5 @@ export default {
 		component.foo = fakeStore(5);
 
 		return assert.htmlEqual(target.innerHTML, `<h1>5</h1>`);
-	},
+	}
 };

--- a/test/runtime/samples/store-resubscribe-observable/_config.js
+++ b/test/runtime/samples/store-resubscribe-observable/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: `42`,
+	html: `42`
 };

--- a/test/runtime/samples/svg-tspan-preserve-space/_config.js
+++ b/test/runtime/samples/svg-tspan-preserve-space/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: `<svg><text x=0 y=50><tspan>foo</tspan> bar<tspan>foo</tspan> bar</text></svg>`,
+	html: `<svg><text x=0 y=50><tspan>foo</tspan> bar<tspan>foo</tspan> bar</text></svg>`
 };

--- a/test/runtime/samples/this-in-function-expressions/_config.js
+++ b/test/runtime/samples/this-in-function-expressions/_config.js
@@ -6,5 +6,5 @@ export default {
 		await btn.dispatchEvent(clickEvent);
 
 		assert.equal(btn.x, 1);
-	},
+	}
 };

--- a/test/runtime/samples/transition-css-deferred-removal/_config.js
+++ b/test/runtime/samples/transition-css-deferred-removal/_config.js
@@ -20,5 +20,5 @@ export default {
 			outer.style.animation,
 			inner.style.animation
 		], animations);
-	},
+	}
 };

--- a/test/runtime/samples/transition-css-duration/_config.js
+++ b/test/runtime/samples/transition-css-duration/_config.js
@@ -9,5 +9,5 @@ export default {
 
 		raf.tick(26);
 		assert.ok(~div.style.animation.indexOf('25ms'));
-	},
+	}
 };

--- a/test/runtime/samples/transition-css-iframe/_config.js
+++ b/test/runtime/samples/transition-css-iframe/_config.js
@@ -14,5 +14,5 @@ export default {
 
 		raf.tick(26);
 		assert.ok(~div.style.animation.indexOf('25ms'));
-	},
+	}
 };

--- a/test/runtime/samples/transition-css-in-out-in/_config.js
+++ b/test/runtime/samples/transition-css-in-out-in/_config.js
@@ -16,5 +16,5 @@ export default {
 
 		// reset original styles
 		assert.equal(div.style.animation, `__svelte_3809512021_1 100ms linear 0ms 1 both`);
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-aborted-outro-in-each/_config.js
+++ b/test/runtime/samples/transition-js-aborted-outro-in-each/_config.js
@@ -35,5 +35,5 @@ export default {
 		assert.equal(spans[0].foo, 1);
 		assert.equal(spans[1].foo, 1);
 		assert.equal(spans[2].foo, 1);
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-aborted-outro/_config.js
+++ b/test/runtime/samples/transition-js-aborted-outro/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		visible: true,
+		visible: true
 	},
 
 	test({ assert, component, target, raf }) {
@@ -20,5 +20,5 @@ export default {
 		assert.htmlEqual(target.innerHTML, `
 			<span>hello</span>
 		`);
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-deferred-b/_config.js
+++ b/test/runtime/samples/transition-js-deferred-b/_config.js
@@ -9,5 +9,5 @@ export default {
 			raf.tick(50);
 			assert.equal(div.foo, 0.5);
 		});
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-deferred/_config.js
+++ b/test/runtime/samples/transition-js-deferred/_config.js
@@ -9,5 +9,5 @@ export default {
 			raf.tick(50);
 			assert.equal(div.foo, 0.5);
 		});
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-destroyed-before-end/_config.js
+++ b/test/runtime/samples/transition-js-destroyed-before-end/_config.js
@@ -13,5 +13,5 @@ export default {
 		component.$destroy();
 
 		raf.tick(100);
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-dynamic-component/_config.js
+++ b/test/runtime/samples/transition-js-dynamic-component/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		x: true,
+		x: true
 	},
 
 	html: `

--- a/test/runtime/samples/transition-js-if-outro-unrelated-component-binding-update/_config.js
+++ b/test/runtime/samples/transition-js-if-outro-unrelated-component-binding-update/_config.js
@@ -5,5 +5,5 @@ export default {
 		await button.dispatchEvent(event);
 		raf.tick(500);
 		assert.htmlEqual(target.innerHTML, "");
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-if-outro-unrelated-component-store-update/_config.js
+++ b/test/runtime/samples/transition-js-if-outro-unrelated-component-store-update/_config.js
@@ -3,5 +3,5 @@ export default {
 		await component.condition.set(false);
 		raf.tick(500);
 		assert.htmlEqual(target.innerHTML, "");
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-intro-enabled-by-option/_config.js
+++ b/test/runtime/samples/transition-js-intro-enabled-by-option/_config.js
@@ -9,5 +9,5 @@ export default {
 
 		raf.tick(50);
 		assert.equal(div.foo, 0.5);
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-intro-skipped-by-default-nested/_config.js
+++ b/test/runtime/samples/transition-js-intro-skipped-by-default-nested/_config.js
@@ -5,5 +5,5 @@ export default {
 
 		raf.tick(50);
 		assert.equal(div.foo, undefined);
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-intro-skipped-by-default/_config.js
+++ b/test/runtime/samples/transition-js-intro-skipped-by-default/_config.js
@@ -5,5 +5,5 @@ export default {
 
 		raf.tick(50);
 		assert.equal(div.foo, undefined);
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-local-and-global/_config.js
+++ b/test/runtime/samples/transition-js-local-and-global/_config.js
@@ -63,5 +63,5 @@ export default {
 
 		raf.tick(400);
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-local-nested-each-keyed/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-each-keyed/_config.js
@@ -26,5 +26,5 @@ export default {
 
 		component.x = false;
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-local-nested-each/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-each/_config.js
@@ -26,5 +26,5 @@ export default {
 
 		component.x = false;
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-local-nested-if/_config.js
+++ b/test/runtime/samples/transition-js-local-nested-if/_config.js
@@ -36,5 +36,5 @@ export default {
 
 		raf.tick(200);
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-local/_config.js
+++ b/test/runtime/samples/transition-js-local/_config.js
@@ -36,5 +36,5 @@ export default {
 
 		raf.tick(200);
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-nested-each-keyed-2/_config.js
+++ b/test/runtime/samples/transition-js-nested-each-keyed-2/_config.js
@@ -7,5 +7,5 @@ export default {
 	test({ assert, component, target, window, raf }) {
 		component.x = false;
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-nested-each-keyed/_config.js
+++ b/test/runtime/samples/transition-js-nested-each-keyed/_config.js
@@ -21,5 +21,5 @@ export default {
 
 		raf.tick(200);
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-nested-each/_config.js
+++ b/test/runtime/samples/transition-js-nested-each/_config.js
@@ -21,5 +21,5 @@ export default {
 
 		raf.tick(200);
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-nested-if/_config.js
+++ b/test/runtime/samples/transition-js-nested-if/_config.js
@@ -21,5 +21,5 @@ export default {
 
 		raf.tick(200);
 		assert.htmlEqual(target.innerHTML, '');
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-parameterised-with-state/_config.js
+++ b/test/runtime/samples/transition-js-parameterised-with-state/_config.js
@@ -15,5 +15,5 @@ export default {
 		assert.equal(div.foo, 200);
 
 		raf.tick(101);
-	},
+	}
 };

--- a/test/runtime/samples/transition-js-parameterised/_config.js
+++ b/test/runtime/samples/transition-js-parameterised/_config.js
@@ -11,5 +11,5 @@ export default {
 		assert.equal(div.foo, 200);
 
 		raf.tick(101);
-	},
+	}
 };

--- a/test/runtime/samples/unchanged-expression-escape/_config.js
+++ b/test/runtime/samples/unchanged-expression-escape/_config.js
@@ -3,5 +3,5 @@ export default {
 		<p>Hello world, what's up? this & that</p>
 		<p>Hello world, what's up? this & that</p>
 		<p>Hello world, what's up?<span></span> this & that</p>
-	`,
+	`
 };

--- a/test/runtime/samples/unchanged-expression-xss/_config.js
+++ b/test/runtime/samples/unchanged-expression-xss/_config.js
@@ -1,3 +1,3 @@
 export default {
-	html: `<p>&lt;b\nstyle='color:\nred;'&gt;RED?!?&lt;/b&gt;</p>`,
+	html: `<p>&lt;b\nstyle='color:\nred;'&gt;RED?!?&lt;/b&gt;</p>`
 };

--- a/test/runtime/samples/whitespace-list/_config.js
+++ b/test/runtime/samples/whitespace-list/_config.js
@@ -18,5 +18,5 @@ export default {
 		const ul = target.querySelector('ul');
 
 		assert.equal(ul.childNodes.length, 5);
-	},
+	}
 };

--- a/test/runtime/samples/window-bind-scroll-update/_config.js
+++ b/test/runtime/samples/window-bind-scroll-update/_config.js
@@ -33,5 +33,5 @@ export default {
 
 		clock.flush();
 		assert.equal(window.pageYOffset, 100);
-	},
+	}
 };

--- a/test/runtime/samples/window-binding-scroll-store/_config.js
+++ b/test/runtime/samples/window-binding-scroll-store/_config.js
@@ -4,8 +4,8 @@ export default {
 		Object.defineProperties(window, {
 			pageYOffset: {
 				value: 0,
-				configurable: true,
-			},
+				configurable: true
+			}
 		});
 	},
 	async test({ assert, component, target, window }) {
@@ -15,8 +15,8 @@ export default {
 		Object.defineProperties(window, {
 			pageYOffset: {
 				value: 234,
-				configurable: true,
-			},
+				configurable: true
+			}
 		});
 
 		await window.dispatchEvent(event);
@@ -25,5 +25,5 @@ export default {
 			target.innerHTML,
 			`<p style="position: fixed; top: 1em; left: 1em;">scroll\ny\nis\n234.\n234\n*\n234\n=\n54756</p><div style="height: 9999px;"></div>`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/window-event-custom/_config.js
+++ b/test/runtime/samples/window-event-custom/_config.js
@@ -11,5 +11,5 @@ export default {
 		assert.htmlEqual(target.innerHTML, `
 			<p>escaped: true</p>
 		`);
-	},
+	}
 };

--- a/test/vars/samples/assumed-global/_config.js
+++ b/test/vars/samples/assumed-global/_config.js
@@ -1,5 +1,5 @@
 export default {
 	test(assert, vars) {
 		assert.deepEqual(vars, []);
-	},
+	}
 };

--- a/test/vars/samples/duplicate-globals/_config.js
+++ b/test/vars/samples/duplicate-globals/_config.js
@@ -1,5 +1,5 @@
 export default {
 	test(assert, vars) {
 		assert.deepEqual(vars, []);
-	},
+	}
 };

--- a/test/vars/samples/duplicate-non-hoistable/_config.js
+++ b/test/vars/samples/duplicate-non-hoistable/_config.js
@@ -13,5 +13,5 @@ export default {
 				writable: true
 			}
 		]);
-	},
+	}
 };

--- a/test/vars/samples/duplicate-vars/_config.js
+++ b/test/vars/samples/duplicate-vars/_config.js
@@ -24,5 +24,5 @@ export default {
 				writable: true
 			}
 		]);
-	},
+	}
 };

--- a/test/vars/samples/implicit-reactive/_config.js
+++ b/test/vars/samples/implicit-reactive/_config.js
@@ -24,5 +24,5 @@ export default {
 				writable: true
 			}
 		]);
-	},
+	}
 };

--- a/test/vars/samples/referenced-from-script/_config.js
+++ b/test/vars/samples/referenced-from-script/_config.js
@@ -10,7 +10,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: false,
-				referenced_from_script: false,
+				referenced_from_script: false
 			},
 			{
 				name: 'j',
@@ -21,7 +21,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: false,
-				referenced_from_script: false,
+				referenced_from_script: false
 			},
 			{
 				name: 'k',
@@ -32,7 +32,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: false,
-				referenced_from_script: false,
+				referenced_from_script: false
 			},
 			{
 				name: 'a',
@@ -43,7 +43,7 @@ export default {
 				reassigned: true,
 				referenced: false,
 				writable: true,
-				referenced_from_script: true,
+				referenced_from_script: true
 			},
 			{
 				name: 'b',
@@ -54,7 +54,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: true,
-				referenced_from_script: true,
+				referenced_from_script: true
 			},
 			{
 				name: 'c',
@@ -65,7 +65,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: true,
-				referenced_from_script: true,
+				referenced_from_script: true
 			},
 			{
 				name: 'd',
@@ -76,7 +76,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: true,
-				referenced_from_script: true,
+				referenced_from_script: true
 			},
 			{
 				name: 'e',
@@ -87,7 +87,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: true,
-				referenced_from_script: false,
+				referenced_from_script: false
 			},
 			{
 				name: 'f',
@@ -98,7 +98,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: true,
-				referenced_from_script: false,
+				referenced_from_script: false
 			},
 			{
 				name: 'g',
@@ -109,7 +109,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: true,
-				referenced_from_script: true,
+				referenced_from_script: true
 			},
 			{
 				name: 'h',
@@ -120,7 +120,7 @@ export default {
 				reassigned: true,
 				referenced: false,
 				writable: true,
-				referenced_from_script: true,
+				referenced_from_script: true
 			},
 			{
 				name: 'foo',
@@ -131,7 +131,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: false,
-				referenced_from_script: false,
+				referenced_from_script: false
 			},
 			{
 				name: 'l',
@@ -142,7 +142,7 @@ export default {
 				reassigned: false,
 				referenced: false,
 				referenced_from_script: true,
-				writable: false,
+				writable: false
 			},
 			{
 				name: 'bar',
@@ -153,8 +153,8 @@ export default {
 				reassigned: false,
 				referenced: false,
 				writable: false,
-				referenced_from_script: false,
-			},
+				referenced_from_script: false
+			}
 		]);
-	},
+	}
 };

--- a/test/vars/samples/template-references/_config.js
+++ b/test/vars/samples/template-references/_config.js
@@ -10,7 +10,7 @@ export default {
 				reassigned: false,
 				referenced: true,
 				referenced_from_script: false,
-				writable: false,
+				writable: false
 			},
 			{
 				export_name: null,
@@ -21,7 +21,7 @@ export default {
 				reassigned: false,
 				referenced: true,
 				referenced_from_script: false,
-				writable: true,
+				writable: true
 			},
 			{
 				export_name: null,
@@ -32,8 +32,8 @@ export default {
 				reassigned: false,
 				referenced: true,
 				referenced_from_script: false,
-				writable: true,
-			},
+				writable: true
+			}
 		]);
-	},
+	}
 };

--- a/test/vars/samples/undeclared/_config.js
+++ b/test/vars/samples/undeclared/_config.js
@@ -1,5 +1,5 @@
 export default {
 	test(assert, vars) {
 		assert.deepEqual(vars, []);
-	},
+	}
 };


### PR DESCRIPTION
To be merged after https://github.com/sveltejs/eslint-config/pull/4 is merged and the config tagged.

This leaves only one lint warning, which is a bit of a complex fix and will need to be debated - the fact that we mutate the node `assert` builtin, in tests for Svelte. I've mostly fixed this locally, but there are still test failures, so this covers the low hanging fruit and cleans up all the other rules, with a view to fixing that one later.

- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

Todo:
- [x] Get svelte-eslint merged and tagged
- [x] Update dependency in `package.json` to point to new tag