### PR TITLE
work around publishing issue with npm v7

### DIFF
--- a/check_publish_env.js
+++ b/check_publish_env.js
@@ -1,0 +1,4 @@
+if (!process.env.PUBLISH) {
+	console.error('npm publish must be run with the PUBLISH environment variable set');
+	process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "dev": "rollup -cw",
     "pretest": "npm run build",
     "posttest": "agadoo internal/index.mjs",
-    "prepublishOnly": "npm run lint && PUBLISH=true npm test",
+    "prepublishOnly": "node check_publish_env.js && npm run lint && npm test",
     "tsd": "tsc -p src/compiler --emitDeclarationOnly && tsc -p src/runtime --emitDeclarationOnly",
     "lint": "eslint \"{src,test}/**/*.{ts,js}\""
   },


### PR DESCRIPTION
This is a horrible solution but I don't know what else to do now that will maintain the `prepare` script, maintain the separate quick build and bundled/REPL-compatible for-publishing build, and also work on Windows.

This adds another step to `prepublishOnly` which ensures that `PUBLISH` is already set. If you set it yourself, then it will still be inherited by the extra `prepare`-triggered build, and so the good build we want to publish won't be clobbered by a bad build.

Works around #5662, but I would want to keep that issue open even if this were merged.