### PR TITLE
Fix port error when running site locally

### DIFF
--- a/site/src/server.js
+++ b/site/src/server.js
@@ -4,7 +4,7 @@ import sirv from 'sirv';
 import * as sapper from '@sapper/server';
 import { sanitize_user, authenticate } from './utils/auth';
 
-const port = process.env.port || 3000;
+const port = process.env.PORT || 3000;
 
 const app = polka({
 	onError: (err, req, res) => {

--- a/site/src/server.js
+++ b/site/src/server.js
@@ -4,7 +4,7 @@ import sirv from 'sirv';
 import * as sapper from '@sapper/server';
 import { sanitize_user, authenticate } from './utils/auth';
 
-const { PORT = 3000 } = process.env;
+const port = process.env.port || 3000;
 
 const app = polka({
 	onError: (err, req, res) => {
@@ -34,4 +34,4 @@ app.use(
 	})
 );
 
-app.listen(PORT);
+app.listen(port);


### PR DESCRIPTION
I'm always getting an error when trying to run the site locally. It looks like `PORT` is set to empty string. I don't quite know why or where it's coming from. It also seems to be fixed by running `git clean -xdf` to blast away all built files, but then I can often run the site just once. Running it a second time it runs into whatever bad state there is

>RangeError [ERR_SOCKET_BAD_PORT]: options.port should be >= 0 and < 65536. Received .
    at validatePort (internal/validators.js:193:11)
    at Server.listen (net.js:1442:5)
    at Polka.listen (/home/bmccann/src/svelte/site/node_modules/polka/build.js:55:22)
    at Object.<anonymous> (/home/bmccann/src/svelte/site/__sapper__/dev/server/server-a1bd56b4.js:13276:5)
    at Module._compile (internal/modules/cjs/loader.js:1251:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1272:10)
    at Module.load (internal/modules/cjs/loader.js:1100:32)
    at Function.Module._load (internal/modules/cjs/loader.js:962:14)
    at Module.require (internal/modules/cjs/loader.js:1140:19)
    at require (internal/modules/cjs/helpers.js:75:18) {
  code: 'ERR_SOCKET_BAD_PORT'
}
