### PR TITLE
allow destructured defaults to refer to variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * In custom elements, call `onMount` functions when connecting and clean up when disconnecting ([#1152](https://github.com/sveltejs/svelte/issues/1152), [#2227](https://github.com/sveltejs/svelte/issues/2227), [#4522](https://github.com/sveltejs/svelte/pull/4522))
+* Allow destructured defaults to refer to other variables ([#5066](https://github.com/sveltejs/svelte/issues/5066))
 * Do not emit `contextual-store` warnings for function parameters or declared variables ([#6008](https://github.com/sveltejs/svelte/pull/6008))
 
 ## 3.32.3

--- a/src/compiler/compile/nodes/AwaitBlock.ts
+++ b/src/compiler/compile/nodes/AwaitBlock.ts
@@ -33,12 +33,12 @@ export default class AwaitBlock extends Node {
 
 		if (this.then_node) {
 			this.then_contexts = [];
-			unpack_destructuring(this.then_contexts, info.value, node => node);
+			unpack_destructuring(this.then_contexts, info.value);
 		}
 
 		if (this.catch_node) {
 			this.catch_contexts = [];
-			unpack_destructuring(this.catch_contexts, info.error, node => node);
+			unpack_destructuring(this.catch_contexts, info.error);
 		}
 
 		this.pending = new PendingBlock(component, this, scope, info.pending);

--- a/src/compiler/compile/nodes/EachBlock.ts
+++ b/src/compiler/compile/nodes/EachBlock.ts
@@ -38,7 +38,7 @@ export default class EachBlock extends AbstractBlock {
 		this.scope = scope.child();
 
 		this.contexts = [];
-		unpack_destructuring(this.contexts, info.context, node => node);
+		unpack_destructuring(this.contexts, info.context);
 
 		this.contexts.forEach(context => {
 			this.scope.add(context.key.name, this.expression.dependencies, this);

--- a/src/compiler/compile/nodes/shared/Context.ts
+++ b/src/compiler/compile/nodes/shared/Context.ts
@@ -25,7 +25,15 @@ export function unpack_destructuring(contexts: Context[], node: Node, modifier: 
 			if (element && element.type === 'RestElement') {
 				unpack_destructuring(contexts, element, node => x`${modifier(node)}.slice(${i})` as Node);
 			} else if (element && element.type === 'AssignmentPattern') {
-				unpack_destructuring(contexts, element.left, node => x`${modifier(node)}[${i}] !== undefined ? ${modifier(node)}[${i}] : ${element.right}` as Node);
+				const n = contexts.length;
+
+				unpack_destructuring(contexts, element.left, node => {
+					const alternate = JSON.parse(JSON.stringify(element.right));
+
+					update_reference(contexts.slice(0, n), node, alternate);
+
+					return x`${modifier(node)}[${i}] !== undefined ? ${modifier(node)}[${i}] : ${alternate.replacement || alternate}` as Node
+				});
 			} else {
 				unpack_destructuring(contexts, element, node => x`${modifier(node)}[${i}]` as Node);
 			}
@@ -44,13 +52,55 @@ export function unpack_destructuring(contexts: Context[], node: Node, modifier: 
 				const key = property.key as Identifier;
 				const value = property.value;
 
-				used_properties.push(x`"${(key as Identifier).name}"`);
+				used_properties.push(x`"${key.name}"`);
 				if (value.type === 'AssignmentPattern') {
-					unpack_destructuring(contexts, value.left, node => x`${modifier(node)}.${key.name} !== undefined ? ${modifier(node)}.${key.name} : ${value.right}` as Node);
+					const n = contexts.length;
+
+					unpack_destructuring(contexts, value.left, node => {
+						const alternate = JSON.parse(JSON.stringify(value.right));
+
+						update_reference(contexts.slice(0, n), node, alternate);
+
+						return x`${modifier(node)}.${key.name} !== undefined ? ${modifier(node)}.${key.name} : ${alternate.replacement || alternate}` as Node
+					});
 				} else {
 					unpack_destructuring(contexts, value, node => x`${modifier(node)}.${key.name}` as Node);
 				}
 			}
 		});
+	}
+}
+
+function update_reference(contexts: Context[], node: Node, parent: any, property?: any) {
+	const current_node = (property !== undefined && parent[property] || parent);
+
+	if (!current_node || !contexts.length) return;
+
+	if (current_node.type === 'Identifier') {
+		contexts.forEach((context) => {
+			const { key, modifier } = context;
+
+			if (current_node.name === key.name) {
+				const replacement = modifier(node);
+				
+				if (property === undefined) {
+					current_node.replacement = replacement;
+				} else {
+					parent[property] = replacement;
+				}
+			}
+		});
+	} else if (current_node.type === 'BinaryExpression') {
+		update_reference(contexts, node, current_node, 'left');
+		update_reference(contexts, node, current_node, 'right');
+	} else if (current_node.type === 'CallExpression') {
+		for (let i = 0; i < current_node.arguments.length; i += 1) {
+			update_reference(contexts, node, current_node.arguments, i);
+		}
+
+		update_reference(contexts, node, current_node, 'callee');
+	} else if (current_node.type === 'MemberExpression') {
+		update_reference(contexts, node, current_node, 'object');
+		update_reference(contexts, node, current_node, 'property');
 	}
 }

--- a/src/compiler/compile/nodes/shared/Context.ts
+++ b/src/compiler/compile/nodes/shared/Context.ts
@@ -32,7 +32,7 @@ export function unpack_destructuring(contexts: Context[], node: Node, modifier: 
 
 					update_reference(contexts.slice(0, n), node, alternate);
 
-					return x`${modifier(node)}[${i}] !== undefined ? ${modifier(node)}[${i}] : ${alternate.replacement || alternate}` as Node
+					return x`${modifier(node)}[${i}] !== undefined ? ${modifier(node)}[${i}] : ${alternate.replacement || alternate}` as Node;
 				});
 			} else {
 				unpack_destructuring(contexts, element, node => x`${modifier(node)}[${i}]` as Node);
@@ -61,7 +61,7 @@ export function unpack_destructuring(contexts: Context[], node: Node, modifier: 
 
 						update_reference(contexts.slice(0, n), node, alternate);
 
-						return x`${modifier(node)}.${key.name} !== undefined ? ${modifier(node)}.${key.name} : ${alternate.replacement || alternate}` as Node
+						return x`${modifier(node)}.${key.name} !== undefined ? ${modifier(node)}.${key.name} : ${alternate.replacement || alternate}` as Node;
 					});
 				} else {
 					unpack_destructuring(contexts, value, node => x`${modifier(node)}.${key.name}` as Node);

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -325,7 +325,8 @@ export default class Expression {
 								// child_ctx[x] = function () { ... }
 								(template_scope.get_owner(deps[0]) as EachBlock).contexts.push({
 									key: func_id,
-									modifier: () => func_expression
+									modifier: () => func_expression,
+									default_modifier: node => node
 								});
 								this.replace(block.renderer.reference(func_id));
 							}

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -9,7 +9,6 @@ export interface Bindings {
 	property: Identifier;
 	snippet: Node;
 	store: string;
-	tail: Node;
 	modifier: (node: Node) => Node;
 }
 

--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -87,7 +87,7 @@ class AwaitBlockBranch extends Wrapper {
 	}
 
 	render_destructure() {
-		const props = this.value_contexts.map(prop => b`#ctx[${this.block.renderer.context_lookup.get(prop.key.name).index}] = ${prop.modifier(x`#ctx[${this.value_index}]`)};`);
+		const props = this.value_contexts.map(prop => b`#ctx[${this.block.renderer.context_lookup.get(prop.key.name).index}] = ${prop.default_modifier(prop.modifier(x`#ctx[${this.value_index}]`), name => this.renderer.reference(name))};`);
 		const get_context = this.block.renderer.component.get_unique_name(`get_${this.status}_context`);
 		this.block.renderer.blocks.push(b`
 			function ${get_context}(#ctx) {

--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -149,8 +149,7 @@ export default class EachBlockWrapper extends Wrapper {
 				property: this.index_name,
 				modifier: prop.modifier,
 				snippet: prop.modifier(x`${this.vars.each_block_value}[${this.index_name}]` as Node),
-				store,
-				tail: prop.modifier(x`[${this.index_name}]` as Node)
+				store
 			});
 		});
 
@@ -347,7 +346,7 @@ export default class EachBlockWrapper extends Wrapper {
 			this.else.fragment.render(this.else.block, null, x`#nodes` as Identifier);
 		}
 
-		this.context_props = this.node.contexts.map(prop => b`child_ctx[${renderer.context_lookup.get(prop.key.name).index}] = ${prop.modifier(x`list[i]`)};`);
+		this.context_props = this.node.contexts.map(prop => b`child_ctx[${renderer.context_lookup.get(prop.key.name).index}] = ${prop.default_modifier(prop.modifier(x`list[i]`), name => renderer.context_lookup.has(name) ? x`child_ctx[${renderer.context_lookup.get(name).index}]`: { type: 'Identifier', name })};`);
 
 		if (this.node.has_binding) this.context_props.push(b`child_ctx[${renderer.context_lookup.get(this.vars.each_block_value.name).index}] = list;`);
 		if (this.node.has_binding || this.node.has_index_binding || this.node.index) this.context_props.push(b`child_ctx[${renderer.context_lookup.get(this.index_name.name).index}] = i;`);

--- a/test/runtime/samples/each-block-destructured-default-before-initialised/_config.js
+++ b/test/runtime/samples/each-block-destructured-default-before-initialised/_config.js
@@ -1,0 +1,3 @@
+export default {
+	error: "Cannot access 'c' before initialization"
+};

--- a/test/runtime/samples/each-block-destructured-default-before-initialised/_config.js
+++ b/test/runtime/samples/each-block-destructured-default-before-initialised/_config.js
@@ -1,3 +1,5 @@
 export default {
-	error: "Cannot access 'c' before initialization"
+	error(assert, err) {
+		assert.ok(err.message === "Cannot access 'c' before initialization" || err.message === 'c is not defined');
+	}
 };

--- a/test/runtime/samples/each-block-destructured-default-before-initialised/main.svelte
+++ b/test/runtime/samples/each-block-destructured-default-before-initialised/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let array = [{a: 1, c: 2}];
+</script>
+
+{#each array as { a, b = c, c }}
+	{a}{b}{c}
+{/each}

--- a/test/runtime/samples/each-block-destructured-default-binding/_config.js
+++ b/test/runtime/samples/each-block-destructured-default-binding/_config.js
@@ -1,0 +1,23 @@
+export default {
+	html: `
+		<input />
+		<input />
+	`,
+	ssrHtml: `
+		<input />
+		<input value="hello" />
+	`,
+
+	test({ assert, component, target, window }) {
+		const [input1, input2] = target.querySelectorAll('input');
+		assert.equal(input1.value, '');
+		assert.equal(input2.value, 'hello');
+
+		const inputEvent = new window.InputEvent('input');
+
+		input2.value = 'world';
+		input2.dispatchEvent(inputEvent);
+		assert.equal(input2.value, 'world');
+		assert.equal(component.array[1].value, 'world');
+	}
+};

--- a/test/runtime/samples/each-block-destructured-default-binding/main.svelte
+++ b/test/runtime/samples/each-block-destructured-default-binding/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	export let array = [{ value: '' }, {}];
+</script>
+
+{#each array as { value = "hello" }}
+	<input bind:value />
+{/each}

--- a/test/runtime/samples/each-block-destructured-default/_config.js
+++ b/test/runtime/samples/each-block-destructured-default/_config.js
@@ -7,16 +7,14 @@ export default {
 	},
 
 	html: `
-		<p class="mammal">raccoon - P. lotor - 25kg</p>
-		<p class="bird">eagle - unknown - 5.4kg</p>
+		<p class="mammal">raccoon - P. lotor - 25kg (55 lb)</p>
+		<p class="bird">eagle - unknown - 5.4kg (12 lb)</p>
 	`,
-
-	
 
 	test({ assert, component, target }) {
 		component.animalEntries = [{ animal: 'cow', class: 'mammal', species: '‎B. taurus' }];
 		assert.htmlEqual(target.innerHTML, `
-			<p class="mammal">cow - ‎B. taurus - 50kg</p>
+			<p class="mammal">cow - ‎B. taurus - 50kg (110 lb)</p>
 		`);
 	}
 };

--- a/test/runtime/samples/each-block-destructured-default/_config.js
+++ b/test/runtime/samples/each-block-destructured-default/_config.js
@@ -1,20 +1,26 @@
 export default {
 	props: {
 		animalEntries: [
-			{ animal: 'raccoon', class: 'mammal', species: 'P. lotor', kilogram: 25 },
-			{ animal: 'eagle', class: 'bird', kilogram: 5.4 }
+			{ animal: 'raccoon', class: 'mammal', species: 'P. lotor', kilogram: 25, bmi: 0.04 },
+			{ animal: 'eagle', class: 'bird', kilogram: 5.4 },
+			{ animal: 'tiger', class: 'mammal', kilogram: 10, pound: 30 },
+			{ animal: 'lion', class: 'mammal', kilogram: 10, height: 50 },
+			{ animal: 'leopard', class: 'mammal', kilogram: 30, height: 50, bmi: 10 }
 		]
 	},
 
 	html: `
-		<p class="mammal">raccoon - P. lotor - 25kg (55 lb)</p>
-		<p class="bird">eagle - unknown - 5.4kg (12 lb)</p>
+		<p class="mammal">raccoon - P. lotor - 25kg (55 lb) - 30cm - 0.04</p>
+		<p class="bird">eagle - unknown - 5.4kg (12 lb) - 30cm - 0.006</p>
+		<p class="mammal">tiger - unknown - 10kg (30 lb) - 30cm - 0.011111111111111112</p>
+		<p class="mammal">lion - unknown - 10kg (22 lb) - 50cm - 0.004</p>
+		<p class="mammal">leopard - unknown - 30kg (66 lb) - 50cm - 10</p>
 	`,
 
 	test({ assert, component, target }) {
 		component.animalEntries = [{ animal: 'cow', class: 'mammal', species: '‎B. taurus' }];
 		assert.htmlEqual(target.innerHTML, `
-			<p class="mammal">cow - ‎B. taurus - 50kg (110 lb)</p>
+			<p class="mammal">cow - ‎B. taurus - 50kg (110 lb) - 30cm - 0.05555555555555555</p>
 		`);
 	}
 };

--- a/test/runtime/samples/each-block-destructured-default/main.svelte
+++ b/test/runtime/samples/each-block-destructured-default/main.svelte
@@ -1,7 +1,8 @@
 <script>
 	export let animalEntries;
+	export const defaultHeight = 30;
 </script>
 
-{#each animalEntries as { animal, species = 'unknown', kilogram: weight = 50, pound = (weight * 2.2).toFixed(0), ...props } }
-	<p {...props}>{animal} - {species} - {weight}kg ({pound} lb)</p>
+{#each animalEntries as { animal, species = 'unknown', kilogram: weight = 50, pound = (weight * 2.2).toFixed(0), height = defaultHeight, bmi = weight / (height * height), ...props } }
+	<p {...props}>{animal} - {species} - {weight}kg ({pound} lb) - {height}cm - {bmi}</p>
 {/each}

--- a/test/runtime/samples/each-block-destructured-default/main.svelte
+++ b/test/runtime/samples/each-block-destructured-default/main.svelte
@@ -2,6 +2,6 @@
 	export let animalEntries;
 </script>
 
-{#each animalEntries as { animal, species = 'unknown', kilogram: weight = 50 , ...props } }
-	<p {...props}>{animal} - {species} - {weight}kg</p>
+{#each animalEntries as { animal, species = 'unknown', kilogram: weight = 50, pound = (weight * 2.2).toFixed(0), ...props } }
+	<p {...props}>{animal} - {species} - {weight}kg ({pound} lb)</p>
 {/each}


### PR DESCRIPTION
Fixed #5066

Continued from https://github.com/sveltejs/svelte/pull/5230, added support to refer to other variables, besides destructured params, and more tests


### Before submitting the PR, please make sure you do the following
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
