### PR TITLE
swipeLeft transition

### DIFF
--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -131,7 +131,27 @@ export function slide(node: Element, {
 			`border-bottom-width: ${t * border_bottom_width}px;`
 	};
 }
-
+interface SwipeLeftParams {
+	delay?: number;
+	duration?: number;
+	easing?: EasingFunction;
+}
+export function swipeLeft(node: Element, { 
+	delay = 0,
+	duration = 500,
+	easing = cubicInOut
+}:SwipeLeftParams ) {
+	return {
+		delay,
+		duration,
+		css: t => {
+			const eased = easing(t);
+			return `
+				transform: translate3d(-${(1-eased)*100}%,0,0);
+				`
+		}
+	};
+}
 interface ScaleParams {
 	delay?: number;
 	duration?: number;


### PR DESCRIPTION
Expands on the existing svelte transitions library to now allow for an element to be brought in from the left.

This was needed as the slide transition only animates vertically, which makes sense for its use case but sometimes it might be better for a left transition.Demo: https://eager-roentgen-4fca47.netlify.app