### PR TITLE
Fix: a11y media element examples:named-exports

### DIFF
--- a/site/content/examples/18-module-context/01-module-exports/AudioPlayer.svelte
+++ b/site/content/examples/18-module-context/01-module-exports/AudioPlayer.svelte
@@ -41,7 +41,8 @@
 		on:play={stopOthers}
 		controls
 		{src}
-	></audio>
+	>
+	<track kind="captions" /></audio>
 </article>
 
 <style>

--- a/site/content/tutorial/17-module-context/01-sharing-code/app-a/AudioPlayer.svelte
+++ b/site/content/tutorial/17-module-context/01-sharing-code/app-a/AudioPlayer.svelte
@@ -22,7 +22,7 @@
 		on:play={stopOthers}
 		controls
 		{src}
-	></audio>
+	><track kind="captions" /></audio>
 </article>
 
 <style>

--- a/site/content/tutorial/17-module-context/01-sharing-code/app-b/AudioPlayer.svelte
+++ b/site/content/tutorial/17-module-context/01-sharing-code/app-b/AudioPlayer.svelte
@@ -27,7 +27,7 @@
 		on:play={stopOthers}
 		controls
 		{src}
-	></audio>
+	><track kind="captions" /></audio>
 </article>
 
 <style>

--- a/site/content/tutorial/17-module-context/02-module-exports/app-a/AudioPlayer.svelte
+++ b/site/content/tutorial/17-module-context/02-module-exports/app-a/AudioPlayer.svelte
@@ -35,7 +35,7 @@
 		on:play={stopOthers}
 		controls
 		{src}
-	></audio>
+	><track kind="captions" /></audio>
 </article>
 
 <style>

--- a/site/content/tutorial/17-module-context/02-module-exports/app-b/AudioPlayer.svelte
+++ b/site/content/tutorial/17-module-context/02-module-exports/app-b/AudioPlayer.svelte
@@ -41,7 +41,7 @@
 		on:play={stopOthers}
 		controls
 		{src}
-	></audio>
+	><track kind="captions" /></audio>
 </article>
 
 <style>


### PR DESCRIPTION
Fix: examples page: named-exports a11y

<img width="871" alt="named-exports" src="https://user-images.githubusercontent.com/41711526/97576306-56fbe300-1a31-11eb-8606-56d50c1019af.png">

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
