### PR TITLE
no warning on contextual-store if declaring it as a parameter / variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * In custom elements, call `onMount` functions when connecting and clean up when disconnecting ([#1152](https://github.com/sveltejs/svelte/issues/1152), [#2227](https://github.com/sveltejs/svelte/issues/2227), [#4522](https://github.com/sveltejs/svelte/pull/4522))
+* Do not emit `contextual-store` warnings for function parameters or declared variables ([#6008](https://github.com/sveltejs/svelte/pull/6008))
 
 ## 3.32.3
 

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -751,7 +751,7 @@ export default class Component {
 					return this.skip();
 				}
 
-				component.warn_on_undefined_store_value_references(node, parent, scope);
+				component.warn_on_undefined_store_value_references(node, parent, prop, scope);
 			},
 
 			leave(node: Node) {
@@ -843,7 +843,7 @@ export default class Component {
 		});
 	}
 
-	warn_on_undefined_store_value_references(node, parent, scope: Scope) {
+	warn_on_undefined_store_value_references(node: Node, parent: Node, prop: string, scope: Scope) {
 		if (
 			node.type === 'LabeledStatement' &&
 			node.label.name === '$' &&
@@ -855,7 +855,7 @@ export default class Component {
 			});
 		}
 
-		if (is_reference(node as Node, parent as Node)) {
+		if (is_reference(node, parent)) {
 			const object = get_object(node);
 			const { name } = object;
 
@@ -865,10 +865,12 @@ export default class Component {
 				}
 
 				if (name[1] !== '$' && scope.has(name.slice(1)) && scope.find_owner(name.slice(1)) !== this.instance_scope) {
-					this.error(node, {
-						code: 'contextual-store',
-						message: 'Stores must be declared at the top level of the component (this may change in a future version of Svelte)'
-					});
+					if (!((/Function/.test(parent.type) && prop === 'params') || (parent.type === 'VariableDeclarator' && prop === 'id'))) {
+						this.error(node as any, {
+							code: 'contextual-store',
+							message: 'Stores must be declared at the top level of the component (this may change in a future version of Svelte)'
+						});
+					}
 				}
 			}
 		}

--- a/test/runtime/samples/store-shadow-scope-declaration/_config.js
+++ b/test/runtime/samples/store-shadow-scope-declaration/_config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/runtime/samples/store-shadow-scope-declaration/main.svelte
+++ b/test/runtime/samples/store-shadow-scope-declaration/main.svelte
@@ -1,0 +1,25 @@
+<script>
+	function test(store) {
+		// allow declaring $store as parameter
+		// it's not referring to the store value of the 
+		// `store` variable in the upper scope
+		return derived(store, $store => {
+
+		});
+	}
+
+	function test2(store) {
+		// allow declaring the `$store` variable
+		// it is not referring to the store value of the `store` variable
+		let $store;
+	}
+</script>
+
+<div
+	on:test={(store) => {
+		derived(store, $store => {});
+	}}
+	on:test2={(store) => {
+		let $store;
+	}}
+/>


### PR DESCRIPTION
This PR fix for the following error:

```svelte
<script>
      function test(store) {
		// should not error when declaring the parameter as `$store`
		return derived(store, $store => {
		});
	}
</script>
```

### Before submitting the PR, please make sure you do the following
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
