### PR TITLE
perf: convert empty text nodes to comments

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -54,7 +54,7 @@ export function space() {
 }
 
 export function empty() {
-	return text('');
+	return document.createComment('');
 }
 
 export function listen(node: EventTarget, event: string, handler: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | EventListenerOptions) {

--- a/test/runtime/samples/raw-mustache-inside-head/_config.js
+++ b/test/runtime/samples/raw-mustache-inside-head/_config.js
@@ -3,14 +3,14 @@ export default {
 		const btn = target.querySelector("button");
 		const clickEvent = new window.MouseEvent("click");
 
-		assert.equal(window.document.head.innerHTML.includes('<style>body { color: blue; }</style><style>body { color: green; }</style>'), true);
+		assert.equal(window.document.head.innerHTML.includes('<style>body { color: blue; }</style><!----><style>body { color: green; }</style>'), true);
 
 		await btn.dispatchEvent(clickEvent);
 
-		assert.equal(window.document.head.innerHTML.includes('<style>body { color: red; }</style><style>body { color: green; }</style>'), true);
+		assert.equal(window.document.head.innerHTML.includes('<style>body { color: red; }</style><!----><style>body { color: green; }</style>'), true);
 
 		await btn.dispatchEvent(clickEvent);
 
-		assert.equal(window.document.head.innerHTML.includes('<style>body { color: blue; }</style><style>body { color: green; }</style>'), true);
+		assert.equal(window.document.head.innerHTML.includes('<style>body { color: blue; }</style><!----><style>body { color: green; }</style>'), true);
 	}
 };


### PR DESCRIPTION
fixes #3586, closes #3642

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
-  [x] Run the tests with `npm test` or `yarn test`)

It's been almost a year since this PR has been opened https://github.com/sveltejs/svelte/pull/3642

Just wanted to reiterate on the current issue we have with text nodes as anchors, also updated some tests.

### Performance

Comment nodes are considerably faster https://www.measurethat.net/Benchmarks/ShowResult/123052

### Correctness

While text nodes are great for reducing clutter in the DOM inspector, it also influences and forces styles we don't need which can lead to unpredictable results. Comment nodes do not have this issue.

### Real world example

On IE browsers support for Wordpress, if two text nodes are parallel to each other, the site would just crash. https://github.com/WordPress/WordPress/pull/461/files

Very keen to have this merged, so we don't have to keep syncing with our [forks](https://www.npmjs.com/package/svelte-nospace?activeTab=versions) every time Svelte updates.

### Not a breaking change

We have been running a [fork](https://www.npmjs.com/package/svelte-nospace?activeTab=versions) for a while now without issues, also the minimal changes on existing tests suggests there should be no issues with having this merged.

Tagging in maintainers who have been involved in previous discussions @Rich-Harris @Conduitry @antony

Would be awesome if we can get a consensus on this, many thanks.