### PR TITLE
[fix] add global compound selector validations

### DIFF
--- a/src/compiler/compile/compiler_errors.ts
+++ b/src/compiler/compile/compiler_errors.ts
@@ -236,7 +236,7 @@ export default {
 	},
 	css_invalid_global_selector_position: {
 		code: 'css-invalid-global-selector-position',
-		message: ':global(...) which not at the start of selector sequence should not contain type or universal selector'
+		message: ':global(...) not at the start of a selector sequence should not contain type or universal selectors'
 	},
 	css_invalid_selector: (selector: string) => ({
 		code: 'css-invalid-selector',

--- a/src/compiler/compile/compiler_errors.ts
+++ b/src/compiler/compile/compiler_errors.ts
@@ -234,6 +234,10 @@ export default {
 		code: 'css-invalid-global-selector',
 		message: ':global(...) must contain a single selector'
 	},
+	css_invalid_global_selector_position: {
+		code: 'css-invalid-global-selector-position',
+		message: ':global(...) which not at the start of selector sequence should not contain type or universal selector'
+	},
 	css_invalid_selector: (selector: string) => ({
 		code: 'css-invalid-selector',
 		message: `Invalid selector "${selector}"`

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -189,7 +189,7 @@ export default class Selector {
 					index !== 0 &&
 					selector.children &&
 					selector.children.length > 0 &&
-					!/[.:#]/.test(selector.children[0].value)
+					!/[.:#\s]/.test(selector.children[0].value)
 				) {
 					component.error(selector, compiler_errors.css_invalid_global_selector_position);
 				}

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -130,6 +130,8 @@ export default class Selector {
 	}
 
 	validate(component: Component) {
+		this.blocks.some((block) => block.validateGlobalCompoundSelector(component));
+
 		let start = 0;
 		let end = this.blocks.length;
 
@@ -637,6 +639,24 @@ class Block {
 			this.selectors[0].name === 'global' &&
 			this.selectors.every((selector) => selector.type === 'PseudoClassSelector' || selector.type === 'PseudoElementSelector')
 		);
+	}
+
+	validateGlobalCompoundSelector(component: Component) {
+		this.selectors.some((selector, index) => {
+			if (selector.type === 'PseudoClassSelector' &&
+					selector.name === 'global' &&
+					index !== 0 &&
+					selector.children &&
+					selector.children.length > 0 &&
+					selector.children[0].value[0] !== '.'
+				) {
+					component.error(selector, {
+						code: 'css-invalid-global',
+						message: ':global(...) which not at the start of selector sequence should not contain type or universal selector'
+					});
+					return false;
+				}
+		});
 	}
 }
 

--- a/test/validator/samples/css-invalid-global-placement-4/errors.json
+++ b/test/validator/samples/css-invalid-global-placement-4/errors.json
@@ -1,6 +1,6 @@
 [{
 	"code": "css-invalid-global-selector-position",
-	"message": ":global(...) which not at the start of selector sequence should not contain type or universal selector",
+	"message": ":global(...) not at the start of a selector sequence should not contain type or universal selectors",
 	"start": {
 		"line": 2,
 		"column": 5

--- a/test/validator/samples/css-invalid-global-placement-4/errors.json
+++ b/test/validator/samples/css-invalid-global-placement-4/errors.json
@@ -1,0 +1,12 @@
+[{
+	"code": "css-invalid-global",
+	"message": ":global(...) which not at the start of selector sequence should not contain type or universal selector",
+	"start": {
+		"line": 2,
+		"column": 5
+	},
+	"end": {
+		"line": 2,
+		"column": 17
+	}
+}]

--- a/test/validator/samples/css-invalid-global-placement-4/errors.json
+++ b/test/validator/samples/css-invalid-global-placement-4/errors.json
@@ -1,5 +1,5 @@
 [{
-	"code": "css-invalid-global",
+	"code": "css-invalid-global-selector-position",
 	"message": ":global(...) which not at the start of selector sequence should not contain type or universal selector",
 	"start": {
 		"line": 2,

--- a/test/validator/samples/css-invalid-global-placement-4/input.svelte
+++ b/test/validator/samples/css-invalid-global-placement-4/input.svelte
@@ -1,0 +1,5 @@
+<style>
+	.foo:global(div) {
+		color: red;
+	}
+</style>

--- a/test/validator/samples/css-invalid-global-placement-4/input.svelte
+++ b/test/validator/samples/css-invalid-global-placement-4/input.svelte
@@ -2,5 +2,4 @@
 	.foo:global(div) {
 		color: red;
 	}
-	
 </style>

--- a/test/validator/samples/css-invalid-global-placement-4/input.svelte
+++ b/test/validator/samples/css-invalid-global-placement-4/input.svelte
@@ -2,4 +2,5 @@
 	.foo:global(div) {
 		color: red;
 	}
+	
 </style>


### PR DESCRIPTION
fixes: https://github.com/sveltejs/svelte/issues/6272

add some simple validations to not allow type or universal selector to appear ```:global(...)``` unless if ```:global(...)``` is the first
