### PR TITLE
Fix generic props relationship in SvelteComponentTyped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix type signatures of `writable` and `readable`. It's possible to invoke them without arguments ([#6291](https://github.com/sveltejs/svelte/issues/6291), [#6345](https://github.com/sveltejs/svelte/issues/6345))
+* Fix generic props relationship in SvelteComponentTyped ([#6400](https://github.com/sveltejs/svelte/pull/6400))
 
 ## 3.38.2
 

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -104,7 +104,7 @@ export interface SvelteComponentDev {
 	$destroy(): void;
 	[accessor: string]: any;
 }
-interface IComponentOptions {
+interface IComponentOptions<Props extends Record<string, any> = Record<string, any>> {
 	target: Element;
 	anchor?: Element;
 	props?: Props;
@@ -232,7 +232,7 @@ export class SvelteComponentTyped<
 	 */
 	$$slot_def: Slots;
 
-	constructor(options: IComponentOptions) {
+	constructor(options: IComponentOptions<Props>) {
 		super(options);
 	}
 }


### PR DESCRIPTION
A recent refactoring commit where the constructor definition was moved to an interface disconnected the props relationship of the props that are passed in the constructor and the instance props