### PR TITLE
Add svelte@next caveat to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-## Is this about svelte@next? This project is currently in a pre-release stage, we do not want any kind of bug reports or questions on GitHub about it
+## Is this about svelte@next? This project is currently in a pre-release stage and breaking changes may occur at any time. Please do not post any kind of bug reports or questions on GitHub about it.
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+## Is this about svelte@next? This project is currently in a pre-release stage, we do not want any kind of bug reports or questions on GitHub about it
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
Adds a big headline to stop people from submitting or asking svelte@next questions/bug reports. Not at all sure about the wording but I feel like it's probably a good idea to have something to the effect in there?