### PR TITLE
[fix] tracking whether transition has started

### DIFF
--- a/src/runtime/internal/transitions.ts
+++ b/src/runtime/internal/transitions.ts
@@ -126,7 +126,8 @@ export function create_in_transition(node: Element & ElementCSSInlineStyle, fn: 
 	return {
 		start() {
 			if (started) return;
-
+			
+			started = true;
 			delete_rule(node);
 
 			if (is_function(config)) {


### PR DESCRIPTION
Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
