### PR TITLE
[docs] Add imperative sentences to tutorial telling user what to do next

### DIFF
--- a/site/content/tutorial/04-logic/04-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/04-each-blocks/text.md
@@ -26,4 +26,6 @@ You can get the current *index* as a second argument, like so:
 {/each}
 ```
 
-If you prefer, you can use destructuring — `each cats as { id, name }` — and replace `cat.id` and `cat.name` with `id` and `name`.
+> If you prefer, you can use destructuring — `each cats as { id, name }` — and replace `cat.id` and `cat.name` with `id` and `name`.
+
+Now loop over `cats` to display their indexes and names.

--- a/site/content/tutorial/05-events/01-dom-events/text.md
+++ b/site/content/tutorial/05-events/01-dom-events/text.md
@@ -9,3 +9,4 @@ As we've briefly seen already, you can listen to any event on an element with th
 	The mouse position is {m.x} x {m.y}
 </div>
 ```
+Now add the event handler to the div.


### PR DESCRIPTION
This clarifies two of the tutorial tasks: 04-each-blocks and 01-dom-events.