### PR TITLE
Add filename to combined source map if needed

### DIFF
--- a/src/compiler/utils/mapped_code.ts
+++ b/src/compiler/utils/mapped_code.ts
@@ -251,6 +251,11 @@ export function combine_sourcemaps(
 
 	if (!map.file) delete map.file; // skip optional field `file`
 
+	// When source maps are combined and the leading map is empty, sources is not set.
+	// Add the filename to the empty array in this case. 
+	// Possibly a bug in the remapping library https://github.com/ampproject/remapping/issues/116
+	if (!map.sources.length) map.sources = [filename];
+
 	return map;
 }
 

--- a/src/compiler/utils/mapped_code.ts
+++ b/src/compiler/utils/mapped_code.ts
@@ -253,7 +253,7 @@ export function combine_sourcemaps(
 
 	// When source maps are combined and the leading map is empty, sources is not set.
 	// Add the filename to the empty array in this case. 
-	// Possibly a bug in the remapping library https://github.com/ampproject/remapping/issues/116
+	// Further improvements to remapping may help address this as well https://github.com/ampproject/remapping/issues/116
 	if (!map.sources.length) map.sources = [filename];
 
 	return map;

--- a/test/sourcemaps/samples/decoded-sourcemap/_config.js
+++ b/test/sourcemaps/samples/decoded-sourcemap/_config.js
@@ -3,7 +3,7 @@ import { magic_string_preprocessor_result, magic_string_replace_all } from '../.
 
 export default {
 
-	js_map_sources: [], // test component has no scripts
+	js_map_sources: ['input.svelte'],
 
 	preprocess: {
 		markup: ({ content, filename }) => {

--- a/test/sourcemaps/samples/external/_config.js
+++ b/test/sourcemaps/samples/external/_config.js
@@ -10,7 +10,7 @@ export const STYLES = '.awesome { color: orange; }\n';
 
 export default {
 	css_map_sources: ['common.scss', 'styles.scss'],
-	js_map_sources: [],
+	js_map_sources: ['input.svelte'],
 	preprocess: [
 		{
 			style: () => {

--- a/test/sourcemaps/samples/preprocessed-no-map/_config.js
+++ b/test/sourcemaps/samples/preprocessed-no-map/_config.js
@@ -1,5 +1,5 @@
 export default {
-	css_map_sources: [],
+	css_map_sources: ['input.svelte'],
 	preprocess: [
 		{
 			style: ({ content }) => {

--- a/test/sourcemaps/samples/sourcemap-basename/_config.js
+++ b/test/sourcemaps/samples/sourcemap-basename/_config.js
@@ -15,7 +15,7 @@ span {
 
 export default {
 	css_map_sources: [external_relative_filename],
-	js_map_sources: [],
+	js_map_sources: ['input.svelte'],
 	preprocess: [
 		{
 			style: ({ content, filename }) => {

--- a/test/sourcemaps/samples/sourcemap-offsets/_config.js
+++ b/test/sourcemaps/samples/sourcemap-offsets/_config.js
@@ -3,7 +3,7 @@ import { magic_string_bundle } from '../../helpers';
 export const EXTERNAL = 'span { --external-var: 1px; }';
 
 export default {
-	js_map_sources: [],
+	js_map_sources: ['input.svelte'],
 	css_map_sources: ['input.svelte', 'external.css'],
 	preprocess: [
 		{


### PR DESCRIPTION
When source maps are combined and the leading map is empty, sources is not set. Add the filename to the empty array in this case. This _may_ be an [upstream issue](https://github.com/ampproject/remapping/issues/116) (but maybe it's also intended, let's see) but either way for our cases it's necessary to set `sources` even for empty maps.
They were not added before this change so I adjusted the tests. The `js.map` output now is closer to what it would be like if there was no preprocessing and there's no JS - in that case Svelte outputs an empty map with `sources` set which looks like this

```
{
    version: 3,
    names: [],
    sources: [ '..path/to/$layout.svelte' ],
    sourcesContent: [ '<p>asd</p>\r\n' ],
    mappings: ';;;;;;;'
}
```

Related https://github.com/sveltejs/kit/issues/424


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
