### PR TITLE
Bump eslint-config to 5.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,8 +144,8 @@
       }
     },
     "@sveltejs/eslint-config": {
-      "version": "github:sveltejs/eslint-config#5d1ba28f99568e42f26d9b7484ab57720f6ec9b4",
-      "from": "github:sveltejs/eslint-config#v5.4.0",
+      "version": "github:sveltejs/eslint-config#54081d752d199dba97db9f578665c87f18469da3",
+      "from": "github:sveltejs/eslint-config#v5.5.0",
       "dev": true
     },
     "@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@rollup/plugin-sucrase": "^3.0.0",
     "@rollup/plugin-typescript": "^2.0.1",
     "@rollup/plugin-virtual": "^2.0.0",
-    "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.4.0",
+    "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.5.0",
     "@types/mocha": "^7.0.0",
     "@types/node": "^8.10.53",
     "@typescript-eslint/eslint-plugin": "^3.0.2",


### PR DESCRIPTION
The code changes were already checked in via https://github.com/sveltejs/svelte/pull/5585, so this just bumps the package to enforce the change