### PR TITLE
docs: styling elements inside html expressions

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -364,6 +364,22 @@ The expression should be valid standalone HTML — `{@html "<div>"}content{@html
 </div>
 ```
 
+---
+
+By default, CSS is locally scoped to the component and Svelte won't target elements inside `{@html expression}` because it doesn't know which elements are going to appear, any unused styles are dead-code-eliminated. To target elements inside the expression, we can use the `:global(...)` modifier, but it will break the CSS scope if the expression is placed at the root level of the component. To mitigate this, we can wrap the expression inside a locally defined element and use the modifier as the descendant of the element.
+
+```sv
+<div class="content">
+	{@html post.content}
+</div>
+
+<style>
+	.content :global(p) {
+		line-height: 1.5;
+	}
+</style>
+```
+
 
 ### {@debug ...}
 


### PR DESCRIPTION
This PR will document how to style elements inside `{@html expression}` and keep it scoped to the element.

There's currently no active issues for this, but it's quite frequently asked by some and in discord. So far, I only found this to be documented as [comments in sapper template](https://github.com/sveltejs/sapper-template/blob/b51e2f2d9769b4a9d2b9e63c9177ce587bee7a9a/src/routes/blog/%5Bslug%5D.svelte#L21-L28), pretty secluded for something quite crucial. I copied and tweaked the comment a bit and add an example block.