### PR TITLE
Fix formatMobile to account for aughts

### DIFF
--- a/site/content/examples/12-svg/02-bar-chart/App.svelte
+++ b/site/content/examples/12-svg/02-bar-chart/App.svelte
@@ -18,7 +18,7 @@
 	let height = 200;
 
 	function formatMobile(tick) {
-		return "'" + tick % 100;
+		return "'" + tick.toString().slice(2);
 	}
 
 	$: xScale = scaleLinear()

--- a/site/content/examples/12-svg/02-bar-chart/App.svelte
+++ b/site/content/examples/12-svg/02-bar-chart/App.svelte
@@ -18,7 +18,7 @@
 	let height = 200;
 
 	function formatMobile(tick) {
-		return "'" + tick.toString().slice(2);
+		return "'" + tick.toString().slice(-2);
 	}
 
 	$: xScale = scaleLinear()

--- a/site/content/examples/12-svg/03-area-chart/App.svelte
+++ b/site/content/examples/12-svg/03-area-chart/App.svelte
@@ -23,7 +23,7 @@
 	$: area = `${path}L${xScale(maxX)},${yScale(0)}L${xScale(minX)},${yScale(0)}Z`;
 
 	function formatMobile (tick) {
-		return "'" + tick.toString().slice(2);
+		return "'" + tick.toString().slice(-2);
 	}
 </script>
 

--- a/site/content/examples/12-svg/03-area-chart/App.svelte
+++ b/site/content/examples/12-svg/03-area-chart/App.svelte
@@ -23,7 +23,7 @@
 	$: area = `${path}L${xScale(maxX)},${yScale(0)}L${xScale(minX)},${yScale(0)}Z`;
 
 	function formatMobile (tick) {
-		return "'" + tick % 100;
+		return "'" + tick.toString().slice(2);
 	}
 </script>
 


### PR DESCRIPTION
This changes the formatMobile function to account for the aughts in the two "chart" SVG examples (I mistakenly called them graphs in my branch name. I'm not sure I actually know the difference.) In the current version '2000' and '2005' are abbreviated to '0 and '5 instead of '00 and '05. Not the most pressing issue, but this is my first open source pull request so I was excited.