### PR TITLE
Link  Svelte Society instead of old Community site

### DIFF
--- a/site/content/faq/700-is-there-a-component-library.md
+++ b/site/content/faq/700-is-there-a-component-library.md
@@ -2,4 +2,4 @@
 question: Is there a UI component library?
 ---
 
-There are several UI component libraries. Find them under the [code section](https://svelte-community.netlify.com/code) of the Svelte Community website.
+There are several UI component libraries as well as standalone components. Find them under the [components section](https://sveltesociety.dev/components) of the Svelte Society website.


### PR DESCRIPTION
Currently the FAQ points to the older, unmaintained Svelte Community site for help finding UI libraries.
This PR links the new Svelte Society site and changes the wording slightly to imply you can also find standalone components there.

