### PR TITLE
More comprehensible Stores type

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -113,7 +113,7 @@ export function writable<T>(value: T, start: StartStopNotifier<T> = noop): Writa
 }
 
 /** One or more `Readable`s. */
-type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>];
+type Stores = Readable<any> | Readable<any>[];
 
 /** One or more values from `Readable` stores. */
 type StoresValues<T> = T extends Readable<infer U> ? U :

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -113,7 +113,7 @@ export function writable<T>(value: T, start: StartStopNotifier<T> = noop): Writa
 }
 
 /** One or more `Readable`s. */
-type Stores = Readable<any> | Readable<any>[];
+type Stores = Readable<any> | Array<Readable<any>>;
 
 /** One or more values from `Readable` stores. */
 type StoresValues<T> = T extends Readable<infer U> ? U :


### PR DESCRIPTION
If Stores can be a "Readable<any>" or a bunch of "Readable<any>"s why not make that array a type that is better readable (Readable<any>[]). Otherwise I have to parse an Array of Readables like that: "list as [Readable<any>, ...Array<Readable<any>>]" which is not very nice.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
