### PR TITLE
Correct `onDestroy` behavior description

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -102,7 +102,7 @@ onDestroy(callback: () => void)
 
 ---
 
-Schedules a callback to run immediately before the component unmounts.
+Schedules a callback to run immediately before the component is unmounted.
 
 Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the only one that runs inside a server-side component.
 

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -102,7 +102,7 @@ onDestroy(callback: () => void)
 
 ---
 
-Schedules a callback to run once the component is unmounted.
+Schedules a callback to run immediately before the component unmounts.
 
 Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the only one that runs inside a server-side component.
 


### PR DESCRIPTION
The documentation implied `onDestroy` callbacks were run _after_ unmount, which is incorrect
https://github.com/sveltejs/svelte/blob/7c1e6a6ce7cce68f41a7628d6b59340673e05046/src/runtime/internal/Component.ts#L79-L81
https://svelte.dev/repl/504565b53a114603beaaa3680dc645f2?version=3.29.4