### PR TITLE
Warn on cross-origin links without "rel"

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -449,6 +449,17 @@ export default class Element extends Node {
 			const href_attribute = attribute_map.get('href') || attribute_map.get('xlink:href');
 			const id_attribute = attribute_map.get('id');
 			const name_attribute = attribute_map.get('name');
+			const target_attribute = attribute_map.get('target');
+			const rel_attribute = attribute_map.get('rel');
+
+			if (target_attribute && target_attribute.get_static_value() === '_blank' && 
+				(!rel_attribute || !/noopener|noreferrer/.test(rel_attribute.get_static_value()))) {
+				// https://web.dev/external-anchors-use-rel-noopener/
+				component.warn(target_attribute, {
+					code: 'missing-attribute',
+					message: 'target="_blank" links should have a rel="noopener" attribute'
+				});
+			}
 
 			if (href_attribute) {
 				const href_value = href_attribute.get_static_value();

--- a/test/validator/samples/missing-rel-cross-origin-link/input.svelte
+++ b/test/validator/samples/missing-rel-cross-origin-link/input.svelte
@@ -1,0 +1,1 @@
+<a href="https://example.com" target="_blank">Click here</a>

--- a/test/validator/samples/missing-rel-cross-origin-link/warnings.json
+++ b/test/validator/samples/missing-rel-cross-origin-link/warnings.json
@@ -1,0 +1,17 @@
+[
+	{
+		"code": "missing-attribute",
+		"end": {
+			"character": 45,
+			"column": 45,
+			"line": 1
+		},
+		"message": "target=\"_blank\" links should have a rel=\"noopener\" attribute",
+		"pos": 30,
+		"start": {
+			"character": 30,
+			"column": 30,
+			"line": 1
+		}
+	}
+]


### PR DESCRIPTION
Cf. https://web.dev/external-anchors-use-rel-noopener/
Fixes #5987

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
