### PR TITLE
allow passing in context in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svelte changelog
 
+## Unreleased
+
+* Allow root-level context to be passed to the component constructor ([#6032](https://github.com/sveltejs/svelte/pull/6032))
+
 ## 3.36.0
 
 * Add `this: void` typing to store functions ([#6094](https://github.com/sveltejs/svelte/pull/6094))

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -904,6 +904,7 @@ The following initialisation options can be provided:
 | `target` | **none** | An `HTMLElement` to render to. This option is required
 | `anchor` | `null` | A child of `target` to render the component immediately before
 | `props` | `{}` | An object of properties to supply to the component
+| `context` | `{}` | An object of context to supply to the component
 | `hydrate` | `false` | See below
 | `intro` | `false` | If `true`, will play transitions on initial render, rather than waiting for subsequent state changes
 

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -904,7 +904,7 @@ The following initialisation options can be provided:
 | `target` | **none** | An `HTMLElement` to render to. This option is required
 | `anchor` | `null` | A child of `target` to render the component immediately before
 | `props` | `{}` | An object of properties to supply to the component
-| `context` | `{}` | An object of context to supply to the component
+| `context` | `new Map()` | A `Map` of context key-value pairs to supply to the component
 | `hydrate` | `false` | See below
 | `intro` | `false` | If `true`, will play transitions on initial render, rather than waiting for subsequent state changes
 

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -904,7 +904,7 @@ The following initialisation options can be provided:
 | `target` | **none** | An `HTMLElement` to render to. This option is required
 | `anchor` | `null` | A child of `target` to render the component immediately before
 | `props` | `{}` | An object of properties to supply to the component
-| `context` | `new Map()` | A `Map` of context key-value pairs to supply to the component
+| `context` | `new Map()` | A `Map` of root-level context key-value pairs to supply to the component
 | `hydrate` | `false` | See below
 | `intro` | `false` | If `true`, will play transitions on initial render, rather than waiting for subsequent state changes
 
@@ -1083,17 +1083,20 @@ const { head, html, css } = App.render({
 });
 ```
 
-You can call the `.render()` with the following parameters:
+---
 
-| option | default | description |
+The `.render()` method accepts the following parameters:
+
+| parameter | default | description |
 | --- | --- | --- |
 | `props` | `{}` | An object of properties to supply to the component
 | `options` | `{}` | An object of options
 
-The `options` object takes in the following properties:
-| key | default | description |
+The `options` object takes in the following options:
+
+| option | default | description |
 | --- | --- | --- |
-| `context` | `new Map()` | A `Map` of context key-value pairs to supply to the component
+| `context` | `new Map()` | A `Map` of root-level context key-value pairs to supply to the component
 
 ```js
 const { head, html, css } = App.render(
@@ -1101,7 +1104,7 @@ const { head, html, css } = App.render(
 	{ answer: 42 },
 	// options
 	{
-		context: new Map([['context-key', 'context-value']]),
+		context: new Map([['context-key', 'context-value']])
 	}
 );
 ```

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -1093,7 +1093,6 @@ You can call the `.render()` with the following parameters:
 The `options` object takes in the following properties:
 | key | default | description |
 | --- | --- | --- |
-| `slots` | `{}` | slots to supply to the component
 | `context` | `new Map()` | A `Map` of context key-value pairs to supply to the component
 
 ```js
@@ -1102,7 +1101,6 @@ const { head, html, css } = App.render(
 	{ answer: 42 },
 	// options
 	{
-		slots: { 'slot-a': (lets) => 'hello world' },
 		context: new Map([['context-key', 'context-value']]),
 	}
 );

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -1088,16 +1088,22 @@ You can call the `.render()` with the following parameters:
 | option | default | description |
 | --- | --- | --- |
 | `props` | `{}` | An object of properties to supply to the component
-| `slots` | `{}` | A object of slots to supply to the component
+| `options` | `{}` | An object of options
+
+The `options` object takes in the following properties:
+| key | default | description |
+| --- | --- | --- |
+| `slots` | `{}` | slots to supply to the component
 | `context` | `new Map()` | A `Map` of context key-value pairs to supply to the component
 
 ```js
 const { head, html, css } = App.render(
 	// props
 	{ answer: 42 },
-	// slots
-	{ 'slot-a': (lets) => 'hello world' },
-	// contexts
-	new Map([['context-key', 'context-value']]),
+	// options
+	{
+		slots: { 'slot-a': (lets) => 'hello world' },
+		context: new Map([['context-key', 'context-value']]),
+	}
 );
 ```

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -1082,3 +1082,22 @@ const { head, html, css } = App.render({
 	answer: 42
 });
 ```
+
+You can call the `.render()` with the following parameters:
+
+| option | default | description |
+| --- | --- | --- |
+| `props` | `{}` | An object of properties to supply to the component
+| `slots` | `{}` | A object of slots to supply to the component
+| `context` | `new Map()` | A `Map` of context key-value pairs to supply to the component
+
+```js
+const { head, html, css } = App.render(
+	// props
+	{ answer: 42 },
+	// slots
+	{ 'slot-a': (lets) => 'hello world' },
+	// contexts
+	new Map([['context-key', 'context-value']]),
+);
+```

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -120,7 +120,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 		on_disconnect: [],
 		before_update: [],
 		after_update: [],
-		context: new Map(parent_component ? parent_component.$$.context : options.context ? Object.entries(options.context) : []),
+		context: new Map(parent_component ? parent_component.$$.context : options.context || []),
 
 		// everything else
 		callbacks: blank_object(),

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -120,7 +120,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 		on_disconnect: [],
 		before_update: [],
 		after_update: [],
-		context: new Map(parent_component ? parent_component.$$.context : []),
+		context: new Map(parent_component ? parent_component.$$.context : options.context ? Object.entries(options.context) : []),
 
 		// everything else
 		callbacks: blank_object(),

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -97,7 +97,7 @@ export function create_ssr_component(fn) {
 	}
 
 	return {
-		render: (props = {}, slots = {}, context = new Map()) => {
+		render: (props = {}, { slots = {}, context = new Map() } = {}) => {
 			on_destroy = [];
 
 			const result: {

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -97,7 +97,7 @@ export function create_ssr_component(fn) {
 	}
 
 	return {
-		render: (props = {}, { slots = {}, context = new Map() } = {}) => {
+		render: (props = {}, { $$slots = {}, context = new Map() } = {}) => {
 			on_destroy = [];
 
 			const result: {
@@ -109,7 +109,7 @@ export function create_ssr_component(fn) {
 				}>;
 			} = { title: '', head: '', css: new Set() };
 
-			const html = $$render(result, props, {}, slots, context);
+			const html = $$render(result, props, {}, $$slots, context);
 
 			run_all(on_destroy);
 

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -74,12 +74,12 @@ export function debug(file, line, column, values) {
 let on_destroy;
 
 export function create_ssr_component(fn) {
-	function $$render(result, props, bindings, slots) {
+	function $$render(result, props, bindings, slots, context) {
 		const parent_component = current_component;
 
 		const $$ = {
 			on_destroy,
-			context: new Map(parent_component ? parent_component.$$.context : []),
+			context: new Map(parent_component ? parent_component.$$.context : context || []),
 
 			// these will be immediately discarded
 			on_mount: [],
@@ -97,7 +97,7 @@ export function create_ssr_component(fn) {
 	}
 
 	return {
-		render: (props = {}, options = {}) => {
+		render: (props = {}, slots = {}, context = new Map()) => {
 			on_destroy = [];
 
 			const result: {
@@ -109,7 +109,7 @@ export function create_ssr_component(fn) {
 				}>;
 			} = { title: '', head: '', css: new Set() };
 
-			const html = $$render(result, props, {}, options);
+			const html = $$render(result, props, {}, slots, context);
 
 			run_all(on_destroy);
 

--- a/src/runtime/tsconfig.json
+++ b/src/runtime/tsconfig.json
@@ -3,7 +3,7 @@
 	"include": ["."],
 
 	"compilerOptions": {
-		"lib": ["es2017", "dom", "dom.iterable"],
+		"lib": ["es2015", "dom", "dom.iterable"],
 		"target": "es2015",
 		"types": [],
 

--- a/src/runtime/tsconfig.json
+++ b/src/runtime/tsconfig.json
@@ -3,7 +3,7 @@
 	"include": ["."],
 
 	"compilerOptions": {
-		"lib": ["es2015", "dom", "dom.iterable"],
+		"lib": ["es2017", "dom", "dom.iterable"],
 		"target": "es2015",
 		"types": [],
 

--- a/test/runtime/samples/constructor-pass-context/Component.svelte
+++ b/test/runtime/samples/constructor-pass-context/Component.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { getContext } from 'svelte';
+
+	const value = getContext('key');
+	const fn = getContext('fn');
+</script>
+
+<div>{value}</div>
+<button on:click={() => fn('hello world')} />

--- a/test/runtime/samples/constructor-pass-context/_config.js
+++ b/test/runtime/samples/constructor-pass-context/_config.js
@@ -23,10 +23,10 @@ export default {
 		const Component = require('./Component.svelte').default;
 
 		const called = [];
-		const { html } = Component.render(undefined, undefined, new Map([
+		const { html } = Component.render(undefined, { context: new Map([
 			['key', 'svelte'],
 			['fn', (value) => called.push(value)]
-		]));
+		]) });
 		assert.htmlEqual(html, '<div>svelte</div><button></button>');
 	}
 };

--- a/test/runtime/samples/constructor-pass-context/_config.js
+++ b/test/runtime/samples/constructor-pass-context/_config.js
@@ -5,10 +5,10 @@ export default {
 		const called = [];
 		const component = new Component({
 			target,
-			context: {
-				key: 'svelte',
-				fn: (value) => called.push(value)
-			}
+			context: new Map([
+				['key', 'svelte'],
+				['fn', (value) => called.push(value)]
+			])
 		});
 		assert.htmlEqual(target.innerHTML, '<div>svelte</div><button></button>');
 

--- a/test/runtime/samples/constructor-pass-context/_config.js
+++ b/test/runtime/samples/constructor-pass-context/_config.js
@@ -18,5 +18,15 @@ export default {
 		assert.deepEqual(called, ['hello world']);
 
 		component.$destroy();
+	},
+	test_ssr({ assert }) {
+		const Component = require('./Component.svelte').default;
+
+		const called = [];
+		const { html } = Component.render(undefined, undefined, new Map([
+			['key', 'svelte'],
+			['fn', (value) => called.push(value)]
+		]));
+		assert.htmlEqual(html, '<div>svelte</div><button></button>');
 	}
 };

--- a/test/runtime/samples/constructor-pass-context/_config.js
+++ b/test/runtime/samples/constructor-pass-context/_config.js
@@ -1,0 +1,22 @@
+export default {
+	async test({ assert, target, window }) {
+		const Component = require('./Component.svelte').default;
+
+		const called = [];
+		const component = new Component({
+			target,
+			context: {
+				key: 'svelte',
+				fn: (value) => called.push(value)
+			}
+		});
+		assert.htmlEqual(target.innerHTML, '<div>svelte</div><button></button>');
+
+		const button = target.querySelector('button');
+		await button.dispatchEvent(new window.MouseEvent('click'));
+
+		assert.deepEqual(called, ['hello world']);
+
+		component.$destroy();
+	}
+};

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -13,6 +13,7 @@ import {
 	shouldUpdateExpected,
 	mkdirp
 } from '../helpers';
+import { set_current_component } from '../../internal';
 
 function tryToReadFile(file) {
 	try {
@@ -127,6 +128,8 @@ describe('ssr', () => {
 				showOutput(dir, { generate: 'ssr', format: 'cjs' });
 				err.stack += `\n\ncmd-click: ${path.relative(process.cwd(), dir)}/main.svelte`;
 				throw err;
+			} finally {
+				set_current_component(null);
 			}
 		});
 	});
@@ -223,6 +226,8 @@ describe('ssr', () => {
 					showOutput(cwd, compileOptions);
 					throw err;
 				}
+			} finally {
+				set_current_component(null);
 			}
 		});
 	});


### PR DESCRIPTION
This allows passing in context through the Svelte Component Constructor API

```js
import Component from './Component.svelte';

const context = new Map();
map.set('a', 123);
map.set('b', 456);

new Component({
   target: document.body,
   context: context,
});
```


### Before submitting the PR, please make sure you do the following
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
