### PR TITLE
Update README.md: discord badge with members online

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/npm/l/svelte.svg" alt="license">
   </a>
   <a href="https://svelte.dev/chat">
-    <img src="https://img.shields.io/badge/chat-on%20discord-7289da.svg" alt="Chat">
+    <img src="https://img.shields.io/discord/457912077277855764?label=chat&logo=discord" alt="Chat">
   </a>
 </p>
 


### PR DESCRIPTION
Per the conversation [here](https://discord.com/channels/457912077277855764/750401468569354431/771757850178355230) this PR adds discord chat badge with the number of people online on discord.


Preview 
![image](https://user-images.githubusercontent.com/3922469/97745407-d3182880-1b0e-11eb-8925-af66d8daed73.png)
