### PR TITLE
site a11y: add missing h1s

### DIFF
--- a/site/src/routes/blog/index.svelte
+++ b/site/src/routes/blog/index.svelte
@@ -18,6 +18,7 @@
 	<meta name="Description" content="Articles about Svelte and UI development">
 </svelte:head>
 
+<h1 class="visually-hidden">Blog</h1>
 <div class='posts stretch'>
 	{#each posts as post}
 		<article class='post' data-pubdate={post.metadata.dateString}>

--- a/site/src/routes/docs/index.svelte
+++ b/site/src/routes/docs/index.svelte
@@ -19,4 +19,5 @@
 	<meta name="Description" content="Cybernetically enhanced web apps">
 </svelte:head>
 
+<h1 class="visually-hidden">API Docs</h1>
 <Docs {sections}/>

--- a/site/src/routes/examples/index.svelte
+++ b/site/src/routes/examples/index.svelte
@@ -100,6 +100,7 @@
 	<meta name="Description" content="Interactive example Svelte apps">
 </svelte:head>
 
+<h1 class="visually-hidden">Examples</h1>
 <div class='examples-container' bind:clientWidth={width}>
 	<div class="viewport offset-{offset}">
 		<TableOfContents {sections} active_section={active_slug} {isLoading} />

--- a/site/src/routes/index.svelte
+++ b/site/src/routes/index.svelte
@@ -34,6 +34,7 @@
 	<meta name="Description" content="Cybernetically enhanced web apps">
 </svelte:head>
 
+<h1 class="visually-hidden">Svelte</h1>
 <Hero
 	title="Svelte"
 	tagline="Cybernetically enhanced web apps"

--- a/site/static/global.css
+++ b/site/static/global.css
@@ -29,3 +29,16 @@ h5:hover .anchor,
 h6:hover .anchor {
 	opacity: 1;
 }
+
+/* visually hidden, but accessible to assistive tech */
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: auto;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
This resolves one of the Axe accessibility violations listed in #5678: [Page must contain a level-one heading](https://dequeuniversity.com/rules/axe/4.0/page-has-heading-one?application=AxeChrome)

Several pages on the site were missing h1 elements. Without this element, it's more difficult for screen readers to jump to the main content of the page.

In order to not affect how the page looks, I applied a class to the headings to hide them visually but still allow them to be accessed by assistive tech.