### PR TITLE
The expression count+=1 moved to count++

### DIFF
--- a/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
+++ b/site/content/tutorial/02-reactivity/01-reactive-assignments/text.md
@@ -14,7 +14,7 @@ Inside the `handleClick` function, all we need to do is change the value of `cou
 
 ```js
 function handleClick() {
-	count += 1;
+	count++;
 }
 ```
 


### PR DESCRIPTION
In most tutorials, people use count++. Now, in the introduction video on the website, the author talks about assignment operation triggering update (the Vue example). Now, what confused me a bit, and made me try the count++ is that, it is obvious that count++ is count = count + 1 or count+=1, but since svelte is a compiler, I was not sure if the compiler, based on the expression of assignment does some work, or not.

That confused me, so it is a good chance that it might confuse other people.
