### PR TITLE
More forgiving SvelteComponentDev typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Throw a parser error for `class:` directives with an empty class name ([#5858](https://github.com/sveltejs/svelte/issues/5858))
 * Fix type inference for derived stores ([#5935](https://github.com/sveltejs/svelte/pull/5935))
 * Make parameters of built-in animations and transitions optional ([#5936](https://github.com/sveltejs/svelte/pull/5936))
+* Make `SvelteComponentDev` typings more forgiving ([#5937](https://github.com/sveltejs/svelte/pull/5937))
 
 ## 3.32.0
 

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -115,6 +115,20 @@ export class SvelteComponentDev extends SvelteComponent {
 	 * ### DO NOT USE!
 	 */
 	$$prop_def: Props;
+	/**
+	 * @private
+	 * For type checking capabilities only.
+	 * Does not exist at runtime.
+	 * ### DO NOT USE!
+	 */
+	$$events_def: any;
+	/**
+	 * @private
+	 * For type checking capabilities only.
+	 * Does not exist at runtime.
+	 * ### DO NOT USE!
+	 */
+	$$slot_def: any;
 
 	constructor(options: {
 		target: Element;


### PR DESCRIPTION
Add `$$events_def` and `$$slot_def` so that TS users can do
```
let el: SvelteComponent;
<SomeComponent bind:this={el} />
```
Without type errors.

Without this change, TS complains that `$$events_def` and `$$slot_def` is missing from `SvelteComponentDev` and therefore cannot be assigned to it.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
