### PR TITLE
site: Replace "active" with "selected" as an example class name

### DIFF
--- a/site/content/tutorial/13-classes/01-classes/app-a/App.svelte
+++ b/site/content/tutorial/13-classes/01-classes/app-a/App.svelte
@@ -7,23 +7,23 @@
 		display: block;
 	}
 
-	.active {
+	.selected {
 		background-color: #ff3e00;
 		color: white;
 	}
 </style>
 
 <button
-	class="{current === 'foo' ? 'active' : ''}"
+	class="{current === 'foo' ? 'selected' : ''}"
 	on:click="{() => current = 'foo'}"
 >foo</button>
 
 <button
-	class="{current === 'bar' ? 'active' : ''}"
+	class="{current === 'bar' ? 'selected' : ''}"
 	on:click="{() => current = 'bar'}"
 >bar</button>
 
 <button
-	class="{current === 'baz' ? 'active' : ''}"
+	class="{current === 'baz' ? 'selected' : ''}"
 	on:click="{() => current = 'baz'}"
 >baz</button>

--- a/site/content/tutorial/13-classes/01-classes/app-b/App.svelte
+++ b/site/content/tutorial/13-classes/01-classes/app-b/App.svelte
@@ -7,23 +7,23 @@
 		display: block;
 	}
 
-	.active {
+	.selected {
 		background-color: #ff3e00;
 		color: white;
 	}
 </style>
 
 <button
-	class:active="{current === 'foo'}"
+	class:selected="{current === 'foo'}"
 	on:click="{() => current = 'foo'}"
 >foo</button>
 
 <button
-	class:active="{current === 'bar'}"
+	class:selected="{current === 'bar'}"
 	on:click="{() => current = 'bar'}"
 >bar</button>
 
 <button
-	class:active="{current === 'baz'}"
+	class:selected="{current === 'baz'}"
 	on:click="{() => current = 'baz'}"
 >baz</button>

--- a/site/content/tutorial/13-classes/01-classes/text.md
+++ b/site/content/tutorial/13-classes/01-classes/text.md
@@ -6,7 +6,7 @@ Like any other attribute, you can specify classes with a JavaScript attribute, s
 
 ```html
 <button
-	class="{current === 'foo' ? 'active' : ''}"
+	class="{current === 'foo' ? 'selected' : ''}"
 	on:click="{() => current = 'foo'}"
 >foo</button>
 ```
@@ -15,9 +15,9 @@ This is such a common pattern in UI development that Svelte includes a special d
 
 ```html
 <button
-	class:active="{current === 'foo'}"
+	class:selected="{current === 'foo'}"
 	on:click="{() => current = 'foo'}"
 >foo</button>
 ```
 
-The `active` class is added to the element whenever the value of the expression is truthy, and removed when it's falsy.
+The `selected` class is added to the element whenever the value of the expression is truthy, and removed when it's falsy.


### PR DESCRIPTION
[Tutorial 13a](https://svelte.dev/tutorial/classes) shows how to dynamically add and remove classes, including the special class directive like this:

```
<button class:active="{current === 'foo'}">foo</button>
```

I got a bit mixed up the first time I read this because I thought that `:active` was a [CSS `:active` pseudo-selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:active). I thought it might be a bit clearer to pick an example class name that does not coincide with any pseudo-class, so I've opened this PR to replace `active` with `selected`.

I have spun up the site locally and made sure that the example code still works, before and after clicking the 'Show me' button.