### PR TITLE
docs: update documentation for preprocessor sourcemap output

### DIFF
--- a/site/content/docs/04-compile-time.md
+++ b/site/content/docs/04-compile-time.md
@@ -237,7 +237,7 @@ const { code } = await svelte.preprocess(source, {
 			return { code: content }
 		}
 		const s = new MagicString(content, { filename })
-		s.overwrite(pos, pos+3, 'bar', { storeName: true })
+		s.overwrite(pos, pos + 3, 'bar', { storeName: true })
 		return {
 			code: s.toString(),
 			map: s.generateMap()

--- a/site/content/docs/04-compile-time.md
+++ b/site/content/docs/04-compile-time.md
@@ -224,16 +224,24 @@ Each `markup`, `script` or `style` function must return an object (or a Promise 
 
 The `markup` function receives the entire component source text, along with the component's `filename` if it was specified in the third argument.
 
-> Preprocessor functions may additionally return a `map` object alongside `code` and `dependencies`, where `map` is a sourcemap representing the transformation. In current versions of Svelte it will be ignored, but future versions of Svelte may take account of preprocessor sourcemaps.
+> Preprocessor functions should additionally return a `map` object alongside `code` and `dependencies`, where `map` is a sourcemap representing the transformation.
 
 ```js
 const svelte = require('svelte/compiler');
+const MagicString = require('magic-string');
 
 const { code } = await svelte.preprocess(source, {
 	markup: ({ content, filename }) => {
+		const pos = content.indexOf('foo');
+		if(pos < 0) {
+			return { code: content }
+		}
+		const s = new MagicString(content, { filename })
+		s.overwrite(pos, pos+3, 'bar', { storeName: true })
 		return {
-			code: content.replace(/foo/g, 'bar')
-		};
+			code: s.toString(),
+			map: s.generateMap()
+		}
 	}
 }, {
 	filename: 'App.svelte'


### PR DESCRIPTION
…, which is used since 3.30

additional thoughts:
- The markup example is altered for brevity (replaces first occurence of foo instead of all), is that ok?
- should the style example be updated with map support too? (and maybe simplified to a generic example given that sass is covered by svelte-preprocess)

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`

cc @dummdidumm, @kaisermann 
