### PR TITLE
change detected language to TypeScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-/site/* -linguist-detectable
+/site/** -linguist-detectable
+/test/** -linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 /site/** -linguist-detectable
-/test/*/samples -linguist-detectable
+/test/*/samples/** -linguist-detectable
 /**/*.svelte linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /site/** -linguist-detectable
 /test/** -linguist-detectable
+/**/*.svelte linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/site/* -linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 /site/** -linguist-detectable
-/test/** -linguist-detectable
+/test/*/samples -linguist-detectable
 /**/*.svelte linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 /site/** -linguist-detectable
-/test/*/samples/** -linguist-detectable
+/test/**/samples/** -linguist-detectable
 /**/*.svelte linguist-detectable


### PR DESCRIPTION
linguist scans the repository and selects the programming language to display.

This PR advises linguist to not look into `/site` and `/test`.
Now linguist selects TypeScript.

resolves issue #4284

Test: https://github.com/baslr?tab=repositories&q=svelte&type=&language= https://github.com/baslr/svelte
<img width="279" alt="Bildschirmfoto 2021-01-12 um 23 43 39" src="https://user-images.githubusercontent.com/1494154/104383390-0f64fd80-5530-11eb-87a6-8cce424afce1.png">

![Bildschirmfoto 2021-01-13 um 13 27 39](https://user-images.githubusercontent.com/1494154/104452368-327cc500-55a3-11eb-90b5-34a77eed9bbb.png)
