### PR TITLE
Force TS to ignore global typings. Fixes: https://github.com/sveltejs…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
 		//"strict": true,
 		"noImplicitThis": true,
 		"noUnusedLocals": true,
-		"noUnusedParameters": true
+		"noUnusedParameters": true,
+		"typeRoots": ["./node_modules/@types"]
 	}
 }


### PR DESCRIPTION
Fix for https://github.com/sveltejs/svelte/issues/5692.

This PR adds a `typeRoots` property to tsconfig, so global types a user may have installed will not break the build. 

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [] Run the tests with `npm test` and lint the project with `npm run lint`
