### PR TITLE
Replace on:change with on:blur

### DIFF
--- a/site/content/tutorial/06-bindings/06-select-bindings/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/06-select-bindings/app-a/App.svelte
@@ -21,7 +21,7 @@
 <h2>Insecurity questions</h2>
 
 <form on:submit|preventDefault={handleSubmit}>
-	<select value={selected} on:change="{() => answer = ''}">
+	<select value={selected} on:blur="{() => answer = ''}">
 		{#each questions as question}
 			<option value={question}>
 				{question.text}

--- a/site/content/tutorial/06-bindings/06-select-bindings/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/06-select-bindings/app-b/App.svelte
@@ -21,7 +21,7 @@
 <h2>Insecurity questions</h2>
 
 <form on:submit|preventDefault={handleSubmit}>
-	<select bind:value={selected} on:change="{() => answer = ''}">
+	<select bind:value={selected} on:blur="{() => answer = ''}">
 		{#each questions as question}
 			<option value={question}>
 				{question.text}


### PR DESCRIPTION
Addresses the A11y warning on the tutorial module Block 6 Lesson 6:
`A11y: on:blur must be used instead of on:change, unless absolutely necessary and it causes no negative consequences for keyboard only or screen reader users. (24:1)`

It appears that this PR has been attempted before but declined due to the change creating some conflicts when using a mouse vs. the keyboard. However, the PR(s?) are several months old and as far as I can tell the change from `on:change` to `on:blur` no longer has any negative effects. Perhaps this is because of browser updates... I checked several browsers and did not notice any of the previously noticed ill effects (I was checking on a Mac... Can anyone verify on IE? If needed I could spin up an AWS Windows VM).

Link to discussion [here](https://github.com/sveltejs/svelte/issues/4946), [here](https://github.com/sveltejs/svelte/pull/4788) and the previous PR [here](https://github.com/sveltejs/svelte/pull/5037).

Tagging previous authors to offer input, if any - @gsimone & @pablote

### Tests
`npm test` returns errors related to WebSocket... `Error: WebSocket is not open: readyState 3 (CLOSED)` I am pretty sure my changes are not causing that. Likely my environment (?). 
3194 passed, 24 pending, 8 failing... 

`npm run lint` checks out okay.