### PR TITLE
Only allow passing functions to lifecycle methods like onMount.

### DIFF
--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -11,19 +11,19 @@ export function get_current_component() {
 	return current_component;
 }
 
-export function beforeUpdate(fn) {
+export function beforeUpdate(fn: () => any) {
 	get_current_component().$$.before_update.push(fn);
 }
 
-export function onMount(fn) {
+export function onMount(fn: () => any) {
 	get_current_component().$$.on_mount.push(fn);
 }
 
-export function afterUpdate(fn) {
+export function afterUpdate(fn: () => any) {
 	get_current_component().$$.after_update.push(fn);
 }
 
-export function onDestroy(fn) {
+export function onDestroy(fn: () => any) {
 	get_current_component().$$.on_destroy.push(fn);
 }
 


### PR DESCRIPTION
Changing the parameter of `onMount` etc to take a function rather than `any`. I accidentally passed an evaluated function rather than the function itself in my TypeScript Sapper project and that gave a runtime rather than a compile-time error.

If I understand it right, `types.d.ts` is created from this file which in turn is used by the Sapper type definitions.