### PR TITLE
feat: addition of exporting for store lifecycle types

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -1,19 +1,19 @@
 import { run_all, subscribe, noop, safe_not_equal, is_function, get_store_value } from 'svelte/internal';
 
 /** Callback to inform of a value updates. */
-type Subscriber<T> = (value: T) => void;
+export type Subscriber<T> = (value: T) => void;
 
 /** Unsubscribes from value updates. */
-type Unsubscriber = () => void;
+export type Unsubscriber = () => void;
 
 /** Callback to update a value. */
-type Updater<T> = (value: T) => T;
+export type Updater<T> = (value: T) => T;
 
 /** Cleanup logic callback. */
-type Invalidator<T> = (value?: T) => void;
+export type Invalidator<T> = (value?: T) => void;
 
 /** Start and stop notification callbacks. */
-type StartStopNotifier<T> = (set: Subscriber<T>) => Unsubscriber | void;
+export type StartStopNotifier<T> = (set: Subscriber<T>) => Unsubscriber | void;
 
 /** Readable interface for subscribing. */
 export interface Readable<T> {


### PR DESCRIPTION
### Motivation:

As developer I want to be ensure that I can provide some features of code like widget system through self-definition of store passing

![image](https://user-images.githubusercontent.com/32175240/111875188-952a7c80-89a9-11eb-91d6-47e912ccdc55.png)

Currently, `svelte/store` allows me import types like `Writable` and `Readable` but for delegates of functions I should define own types for types of Svelte update, subscriber and so on

I think that we should be able to import types from `svelte/store` to save a consistence in code and be ensure that some update of Svelte not destroys code