### PR TITLE
Added track kind

### DIFF
--- a/site/content/tutorial/06-bindings/10-media-elements/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/10-media-elements/app-a/App.svelte
@@ -113,7 +113,9 @@
 		src="https://sveltejs.github.io/assets/caminandes-llamigos.mp4"
 		on:mousemove={handleMousemove}
 		on:mousedown={handleMousedown}
-	></video>
+	>
+	<track kind="captions">
+	</video>
 
 	<div class="controls" style="opacity: {duration && showControls ? 1 : 0}">
 		<progress value="{(time / duration) || 0}"/>


### PR DESCRIPTION
This should be there. <track kind="captions"> To avoid the following error A11y: Media elements must have a <track kind="captions"> (111:1)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
