### PR TITLE
Move function declaration before reference

### DIFF
--- a/site/content/tutorial/04-logic/06-await-blocks/app-a/App.svelte
+++ b/site/content/tutorial/04-logic/06-await-blocks/app-a/App.svelte
@@ -1,6 +1,4 @@
 <script>
-	let promise = getRandomNumber();
-
 	async function getRandomNumber() {
 		const res = await fetch(`tutorial/random-number`);
 		const text = await res.text();
@@ -11,6 +9,8 @@
 			throw new Error(text);
 		}
 	}
+
+	let promise = getRandomNumber();
 
 	function handleClick() {
 		promise = getRandomNumber();

--- a/site/content/tutorial/04-logic/06-await-blocks/app-b/App.svelte
+++ b/site/content/tutorial/04-logic/06-await-blocks/app-b/App.svelte
@@ -1,6 +1,4 @@
 <script>
-	let promise = getRandomNumber();
-
 	async function getRandomNumber() {
 		const res = await fetch(`tutorial/random-number`);
 		const text = await res.text();
@@ -11,6 +9,8 @@
 			throw new Error(text);
 		}
 	}
+	
+	let promise = getRandomNumber();
 
 	function handleClick() {
 		promise = getRandomNumber();


### PR DESCRIPTION
The way the example is currently presented requires that the user have an understanding of how Javascript hoists functions. 

By moving the function declaration before the function reference, the order of the code becomes more clear to the reader, which I think is valuable here. 

I think it's more important that this material clearly teach the behavior of Svelte, rather than the nuances of Javascript.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
