### PR TITLE
Remove duplicate sentence

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -418,8 +418,6 @@ The expression should be valid standalone HTML — `{@html "<div>"}content{@html
 
 The `{@debug ...}` tag offers an alternative to `console.log(...)`. It logs the values of specific variables whenever they change, and pauses code execution if you have devtools open.
 
-It accepts a comma-separated list of variable names (not arbitrary expressions).
-
 ```sv
 <script>
 	let user = {


### PR DESCRIPTION
The sentence, "`@debug` accepts a comma-separated list of variable names (not arbitrary expressions)" is repeated a few lines below, where it's accompanied by an example showing how variable names are accepted but expressions are not. Since they're back to back, it reads as redundant (imo).