### PR TITLE
Fix: unused export property toggle

### DIFF
--- a/site/content/examples/21-miscellaneous/02-immutable-data/ImmutableTodo.svelte
+++ b/site/content/examples/21-miscellaneous/02-immutable-data/ImmutableTodo.svelte
@@ -5,7 +5,6 @@
 	import flash from './flash.js';
 
 	export let todo;
-	export let toggle;
 
 	let div;
 

--- a/site/content/examples/21-miscellaneous/02-immutable-data/MutableTodo.svelte
+++ b/site/content/examples/21-miscellaneous/02-immutable-data/MutableTodo.svelte
@@ -3,7 +3,6 @@
 	import flash from './flash.js';
 
 	export let todo;
-	export let toggle;
 
 	let div;
 


### PR DESCRIPTION

I found Immutable  data Example Page  ImmutableTodo has unused export property 'toggle'. 

removed ImmutableTodo.svelte and MutableTodo.svelte `export let toggle;`

<img width="1235" alt="ss" src="https://user-images.githubusercontent.com/41711526/94761096-29def500-03df-11eb-8f37-4ef8c0fd16af.png">


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
