### PR TITLE
docs: broken link to easing function

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -777,7 +777,7 @@ The `flip` function calculates the start and end position of an element and anim
 
 * `delay` (`number`, default 0) — milliseconds before starting
 * `duration` (`number` | `function`, default `d => Math.sqrt(d) * 120`) — see below
-* `easing` (`function`, default [`cubicOut`](docs#cubicOut)) — an [easing function](docs#svelte_easing)
+* `easing` (`function`, default `cubicOut`) — an [easing function](docs#svelte_easing)
 
 
 `duration` can be be provided as either:


### PR DESCRIPTION
I also checked the other names of easing functions but found no other link to remove.

Thank you all for svelte !

<details>
<summary>PR checks (not applicable)</summary>

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
</details>