### PR TITLE
docs a11y: wrap code blocks instead of overflowing

### DIFF
--- a/site/static/prism.css
+++ b/site/static/prism.css
@@ -36,7 +36,7 @@ pre[class*='language-'] {
 
 /*	code-blocks ---------------------------- */
 pre[class*='language-'] {
-	overflow: auto;
+	white-space: pre-wrap;
 	padding: 1.5rem 2rem;
 	margin: .8rem 0 2.4rem;
 	/* max-width: var(--code-w); */


### PR DESCRIPTION
This PR resolves one of the Axe accessibility violations in #5678: [Ensure that scrollable region has keyboard access](https://dequeuniversity.com/rules/axe/4.0/scrollable-region-focusable?application=AxeChrome) (74 count).

The code blocks were set to `overflow: auto` so that they would horizontally scroll when the content became too long. However, this had accessibility issues because keyboard-only users had no way to scroll the code blocks and would be unable to see part of the examples.

One way to fix this would be to add `tabindex="0"` to all code blocks to allow them to be focused and scrolled. However, this would make all 200+ code blocks in the documentation tab stops, even when they don't overflow. This could make it more tedious to navigate the docs using the keyboard. In addition, [focusable elements must have an accessible name](https://www.w3.org/TR/using-aria/#fifth), which the code blocks do not have.

Because of these issues, I instead chose to force the code blocks to wrap instead of overflowing. This doesn't affect many code blocks when viewing the docs on a desktop, because the screen is wide enough to fit most lines. The code blocks wrap more aggressively on mobile, but they are still readable. IMO, this is an acceptable trade-off to make sure the docs are accessible to as many people as possible.

Example wrapping on desktop:
![image](https://user-images.githubusercontent.com/4992896/100137007-a7077300-2e40-11eb-8b62-cb7b4601409e.png)

Example wrapping on mobile:
![image](https://user-images.githubusercontent.com/4992896/100136982-9c4cde00-2e40-11eb-98ab-8b0ca75a5506.png)

