### PR TITLE
Improve hydration by reordering optimally

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -1,7 +1,7 @@
 import { add_render_callback, flush, schedule_update, dirty_components } from './scheduler';
 import { current_component, set_current_component } from './lifecycle';
 import { blank_object, is_empty, is_function, run, run_all, noop } from './utils';
-import { children, detach } from './dom';
+import { children, detach, start_hydrating, end_hydrating } from './dom';
 import { transition_in } from './transitions';
 
 interface Fragment {
@@ -150,6 +150,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 
 	if (options.target) {
 		if (options.hydrate) {
+			start_hydrating();
 			const nodes = children(options.target);
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			$$.fragment && $$.fragment!.l(nodes);
@@ -161,6 +162,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 
 		if (options.intro) transition_in(component.$$.fragment);
 		mount_component(component, options.target, options.anchor, options.customElement);
+		end_hydrating();
 		flush();
 	}
 

--- a/test/hydration/samples/head-meta-hydrate-duplicate/_after_head.html
+++ b/test/hydration/samples/head-meta-hydrate-duplicate/_after_head.html
@@ -1,4 +1,4 @@
-<title>Some Title</title>
 <link href="/" rel="canonical">
 <meta content="some description" name="description">
 <meta content="some keywords" name="keywords">
+<title>Some Title</title>


### PR DESCRIPTION
(Hopefully) Closes #4308.

I am new to working with Svelte so I apologize for any errors beforehand.

### Explanation

I tried to improve https://github.com/sveltejs/svelte/pull/6204 based on the thread #4308. I personally had problems with elements with CSS animations flickering due to hydration detaching and reattaching nodes (implicitly by re-inserting them) as described in the thread. The page that I was having problems with was almost entirely static, so seeing all the static nodes refresh went against my intuition as to how hydrate would work. So I looked into how this situation could be improved.

### Old algorithm

_Edit:_ The algorithm has been improved significantly. See https://github.com/sveltejs/svelte/pull/6395#issuecomment-858543236 for the new algorithm

During hydration, this new implementation tries to pick a sequence of nodes that we are able to not detach: the first common subsequence of the original Nodes and the `claim_*` requests.

For example, if the original nodes are:
 `B C D E F D G`

and the `claim_element` function calls are as follows:
`A B C D D E F G H`

the first common subsequence would look like
`B C D D G`

You can find this subsequence by iterating through the `claim_element`s and keeping a pointer on the original nodes that you are only able to move forward. For every `claim_element`, if you are able to move the pointer to a matching node on the right, do it. Otherwise, do not move the pointer.

The algorithm chooses to preserve the nodes within this subsequence (i.e. not detach them). The rest of the nodes that are requested by `claim_*` are handled as before: they are either found among existing nodes to be detached or created anew.

Normally, after the claims are done, `append` and `insert` are called with every single child, since the caller assumes that all the children are detached. Since this is not the case anymore (the shared subsequence was not detached), we need to transparently make sure that `append` does what is expected, which in this case might be to insert a node in the middle of existing non-detached children. During `append`, the algorithm tracks the _last appended node_, i.e., what the caller thinks is actually the last child of the `target`. Thus, we can deduce where the caller actually wants to append the node. The `insert` function works similarly.

### Possible optimizations

Note that the first common subsequence is not the longest common subsequence:
`B C D E F G`

We would prefer to not detach as many nodes as possible, so the _longest_ common subsequence would theoretically be preferable. However, since the `claim_*` functions (if I understand them correctly) are expected to return Nodes directly (and greedily), I am not sure a change can be implemented without changing the compiler side.

Even though finding the optimal (longest) subsequence to not detach is problematic, it should be possible to further improve the greedy approach based on heuristics. In the example above, the second `D` node that is claimed results in the two nodes `E` and `F` getting detached. If the `D` node is just _Text_ and `E/F` are large _Elements_, that would be quite a sad occurrence. This could be optimized in the future handling Text Nodes differently. I did not implement such an optimization since I was not sure my assumptions are correct and would love to receive feedback.

One might also look into what virtual DOM front-end frameworks are doing to find minimal differences https://github.com/localvoid/ivi/blob/2c81ead934b9128e092cc2a5ef2d3cabc73cb5dd/packages/ivi/src/vdom/implementation.ts#L1367 . But I am not sure how applicable those will be to our situation.

There may be many more possible optimizations! I am relatively inexperienced with front-end development so I might be missing many optimization opportunities.

### Possible issues

Within the code, I added an additional property `actual_end_child` to `Node` objects during `append` and `insert` calls to make tracking last appended nodes easier. If this is a problem, we can switch to using a `Map<Node, Node>`.

### Tests

The code passed all the tests but I did not add any new tests since I wasn't sure how to test for whether nodes are being detached. Maybe a _total number of nodes detached_ counter could be used to ensure that the algorithm is working and further optimizations do not cause regressions. Any feedback on this is appreciated.
