### PR TITLE
fix(site): ensure "text/plain" on error response

### DIFF
--- a/site/src/server.js
+++ b/site/src/server.js
@@ -10,7 +10,9 @@ const app = polka({
 	onError: (err, req, res) => {
 		const error = err.message || err;
 		const code = err.code || err.status || 500;
-		res.headersSent || send(res, code, { error });
+		res.headersSent || send(res, code, { error }, {
+			'content-type': 'text/plain'
+		});
 	}
 });
 


### PR DESCRIPTION
Not sure that we have any tests for `/site` aside from the slugger.

- Closes #5820
