### PR TITLE
fix: Set return type of get_store_value to store value type

### DIFF
--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -62,7 +62,7 @@ export function subscribe(store, ...callbacks) {
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 
-export function get_store_value<T, S extends Readable<T>>(store: S): T {
+export function get_store_value<T>(store: Readable<T>): T {
 	let value;
 	subscribe(store, _ => value = _)();
 	return value;


### PR DESCRIPTION
Im not really sure if i missed something, but at least it fixes my issue

before:
![2020-09-30-125529_726x197_scrot](https://user-images.githubusercontent.com/5238989/94668409-dc01b880-031c-11eb-8692-4e1cacbded0b.png)

after:
![2020-09-30-125550_536x191_scrot](https://user-images.githubusercontent.com/5238989/94668463-ef148880-031c-11eb-8205-c567ce6e7022.png)


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
