### PR TITLE
Fix await block scope issue when update

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -232,7 +232,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 
 		const dependencies = this.node.expression.dynamic_dependencies();
 
-		const update_child_context = b`@update_child_context(${info}, #ctx, #dirty)`;
+		const update_await_block_branch = b`@update_await_block_branch(${info}, #ctx, #dirty)`;
 
 		if (dependencies.length > 0) {
 			const condition = x`
@@ -249,7 +249,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 					if (${condition}) {
 
 					} else {
-						${update_child_context}
+						${update_await_block_branch}
 					}
 				`);
 			} else {
@@ -260,7 +260,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 		} else {
 			if (this.pending.block.has_update_method) {
 				block.chunks.update.push(b`
-					${update_child_context}
+					${update_await_block_branch}
 				`);
 			}
 		}

--- a/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/AwaitBlock.ts
@@ -232,14 +232,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 
 		const dependencies = this.node.expression.dynamic_dependencies();
 
-		let update_child_context;
-		if (this.then.value && this.catch.value) {
-			update_child_context = b`#child_ctx[${this.then.value_index}] = #child_ctx[${this.catch.value_index}] = ${info}.resolved;`;
-		} else if (this.then.value) {
-			update_child_context = b`#child_ctx[${this.then.value_index}] = ${info}.resolved;`;
-		} else if (this.catch.value) {
-			update_child_context = b`#child_ctx[${this.catch.value_index}] = ${info}.resolved;`;
-		}
+		const update_child_context = b`@update_child_context(${info}, #ctx, #dirty)`;
 
 		if (dependencies.length > 0) {
 			const condition = x`
@@ -256,9 +249,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 					if (${condition}) {
 
 					} else {
-						const #child_ctx = #ctx.slice();
 						${update_child_context}
-						${info}.block.p(#child_ctx, #dirty);
 					}
 				`);
 			} else {
@@ -269,11 +260,7 @@ export default class AwaitBlockWrapper extends Wrapper {
 		} else {
 			if (this.pending.block.has_update_method) {
 				block.chunks.update.push(b`
-					{
-						const #child_ctx = #ctx.slice();
-						${update_child_context}
-						${info}.block.p(#child_ctx, #dirty);
-					}
+					${update_child_context}
 				`);
 			}
 		}

--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -83,3 +83,17 @@ export function handle_promise(promise, info) {
 		info.resolved = promise;
 	}
 }
+
+export function update_child_context(info, ctx, dirty) {
+	const child_ctx = ctx.slice();
+	const { resolved } = info;
+
+	if (info.current === info.then) {
+		child_ctx[info.value] = resolved;
+	}
+	if (info.current === info.catch) {
+		child_ctx[info.error] = resolved;
+	}
+
+	info.block.p(child_ctx, dirty);
+}

--- a/src/runtime/internal/await_block.ts
+++ b/src/runtime/internal/await_block.ts
@@ -84,7 +84,7 @@ export function handle_promise(promise, info) {
 	}
 }
 
-export function update_child_context(info, ctx, dirty) {
+export function update_await_block_branch(info, ctx, dirty) {
 	const child_ctx = ctx.slice();
 	const { resolved } = info;
 

--- a/test/runtime/samples/await-with-update-catch-scope/_config.js
+++ b/test/runtime/samples/await-with-update-catch-scope/_config.js
@@ -1,6 +1,6 @@
 export default {
 	props: {
-		thePromise: new Promise((_) => {}),
+		thePromise: new Promise((_) => {})
 	},
 
 	html: `
@@ -8,7 +8,7 @@ export default {
 	`,
 
 	async test({ assert, component, target }) {
-		await (component.thePromise = Promise.resolve("abc"));
+		await (component.thePromise = Promise.resolve('abc'));
 
 		assert.htmlEqual(
 			target.innerHTML,
@@ -33,7 +33,7 @@ export default {
 		);
 
 		try {
-			await (component.thePromise = Promise.reject("failure"));
+			await (component.thePromise = Promise.reject('failure'));
 		} catch (error) {
 			// ignore
 		}
@@ -47,5 +47,5 @@ export default {
 			</div>
 			`
 		);
-	},
+	}
 };

--- a/test/runtime/samples/await-with-update-catch-scope/_config.js
+++ b/test/runtime/samples/await-with-update-catch-scope/_config.js
@@ -1,0 +1,51 @@
+export default {
+	props: {
+		thePromise: new Promise((_) => {}),
+	},
+
+	html: `
+		<div>error: undefined</div>
+	`,
+
+	async test({ assert, component, target }) {
+		await (component.thePromise = Promise.resolve("abc"));
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<div>
+				error: undefined
+				After Resolve: undefined
+			</div>
+			`
+		);
+
+		component.error = 'external error occurred';
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<div>
+				error: ${component.error}
+				After Resolve: ${component.error}
+			</div>
+			`
+		);
+
+		try {
+			await (component.thePromise = Promise.reject("failure"));
+		} catch (error) {
+			// ignore
+		}
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<div>
+				error: ${component.error}
+				Rejected: failure
+			</div>
+			`
+		);
+	},
+};

--- a/test/runtime/samples/await-with-update-catch-scope/main.svelte
+++ b/test/runtime/samples/await-with-update-catch-scope/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	export let thePromise;
+	export let error;
+</script>
+
+<div>
+	error: {error}
+	{#await thePromise then _}
+		After Resolve: {error}
+	{:catch error}
+		Rejected: {error}
+	{/await}
+</div>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

Fix await block scope issue during update (#6173). During the update, the `child_ctx` passed into await block branch is mutated no matter the state of the await block. This normally won't cause any issue. But when the `error` or the `value` of the await block is shadowing some instance variable. It would cause a scope issue. 

For example, in this [repo](https://svelte.dev/repl/8aa621af75574acd8d4c041517dee038?version=3.37.0)
The error variable is overridden by the resolved result.
As for the error in #6173, It is because the error variable has also been overridden. Thus it would try to render the non-exist if block.

The solution I come up with is to only update `child_ctx` with the index of the current await branch context. Because the update code is not a one-liner anymore. I moved it to a runtime function. 