### PR TITLE
04-group-inputs: add Oxford comma

### DIFF
--- a/site/content/tutorial/06-bindings/04-group-inputs/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/04-group-inputs/app-a/App.svelte
@@ -4,7 +4,7 @@
 
 	function join(flavours) {
 		if (flavours.length === 1) return flavours[0];
-		return `${flavours.slice(0, -1).join(', ')} and ${flavours[flavours.length - 1]}`;
+		return `${flavours.slice(0, -1).join(', ')}, and ${flavours[flavours.length - 1]}`;
 	}
 </script>
 

--- a/site/content/tutorial/06-bindings/04-group-inputs/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/04-group-inputs/app-b/App.svelte
@@ -10,7 +10,7 @@
 
 	function join(flavours) {
 		if (flavours.length === 1) return flavours[0];
-		return `${flavours.slice(0, -1).join(', ')} and ${flavours[flavours.length - 1]}`;
+		return `${flavours.slice(0, -1).join(', ')}, and ${flavours[flavours.length - 1]}`;
 	}
 </script>
 


### PR DESCRIPTION
When there are 3 or more items in a list, the second-to last item (before the word 'and') should be followed by a comma:
"Let's go to eat George, Betty, and Martha!" (meaning "you three, let's go eat!")
vs
"Let's go to eat George, Betty and Martha!" (meaning, "Betty and Martha, let's eat George")