### PR TITLE
Add docs for compound :global selector

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -277,6 +277,12 @@ To apply styles to a selector globally, use the `:global(...)` modifier.
 			 to this component */
 		color: goldenrod;
 	}
+
+	p:global(.red) {
+		/* this will apply to <p> elements belonging to this 
+			 component that have the class "red" dynamically
+			 applied (e.g. via node.classList.add) */
+	}
 </style>
 ```
 

--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -279,9 +279,11 @@ To apply styles to a selector globally, use the `:global(...)` modifier.
 	}
 
 	p:global(.red) {
-		/* this will apply to <p> elements belonging to this 
-			 component that have the class "red" dynamically
-			 applied (e.g. via node.classList.add) */
+		/* this will apply to all <p> elements belonging to this 
+			 component with a class of red, even if class="red" does
+			 not appear in the markup. This is useful when the class 
+			 of the element is dynamically applied, for instance 
+			 when updating the element's classList property directly. */
 	}
 </style>
 ```

--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -281,7 +281,8 @@ To apply styles to a selector globally, use the `:global(...)` modifier.
 	p:global(.red) {
 		/* this will apply to all <p> elements belonging to this 
 			 component with a class of red, even if class="red" does
-			 not appear in the markup. This is useful when the class 
+			 not initially appear in the markup, and is instead 
+			 added at runtime. This is useful when the class 
 			 of the element is dynamically applied, for instance 
 			 when updating the element's classList property directly. */
 	}


### PR DESCRIPTION
Fixes #6269

This PR adds documentation for the newly-implemented compound :global selector, e.g. `p:global(.red)`. I followed how `div :global(strong)` was documented and updated the code block in the docs.

Let me know if you think this change needs more documentation, or if the code block is enough.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
