### PR TITLE
Tutorial: remove outline on scrollbar thumb

### DIFF
--- a/site/src/routes/tutorial/[slug]/index.svelte
+++ b/site/src/routes/tutorial/[slug]/index.svelte
@@ -198,7 +198,6 @@
 	.chapter-markup::-webkit-scrollbar-thumb {
 		background-color: rgba(255,255,255,.7);
 		border-radius: 1em;
-		outline: 1px solid green;
 	}
 
 	.chapter-markup :global(p) > :global(code),


### PR DESCRIPTION
Before | After
-------|-------
![image](https://user-images.githubusercontent.com/9000376/111245511-fcb78500-85c1-11eb-994a-40564ac1a359.png) | ![image](https://user-images.githubusercontent.com/9000376/111245444-df82b680-85c1-11eb-97db-350e7ff9fd2e.png)

I think it goes mostly unnoticed as it's of low contrast with the grey surroundings but it sure is out of place.


