### PR TITLE
Preparing for adding unused warning to eslint config

### DIFF
--- a/test/runtime/samples/this-in-function-expressions/_config.js
+++ b/test/runtime/samples/this-in-function-expressions/_config.js
@@ -1,6 +1,6 @@
 export default {
 	async test({ assert, target, window }) {
-		const [_, btn] = target.querySelectorAll('button');
+		const [, btn] = target.querySelectorAll('button');
 		const clickEvent = new window.MouseEvent('click');
 
 		await btn.dispatchEvent(clickEvent);


### PR DESCRIPTION
Fixed the last unused variable warning in the code. It will make lint fail when sveltejs/eslint-config#10 is merged.