### PR TITLE
site: fix falling back to default port

### DIFF
--- a/site/src/server.js
+++ b/site/src/server.js
@@ -4,11 +4,11 @@ import sirv from 'sirv';
 import * as sapper from '@sapper/server';
 import { sanitize_user, authenticate } from './utils/auth';
 
-const { PORT } = process.env;
-
-if (!PORT) {
-	throw new Error(`PORT "${PORT}" specified. Check your .env file.`);
+if (!process.env.PORT) {
+	process.env.PORT = 3000;
 }
+
+const { PORT } = process.env;
 
 const app = polka({
 	onError: (err, req, res) => {

--- a/site/src/server.js
+++ b/site/src/server.js
@@ -4,7 +4,11 @@ import sirv from 'sirv';
 import * as sapper from '@sapper/server';
 import { sanitize_user, authenticate } from './utils/auth';
 
-const { PORT = 3000 } = process.env;
+const { PORT } = process.env;
+
+if (!PORT) {
+	throw new Error(`PORT "${PORT}" specified. Check your .env file.`);
+}
 
 const app = polka({
 	onError: (err, req, res) => {


### PR DESCRIPTION
No need to specify a default of `3000`. It will get it as the default anyway (not quite sure where it's coming from though)

Adds some validation. I tried to build the site and it complained my mapbox key was missing, so I created an .env file and stuck a fake key in there to get the site to build for testing. Then I tried `npm run dev` again and the server would no longer start, but I didn't connect it to having created an `.env` file. I hadn't looked at the other fields and didn't realize there was a `PORT` in there. It took me quite awhile to figure out what was happening. Hopefully this will help others who might run into this