### PR TITLE
Feat: Direct chat link to society-chat channel

### DIFF
--- a/site/src/routes/chat.js
+++ b/site/src/routes/chat.js
@@ -1,4 +1,4 @@
 export function get(req, res) {
-	res.writeHead(302, { Location: 'https://discord.gg/yy75DKs' });
+	res.writeHead(302, { Location: 'https://discord.gg/WY6CQS4' });
 	res.end();
 }


### PR DESCRIPTION
The current chat link on the site ([https://svelte.dev/chat](https://svelte.dev/chat)) redirects to the Discord server's "svelte" channel. This change redirects it to the "society-chat" channel instead, using this invite link: [https://discord.gg/WY6CQS4](https://discord.gg/WY6CQS4)

Stemmed from [this point by antony on Discord](https://discordapp.com/channels/457912077277855764/728292755087818924/761151174392938537), it's entirely up for discussion/closing.

