### PR TITLE
fix: #4954 Delayed bidirectional transition prevents components from unmounting

### DIFF
--- a/src/runtime/internal/transitions.ts
+++ b/src/runtime/internal/transitions.ts
@@ -273,7 +273,7 @@ export function create_bidirectional_transition(node: Element & ElementCSSInline
 			outros.r += 1;
 		}
 
-		if (running_program) {
+		if (running_program || pending_program) {
 			pending_program = program;
 		} else {
 			// if this is an intro, and there's a delay, we need to do


### PR DESCRIPTION
To reproduce: Toggle Checkbox multiple times within a second

https://svelte.dev/repl/61d6a8c1cf8a4a819d40e44037617f44?version=3.24.1


![Honeycam 2020-09-05 00-56-04](https://user-images.githubusercontent.com/17820596/92260318-aed70b80-ef12-11ea-8e56-2b2f381d7e49.gif)

- Current Behavior

When `running_program == null && pending_program != null` (This happens because `pending_program` has a delay) and **new program** comes, **new program** is assigned to `running_program` and old `pending_program` remains what it was. Eventually, **new program** will be stopped by `pending_program`. Notice that `pending_program` comes before **new program** but it intercepts new one.

- Solution

If `pending_program != null` and **new program** comes, `pending_program` should be assigned as **new program**
