### PR TITLE
[feat] a11y: add aria-proptype validation

### DIFF
--- a/test/validator/samples/a11y-aria-proptypes-drag-and-drop/input.svelte
+++ b/test/validator/samples/a11y-aria-proptypes-drag-and-drop/input.svelte
@@ -1,0 +1,2 @@
+<span aria-dropeffect="copy execute badvalue">foo</span>
+<span aria-grabbed="yes">foo</span>

--- a/test/validator/samples/a11y-aria-proptypes-drag-and-drop/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-drag-and-drop/warnings.json
@@ -1,0 +1,33 @@
+[
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 45,
+      "column": 45,
+      "line": 1
+    },
+    "message": "A11y: The value for the aria attribute 'aria-dropeffect' must be a space-separated list of one or more of copy, execute, link, move, none, popup",
+    "pos": 6,
+    "start": {
+      "character": 6,
+      "column": 6,
+      "line": 1
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 81,
+      "column": 24,
+      "line": 2
+    },
+    "message": "A11y: The value for the aria attribute 'aria-grabbed' must be exactly one of true, false, or undefined",
+    "pos": 63,
+    "start": {
+      "character": 63,
+      "column": 6,
+      "line": 2
+    }
+  }
+]

--- a/test/validator/samples/a11y-aria-proptypes-global/input.svelte
+++ b/test/validator/samples/a11y-aria-proptypes-global/input.svelte
@@ -1,0 +1,9 @@
+<span aria-hidden="yes">foo</span>
+<span aria-current="some wrong values">foo</span>
+<span aria-details>foo</span>
+<span aria-disabled="yes">foo</span>
+<span aria-haspopup="listbox tree">foo</span>
+<span aria-invalid="grammar spelling">foo</span>
+<span aria-keyshortcuts>foo</span>
+<span aria-label>foo</span>
+<span aria-roledescription>foo</span>

--- a/test/validator/samples/a11y-aria-proptypes-global/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-global/warnings.json
@@ -1,0 +1,145 @@
+[
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "message": "A11y: The value for the aria attribute 'aria-hidden' must be exactly one of true, false, or undefined",
+    "start": {
+      "line": 1,
+      "column": 6,
+      "character": 6
+    },
+    "end": {
+      "line": 1,
+      "column": 23,
+      "character": 23
+    },
+    "pos": 6
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 73,
+      "column": 38,
+      "line": 2
+    },
+    "message": "A11y: The value for the aria attribute 'aria-current' must be exactly one of page, step, location, date, time, true, false",
+    "pos": 41,
+    "start": {
+      "character": 41,
+      "column": 6,
+      "line": 2
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "message": "A11y: The value for the aria attribute 'aria-details' must be a string that represents a DOM element ID",
+    "start": {
+      "line": 3,
+      "column": 6,
+      "character": 91
+    },
+    "end": {
+      "line": 3,
+      "column": 18,
+      "character": 103
+    },
+    "pos": 91
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 140,
+      "column": 25,
+      "line": 4
+    },
+    "message": "A11y: The value for the aria attribute 'aria-disabled' must be exactly one of true or false",
+    "pos": 121,
+    "start": {
+      "character": 121,
+      "column": 6,
+      "line": 4
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 186,
+      "column": 34,
+      "line": 5
+    },
+    "message": "A11y: The value for the aria attribute 'aria-haspopup' must be exactly one of false, true, menu, listbox, tree, grid, dialog",
+    "pos": 158,
+    "start": {
+      "character": 158,
+      "column": 6,
+      "line": 5
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 235,
+      "column": 37,
+      "line": 6
+    },
+    "message": "A11y: The value for the aria attribute 'aria-invalid' must be exactly one of grammar, false, spelling, true",
+    "pos": 204,
+    "start": {
+      "character": 204,
+      "column": 6,
+      "line": 6
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 270,
+      "column": 23,
+      "line": 7
+    },
+    "message": "A11y: The value for the aria attribute 'aria-keyshortcuts' must be of type string",
+    "pos": 253,
+    "start": {
+      "character": 253,
+      "column": 6,
+      "line": 7
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 298,
+      "column": 16,
+      "line": 8
+    },
+    "message": "A11y: The value for the aria attribute 'aria-label' must be of type string",
+    "pos": 288,
+    "start": {
+      "character": 288,
+      "column": 6,
+      "line": 8
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 336,
+      "column": 26,
+      "line": 9
+    },
+    "message": "A11y: The value for the aria attribute 'aria-roledescription' must be of type string",
+    "pos": 316,
+    "start": {
+      "character": 316,
+      "column": 6,
+      "line": 9
+    }
+  }
+]

