### PR TITLE
Add trusted modifier

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -82,7 +82,8 @@ const valid_modifiers = new Set([
 	'once',
 	'passive',
 	'nonpassive',
-	'self'
+	'self',
+	'trusted'
 ]);
 
 const passive_events = new Set([

--- a/src/compiler/compile/render_dom/wrappers/Element/EventHandler.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/EventHandler.ts
@@ -42,6 +42,7 @@ export default class EventHandlerWrapper {
 		if (this.node.modifiers.has('preventDefault')) snippet = x`@prevent_default(${snippet})`;
 		if (this.node.modifiers.has('stopPropagation')) snippet = x`@stop_propagation(${snippet})`;
 		if (this.node.modifiers.has('self')) snippet = x`@self(${snippet})`;
+		if (this.node.modifiers.has('trusted')) snippet = x`@trusted(${snippet})`;
 
 		const args = [];
 

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -85,6 +85,13 @@ export function self(fn) {
 	};
 }
 
+export function trusted(fn) {
+	return function(event) {
+		// @ts-ignore
+		if (event.isTrusted) fn.call(this, event);
+	};
+}
+
 export function attr(node: Element, attribute: string, value?: string) {
 	if (value == null) node.removeAttribute(attribute);
 	else if (node.getAttribute(attribute) !== value) node.setAttribute(attribute, value);

--- a/test/runtime/samples/event-handler-modifier-trusted/_config.js
+++ b/test/runtime/samples/event-handler-modifier-trusted/_config.js
@@ -1,0 +1,9 @@
+export default {
+	async test({ assert, component, target, window }) {
+		const button = target.querySelector('button');
+		const event = new window.MouseEvent('click');
+
+		await button.dispatchEvent(event);
+		assert.equal(component.trusted, false);
+	}
+};

--- a/test/runtime/samples/event-handler-modifier-trusted/_config.js
+++ b/test/runtime/samples/event-handler-modifier-trusted/_config.js
@@ -4,6 +4,6 @@ export default {
 		const event = new window.MouseEvent('click');
 
 		await button.dispatchEvent(event);
-		assert.equal(component.trusted, false);
+		assert.equal(component.trusted, true);
 	}
 };

--- a/test/runtime/samples/event-handler-modifier-trusted/main.svelte
+++ b/test/runtime/samples/event-handler-modifier-trusted/main.svelte
@@ -1,5 +1,5 @@
 <script>
-	export let trusted = false;
+	export let trusted = true;
 </script>
 
-<button on:click|trusted="{() => trusted = true}">Only trusted events: {trusted?'true':'false'}</button>
+<button on:click|trusted="{() => trusted = false}">Only trusted events: {trusted?'true':'false'}</button>

--- a/test/runtime/samples/event-handler-modifier-trusted/main.svelte
+++ b/test/runtime/samples/event-handler-modifier-trusted/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let trusted = false;
+</script>
+
+<button on:click|trusted="{() => trusted = true}">Only trusted events: {trusted?'true':'false'}</button>

--- a/test/validator/samples/event-modifiers-invalid/errors.json
+++ b/test/validator/samples/event-modifiers-invalid/errors.json
@@ -1,5 +1,5 @@
 [{
-	"message": "Valid event modifiers are preventDefault, stopPropagation, capture, once, passive, nonpassive or self",
+	"message": "Valid event modifiers are preventDefault, stopPropagation, capture, once, passive, nonpassive, self or trusted",
 	"code": "invalid-event-modifier",
 	"start": {
 		"line": 1,


### PR DESCRIPTION
Fixes #6137

Adding a trusted modifier to make events not be dispatchable by console/sourcecode.
Useful to prevent injected code to automatically dispatch event for preventing botting
