### PR TITLE
Changed "on to" to "onto" in tutorial 03

### DIFF
--- a/site/content/tutorial/03-props/03-spread-props/text.md
+++ b/site/content/tutorial/03-props/03-spread-props/text.md
@@ -2,7 +2,7 @@
 title: Spread props
 ---
 
-If you have an object of properties, you can 'spread' them on to a component instead of specifying each one:
+If you have an object of properties, you can 'spread' them onto a component instead of specifying each one:
 
 ```html
 <Info {...pkg}/>


### PR DESCRIPTION
Changed to "onto" because it is standard and more easily readable.
