### PR TITLE
clarified readonly prop access

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -57,6 +57,8 @@ In development mode (see the [compiler options](docs#svelte_compile)), a warning
 
 If you export a `const`, `class` or `function`, it is readonly from outside the component. Function *expressions* are valid props, however.
 
+Readonly props can be accessed as properties on the element, tied to the component using [`bind:this` syntax](docs#bind_element).
+
 ```sv
 <script>
 	// these are readonly


### PR DESCRIPTION
Was personally unaware how readonly props can be accessed until I found [this stackoverflow answer](https://stackoverflow.com/questions/58287729/how-can-i-export-a-function-from-a-svelte-component-that-changes-a-value-in-the) through some googling recently. Does not seem to be mentioned anywhere in the docs.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
