### PR TITLE
Mark optional fragment types

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -5,18 +5,18 @@ import { children, detach } from './dom';
 import { transition_in } from './transitions';
 
 interface Fragment {
-	key: string|null;
-	first: null;
+	key?: string|null;
+	first?: null;
 	/* create  */ c: () => void;
-	/* claim   */ l: (nodes: any) => void;
-	/* hydrate */ h: () => void;
+	/* claim   */ l?: (nodes: any) => void;
+	/* hydrate */ h?: () => void;
 	/* mount   */ m: (target: HTMLElement, anchor: any) => void;
-	/* update  */ p: (ctx: any, dirty: any) => void;
-	/* measure */ r: () => void;
-	/* fix     */ f: () => void;
-	/* animate */ a: () => void;
-	/* intro   */ i: (local: any) => void;
-	/* outro   */ o: (local: any) => void;
+	/* update  */ p?: (ctx: any, dirty: any) => void;
+	/* measure */ r?: () => void;
+	/* fix     */ f?: () => void;
+	/* animate */ a?: () => void;
+	/* intro   */ i?: (local: any) => void;
+	/* outro   */ o?: (local: any) => void;
 	/* destroy */ d: (detaching: 0|1) => void;
 }
 interface T$$ {

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -11,7 +11,7 @@ interface Fragment {
 	/* claim   */ l?: (nodes: any) => void;
 	/* hydrate */ h?: () => void;
 	/* mount   */ m: (target: HTMLElement, anchor: any) => void;
-	/* update  */ p?: (ctx: any, dirty: any) => void;
+	/* update  */ p: (ctx: any, dirty: any) => void;
 	/* measure */ r?: () => void;
 	/* fix     */ f?: () => void;
 	/* animate */ a?: () => void;


### PR DESCRIPTION
<img width="439" alt="Code_2020-12-27_04-12-27" src="https://user-images.githubusercontent.com/30108880/103163242-e76d5e80-47fb-11eb-9fe8-92d89f4c1844.png">
The typing for fragments wrongly requires all properties. 

This PR makes all but `.c()`, `.m()`, `.p()` and `.d()` optional, which AFAIK are the only ones internals always assume to be specified