### PR TITLE
force periscopic version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "locate-character": "^2.0.5",
     "magic-string": "^0.25.3",
     "mocha": "^6.2.0",
-    "periscopic": "^2.0.1",
+    "periscopic": "2.0.1",
     "puppeteer": "^2.1.1",
     "rollup": "^1.27.14",
     "source-map": "^0.7.3",


### PR DESCRIPTION
solve issue https://github.com/sveltejs/svelte/issues/5358

code-red 0.1.3 is only working with periscopic 2.0.1

periscopic 2.0.2 is causing errors in code-red:
TypeError: Cannot read property 'find_owner' of undefined

state.scope is undefined in
code-red/src/print/handlers.ts
```js
 Identifier(node: Identifier, state) { 
 	let name = node.name; 
  
 	if (name[0] === '@') { 
 		name = state.getName(name.slice(1)); 
 	} else if (node.name[0] === '#') { 
 		const owner = state.scope.find_owner(node.name); 
```
