### PR TITLE
Set 'current' if the block has outros without intro (Fix #5120)

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -226,7 +226,9 @@ export default class Block {
 		const { dev } = this.renderer.options;
 
 		if (this.has_outros) {
-			this.add_variable({ type: 'Identifier', name: '#current' });
+
+			this.add_variable({ type: 'Identifier', name: '#current' },
+				this.chunks.intro.length === 0 ? x`true` : undefined);
 
 			if (this.chunks.intro.length > 0) {
 				this.chunks.intro.push(b`#current = true;`);

--- a/test/runtime/samples/reactive-mixed-slots/Component.svelte
+++ b/test/runtime/samples/reactive-mixed-slots/Component.svelte
@@ -1,0 +1,4 @@
+<slot name="named"/>
+<slot/>
+
+<script></script>

--- a/test/runtime/samples/reactive-mixed-slots/Empty.svelte
+++ b/test/runtime/samples/reactive-mixed-slots/Empty.svelte
@@ -1,0 +1,1 @@
+<script></script>

--- a/test/runtime/samples/reactive-mixed-slots/_config.js
+++ b/test/runtime/samples/reactive-mixed-slots/_config.js
@@ -1,0 +1,15 @@
+export default {
+	html: `
+    <div slot='named'></div>
+    <a href='___init'>___init</a>
+    `,
+
+	test({ assert, component, target }) {
+        component.value = 'update';
+        
+        assert.htmlEqual(target.innerHTML, `
+            <div slot='named'></div>
+            <a href='___update'>___update</a>
+		`);
+	}
+};

--- a/test/runtime/samples/reactive-mixed-slots/main.svelte
+++ b/test/runtime/samples/reactive-mixed-slots/main.svelte
@@ -1,0 +1,11 @@
+<script>
+    import Component from './Component.svelte';
+    import Empty from './Empty.svelte';
+
+    export let value = "init"
+</script>
+
+<Component>
+    <div slot="named"><Empty/></div>
+    <a href="___{value}">___{value}</a>
+</Component>


### PR DESCRIPTION
If a block have outros, but doesn't have intros, then the 'current' local property is never updated and always evaluate to false.
Some reactive properties are then never updated, because the update is bypassed with "!current || update"


### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`
