### PR TITLE
Ci tests retry on timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: nick-invision/retry@v1
+    - uses: nick-invision/retry@v2
       with:
         timeout_minutes: 2
         max_attempts: 3
         retry_on: timeout
         command: npm install
-    - uses: nick-invision/retry@v1
+    - uses: nick-invision/retry@v2
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -43,13 +43,13 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
-    - uses: nick-invision/retry@v1
+    - uses: nick-invision/retry@v2
       with:
         timeout_minutes: 2
         max_attempts: 3
         retry_on: timeout
         command: npm install
-    - uses: nick-invision/retry@v1
+    - uses: nick-invision/retry@v2
       with:
         timeout_minutes: 5
         max_attempts: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,13 @@ jobs:
       with:
         timeout_minutes: 2
         max_attempts: 3
+        retry_on: timeout
         command: npm install
     - uses: nick-invision/retry@v1
       with:
         timeout_minutes: 5
         max_attempts: 3
+        retry_on: timeout
         command: npm test
       env:
         CI: true
@@ -45,9 +47,11 @@ jobs:
       with:
         timeout_minutes: 2
         max_attempts: 3
+        retry_on: timeout
         command: npm install
     - uses: nick-invision/retry@v1
       with:
         timeout_minutes: 5
         max_attempts: 3
+        retry_on: timeout
         command: 'npm run test:unit'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,16 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
+    - uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 2
+        max_attempts: 3
+        command: npm install
+    - uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        command: npm test
       env:
         CI: true
   Lint:
@@ -33,4 +41,13 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
-    - run: 'npm i && npm run test:unit'
+    - uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 2
+        max_attempts: 3
+        command: npm install
+    - uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        command: 'npm run test:unit'


### PR DESCRIPTION
problem:
sometimes few tests fail cos of timeout, mostly on macos and windows
currently, the whole test suite must be restarted to retry the failed test

solution:
use the plugin [nick-invision/retry](https://github.com/nick-invision/retry) to retry only the timed-out tests

[retry version 2](https://github.com/nick-invision/retry/pull/17) supports the option `retry_on: timeout`