### PR TITLE
travis CI - retry tests on timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+language: node_js
+
+os:
+  - linux
+  - osx
+  - windows
+
+jobs:
+  include:
+
+  # stage 1: check syntax. no retry
+
+  - name: "Lint"
+    stage: stage_1
+    node_js: 10
+    os: linux
+    script: npm run lint
+
+  # stage 2: wait for one test to pass. no retry
+
+  - name: "First Test Node 10 Linux"
+    stage: stage_2
+    node_js: 10
+    os: linux
+    script: npm run test
+
+  # stage 3: run other tests in parallel. retry failed
+
+  - name: "Unit Test Node 10"
+    stage: stage_3
+    node_js: 10
+    env: COMMAND=test:unit
+
+  - name: "Test Node 14"
+    node_js: 14
+    env: COMMAND=test
+
+  - name: "Test Node 12"
+    node_js: 12
+    env: COMMAND=test
+
+  - name: "Test Node 10"
+    node_js: 10
+    env: COMMAND=test
+    os:
+      - osx
+      - windows
+
+  - name: "Test Node 8"
+    node_js: 8
+    env: COMMAND=test
+
+# retry test after timeout or non-zero exit code
+script: travis_retry npm run $COMMAND

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ os:
   - osx
   - windows
 
+env: COMMAND=test
+
+# retry test after timeout or non-zero exit code
+script: travis_retry npm run $COMMAND
+
 jobs:
   include:
 
@@ -26,29 +31,24 @@ jobs:
 
   # stage 3: run other tests in parallel. retry failed
 
-  - name: "Unit Test Node 10"
+  - name: "Test Node 10"
     stage: stage_3
+    node_js: 10
+    os:
+      - osx
+      - windows
+    #env: COMMAND=test
+
+  - name: "Unit Test Node 10"
     node_js: 10
     env: COMMAND=test:unit
 
   - name: "Test Node 14"
     node_js: 14
-    env: COMMAND=test
+    #env: COMMAND=test
 
   - name: "Test Node 12"
     node_js: 12
-    env: COMMAND=test
-
-  - name: "Test Node 10"
-    node_js: 10
-    env: COMMAND=test
-    os:
-      - osx
-      - windows
 
   - name: "Test Node 8"
     node_js: 8
-    env: COMMAND=test
-
-# retry test after timeout or non-zero exit code
-script: travis_retry npm run $COMMAND


### PR DESCRIPTION
on travis CI: run tests in stages, retry tests on timeout

problem: tests are not retried on [timeout after 10 minutes of no output](https://docs.travis-ci.com/user/customizing-the-build/#build-timeouts)
and we (unprivileged users) must trigger a new test with an empty commit
like `git commit --allow-empty -m "trigger test on travis ci"`
to re-run all tests, including passed tests
solution: wrap tests in [travis_retry](https://docs.travis-ci.com/user/common-build-problems/#travis_retry)

problem: failed tests return a non-zero exit code and trigger retry
solution: [run tests in stages](https://docs.travis-ci.com/user/build-stages/) (serial not parallel) to wait for one passed test
and only then run all other tests with retry

code is not tested, obviously ....
travis seems to prefer the hidden config (github settings?)

tests on osx and windows seem to hang more often
so stage 1 + stage 2 are run on linux only