### PR TITLE
ci: increase timeouts to avoid random breaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   Tests:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [8, 10, 12, 14]
@@ -27,7 +27,7 @@ jobs:
         CI: true
   Lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
@@ -42,7 +42,7 @@ jobs:
     - run: 'npm i && npm run lint'
   Unit:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]


### PR DESCRIPTION
### Description

After submitting my first two PRs, I noticed that Github Checks sometimes breaks because of a timing issue.

Most of the time, this is due to one this two jobs:
- `CI / Tests (8, windows-latest) (pull_request)`
- `CI / Unit (macOS-latest) (pull_request)`

This is frustrating because you never know if you breaks something or if it's a timing issue.

### Solution

Increase the timing on Github Actions.

### Discussion

I added 5 minutes to both `Tests` and `Unit` jobs.
I also increased `Lint` to set the timeout at `5` to be sure that we will never run into this issue with this job.

Are you OK with these new timings?

Thanks