### PR TITLE
Add a script for copy-workers

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
   "description": "Docs and examples for Svelte",
   "scripts": {
     "dev": "npm run copy-workers && sapper dev",
-    "copy-workers": "rm -rf static/workers && cp -r node_modules/@sveltejs/svelte-repl/workers static",
+    "copy-workers": "node scripts/copy-workers.js",
     "migrate": "node-pg-migrate -r dotenv/config",
     "sapper": "npm run copy-workers && sapper build --legacy",
     "update": "node scripts/update_template.js && node scripts/get-contributors.js && node scripts/update_whos_using.js",

--- a/site/scripts/copy-workers.js
+++ b/site/scripts/copy-workers.js
@@ -1,0 +1,4 @@
+const sh = require('shelljs');
+
+sh.rm('-rf', 'static/workers');
+sh.cp('-r', 'node_modules/@sveltejs/svelte-repl/workers', 'static');


### PR DESCRIPTION
This hopefully makes it cross-platform compatible. I don't have a Windows machine to test it on, but see that this is the pattern the other scripts follow