### PR TITLE
[fix] dynamic autofocus

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -71,7 +71,7 @@ export default class Block {
 	get_unique_name: (name: string) => Identifier;
 
 	has_update_method = false;
-	autofocus: string;
+	autofocus?: { element_var: string, condition_expression?: any };
 
 	constructor(options: BlockOptions) {
 		this.parent = options.parent;
@@ -239,7 +239,11 @@ export default class Block {
 		}
 
 		if (this.autofocus) {
-			this.chunks.mount.push(b`${this.autofocus}.focus();`);
+			if (this.autofocus.condition_expression) {
+				this.chunks.mount.push(b`if (${this.autofocus.condition_expression}) ${this.autofocus.element_var}.focus();`);
+			} else {
+				this.chunks.mount.push(b`${this.autofocus.element_var}.focus();`);
+			}
 		}
 
 		this.render_listeners();

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -169,8 +169,11 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 		}
 
 		// special case – autofocus. has to be handled in a bit of a weird way
-		if (this.node.is_true && name === 'autofocus') {
-			block.autofocus = element.var;
+		if (name === 'autofocus') {
+			block.autofocus = {
+				element_var: element.var,
+				condition_expression: this.node.is_true ? undefined : value
+			};
 		}
 	}
 

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -679,6 +679,12 @@ export default class ElementWrapper extends Wrapper {
 				`);
 			}
 		}
+
+		if (['button', 'input', 'keygen', 'select', 'textarea'].includes(this.node.name)) {
+			block.chunks.mount.push(b`
+				if (${this.var}.autofocus) ${this.var}.focus();
+			`);
+		}
 	}
 
 	add_transitions(

--- a/test/runtime/samples/autofocus/_config.js
+++ b/test/runtime/samples/autofocus/_config.js
@@ -2,7 +2,23 @@ export default {
 	html: '',
 
 	test({ assert, component, target, window }) {
-		component.visible = true;
-		assert.equal(target.querySelector('input'), window.document.activeElement);
+		component.active = 'default';
+		assert.equal(target.querySelector('input[title="default"]'), window.document.activeElement);
+
+		component.active = 'dynamic-false';
+		assert.notEqual(target.querySelector('input[title="dynamic-false"]'), window.document.activeElement);
+
+		// when dynamically set autofocus to true, don't autofocus
+		component.autofocusFalse = true;
+		assert.notEqual(target.querySelector('input[title="dynamic-false"]'), window.document.activeElement);
+
+		component.active = 'dynamic-true';
+		assert.equal(target.querySelector('input[title="dynamic-true"]'), window.document.activeElement);
+
+		component.active = 'spread';
+		assert.equal(target.querySelector('input[title="spread"]'), window.document.activeElement);
+
+		component.active = 'spread-override';
+		assert.notEqual(target.querySelector('input[title="spread-override"]'), window.document.activeElement);
 	}
 };

--- a/test/runtime/samples/autofocus/main.svelte
+++ b/test/runtime/samples/autofocus/main.svelte
@@ -1,8 +1,18 @@
 <script>
-	export let visible = false;
-	let input;
+	export let active = 'default';
+	export let autofocusFalse = false;
+	export let autofocusTrue = true;
+	let spread = { autofocus: true };
 </script>
 
-{#if visible}
-	<input bind:this={input} autofocus>
+{#if active === 'default'}
+	<input title={active} autofocus />
+{:else if active === 'dynamic-false'}
+	<input title={active} autofocus={autofocusFalse} />
+{:else if active === 'dynamic-true'}
+	<input title={active} autofocus={autofocusTrue} />
+{:else if active === 'spread'}
+	<input title={active} {...spread} />
+{:else if active === 'spread-override'}
+	<input title={active} {...spread} autofocus={false} />
 {/if}


### PR DESCRIPTION
Fixes #4995. Supersedes initial implementation in #5070.

This ensures element's with `autofocus={foo}` will focus the element if `foo` is true and **on mount only**. If `foo` changes from false to true, it will not trigger a re-focus as I don't think it's a desired behavior.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
