### PR TITLE
docs: update 7GUIs example links

### DIFF
--- a/site/content/examples/20-7guis/01-7guis-counter/App.svelte
+++ b/site/content/examples/20-7guis/01-7guis-counter/App.svelte
@@ -1,7 +1,7 @@
+<!-- https://eugenkiss.github.io/7guis/tasks#counter -->
 <script>
 	let count = 0;
 </script>
 
-<!-- https://github.com/eugenkiss/7guis/wiki#counter -->
 <input type=number bind:value={count}>
 <button on:click="{() => count += 1}">count</button>

--- a/site/content/examples/20-7guis/02-7guis-temperature/App.svelte
+++ b/site/content/examples/20-7guis/02-7guis-temperature/App.svelte
@@ -1,4 +1,4 @@
-<!-- https://github.com/eugenkiss/7guis/wiki#temperature-converter -->
+<!-- https://eugenkiss.github.io/7guis/tasks/#temp -->
 <input value={c} on:input="{e => setBothFromC(e.target.value)}" type=number> °c =
 <input value={f} on:input="{e => setBothFromF(e.target.value)}" type=number> °f
 

--- a/site/content/examples/20-7guis/03-7guis-flight-booker/App.svelte
+++ b/site/content/examples/20-7guis/03-7guis-flight-booker/App.svelte
@@ -1,3 +1,4 @@
+<!-- https://eugenkiss.github.io/7guis/tasks/#flight -->
 <script>
 	const tomorrow = new Date(Date.now() + 86400000);
 
@@ -44,7 +45,6 @@
 	}
 </style>
 
-<!-- https://github.com/eugenkiss/7guis/wiki#flight-booker -->
 <select bind:value={isReturn}>
 	<option value={false}>one-way flight</option>
 	<option value={true}>return flight</option>


### PR DESCRIPTION
Some of the links in the 7GUIs examples were pointing to an outdated wiki page. This PR updates those links and moves them to the top of the file for consistency.

The timer, CRUD, and circles examples were already pointing to the correct location.