### PR TITLE
Use the 'Slot' as the type for the Slot node

### DIFF
--- a/src/compiler/compile/nodes/Slot.ts
+++ b/src/compiler/compile/nodes/Slot.ts
@@ -6,7 +6,7 @@ import { INode } from './interfaces';
 import { TemplateNode } from '../../interfaces';
 
 export default class Slot extends Element {
-	type: 'Element';
+	type: 'Slot';
 	name: string;
 	children: INode[];
 	slot_name: string;


### PR DESCRIPTION
To allow TypeScript union discrimination

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
