### PR TITLE
site: fix scrollbar bug on Svelte docs page

### DIFF
--- a/site/src/routes/_layout.svelte
+++ b/site/src/routes/_layout.svelte
@@ -62,7 +62,6 @@
 
 <style>
 	main {
-		height: 100%;
 		position: relative;
 		margin: 0 auto;
 		/* padding: var(--nav-h) var(--side-nav) 0 var(--side-nav); */


### PR DESCRIPTION
relative to https://github.com/sveltejs/site-kit/issues/20

If set `height: 100%` to `main` tag, `main` contents always fits `#sapper`, and `window.scrollY` return `0`. Therefore, can't find current section.