### PR TITLE
tutorial: remove unnecessary call performance.now() inside raf

### DIFF
--- a/site/content/tutorial/06-bindings/12-bind-this/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/12-bind-this/app-a/App.svelte
@@ -5,9 +5,9 @@
 
 	onMount(() => {
 		const ctx = canvas.getContext('2d');
-		let frame;
+		let frame = requestAnimationFrame(loop);
 
-		(function loop() {
+		function loop(t) {
 			frame = requestAnimationFrame(loop);
 
 			const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
@@ -16,8 +16,6 @@
 				const i = p / 4;
 				const x = i % canvas.width;
 				const y = i / canvas.height >>> 0;
-
-				const t = window.performance.now();
 
 				const r = 64 + (128 * x / canvas.width) + (64 * Math.sin(t / 1000));
 				const g = 64 + (128 * y / canvas.height) + (64 * Math.cos(t / 1000));
@@ -30,7 +28,7 @@
 			}
 
 			ctx.putImageData(imageData, 0, 0);
-		}());
+		}
 
 		return () => {
 			cancelAnimationFrame(frame);

--- a/site/content/tutorial/06-bindings/12-bind-this/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/12-bind-this/app-b/App.svelte
@@ -5,9 +5,9 @@
 
 	onMount(() => {
 		const ctx = canvas.getContext('2d');
-		let frame;
+		let frame = requestAnimationFrame(loop);
 
-		(function loop() {
+		function loop(t) {
 			frame = requestAnimationFrame(loop);
 
 			const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
@@ -16,8 +16,6 @@
 				const i = p / 4;
 				const x = i % canvas.width;
 				const y = i / canvas.height >>> 0;
-
-				const t = window.performance.now();
 
 				const r = 64 + (128 * x / canvas.width) + (64 * Math.sin(t / 1000));
 				const g = 64 + (128 * y / canvas.height) + (64 * Math.cos(t / 1000));
@@ -30,7 +28,7 @@
 			}
 
 			ctx.putImageData(imageData, 0, 0);
-		}());
+		}
 
 		return () => {
 			cancelAnimationFrame(frame);


### PR DESCRIPTION
The `callback` called via `requestAnimationFrame(callback)` already contains the timestamp in the first argument, calling `performance.now()` inside raf is not required.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
