### PR TITLE
Fix undefined outros variable in transitions

### DIFF
--- a/src/runtime/internal/transitions.ts
+++ b/src/runtime/internal/transitions.ts
@@ -50,7 +50,7 @@ export function transition_in(block, local?: 0 | 1) {
 
 export function transition_out(block, local: 0 | 1, detach: 0 | 1, callback) {
 	if (block && block.o) {
-		if (outroing.has(block)) return;
+		if (outroing.has(block) || !outros) return;
 		outroing.add(block);
 
 		outros.c.push(() => {


### PR DESCRIPTION
This error occures in the method transition_out when trying to use a component from external dependancy and wrapping it inside a <div in:{...} out:{...}/>.

-  The tests with `npm test` and lint the project with `npm run lint` was succesful

Error message: Cannot read property 'c' of undefined.