### PR TITLE
Fix: Media elements a11y

### DIFF
--- a/site/content/examples/05-bindings/09-media-elements/App.svelte
+++ b/site/content/examples/05-bindings/09-media-elements/App.svelte
@@ -115,8 +115,9 @@
 		on:mousedown={handleMousedown}
 		bind:currentTime={time}
 		bind:duration
-		bind:paused
-	></video>
+		bind:paused>
+			<track kind="captions"/>
+	</video>
 
 	<div class="controls" style="opacity: {duration && showControls ? 1 : 0}">
 		<progress value="{(time / duration) || 0}"/>


### PR DESCRIPTION
Fix Accessibility warning log. Example page:media-elements

<img width="598" alt="fix_media_elements" src="https://user-images.githubusercontent.com/41711526/97447482-ee4e3100-1972-11eb-94e2-7dcaa34ff43b.png">


### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
