### PR TITLE
Change color on 404 page; Update to _error.svelte

### DIFF
--- a/site/src/routes/_error.svelte
+++ b/site/src/routes/_error.svelte
@@ -28,7 +28,7 @@
 	p { margin: 1em auto }
 
 	.error {
-		background-color: #da106e;
+		background-color: var(--second);
 		color: white;
 		padding: 12px 16px;
 		font: 600 16px/1.7 var(--font);


### PR DESCRIPTION
The colour on broken pages have `#da106e` and is not a part of `theme-default` in [site-kit](https://github.com/sveltejs/site-kit/blob/master/base.css#L33).

Also `#676778` is easy on the eyes.



Before
![image](https://user-images.githubusercontent.com/3922469/105990368-5faf9400-60c8-11eb-89da-22af05a011d3.png)


After 

![image](https://user-images.githubusercontent.com/3922469/105990402-69d19280-60c8-11eb-8f8a-f30ead7bc83e.png)



