### PR TITLE
fix: typing get svelte/store

### DIFF
--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -62,7 +62,7 @@ export function subscribe(store, ...callbacks) {
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 
-export function get_store_value<T, S extends Readable<T>>(store: S): T {
+export function get_store_value<T>(store: Readable<T>): T {
 	let value;
 	subscribe(store, _ => value = _)();
 	return value;


### PR DESCRIPTION
The new typing for get_store_value introduced in 3.29.0 doesn't work and generates multiple ` Object is of type 'unknown'.` errors in our codebase.

See the `.D.TS` tab in [playground](https://www.typescriptlang.org/play?ts=4.0.2#code/C4TwDgpgBAysD2AnCAeAKgPigXigbwCgooBnYAQ2AgC4o0CBfAgMwFcA7AY2AEt52oAcwjA4lVGgA0sKBAAeVdgBMSsBMnQYMAChK0YASlpp8RKMmCtEAkgDoy4xgU78ypdTTVJU7VgFsAIwhELFw8d3FaAEYAJgBmKCYXdjcHKhwhETEqXQ8DKAB6Aoj0nlUOAGt2eAB3AR4UqnIlKHhmKGAAC2h5SG4IFt9A4KA) to see that typescript thinks the return value is `unknown`.

Demo of the fix: [playground](https://www.typescriptlang.org/play?ts=4.0.2#code/C4TwDgpgBAysD2AnCAeAKgPigXigbwCgooBnYAQ2AgC4o0CBfAgMwFcA7AY2AEt52oAcwjA4lVJgAUJWnCQSMASlpp8RKMmCtEAkgDoy4xgU78ypBMlmXU7VgFsARhERZceC+NoBGAEwBmKCZTdnNDKhwhETEqaRtFKAB6RM8InhIoOycXKAAdeESgA)