### PR TITLE
Make unused `transition_out` parameters optional

### DIFF
--- a/src/runtime/internal/transitions.ts
+++ b/src/runtime/internal/transitions.ts
@@ -48,7 +48,7 @@ export function transition_in(block, local?: 0 | 1) {
 	}
 }
 
-export function transition_out(block, local: 0 | 1, detach: 0 | 1, callback) {
+export function transition_out(block, local: 0 | 1, detach?: 0 | 1, callback?) {
 	if (block && block.o) {
 		if (outroing.has(block)) return;
 		outroing.add(block);


### PR DESCRIPTION
The compiler usually skips the last two arguments of `transition_out`
![Code_2020-10-26_11-04-24](https://user-images.githubusercontent.com/30108880/97159352-06f3f680-177b-11eb-8c4c-e4e7eca19a61.png)
https://svelte.dev/repl/4d97f6be1ef14dc7b814903790d49afc?version=3.29.4