### PR TITLE
feat(Transition): Add `direction` to `slide` Transition

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -659,6 +659,7 @@ Slides an element in and out.
 * `delay` (`number`, default 0) — milliseconds before starting
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicOut`) — an [easing function](docs#svelte_easing)
+* `direction` (`string`, default `vertical`) — direction of transition, vertical or horizontal
 
 ```sv
 <script>
@@ -667,7 +668,7 @@ Slides an element in and out.
 </script>
 
 {#if condition}
-	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut }}">
+	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut, direction: 'vertical' }}">
 		slides in and out
 	</div>
 {/if}

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -659,7 +659,7 @@ Slides an element in and out.
 * `delay` (`number`, default 0) — milliseconds before starting
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicOut`) — an [easing function](docs#svelte_easing)
-* `direction` (`string`, default `vertical`) — direction of transition, vertical or horizontal
+* `direction` (`string`, default `vertical`) — direction of transition, `"vertical"` or `"horizontal"`
 
 ```sv
 <script>

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -668,7 +668,7 @@ Slides an element in and out.
 </script>
 
 {#if condition}
-	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut, direction: 'vertical' }}">
+	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut, direction: 'horizontal' }}">
 		slides in and out
 	</div>
 {/if}

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -3,6 +3,8 @@ import { assign, is_function } from 'svelte/internal';
 
 type EasingFunction = (t: number) => number;
 
+type SlideDirections = "vertical" | "horizontal"
+
 export interface TransitionConfig {
 	delay?: number;
 	duration?: number;
@@ -98,15 +100,18 @@ interface SlideParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
+	direction?: SlideDirections
 }
 
 export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
-	easing = cubicOut
+	easing = cubicOut,
+	direction = "vertical"
 }: SlideParams): TransitionConfig {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
+	const width = parseFloat(style.width);
 	const height = parseFloat(style.height);
 	const padding_top = parseFloat(style.paddingTop);
 	const padding_bottom = parseFloat(style.paddingBottom);
@@ -114,6 +119,8 @@ export function slide(node: Element, {
 	const margin_bottom = parseFloat(style.marginBottom);
 	const border_top_width = parseFloat(style.borderTopWidth);
 	const border_bottom_width = parseFloat(style.borderBottomWidth);
+	const targetProp = direction === 'vertical' ? 'height' : 'width';
+	const targetPropVal = targetProp === 'height' ? height : width;
 
 	return {
 		delay,
@@ -122,7 +129,7 @@ export function slide(node: Element, {
 		css: t =>
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
-			`height: ${t * height}px;` +
+			`${targetProp}: ${t * targetPropVal}px;` +
 			`padding-top: ${t * padding_top}px;` +
 			`padding-bottom: ${t * padding_bottom}px;` +
 			`margin-top: ${t * margin_top}px;` +

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -3,7 +3,7 @@ import { assign, is_function } from 'svelte/internal';
 
 type EasingFunction = (t: number) => number;
 
-type SlideDirections = "vertical" | "horizontal"
+type SlideDirections = 'vertical' | 'horizontal'
 
 export interface TransitionConfig {
 	delay?: number;
@@ -107,7 +107,7 @@ export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
 	easing = cubicOut,
-	direction = "vertical"
+	direction = 'vertical'
 }: SlideParams): TransitionConfig {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -118,7 +118,7 @@ export function slide(node: Element, {
 	const border_top_width = parseFloat(style.borderTopWidth);
 	const border_bottom_width = parseFloat(style.borderBottomWidth);
 	const targetProp = direction === 'vertical' ? 'height' : 'width';
-	const targetPropVal = targetProp === 'height' ? parseFloat(style.height) : parseFloat(style.width);
+	const targetPropVal = parseFloat(style[targetProp]);
 
 	return {
 		delay,

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -118,7 +118,7 @@ export function slide(node: Element, {
 	const border_top_width = parseFloat(style.borderTopWidth);
 	const border_bottom_width = parseFloat(style.borderBottomWidth);
 	const targetProp = direction === 'vertical' ? 'height' : 'width';
-	const targetPropVal = targetProp === 'height' ? parseFloat(height) : parseFloat(width);
+	const targetPropVal = targetProp === 'height' ? parseFloat(style.height) : parseFloat(style.width);
 
 	return {
 		delay,

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -111,8 +111,6 @@ export function slide(node: Element, {
 }: SlideParams): TransitionConfig {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
-	const width = parseFloat(style.width);
-	const height = parseFloat(style.height);
 	const padding_top = parseFloat(style.paddingTop);
 	const padding_bottom = parseFloat(style.paddingBottom);
 	const margin_top = parseFloat(style.marginTop);
@@ -120,7 +118,7 @@ export function slide(node: Element, {
 	const border_top_width = parseFloat(style.borderTopWidth);
 	const border_bottom_width = parseFloat(style.borderBottomWidth);
 	const targetProp = direction === 'vertical' ? 'height' : 'width';
-	const targetPropVal = targetProp === 'height' ? height : width;
+	const targetPropVal = targetProp === 'height' ? parseFloat(height) : parseFloat(width);
 
 	return {
 		delay,


### PR DESCRIPTION
Now you can choose the `slide` Transition direction, Horizontal or Vertical.

**Sample usecase:**
![gap](https://user-images.githubusercontent.com/5238989/94564384-c933a900-0274-11eb-9a51-fd11dc964780.gif)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
