### PR TITLE
Allow document level hydration (#5547).

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -5,7 +5,9 @@ export function append(target: Node, node: Node) {
 }
 
 export function insert(target: Node, node: Node, anchor?: Node) {
-	target.insertBefore(node, anchor || null);
+	if (target != document) {
+		target.insertBefore(node, anchor || null);
+	}
 }
 
 export function detach(node: Node) {


### PR DESCRIPTION
Related to issue https://github.com/sveltejs/svelte/issues/5547

This change allows you to target the top level `<html>` element for hydration. Without this change, if you try this you would receive an error that you can't run `insertBefore` on Node.