### PR TITLE
[docs] Fix broken link to old blog post using Internet Archive

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -697,7 +697,7 @@ Videos additionally have readonly `videoWidth` and `videoHeight` bindings.
 
 ---
 
-Block-level elements have 4 readonly bindings, measured using a technique similar to [this one](http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/):
+Block-level elements have 4 readonly bindings, measured using a technique similar to [this one](https://web.archive.org/web/20200926123939/http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/):
 
 * `clientWidth`
 * `clientHeight`


### PR DESCRIPTION
Quick fix for a broken link in the section https://svelte.dev/docs#Block-level_element_bindings

## Before

The link pointed to this website that is no longer available http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/

## After
Link updated to use Internet Archive to show the same blog post but with a permanent link instead https://web.archive.org/web/20200926123939/http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/

Let me know if you need anything more before this can be merged!