### PR TITLE
fix destructuring to get multiple stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix specificity of certain styles involving a child selector ([#4795](https://github.com/sveltejs/svelte/issues/4795))
 * Fix transitions that are parameterised with stores ([#5244](https://github.com/sveltejs/svelte/issues/5244))
 * Fix scoping of styles involving child selector and `*` ([#5370](https://github.com/sveltejs/svelte/issues/5370))
+* Fix destructuring which reassigns stores ([#5388](https://github.com/sveltejs/svelte/issues/5388))
 
 ## 3.25.0
 

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -947,12 +947,6 @@ export default class Component {
 							const variable = component.var_lookup.get(name);
 
 							if (variable.export_name && variable.writable) {
-								const insert = variable.subscribable
-									? get_insert(variable)
-									: null;
-
-								parent[key].splice(index + 1, 0, insert);
-
 								declarator.id = {
 									type: 'ObjectPattern',
 									properties: [{
@@ -973,7 +967,9 @@ export default class Component {
 								};
 
 								declarator.init = x`$$props`;
-							} else if (variable.subscribable) {
+							}
+
+							if (variable.subscribable && declarator.init) {
 								const insert = get_insert(variable);
 								parent[key].splice(index + 1, 0, ...insert);
 							}

--- a/src/compiler/compile/render_dom/Renderer.ts
+++ b/src/compiler/compile/render_dom/Renderer.ts
@@ -166,12 +166,14 @@ export default class Renderer {
 		return member;
 	}
 
-	invalidate(name: string, value?) {
+	invalidate(name: string, value?, main_execution_context: boolean = false) {
 		const variable = this.component.var_lookup.get(name);
 		const member = this.context_lookup.get(name);
 
 		if (variable && (variable.subscribable && (variable.reassigned || variable.export_name))) {
-			return x`${`$$subscribe_${name}`}($$invalidate(${member.index}, ${value || name}))`;
+			return main_execution_context
+			  ? x`${`$$subscribe_${name}`}(${value || name})`
+			  : x`${`$$subscribe_${name}`}($$invalidate(${member.index}, ${value || name}))`;
 		}
 
 		if (name[0] === '$' && name[1] !== '$') {

--- a/test/runtime/samples/reactive-assignment-in-complex-declaration-with-store/_config.js
+++ b/test/runtime/samples/reactive-assignment-in-complex-declaration-with-store/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `<h1>2 2 xxx 5 6</h1>`
+};

--- a/test/runtime/samples/reactive-assignment-in-complex-declaration-with-store/main.svelte
+++ b/test/runtime/samples/reactive-assignment-in-complex-declaration-with-store/main.svelte
@@ -1,16 +1,16 @@
 <script>
-  import { writable } from 'svelte/store';
+	import { writable } from 'svelte/store';
 
-  let eid = writable(1);
-  let foo;
-  let u;
-  let v;
+	let eid = writable(1);
+	let foo;
+	let u;
+	let v;
 	let w;
-  [u, v, w] = [
-    {id: eid = writable(foo = 2), name: 'xxx'},
-    5,
+	[u, v, w] = [
+		{id: eid = writable(foo = 2), name: 'xxx'},
+		5,
 		writable(6)
-  ];
+	];
 </script>
 
 <h1>{foo} {$eid} {u.name} {v} {$w}</h1>

--- a/test/runtime/samples/reactive-assignment-in-complex-declaration-with-store/main.svelte
+++ b/test/runtime/samples/reactive-assignment-in-complex-declaration-with-store/main.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { writable } from 'svelte/store';
+
+  let eid = writable(1);
+  let foo;
+  let u;
+  let v;
+	let w;
+  [u, v, w] = [
+    {id: eid = writable(foo = 2), name: 'xxx'},
+    5,
+		writable(6)
+  ];
+</script>
+
+<h1>{foo} {$eid} {u.name} {v} {$w}</h1>

--- a/test/runtime/samples/reactive-assignment-in-declaration/main.svelte
+++ b/test/runtime/samples/reactive-assignment-in-declaration/main.svelte
@@ -1,6 +1,9 @@
 <script>
 	let foo;
 	let bar = (foo = 1);
+	function a() {
+		bar = (foo = 1);
+	}
 </script>
 
 <h1>{foo} {bar}</h1>

--- a/test/runtime/samples/reactive-assignment-in-for-loop-head/main.svelte
+++ b/test/runtime/samples/reactive-assignment-in-for-loop-head/main.svelte
@@ -4,6 +4,11 @@
   for (let bar = (foo1 = 0); bar < 5; bar += 1) {
     foo2 = foo1;
   }
+  function a() {
+    for (let bar = (foo1 = 0); bar < 5; bar += 1) {
+      foo2 = foo1;
+    }
+  }
 </script>
 
 <h1>{foo1} {foo2}</h1>

--- a/test/runtime/samples/reactive-assignment-in-for-loop-head/main.svelte
+++ b/test/runtime/samples/reactive-assignment-in-for-loop-head/main.svelte
@@ -1,14 +1,14 @@
 <script>
-  let foo1;
-  let foo2;
-  for (let bar = (foo1 = 0); bar < 5; bar += 1) {
-    foo2 = foo1;
-  }
-  function a() {
-    for (let bar = (foo1 = 0); bar < 5; bar += 1) {
-      foo2 = foo1;
-    }
-  }
+	let foo1;
+	let foo2;
+	for (let bar = (foo1 = 0); bar < 5; bar += 1) {
+		foo2 = foo1;
+	}
+	function a() {
+		for (let bar = (foo1 = 0); bar < 5; bar += 1) {
+			foo2 = foo1;
+		}
+	}
 </script>
 
 <h1>{foo1} {foo2}</h1>

--- a/test/runtime/samples/store-resubscribe-c/_config.js
+++ b/test/runtime/samples/store-resubscribe-c/_config.js
@@ -1,0 +1,3 @@
+export default {
+	html: `31 42`
+};

--- a/test/runtime/samples/store-resubscribe-c/main.svelte
+++ b/test/runtime/samples/store-resubscribe-c/main.svelte
@@ -2,13 +2,13 @@
 	import { writable } from 'svelte/store';
 	const context = {
 		store1: writable(31),
-		store2: writable(42),
-	}
+		store2: writable(42)
+	};
 	let store1;
 	let store2;
 	({
 		store1,
-		store2,
+		store2
 	} = context);
 </script>
 

--- a/test/runtime/samples/store-resubscribe-c/main.svelte
+++ b/test/runtime/samples/store-resubscribe-c/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { writable } from 'svelte/store';
+	const context = {
+		store1: writable(31),
+		store2: writable(42),
+	}
+	let store1;
+	let store2;
+	({
+		store1,
+		store2,
+	} = context);
+</script>
+
+{$store1}
+{$store2}


### PR DESCRIPTION
Fixes #5388

Root cause: from https://github.com/sveltejs/svelte/pull/4069, we skip `$$invalidate` calls if the assignment happen at the main execution context, this skips the `subscribe_store` instrumentation as well.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
