### PR TITLE
fix(tutorial): improve chapter on Keyed Each Blocks

### DIFF
--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/App.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/App.svelte
@@ -1,23 +1,23 @@
 <script>
 	import Thing from './Thing.svelte';
 
-	let things = [
-		{ id: 1, color: '#0d0887' },
-		{ id: 2, color: '#6a00a8' },
-		{ id: 3, color: '#b12a90' },
-		{ id: 4, color: '#e16462' },
-		{ id: 5, color: '#fca636' }
+	let array = [
+		{ id: 1, data: 1 },
+		{ id: 2, data: 2 },
+		{ id: 3, data: 3 },
+		{ id: 4, data: 4 },
+		{ id: 5, data: 5 }
 	];
 
 	function handleClick() {
-		things = things.slice(1);
+		array = array.slice(1);
 	}
 </script>
 
 <button on:click={handleClick}>
-	Remove first thing
+	Remove first element
 </button>
 
-{#each things as thing}
-	<Thing current={thing.color}/>
+{#each array as element}
+	<Thing current={element.data}/>
 {/each}

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
@@ -6,19 +6,14 @@
 	const initial = current;
 </script>
 
-<p>
-	<span style="background-color: {initial}">initial</span>
-	<span style="background-color: {current}">current</span>
-</p>
+<p>initial: {initial}, current: {current}</p>
 
 <style>
-	span {
-		display: inline-block;
-		padding: 0.2em 0.5em;
-		margin: 0 0.2em 0.2em 0;
-		width: 4em;
+	p {
+		background-color: #ededed;
+		padding: 0.5em 0;
+		margin: 1em 0;
 		text-align: center;
 		border-radius: 0.2em;
-		color: white;
 	}
 </style>

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/App.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/App.svelte
@@ -1,23 +1,23 @@
 <script>
 	import Thing from './Thing.svelte';
 
-	let things = [
-		{ id: 1, color: '#0d0887' },
-		{ id: 2, color: '#6a00a8' },
-		{ id: 3, color: '#b12a90' },
-		{ id: 4, color: '#e16462' },
-		{ id: 5, color: '#fca636' }
+	let array = [
+		{ id: 1, data: 1 },
+		{ id: 2, data: 2 },
+		{ id: 3, data: 3 },
+		{ id: 4, data: 4 },
+		{ id: 5, data: 5 }
 	];
 
 	function handleClick() {
-		things = things.slice(1);
+		array = array.slice(1);
 	}
 </script>
 
 <button on:click={handleClick}>
-	Remove first thing
+	Remove first element
 </button>
 
-{#each things as thing (thing.id)}
-	<Thing current={thing.color}/>
+{#each array as element (element.id)}
+	<Thing current={element.data}/>
 {/each}

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
@@ -6,19 +6,14 @@
 	const initial = current;
 </script>
 
-<p>
-	<span style="background-color: {initial}">initial</span>
-	<span style="background-color: {current}">current</span>
-</p>
+<p>initial: {initial}, current: {current}</p>
 
 <style>
-	span {
-		display: inline-block;
-		padding: 0.2em 0.5em;
-		margin: 0 0.2em 0.2em 0;
-		width: 4em;
+	p {
+		background-color: #ededed;
+		padding: 0.5em 0;
+		margin: 1em 0;
 		text-align: center;
 		border-radius: 0.2em;
-		color: white;
 	}
 </style>

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
@@ -2,11 +2,11 @@
 title: Keyed each blocks
 ---
 
-By default, when you add / remove an item from the iterable that the `each` block iterates over, it will add / remove the component instance at the *end* of the block instead of the corresponding instance. If you add / remove items from anywhere other than the end of the iterable, this leads to each component instance corresponding to a different element of the iterable than the one it was first created for. This might not be what you want.
+By default, when you add / remove an item from the iterable that the `each` block iterates over, it will add / remove the component instance at the *end* of the block instead of the instance corresponding to that element of the iterable. If you add / remove an item from anywhere other than the end of the iterable, this leads to each component instance corresponding to a different element of the iterable than the one it was first created for. That might not be what you want.
 
-It's easier to understand with an example. For each element of the array, <code>#each</code> creates one instance of the `<Thing>` component seen as a row. The initial value shows to which element of the original array the instance corresponded when it was created, while the current value shows which element of the current array it corresponds to now. The expected behavior would be that both values match.
+It's easier to understand with an example. For each element of the array, <code>#each</code> creates one instance of the `<Thing>` component which you can see as rows. The initial value shows to which element of the original array the instance corresponded when it was created, while the current value shows which element of the current array it corresponds to now. The expected behavior would be that both values match.
 
-Click the 'Remove first element' button a few times, and notice that it's removing `<Thing>` components from the end, and updating the value for those that remain. Instead, we'd like to remove the first `<Thing>` component and leave the rest unaffected.
+Click the 'Remove first element' button a few times, and notice that it's removing `<Thing>` components from the end, and updating the prop for those that remain. Instead, we'd like to remove the first `<Thing>` component and leave the rest unaffected.
 
 To do that, we specify a unique identifier for the `each` block in parentheses:
 

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
@@ -2,18 +2,20 @@
 title: Keyed each blocks
 ---
 
-By default, when you modify the value of an `each` block, it will add and remove items at the *end* of the block, and update any values that have changed. That might not be what you want.
+By default, when you add / remove an item from the iterable that the `each` block iterates over, it will add / remove the component instance at the *end* of the block instead of the corresponding instance. If you add / remove items from anywhere other than the end of the iterable, this leads to each component instance corresponding to a different element of the iterable than the one it was first created for. This might not be what you want.
 
-It's easier to show why than to explain. Click the 'Remove first thing' button a few times, and notice that it's removing `<Thing>` components from the end and updating the `color` for those that remain. Instead, we'd like to remove the first `<Thing>` component and leave the rest unaffected.
+It's easier to understand with an example. For each element of the array, <code>#each</code> creates one instance of the `<Thing>` component seen as a row. The initial value shows to which element of the original array the instance corresponded when it was created, while the current value shows which element of the current array it corresponds to now. The expected behavior would be that both values match.
 
-To do that, we specify a unique identifier for the `each` block:
+Click the 'Remove first element' button a few times, and notice that it's removing `<Thing>` components from the end, and updating the value for those that remain. Instead, we'd like to remove the first `<Thing>` component and leave the rest unaffected.
+
+To do that, we specify a unique identifier for the `each` block in parentheses:
 
 ```html
-{#each things as thing (thing.id)}
-	<Thing current={thing.color}/>
+{#each array as element (element.id)}
+	<Thing current={element.id}/>
 {/each}
 ```
 
-The `(thing.id)` tells Svelte how to figure out what changed.
+The `(element.id)` tells Svelte how to figure out what changed.
 
-> You can use any object as the key, as Svelte uses a `Map` internally — in other words you could do `(thing)` instead of `(thing.id)`. Using a string or number is generally safer, however, since it means identity persists without referential equality, for example when updating with fresh data from an API server.
+> You can use any object as the key, as Svelte uses a `Map` internally — in other words you could do `(element)` instead of `(element.id)`. Using a string or number is generally safer, however, since it means identity persists without referential equality, for example when updating with fresh data from an API server.

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
@@ -2,11 +2,11 @@
 title: Keyed each blocks
 ---
 
-By default, when you add an element to the array that the `each` block iterates over, it will add an item at the *end* of the block instead of at the same position as the element's index, and update the attributes of the existing items. This means that if you add an element to the array anywhere other than at the end, this leads to each item corresponding to a different element of the array than the one it was first created for. The same goes for removing an element from the array. That might not be what you want.
+By default, when you add an element to the array that the `each` block iterates over, it will add an item at the *end* of the block instead of at the same position as the element in the array, and update the attributes of the existing items. This means that if you add an element to the array anywhere other than at the end, this leads to each item corresponding to a different element of the array than the one it was created for. The same goes for removing an element from the array. That might not be what you want.
 
-It's easier to understand with an example. For each element of the array, <code>#each</code> creates one `<Thing>` component which you can see as rows. The initial value corresponds to the element of the original array for which the component was created, while the current value shows the element of the current array it corresponds to now. The expected behavior would be that both values match.
+It's easier to understand with an example. For each element of the array, <code>#each</code> creates one `<Thing>` component which you can see as a row. The initial value corresponds to the element of the original array for which the component was created, while the current value shows the element of the array it corresponds to currently. The expected behavior would be that for a component both values always match.
 
-Click the 'Remove first element' button a few times, and notice that it's removing `<Thing>` components from the end, and updating the prop for those that remain. Instead, we'd like to remove the first `<Thing>` component and leave the rest unaffected.
+Click the 'Remove first element' button a few times. Notice how it's removing `<Thing>` components from the end and updating the prop for those that remain. Instead, we'd like the button to remove only the first `<Thing>` component and leave the rest unaffected.
 
 To do that, we specify a unique identifier for the `each` block in parentheses:
 

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
@@ -2,9 +2,9 @@
 title: Keyed each blocks
 ---
 
-By default, when you add / remove an item from the iterable that the `each` block iterates over, it will add / remove the component instance at the *end* of the block instead of the instance corresponding to that element of the iterable. If you add / remove an item from anywhere other than the end of the iterable, this leads to each component instance corresponding to a different element of the iterable than the one it was first created for. That might not be what you want.
+By default, when you add an element to the array that the `each` block iterates over, it will add an item at the *end* of the block instead of at the same position as the element's index. This means that if you add an element to the array anywhere other than at the end, this leads to each item corresponding to a different element of the array than the one it was first created for. The same goes for removing an element. That might not be what you want.
 
-It's easier to understand with an example. For each element of the array, <code>#each</code> creates one instance of the `<Thing>` component which you can see as rows. The initial value shows to which element of the original array the instance corresponded when it was created, while the current value shows which element of the current array it corresponds to now. The expected behavior would be that both values match.
+It's easier to understand with an example. For each element of the array, <code>#each</code> creates one `<Thing>` component which you can see as rows. The initial value shows to which element of the array the component instance corresponded when it was created, while the current value shows which element of the current array it corresponds to now. The expected behavior would be that both values match.
 
 Click the 'Remove first element' button a few times, and notice that it's removing `<Thing>` components from the end, and updating the prop for those that remain. Instead, we'd like to remove the first `<Thing>` component and leave the rest unaffected.
 

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
@@ -2,9 +2,9 @@
 title: Keyed each blocks
 ---
 
-By default, when you add an element to the array that the `each` block iterates over, it will add an item at the *end* of the block instead of at the same position as the element's index. This means that if you add an element to the array anywhere other than at the end, this leads to each item corresponding to a different element of the array than the one it was first created for. The same goes for removing an element. That might not be what you want.
+By default, when you add an element to the array that the `each` block iterates over, it will add an item at the *end* of the block instead of at the same position as the element's index, and update the attributes of the existing items. This means that if you add an element to the array anywhere other than at the end, this leads to each item corresponding to a different element of the array than the one it was first created for. The same goes for removing an element from the array. That might not be what you want.
 
-It's easier to understand with an example. For each element of the array, <code>#each</code> creates one `<Thing>` component which you can see as rows. The initial value shows to which element of the array the component instance corresponded when it was created, while the current value shows which element of the current array it corresponds to now. The expected behavior would be that both values match.
+It's easier to understand with an example. For each element of the array, <code>#each</code> creates one `<Thing>` component which you can see as rows. The initial value corresponds to the element of the original array for which the component was created, while the current value shows the element of the current array it corresponds to now. The expected behavior would be that both values match.
 
 Click the 'Remove first element' button a few times, and notice that it's removing `<Thing>` components from the end, and updating the prop for those that remain. Instead, we'd like to remove the first `<Thing>` component and leave the rest unaffected.
 


### PR DESCRIPTION
(Continuing #5436 because I had deleted my fork. Sorry!)

I found the chapter on Keyed Each Blocks of the tutorial very confusing, so I tried to improve it.

To begin with, the explanation is very loose. For example, the first sentence is

> [...] when you modify the value of an each block [...]

What is "a value of an each block"? I think "a value of the array that the `#each` block iterates over" would be much clearer.

Also, the example wasn't very easy to understand.
- It's not visually clear that each row corresponds to an instance of the  `<Thing>` component and not each box. I tried to visually separate each row to make that more clear.
- Although colors are nice to immediately see differences, I found it hard to make sense of which color corresponds to which element of the array. I think numbers are simpler and easier to keep track of.
- It's confusing that the array `things` is named identically to the component `<Thing>`. I think the name "array" for the array and "element" for its elements make it clearer.

Here is a sample, after clicking 2 times the "Remove first element" button. Note how with numbers you immediately see that the first two elements are missing, while with colors it's harder to spot.

<img width="500" alt="before" src="https://user-images.githubusercontent.com/33468089/99544456-9f654b80-29b4-11eb-92c6-b10a792064ba.png">

<img width="500" alt="after" src="https://user-images.githubusercontent.com/33468089/99544453-9d9b8800-29b4-11eb-99f6-0cfbddc592a5.png">

I hope my proposed changes makes this chapter much easier to understand.