### PR TITLE
[docs] don't skip heading levels

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -22,7 +22,7 @@ All three sections — script, styles and markup — are optional.
 
 ### &lt;script&gt;
 
-A `<script>` block contains JavaScript that runs when a component instance is created. Variables declared (or imported) at the top level are 'visible' from the component's markup. There are four additional rules:
+A `<script>` block contains JavaScript that runs when a component instance is created. The variables declared (or imported) at the top level are 'visible' from the component's markup.
 
 #### props
 

--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -24,7 +24,7 @@ All three sections — script, styles and markup — are optional.
 
 A `<script>` block contains JavaScript that runs when a component instance is created. Variables declared (or imported) at the top level are 'visible' from the component's markup. There are four additional rules:
 
-##### 1. `export` creates a component prop
+#### props
 
 ---
 
@@ -85,7 +85,7 @@ You can use reserved words as prop names.
 </script>
 ```
 
-##### 2. Assignments are 'reactive'
+#### reactive assignments
 
 ---
 
@@ -107,7 +107,7 @@ Because Svelte's reactivity is based on assignments, using array methods like `.
 </script>
 ```
 
-##### 3. `$:` marks a statement as reactive
+#### reactive statements (`$:`)
 
 ---
 
@@ -169,7 +169,7 @@ If a statement consists entirely of an assignment to an undeclared variable, Sve
 </script>
 ```
 
-##### 4. Prefix stores with `$` to access their values
+#### accessing stores (`$`)
 
 ---
 


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/pull/5679 as an alternative to that PR. Rather than figure out how to change the parser to hide headings as @geoffrich and @pngwn were discussing, I wonder if it wouldn't be easier and actually more helpful to just make headings that can be displayed in the sidebar

Here's a partial screenshot of what it looks like. It turns out Linux hasn't figured how how to do screenshots on 4k monitors amongst the many other problems it has with those displays

![Screenshot from 2021-06-30 16-10-28](https://user-images.githubusercontent.com/322311/124042725-53549d80-d9be-11eb-95f5-e682bf3817a7.png)
