### PR TITLE
site: a11y change select on:change to on:blur

### DIFF
--- a/site/content/examples/05-bindings/06-select-bindings/App.svelte
+++ b/site/content/examples/05-bindings/06-select-bindings/App.svelte
@@ -21,7 +21,7 @@
 <h2>Insecurity questions</h2>
 
 <form on:submit|preventDefault={handleSubmit}>
-	<select bind:value={selected} on:change="{() => answer = ''}">
+	<select bind:value={selected} on:blur="{() => answer = ''}">
 		{#each questions as question}
 			<option value={question}>
 				{question.text}

--- a/site/content/tutorial/06-bindings/06-select-bindings/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/06-select-bindings/app-a/App.svelte
@@ -21,7 +21,7 @@
 <h2>Insecurity questions</h2>
 
 <form on:submit|preventDefault={handleSubmit}>
-	<select value={selected} on:change="{() => answer = ''}">
+	<select value={selected} on:blur="{() => answer = ''}">
 		{#each questions as question}
 			<option value={question}>
 				{question.text}

--- a/site/content/tutorial/06-bindings/06-select-bindings/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/06-select-bindings/app-b/App.svelte
@@ -21,7 +21,7 @@
 <h2>Insecurity questions</h2>
 
 <form on:submit|preventDefault={handleSubmit}>
-	<select bind:value={selected} on:change="{() => answer = ''}">
+	<select bind:value={selected} on:blur="{() => answer = ''}">
 		{#each questions as question}
 			<option value={question}>
 				{question.text}

--- a/site/content/tutorial/06-bindings/06-select-bindings/text.md
+++ b/site/content/tutorial/06-bindings/06-select-bindings/text.md
@@ -5,7 +5,7 @@ title: Select bindings
 We can also use `bind:value` with `<select>` elements. Update line 24:
 
 ```html
-<select bind:value={selected} on:change="{() => answer = ''}">
+<select bind:value={selected} on:blur="{() => answer = ''}">
 ```
 
 Note that the `<option>` values are objects rather than strings. Svelte doesn't mind.

--- a/test/runtime/samples/select-change-handler/main.svelte
+++ b/test/runtime/samples/select-change-handler/main.svelte
@@ -8,7 +8,7 @@
 	}
 </script>
 
-<select bind:value={selected} on:change="{() => updateLastChangedTo(selected)}">
+<select bind:value={selected} on:blur="{() => updateLastChangedTo(selected)}">
 	{#each options as option}
 		<option value="{option.id}">{option.id}</option>
 	{/each}


### PR DESCRIPTION
On this part of the tutorial, there's an a11y warning that may be worth fixing: https://svelte.dev/tutorial/select-bindings

- a11y warned on:blur must be used instead of on:change

- the warning distracts the user from the tutorial's objective. 