### PR TITLE
[feat] Add local autosave functionality to the REPL for unauthenticated users

### DIFF
--- a/site/src/routes/repl/[id]/_components/AppControls/index.svelte
+++ b/site/src/routes/repl/[id]/_components/AppControls/index.svelte
@@ -86,6 +86,8 @@
 		if (saving) return;
 
 		if (!canSave) {
+			// Save to local storage
+			localStorage.setItem("repl_content", JSON.stringify(repl.toJSON()))
 			fork(true);
 			return;
 		}

--- a/site/src/routes/repl/[id]/_components/AppControls/index.svelte
+++ b/site/src/routes/repl/[id]/_components/AppControls/index.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher, getContext, onDestroy, onMount } from 'svelte';
 	import { stores } from '@sapper/app';
 	import UserMenu from './UserMenu.svelte';
 	import { Icon } from '@sveltejs/site-kit';
@@ -82,12 +82,18 @@
 		saving = false;
 	}
 
+	function saveLocal() {
+		localStorage.setItem("repl_content", JSON.stringify(repl.toJSON()));
+		localStorage.setItem("repl_name", name);
+	}
+
 	async function save() {
 		if (saving) return;
 
 		if (!canSave) {
 			// Save to local storage
-			localStorage.setItem("repl_content", JSON.stringify(repl.toJSON()))
+			// TODO: Add some feedback to let the user know they saved
+			saveLocal();
 			fork(true);
 			return;
 		}
@@ -165,6 +171,20 @@ export default app;` });
 
 		downloading = false;
 	}
+
+	const autosave_interval = setInterval(() => {
+		// Only run when user isn't logged in
+		// We could also run save() every 5 seconds
+		// That would make it autosave for logged in users
+		// as well. But that's not what this PR is about.
+		if (!canSave) {
+			saveLocal()
+		}
+	}, 2000);
+
+	onDestroy(() => {
+		clearInterval(autosave_interval);
+	});
 </script>
 
 <svelte:window on:keydown={handleKeydown} />

--- a/site/src/routes/repl/[id]/index.svelte
+++ b/site/src/routes/repl/[id]/index.svelte
@@ -47,6 +47,17 @@
 			return;
 		}
 
+		const local_repl_content = localStorage.getItem("repl_content")
+
+		// Check if user is not logged in and has local data
+		if (id == 'hello-world' && local_repl_content && !$session.user) {
+			setTimeout(() => {
+				repl.set(JSON.parse(local_repl_content))
+			}, 300) // Wait for repl var (it's undefined when this function gets called)
+			// TODO: Fix this possible race condition
+			return
+		}
+
 		// TODO handle `relaxed` logic
 		fetch(`repl/${id}.json`).then(r => {
 			if (r.ok) {

--- a/site/src/routes/repl/[id]/index.svelte
+++ b/site/src/routes/repl/[id]/index.svelte
@@ -53,6 +53,7 @@
 		if (id == 'hello-world' && local_repl_content && !$session.user) {
 			setTimeout(() => {
 				repl.set(JSON.parse(local_repl_content))
+				name = localStorage.getItem("repl_name")
 			}, 300) // Wait for repl var (it's undefined when this function gets called)
 			// TODO: Fix this possible race condition
 			return


### PR DESCRIPTION
### Local autosave
This pull request is to add the feature that was suggested in this issue:  #6248 

As of now, unauthenticated users lose their progress when they refresh their page or accidentally close it. This PR intends to fix that problem by saving their progress locally.