### PR TITLE
Bubble svelte dev events

### DIFF
--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -2,7 +2,7 @@ import { custom_event, append, insert, detach, listen, attr } from './dom';
 import { SvelteComponent } from './Component';
 
 export function dispatch_dev<T=any>(type: string, detail?: T) {
-	document.dispatchEvent(custom_event(type, { version: '__VERSION__', ...detail }));
+	document.dispatchEvent(custom_event(type, { version: '__VERSION__', ...detail }, true));
 }
 
 export function append_dev(target: Node, node: Node) {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -307,9 +307,9 @@ export function toggle_class(element, name, toggle) {
 	element.classList[toggle ? 'add' : 'remove'](name);
 }
 
-export function custom_event<T=any>(type: string, detail?: T) {
+export function custom_event<T=any>(type: string, detail?: T, bubbles: boolean = false) {
 	const e: CustomEvent<T> = document.createEvent('CustomEvent');
-	e.initCustomEvent(type, false, false, detail);
+	e.initCustomEvent(type, bubbles, false, detail);
 	return e;
 }
 


### PR DESCRIPTION
This is a small change to allow svelte events emitted in dev mode to bubble. In Svelte DevTools adding the listener to document before any svelte code executes is challenging. The current approach, while it works most of the time, fails in some cases such as when the svelte bundle is especially small. Having the events bubble allows me to add the listener to window instead of document which can happen much soon in the page life cycle.

In short: this change allows the Svelte DevTools bootstrapping code to be simpler and more robust.