### PR TITLE
Fixed outdated typescriptlang.org link in comment

### DIFF
--- a/src/compiler/compile/nodes/interfaces.ts
+++ b/src/compiler/compile/nodes/interfaces.ts
@@ -32,7 +32,7 @@ import Transition from './Transition';
 import Window from './Window';
 
 // note: to write less types each of types in union below should have type defined as literal
-// https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions
+// https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#discriminating-unions
 export type INode = Action
 | Animation
 | Attribute


### PR DESCRIPTION
The link in the comment pointed to an anchor which didn't exist on the page, so I did a search on the anchor and found out the information had moved to a separate page.

### Before submitting the PR, please make sure you do the following
- [x] (not applicable, simple comment change) It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] (not applicable, read manual test below) Ideally, include a test that fails without this PR but passes with it.
  - The manual test would be to go to the old link and see that it doesn't contain information about discriminating unions (fail) and then going to the new link and seeing that it does contain information about discriminating unions (success).

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
