### PR TITLE
handle undefined input value with spread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Include selector in message of `unused-css-selector` warning ([#5252](https://github.com/sveltejs/svelte/issues/5252))
 * Fix using `<Namespaced.Component/>`s in child `{#await}`/`{#each}` contexts ([#5255](https://github.com/sveltejs/svelte/issues/5255))
 * Fix using `<svelte:component>` in `{:catch}` ([#5259](https://github.com/sveltejs/svelte/issues/5259))
+* Fix setting one-way bound `<input>` `value` to `undefined` when it has spread attributes ([#5270](https://github.com/sveltejs/svelte/issues/5270))
 
 ## 3.24.1
 

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -726,14 +726,17 @@ export default class ElementWrapper extends Wrapper {
 				if (${block.renderer.dirty(Array.from(dependencies))} && ${data}.multiple) @select_options(${this.var}, ${data}.value);
 			`);
 		} else if (this.node.name === 'input' && this.attributes.find(attr => attr.node.name === 'value')) {
-			block.chunks.mount.push(b`
-				${this.var}.value = ${data}.value;
-			`);
-			block.chunks.update.push(b`
-				if ('value' in ${data}) {
+			const type = this.node.get_static_attribute_value('type');
+			if (type === null || type === "" || type === "text" || type === "email" || type === "password") {
+				block.chunks.mount.push(b`
 					${this.var}.value = ${data}.value;
-				}
-			`);
+				`);
+				block.chunks.update.push(b`
+					if ('value' in ${data}) {
+						${this.var}.value = ${data}.value;
+					}
+				`);
+			}
 		}
 	}
 

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -725,6 +725,15 @@ export default class ElementWrapper extends Wrapper {
 			block.chunks.update.push(b`
 				if (${block.renderer.dirty(Array.from(dependencies))} && ${data}.multiple) @select_options(${this.var}, ${data}.value);
 			`);
+		} else if (this.node.name === 'input' && this.attributes.find(attr => attr.node.name === 'value')) {
+			block.chunks.mount.push(b`
+				${this.var}.value = ${data}.value;
+			`);
+			block.chunks.update.push(b`
+				if ('value' in ${data}) {
+					${this.var}.value = ${data}.value;
+				}
+			`);
 		}
 	}
 

--- a/test/runtime/samples/spread-element-input-value-undefined/_config.js
+++ b/test/runtime/samples/spread-element-input-value-undefined/_config.js
@@ -8,5 +8,5 @@ export default {
 		component.value = "foobar";
 
 		assert.equal(input.value, "foobar");
-	},
+	}
 };

--- a/test/runtime/samples/spread-element-input-value-undefined/_config.js
+++ b/test/runtime/samples/spread-element-input-value-undefined/_config.js
@@ -1,0 +1,12 @@
+export default {
+	async test({ assert, component, target, window }) {
+		const input = target.querySelector("input");
+		component.value = undefined;
+
+		assert.equal(input.value, "undefined");
+
+		component.value = "foobar";
+
+		assert.equal(input.value, "foobar");
+	},
+};

--- a/test/runtime/samples/spread-element-input-value-undefined/main.svelte
+++ b/test/runtime/samples/spread-element-input-value-undefined/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let value = '';
+</script>
+
+<input {value} {...{}} />


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/5270

this caused by the difference between `setAttribute` vs setting the property using `propertyName`.

not really sure is this the right way of handling it? if so, should we also handle all the other attribute that has a custom propertyName in https://github.com/sveltejs/svelte/blob/402106330530965ff5a1a5f05fc6529403486328/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts#L291 ?



### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases, features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
### Tests
- [x] Run the tests with `npm test` or `yarn test`)
