### PR TITLE
docs: increase syntax highlighting color contrast

### DIFF
--- a/site/static/prism.css
+++ b/site/static/prism.css
@@ -7,12 +7,12 @@
 /*	colors --------------------------------- */
 pre[class*='language-'] {
 	--background: var(--back-light);
-	--base:       hsl(45, 7%, 45%);
-	--comment:    hsl(210, 25%, 60%);
-	--keyword:    hsl(204, 58%, 45%);
-	--function:   hsl(19, 67%, 45%);
-	--string:     hsl(41, 37%, 45%);
-	--number:     hsl(102, 27%, 50%);
+	--base:       #545454;
+	--comment:    #696969;
+	--keyword:    #007f8a;
+	--function:   #bb5525;
+	--string:     #856e3d;
+	--number:     #008000;
 	--tags:       var(--function);
 	--important:  var(--string);
 }


### PR DESCRIPTION
This partially resolves one of the Axe Accessibility violations listed in #5678: [Elements must have sufficient color contrast](https://dequeuniversity.com/rules/axe/4.0/color-contrast?application=AxeChrome) (2018 count). 

This reduces the number of color contrast violations from 2018 to 228. The colors for the syntax highlighting tokens were below the WCAG AA threshold of 4.5. This meant that people with low vision could have difficulty reading the text. Below is a list of contrast ratios for each token, before and after the change.

- base: was 4.26, now 7.21
- comment: was 2.8, now 5.23
- keyword: was 4.1, now 4.54
- function: was 4.31, now 4.5
- string: was 3.49, now 4.65
- number: was 2.84, now 4.89

Before:
![image](https://user-images.githubusercontent.com/4992896/99280708-7f802d00-27e6-11eb-9994-5dd7bc35abca.png)

After:
![image](https://user-images.githubusercontent.com/4992896/99280918-c110d800-27e6-11eb-9220-b228f19148ac.png)

I adapted some of the colors from Eric Bailey's [accessible syntax highlighting themes](https://github.com/ericwbailey/a11y-syntax-highlighting).