--- a/test/validator/samples/a11y-aria-proptypes-live-region/input.svelte
+++ b/test/validator/samples/a11y-aria-proptypes-live-region/input.svelte
@@ -1,0 +1,4 @@
+<span aria-atomic="yes">foo</span>
+<span aria-busy="yes">foo</span>
+<span aria-live="assertive polite">foo</span>
+<span aria-relevant="additions removals badvalue">foo</span>

--- a/test/validator/samples/a11y-aria-proptypes-live-region/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-live-region/warnings.json
@@ -1,0 +1,65 @@
+[
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 23,
+      "column": 23,
+      "line": 1
+    },
+    "message": "A11y: The value for the aria attribute 'aria-atomic' must be exactly one of true or false",
+    "pos": 6,
+    "start": {
+      "character": 6,
+      "column": 6,
+      "line": 1
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 56,
+      "column": 21,
+      "line": 2
+    },
+    "message": "A11y: The value for the aria attribute 'aria-busy' must be exactly one of true or false",
+    "pos": 41,
+    "start": {
+      "character": 41,
+      "column": 6,
+      "line": 2
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 102,
+      "column": 34,
+      "line": 3
+    },
+    "message": "A11y: The value for the aria attribute 'aria-live' must be exactly one of assertive, off, polite",
+    "pos": 74,
+    "start": {
+      "character": 74,
+      "column": 6,
+      "line": 3
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 163,
+      "column": 49,
+      "line": 4
+    },
+    "message": "A11y: The value for the aria attribute 'aria-relevant' must be a space-separated list of one or more of additions, all, removals, text",
+    "pos": 120,
+    "start": {
+      "character": 120,
+      "column": 6,
+      "line": 4
+    }
+  }
+]

--- a/test/validator/samples/a11y-aria-proptypes-relationship/input.svelte
+++ b/test/validator/samples/a11y-aria-proptypes-relationship/input.svelte
@@ -1,0 +1,16 @@
+<span aria-activedescendant>foo</span>
+<span aria-colcount="one">foo</span>
+<span aria-colindex="one">foo</span>
+<span aria-colspan="one">foo</span>
+<span aria-controls>foo</span>
+<span aria-describedby>foo</span>
+<span aria-details>foo</span>
+<span aria-errormessage>foo</span>
+<span aria-flowto>foo</span>
+<span aria-labelledby>foo</span>
+<span aria-owns>foo</span>
+<span aria-posinset="one">foo</span>
+<span aria-rowcount="one">foo</span>
+<span aria-rowindex="one">foo</span>
+<span aria-rowspan="one">foo</span>
+<span aria-setsize="one">foo</span>

--- a/test/validator/samples/a11y-aria-proptypes-relationship/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-relationship/warnings.json
@@ -1,0 +1,258 @@
+[
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 27,
+      "column": 27,
+      "line": 1
+    },
+    "message": "A11y: The value for the aria attribute 'aria-activedescendant' must be a string that represents a DOM element ID",
+    "pos": 6,
+    "start": {
+      "character": 6,
+      "column": 6,
+      "line": 1
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 64,
+      "column": 25,
+      "line": 2
+    },
+    "message": "A11y: The value for the aria attribute 'aria-colcount' must be of type integer",
+    "pos": 45,
+    "start": {
+      "character": 45,
+      "column": 6,
+      "line": 2
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 101,
+      "column": 25,
+      "line": 3
+    },
+    "message": "A11y: The value for the aria attribute 'aria-colindex' must be of type integer",
+    "pos": 82,
+    "start": {
+      "character": 82,
+      "column": 6,
+      "line": 3
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 137,
+      "column": 24,
+      "line": 4
+    },
+    "message": "A11y: The value for the aria attribute 'aria-colspan' must be of type integer",
+    "pos": 119,
+    "start": {
+      "character": 119,
+      "column": 6,
+      "line": 4
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 168,
+      "column": 19,
+      "line": 5
+    },
+    "message": "A11y: The value for the aria attribute 'aria-controls' must be a space-separated list of strings that represent DOM element IDs",
+    "pos": 155,
+    "start": {
+      "character": 155,
+      "column": 6,
+      "line": 5
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 202,
+      "column": 22,
+      "line": 6
+    },
+    "message": "A11y: The value for the aria attribute 'aria-describedby' must be a space-separated list of strings that represent DOM element IDs",
+    "pos": 186,
+    "start": {
+      "character": 186,
+      "column": 6,
+      "line": 6
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 232,
+      "column": 18,
+      "line": 7
+    },
+    "message": "A11y: The value for the aria attribute 'aria-details' must be a string that represents a DOM element ID",
+    "pos": 220,
+    "start": {
+      "character": 220,
+      "column": 6,
+      "line": 7
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 267,
+      "column": 23,
+      "line": 8
+    },
+    "message": "A11y: The value for the aria attribute 'aria-errormessage' must be a string that represents a DOM element ID",
+    "pos": 250,
+    "start": {
+      "character": 250,
+      "column": 6,
+      "line": 8
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 296,
+      "column": 17,
+      "line": 9
+    },
+    "message": "A11y: The value for the aria attribute 'aria-flowto' must be a space-separated list of strings that represent DOM element IDs",
+    "pos": 285,
+    "start": {
+      "character": 285,
+      "column": 6,
+      "line": 9
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 329,
+      "column": 21,
+      "line": 10
+    },
+    "message": "A11y: The value for the aria attribute 'aria-labelledby' must be a space-separated list of strings that represent DOM element IDs",
+    "pos": 314,
+    "start": {
+      "character": 314,
+      "column": 6,
+      "line": 10
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 356,
+      "column": 15,
+      "line": 11
+    },
+    "message": "A11y: The value for the aria attribute 'aria-owns' must be a space-separated list of strings that represent DOM element IDs",
+    "pos": 347,
+    "start": {
+      "character": 347,
+      "column": 6,
+      "line": 11
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 393,
+      "column": 25,
+      "line": 12
+    },
+    "message": "A11y: The value for the aria attribute 'aria-posinset' must be of type integer",
+    "pos": 374,
+    "start": {
+      "character": 374,
+      "column": 6,
+      "line": 12
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 430,
+      "column": 25,
+      "line": 13
+    },
+    "message": "A11y: The value for the aria attribute 'aria-rowcount' must be of type integer",
+    "pos": 411,
+    "start": {
+      "character": 411,
+      "column": 6,
+      "line": 13
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 467,
+      "column": 25,
+      "line": 14
+    },
+    "message": "A11y: The value for the aria attribute 'aria-rowindex' must be of type integer",
+    "pos": 448,
+    "start": {
+      "character": 448,
+      "column": 6,
+      "line": 14
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 503,
+      "column": 24,
+      "line": 15
+    },
+    "message": "A11y: The value for the aria attribute 'aria-rowspan' must be of type integer",
+    "pos": 485,
+    "start": {
+      "character": 485,
+      "column": 6,
+      "line": 15
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 539,
+      "column": 24,
+      "line": 16
+    },
+    "message": "A11y: The value for the aria attribute 'aria-setsize' must be of type integer",
+    "pos": 521,
+    "start": {
+      "character": 521,
+      "column": 6,
+      "line": 16
+    }
+  }
+]
+

