### PR TITLE
Changing hex codes to colour names to improve readability of the tutorial.

### DIFF
--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/App.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/App.svelte
@@ -2,11 +2,11 @@
 	import Thing from './Thing.svelte';
 
 	let things = [
-		{ id: 1, color: '#0d0887' },
-		{ id: 2, color: '#6a00a8' },
-		{ id: 3, color: '#b12a90' },
-		{ id: 4, color: '#e16462' },
-		{ id: 5, color: '#fca636' }
+		{ id: 1, color: 'darkblue' },
+		{ id: 2, color: 'indigo' },
+		{ id: 3, color: 'deeppink' },
+		{ id: 4, color: 'salmon' },
+		{ id: 5, color: 'gold' }
 	];
 
 	function handleClick() {

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/App.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/App.svelte
@@ -1,7 +1,7 @@
 <script>
 	import Thing from './Thing.svelte';
 
-		let things = [
+	let things = [
 		{ id: 1, color: 'darkblue' },
 		{ id: 2, color: 'indigo' },
 		{ id: 3, color: 'deeppink' },

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/App.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/App.svelte
@@ -1,12 +1,12 @@
 <script>
 	import Thing from './Thing.svelte';
 
-	let things = [
-		{ id: 1, color: '#0d0887' },
-		{ id: 2, color: '#6a00a8' },
-		{ id: 3, color: '#b12a90' },
-		{ id: 4, color: '#e16462' },
-		{ id: 5, color: '#fca636' }
+		let things = [
+		{ id: 1, color: 'darkblue' },
+		{ id: 2, color: 'indigo' },
+		{ id: 3, color: 'deeppink' },
+		{ id: 4, color: 'salmon' },
+		{ id: 5, color: 'gold' }
 	];
 
 	function handleClick() {


### PR DESCRIPTION

The Svelte tutorial is very well written but I was stumped in one particular chapter: [Keyed each blocks](https://svelte.dev/tutorial/keyed-each-blocks). Here it explains Svelte's behaviour when looping through an array of objects using an each block.


This was a bit tricky to understand for beginners and the hex colour codes did not make things easy, so I looked for the nearest named colours to the hex code present in the tutorial, this would enable new learners to visualize and understand the reactive behaviour here. 
For instance `#0d0887` being removed from the UI is hard to track for humans, whereas  understanding `indigo` being removed from the UI is exponentially easier.

I hope this fixes #5760  to some extent.
