### PR TITLE
Use ResizeObserver instead of iframes if available

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -261,6 +261,7 @@ export function is_crossorigin() {
 
 export function add_resize_listener(node: HTMLElement, fn: () => void) {
 	if ('ResizeObserver' in window) {
+		// @ts-ignore https://github.com/Microsoft/TypeScript/issues/28502
 		const obs = new ResizeObserver(fn) as any;
 		obs.observe(node);
 		return obs.disconnect.bind(obs);

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -260,6 +260,11 @@ export function is_crossorigin() {
 }
 
 export function add_resize_listener(node: HTMLElement, fn: () => void) {
+	if ('ResizeObserver' in window) {
+		const obs = new ResizeObserver(fn);
+		obs.observe(node);
+		return obs.disconnect.bind(obs);
+	}
 	const computed_style = getComputedStyle(node);
 	const z_index = (parseInt(computed_style.zIndex) || 0) - 1;
 

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -261,7 +261,7 @@ export function is_crossorigin() {
 
 export function add_resize_listener(node: HTMLElement, fn: () => void) {
 	if ('ResizeObserver' in window) {
-		const obs = new ResizeObserver(fn);
+		const obs = new ResizeObserver(fn) as any;
 		obs.observe(node);
 		return obs.disconnect.bind(obs);
 	}


### PR DESCRIPTION
https://caniuse.com/resizeobserver 87%
note that [typescript dom libs do not include types for ResizeObserver](https://github.com/Microsoft/TypeScript/issues/28502)
untested