### PR TITLE
Update <svelte:options> copy

### DIFF
--- a/site/content/tutorial/16-special-elements/07-svelte-options/text.md
+++ b/site/content/tutorial/16-special-elements/07-svelte-options/text.md
@@ -2,7 +2,7 @@
 title: <svelte:options>
 ---
 
-Lastly, `<svelte:options>` allows you to specify compiler options.
+The `<svelte:options>` element allows you to specify compiler options.
 
 We'll use the `immutable` option as an example. In this app, the `<Todo>` component flashes whenever it receives new data. Clicking on one of the items toggles its `done` state by creating an updated `todos` array. This causes the *other* `<Todo>` items to flash, even though they don't end up making any changes to the DOM.
 


### PR DESCRIPTION
<svelte:options> is not the last lesson in "Special Elements". So, I removed the word "Lastly" and changed the copy to reflect that.
