### PR TITLE
Update 200-are-there-any-video-courses.md

### DIFF
--- a/site/content/faq/200-are-there-any-video-courses.md
+++ b/site/content/faq/200-are-there-any-video-courses.md
@@ -6,7 +6,7 @@ Rich Harris, the creator of Svelte, taught a course:
 
 - [Frontend Masters](https://frontendmasters.com/courses/svelte/)
 
-There are also a couple of third-party courses:
+There are also a number of third-party courses:
 
 - [Egghead](https://egghead.io/browse/frameworks/svelte)
 - [Udemy](https://www.udemy.com/courses/search/?q=sveltejs+svelte)

--- a/site/content/faq/200-are-there-any-video-courses.md
+++ b/site/content/faq/200-are-there-any-video-courses.md
@@ -8,7 +8,7 @@ Rich Harris, the creator of Svelte, taught a course:
 
 There are also a couple of third-party courses:
 
-- [Egghead](https://egghead.io/playlists/getting-started-with-svelte-3-05a8541a)
-- [Udemy](https://www.udemy.com/sveltejs-the-complete-guide/)
+- [Egghead](https://egghead.io/browse/frameworks/svelte)
+- [Udemy](https://www.udemy.com/courses/search/?q=sveltejs+svelte)
 
 Note that Udemy very frequently has discounts over 90%.


### PR DESCRIPTION
Regarding the training available on some websites (egghead, udemy) , it would be fairer to provide a search URL with a keyword rather than a link to a single course.
This is for the sake of fairness for all training authors and to show that the offer is growing, as is the rate of adoption of svelteJS !