### PR TITLE
Tutorial: Description fix - each block bindings

### DIFF
--- a/site/content/tutorial/06-bindings/09-each-block-bindings/text.md
+++ b/site/content/tutorial/06-bindings/09-each-block-bindings/text.md
@@ -5,15 +5,17 @@ title: Each block bindings
 You can even bind to properties inside an `each` block.
 
 ```html
-<input
-	type=checkbox
-	bind:checked={todo.done}
->
+{#each todos as todo}
+	<input
+		type=checkbox
+		bind:checked={todo.done}
+	>
 
-<input
-	placeholder="What needs to be done?"
-	bind:value={todo.text}
->
+	<input
+		placeholder="What needs to be done?"
+		bind:value={todo.text}
+	>
+{/each}
 ```
 
 > Note that interacting with these `<input>` elements will mutate the array. If you prefer to work with immutable data, you should avoid these bindings and use event handlers instead.


### PR DESCRIPTION
The chapter highlights event binding in `each` block which is missing within the snippet. Thus it seems reasonable to include it within the description snippet block.
