### PR TITLE
Standardize site building command

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -9,7 +9,7 @@ sapper:
 	@echo "\n~> updating template & contributors list"
 	@npm run update
 	@echo "\n~> building Sapper app"
-	@npm run sapper
+	@npm run build
 
 
 docker:

--- a/site/README.md
+++ b/site/README.md
@@ -47,7 +47,7 @@ In order for the REPL's GitHub integration to work properly when running locally
 
 ## Building the site
 
-To build the website, run `npm run sapper`. The output can be found in `__sapper__/build`.
+To build the website, run `npm run build`. The output can be found in `__sapper__/build`.
 
 ## Testing
 

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
     "dev": "npm run copy-workers && sapper dev",
     "copy-workers": "node scripts/copy-workers.js",
     "migrate": "node-pg-migrate -r dotenv/config",
-    "sapper": "npm run copy-workers && sapper build --legacy",
+    "build": "npm run copy-workers && sapper build --legacy",
     "update": "node scripts/update_template.js && node scripts/get-contributors.js && node scripts/update_whos_using.js",
     "start": "node __sapper__/build",
     "test": "mocha -r esm test/**",


### PR DESCRIPTION
It drives me crazy that the command is `npm run sapper` because it's different than all the other Sapper sites (the template, my own projects, the example projects), so my muscle memory always fails me.