### PR TITLE
fix custombutton colors for a11y contrast

### DIFF
--- a/site/content/tutorial/05-events/06-dom-event-forwarding/app-a/CustomButton.svelte
+++ b/site/content/tutorial/05-events/06-dom-event-forwarding/app-a/CustomButton.svelte
@@ -2,18 +2,18 @@
 	button {
 		height: 4rem;
 		width: 8rem;
-		background-color: #aaa;
-		border-color: #f1c40f;
-		color: #f1c40f;
+		background-color: #ddd;
+		border-color: #ff3e00;
+		color: #ff3e00;
 		font-size: 1.25rem;
-		background-image: linear-gradient(45deg, #f1c40f 50%, transparent 50%);
+		background-image: linear-gradient(45deg, #ff3e00 50%, transparent 50%);
 		background-position: 100%;
 		background-size: 400%;
 		transition: background 300ms ease-in-out;
 	}
 	button:hover {
 		background-position: 0;
-		color: #aaa;
+		color: #ddd;
 	}
 </style>
 

--- a/site/content/tutorial/05-events/06-dom-event-forwarding/app-b/CustomButton.svelte
+++ b/site/content/tutorial/05-events/06-dom-event-forwarding/app-b/CustomButton.svelte
@@ -2,18 +2,18 @@
 	button {
 		height: 4rem;
 		width: 8rem;
-		background-color: #aaa;
-		border-color: #f1c40f;
-		color: #f1c40f;
+		background-color: #ddd;
+		border-color: #ff3e00;
+		color: #ff3e00;
 		font-size: 1.25rem;
-		background-image: linear-gradient(45deg, #f1c40f 50%, transparent 50%);
+		background-image: linear-gradient(45deg, #ff3e00 50%, transparent 50%);
 		background-position: 100%;
 		background-size: 400%;
 		transition: background 300ms ease-in-out;
 	}
 	button:hover {
 		background-position: 0;
-		color: #aaa;
+		color: #ddd;
 	}
 </style>
 


### PR DESCRIPTION
The color contrast between the current `CustomButton`'s `background-color` (#aaa) and `color`/`border-color` (#f1c40f) does not meet the minimum WCAG criteria. It fails the WCAG AA Standard with a contrast ratio of 1.4.

Since it's kind of hard to meet the contrast ratio standard by keeping a vibrant yellow color (similar to the current one) and a light background, I consider it better to switch the yellow color for an orange/tan color (similar to the Svelte color) and a lighter background color, so it passes WCAG AA.
