### PR TITLE
Swap the order of the two derived store signatures to fix TS inference

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -125,10 +125,12 @@ type StoresValues<T> = T extends Readable<infer U> ? U :
  *
  * @param stores - input stores
  * @param fn - function callback that aggregates the values
+ * @param initial_value - when used asynchronously
  */
 export function derived<S extends Stores, T>(
 	stores: S,
-	fn: (values: StoresValues<S>) => T
+	fn: (values: StoresValues<S>, set: (value: T) => void) => Unsubscriber | void,
+	initial_value?: T
 ): Readable<T>;
 
 /**
@@ -137,12 +139,10 @@ export function derived<S extends Stores, T>(
  *
  * @param stores - input stores
  * @param fn - function callback that aggregates the values
- * @param initial_value - when used asynchronously
  */
 export function derived<S extends Stores, T>(
 	stores: S,
-	fn: (values: StoresValues<S>, set: (value: T) => void) => Unsubscriber | void,
-	initial_value?: T
+	fn: (values: StoresValues<S>) => T
 ): Readable<T>;
 
 export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Readable<T> {


### PR DESCRIPTION
**Before**
- Using `derived(store, (value, set) => {})` fails to infer the parameters of the second function (it infers them as `any` which seems to indicate it picked the simpler signature where the function only has one parameter)
- All other forms compile fine, even the one with the set param and a start value.

**After**
- All combinations compile and infer properly.

I just swapped the order of the two declarations, now forcing TS to consider the more complex signature first.

PS: Have you considered progressively rewriting the tests in typescript to catch these kinds of issues?

Cheers