### PR TITLE
Fixed incorrect line number in select bindings tutorial text.

### DIFF
--- a/site/content/tutorial/06-bindings/06-select-bindings/text.md
+++ b/site/content/tutorial/06-bindings/06-select-bindings/text.md
@@ -2,7 +2,7 @@
 title: Select bindings
 ---
 
-We can also use `bind:value` with `<select>` elements. Update line 24:
+We can also use `bind:value` with `<select>` elements. Update line 20:
 
 ```html
 <select bind:value={selected} on:change="{() => answer = ''}">


### PR DESCRIPTION
Tutorial chapter 6 (bindings) sub-chapter 6 (select bindings) referenced wrong line number in markdown text.
