### PR TITLE
Add register to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
       "import": "./motion/index.mjs",
       "require": "./motion/index.js"
     },
+    "./register": {
+      "require": "./register.js"
+    },
     "./store": {
       "import": "./store/index.mjs",
       "require": "./store/index.js"


### PR DESCRIPTION
This PR is to fix the error that occurs when trying to `require ('svelte/register')` which was introduced when the exports field was added recently. The issue can be found at https://github.com/sveltejs/svelte/issues/5670

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
