### PR TITLE
remove unnecessary indent_size rule from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,4 +13,3 @@ insert_final_newline = false
 
 [{package.json,.travis.yml,.eslintrc.json}]
 indent_style = space
-indent_size = 2


### PR DESCRIPTION
I removed not needed rule from editorconfig. Indent size is not overwritten anywhere so there is no need to repeat this line for configuration files like