### PR TITLE
[docs] Fix property name typo for event.isTrusted

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -516,7 +516,7 @@ The following modifiers are available:
 * `capture` — fires the handler during the *capture* phase instead of the *bubbling* phase
 * `once` — remove the handler after the first time it runs
 * `self` — only trigger handler if event.target is the element itself
-* `trusted` — only trigger handler if `event.trusted` is `true`. I.e. if the event is triggered by a user action.
+* `trusted` — only trigger handler if `event.isTrusted` is `true`. I.e. if the event is triggered by a user action.
 
 Modifiers can be chained together, e.g. `on:click|once|capture={...}`.
 

--- a/site/content/tutorial/05-events/03-event-modifiers/text.md
+++ b/site/content/tutorial/05-events/03-event-modifiers/text.md
@@ -25,6 +25,6 @@ The full list of modifiers:
 * `capture` — fires the handler during the *capture* phase instead of the *bubbling* phase ([MDN docs](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture))
 * `once` — remove the handler after the first time it runs
 * `self` — only trigger handler if event.target is the element itself
-* `trusted` — only trigger handler if `event.trusted` is `true`. I.e. if the event is triggered by a user action.
+* `trusted` — only trigger handler if `event.isTrusted` is `true`. I.e. if the event is triggered by a user action.
 
 You can chain modifiers together, e.g. `on:click|once|capture={...}`.


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/6595. See issue for details!