### PR TITLE
Remove misleading a11y caption warning on <audio>

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -521,7 +521,7 @@ export default class Element extends Node {
 			}
 		}
 
-		if (this.is_media_node()) {
+		if (this.name === 'video') {
 			if (attribute_map.has('muted')) {
 				return;
 			}
@@ -535,7 +535,7 @@ export default class Element extends Node {
 			if (!has_caption) {
 				component.warn(this, {
 					code: 'a11y-media-has-caption',
-					message: 'A11y: Media elements must have a <track kind="captions">'
+					message: 'A11y: <video> elements must have a <track kind="captions">'
 				});
 			}
 		}

--- a/test/validator/samples/a11y-media-has-caption/input.svelte
+++ b/test/validator/samples/a11y-media-has-caption/input.svelte
@@ -1,4 +1,4 @@
 <video><track kind="captions"/></video>
 <video></video>
 <video><track /></video>
-<audio muted></audio>
+<audio></audio>

--- a/test/validator/samples/a11y-media-has-caption/warnings.json
+++ b/test/validator/samples/a11y-media-has-caption/warnings.json
@@ -6,7 +6,7 @@
       "column": 15,
       "line": 2
     },
-    "message": "A11y: Media elements must have a <track kind=\"captions\">",
+    "message": "A11y: <video> elements must have a <track kind=\"captions\">",
     "pos": 40,
     "start": {
       "character": 40,
@@ -21,7 +21,7 @@
       "column": 24,
       "line": 3
     },
-    "message": "A11y: Media elements must have a <track kind=\"captions\">",
+    "message": "A11y: <video> elements must have a <track kind=\"captions\">",
     "pos": 56,
     "start": {
       "character": 56,


### PR DESCRIPTION
Related to #5967 . Closes https://github.com/sveltejs/svelte/pull/6157

This PR removes the a11y warning for missing `<track kind="captions">` on audio elements.

- [Browsers ignore tracks within audio elements](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/)
- The [corresponding axe-core rule](https://github.com/dequelabs/axe-core/pull/1071) the original check was based on has been deprecated
- The [corresponding Lighthouse audit](https://web.dev/audio-caption/) has been deprecated

The associated test has also been updated.

Merging this PR should not close the associated issue -- the intent of the issue was to remove the warning for audio and video, but there was some debate. Since there was clear agreement in removing the warning for audio elements, I thought to go for the quick win until consensus is reached around video captions.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
