### PR TITLE
Automatic image optimization

### DIFF
--- a/site/scripts/get-contributors.js
+++ b/site/scripts/get-contributors.js
@@ -1,4 +1,3 @@
-require('dotenv/config');
 const fs = require('fs');
 const fetch = require('node-fetch');
 const Jimp = require('jimp');
@@ -6,7 +5,6 @@ const Jimp = require('jimp');
 process.chdir(__dirname);
 
 const base = `https://api.github.com/repos/sveltejs/svelte/contributors`;
-const { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET } = process.env;
 
 const SIZE = 64;
 
@@ -15,7 +13,7 @@ async function main() {
 	let page = 1;
 
 	while (true) {
-		const res = await fetch(`${base}?client_id=${GITHUB_CLIENT_ID}&client_secret=${GITHUB_CLIENT_SECRET}&per_page=100&page=${page++}`);
+		const res = await fetch(`${base}?per_page=100&page=${page++}`);
 		const list = await res.json();
 
 		if (list.length === 0) break;

--- a/site/scripts/get-contributors.js
+++ b/site/scripts/get-contributors.js
@@ -39,9 +39,29 @@ async function main() {
 		sprite.composite(image, i * SIZE, 0);
 	}
 
-	await sprite.quality(80).write(`../static/contributors.jpg`);
-	// TODO: Optimizing the static/contributors.jpg image should probably get automated as well
-	console.log('remember to additionally optimize the resulting /static/contributors.jpg image file via e.g. https://squoosh.app ');
+	await sprite.quality(80).getBuffer(Jimp.MIME_JPEG, (err, buffer) => {
+		let quality = 75;
+
+		let content = `--xxxxxxxxxx\r\nContent-Disposition: form-data; name="qlty"; \r\n\r\n${quality}\r\n--xxxxxxxxxx\r\nContent-Disposition: form-data; name="files"; filename="contributors.jpg"\r\nContent-Type:application/octet-stream\r\n\r\n`;
+		let end = `\r\n--xxxxxxxxxx--\r\n`;
+
+		let body = Buffer.concat([Buffer.from(content, "utf8"), new Buffer(buffer, "binary"), Buffer.from(end)]);
+
+		fetch('https://api.resmush.it/ws.php', {
+		    method: 'POST',
+		    headers: {
+		        "Content-type": 'multipart/form-data; boundary=xxxxxxxxxx',
+		    },
+		    body: body
+		}).then(async (res) => {
+			let response = await res.json()
+			console.log(`Reduced file size by ${response.percent}%`)
+
+		    fetch(response.dest).then(async image => {
+		    	fs.writeFileSync('../static/contributors.jpg', await image.buffer());
+		    });
+		});
+	});
 
 	const str = `[\n\t${authors.map(a => `'${a.login}'`).join(',\n\t')}\n]`;
 


### PR DESCRIPTION
Completed a `TODO` in the `get-contributors.js` file.
This pull request adds automatic optimization of the `contributors.jpg` image using [reSmush.it](https://resmush.it/). One can also fine tune the image optimization level using the `quality` variable. I chose `75` as the current value after some testing as at this level the image is reduced in size, however it still retains enough quality to not impact the final look of the contributors list.
Alternatively [squoosh](https://github.com/GoogleChromeLabs/squoosh/tree/dev/libsquoosh) could also be used to optimize the image, however I was unsure whether it's allowed to add a new dependency to the project or not. If it is please let me know and I can change the PR to use Squoosh. 

This PR also removes the GitHub API tokens in the file, as the API route to fetch the contributors list doesn't require authentication.

### Before submitting the PR, please make sure you do the following
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
