### PR TITLE
[Site:Tutorial] On mobile devices, the text on the tutorial buttons isn't properly aligned with the buttons' box

### DIFF
--- a/site/src/components/ScreenToggle.svelte
+++ b/site/src/components/ScreenToggle.svelte
@@ -20,9 +20,9 @@
 		margin: 0 .15em;
 		width: 4em;
 		height: 1em;
-		padding: .2em .4em .3em;
+		padding: .3em .4em;
 		border-radius: var(--border-r);
-		line-height: normal;
+		line-height: 1em;
 		box-sizing: content-box;
 		color: #888;
 		border: 1px solid var(--back-light);


### PR DESCRIPTION
Going through the Svelte tutorial, I noticed that on mobile devices the buttons `Tutorial/Input/Output` buttons didn't have the proper text alignment on them.
This PR intends to fix that by providing the same `line-height` as the `button height` and changing the `padding` so slightly so we have the same room above and below the `text`.

Closes #6393 

| Before 😞 | After 🤯 |
| - | - |
| <img width="338" alt="Screenshot 2021-06-09 at 19 33 00" src="https://user-images.githubusercontent.com/30603437/121411266-5c23f780-c95b-11eb-9f7a-a9b6243fcf70.png"> | <img width="336" alt="Screenshot 2021-06-09 at 19 33 25" src="https://user-images.githubusercontent.com/30603437/121411284-5f1ee800-c95b-11eb-8537-575cb72860d0.png"> | 


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
