### PR TITLE
[docs] replace shift by the correct key to hold: control

### DIFF
--- a/site/content/tutorial/06-bindings/07-multiple-select-bindings/text.md
+++ b/site/content/tutorial/06-bindings/07-multiple-select-bindings/text.md
@@ -18,4 +18,4 @@ Returning to our [earlier ice cream example](tutorial/group-inputs), we can repl
 </select>
 ```
 
-> Press and hold the `shift` key for selecting multiple options.
+> Press and hold the `control` key for selecting multiple options.


### PR DESCRIPTION
`control` will allow to select several options. `shift` will select a range from the first to the last (starting from either top or bottom).
If we click on `Cookies and cream` and then on `Raspberry ripple` while holding `shift`, all of the 3 checkboxes will be selected (from the 1st **to** the 3rd).
If you hold `control`, this will properly select the 1st **and** the 3rd.

An example can be seen here: https://html.com/attributes/select-multiple/

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
