### PR TITLE
More specific type for CompleOptions.generate

### DIFF
--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -108,7 +108,7 @@ export interface CompileOptions {
 	format?: ModuleFormat;
 	name?: string;
 	filename?: string;
-	generate?: string | false;
+	generate?: 'dom' | 'ssr' | false;
 
 	outputFilename?: string;
 	cssOutputFilename?: string;


### PR DESCRIPTION
This allows for tighter compile-time checking