### PR TITLE
Fixes #5858: Class binding name cannot be empty

### DIFF
--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -387,12 +387,12 @@ function read_attribute(parser: Parser, unique_names: Set<string>) {
 			}, start);
 		}
 
-        if (type === 'Class' && directive_name === '') {
-            parser.error({
-                code: 'invalid-class-directive-value',
-                message: 'Class binding name cannot be empty'
-            }, start + colon_index + 1);
-        }
+		if (type === 'Class' && directive_name === '') {
+			parser.error({
+				code: 'invalid-class-directive-value',
+				message: 'Class binding name cannot be empty'
+			}, start + colon_index + 1);
+		}
 
 		if (value[0]) {
 			if ((value as any[]).length > 1 || value[0].type === 'Text') {

--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -387,6 +387,13 @@ function read_attribute(parser: Parser, unique_names: Set<string>) {
 			}, start);
 		}
 
+        if (type === 'Class' && directive_name === '') {
+            parser.error({
+                code: 'invalid-class-directive-value',
+                message: 'Class binding name cannot be empty'
+            }, start + colon_index + 1);
+        }
+
 		if (value[0]) {
 			if ((value as any[]).length > 1 || value[0].type === 'Text') {
 				parser.error({

--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -389,7 +389,7 @@ function read_attribute(parser: Parser, unique_names: Set<string>) {
 
 		if (type === 'Class' && directive_name === '') {
 			parser.error({
-				code: 'invalid-class-directive-value',
+				code: 'invalid-class-directive',
 				message: 'Class binding name cannot be empty'
 			}, start + colon_index + 1);
 		}

--- a/test/parser/samples/error-empty-classname-binding/error.json
+++ b/test/parser/samples/error-empty-classname-binding/error.json
@@ -1,10 +1,10 @@
 {
-    "code": "invalid-class-directive-value",
-    "message": "Class binding name cannot be empty",
-    "start": {
-        "line": 1,
-        "column": 10,
-        "character": 10
-    },
-    "pos": 10
+	"code": "invalid-class-directive-value",
+	"message": "Class binding name cannot be empty",
+	"start": {
+		"line": 1,
+		"column": 10,
+		"character": 10
+	},
+	"pos": 10
 }

--- a/test/parser/samples/error-empty-classname-binding/error.json
+++ b/test/parser/samples/error-empty-classname-binding/error.json
@@ -1,5 +1,5 @@
 {
-	"code": "invalid-class-directive-value",
+	"code": "invalid-class-directive",
 	"message": "Class binding name cannot be empty",
 	"start": {
 		"line": 1,

--- a/test/parser/samples/error-empty-classname-binding/error.json
+++ b/test/parser/samples/error-empty-classname-binding/error.json
@@ -1,0 +1,10 @@
+{
+    "code": "invalid-class-directive-value",
+    "message": "Class binding name cannot be empty",
+    "start": {
+        "line": 1,
+        "column": 10,
+        "character": 10
+    },
+    "pos": 10
+}

--- a/test/parser/samples/error-empty-classname-binding/input.svelte
+++ b/test/parser/samples/error-empty-classname-binding/input.svelte
@@ -1,0 +1,1 @@
+<h1 class:={true}>Hello</h1>


### PR DESCRIPTION
Fixes #5858: Class binding name cannot be empty

Includes a test that fails without this patch.

---

@tanhauhau I completely messed up when pushing the review patch to the last PR, so I closed it, and re-forked svelte completely. The changes you requested are included in this PR.
