### PR TITLE
changed to colour names instead of hex codes for readability

### DIFF
--- a/site/content/examples/03-logic/04-keyed-each-blocks/App.svelte
+++ b/site/content/examples/03-logic/04-keyed-each-blocks/App.svelte
@@ -2,11 +2,11 @@
 	import Thing from './Thing.svelte';
 
 	let things = [
-		{ id: 1, color: '#0d0887' },
-		{ id: 2, color: '#6a00a8' },
-		{ id: 3, color: '#b12a90' },
-		{ id: 4, color: '#e16462' },
-		{ id: 5, color: '#fca636' }
+		{ id: 1, color: 'darkblue' },
+		{ id: 2, color: 'indigo' },
+		{ id: 3, color: 'deeppink' },
+		{ id: 4, color: 'salmon' },
+		{ id: 5, color: 'gold' }
 	];
 
 	function handleClick() {


### PR DESCRIPTION
As discussed in PR #5761 , using colour names instead of hex codes improves readability of these examples.

It is easier to visualize gold, it isn't as easy to visualize `#fca636`, hence this minor fix.