### PR TITLE
Add additional function overload for derived

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -139,6 +139,20 @@ export function derived<S extends Stores, T>(
  *
  * @param stores - input stores
  * @param fn - function callback that aggregates the values
+ * @param initial_value - initial value
+ */
+export function derived<S extends Stores, T>(
+	stores: S,
+	fn: (values: StoresValues<S>) => T,
+	initial_value?: T
+): Readable<T>;
+
+/**
+ * Derived value store by synchronizing one or more readable stores and
+ * applying an aggregation function over its input values.
+ *
+ * @param stores - input stores
+ * @param fn - function callback that aggregates the values
  */
 export function derived<S extends Stores, T>(
 	stores: S,


### PR DESCRIPTION
## Summary
Add an additional overload for `derived` to allow explicitly setting an initial value for non-async derived stores.

## Details
After a long overdue svelte version update, I started getting some type errors on any non-async derived store that I had explicitly set an initial value. For example, 

```ts
export const isSlow = derived(delta, ($delta) => $delta > 300, false);
```

Perhaps the correct way to handle the initial value is through the initial values of the stores that it is derived from, but I guess it feels safer to me to also explicitly set it on the derived store.

Assuming that this usage is acceptable then the additional overload keeps typescript happy. 😄 

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
