### PR TITLE
fix: Code unity at "for in"

### DIFF
--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -127,14 +127,14 @@ export function update_slot_spread(slot, slot_definition, ctx, $$scope, dirty, g
 
 export function exclude_internal_props(props) {
 	const result = {};
-	for (const k in props) if (k[0] !== '$') result[k] = props[k];
+	for (const key in props) if (key[0] !== '$') result[key] = props[key];
 	return result;
 }
 
 export function compute_rest_props(props, keys) {
 	const rest = {};
 	keys = new Set(keys);
-	for (const k in props) if (!keys.has(k) && k[0] !== '$') rest[k] = props[k];
+	for (const key in props) if (!keys.has(key) && key[0] !== '$') rest[key] = props[key];
 	return rest;
 }
 


### PR DESCRIPTION
If 'for in' is used, it seems that you need to incorporate it into the variable'k' or'key'.
It's simple, but this gives the code some unity.

It also looks like a more stable code.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
