### PR TITLE
Export the EasingFunction type

### DIFF
--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -1,7 +1,7 @@
 import { cubicOut, cubicInOut, linear } from 'svelte/easing';
 import { assign, is_function } from 'svelte/internal';
 
-type EasingFunction = (t: number) => number;
+export type EasingFunction = (t: number) => number;
 
 export interface TransitionConfig {
 	delay?: number;


### PR DESCRIPTION
Just adds a bit of convenience when you want to define a custom transition, you could simply import `EasingFunction` to use as the type of the `easing` parameter of your transition function if you have one, rather than having to duplicate it in your own code.