### PR TITLE
[feat] Introduce parameter to allow for horizontal slide transition

### DIFF
--- a/site/content/docs/04-run-time.md
+++ b/site/content/docs/04-run-time.md
@@ -768,6 +768,7 @@ Slides an element in and out.
 * `delay` (`number`, default 0) — milliseconds before starting
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicOut`) — an [easing function](/docs#run-time-svelte-easing)
+* `axis` (`x` | `y`, default `y`) — the axis of motion along which the transition occurs
 
 ```sv
 <script>
@@ -776,8 +777,8 @@ Slides an element in and out.
 </script>
 
 {#if condition}
-	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut }}">
-		slides in and out
+	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut, axis: 'x'}}">
+		slides in and out horizontally
 	</div>
 {/if}
 ```

--- a/site/content/docs/04-run-time.md
+++ b/site/content/docs/04-run-time.md
@@ -768,7 +768,7 @@ Slides an element in and out.
 * `delay` (`number`, default 0) — milliseconds before starting
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicOut`) — an [easing function](/docs#run-time-svelte-easing)
-* `axis` (`x` | `y`, default `y`) — the axis of motion along which the transition occurs
+- `axis` (`x` | `y`, default `y`) — the axis of motion along which the transition occurs
 
 ```sv
 <script>

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -98,12 +98,15 @@ export interface SlideParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
+	xAxis?: number;
+	yAxis?: number;
 }
 
 export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
 	easing = cubicOut
+
 }: SlideParams = {}): TransitionConfig {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -112,10 +112,10 @@ export function slide(node: Element, {
 	const primary_dimension = axis === 'y' ? 'height' : 'width';
 	const primary_dimension_value = parseFloat(style[primary_dimension]);
 	const secondary_dimensions = axis === 'y' ? ['Top', 'Bottom'] : ['Left', 'Right'];
-	const padding_first_value = parseFloat(style.padding[secondary_dimensions[0]]);
-	const padding_second_value = parseFloat(style.padding[secondary_dimensions[1]]);
-	const margin_first_value = parseFloat(style.margin[secondary_dimensions[0]]);
-	const margin_second_value = parseFloat(style.margin[secondary_dimensions[1]]);
+	const padding_first_value = parseFloat(style.padding + secondary_dimensions[0]);
+	const padding_second_value = parseFloat(style.padding + secondary_dimensions[1]);
+	const margin_first_value = parseFloat(style.margin + secondary_dimensions[0]);
+	const margin_second_value = parseFloat(style.margin + secondary_dimensions[1]);
 	const border_width_first_value = parseFloat(style['border'.concat(secondary_dimensions[0].concat('Width'))]);
 	const border_width_second_value = parseFloat(style['border'.concat(secondary_dimensions[1].concat('Width'))]);
 	return {

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -98,40 +98,46 @@ export interface SlideParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
-	xAxis?: number;
-	yAxis?: number;
+	axis?: "x" | "y";
 }
 
 export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
-	easing = cubicOut
-
+	easing = cubicOut,
+	axis = "y"
 }: SlideParams = {}): TransitionConfig {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
 	const height = parseFloat(style.height);
+	const width = parseFloat(style.width);
 	const padding_top = parseFloat(style.paddingTop);
 	const padding_bottom = parseFloat(style.paddingBottom);
+	const padding_left = parseFloat(style.paddingLeft);
+	const padding_right = parseFloat(style.paddingRight);
 	const margin_top = parseFloat(style.marginTop);
 	const margin_bottom = parseFloat(style.marginBottom);
+	const margin_left = parseFloat(style.marginLeft);
+	const margin_right = parseFloat(style.marginRight);
 	const border_top_width = parseFloat(style.borderTopWidth);
 	const border_bottom_width = parseFloat(style.borderBottomWidth);
+	const border_left_width = parseFloat(style.borderLeftWidth);
+	const border_right_width = parseFloat(style.borderRightWidth);
 
 	return {
 		delay,
 		duration,
 		easing,
 		css: t =>
+			`--yAxisT: ${axis === "y" ? t : 1};` +
+			`--xAxisT: ${axis === "x" ? t : 1};` +
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
-			`height: ${t * height}px;` +
-			`padding-top: ${t * padding_top}px;` +
-			`padding-bottom: ${t * padding_bottom}px;` +
-			`margin-top: ${t * margin_top}px;` +
-			`margin-bottom: ${t * margin_bottom}px;` +
-			`border-top-width: ${t * border_top_width}px;` +
-			`border-bottom-width: ${t * border_bottom_width}px;`
+			`height: calc(var(--yAxisT) * ${height}px);` +
+			`width: calc(var(--xAxisT) * ${width}px);` +
+			`padding: calc(var(--yAxisT) * ${padding_top}px) calc(var(--xAxisT) * ${padding_right}px) calc(var(--yAxisT) * ${padding_bottom}px) $calc(var(--xAxisT) * ${padding_left}px);` +
+			`margin: calc(var(--yAxisT) * ${margin_top}px)  calc(var(--xAxisT) * ${margin_right}px) calc(var(--yAxisT) * ${margin_bottom}px) calc(var(--xAxisT) * ${margin_left}px);` +
+			`border-width: calc(var(--yAxisT) * ${border_top_width}px) calc(var(--xAxisT) * ${border_right_width}px) calc(var(--yAxisT) * ${border_bottom_width}px) calc(var(--xAxisT) * ${border_left_width}px);`
 	};
 }
 

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -105,9 +105,9 @@ export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
 	easing = cubicOut,
-	axis = 'x'
+	axis = 'y'
 }: SlideParams = {}): TransitionConfig {
-	const direction: { x: 1 | 0, y: 1 | 0 } = { x: axis === 'x' ? 1 : 0, y: axis === 'y' ? 1 : 0 };
+	const direction = { x: axis === 'x' ? 1 : 0, y: axis === 'y' ? 1 : 0 };
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
 	const height = parseFloat(style.height);

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -98,14 +98,14 @@ export interface SlideParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
-	axis?: "x" | "y";
+	axis?: 'x' | 'y';
 }
 
 export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
 	easing = cubicOut,
-	axis = "y"
+	axis = 'y'
 }: SlideParams = {}): TransitionConfig {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
@@ -129,8 +129,8 @@ export function slide(node: Element, {
 		duration,
 		easing,
 		css: t =>
-			`--yAxisT: ${axis === "y" ? t : 1};` +
-			`--xAxisT: ${axis === "x" ? t : 1};` +
+			`--y_axis_t: ${axis === 'y' ? t : 1};` +
+			`--x_axis_t: ${axis === 'x' ? t : 1};` +
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
 			`height: calc(var(--yAxisT) * ${height}px);` +

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -112,12 +112,12 @@ export function slide(node: Element, {
 	const primary_dimension = axis === 'y' ? 'height' : 'width';
 	const primary_dimension_value = parseFloat(style[primary_dimension]);
 	const secondary_dimensions = axis === 'y' ? ['Top', 'Bottom'] : ['Left', 'Right'];
-	const padding_first_value = parseFloat(style.padding + secondary_dimensions[0]);
-	const padding_second_value = parseFloat(style.padding + secondary_dimensions[1]);
-	const margin_first_value = parseFloat(style.margin + secondary_dimensions[0]);
-	const margin_second_value = parseFloat(style.margin + secondary_dimensions[1]);
-	const border_width_first_value = parseFloat(style['border'.concat(secondary_dimensions[0].concat('Width'))]);
-	const border_width_second_value = parseFloat(style[`border${secondary_dimensions[1]}Width`]);
+	const padding_start_value = parseFloat(style.padding + secondary_dimensions[0]);
+	const padding_end_value = parseFloat(style.padding + secondary_dimensions[1]);
+	const margin_start_value = parseFloat(style.margin + secondary_dimensions[0]);
+	const margin_end_value = parseFloat(style.margin + secondary_dimensions[1]);
+	const border_width_start_value = parseFloat(style[`border${secondary_dimensions[0]}Width`]);
+	const border_width_end_value = parseFloat(style[`border${secondary_dimensions[1]}Width`]);
 	return {
 		delay,
 		duration,
@@ -126,12 +126,12 @@ export function slide(node: Element, {
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
 			`${primary_dimension}: ${t * primary_dimension_value}px;` +
-			`padding-${secondary_dimensions[0].toLowerCase()}: ${t * padding_first_value}px;` +
-			`padding-${secondary_dimensions[1].toLowerCase()}: ${t * padding_second_value}px;` +
-			`margin-${secondary_dimensions[0].toLowerCase()}: ${t * margin_first_value}px;` +
-			`margin-${secondary_dimensions[1].toLowerCase()}: ${t * margin_second_value}px;` +
-			`border-${secondary_dimensions[0].toLowerCase()}-width: ${t * border_width_first_value}px;` +
-			`border-${secondary_dimensions[1].toLowerCase()}-width: ${t * border_width_second_value}px;`
+			`padding-${secondary_dimensions[0].toLowerCase()}: ${t * padding_start_value}px;` +
+			`padding-${secondary_dimensions[1].toLowerCase()}: ${t * padding_end_value}px;` +
+			`margin-${secondary_dimensions[0].toLowerCase()}: ${t * margin_start_value}px;` +
+			`margin-${secondary_dimensions[1].toLowerCase()}: ${t * margin_end_value}px;` +
+			`border-${secondary_dimensions[0].toLowerCase()}-width: ${t * border_width_start_value}px;` +
+			`border-${secondary_dimensions[1].toLowerCase()}-width: ${t * border_width_end_value}px;`
 	};
 }
 

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -109,15 +109,16 @@ export function slide(node: Element, {
 }: SlideParams = {}): TransitionConfig {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
-	const primary_dimension = axis === 'y' ? 'height' : 'width';
-	const primary_dimension_value = parseFloat(style[primary_dimension]);
-	const secondary_dimensions = axis === 'y' ? ['Top', 'Bottom'] : ['Left', 'Right'];
-	const padding_start_value = parseFloat(style.padding + secondary_dimensions[0]);
-	const padding_end_value = parseFloat(style.padding + secondary_dimensions[1]);
-	const margin_start_value = parseFloat(style.margin + secondary_dimensions[0]);
-	const margin_end_value = parseFloat(style.margin + secondary_dimensions[1]);
-	const border_width_start_value = parseFloat(style[`border${secondary_dimensions[0]}Width`]);
-	const border_width_end_value = parseFloat(style[`border${secondary_dimensions[1]}Width`]);
+	const primary_property = axis === 'y' ? 'height' : 'width';
+	const primary_property_value = parseFloat(style[primary_property]);
+	const secondary_properties = axis === 'y' ? ['top', 'bottom'] : ['left', 'right'];
+	const capitalized_secondary_properties = secondary_properties.map((e) => `${e[0].toUpperCase()}${e.slice(1)}`);
+	const padding_start_value = parseFloat(style[`padding${capitalized_secondary_properties[0]}`]);
+	const padding_end_value = parseFloat(style[`padding${capitalized_secondary_properties[1]}`]);
+	const margin_start_value = parseFloat(style[`margin${capitalized_secondary_properties[0]}`]);
+	const margin_end_value = parseFloat(style[`margin${capitalized_secondary_properties[1]}`]);
+	const border_width_start_value = parseFloat(style[`border${capitalized_secondary_properties[0]}Width`]);
+	const border_width_end_value = parseFloat(style[`border${capitalized_secondary_properties[1]}Width`]);
 	return {
 		delay,
 		duration,
@@ -125,13 +126,13 @@ export function slide(node: Element, {
 		css: t =>
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
-			`${primary_dimension}: ${t * primary_dimension_value}px;` +
-			`padding-${secondary_dimensions[0].toLowerCase()}: ${t * padding_start_value}px;` +
-			`padding-${secondary_dimensions[1].toLowerCase()}: ${t * padding_end_value}px;` +
-			`margin-${secondary_dimensions[0].toLowerCase()}: ${t * margin_start_value}px;` +
-			`margin-${secondary_dimensions[1].toLowerCase()}: ${t * margin_end_value}px;` +
-			`border-${secondary_dimensions[0].toLowerCase()}-width: ${t * border_width_start_value}px;` +
-			`border-${secondary_dimensions[1].toLowerCase()}-width: ${t * border_width_end_value}px;`
+			`${primary_property}: ${t * primary_property_value}px;` +
+			`padding-${secondary_properties[0]}: ${t * padding_start_value}px;` +
+			`padding-${secondary_properties[1]}: ${t * padding_end_value}px;` +
+			`margin-${secondary_properties[0]}: ${t * margin_start_value}px;` +
+			`margin-${secondary_properties[1]}: ${t * margin_end_value}px;` +
+			`border-${secondary_properties[0]}-width: ${t * border_width_start_value}px;` +
+			`border-${secondary_properties[1]}-width: ${t * border_width_end_value}px;`
 	};
 }
 

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -135,7 +135,7 @@ export function slide(node: Element, {
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
 			`height: calc(var(--yAxisT) * ${height}px);` +
 			`width: calc(var(--xAxisT) * ${width}px);` +
-			`padding: calc(var(--yAxisT) * ${padding_top}px) calc(var(--xAxisT) * ${padding_right}px) calc(var(--yAxisT) * ${padding_bottom}px) $calc(var(--xAxisT) * ${padding_left}px);` +
+			`padding: calc(var(--yAxisT) * ${padding_top}px) calc(var(--xAxisT) * ${padding_right}px) calc(var(--yAxisT) * ${padding_bottom}px) calc(var(--xAxisT) * ${padding_left}px);` +
 			`margin: calc(var(--yAxisT) * ${margin_top}px)  calc(var(--xAxisT) * ${margin_right}px) calc(var(--yAxisT) * ${margin_bottom}px) calc(var(--xAxisT) * ${margin_left}px);` +
 			`border-width: calc(var(--yAxisT) * ${border_top_width}px) calc(var(--xAxisT) * ${border_right_width}px) calc(var(--yAxisT) * ${border_bottom_width}px) calc(var(--xAxisT) * ${border_left_width}px);`
 	};

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -117,7 +117,7 @@ export function slide(node: Element, {
 	const margin_first_value = parseFloat(style.margin + secondary_dimensions[0]);
 	const margin_second_value = parseFloat(style.margin + secondary_dimensions[1]);
 	const border_width_first_value = parseFloat(style['border'.concat(secondary_dimensions[0].concat('Width'))]);
-	const border_width_second_value = parseFloat(style['border'.concat(secondary_dimensions[1].concat('Width'))]);
+	const border_width_second_value = parseFloat(style[`border${secondary_dimensions[1]}Width`]);
 	return {
 		delay,
 		duration,

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -107,15 +107,17 @@ export function slide(node: Element, {
 	easing = cubicOut,
 	axis = 'y'
 }: SlideParams = {}): TransitionConfig {
-	const direction: { x: 1 | 0, y: 1 | 0 } = { x: axis === 'x' ? 1 : 0, y: axis === 'y' ? 1 : 0 };
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
-	const height = parseFloat(style.height);
-	const width = parseFloat(style.width);
-	const padding = { top: parseFloat(style.paddingTop), right: parseFloat(style.paddingRight), bottom: parseFloat(style.paddingBottom), left: parseFloat(style.paddingLeft) };
-	const margin = { top: parseFloat(style.marginTop), right: parseFloat(style.marginRight), bottom: parseFloat(style.marginBottom), left: parseFloat(style.marginLeft) };
-	const border_width = { top: parseFloat(style.borderTopWidth), right: parseFloat(style.borderRightWidth), bottom: parseFloat(style.borderBottomWidth), left: parseFloat(style.borderLeftWidth) };
-
+	const primary_dimension = axis === 'y' ? 'height' : 'width';
+	const primary_dimension_value = parseFloat(style[primary_dimension]);
+	const secondary_dimensions = axis === 'y' ? ['Top', 'Bottom'] : ['Left', 'Right'];
+	const padding_first_value = parseFloat(style.padding[secondary_dimensions[0]]);
+	const padding_second_value = parseFloat(style.padding[secondary_dimensions[1]]);
+	const margin_first_value = parseFloat(style.margin[secondary_dimensions[0]]);
+	const margin_second_value = parseFloat(style.margin[secondary_dimensions[1]]);
+	const border_width_first_value = parseFloat(style['border'.concat(secondary_dimensions[0].concat('Width'))]);
+	const border_width_second_value = parseFloat(style['border'.concat(secondary_dimensions[1].concat('Width'))]);
 	return {
 		delay,
 		duration,
@@ -123,11 +125,13 @@ export function slide(node: Element, {
 		css: t =>
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
-			`height: ${t ** direction.y * height}px;` +
-			`width: ${t ** direction.x * width}px;` +
-			`padding: ${t ** direction.y * padding.top}px ${t ** direction.x * padding.right}px ${t ** direction.y * padding.bottom}px) ${t ** direction.x * padding.left}px;` +
-			`margin: ${t ** direction.y * margin.top}px  ${t ** direction.x * margin.right}px ${t ** direction.y * margin.bottom}px ${t ** direction.x * margin.left}px;` +
-			`border-width: ${t ** direction.y * border_width.top}px ${t ** direction.x * border_width.right}px ${t ** direction.y * border_width.bottom}px ${t ** direction.x * border_width.left}px;`
+			`${primary_dimension}: ${t * primary_dimension_value}px;` +
+			`padding-${secondary_dimensions[0].toLowerCase()}: ${t * padding_first_value}px;` +
+			`padding-${secondary_dimensions[1].toLowerCase()}: ${t * padding_second_value}px;` +
+			`margin-${secondary_dimensions[0].toLowerCase()}: ${t * margin_first_value}px;` +
+			`margin-${secondary_dimensions[1].toLowerCase()}: ${t * margin_second_value}px;` +
+			`border-${secondary_dimensions[0].toLowerCase()}-width: ${t * border_width_first_value}px;` +
+			`border-${secondary_dimensions[1].toLowerCase()}-width: ${t * border_width_second_value}px;`
 	};
 }
 

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -105,8 +105,9 @@ export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
 	easing = cubicOut,
-	axis = 'y'
+	axis = 'x'
 }: SlideParams = {}): TransitionConfig {
+	const direction: { x: 1 | 0, y: 1 | 0 } = { x: axis === 'x' ? 1 : 0, y: axis === 'y' ? 1 : 0 };
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
 	const height = parseFloat(style.height);
@@ -129,15 +130,13 @@ export function slide(node: Element, {
 		duration,
 		easing,
 		css: t =>
-			`--y_axis_t: ${axis === 'y' ? t : 1};` +
-			`--x_axis_t: ${axis === 'x' ? t : 1};` +
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
-			`height: calc(var(--yAxisT) * ${height}px);` +
-			`width: calc(var(--xAxisT) * ${width}px);` +
-			`padding: calc(var(--yAxisT) * ${padding_top}px) calc(var(--xAxisT) * ${padding_right}px) calc(var(--yAxisT) * ${padding_bottom}px) calc(var(--xAxisT) * ${padding_left}px);` +
-			`margin: calc(var(--yAxisT) * ${margin_top}px)  calc(var(--xAxisT) * ${margin_right}px) calc(var(--yAxisT) * ${margin_bottom}px) calc(var(--xAxisT) * ${margin_left}px);` +
-			`border-width: calc(var(--yAxisT) * ${border_top_width}px) calc(var(--xAxisT) * ${border_right_width}px) calc(var(--yAxisT) * ${border_bottom_width}px) calc(var(--xAxisT) * ${border_left_width}px);`
+			`height: ${t ** direction.y * height}px;` +
+			`width: ${t ** direction.x * width}px;` +
+			`padding: ${t ** direction.y * padding_top}px ${t ** direction.x * padding_right}px ${t ** direction.y * padding_bottom}px) ${t ** direction.x * padding_left}px;` +
+			`margin: ${t ** direction.y * margin_top}px  ${t ** direction.x * margin_right}px ${t ** direction.y * margin_bottom}px ${t ** direction.x * margin_left}px;` +
+			`border-width: ${t ** direction.y * border_top_width}px ${t ** direction.x * border_right_width}px ${t ** direction.y * border_bottom_width}px ${t ** direction.x * border_left_width}px;`
 	};
 }
 

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -112,18 +112,9 @@ export function slide(node: Element, {
 	const opacity = +style.opacity;
 	const height = parseFloat(style.height);
 	const width = parseFloat(style.width);
-	const padding_top = parseFloat(style.paddingTop);
-	const padding_bottom = parseFloat(style.paddingBottom);
-	const padding_left = parseFloat(style.paddingLeft);
-	const padding_right = parseFloat(style.paddingRight);
-	const margin_top = parseFloat(style.marginTop);
-	const margin_bottom = parseFloat(style.marginBottom);
-	const margin_left = parseFloat(style.marginLeft);
-	const margin_right = parseFloat(style.marginRight);
-	const border_top_width = parseFloat(style.borderTopWidth);
-	const border_bottom_width = parseFloat(style.borderBottomWidth);
-	const border_left_width = parseFloat(style.borderLeftWidth);
-	const border_right_width = parseFloat(style.borderRightWidth);
+	const padding = { top: parseFloat(style.paddingTop), right: parseFloat(style.paddingRight), bottom: parseFloat(style.paddingBottom), left: parseFloat(style.paddingLeft) };
+	const margin = { top: parseFloat(style.marginTop), right: parseFloat(style.marginRight), bottom: parseFloat(style.marginBottom), left: parseFloat(style.marginLeft) };
+	const border_width = { top: parseFloat(style.borderTopWidth), right: parseFloat(style.borderRightWidth), bottom: parseFloat(style.borderBottomWidth), left: parseFloat(style.borderLeftWidth) };
 
 	return {
 		delay,
@@ -134,9 +125,9 @@ export function slide(node: Element, {
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
 			`height: ${t ** direction.y * height}px;` +
 			`width: ${t ** direction.x * width}px;` +
-			`padding: ${t ** direction.y * padding_top}px ${t ** direction.x * padding_right}px ${t ** direction.y * padding_bottom}px) ${t ** direction.x * padding_left}px;` +
-			`margin: ${t ** direction.y * margin_top}px  ${t ** direction.x * margin_right}px ${t ** direction.y * margin_bottom}px ${t ** direction.x * margin_left}px;` +
-			`border-width: ${t ** direction.y * border_top_width}px ${t ** direction.x * border_right_width}px ${t ** direction.y * border_bottom_width}px ${t ** direction.x * border_left_width}px;`
+			`padding: ${t ** direction.y * padding.top}px ${t ** direction.x * padding.right}px ${t ** direction.y * padding.bottom}px) ${t ** direction.x * padding.left}px;` +
+			`margin: ${t ** direction.y * margin.top}px  ${t ** direction.x * margin.right}px ${t ** direction.y * margin.bottom}px ${t ** direction.x * margin.left}px;` +
+			`border-width: ${t ** direction.y * border_width.top}px ${t ** direction.x * border_width.right}px ${t ** direction.y * border_width.bottom}px ${t ** direction.x * border_width.left}px;`
 	};
 }
 

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -107,7 +107,7 @@ export function slide(node: Element, {
 	easing = cubicOut,
 	axis = 'y'
 }: SlideParams = {}): TransitionConfig {
-	const direction = { x: axis === 'x' ? 1 : 0, y: axis === 'y' ? 1 : 0 };
+	const direction: { x: 1 | 0, y: 1 | 0 } = { x: axis === 'x' ? 1 : 0, y: axis === 'y' ? 1 : 0 };
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
 	const height = parseFloat(style.height);


### PR DESCRIPTION
First of all: this is my first ever PR and I have to thank all the developers of svelte for sparking my passion when it comes to WebDevelopment. Because .svelte files really embrace the basic web-technologies, it made frameworks so much more accessible! I was always deterred from becoming a web-developer due to (perceived) complexity, but svelte finally opened up this possibility for me! Thank you!

Because I am relatively new, please make sure to double check my code for bad practices or coding errors!
Please point out to me if I made any formal errors with this PR besides the test cases I was to inexperienced to write.

### Description

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason.

I created an issue for this feature request myself earlier today: #6182 . 
Basically, I am proposing to expand the parameters the slide transition takes in, in order to allow for the sliding animation to occur on two axes: horizontally or vertically. Slide provides a beautiful and realistic user experience. However, it is limited in terms of usability, because out of the box it only supports vertical sliding.
Using the slide transition horizontally creates a really beautiful effect, that resembles a slide of cards and is directionally aligned with back arrows, text flow and other UI components.
This is a feature worth including into svelte, because the "batteries included" rich transition suite is a key factor in developer experience. This PR strives to make a preexisting transition more versatile, by adding an optional parameter to the API without breaking the default behavior.

You can see this implementation in action [in this REPL](https://svelte.dev/repl/6d5239f09b0b4dc6aafeb70606a0fe94?version=3.46.4), albeit without typescript.


### Update Documentation

Because the API changed, I updated the Documentation. I hope the format and wording is appropriate.


### Assistance required: Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
-  [ ] Ideally, include a test that fails without this PR but passes with it.

Both `npm test` and `npm run lint` ran without hiccups. However, i failed to implement my own tests to test my solution. 
I would highly appreciate it, if someone could point me to introductory ressources for writing tests, so that I can submit them later.

EDIT: Updated REPL