### PR TITLE
[fix] hydration improvements

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -132,7 +132,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 			`);
 		} else if (this.is_src) {
 			block.chunks.hydrate.push(
-				b`if (${element.var}.src !== (new URL(${init}, location)).href) ${method}(${element.var}, "${name}", ${this.last});`
+				b`if (new URL(${element.var}.src, location).href !== (new URL(${init}, location)).href) ${method}(${element.var}, "${name}", ${this.last});`
 			);
 			updater = b`${method}(${element.var}, "${name}", ${should_cache ? this.last : value});`;
 		} else if (property_name) {
@@ -193,7 +193,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 
 		if (should_cache) {
 			condition = this.is_src
-				? x`${condition} && (${element.var}.src !== (new URL((${last} = ${value}), location)).href)`
+				? x`${condition} && (new URL(${element.var}.src, location).href !== (new URL((${last} = ${value}), location)).href)`
 				: x`${condition} && (${last} !== (${last} = ${value}))`;
 		}
 

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -132,7 +132,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 			`);
 		} else if (this.is_src) {
 			block.chunks.hydrate.push(
-				b`if (new URL(${element.var}.src, location).href !== (new URL(${init}, location)).href) ${method}(${element.var}, "${name}", ${this.last});`
+				b`if (!@src_url_equal(${element.var}.src, ${init})) ${method}(${element.var}, "${name}", ${this.last});`
 			);
 			updater = b`${method}(${element.var}, "${name}", ${should_cache ? this.last : value});`;
 		} else if (property_name) {
@@ -193,7 +193,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 
 		if (should_cache) {
 			condition = this.is_src
-				? x`${condition} && (new URL(${element.var}.src, location).href !== (new URL((${last} = ${value}), location)).href)`
+				? x`${condition} && (!@src_url_equal(${element.var}.src, (${last} = ${value})))`
 				: x`${condition} && (${last} !== (${last} = ${value}))`;
 		}
 

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -132,7 +132,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 			`);
 		} else if (this.is_src) {
 			block.chunks.hydrate.push(
-				b`if (${element.var}.src !== ${init}) ${method}(${element.var}, "${name}", ${this.last});`
+				b`if (${element.var}.src !== (new URL(${init}, location)).href) ${method}(${element.var}, "${name}", ${this.last});`
 			);
 			updater = b`${method}(${element.var}, "${name}", ${should_cache ? this.last : value});`;
 		} else if (property_name) {
@@ -193,7 +193,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 
 		if (should_cache) {
 			condition = this.is_src
-				? x`${condition} && (${element.var}.src !== (${last} = ${value}))`
+				? x`${condition} && (${element.var}.src !== (new URL((${last} = ${value}), location)).href)`
 				: x`${condition} && (${last} !== (${last} = ${value}))`;
 		}
 

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -36,9 +36,21 @@ function init_hydrate(target: NodeEx) {
 	target.hydrate_init = true;
 
 	type NodeEx2 = NodeEx & {claim_order: number};
-
-	// We know that all children have claim_order values since the unclaimed have been detached
-	const children = Array.from(target.childNodes as NodeListOf<NodeEx>).filter(x => x.claim_order !== undefined) as NodeEx2[];
+	
+	// We know that all children have claim_order values since the unclaimed have been detached if target is not head
+	let children: ArrayLike<NodeEx2> = target.childNodes as NodeListOf<NodeEx2>;
+	
+	// If target is head, there may be children without claim_order
+	if (target.nodeName.toLowerCase() == "head") {
+		const myChildren = [];
+		for (let i = 0; i < children.length; i++) {
+			const node = children[i];
+			if (node.claim_order !== undefined) {
+				myChildren.push(node)
+			}
+		}
+		children = myChildren;
+	}
 	
 	/* 
 	* Reorder claimed children optimally.

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -126,8 +126,8 @@ export function append(target: NodeEx, node: NodeEx) {
 		}
 		
 		if (node !== target.actual_end_child) {
+			// We only insert if the ordering of this node should be modified or the parent node is not target
 			if (node.claim_order !== undefined || node.parentNode !== target) {
-				// We only insert if the ordering of this node should be modified or the parent node is not target
 				target.insertBefore(node, target.actual_end_child);
 			}
 		} else {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -82,8 +82,9 @@ function init_hydrate(target: NodeEx) {
 		// Find the largest subsequence length such that it ends in a value less than our current value
 
 		// upper_bound returns first greater value, so we subtract one
-		const seqLen = upper_bound(1, longest + 1, idx => children[m[idx]].claim_order, current) - 1;
-
+		// with fast path for when we are on the current longest subsequence
+		const seqLen = ((longest > 0 && children[m[longest]].claim_order <= current) ? longest + 1 : upper_bound(1, longest, idx => children[m[idx]].claim_order, current)) - 1;
+		
 		p[i] = m[seqLen] + 1;
 
 		const newLen = seqLen + 1;

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -36,12 +36,12 @@ function init_hydrate(target: NodeEx) {
 	target.hydrate_init = true;
 
 	type NodeEx2 = NodeEx & {claim_order: number};
-	
-	// We know that all children have claim_order values since the unclaimed have been detached if target is not head
+
+	// We know that all children have claim_order values since the unclaimed have been detached if target is not <head>
 	let children: ArrayLike<NodeEx2> = target.childNodes as NodeListOf<NodeEx2>;
-	
-	// If target is head, there may be children without claim_order
-	if (target.nodeName.toLowerCase() === 'head') {
+
+	// If target is <head>, there may be children without claim_order
+	if (target.nodeName === 'HEAD') {
 		const myChildren = [];
 		for (let i = 0; i < children.length; i++) {
 			const node = children[i];
@@ -51,8 +51,8 @@ function init_hydrate(target: NodeEx) {
 		}
 		children = myChildren;
 	}
-	
-	/* 
+
+	/*
 	* Reorder claimed children optimally.
 	* We can reorder claimed children optimally by finding the longest subsequence of
 	* nodes that are already claimed in order and only moving the rest. The longest
@@ -84,7 +84,7 @@ function init_hydrate(target: NodeEx) {
 		// upper_bound returns first greater value, so we subtract one
 		// with fast path for when we are on the current longest subsequence
 		const seqLen = ((longest > 0 && children[m[longest]].claim_order <= current) ? longest + 1 : upper_bound(1, longest, idx => children[m[idx]].claim_order, current)) - 1;
-		
+
 		p[i] = m[seqLen] + 1;
 
 		const newLen = seqLen + 1;
@@ -132,12 +132,12 @@ export function append(target: NodeEx, node: NodeEx) {
 		if ((target.actual_end_child === undefined) || ((target.actual_end_child !== null) && (target.actual_end_child.parentElement !== target))) {
 			target.actual_end_child = target.firstChild;
 		}
-		
+
 		// Skip nodes of undefined ordering
 		while ((target.actual_end_child !== null) && (target.actual_end_child.claim_order === undefined)) {
 			target.actual_end_child = target.actual_end_child.nextSibling;
 		}
-		
+
 		if (node !== target.actual_end_child) {
 			// We only insert if the ordering of this node should be modified or the parent node is not target
 			if (node.claim_order !== undefined || node.parentNode !== target) {
@@ -335,7 +335,7 @@ function init_claim_info(nodes: ChildNodeArray) {
 function claim_node<R extends ChildNodeEx>(nodes: ChildNodeArray, predicate: (node: ChildNodeEx) => node is R, processNode: (node: ChildNodeEx) => ChildNodeEx | undefined, createNode: () => R, dontUpdateLastIndex: boolean = false) {
 	// Try to find nodes in an order such that we lengthen the longest increasing subsequence
 	init_claim_info(nodes);
-	
+
 	const resultNode = (() => {
 		// We first try to find an element after the previous one
 		for (let i = nodes.claim_info.last_index; i < nodes.length; i++) {
@@ -448,7 +448,7 @@ export function claim_html_tag(nodes) {
 	if (start_index === end_index) {
 		return new HtmlTag();
 	}
-	
+
 	init_claim_info(nodes);
 	const html_tag_nodes = nodes.splice(start_index, end_index + 1);
 	detach(html_tag_nodes[0]);

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -40,13 +40,13 @@ export function safe_not_equal(a, b) {
 	return a != a ? b == b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
 }
 
-const relative_to_absolute = (function() {
-    const anchor = document.createElement('a');
-    return function(url) {
-        anchor.href = url;
-        return anchor.href;
-    };
-})();
+const relative_to_absolute : ((url: string) => string) & {anchor?: HTMLAnchorElement} = (url: string) => {
+	if (relative_to_absolute.anchor === undefined) {
+		relative_to_absolute.anchor = document.createElement('a');
+	}
+	relative_to_absolute.anchor.href = url;
+    return relative_to_absolute.anchor.href;
+};
 
 export function src_url_equal(element_src, url) {
 	return element_src === relative_to_absolute(url);

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -40,8 +40,16 @@ export function safe_not_equal(a, b) {
 	return a != a ? b == b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
 }
 
-export function src_url_equal(a, b) {
-	return new URL(a, window.location.origin).href === (new URL(b, window.location.origin)).href;
+const relative_to_absolute = (function() {
+    const anchor = document.createElement('a');
+    return function(url) {
+        anchor.href = url;
+        return anchor.href;
+    };
+})();
+
+export function src_url_equal(element_src, url) {
+	return element_src === relative_to_absolute(url);
 }
 
 export function not_equal(a, b) {

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -40,16 +40,14 @@ export function safe_not_equal(a, b) {
 	return a != a ? b == b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
 }
 
-const relative_to_absolute : ((url: string) => string) & {anchor?: HTMLAnchorElement} = (url: string) => {
-	if (relative_to_absolute.anchor === undefined) {
-		relative_to_absolute.anchor = document.createElement('a');
-	}
-	relative_to_absolute.anchor.href = url;
-    return relative_to_absolute.anchor.href;
-};
+let src_url_equal_anchor;
 
 export function src_url_equal(element_src, url) {
-	return element_src === relative_to_absolute(url);
+	if (!src_url_equal_anchor) {
+		src_url_equal_anchor = document.createElement('a');
+	}
+	src_url_equal_anchor.href = url;
+	return element_src === src_url_equal_anchor.href;
 }
 
 export function not_equal(a, b) {

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -40,6 +40,10 @@ export function safe_not_equal(a, b) {
 	return a != a ? b == b : a !== b || ((a && typeof a === 'object') || typeof a === 'function');
 }
 
+export function src_url_equal(a, b) {
+	return new URL(a, window.location.origin).href === (new URL(b, window.location.origin)).href;
+}
+
 export function not_equal(a, b) {
 	return a != a ? b == b : a !== b;
 }

--- a/test/hydration/samples/head-meta-hydrate-duplicate/_after_head.html
+++ b/test/hydration/samples/head-meta-hydrate-duplicate/_after_head.html
@@ -1,4 +1,4 @@
+<title>Some Title</title>
 <link href="/" rel="canonical">
 <meta content="some description" name="description">
 <meta content="some keywords" name="keywords">
-<title>Some Title</title>

--- a/test/js/samples/hydrated-void-element/expected.js
+++ b/test/js/samples/hydrated-void-element/expected.js
@@ -35,7 +35,7 @@ function create_fragment(ctx) {
 			this.h();
 		},
 		h() {
-			if (img.src !== (img_src_value = "donuts.jpg")) attr(img, "src", img_src_value);
+			if (img.src !== new URL(img_src_value = "donuts.jpg", location).href) attr(img, "src", img_src_value);
 			attr(img, "alt", "donuts");
 		},
 		m(target, anchor) {

--- a/test/js/samples/hydrated-void-element/expected.js
+++ b/test/js/samples/hydrated-void-element/expected.js
@@ -35,7 +35,7 @@ function create_fragment(ctx) {
 			this.h();
 		},
 		h() {
-			if (img.src !== new URL(img_src_value = "donuts.jpg", location).href) attr(img, "src", img_src_value);
+			if (new URL(img.src, location).href !== new URL(img_src_value = "donuts.jpg", location).href) attr(img, "src", img_src_value);
 			attr(img, "alt", "donuts");
 		},
 		m(target, anchor) {

--- a/test/js/samples/hydrated-void-element/expected.js
+++ b/test/js/samples/hydrated-void-element/expected.js
@@ -11,7 +11,8 @@ import {
 	insert,
 	noop,
 	safe_not_equal,
-	space
+	space,
+	src_url_equal
 } from "svelte/internal";
 
 function create_fragment(ctx) {
@@ -35,7 +36,7 @@ function create_fragment(ctx) {
 			this.h();
 		},
 		h() {
-			if (new URL(img.src, location).href !== new URL(img_src_value = "donuts.jpg", location).href) attr(img, "src", img_src_value);
+			if (!src_url_equal(img.src, img_src_value = "donuts.jpg")) attr(img, "src", img_src_value);
 			attr(img, "alt", "donuts");
 		},
 		m(target, anchor) {

--- a/test/js/samples/src-attribute-check/expected.js
+++ b/test/js/samples/src-attribute-check/expected.js
@@ -35,9 +35,9 @@ function create_fragment(ctx) {
 		},
 		h() {
 			attr(img0, "alt", "potato");
-			if (img0.src !== (img0_src_value = /*url*/ ctx[0])) attr(img0, "src", img0_src_value);
+			if (img0.src !== new URL(img0_src_value = /*url*/ ctx[0], location).href) attr(img0, "src", img0_src_value);
 			attr(img1, "alt", "potato");
-			if (img1.src !== (img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"))) attr(img1, "src", img1_src_value);
+			if (img1.src !== new URL(img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"), location).href) attr(img1, "src", img1_src_value);
 		},
 		m(target, anchor) {
 			insert(target, img0, anchor);
@@ -45,11 +45,11 @@ function create_fragment(ctx) {
 			insert(target, img1, anchor);
 		},
 		p(ctx, [dirty]) {
-			if (dirty & /*url*/ 1 && img0.src !== (img0_src_value = /*url*/ ctx[0])) {
+			if (dirty & /*url*/ 1 && img0.src !== new URL(img0_src_value = /*url*/ ctx[0], location).href) {
 				attr(img0, "src", img0_src_value);
 			}
 
-			if (dirty & /*slug*/ 2 && img1.src !== (img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"))) {
+			if (dirty & /*slug*/ 2 && img1.src !== new URL(img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"), location).href) {
 				attr(img1, "src", img1_src_value);
 			}
 		},

--- a/test/js/samples/src-attribute-check/expected.js
+++ b/test/js/samples/src-attribute-check/expected.js
@@ -10,7 +10,8 @@ import {
 	insert,
 	noop,
 	safe_not_equal,
-	space
+	space,
+	src_url_equal
 } from "svelte/internal";
 
 function create_fragment(ctx) {
@@ -35,9 +36,9 @@ function create_fragment(ctx) {
 		},
 		h() {
 			attr(img0, "alt", "potato");
-			if (new URL(img0.src, location).href !== new URL(img0_src_value = /*url*/ ctx[0], location).href) attr(img0, "src", img0_src_value);
+			if (!src_url_equal(img0.src, img0_src_value = /*url*/ ctx[0])) attr(img0, "src", img0_src_value);
 			attr(img1, "alt", "potato");
-			if (new URL(img1.src, location).href !== new URL(img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"), location).href) attr(img1, "src", img1_src_value);
+			if (!src_url_equal(img1.src, img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"))) attr(img1, "src", img1_src_value);
 		},
 		m(target, anchor) {
 			insert(target, img0, anchor);
@@ -45,11 +46,11 @@ function create_fragment(ctx) {
 			insert(target, img1, anchor);
 		},
 		p(ctx, [dirty]) {
-			if (dirty & /*url*/ 1 && new URL(img0.src, location).href !== new URL(img0_src_value = /*url*/ ctx[0], location).href) {
+			if (dirty & /*url*/ 1 && !src_url_equal(img0.src, img0_src_value = /*url*/ ctx[0])) {
 				attr(img0, "src", img0_src_value);
 			}
 
-			if (dirty & /*slug*/ 2 && new URL(img1.src, location).href !== new URL(img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"), location).href) {
+			if (dirty & /*slug*/ 2 && !src_url_equal(img1.src, img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"))) {
 				attr(img1, "src", img1_src_value);
 			}
 		},

--- a/test/js/samples/src-attribute-check/expected.js
+++ b/test/js/samples/src-attribute-check/expected.js
@@ -35,9 +35,9 @@ function create_fragment(ctx) {
 		},
 		h() {
 			attr(img0, "alt", "potato");
-			if (img0.src !== new URL(img0_src_value = /*url*/ ctx[0], location).href) attr(img0, "src", img0_src_value);
+			if (new URL(img0.src, location).href !== new URL(img0_src_value = /*url*/ ctx[0], location).href) attr(img0, "src", img0_src_value);
 			attr(img1, "alt", "potato");
-			if (img1.src !== new URL(img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"), location).href) attr(img1, "src", img1_src_value);
+			if (new URL(img1.src, location).href !== new URL(img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"), location).href) attr(img1, "src", img1_src_value);
 		},
 		m(target, anchor) {
 			insert(target, img0, anchor);
@@ -45,11 +45,11 @@ function create_fragment(ctx) {
 			insert(target, img1, anchor);
 		},
 		p(ctx, [dirty]) {
-			if (dirty & /*url*/ 1 && img0.src !== new URL(img0_src_value = /*url*/ ctx[0], location).href) {
+			if (dirty & /*url*/ 1 && new URL(img0.src, location).href !== new URL(img0_src_value = /*url*/ ctx[0], location).href) {
 				attr(img0, "src", img0_src_value);
 			}
 
-			if (dirty & /*slug*/ 2 && img1.src !== new URL(img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"), location).href) {
+			if (dirty & /*slug*/ 2 && new URL(img1.src, location).href !== new URL(img1_src_value = "" + (/*slug*/ ctx[1] + ".jpg"), location).href) {
 				attr(img1, "src", img1_src_value);
 			}
 		},


### PR DESCRIPTION
This PR tries to address some issues that were not addressed by https://github.com/sveltejs/svelte/pull/6395 and issues pointed out by @benmccann and @ankitstarski

- An img element's src value should only be set if it is not the expected value. This check existed, but failed to account for relative paths which were returned as absolute paths when checking `img.src`.
- Existing nodes under `<head>` that are not claimed but also not detached should be ignored by `init_hydrate`. These nodes have `node.claim_order === undefined`
- The function `claim_html_tag` should also set `claim_order`.

Edit:
- Add a fast path to `init_hydrate` for when most of the nodes are on the longest increasing subsequence.
- Improve claims for text nodes: There are many cases where we try to only claim a prefix of the text node. In these cases, we can use `splitText` to actually only claim the prefix. (Merging text siblings might help further https://github.com/sveltejs/svelte/pull/3766)

Edit2:
- Seems to partially address https://github.com/sveltejs/svelte/issues/6463

### Potential issues:
- ~~Is it possible that `location` is overwritten at a local scope by the compiler? This would cause URL normalization to break.~~
