### PR TITLE
feat: css unit handling for fly transition

### DIFF
--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -68,6 +68,7 @@ interface FlyParams {
 	x?: number;
 	y?: number;
 	opacity?: number;
+	unit?: string;
 }
 
 export function fly(node: Element, {
@@ -76,7 +77,8 @@ export function fly(node: Element, {
 	easing = cubicOut,
 	x = 0,
 	y = 0,
-	opacity = 0
+	opacity = 0,
+	unit = 'px'
 }: FlyParams = {}): TransitionConfig {
 	const style = getComputedStyle(node);
 	const target_opacity = +style.opacity;
@@ -89,7 +91,7 @@ export function fly(node: Element, {
 		duration,
 		easing,
 		css: (t, u) => `
-			transform: ${transform} translate(${(1 - t) * x}px, ${(1 - t) * y}px);
+			transform: ${transform} translate(${(1 - t) * x}${unit}, ${(1 - t) * y}${unit});
 			opacity: ${target_opacity - (od * u)}`
 	};
 }


### PR DESCRIPTION
It would be great to be able to give CSS unit parameter to **transition fly** function. 

**'fly'** is the best candidate. It defines an absolute/arbitrary transformation while the others define rather a transformation relative to an existing div's style.

Units are quiet often left behind in a lot of js library, 'px' is not the only one :)

use: `<div transition:fly={{ y: 1, unit: 'em' }}></div>`

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
