### PR TITLE
make crossfade fallback param optional

### DIFF
--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -207,7 +207,7 @@ export interface CrossfadeParams {
 type ClientRectMap = Map<any, { rect: ClientRect }>;
 
 export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
-	fallback: (node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig;
+	fallback?: (node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig;
 }) {
 	const to_receive: ClientRectMap = new Map();
 	const to_send: ClientRectMap = new Map();


### PR DESCRIPTION
It would be nice to mark the `fallback` param of the `crossfade` function from `"svelte/transition"` as optional to avoid passing an empty function when no fallback is desired.


before:
``` ts
  const [send, receive] = crossfade({
    duration: 600,
    fallback: () => ({}),
  });
```

after:
``` ts
  const [send, receive] = crossfade({ duration: 600 });
```

### Notes
I think this was also intended by the author because there is already a null check for `fallback`.
`return fallback && fallback(node, params, intro);`