### PR TITLE
[fix] standalone :global() with multiple selectors shouldn't be treated as error

### DIFF
--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -142,6 +142,15 @@ export default class Selector {
 			}
 		}
 
+		this.validate_global_with_multiple_selectors(component);
+	}
+
+	validate_global_with_multiple_selectors(component: Component) {
+		if (this.blocks.length === 1 && this.blocks[0].selectors.length === 1) {
+			// standalone :global() with multiple selectors is OK
+			return;
+		}
+
 		for (const block of this.blocks) {
 			for (const selector of block.selectors) {
 				if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {

--- a/test/validator/samples/css-invalid-global-selector-5/errors.json
+++ b/test/validator/samples/css-invalid-global-selector-5/errors.json
@@ -3,15 +3,15 @@
 		"code": "css-invalid-global-selector",
 		"message": ":global(...) must contain a single selector",
 		"start": {
-			"line": 11,
-			"column": 5,
-			"character": 143
+			"line": 5,
+			"column": 1,
+			"character": 54
 		},
 		"end": {
-			"line": 11,
-			"column": 24,
-			"character": 162
+			"line": 5,
+			"column": 20,
+			"character": 73
 		},
-		"pos": 143
+		"pos": 54
 	}
 ]

--- a/test/validator/samples/css-invalid-global-selector-5/input.svelte
+++ b/test/validator/samples/css-invalid-global-selector-5/input.svelte
@@ -1,0 +1,12 @@
+<style>
+	:global(h1, h2, h3), div {
+		color: red;
+	}
+	:global(h1, h2, h3) div {
+		color: red;
+	}
+</style>
+
+<div>
+	<h1>hello world</h1>
+</div>

--- a/test/validator/samples/css-invalid-global-selector-6/errors.json
+++ b/test/validator/samples/css-invalid-global-selector-6/errors.json
@@ -3,15 +3,15 @@
 		"code": "css-invalid-global-selector",
 		"message": ":global(...) must contain a single selector",
 		"start": {
-			"line": 11,
-			"column": 5,
-			"character": 143
+			"line": 5,
+			"column": 1,
+			"character": 54
 		},
 		"end": {
-			"line": 11,
-			"column": 24,
-			"character": 162
+			"line": 5,
+			"column": 20,
+			"character": 73
 		},
-		"pos": 143
+		"pos": 54
 	}
 ]

--- a/test/validator/samples/css-invalid-global-selector-6/input.svelte
+++ b/test/validator/samples/css-invalid-global-selector-6/input.svelte
@@ -1,0 +1,12 @@
+<style>
+	:global(.h1\,h2\,h3).foo {
+		color: red;
+	}
+	:global(h1, h2, h3).foo {
+		color: red;
+	}
+</style>
+
+<div>
+	<h1>hello world</h1>
+</div>

--- a/test/validator/samples/css-invalid-global-selector/input.svelte
+++ b/test/validator/samples/css-invalid-global-selector/input.svelte
@@ -2,6 +2,12 @@
 	div :global(.h1\,h2\,h3) {
 		color: red;
 	}
+	:global(h1, h2, h3) {
+		color: red;
+	}
+	div, :global(h1, h2, h3) {
+		color: red;
+	}
 	div :global(h1, h2, h3) {
 		color: red;
 	}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/6477

do not throw error for cases like:

```css
div, :global(a, b), div { }
:global(a, b) { }
```

### Before submitting the PR, please make sure you do the following
- ~~[ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs~~
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
