### PR TITLE
Correctly display elapsed in the tutorial example

### DIFF
--- a/site/content/tutorial/08-stores/04-derived-stores/app-a/stores.js
+++ b/site/content/tutorial/08-stores/04-derived-stores/app-a/stores.js
@@ -14,5 +14,5 @@ const start = new Date();
 
 export const elapsed = derived(
 	time,
-	$time => {}
+	$time => Math.round(($time - start) / 1000)
 );


### PR DESCRIPTION
Otherwise people learning svelte will see a `This page has been open for undefined seconds`

![Screenshot 2021-03-06 at 16 29 13](https://user-images.githubusercontent.com/1476561/110213743-3dfcb600-7e99-11eb-9562-d0fcbd1e62d0.png)

