### PR TITLE
docs: mention that <svelte:self> can be in a slot

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1430,7 +1430,7 @@ Named slots can also expose values. The `let:` directive goes on the element wit
 
 The `<svelte:self>` element allows a component to include itself, recursively.
 
-It cannot appear at the top level of your markup; it must be inside an if or each block to prevent an infinite loop.
+It cannot appear at the top level of your markup; it must be inside an if or each block or passed to a component's slot to prevent an infinite loop.
 
 ```sv
 <script>


### PR DESCRIPTION
This PR updates the [docs](https://svelte.dev/docs#svelte_self) for `<svelte:self>` to mention that it can also be placed in a component's slot.

This was merged as part of #4532 but it doesn't look like the docs were updated.
