### PR TITLE
Style tags that were not at top level were missing end attribute

### DIFF
--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -226,7 +226,7 @@ export default function tag(parser: Parser) {
 	} else if (name === 'script' || name === 'style') {
 		// special case
 		const start = parser.index;
-		const data = parser.read_until(new RegExp(`<\\/${name}>`));
+		const data = parser.read_until(new RegExp(`</${name}>`));
 		const end = parser.index;
 		element.children.push({ start, end, type: 'Text', data });
 		parser.eat(`</${name}>`, true);

--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -223,21 +223,14 @@ export default function tag(parser: Parser) {
 		);
 		parser.read(/<\/textarea>/);
 		element.end = parser.index;
-	} else if (name === 'script') {
+	} else if (name === 'script' || name === 'style') {
 		// special case
 		const start = parser.index;
-		const data = parser.read_until(/<\/script>/);
+		const data = parser.read_until(new RegExp(`<\\/${name}>`));
 		const end = parser.index;
 		element.children.push({ start, end, type: 'Text', data });
-		parser.eat('</script>', true);
+		parser.eat(`</${name}>`, true);
 		element.end = parser.index;
-	} else if (name === 'style') {
-		// special case
-		const start = parser.index;
-		const data = parser.read_until(/<\/style>/);
-		const end = parser.index;
-		element.children.push({ start, end, type: 'Text', data });
-		parser.eat('</style>', true);
 	} else {
 		parser.stack.push(element);
 	}

--- a/test/parser/samples/style-inside-head/input.svelte
+++ b/test/parser/samples/style-inside-head/input.svelte
@@ -1,0 +1,1 @@
+<svelte:head><style></style></svelte:head>

--- a/test/parser/samples/style-inside-head/output.json
+++ b/test/parser/samples/style-inside-head/output.json
@@ -1,0 +1,33 @@
+{
+	"html": {
+		"start": 0,
+		"end": 42,
+		"type": "Fragment",
+		"children": [
+			{
+				"start": 0,
+				"end": 42,
+				"type": "Head",
+				"name": "svelte:head",
+				"attributes": [],
+				"children": [
+					{
+						"start": 13,
+						"end": 28,
+						"type": "Element",
+						"name": "style",
+						"attributes": [],
+						"children": [
+							{
+								"start": 20,
+								"end": 20,
+								"type": "Text",
+								"data": ""
+							}
+						]
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
If a `style` tag was not at the top level, the `end` property of it was empty. This is because the line `element.end = parser.index;` was missing for the `style` case in that changed code.

This fixes sveltejs/language-tools#586 and (very likely) fixes sveltejs/prettier-plugin-svelte#149

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
