### PR TITLE
Proposal: add preprocessor nesting

### DIFF
--- a/site/content/docs/04-compile-time.md
+++ b/site/content/docs/04-compile-time.md
@@ -312,6 +312,51 @@ const { code } = await svelte.preprocess(source, [
 });
 ```
 
+An additional level of nesting allows more control over the timing of subsequent `markup` functions.
+
+```js
+const svelte = require('svelte/compiler');
+
+const { code } = await svelte.preprocess(source, [
+	[
+		{
+			markup: () => {
+				console.log('this runs first');
+			},
+			script: () => {
+				console.log('this runs third');
+			},
+			style: () => {
+				console.log('this runs fifth');
+			}
+		},
+		{
+			markup: () => {
+				console.log('this runs second');
+			},
+			script: () => {
+				console.log('this runs fourth');
+			},
+			style: () => {
+				console.log('this runs sixth');
+			}
+		}
+	],
+	{
+		markup: () => {
+			console.log('this runs seventh');
+		},
+		script: () => {
+			console.log('this runs eighth');
+		},
+		style: () => {
+			console.log('this runs ninth');
+		}
+	}
+], {
+	filename: 'App.svelte'
+});
+```
 
 ### `svelte.walk`
 

--- a/test/preprocess/samples/multiple-preprocessors-grouped/_config.js
+++ b/test/preprocess/samples/multiple-preprocessors-grouped/_config.js
@@ -1,0 +1,37 @@
+export default {
+	preprocess: [
+		[
+			{
+				markup: ({ content }) => ({ code: content.replace(/one/g, 'two') }),
+				script: ({ content }) => ({ code: content.replace(/three/g, 'four') }),
+				style:  ({ content }) => ({ code: content.replace(/four/g, 'nine') })
+			},
+			{
+				markup: ({ content }) => ({ code: content.replace(/two/g, 'three') }),
+				script: ({ content }) => ({ code: content.replace(/four/g, 'five') }),
+				style:  ({ content }) => ({ code: content.replace(/three/g, 'four') })
+			}
+		],
+		{
+			markup: ({ content }) => ({ code: content.replace(/three|four|five/g, 'reset-markup') }),
+			script: ({ content }) => ({ code: content.replace(/reset-markup/g, 'reset-script') }),
+			style:  ({ content }) => ({ code: content.replace(/reset-markup/g, 'reset-style') })
+		},
+		[
+			{
+				markup: ({ content }) => ({ 
+					code: content
+						.replace(/reset-markup/, 'six')
+						.replace(/reset-style/, 'six')
+						.replace(/reset-script/, 'six') }),
+				script: ({ content }) => ({ code: content.replace(/seven/g, 'eight') }),
+				style:  ({ content }) => ({ code: content.replace(/eight/g, 'nine') })
+			},
+			{
+				markup: ({ content }) => ({ code: content.replace(/six/g, 'seven') }),
+				script: ({ content }) => ({ code: content.replace(/eight/g, 'nine') }),
+				style:  ({ content }) => ({ code: content.replace(/seven/g, 'eight') })
+			}
+		]
+	]
+};

--- a/test/preprocess/samples/multiple-preprocessors-grouped/input.svelte
+++ b/test/preprocess/samples/multiple-preprocessors-grouped/input.svelte
@@ -1,0 +1,11 @@
+<p>one</p>
+
+<style>
+	.one {
+		color: red;
+	}
+</style>
+
+<script>
+	console.log('one');
+</script>

--- a/test/preprocess/samples/multiple-preprocessors-grouped/output.svelte
+++ b/test/preprocess/samples/multiple-preprocessors-grouped/output.svelte
@@ -1,0 +1,11 @@
+<p>seven</p>
+
+<style>
+	.eight {
+		color: red;
+	}
+</style>
+
+<script>
+	console.log('nine');
+</script>


### PR DESCRIPTION
This allows for developers to ensure that certain `markup` functions
are run *after* other `script` or `style` functions have run.

~I will take care of further addition of tests and whatnot if there is agreement that this is a feature worth having.~ I couldn't resist making the tests pass. 😅 

## Problem
Some preprocessors need to run against the `markup` function to be useful. In the particular case of [Svelte Image](https://github.com/matyunya/svelte-image), it uses the `markup` function to gain access to the whole component, then uses `svelte.parse` to get an AST.

But whoops! If you like developing with Typescript, Svelte Image won't work for you because Typescript isn't removed until the `script` phase of the preprocessor function, and `svelte.parse` doesn't understand Typescript.

## Workaround
Preprocessors that _really_ need access to `markup` after all other processors have finished could be forced last in this way (again with svelte image as the example)

```js
const svelte = require("svelte/compiler")
const sveltePreprocess = require("svelte-preprocess")
const image = require("svelte-image")

// Ask developers to define this function or something like it:
function runOthersBeforeImage(otherProcessors) {
  return {
    markup: async ({ content, filename }) => {
      const otherProcessorsReturn = await svelte.preprocess(
        content,
        otherProcessors,
        { filename },
      )
      content = otherProcessorsReturn.code

      const { code } = await image({}).markup({ content, filename })
      return {
        ...otherProcessorsReturn,
        code,
      }
    },
  }
}

module.exports = {
  preprocess: [
    runOthersBeforeImage(
      sveltePreprocess({
        defaults: {
          style: "postcss",
        },
        postcss: true,
      }),
    ),
  ],
  // ... other stuff
}
```

So this solution works, but wouldn't we be calling `svelte.preprocess` more than necessary, ultimately? not sure if that has any downsides. Like maybe you lose all sense of "who did what" when it comes to dependencies and source maps. But I could be wrong. I don't know a whole lot about the internals of Svelte, but I do know that if we were to nest everything, all the processing would be done against one instance of `PreprocessResult`, instead of multiple ones.

Perhaps if my proposal isn't up to snuff, we should at least consider adding documentation that points people toward the workaround above, since this issue comes up from time to time.

## My proposal: allow nested preprocessors

Here is my addition to the documentation:

> An additional level of nesting allows more control over the timing of subsequent `markup` functions.
> 
> ```js
> const svelte = require('svelte/compiler');
> 
> const { code } = await svelte.preprocess(source, [
> 	[
> 		{
> 			markup: () => {
> 				console.log('this runs first');
> 			},
> 			script: () => {
> 				console.log('this runs third');
> 			},
> 			style: () => {
> 				console.log('this runs fifth');
> 			}
> 		},
> 		{
> 			markup: () => {
> 				console.log('this runs second');
> 			},
> 			script: () => {
> 				console.log('this runs fourth');
> 			},
> 			style: () => {
> 				console.log('this runs sixth');
> 			}
> 		}
> 	],
> 	{
> 		markup: () => {
> 			console.log('this runs seventh');
> 		},
> 		script: () => {
> 			console.log('this runs eighth');
> 		},
> 		style: () => {
> 			console.log('this runs ninth');
> 		}
> 	}
> ], {
> 	filename: 'App.svelte'
> });
> ```

My main goal here is to get this pushed all the way into the config files for Svelte, Sapper, and SvelteKit projects. I am _guessing_ that this is either the exact way to do it, or that it is the start of that goal.

----------
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
> The need was discussed, if not this implementation, in #5293 and #4141. There is another PR (#4282) that addresses the need, but in a different way. I prefer my method, as the one in the other PR is an all-or-nothing proposition based on an option flag. With this one, you can completely preserve the notion of "all markup, then scripts, then styles" within whatever groups you define.
>
>There are likely other issues that bring up the need to control when preprocessors run compared to others, but I don't know what other wording to search for.

- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
