### PR TITLE
docs: update Keyed Each Blocks tutorial

### DIFF
--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/App.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/App.svelte
@@ -2,11 +2,11 @@
 	import Thing from './Thing.svelte';
 
 	let things = [
-		{ id: 1, color: 'darkblue' },
-		{ id: 2, color: 'indigo' },
-		{ id: 3, color: 'deeppink' },
-		{ id: 4, color: 'salmon' },
-		{ id: 5, color: 'gold' }
+		{ id: 1, name: 'apple' },
+		{ id: 2, name: 'banana' },
+		{ id: 3, name: 'carrot' },
+		{ id: 4, name: 'doughnut' },
+		{ id: 5, name: 'egg' },
 	];
 
 	function handleClick() {
@@ -19,5 +19,5 @@
 </button>
 
 {#each things as thing}
-	<Thing current={thing.color}/>
+	<Thing name={thing.name}/>
 {/each}

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
@@ -1,24 +1,33 @@
 <script>
-	// `current` is updated whenever the prop value changes...
-	export let current;
+	let emojis = {
+        apple: "🍎",
+        banana: "🍌",
+        carrot: "🥕",
+        doughnut: "🍩",
+        egg: "🥚"
+	}
 
-	// ...but `initial` is fixed upon initialisation
-	const initial = current;
+	// the name is updated whenever the prop value changes...
+	export let name;
+
+	// ...but the "emoji" variable is fixed upon initialisation of the component
+	const emoji = emojis[name];
 </script>
 
 <p>
-	<span style="background-color: {initial}">initial</span>
-	<span style="background-color: {current}">current</span>
+	<span>The emoji for { name } is { emoji }</span>
 </p>
 
 <style>
+	p {
+		margin: 0.8em 0;
+	}
 	span {
 		display: inline-block;
-		padding: 0.2em 0.5em;
-		margin: 0 0.2em 0.2em 0;
-		width: 4em;
+		padding: 0.2em 1em 0.3em;
 		text-align: center;
 		border-radius: 0.2em;
-		color: white;
+		vertical-align: center;
+		background-color: #FFDFD3;
 	}
 </style>

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
@@ -27,7 +27,6 @@
 		padding: 0.2em 1em 0.3em;
 		text-align: center;
 		border-radius: 0.2em;
-		vertical-align: center;
 		background-color: #FFDFD3;
 	}
 </style>

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
@@ -1,5 +1,5 @@
 <script>
-	let emojis = {
+	const emojis = {
         apple: "🍎",
         banana: "🍌",
         carrot: "🥕",

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/App.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/App.svelte
@@ -2,11 +2,11 @@
 	import Thing from './Thing.svelte';
 
 	let things = [
-		{ id: 1, color: 'darkblue' },
-		{ id: 2, color: 'indigo' },
-		{ id: 3, color: 'deeppink' },
-		{ id: 4, color: 'salmon' },
-		{ id: 5, color: 'gold' }
+		{ id: 1, name: 'apple' },
+		{ id: 2, name: 'banana' },
+		{ id: 3, name: 'carrot' },
+		{ id: 4, name: 'doughnut' },
+		{ id: 5, name: 'egg' },
 	];
 
 	function handleClick() {
@@ -18,6 +18,6 @@
 	Remove first thing
 </button>
 
-{#each things as thing (thing.id)}
-	<Thing current={thing.color}/>
+{#each things as thing (thing.id) }
+	<Thing name={thing.name}/>
 {/each}

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
@@ -1,24 +1,33 @@
 <script>
-	// `current` is updated whenever the prop value changes...
-	export let current;
+	let emojis = {
+        apple: "🍎",
+        banana: "🍌",
+        carrot: "🥕",
+        doughnut: "🍩",
+        egg: "🥚"
+	}
 
-	// ...but `initial` is fixed upon initialisation
-	const initial = current;
+	// the name is updated whenever the prop value changes...
+	export let name;
+
+	// ...but the "emoji" variable is fixed upon initialisation of the component
+	const emoji = emojis[name];
 </script>
 
 <p>
-	<span style="background-color: {initial}">initial</span>
-	<span style="background-color: {current}">current</span>
+	<span>The emoji for { name } is { emoji }</span>
 </p>
 
 <style>
+	p {
+		margin: 0.8em 0;
+	}
 	span {
 		display: inline-block;
-		padding: 0.2em 0.5em;
-		margin: 0 0.2em 0.2em 0;
-		width: 4em;
+		padding: 0.2em 1em 0.3em;
 		text-align: center;
 		border-radius: 0.2em;
-		color: white;
+		vertical-align: center;
+		background-color: #FFDFD3;
 	}
 </style>

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
@@ -27,7 +27,6 @@
 		padding: 0.2em 1em 0.3em;
 		text-align: center;
 		border-radius: 0.2em;
-		vertical-align: center;
 		background-color: #FFDFD3;
 	}
 </style>

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
@@ -1,5 +1,5 @@
 <script>
-	let emojis = {
+	const emojis = {
         apple: "🍎",
         banana: "🍌",
         carrot: "🥕",

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
@@ -4,16 +4,18 @@ title: Keyed each blocks
 
 By default, when you modify the value of an `each` block, it will add and remove items at the *end* of the block, and update any values that have changed. That might not be what you want.
 
-It's easier to show why than to explain. Click the 'Remove first thing' button a few times, and notice that it's removing `<Thing>` components from the end and updating the `color` for those that remain. Instead, we'd like to remove the first `<Thing>` component and leave the rest unaffected.
+It's easier to show why than to explain. Click the 'Remove first thing' button a few times, and notice what happens: It removes the first `<Thing>` component, but the *last* DOM node. Then it updates the `name` value in the remaining DOM nodes, but not the emoji. 
 
-To do that, we specify a unique identifier for the `each` block:
+Instead, we'd like to remove only the first `<Thing>` component and its DOM node, and leave the rest unaffected.
+
+To do that, we specify a unique identifier (or "key") for the `each` block:
 
 ```html
 {#each things as thing (thing.id)}
-	<Thing current={thing.color}/>
+	<Thing name={thing.name}/>
 {/each}
 ```
 
-The `(thing.id)` tells Svelte how to figure out what changed.
+Here, `(thing.id)` is the key, which tells Svelte how to figure out which DOM node to change when the component changes.
 
 > You can use any object as the key, as Svelte uses a `Map` internally — in other words you could do `(thing)` instead of `(thing.id)`. Using a string or number is generally safer, however, since it means identity persists without referential equality, for example when updating with fresh data from an API server.

--- a/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/05-keyed-each-blocks/text.md
@@ -6,7 +6,7 @@ By default, when you modify the value of an `each` block, it will add and remove
 
 It's easier to show why than to explain. Click the 'Remove first thing' button a few times, and notice what happens: It removes the first `<Thing>` component, but the *last* DOM node. Then it updates the `name` value in the remaining DOM nodes, but not the emoji. 
 
-Instead, we'd like to remove only the first `<Thing>` component and its DOM node, and leave the rest unaffected.
+Instead, we'd like to remove only the first `<Thing>` component and its DOM node, and leave the others unaffected.
 
 To do that, we specify a unique identifier (or "key") for the `each` block:
 
@@ -16,6 +16,6 @@ To do that, we specify a unique identifier (or "key") for the `each` block:
 {/each}
 ```
 
-Here, `(thing.id)` is the key, which tells Svelte how to figure out which DOM node to change when the component changes.
+Here, `(thing.id)` is the *key*, which tells Svelte how to figure out which DOM node to change when the component updates.
 
 > You can use any object as the key, as Svelte uses a `Map` internally — in other words you could do `(thing)` instead of `(thing.id)`. Using a string or number is generally safer, however, since it means identity persists without referential equality, for example when updating with fresh data from an API server.


### PR DESCRIPTION
## Issue

Fixes #6357 
 
The Tutorial page for Keyed Each Blocks was quite a challenge to parse, and I’m coming from React and Vue, where Keys are already a familiar concept. I genuinely thought the Svelte tutorial was trying to describe some other issue. I suspect that somebody using Svelte as their first framework would be confused too.

**In brief,   I think the demo is not good at illustrating the bug (and consequently, the need to use Keys).**

I've left more info in the issue description.

## Fixes

My solutions in this PR:
1. Make something closer to a real-world use case, so Expected Behaviour will be more intuitive. For example, deriving a variable from a prop by using a lookup, rather than directly reassigning it.
2. Use a clear sequence of objects (e.g. alphabetized words)
3. Make an intuitive match between the prop and the derived variable, so the bug looks like clearly “undesired behaviour” (e.g. a word and the corresponding emoji)
4. Add the minimum amount of text to the Tutorial text to explain the bug and why Keys fix it.

## Risks

* Tutorial text may be too wordy
* It's still unclear why keys fix things
* Now you want to eat a doughnut

## Gifs

![Svelte PR - Keyed Each Blocks demo](https://user-images.githubusercontent.com/27756206/119285526-15ae6900-bbf7-11eb-9ece-fd6e60b41c31.gif)
