### PR TITLE
ci: cache npm directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - id: npm-cache-dir
+      run: echo "::set-output name=dir::$(npm config get cache)"
+    - uses: actions/cache@v2
+      id: npm-cache
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-node-
     - run: npm install
     - run: npm test
       env:
@@ -23,6 +31,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
+    - id: npm-cache-dir
+      run: echo "::set-output name=dir::$(npm config get cache)"
+    - uses: actions/cache@v2
+      id: npm-cache
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-node-
     - run: 'npm i && npm run lint'
   Unit:
     runs-on: ${{ matrix.os }}
@@ -33,4 +49,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
+    - id: npm-cache-dir
+      run: echo "::set-output name=dir::$(npm config get cache)"
+    - uses: actions/cache@v2
+      id: npm-cache
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-node-
     - run: 'npm i && npm run test:unit'


### PR DESCRIPTION
Many CI workflows have been failing because they timeout. This PR adds cache to the CI.
However this only caches ~/.npm and not node_modules as *it's not recommended* (https://github.com/actions/cache/blob/main/examples.md#node---npm). That includes the main culprit which is Chromium being downloaded on each run.

None of my test runs, that used cache, failed due to timeout.

If this gets merged, it should probably also be ported to Sapper.