### PR TITLE
fix: global with pseudo element should be considered as global

### DIFF
--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -594,9 +594,10 @@ class Block {
 
 	get global() {
 		return (
+			this.selectors.length >= 1 &&
 			this.selectors[0].type === 'PseudoClassSelector' &&
 			this.selectors[0].name === 'global' &&
-			!this.selectors.some((selector) => selector.type === 'ClassSelector')
+			this.selectors.every((selector) => selector.type === 'PseudoClassSelector')
 		);
 	}
 }

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -594,9 +594,9 @@ class Block {
 
 	get global() {
 		return (
-			this.selectors.length === 1 &&
 			this.selectors[0].type === 'PseudoClassSelector' &&
-			this.selectors[0].name === 'global'
+			this.selectors[0].name === 'global' &&
+			!this.selectors.some((selector) => selector.type === 'ClassSelector')
 		);
 	}
 }

--- a/test/validator/samples/css-invalid-global-placement-2/errors.json
+++ b/test/validator/samples/css-invalid-global-placement-2/errors.json
@@ -1,0 +1,15 @@
+[{
+	"code": "css-invalid-global",
+	"message": ":global(...) can be at the start or end of a selector sequence, but not in the middle",
+	"start": {
+		"line": 2,
+		"column": 6,
+		"character": 14
+	},
+	"end": {
+		"line": 2,
+		"column": 19,
+		"character": 27
+	},
+	"pos": 14
+}]

--- a/test/validator/samples/css-invalid-global-placement-2/input.svelte
+++ b/test/validator/samples/css-invalid-global-placement-2/input.svelte
@@ -1,0 +1,5 @@
+<style>
+	.foo :global(.bar):first-child .baz {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
Hi,
in PR, https://github.com/sveltejs/svelte/pull/6223/files#diff-145a1fa56c966be609d17f4af6eb9c2a0a97cd2f1c9c86bf64841595f254f51dR597, an additional check was introduced to make sure the number of selectors is equal to 1, however this also covers pseudo elements which in turn break some of the existing capabilities as describe in https://github.com/sveltejs/svelte/issues/6306
```
 .container :global(section) > :global(*):first-child {
	color: red;
}
```
```global(*):first-child``` is no longer considered as a global where previously it was considered.

Thus, adding a negation check that if there is a ```ClassSelector```, it should be excluded from ```global``` check.

cc: @tanhauhau (PR https://github.com/sveltejs/svelte/pull/6223 author)