### PR TITLE
fixed minor typo in each loop animation error

### DIFF
--- a/src/compiler/compile/nodes/Animation.ts
+++ b/src/compiler/compile/nodes/Animation.ts
@@ -27,7 +27,7 @@ export default class Animation extends Node {
 			// TODO can we relax the 'immediate child' rule?
 			component.error(this, {
 				code: 'invalid-animation',
-				message: 'An element that use the animate directive must be the immediate child of a keyed each block'
+				message: 'An element that uses the animate directive must be the immediate child of a keyed each block'
 			});
 		}
 

--- a/src/compiler/compile/nodes/EachBlock.ts
+++ b/src/compiler/compile/nodes/EachBlock.ts
@@ -61,7 +61,7 @@ export default class EachBlock extends AbstractBlock {
 				const child = this.children.find(child => !!(child as Element).animation);
 				component.error((child as Element).animation, {
 					code: 'invalid-animation',
-					message: 'An element that use the animate directive must be the sole child of a keyed each block'
+					message: 'An element that uses the animate directive must be the sole child of a keyed each block'
 				});
 			}
 		}

--- a/test/validator/samples/animation-not-in-each/errors.json
+++ b/test/validator/samples/animation-not-in-each/errors.json
@@ -1,6 +1,6 @@
 [{
 	"code": "invalid-animation",
-	"message": "An element that use the animate directive must be the immediate child of a keyed each block",
+	"message": "An element that uses the animate directive must be the immediate child of a keyed each block",
 	"start": {
 		"line": 5,
 		"column": 5,

--- a/test/validator/samples/animation-not-in-keyed-each/errors.json
+++ b/test/validator/samples/animation-not-in-keyed-each/errors.json
@@ -1,6 +1,6 @@
 [{
 	"code": "invalid-animation",
-	"message": "An element that use the animate directive must be the immediate child of a keyed each block",
+	"message": "An element that uses the animate directive must be the immediate child of a keyed each block",
 	"start": {
 		"line": 6,
 		"column": 6,

--- a/test/validator/samples/animation-siblings/errors.json
+++ b/test/validator/samples/animation-siblings/errors.json
@@ -1,6 +1,6 @@
 [{
 	"code": "invalid-animation",
-	"message": "An element that use the animate directive must be the sole child of a keyed each block",
+	"message": "An element that uses the animate directive must be the sole child of a keyed each block",
 	"start": {
 		"line": 6,
 		"column": 6,


### PR DESCRIPTION
# Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`

This error message has a typo:
`An element that use the animate directive must be the immediate child of a keyed each block`

It should instead be 
`An element that uses the animate directive must be the immediate child of a keyed each block`

or maybe 
`Elements that use the animate directive must be the immediate child of a keyed each block`.

I decided on the former.

I'm not sure if this is worth the PR but it was bugging me