### PR TITLE
Add "context" typing on SvelteComponent options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Avoid recreating DOM elements during hydration ([#6204](https://github.com/sveltejs/svelte/pull/6204))
 * Add missing function overload for `derived` to allow explicitly setting an initial value for non-async derived stores ([#6172](https://github.com/sveltejs/svelte/pull/6172))
 * Pass full markup source to script/style preprocessors ([#6169](https://github.com/sveltejs/svelte/pull/6169))
+* Add "context" typing to SvelteComponent constructor options ([#6236](https://github.com/sveltejs/svelte/pull/6236))
 
 ## 3.37.0
 

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -104,6 +104,16 @@ export interface SvelteComponentDev {
 	$destroy(): void;
 	[accessor: string]: any;
 }
+interface IComponentOptions {
+	target: Element;
+	anchor?: Element;
+	props?: Props;
+	context: Record<string, unknown>;
+	hydrate?: boolean;
+	intro?: boolean;
+	$$inline?: boolean;
+}
+
 /**
  * Base class for Svelte components with some minor dev-enhancements. Used when dev=true.
  */
@@ -130,14 +140,7 @@ export class SvelteComponentDev extends SvelteComponent {
 	 */
 	$$slot_def: any;
 
-	constructor(options: {
-		target: Element;
-		anchor?: Element;
-		props?: Props;
-		hydrate?: boolean;
-		intro?: boolean;
-		$$inline?: boolean;
-    }) {
+	constructor(options: IComponentOptions) {
 		if (!options || (!options.target && !options.$$inline)) {
 			throw new Error("'target' is a required option");
 		}
@@ -174,9 +177,9 @@ export interface SvelteComponentTyped<
 /**
  * Base class to create strongly typed Svelte components.
  * This only exists for typing purposes and should be used in `.d.ts` files.
- * 
+ *
  * ### Example:
- * 
+ *
  * You have component library on npm called `component-library`, from which
  * you export a component called `MyComponent`. For Svelte+TypeScript users,
  * you want to provide typings. Therefore you create a `index.d.ts`:
@@ -193,7 +196,7 @@ export interface SvelteComponentTyped<
  * </script>
  * <MyComponent foo={'bar'} />
  * ```
- * 
+ *
  * #### Why not make this part of `SvelteComponent(Dev)`?
  * Because
  * ```ts
@@ -229,14 +232,7 @@ export class SvelteComponentTyped<
 	 */
 	$$slot_def: Slots;
 
-	constructor(options: {
-		target: Element;
-		anchor?: Element;
-		props?: Props;
-		hydrate?: boolean;
-		intro?: boolean;
-		$$inline?: boolean;
-    }) {
+	constructor(options: IComponentOptions) {
 		super(options);
 	}
 }

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -108,7 +108,7 @@ interface IComponentOptions {
 	target: Element;
 	anchor?: Element;
 	props?: Props;
-	context?: Record<string, unknown>;
+	context?: Map<any, any>;
 	hydrate?: boolean;
 	intro?: boolean;
 	$$inline?: boolean;

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -108,7 +108,7 @@ interface IComponentOptions {
 	target: Element;
 	anchor?: Element;
 	props?: Props;
-	context: Record<string, unknown>;
+	context?: Record<string, unknown>;
 	hydrate?: boolean;
 	intro?: boolean;
 	$$inline?: boolean;


### PR DESCRIPTION
Added missing "context" typing on `SvelteComponentDev` and `SvelteComponentTyped` options
```javascript
new Component({
    target:parent,
    context: { // throws error on typescript
        key: value
    }
})
```