--- a/test/validator/samples/a11y-aria-proptypes-widget/input.svelte
+++ b/test/validator/samples/a11y-aria-proptypes-widget/input.svelte
@@ -1,0 +1,18 @@
+<span aria-autocomplete="yes">foo</span>
+<span aria-checked="yes">foo</span>
+<span aria-expanded="yes">foo</span>
+<span aria-level="one">foo</span>
+<span aria-modal="yes">foo</span>
+<span aria-multiline="yes">foo</span>
+<span aria-multiselectable="yes">foo</span>
+<span aria-orientation="vertical horizontal">foo</span>
+<span aria-placeholder>foo</span>
+<span aria-pressed="yes">foo</span>
+<span aria-readonly="yes">foo</span>
+<span aria-required="yes">foo</span>
+<span aria-selected="yes">foo</span>
+<span aria-sort="ascending descending">foo</span>
+<span aria-valuemax="one">foo</span>
+<span aria-valuemin="one">foo</span>
+<span aria-valuenow="one">foo</span>
+<span aria-valuetext>foo</span>

--- a/test/validator/samples/a11y-aria-proptypes-widget/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-widget/warnings.json
@@ -1,0 +1,289 @@
+[
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "message": "A11y: The value for the aria attribute 'aria-autocomplete' must be exactly one of inline, list, both, none",
+    "start": {
+      "line": 1,
+      "column": 6,
+      "character": 6
+    },
+    "end": {
+      "line": 1,
+      "column": 29,
+      "character": 29
+    },
+    "pos": 6
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 65,
+      "column": 24,
+      "line": 2
+    },
+    "message": "A11y: The value for the aria attribute 'aria-checked' must be exactly one of true, false, or mixed",
+    "pos": 47,
+    "start": {
+      "character": 47,
+      "column": 6,
+      "line": 2
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 102,
+      "column": 25,
+      "line": 3
+    },
+    "message": "A11y: The value for the aria attribute 'aria-expanded' must be exactly one of true, false, or undefined",
+    "pos": 83,
+    "start": {
+      "character": 83,
+      "column": 6,
+      "line": 3
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 136,
+      "column": 22,
+      "line": 4
+    },
+    "message": "A11y: The value for the aria attribute 'aria-level' must be of type integer",
+    "pos": 120,
+    "start": {
+      "character": 120,
+      "column": 6,
+      "line": 4
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 170,
+      "column": 22,
+      "line": 5
+    },
+    "message": "A11y: The value for the aria attribute 'aria-modal' must be exactly one of true or false",
+    "pos": 154,
+    "start": {
+      "character": 154,
+      "column": 6,
+      "line": 5
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 208,
+      "column": 26,
+      "line": 6
+    },
+    "message": "A11y: The value for the aria attribute 'aria-multiline' must be exactly one of true or false",
+    "pos": 188,
+    "start": {
+      "character": 188,
+      "column": 6,
+      "line": 6
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 252,
+      "column": 32,
+      "line": 7
+    },
+    "message": "A11y: The value for the aria attribute 'aria-multiselectable' must be exactly one of true or false",
+    "pos": 226,
+    "start": {
+      "character": 226,
+      "column": 6,
+      "line": 7
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 308,
+      "column": 44,
+      "line": 8
+    },
+    "message": "A11y: The value for the aria attribute 'aria-orientation' must be exactly one of vertical, undefined, horizontal",
+    "pos": 270,
+    "start": {
+      "character": 270,
+      "column": 6,
+      "line": 8
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 342,
+      "column": 22,
+      "line": 9
+    },
+    "message": "A11y: The value for the aria attribute 'aria-placeholder' must be of type string",
+    "pos": 326,
+    "start": {
+      "character": 326,
+      "column": 6,
+      "line": 9
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 378,
+      "column": 24,
+      "line": 10
+    },
+    "message": "A11y: The value for the aria attribute 'aria-pressed' must be exactly one of true, false, or mixed",
+    "pos": 360,
+    "start": {
+      "character": 360,
+      "column": 6,
+      "line": 10
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 415,
+      "column": 25,
+      "line": 11
+    },
+    "message": "A11y: The value for the aria attribute 'aria-readonly' must be exactly one of true or false",
+    "pos": 396,
+    "start": {
+      "character": 396,
+      "column": 6,
+      "line": 11
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 452,
+      "column": 25,
+      "line": 12
+    },
+    "message": "A11y: The value for the aria attribute 'aria-required' must be exactly one of true or false",
+    "pos": 433,
+    "start": {
+      "character": 433,
+      "column": 6,
+      "line": 12
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 489,
+      "column": 25,
+      "line": 13
+    },
+    "message": "A11y: The value for the aria attribute 'aria-selected' must be exactly one of true, false, or undefined",
+    "pos": 470,
+    "start": {
+      "character": 470,
+      "column": 6,
+      "line": 13
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 539,
+      "column": 38,
+      "line": 14
+    },
+    "message": "A11y: The value for the aria attribute 'aria-sort' must be exactly one of ascending, descending, none, other",
+    "pos": 507,
+    "start": {
+      "character": 507,
+      "column": 6,
+      "line": 14
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 576,
+      "column": 25,
+      "line": 15
+    },
+    "message": "A11y: The value for the aria attribute 'aria-valuemax' must be of type number",
+    "pos": 557,
+    "start": {
+      "character": 557,
+      "column": 6,
+      "line": 15
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 613,
+      "column": 25,
+      "line": 16
+    },
+    "message": "A11y: The value for the aria attribute 'aria-valuemin' must be of type number",
+    "pos": 594,
+    "start": {
+      "character": 594,
+      "column": 6,
+      "line": 16
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 650,
+      "column": 25,
+      "line": 17
+    },
+    "message": "A11y: The value for the aria attribute 'aria-valuenow' must be of type number",
+    "pos": 631,
+    "start": {
+      "character": 631,
+      "column": 6,
+      "line": 17
+    }
+  },
+
+  {
+    "code": "a11y-invalid-aria-attribute-value",
+    "end": {
+      "character": 682,
+      "column": 20,
+      "line": 18
+    },
+    "message": "A11y: The value for the aria attribute 'aria-valuetext' must be of type string",
+    "pos": 668,
+    "start": {
+      "character": 668,
+      "column": 6,
+      "line": 18
+    }
+  }
+]


### PR DESCRIPTION
As per #820, this is an attempt to begin adding support for validating `aria-proptypes`. 

~~I'm starting small because I wanted to open a PR as a discussion point to verify that I'm going about this the right way. I suspect if the approach looks good it will be easy to continue to add support for all the cases that are validated by the [aria-query props map](https://github.com/A11yance/aria-query/blob/main/src/ariaPropsMap.js)~~ I just went ahead and finished the all the proptype validations 🤓 

I had considered adding that library, but then saw that the core compiler seems to be fairly light on dependencies.

I wasn't sure how granular to make the test partitions seeing as there a large number of these proptypes, as a start I placed tests grouped into categories that the W3C taxonomy page lists: https://www.w3.org/TR/wai-aria/#state_prop_taxonomy

- [x] global
- [x] widget
- [x] live-region
- [x] drag-and-drop
- [x] relationship

### Before submitting the PR, please make sure you do the following
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
