### PR TITLE
[docs] Fix Chapter 17 Compiler warnings  AudioPlayer.svelte

### DIFF
--- a/site/content/tutorial/17-module-context/01-sharing-code/app-a/AudioPlayer.svelte
+++ b/site/content/tutorial/17-module-context/01-sharing-code/app-a/AudioPlayer.svelte
@@ -29,5 +29,7 @@
 		on:play={stopOthers}
 		controls
 		{src}
-	></audio>
+	>
+		<track kind="captions"/>
+	</audio>
 </article>


### PR DESCRIPTION
In Tutorial 17 (a.  svelte compiler is issuing a warning 'Media elements must have a <track kind="captions">' child element.

![Screen Shot 2021-04-01 at 16 08 59](https://user-images.githubusercontent.com/144485/113248262-4a452900-9308-11eb-873f-dffe216cc919.png)

I havent set up an environment to do testing.  Sorry.  Of course your chosen remedy would need to be applied to  
* app-a and, 
* app-b

Thanks
