### PR TITLE
fix (tutorial): use different random image service

### DIFF
--- a/site/content/examples/06-lifecycle/00-onmount/App.svelte
+++ b/site/content/examples/06-lifecycle/00-onmount/App.svelte
@@ -4,7 +4,7 @@
 	let photos = [];
 
 	onMount(async () => {
-		const res = await fetch(`https://jsonplaceholder.typicode.com/photos?_limit=20`);
+		const res = await fetch(`https://picsum.photos/v2/list?limit=20`);
 		photos = await res.json();
 	});
 </script>
@@ -28,8 +28,8 @@
 <div class="photos">
 	{#each photos as photo}
 		<figure>
-			<img src={photo.thumbnailUrl} alt={photo.title}>
-			<figcaption>{photo.title}</figcaption>
+			<img src={photo.download_url.replace(/\/\d+\/\d+$/, '/128/128')} alt={photo.author}>
+			<figcaption>{photo.author}</figcaption>
 		</figure>
 	{:else}
 		<!-- this block renders when photos.length === 0 -->

--- a/site/content/tutorial/07-lifecycle/01-onmount/app-a/App.svelte
+++ b/site/content/tutorial/07-lifecycle/01-onmount/app-a/App.svelte
@@ -21,8 +21,8 @@
 <div class="photos">
 	{#each photos as photo}
 		<figure>
-			<img src={photo.thumbnailUrl} alt={photo.title}>
-			<figcaption>{photo.title}</figcaption>
+			<img src={photo.download_url.replace(/\/\d+\/\d+$/, '/128/128')} alt={photo.author}>
+			<figcaption>{photo.author}</figcaption>
 		</figure>
 	{:else}
 		<!-- this block renders when photos.length === 0 -->

--- a/site/content/tutorial/07-lifecycle/01-onmount/app-b/App.svelte
+++ b/site/content/tutorial/07-lifecycle/01-onmount/app-b/App.svelte
@@ -4,7 +4,7 @@
 	let photos = [];
 
 	onMount(async () => {
-		const res = await fetch(`https://jsonplaceholder.typicode.com/photos?_limit=20`);
+		const res = await fetch(`https://picsum.photos/v2/list?limit=20`);
 		photos = await res.json();
 	});
 </script>
@@ -28,8 +28,8 @@
 <div class="photos">
 	{#each photos as photo}
 		<figure>
-			<img src={photo.thumbnailUrl} alt={photo.title}>
-			<figcaption>{photo.title}</figcaption>
+			<img src={photo.download_url.replace(/\/\d+\/\d+$/, '/128/128')} alt={photo.author}>
+			<figcaption>{photo.author}</figcaption>
 		</figure>
 	{:else}
 		<!-- this block renders when photos.length === 0 -->

--- a/site/content/tutorial/07-lifecycle/01-onmount/text.md
+++ b/site/content/tutorial/07-lifecycle/01-onmount/text.md
@@ -15,7 +15,7 @@ We'll add an `onMount` handler that loads some data over the network:
 	let photos = [];
 
 	onMount(async () => {
-		const res = await fetch(`https://jsonplaceholder.typicode.com/photos?_limit=20`);
+		const res = await fetch(`https://picsum.photos/v2/list?limit=20`);
 		photos = await res.json();
 	});
 </script>


### PR DESCRIPTION
The ["Lifecycle / onMount" tutorial](https://svelte.dev/tutorial/onmount) uses a service which appears to be unmaintained -- attempting to load images results in `NET::ERR_CERT_DATE_INVALID`. Hmm, just looked more carefully and it looks like their certificate just expired yesterday, so that's a bit less troubling... But at any rate, it's broken right now. I jumped to conclusions since [their website's](https://placeholder.com/) copyright reads "© 2010-2019".

This PR currently uses:
```html
<img src={photo.download_url.replace(/\/\d+\/\d+$/, '/128/128')} alt={photo.author}>
```

... Alternately, that regex could be moved to a function:
```js
function thumbnail(url) {
  return url.replace(/\/\d+\/\d+$/, '/128/128');
}
```

UPDATE: Just checked, and the certificate issue has been resolved. Here's an example of a URL that was not working yesterday: https://via.placeholder.com/150/92c952