### PR TITLE
docs: make yaml frontmatter in blogs valid

### DIFF
--- a/site/content/blog/2016-11-26-frameworks-without-the-framework.md
+++ b/site/content/blog/2016-11-26-frameworks-without-the-framework.md
@@ -1,5 +1,5 @@
 ---
-title: Frameworks without the framework: why didn't we think of this sooner?
+title: "Frameworks without the framework: why didn't we think of this sooner?"
 description: You can't write serious applications in vanilla JavaScript without hitting a complexity wall. But a compiler can do it for you.
 author: Rich Harris
 authorURL: https://twitter.com/Rich_Harris

--- a/site/content/blog/2017-12-31-sapper-towards-the-ideal-web-app-framework.md
+++ b/site/content/blog/2017-12-31-sapper-towards-the-ideal-web-app-framework.md
@@ -1,5 +1,5 @@
 ---
-title: Sapper: Towards the ideal web app framework
+title: "Sapper: Towards the ideal web app framework"
 description: Taking the next-plus-one step
 author: Rich Harris
 authorURL: https://twitter.com/Rich_Harris

--- a/site/content/blog/2019-04-22-svelte-3-rethinking-reactivity.md
+++ b/site/content/blog/2019-04-22-svelte-3-rethinking-reactivity.md
@@ -1,5 +1,5 @@
 ---
-title: Svelte 3: Rethinking reactivity
+title: "Svelte 3: Rethinking reactivity"
 description: It's finally here
 author: Rich Harris
 authorURL: https://twitter.com/Rich_Harris

--- a/site/content/blog/2020-10-01-whats-new-in-svelte-october-2020.md
+++ b/site/content/blog/2020-10-01-whats-new-in-svelte-october-2020.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in Svelte: October 2020
+title: "What's new in Svelte: October 2020"
 description: New object methods, in-depth learning resources and tons of integration examples!
 author: Daniel Sandoval
 authorURL: https://desandoval.net

--- a/site/content/blog/2020-11-01-whats-new-in-svelte-november-2020.md
+++ b/site/content/blog/2020-11-01-whats-new-in-svelte-november-2020.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in Svelte: November 2020
+title: "What's new in Svelte: November 2020"
 description: Slot forwarding fixes, SvelteKit for faster local development, and more from Svelte Summit
 author: Daniel Sandoval
 authorURL: https://desandoval.net

--- a/site/content/blog/2020-12-01-whats-new-in-svelte-december-2020.md
+++ b/site/content/blog/2020-12-01-whats-new-in-svelte-december-2020.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in Svelte: December 2020
+title: "What's new in Svelte: December 2020"
 description: Better tooling, export maps and improvements to slots and context
 author: Daniel Sandoval
 authorURL: https://desandoval.net

--- a/site/content/blog/2021-01-01-whats-new-in-svelte-january-2021.md
+++ b/site/content/blog/2021-01-01-whats-new-in-svelte-january-2021.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in Svelte: January 2021
+title: "What's new in Svelte: January 2021"
 description: A Svelte-packed showcase to kick-off the new year!
 author: Daniel Sandoval
 authorURL: https://desandoval.net

--- a/site/content/blog/2021-02-01-whats-new-in-svelte-february-2021.md
+++ b/site/content/blog/2021-02-01-whats-new-in-svelte-february-2021.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in Svelte: February 2021
+title: "What's new in Svelte: February 2021"
 description: Integrations and improvements at lightning speed...
 author: Daniel Sandoval
 authorURL: https://desandoval.net

--- a/site/content/blog/2021-03-01-whats-new-in-svelte-march-2021.md
+++ b/site/content/blog/2021-03-01-whats-new-in-svelte-march-2021.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in Svelte: March 2021
+title: "What's new in Svelte: March 2021"
 description: Call for Svelte Summit Speakers! Improved SSR, non-HTML5 compilation targets, and ESLint TypeScript support
 author: Daniel Sandoval
 authorURL: https://desandoval.net

--- a/site/content/blog/2021-04-01-whats-new-in-svelte-april-2021.md
+++ b/site/content/blog/2021-04-01-whats-new-in-svelte-april-2021.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in Svelte: April 2021
+title: "What's new in Svelte: April 2021"
 description: SvelteKit beta and new way to use slots
 author: Daniel Sandoval
 authorURL: https://desandoval.net


### PR DESCRIPTION
Some of the blog posts have invalid YAML in their frontmatter. `:` has special meaning in YAML. This was not a problem in the past because we were parsing the YAML ourselves and our 'parser' did not care. This is a problem for a full YAML parser.

It is fixed in this PR.