### PR TITLE
Document that PostCSS is needed as a dependency for :global(...) to work

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -264,6 +264,9 @@ This works by adding a class to affected elements, which is based on a hash of t
 
 To apply styles to a selector globally, use the `:global(...)` modifier.
 
+> Svelte uses [PostCSS](https://postcss.org/) to process global styles. It needs 
+to be added as a dependency for this modifier to work.
+
 ```sv
 <style>
 	:global(body) {


### PR DESCRIPTION
Adds missing documentation informs the user that PostCSS is needed as a dependency for `:global(...)` to work.

Suggestions on how to word this better are welcome.

Thanks!