### PR TITLE
[docs] Update auto-subscriptions tutorial to explicitly say that subscribe returns unsubscribe

### DIFF
--- a/site/content/tutorial/08-stores/02-auto-subscriptions/text.md
+++ b/site/content/tutorial/08-stores/02-auto-subscriptions/text.md
@@ -11,6 +11,7 @@ const unsubscribe = count.subscribe(value => {
 	count_value = value;
 });
 ```
+> Calling a `subscribe` method returns an `unsubscribe` function.
 
 You now declared `unsubscribe`, but it still needs be to called, for example through the `onDestroy` [lifecycle hook](tutorial/ondestroy):
 


### PR DESCRIPTION
Update of tutorial/stores/auto-subscriptions/text.md to explicitly say that subscription method returns an unsubscribe fn #6448