### PR TITLE
Allow unknown namespaced attributes to be emitted in their original case

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "posttest": "agadoo internal/index.mjs",
     "prepublishOnly": "npm run lint && PUBLISH=true npm test",
     "tsd": "tsc -p src/compiler --emitDeclarationOnly && tsc -p src/runtime --emitDeclarationOnly",
-    "lint": "eslint '{src,test}/**/*.{ts,js}'"
+    "lint": "eslint \"{src,test}/**/*.{ts,js}\""
   },
   "repository": {
     "type": "git",

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -70,7 +70,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 		const namespace = this.parent.node.namespace;
 		// some processing only applies to html namespace (and not MathML, SVG, or Svelte Native etc)
 		if (namespace && namespace != 'html' && namespace != namespaces.html) {
-			// attributes outside of the html namespaced may be case sensitive
+			// attributes outside of the html namespace may be case sensitive
 			// namespaces for which we don't have case corrections, are left in their original case (required for svelte-native)
 			this.name = (valid_namespaces.indexOf(namespace) >= 0) ? fix_attribute_casing(this.node.name) : this.node.name;
 			this.is_indirectly_bound_value = false;

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -8,6 +8,7 @@ import Expression from '../../../nodes/shared/Expression';
 import Text from '../../../nodes/Text';
 import handle_select_value_binding from './handle_select_value_binding';
 import { Identifier, Node } from 'estree';
+import { namespaces, valid_namespaces } from '../../../../utils/namespaces';
 
 export class BaseAttributeWrapper {
 	node: Attribute;
@@ -65,17 +66,33 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 				handle_select_value_binding(this, node.dependencies);
 			}
 		}
+		
+		const namespace = this.parent.node.namespace;
+		// some processing only applies to html namespace (and not MathML, SVG, or Svelte Native etc)
+		if (namespace && namespace != 'html' && namespace != namespaces.html) {
+			// attributes outside of the html namespaced may be case sensitive
+			// namespaces for which we don't have case corrections, are left in their original case (required for svelte-native)
+			this.name = (valid_namespaces.indexOf(namespace) >= 0) ? fix_attribute_casing(this.node.name) : this.node.name;
+			this.is_indirectly_bound_value = false;
+			this.metadata = null;
+			this.property_name = null;
+			this.is_select_value_attribute = false;
+			this.is_input_value = false;
+		} else {
+			this.name = fix_attribute_casing(this.node.name);
+			this.metadata = this.get_metadata();
+			this.is_indirectly_bound_value = is_indirectly_bound_value(this);
+			this.property_name = this.is_indirectly_bound_value
+				? '__value'
+				: this.metadata && this.metadata.property_name;
 
-		this.name = fix_attribute_casing(this.node.name);
-		this.metadata = this.get_metadata();
-		this.is_indirectly_bound_value = is_indirectly_bound_value(this);
-		this.property_name = this.is_indirectly_bound_value
-			? '__value'
-			: this.metadata && this.metadata.property_name;
+			this.is_select_value_attribute = this.name === 'value' && this.parent.node.name === 'select';
+			this.is_input_value = this.name === 'value' && this.parent.node.name === 'input';
+		}
+
 		this.is_src = this.name === 'src'; // TODO retire this exception in favour of https://github.com/sveltejs/svelte/issues/3750
-		this.is_select_value_attribute = this.name === 'value' && this.parent.node.name === 'select';
-		this.is_input_value = this.name === 'value' && this.parent.node.name === 'input';
 		this.should_cache = should_cache(this);
+
 	}
 
 	render(block: Block) {

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -8,7 +8,7 @@ import Expression from '../../../nodes/shared/Expression';
 import Text from '../../../nodes/Text';
 import handle_select_value_binding from './handle_select_value_binding';
 import { Identifier, Node } from 'estree';
-import { namespaces, valid_namespaces } from '../../../../utils/namespaces';
+import { valid_namespaces } from '../../../../utils/namespaces';
 
 export class BaseAttributeWrapper {
 	node: Attribute;
@@ -68,13 +68,13 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 		}
 		
 		const namespace = this.parent.node.namespace;
-		// some processing only applies to html namespace (and not MathML, SVG, or Svelte Native etc)
-		if (namespace && namespace != 'html' && namespace != namespaces.html) {
-			// attributes outside of the html namespace may be case sensitive
-			// namespaces for which we don't have case corrections, are left in their original case (required for svelte-native)
-			this.name = (valid_namespaces.indexOf(namespace) >= 0) ? fix_attribute_casing(this.node.name) : this.node.name;
+		
+		// some processing only applies to known namespaces
+		if (namespace && !valid_namespaces.includes(namespace)) {
+			// attributes outside of the valid namespace may be case sensitive (eg svelte native). We leave them in their current case
+			this.name = this.node.name;
+			this.metadata = this.get_metadata();
 			this.is_indirectly_bound_value = false;
-			this.metadata = null;
 			this.property_name = null;
 			this.is_select_value_attribute = false;
 			this.is_input_value = false;
@@ -92,7 +92,6 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 
 		this.is_src = this.name === 'src'; // TODO retire this exception in favour of https://github.com/sveltejs/svelte/issues/3750
 		this.should_cache = should_cache(this);
-
 	}
 
 	render(block: Block) {

--- a/test/runtime/samples/attribute-casing-unknown-namespace/_config.js
+++ b/test/runtime/samples/attribute-casing-unknown-namespace/_config.js
@@ -12,7 +12,7 @@ export default {
 
 	test({ assert, target }) {
 		const attr = sel => target.querySelector(sel).attributes[0].name;
-		assert.equal(attr('page'), "horizontalAlignment");
-		assert.equal(attr('button'), "textWrap");
+		assert.equal(attr('page'), 'horizontalAlignment');
+		assert.equal(attr('button'), 'textWrap');
 	}
 };

--- a/test/runtime/samples/attribute-casing-unknown-namespace/_config.js
+++ b/test/runtime/samples/attribute-casing-unknown-namespace/_config.js
@@ -1,0 +1,18 @@
+// Test support for unknown namespaces preserving attribute case (eg svelte-native).
+
+export default {
+	html: `
+		<page xmlns="tns" horizontalAlignment="center">
+			<button textWrap="true" text="button">
+		</page>
+	`,
+	options: {
+		hydrate: false, // Hydrations currently doesn't work, the case sensitivity is only handled for svg elements.
+	},
+
+	test({ assert, target }) {
+		const attr = sel => target.querySelector(sel).attributes[0].name;
+		assert.equal(attr('page'), "horizontalAlignment");
+		assert.equal(attr('button'), "textWrap")
+	}
+};

--- a/test/runtime/samples/attribute-casing-unknown-namespace/_config.js
+++ b/test/runtime/samples/attribute-casing-unknown-namespace/_config.js
@@ -7,12 +7,12 @@ export default {
 		</page>
 	`,
 	options: {
-		hydrate: false, // Hydrations currently doesn't work, the case sensitivity is only handled for svg elements.
+		hydrate: false // Hydrations currently doesn't work, the case sensitivity is only handled for svg elements.
 	},
 
 	test({ assert, target }) {
 		const attr = sel => target.querySelector(sel).attributes[0].name;
 		assert.equal(attr('page'), "horizontalAlignment");
-		assert.equal(attr('button'), "textWrap")
+		assert.equal(attr('button'), "textWrap");
 	}
 };

--- a/test/runtime/samples/attribute-casing-unknown-namespace/main.svelte
+++ b/test/runtime/samples/attribute-casing-unknown-namespace/main.svelte
@@ -1,0 +1,3 @@
+<page horizontalAlignment="center" xmlns="tns">
+	<button textWrap="true" text="button">
+</page>


### PR DESCRIPTION
This PR allows attribute case to be retained for elements not in any of the known namespaces.
Current code forces all to lowercase and fixes the SVG specific attributes. There are other namespaces which contain case sensitive attributes, such as Svelte Native. 
Currently svelte native [has to recurse the object prototype](https://github.com/halfnelson/svelte-native/blob/c46e5544a84b7afc2661011ff4e58353ced4a213/src/dom/native/NativeElementNode.ts#L73) of the element being updated and try to resolve the correct case. This has been a never ending source of bugs. 

This PR also avoids setting several other Attribute values that only apply to code in the html namespace.

```html
<page xmlns="tns">
<label textWrap="true">Hello {name}!</label>
</page>
```

Before this fix
```js
	attr(label, "textwrap", "true");
```

After
```js
	attr(label, "textWrap", "true");
```

Might be able to be merged with https://github.com/sveltejs/svelte/pull/5193



### Tests

Test in `test/runtime/samples/attribute/casing-unknown-namespace`