### PR TITLE
Edited tutorial to give more context.

### DIFF
--- a/site/content/tutorial/06-bindings/05-textarea-inputs/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/05-textarea-inputs/app-a/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	import marked from 'marked';
-	let value = `Some words are *italic*, some are **bold**`;
+	let value = `Some words are *italic*, some are **bold** (Scroll down to see markdown output).`;
 </script>
 
 <style>

--- a/site/content/tutorial/06-bindings/05-textarea-inputs/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/05-textarea-inputs/app-a/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	import marked from 'marked';
-	let value = `Some words are *italic*, some are **bold** (Scroll down to see markdown output).`;
+	let value = `Some words are *italic*, some are **bold** (You may have to scroll down to see the markdown output).`;
 </script>
 
 <style>

--- a/site/content/tutorial/06-bindings/05-textarea-inputs/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/05-textarea-inputs/app-b/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	import marked from 'marked';
-	let value = `Some words are *italic*, some are **bold**`;
+	let value = `Some words are *italic*, some are **bold** (Scroll down to see markdown output).`;
 </script>
 
 <style>

--- a/site/content/tutorial/06-bindings/05-textarea-inputs/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/05-textarea-inputs/app-b/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	import marked from 'marked';
-	let value = `Some words are *italic*, some are **bold** (Scroll down to see markdown output).`;
+	let value = `Some words are *italic*, some are **bold** (You may have to scroll down to see the markdown output).`;
 </script>
 
 <style>


### PR DESCRIPTION
I own a 13 inch MacBook Air and when I did [the Bindings/Textarea tutorial](https://svelte.dev/tutorial/textarea-inputs) with my browser maximized, I was stuck for a few seconds as I couldn't find out the rendered markdown output(See below):

![Screen Shot 2020-12-14 at 7 39 38 PM](https://user-images.githubusercontent.com/4549937/102152963-24247780-3e44-11eb-8079-8de217285182.png)


The markdown output is hidden below the text area and one needs to scroll to find it, this results in a mildly sub-optimal experience, hence, I have modified the string to ask new Svelte learners to scroll below, like this:

![Screen Shot 2020-12-14 at 7 41 02 PM](https://user-images.githubusercontent.com/4549937/102153049-559d4300-3e44-11eb-86bd-963641dc4ff5.png)
