### PR TITLE
add: parse attached sourcemap from preprocessor

### DIFF
--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -1,7 +1,12 @@
 import { RawSourceMap, DecodedSourceMap } from '@ampproject/remapping/dist/types/types';
 import { decode as decode_mappings } from 'sourcemap-codec';
 import { getLocator } from 'locate-character';
-import { StringWithSourcemap, sourcemap_add_offset, combine_sourcemaps } from '../utils/string_with_sourcemap';
+import {
+	StringWithSourcemap,
+	sourcemap_add_offset,
+	combine_sourcemaps,
+	parse_attached_sourcemap
+} from '../utils/string_with_sourcemap';
 
 export interface Processed {
 	code: string;
@@ -178,6 +183,8 @@ function get_replacement(
 		file_basename, prefix, get_location(offset));
 	const suffix_with_map = StringWithSourcemap.from_source(
 		file_basename, suffix, get_location(offset + prefix.length + original.length));
+
+	parse_attached_sourcemap(processed);
 
 	// Convert the preprocessed code and its sourcemap to a StringWithSourcemap
 	let decoded_map: DecodedSourceMap;

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -175,7 +175,8 @@ function get_replacement(
 	original: string,
 	processed: Processed,
 	prefix: string,
-	suffix: string
+	suffix: string,
+	tag_name: 'script' | 'style'
 ): StringWithSourcemap {
 
 	// Convert the unchanged prefix and suffix to StringWithSourcemap
@@ -184,7 +185,7 @@ function get_replacement(
 	const suffix_with_map = StringWithSourcemap.from_source(
 		file_basename, suffix, get_location(offset + prefix.length + original.length));
 
-	parse_attached_sourcemap(processed);
+	parse_attached_sourcemap(processed, tag_name);
 
 	// Convert the preprocessed code and its sourcemap to a StringWithSourcemap
 	let decoded_map: DecodedSourceMap;
@@ -289,7 +290,7 @@ export default async function preprocess(
 				if (!processed || !processed.map && processed.code === content) {
 					return no_change();
 				}
-				return get_replacement(file_basename, offset, get_location, content, processed, `<${tag_name}${attributes}>`, `</${tag_name}>`);
+				return get_replacement(file_basename, offset, get_location, content, processed, `<${tag_name}${attributes}>`, `</${tag_name}>`, tag_name);
 			}
 		);
 		source = res.string;

--- a/src/compiler/utils/string_with_sourcemap.ts
+++ b/src/compiler/utils/string_with_sourcemap.ts
@@ -291,8 +291,7 @@ export function apply_preprocessor_sourcemap(filename: string, svelte_map: Sourc
 	return result_map as SourceMap;
 }
 
-// find attached sourcemap in processed.code
-// TODO? handle multiple attached maps, combine with processed.map
+// parse attached sourcemap in processed.code
 export function parse_attached_sourcemap(processed: Processed): void {
 	const magic_prefix = '\n/*# sourceMappingURL=data:application/json;';
 	const cut_index = processed.code.lastIndexOf('\n');

--- a/src/compiler/utils/string_with_sourcemap.ts
+++ b/src/compiler/utils/string_with_sourcemap.ts
@@ -308,18 +308,19 @@ export function parse_attached_sourcemap(processed: Processed, tag_name: 'script
 		if (map_data) {
 			// sourceMappingURL is data URL
 			if (processed.map) {
-				log_warning('not implemented. ' +
-					'found sourcemap in both processed.code and processed.map. ' +
-					'please make your preprocessor return only one sourcemap.');
+				log_warning('Not implemented. ' +
+					'Found sourcemap in both processed.code and processed.map. ' +
+					'Please update your preprocessor to return only one sourcemap.');
+				// ignore attached sourcemap
+				return '';
 			}
 			processed.map = b64dec(map_data); // use attached sourcemap
 			return ''; // remove from processed.code
 		}
 		// sourceMappingURL is path or URL
 		if (!processed.map) {
-			log_warning('value error. processed.map is empty, ' +
-				`but processed.code has attached sourcemap path ${JSON.stringify(map_url)}. ` +
-				'please make your preprocessor return a sourcemap.');
+			log_warning(`Found sourcemap path ${JSON.stringify(map_url)} in processed.code, but no sourcemap data. ` +
+				'Please update your preprocessor to return sourcemap data directly.');
 		}
 		// ignore sourcemap path
 		return ''; // remove from processed.code

--- a/test/sourcemaps/index.ts
+++ b/test/sourcemaps/index.ts
@@ -42,7 +42,7 @@ describe('sourcemaps', () => {
 					filename: 'input.svelte'
 				}
 			);
-	
+
 			const { js, css } = svelte.compile(
 				preprocessed.code, {
 				filename: 'input.svelte',

--- a/test/sourcemaps/index.ts
+++ b/test/sourcemaps/index.ts
@@ -31,7 +31,8 @@ describe('sourcemaps', () => {
 			const inputCode = fs.readFileSync(inputFile, 'utf-8');
 			const input = {
 				code: inputCode,
-				locate: getLocator(inputCode)
+				locate: getLocator(inputCode),
+				locate_1: getLocator(inputCode, { offsetLine: 1 })
 			};
 
 			const preprocessed = await svelte.preprocess(
@@ -86,12 +87,14 @@ describe('sourcemaps', () => {
 
 			assert.deepEqual(
 				js.map.sources.slice().sort(),
-				(config.js_map_sources || ['input.svelte']).sort()
+				(config.js_map_sources || ['input.svelte']).sort(),
+				'js.map.sources is wrong'
 			);
 			if (css.map) {
 				assert.deepEqual(
 					css.map.sources.slice().sort(),
-					(config.css_map_sources || ['input.svelte']).sort()
+					(config.css_map_sources || ['input.svelte']).sort(),
+					'css.map.sources is wrong'
 				);
 			}
 

--- a/test/sourcemaps/samples/attached-sourcemap/_config.js
+++ b/test/sourcemaps/samples/attached-sourcemap/_config.js
@@ -1,37 +1,44 @@
 import MagicString from 'magic-string';
 
 let indent_size = 4;
-function get_processor(search, replace) {
-	return ({ content, filename }) => {
-		let code = content.slice();
-		const ms = new MagicString(code);
+let comment_multi = true;
+function get_processor(tag_name, search, replace) {
+	return {
+		[tag_name]: ({ content, filename }) => {
+			let code = content.slice();
+			const ms = new MagicString(code);
 
-		const idx = ms.original.indexOf(search);
-		if (idx == -1) throw new Error('search not found in src');
-		ms.overwrite(idx, idx + search.length, replace, { storeName: true });
+			const idx = ms.original.indexOf(search);
+			if (idx == -1) throw new Error('search not found in src');
+			ms.overwrite(idx, idx + search.length, replace, { storeName: true });
 
-		// change line + column
-		const indent = Array.from({ length: indent_size }).join(' ');
-		ms.prependLeft(idx, '\n'+indent);
+			// change line + column
+			const indent = Array.from({ length: indent_size }).join(' ');
+			ms.prependLeft(idx, '\n'+indent);
 
-		const map_opts = { source: filename, hires: true, includeContent: false };
-		const map = ms.generateMap(map_opts);
-		const attach_line = `\n/*# sourceMappingURL=${map.toUrl()} */`;
-		code = ms.toString() + attach_line;
+			const map_opts = { source: filename, hires: true, includeContent: false };
+			const map = ms.generateMap(map_opts);
+			const attach_line = (tag_name == 'style' || comment_multi)
+				? `\n/*# sourceMappingURL=${map.toUrl()} */`
+				: `\n//# sourceMappingURL=${map.toUrl()}` // only in script
+			;
+			code = ms.toString() + attach_line;
 
-		indent_size += 2;
-		return { code };
+			indent_size += 2;
+			if (tag_name == 'script') comment_multi = !comment_multi;
+			return { code };
+		}
 	};
 }
 
 export default {
 	preprocess: [
 
-		{ script: get_processor('replace_me_script', 'done_replace_script_1') },
-		{ script: get_processor('done_replace_script_1', 'done_replace_script_2') },
+		get_processor('script', 'replace_me_script', 'done_replace_script_1'),
+		get_processor('script', 'done_replace_script_1', 'done_replace_script_2'),
 
-		{ style: get_processor('.replace_me_style', '.done_replace_style_1') },
-		{ style: get_processor('.done_replace_style_1', '.done_replace_style_2') }
+		get_processor('style', '.replace_me_style', '.done_replace_style_1'),
+		get_processor('style', '.done_replace_style_1', '.done_replace_style_2')
 
 	]
 };

--- a/test/sourcemaps/samples/attached-sourcemap/_config.js
+++ b/test/sourcemaps/samples/attached-sourcemap/_config.js
@@ -1,0 +1,37 @@
+import MagicString from 'magic-string';
+
+let indent_size = 4;
+function get_processor(search, replace) {
+	return ({ content, filename }) => {
+		let code = content.slice();
+		const ms = new MagicString(code);
+
+		const idx = ms.original.indexOf(search);
+		if (idx == -1) throw new Error('search not found in src');
+		ms.overwrite(idx, idx + search.length, replace, { storeName: true });
+
+		// change line + column
+		const indent = Array.from({ length: indent_size }).join(' ');
+		ms.prependLeft(idx, '\n'+indent);
+
+		const map_opts = { source: filename, hires: true, includeContent: false };
+		const map = ms.generateMap(map_opts);
+		const attach_line = `\n/*# sourceMappingURL=${map.toUrl()} */`;
+		code = ms.toString() + attach_line;
+
+		indent_size += 2;
+		return { code };
+	};
+}
+
+export default {
+	preprocess: [
+
+		{ script: get_processor('replace_me_script', 'done_replace_script_1') },
+		{ script: get_processor('done_replace_script_1', 'done_replace_script_2') },
+
+		{ style: get_processor('.replace_me_style', '.done_replace_style_1') },
+		{ style: get_processor('.done_replace_style_1', '.done_replace_style_2') }
+
+	]
+};

--- a/test/sourcemaps/samples/attached-sourcemap/input.svelte
+++ b/test/sourcemaps/samples/attached-sourcemap/input.svelte
@@ -1,0 +1,11 @@
+<style>
+	.replace_me_style {
+		color: red;
+	}
+</style>
+<script>
+	let
+		replace_me_script = 'hello'
+	;
+</script>
+<h1 class="done_replace_style_2">{done_replace_script_2}</h1>

--- a/test/sourcemaps/samples/attached-sourcemap/test.js
+++ b/test/sourcemaps/samples/attached-sourcemap/test.js
@@ -1,0 +1,45 @@
+import * as assert from 'assert';
+
+const get_line_column = obj => ({ line: obj.line, column: obj.column });
+
+export function test({ input, css, js }) {
+
+	let out_obj, loc_output, actual, loc_input, expected;
+
+	out_obj = js;
+	// we need the seconds occurence in output.js
+	loc_output = out_obj.locate_1('done_replace_script_2');
+	loc_output = out_obj.locate_1('done_replace_script_2', loc_output.character + 1);
+	actual = out_obj.mapConsumer.originalPositionFor(loc_output);
+	loc_input = input.locate_1('replace_me_script');
+	expected = {
+		source: 'input.svelte',
+		name: 'replace_me_script',
+		...get_line_column(loc_input)
+	};
+	assert.deepEqual(actual, expected);
+
+	out_obj = css;
+	loc_output = out_obj.locate_1('.done_replace_style_2');
+	actual = out_obj.mapConsumer.originalPositionFor(loc_output);
+	// first occurence in input.svelte
+	loc_input = input.locate_1('.replace_me_style');
+	expected = {
+		source: 'input.svelte',
+		name: '.replace_me_style',
+		...get_line_column(loc_input)
+	};
+	assert.deepEqual(actual, expected);
+
+	assert.equal(
+		js.code.indexOf('\n/*# sourceMappingURL=data:application/json;base64,'),
+		-1,
+		'magic-comment attachments were NOT removed'
+	);
+
+	assert.equal(
+		css.code.indexOf('\n/*# sourceMappingURL=data:application/json;base64,'),
+		-1,
+		'magic-comment attachments were NOT removed'
+	);
+}

--- a/test/sourcemaps/samples/attached-sourcemap/test.js
+++ b/test/sourcemaps/samples/attached-sourcemap/test.js
@@ -7,7 +7,8 @@ export function test({ input, css, js }) {
 	let out_obj, loc_output, actual, loc_input, expected;
 
 	out_obj = js;
-	// we need the seconds occurence in output.js
+	// we need the second occurence of 'done_replace_script_2' in output.js
+	// the first occurence is mapped back to markup '{done_replace_script_2}'
 	loc_output = out_obj.locate_1('done_replace_script_2');
 	loc_output = out_obj.locate_1('done_replace_script_2', loc_output.character + 1);
 	actual = out_obj.mapConsumer.originalPositionFor(loc_output);
@@ -22,7 +23,6 @@ export function test({ input, css, js }) {
 	out_obj = css;
 	loc_output = out_obj.locate_1('.done_replace_style_2');
 	actual = out_obj.mapConsumer.originalPositionFor(loc_output);
-	// first occurence in input.svelte
 	loc_input = input.locate_1('.replace_me_style');
 	expected = {
 		source: 'input.svelte',


### PR DESCRIPTION
solve issue https://github.com/sveltejs/svelte-preprocess/issues/286

allow preprocessors to return sourcemaps not only in `result.map`
but also attached to `result.code` as 'magic comment' in script or style

```js
var code = 'here';
/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW ... vgICB9XG4iXX0= */
```

or in script
```js
var code = 'here';
//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW ... vgICB9XG4iXX0=
```

the attached sourcemap is removed, so the browser does not double-parse the sourcemap
that was the original problem in issue 286
this removal is asserted by the test

for now, support only one sourcemap, either in `result.map` or attached to `result.code`, not both --> fatal error

also for now, this works only for `script` and `style` preprocessors
in theory, the 'magic comment' strategy is also possible in html