### PR TITLE
clean up $$props before instance scripts executed

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -210,8 +210,8 @@ export default function dom(
 			`;
 
 			props_inject = b`
-				if ($$props && "$$inject" in $$props) {
-					$$self.$inject_state($$props.$$inject);
+				if ($$inject) {
+					$$self.$inject_state($$inject);
 				}
 			`;
 		}
@@ -425,6 +425,9 @@ export default function dom(
 				${resubscribable_reactive_store_unsubscribers}
 
 				${component.slots.size || component.compile_options.dev || uses_slots ? b`let { $$slots: #slots = {}, $$scope } = $$props;` : null}
+				${props_inject ? b`let { $$inject } = $$props;` : null}
+				${uses_props && b`$$props = @exclude_internal_props($$props);`}
+
 				${component.compile_options.dev && b`@validate_slots('${component.tag}', #slots, [${[...component.slots.keys()].map(key => `'${key}'`).join(',')}]);`}
 				${compute_slots}
 
@@ -451,8 +454,6 @@ export default function dom(
 				`}
 
 				${fixed_reactive_declarations}
-
-				${uses_props && b`$$props = @exclude_internal_props($$props);`}
 
 				return ${return_value};
 			}

--- a/test/js/samples/capture-inject-state/expected.js
+++ b/test/js/samples/capture-inject-state/expected.js
@@ -106,6 +106,7 @@ function instance($$self, $$props, $$invalidate) {
 
 	$$self.$$.on_destroy.push(() => $$unsubscribe_prop());
 	let { $$slots: slots = {}, $$scope } = $$props;
+	let { $$inject } = $$props;
 	validate_slots("Component", slots, []);
 	let { prop } = $$props;
 	validate_store(prop, "prop");
@@ -147,8 +148,8 @@ function instance($$self, $$props, $$invalidate) {
 		if ("computed" in $$props) computed = $$props.computed;
 	};
 
-	if ($$props && "$$inject" in $$props) {
-		$$self.$inject_state($$props.$$inject);
+	if ($$inject) {
+		$$self.$inject_state($$inject);
 	}
 
 	$: computed = local * 2;

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -70,6 +70,7 @@ function create_fragment(ctx) {
 
 function instance($$self, $$props, $$invalidate) {
 	let { $$slots: slots = {}, $$scope } = $$props;
+	let { $$inject } = $$props;
 	validate_slots("Component", slots, []);
 	let { name } = $$props;
 	const writable_props = ["name"];
@@ -88,8 +89,8 @@ function instance($$self, $$props, $$invalidate) {
 		if ("name" in $$props) $$invalidate(0, name = $$props.name);
 	};
 
-	if ($$props && "$$inject" in $$props) {
-		$$self.$inject_state($$props.$$inject);
+	if ($$inject) {
+		$$self.$inject_state($$inject);
 	}
 
 	return [name];

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -171,6 +171,7 @@ function create_fragment(ctx) {
 
 function instance($$self, $$props, $$invalidate) {
 	let { $$slots: slots = {}, $$scope } = $$props;
+	let { $$inject } = $$props;
 	validate_slots("Component", slots, []);
 	let { things } = $$props;
 	let { foo } = $$props;
@@ -198,8 +199,8 @@ function instance($$self, $$props, $$invalidate) {
 		if ("baz" in $$props) $$invalidate(3, baz = $$props.baz);
 	};
 
-	if ($$props && "$$inject" in $$props) {
-		$$self.$inject_state($$props.$$inject);
+	if ($$inject) {
+		$$self.$inject_state($$inject);
 	}
 
 	return [things, foo, bar, baz];

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -165,6 +165,7 @@ function create_fragment(ctx) {
 
 function instance($$self, $$props, $$invalidate) {
 	let { $$slots: slots = {}, $$scope } = $$props;
+	let { $$inject } = $$props;
 	validate_slots("Component", slots, []);
 	let { things } = $$props;
 	let { foo } = $$props;
@@ -186,8 +187,8 @@ function instance($$self, $$props, $$invalidate) {
 		if ("foo" in $$props) $$invalidate(1, foo = $$props.foo);
 	};
 
-	if ($$props && "$$inject" in $$props) {
-		$$self.$inject_state($$props.$$inject);
+	if ($$inject) {
+		$$self.$inject_state($$inject);
 	}
 
 	return [things, foo];

--- a/test/js/samples/debug-hoisted/expected.js
+++ b/test/js/samples/debug-hoisted/expected.js
@@ -50,6 +50,7 @@ function create_fragment(ctx) {
 
 function instance($$self, $$props, $$invalidate) {
 	let { $$slots: slots = {}, $$scope } = $$props;
+	let { $$inject } = $$props;
 	validate_slots("Component", slots, []);
 	let obj = { x: 5 };
 	let kobzol = 5;
@@ -66,8 +67,8 @@ function instance($$self, $$props, $$invalidate) {
 		if ("kobzol" in $$props) $$invalidate(1, kobzol = $$props.kobzol);
 	};
 
-	if ($$props && "$$inject" in $$props) {
-		$$self.$inject_state($$props.$$inject);
+	if ($$inject) {
+		$$self.$inject_state($$inject);
 	}
 
 	return [obj, kobzol];

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -66,6 +66,7 @@ function create_fragment(ctx) {
 
 function instance($$self, $$props, $$invalidate) {
 	let { $$slots: slots = {}, $$scope } = $$props;
+	let { $$inject } = $$props;
 	validate_slots("Component", slots, []);
 	let { foo } = $$props;
 	let bar;
@@ -86,8 +87,8 @@ function instance($$self, $$props, $$invalidate) {
 		if ("bar" in $$props) $$invalidate(1, bar = $$props.bar);
 	};
 
-	if ($$props && "$$inject" in $$props) {
-		$$self.$inject_state($$props.$$inject);
+	if ($$inject) {
+		$$self.$inject_state($$inject);
 	}
 
 	$$self.$$.update = () => {

--- a/test/js/samples/loop-protect/expected.js
+++ b/test/js/samples/loop-protect/expected.js
@@ -68,6 +68,7 @@ function foo() {
 
 function instance($$self, $$props, $$invalidate) {
 	let { $$slots: slots = {}, $$scope } = $$props;
+	let { $$inject } = $$props;
 	validate_slots("Component", slots, []);
 	let node;
 
@@ -126,8 +127,8 @@ function instance($$self, $$props, $$invalidate) {
 		if ("node" in $$props) $$invalidate(0, node = $$props.node);
 	};
 
-	if ($$props && "$$inject" in $$props) {
-		$$self.$inject_state($$props.$$inject);
+	if ($$inject) {
+		$$self.$inject_state($$inject);
 	}
 
 	$: {

--- a/test/runtime/samples/dynamic-component-slot-props/Foo.svelte
+++ b/test/runtime/samples/dynamic-component-slot-props/Foo.svelte
@@ -1,0 +1,6 @@
+<script>
+  export let log;
+  log($$props);
+</script>
+<slot name='other'></slot>
+<slot></slot>

--- a/test/runtime/samples/dynamic-component-slot-props/_config.js
+++ b/test/runtime/samples/dynamic-component-slot-props/_config.js
@@ -1,0 +1,14 @@
+let logs = [];
+export default {
+	props: {
+		log(message) {
+			logs.push(message);
+		}
+	},
+	before_app() {
+		logs = [];
+	},
+	test({ assert, component, target }) {
+		assert.deepEqual(Object.keys(logs[0]), ['x', 'log']);
+	}
+};

--- a/test/runtime/samples/dynamic-component-slot-props/main.svelte
+++ b/test/runtime/samples/dynamic-component-slot-props/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Foo from './Foo.svelte';
+	export let log;
+	const x = 'x';
+</script>
+
+<svelte:component this="{Foo}" {...{ x, log }}>
+	<div>Something</div>
+</svelte:component>


### PR DESCRIPTION
Warning: this might be a breaking change, if the you use `$$props.$$scope`, `$$props.$$inject`, `$$props.$$slots` etc in your code.

Fixes #5904

### Before submitting the PR, please make sure you do the following
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
