### PR TITLE
[fix] Set selectedIndex to -1 when no option matches bound select value

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -221,6 +221,8 @@ export function select_option(select, value) {
 			return;
 		}
 	}
+
+	select.selectedIndex = -1; // no option should be selected
 }
 
 export function select_options(select, value) {

--- a/test/runtime/samples/binding-select-initial-value-undefined/_config.js
+++ b/test/runtime/samples/binding-select-initial-value-undefined/_config.js
@@ -14,6 +14,7 @@ export default {
 	`,
 
 	test({ assert, component, target }) {
+		assert.equal(component.selected, 'a');
 		const select = target.querySelector('select');
 		const options = [...target.querySelectorAll('option')];
 

--- a/test/runtime/samples/binding-select-unmatched/_config.js
+++ b/test/runtime/samples/binding-select-unmatched/_config.js
@@ -1,0 +1,60 @@
+export default {
+	html: `
+		<p>selected: null</p>
+
+		<select>
+			<option value='a'>a</option>
+			<option value='b'>b</option>
+			<option value='c'>c</option>
+		</select>
+
+		<p>selected: null</p>
+	`,
+
+	async test({ assert, component, target }) {
+		const select = target.querySelector('select');
+		const options = [...target.querySelectorAll('option')];
+
+		assert.equal(component.selected, null);
+
+		// no option should be selected since none of the options matches the bound value
+		assert.equal(select.value, '');
+		assert.equal(select.selectedIndex, -1);
+		assert.ok(!options[0].selected);
+
+		component.selected = 'a'; // first option should now be selected
+		assert.equal(select.value, 'a');
+		assert.ok(options[0].selected);
+
+		assert.htmlEqual(target.innerHTML, `
+			<p>selected: a</p>
+
+			<select>
+				<option value='a'>a</option>
+				<option value='b'>b</option>
+				<option value='c'>c</option>
+			</select>
+
+			<p>selected: a</p>
+		`);
+
+		component.selected = 'd'; // doesn't match an option
+
+		// now no option should be selected again
+		assert.equal(select.value, '');
+		assert.equal(select.selectedIndex, -1);
+		assert.ok(!options[0].selected);
+
+		assert.htmlEqual(target.innerHTML, `
+			<p>selected: d</p>
+
+			<select>
+				<option value='a'>a</option>
+				<option value='b'>b</option>
+				<option value='c'>c</option>
+			</select>
+
+			<p>selected: d</p>
+		`);
+	}
+};

--- a/test/runtime/samples/binding-select-unmatched/main.svelte
+++ b/test/runtime/samples/binding-select-unmatched/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	// set as null so no option will be selected by default
+	export let selected = null;
+</script>
+
+<p>selected: {selected}</p>
+
+<select bind:value={selected}>
+	<option>a</option>
+	<option>b</option>
+	<option>c</option>
+</select>
+
+<p>selected: {selected}</p>


### PR DESCRIPTION
Previously, when the bound value of a select element was set to `null` or any other value not matching one of the options, the first option would appear selected. So even if the select element was `required`, users could submit the form and end up sending a different value than what it appeared they were submitting.

With this change, if a select element is bound to a value that doesn't match one of its options, then none of the options will appear selected. This helps catch bugs during development when the bound value inadvertently doesn't match an option. It also makes it possible to bind a `required` select element to `null`, and cause the browser to require users to explicitly select an option before the form can be submitted.

Resolves #6126.

With this change Svelte will match the behavior of [Vue.js](https://stackblitz.com/edit/vue-select-behavior?file=src%2FApp.vue) and [Angular](https://stackblitz.com/edit/angular-select-behavior?file=src%2Fapp%2Fapp.component.ts).