### PR TITLE
feat: spring easing functions

### DIFF
--- a/src/runtime/easing/index.ts
+++ b/src/runtime/easing/index.ts
@@ -1,3 +1,5 @@
+import { springFrames } from "svelte/motion";
+
 /*
 Adapted from https://github.com/mattdesl
 Distributed under MIT License https://github.com/mattdesl/eases/blob/master/LICENSE.md
@@ -168,4 +170,36 @@ export function sineIn(t: number) {
 
 export function sineOut(t: number) {
 	return Math.sin((t * Math.PI) / 2);
+}
+
+const springEasing = (frames, inDirection = true) => t => {
+	t = inDirection ? t : 1 - t;
+	const indexPrecise = t * frames.length;
+	const indexExcess = indexPrecise % 1;
+
+	const a = frames[indexPrecise - indexExcess];
+	let b = frames[indexPrecise - indexExcess + 1];
+	if (b == null) {
+		b = a;
+	}
+
+	return indexExcess ? a + (b - a) * indexExcess : a;
+};
+
+export function springEnter(from, to, opts) {
+	const frames = springFrames(from, to, opts);
+
+	return { 
+        duration: (frames.length * 1000) / 60,
+        easing: springEasing(frames) 
+    };
+}
+
+export function springLeave(from, to, opts) {
+	const frames = springFrames(from, to, opts);
+
+	return { 
+        duration: (frames.length * 1000) / 60,
+        easing: springEasing(frames, false) 
+    };
 }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [❌] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [✅] This message body should clearly illustrate what problems it solves.
- [TODO] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [TODO] Run the tests with `npm test` and lint the project with `npm run lint`

I'm opening this PR both for early feedback, and also to get some help setting up my environment. I've tested this code locally, by modifying the Svelte source in node_modules of a running web app, but I can't get my Svelte clone to `npm i`. I get a ton of errors that look like this:

![image](https://user-images.githubusercontent.com/11261266/97089129-62977600-15fb-11eb-8b47-0070a4850bc5.png)

---

The changes in this PR would allow you to use spring animations inside of transitions. Rich helped me to understand how easing functions work, and how to translate them to what a transition is looking for. I took that and integrated it into your easing package, and added code to manually unpack a spring, and get the eventual values up front.

The usage would look like this

```js
const { easing: modalSpringIn, duration } = springEnter(frames);

function modalIn() {
  return {
    duration,
    css: t => {
      const transformY = modalSpringIn(t);
      const opacity = expoOut(t);

      return `
        transform: translate3d(0px, ${transformY}px, 0px);
        opacity: ${opacity};
      `;
    },
  };
}
```

```html
<div in:modalIn out:modalOut bind:this={root}>
  <slot />
</div>
```

which would fade in a modal, as it bounces into place.

Are these changes you're interested in?

If so, there's one other thing I need a bit of help understanding. In spring.ts, you'll see I'm running dt = 1 on all subsequent calls to spring_tick, which would be a perfect 60fps iiuc. But what should the initial value of dt be, for the first run, in a perfect world? On subsequent runs, dt is usually 0.99 or so, but on the initial run, it's usually -.2, or something. On the first run, now() is *less than* last_time, which I don't quite understand. now() seems to be provided by performance.now() (when on the front end) and is updated via what's passed to the rAF callback.  

I guess what I really need to know is what dt would be initially in an ideal circumstance. 0? 

EDIT - setting `dt` to 1 permanently does appear to be more correct. I had doubted it initially since the initial change seemed too steep, but I think that may have been because of the spring config I had at the time. So I'm left wondering if what I described just above is a bug in the Svelte source?