### PR TITLE
Ensuring parentNode exists before detaching

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -9,7 +9,7 @@ export function insert(target: Node, node: Node, anchor?: Node) {
 }
 
 export function detach(node: Node) {
-	node.parentNode.removeChild(node);
+	node.parentNode && node.parentNode.removeChild(node);
 }
 
 export function destroy_each(iterations, detaching) {


### PR DESCRIPTION
This fix adds a check to prevent error in case the parentNode is null. This error is encountered in situations where raw @html content is used and has been mutated by non-svelte code. In some cases, when the raw @html code is being detached from the DOM, it is no longer part of the DOM.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
