### PR TITLE
[ Typo] Tutorial instructions refer to wrong line number in code

### DIFF
--- a/site/content/tutorial/06-bindings/10-media-elements/text.md
+++ b/site/content/tutorial/06-bindings/10-media-elements/text.md
@@ -4,7 +4,7 @@ title: Media elements
 
 The `<audio>` and `<video>` elements have several properties that you can bind to. This example demonstrates a few of them.
 
-On line 116, add `currentTime={time}`, `duration` and `paused` bindings:
+On line 58, add `currentTime={time}`, `duration` and `paused` bindings to video element:
 
 ```html
 <video

--- a/site/content/tutorial/06-bindings/10-media-elements/text.md
+++ b/site/content/tutorial/06-bindings/10-media-elements/text.md
@@ -4,7 +4,7 @@ title: Media elements
 
 The `<audio>` and `<video>` elements have several properties that you can bind to. This example demonstrates a few of them.
 
-On line 58, add `currentTime={time}`, `duration` and `paused` bindings to video element:
+On line 58, add `currentTime={time}`, `duration` and `paused` bindings:
 
 ```html
 <video


### PR DESCRIPTION
Fix typo in instructions on https://svelte.dev/tutorial/media-elements

Video element is not on line 116, it's on line 58 - looks like instructions don't reflect changes to previous .svelte refactor
