### PR TITLE
Docs: Rename slot let section

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1354,7 +1354,7 @@ Note that explicitly passing in an empty named slot will add that slot's name to
 </Card>
 ```
 
-#### [`<slot let:`*name*`={`*value*`}>`](slot_let)
+#### [`<slot key={`*value*`}>`](slot_let)
 
 ---
 


### PR DESCRIPTION
I think the title of this section is a bit confusing, since `<slot let:name={value} />` is not actually the correct syntax
