### PR TITLE
[feat] Error handling API as discussed in #1096

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -461,6 +461,10 @@ export default class Block {
 
 			this.add_variable(dispose);
 
+            this.event_listeners.forEach(event_listener => {
+                event_listener.arguments[2] = x`@attach_error_handler.call(${event_listener.arguments[0]}, #component, ${event_listener.arguments[2]})`;
+            });
+
 			if (this.event_listeners.length === 1) {
 				this.chunks.mount.push(
 					b`

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -329,7 +329,7 @@ export default function dom(
 	const has_create_fragment = component.compile_options.dev || block.has_content();
 	if (has_create_fragment) {
 		body.push(b`
-			function create_fragment(#ctx) {
+			function create_fragment(#ctx, #component) {
 				${block.get_contents()}
 			}
 		`);
@@ -450,6 +450,15 @@ export default function dom(
 			}) as Expression)
 		};
 
+        const instance_try_block: any = b`
+            try {}
+            catch(e) {
+                @handle_error($$self, e);
+            }
+        `;
+
+        instance_try_block[0].block.body = instance_javascript.flat();
+
 		body.push(b`
 			function ${definition}(${args}) {
 				${injected.map(name => b`let ${name};`)}
@@ -466,7 +475,7 @@ export default function dom(
 				${component.compile_options.dev && b`@validate_slots('${component.tag}', #slots, [${[...component.slots.keys()].map(key => `'${key}'`).join(',')}]);`}
 				${compute_slots}
 
-				${instance_javascript}
+				${instance_try_block}
 
 				${unknown_props_check}
 

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -3,6 +3,7 @@ import './ambient';
 export {
 	onMount,
 	onDestroy,
+    onError,
 	beforeUpdate,
 	afterUpdate,
 	setContext,

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -106,13 +106,13 @@ function make_dirty(component, i) {
 }
 
 export function attach_error_handler(component, fn) {
-    return () => {
+    return (...rest) => {
         try {
-            fn.call(this, ...arguments);
+            fn.call(this, ...rest);
         } catch (e) {
             handle_error(component, e);
         }
-    }
+    };
 }
 
 export function handle_error(component, e) {

--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -27,6 +27,10 @@ export function onDestroy(fn: () => any) {
 	get_current_component().$$.on_destroy.push(fn);
 }
 
+export function onError(fn: () => any) {
+    get_current_component().$$.on_error.push(fn);
+}
+
 export function createEventDispatcher<
 	EventMap extends {} = any
 >(): <EventKey extends Extract<keyof EventMap, string>>(type: EventKey, detail?: EventMap[EventKey]) => void {


### PR DESCRIPTION
Started a draft for the Error Handling API that was discussed in #1096. Created this draft pull request to track progress and for feedback on the code/changes.

The proposed feature would add a `onError` event to components that catch errors thrown within the component and would work something like this:

```svelte
<script>
import { onError } from "svelte";

var a = {};

onError(e => {
    // Handle error
});
</script>

<span>{a.b.c}</span>
```

Let me know what you think.

### Todo
- [X] Catch errors that occur during the initial component creation (contents of script tag)
- [X] Catch errors from event listeners (for example on:click)
- [ ] Catch errors that occur in template blocks
- [ ] Allow errors to bubble to parent component
- [ ] SSR (not very familiar with)
- [ ] Write tests

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
