### PR TITLE
[fix] use consistent relative source filename for js sourcemaps

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -343,19 +343,21 @@ export default class Component {
 				? { code: null, map: null }
 				: result.css;
 
+			const sourcemap_source_filename = get_sourcemap_source_filename(compile_options);
+
 			js = print(program, {
-				sourceMapSource: compile_options.filename
+				sourceMapSource: sourcemap_source_filename
 			});
 
 			js.map.sources = [
-				compile_options.filename ? get_relative_path(compile_options.outputFilename || '', compile_options.filename) : null
+				sourcemap_source_filename
 			];
 
 			js.map.sourcesContent = [
 				this.source
 			];
 
-			js.map = apply_preprocessor_sourcemap(this.file, js.map, compile_options.sourcemap as (string | RawSourceMap | DecodedSourceMap));
+			js.map = apply_preprocessor_sourcemap(sourcemap_source_filename, js.map, compile_options.sourcemap as (string | RawSourceMap | DecodedSourceMap));
 		}
 
 		return {
@@ -1550,4 +1552,19 @@ function get_relative_path(from: string, to: string) {
 	}
 
 	return from_parts.concat(to_parts).join('/');
+}
+
+function get_basename(filename: string) {
+	return filename.split(/[/\\]/).pop();
+}
+
+function get_sourcemap_source_filename(compile_options: CompileOptions) {
+	if (compile_options.filename) {
+		if (compile_options.outputFilename) {
+			return get_relative_path(compile_options.outputFilename, compile_options.filename);
+		} else {
+			return get_basename(compile_options.filename);
+		}
+	}
+	return null;
 }

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -1559,12 +1559,9 @@ function get_basename(filename: string) {
 }
 
 function get_sourcemap_source_filename(compile_options: CompileOptions) {
-	if (compile_options.filename) {
-		if (compile_options.outputFilename) {
-			return get_relative_path(compile_options.outputFilename, compile_options.filename);
-		} else {
-			return get_basename(compile_options.filename);
-		}
-	}
-	return null;
+	if (!compile_options.filename) return null;
+
+	return compile_options.outputFilename
+		? get_relative_path(compile_options.outputFilename, compile_options.filename)
+		: get_basename(compile_options.filename);
 }

--- a/test/sourcemaps/samples/sourcemap-basename-without-outputname/_config.js
+++ b/test/sourcemaps/samples/sourcemap-basename-without-outputname/_config.js
@@ -1,0 +1,18 @@
+export const component_filepath = 'src/some/deep/path/input.svelte';
+
+export const component_file_basename = 'input.svelte';
+
+export default {
+
+	js_map_sources: [component_file_basename],
+
+	options: {
+		filename: component_filepath
+	},
+	compile_options: {
+		filename: component_filepath,
+		// ../../index.ts initializes output filenames, reset to undefined for this test
+		outputFilename: undefined,
+		cssOutputFilename: undefined
+	}
+};

--- a/test/sourcemaps/samples/sourcemap-basename-without-outputname/_config.js
+++ b/test/sourcemaps/samples/sourcemap-basename-without-outputname/_config.js
@@ -1,11 +1,26 @@
-export const component_filepath = 'src/some/deep/path/input.svelte';
 
+import {magic_string_bundle} from '../../helpers';
+
+export const component_filepath = 'src/some/deep/path/input.svelte';
 export const component_file_basename = 'input.svelte';
+export const css_file_basename = 'input.css';
+
+const input_css = ' h1 {color: blue;}';
 
 export default {
-
+	preprocess: [
+		{
+			style: ({ content, filename }) => {
+				const style_to_add = `/* Filename from preprocess: ${filename} */` + input_css;
+				return  magic_string_bundle([
+					{ code: content, filename: component_file_basename },
+					{ code: style_to_add, filename: css_file_basename }
+				],component_filepath);
+			}
+		}
+	],
 	js_map_sources: [component_file_basename],
-
+	css_map_sources: [css_file_basename,component_file_basename],
 	options: {
 		filename: component_filepath
 	},

--- a/test/sourcemaps/samples/sourcemap-basename-without-outputname/input.svelte
+++ b/test/sourcemaps/samples/sourcemap-basename-without-outputname/input.svelte
@@ -1,1 +1,2 @@
 <h1>sourcemap-basename-without-outputname</h1>
+<style src="input.css">h1 {color: red;}</style>

--- a/test/sourcemaps/samples/sourcemap-basename-without-outputname/input.svelte
+++ b/test/sourcemaps/samples/sourcemap-basename-without-outputname/input.svelte
@@ -1,0 +1,1 @@
+<h1>sourcemap-basename-without-outputname</h1>

--- a/test/sourcemaps/samples/sourcemap-basename-without-outputname/test.js
+++ b/test/sourcemaps/samples/sourcemap-basename-without-outputname/test.js
@@ -1,0 +1,3 @@
+// no additional test needed, _config.js values and the js.map.sources assertion in ../../index.ts cover it
+export function test() {}
+


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

sveltekit issue for vite printing warnings about wrong sourcemap paths: https://github.com/sveltejs/kit/issues/2029
and vite issue here: https://github.com/vitejs/vite/issues/4423#issuecomment-889308451

also this PR/discussion if a change should be reverted that could also fix it: https://github.com/sveltejs/svelte/pull/6572


note while i did test that with this change vite no longer logs that warning in kit, i'm not 100% sure that this fix is 100% correct. I'm confused why there were 3 different ways to handle it before and it may very well have been on purpose.

cc @dummdidumm  @tanhauhau 
