### PR TITLE
WIP 5944 Fix race condition: Add event listeners to DOM elements before mounting them

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -459,7 +459,7 @@ export default class Block {
 			this.add_variable(dispose);
 
 			if (this.event_listeners.length === 1) {
-				this.chunks.mount.push(
+				this.chunks.mount.unshift(
 					b`
 						if (!#mounted) {
 							${dispose} = ${this.event_listeners[0]};
@@ -472,7 +472,7 @@ export default class Block {
 					b`${dispose}();`
 				);
 			} else {
-				this.chunks.mount.push(b`
+				this.chunks.mount.unshift(b`
 					if (!#mounted) {
 						${dispose} = [
 							${this.event_listeners}


### PR DESCRIPTION
This is a WIP on #5944 - Trying to fix a race condition where a _svelte:head_ tag containing a script with a _src_ attribute doesn't have it's _onload_ handler attached before after the element is added to the DOM, resulting in a race condition, where if the browser finishes getting the script before the _onload_ listener is attached, the _onload_ event handler will not run, see the Issue for more information about the bug.

So far, it fixes the bug in question by rewriting code generation for the "mount" function of Fragments so that attaching event listeners comes before appending the elements to the DOM.

**Help needed!** Currently, this breaks the test "deconflict-contextual-action".
As far as I can tell, the test seems to rely on the current order...? I don't know why. Maybe switching this order would break something else. Maybe there are cases where the elements have to be added to the DOM before the event listeners are attached (maybe in order to prevent an event handler to fire at an incorrect time?)... I am lost.

So, bottom line: I don't know why the mount code is being generated in this order. Does it matter, for reasons that I cannot see?
- If that is the case, which other ways could we solve this issue?
- If that is NOT the case, can the failing test be rewritten?
