### PR TITLE
[fix] relax store derived function signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add a11y warning `a11y-mouse-events-have-key-events` which checks that `mouseover`/`mouseout` are accompanied by `focus`/`blur` event handlers ([#5938](https://github.com/sveltejs/svelte/pull/5938))
 * Remove deprecated a11y warning `a11y-no-onchange warning` ([#6457](https://github.com/sveltejs/svelte/issues/6457))
 * Stop checking `a11y-media-has-caption` a11y warning on `<audio>` elements ([#6054](https://github.com/sveltejs/svelte/issues/6054))
+* Relax `derived` function signature ([#6178](https://github.com/sveltejs/svelte/issues/6178))
 
 ## 3.38.3
 

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -113,7 +113,7 @@ export function writable<T>(value?: T, start: StartStopNotifier<T> = noop): Writ
 }
 
 /** One or more `Readable`s. */
-type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>];
+type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>;
 
 /** One or more values from `Readable` stores. */
 type StoresValues<T> = T extends Readable<infer U> ? U :


### PR DESCRIPTION
With this fix, doing
```
const stores= [writable(0), writable(1)]
derived(stores, ([a,b,c]) => {});
```
works without type errors. The propblem with the previous type signature was that it's too strict for TypeScript's suboptimal inference of the value `stores` in that example, which is `Array<Readable<any>>`, which does not convey the info "at least one element", which the old Stores signature required.
Runtime-wise, it's no problem passing an empty array to derived.

The new signature is only appended to, not replaced, because the old signature is able to correctly infer the values of each array entry: For `derived([writable(0), writable('foo')], ([a, b]) => {});` the parameters `a` and `b` are correctly inferred as `number` and `string`. If the type would be changed to `type Stores = Readable<any> | Array<Readable<any>>` that would be no longer the case.

Fixes #6178

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
