### PR TITLE
Improve ssr hydration performance

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -1,7 +1,7 @@
 import { add_render_callback, flush, schedule_update, dirty_components } from './scheduler';
 import { current_component, set_current_component } from './lifecycle';
 import { blank_object, is_empty, is_function, run, run_all, noop } from './utils';
-import { children, detach } from './dom';
+import { children, detach, start_hydrating, end_hydrating } from './dom';
 import { transition_in } from './transitions';
 
 interface Fragment {
@@ -147,6 +147,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 
 	if (options.target) {
 		if (options.hydrate) {
+			start_hydrating();
 			const nodes = children(options.target);
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			$$.fragment && $$.fragment!.l(nodes);
@@ -158,6 +159,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 
 		if (options.intro) transition_in(component.$$.fragment);
 		mount_component(component, options.target, options.anchor);
+		end_hydrating();
 		flush();
 	}
 

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -210,12 +210,12 @@ export function claim_element(nodes, name, attributes, svg) {
 }
 
 export function claim_text(nodes, data) {
-	const node = nodes.shift();
+	const node = nodes[0];
 	if (node) {
 		if (node.nodeType === 3) {
 			node.data = '' + data;
-			return node;
-		} else {
+			return nodes.shift();
+		} else if (!data.match(/\s+/)) {
 			console.error(`Hydration error: Expected text node "${data}" but found`, node);
 			detach(node);
 		}

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -1,6 +1,6 @@
 import { has_prop } from './utils';
 
-let is_hydrating = true;
+let is_hydrating = false;
 const nodes_to_detach = new Set<Node>();
 
 export function start_hydrating() {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -199,7 +199,7 @@ export function claim_element(nodes, name, attributes, svg) {
 			return node;
 		} else {
 			// Ignore hydration errors caused by empty text nodes
-			if (node.nodeType !== 3 || !node.data.match(/\s+/)) {
+			if (node.nodeType !== 3 || (node.data !== ' ' && node.data !== '')) {
 				console.error(`Hydration error: Expected node "${name}" but found`, node);
 			}
 			detach(node);
@@ -211,15 +211,19 @@ export function claim_element(nodes, name, attributes, svg) {
 
 export function claim_text(nodes, data) {
 	const node = nodes[0];
+
 	if (node) {
 		if (node.nodeType === 3) {
 			node.data = '' + data;
 			return nodes.shift();
-		} else if (!data.match(/\s+/)) {
-			console.error(`Hydration error: Expected text node "${data}" but found`, node);
-			detach(node);
+		} else if (data !== ' ' && data !== '') {
+			console.error(
+				`Hydration error: Expected text node "${data}" but found`,
+				node
+			);
 		}
 	}
+
 	return text(data);
 }
 


### PR DESCRIPTION
### Background
This PR improves SSR hydration performance through minimizing DOM mutations during hydration by avoiding de- and reattaching nodes during hydration. This should fix #1067, #4308 and parts of #5108.

In order for this to work I added a new new "hydration mode". This way it's possible to maintain the detach by default behavior during hydration without modifying the generated component output. There might be better ways to do this if we reconsider fragment creation (as suggested in #3898 and #4219) but that would be a significant undertaking.

The existing append, insert and detached methods have been modified to track which nodes are claimed during hydration. That way unclaimed nodes can then removed from the DOM at the end of hydration without touching the remaining nodes.

In order for this to work the append, insert and detach methods have also been made idempotent (i.e. "upserts") in order to allow attaching an already attached DOM node.

Finally I also added some basic logging of hydration errors to the console.

### Results 

Initial local benchmarks against johnells.se (which runs on Sapper) shows a 50% reduction of LCP when running Lighthouse, which results in decent PageSpeed score improvement.

### Next steps

- [ ] Add test case