### PR TITLE
Add a readOnly function to svelte/store and documentation

### DIFF
--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -365,6 +365,38 @@ const delayed = derived([a, b], ([$a, $b], set) => {
 });
 ```
 
+
+#### `readOnly`
+
+```js
+readable = readOnly(writable: Writable<T>)
+```
+
+---
+
+Sometimes readable and derived aren't the ideal tools for more complex custom stores. For stores that need to only be writable in their module, and _not_ outside, you can use `readOnly` to get a readonly version of a writable store.
+
+```js
+import { writable, readOnly } from 'svelte/store';
+
+const userStore = writable({});
+
+export function logIn(username, password) {
+	if (password == 'password') {
+		userStore.set({ username, error: null });
+	} else {
+		userStore.set({ username: null, error: 'Bad Password' });
+	}
+}
+
+export function logOut() {
+	userStore.set({});
+}
+
+export const user = readOnly(userStore);
+```
+
+
 #### `get`
 
 ```js

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -197,6 +197,17 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 }
 
 /**
+ * Get a readable store from a writable store.
+ *
+ * @param store writable
+ *
+ * @returns readable store
+ */
+export function readOnly<T>(store: Writable<T>): Readable<T> {
+	return { subscribe: store.subscribe };
+}
+
+/**
  * Get the current value from a store by subscribing and immediately unsubscribing.
  * @param store readable
  */


### PR DESCRIPTION
This is a single, tree-shakable function added to the svelte/store runtime. I re-write this for almost every project, it's a handy way to create a custom store and prevent directly modifying a store from outside a module. The custom-element tests all failed, and I couldn't work out how to add a test for this since the ideal test would be something like:

```
import {writable, readOnly} from 'svelte/store';
function test() {
  const writableStore = writable(null);
  const readableStore = readOnly(writableStore);

  assertNotNull(writableStore.set);
  assertFalsey(readableStore.set);
}
```

I'm happy to make any changes needed, or for this to be rejected, but the easiest way to get the conversation going is with a PR.