### PR TITLE
[fix] hydration append issue

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -185,7 +185,7 @@ export function append_hydration(target: NodeEx, node: NodeEx) {
 		} else {
 			target.actual_end_child = node.nextSibling;
 		}
-	} else if (node.parentNode !== target) {
+	} else if (node.parentNode !== target || node.nextSibling !== null) {
 		target.appendChild(node);
 	}
 }

--- a/test/runtime/samples/key-block-post-hydrate/_config.js
+++ b/test/runtime/samples/key-block-post-hydrate/_config.js
@@ -1,0 +1,19 @@
+export default {
+	html: `
+	<div>
+	<div><span class="name">item 1</span><span>something</span></div>
+	<div><span class="name">item 2</span><span>something</span></div>
+	<div><span class="name">item 3</span><span>something</span></div>
+	</div>
+	`,
+	test({ assert, component, target }) {
+		component.sortById = false;
+		assert.htmlEqual( target.innerHTML, `
+		<div>
+		<div><span class="name">item 3</span><span>something</span></div>
+		<div><span class="name">item 2</span><span>something</span></div>
+		<div><span class="name">item 1</span><span>something</span></div>
+		</div>
+		`);
+	}
+};

--- a/test/runtime/samples/key-block-post-hydrate/main.svelte
+++ b/test/runtime/samples/key-block-post-hydrate/main.svelte
@@ -1,0 +1,23 @@
+<script>
+  export let sortById = true;
+  let items = [
+    { id: 1, name: "item 1", value: 3 },
+    { id: 2, name: "item 2", value: 2 },
+    { id: 3, name: "item 3", value: 1 },
+  ];
+
+  $: items = items.sort((a, b) => { return sortById ? a.id - b.id : a.value - b.value; });
+</script>
+
+<div>
+  {#each items as item (item.id)}
+  <div>
+    {#if item.name}
+      <span class="name">
+        {item.name}
+      </span>
+    {/if}
+    <span>something</span>
+  </div>
+  {/each}
+</div>


### PR DESCRIPTION
(Hopefully) Fixes #6561 (issue with keyed each block) ~~and fixes 6463 (hydration duplicates elements in `head`)~~

Fix for issue #6561 is in the `append_hydration` function where an append operation was omitted in a case where `node.parentNode === target` but `node.nextSibling !== null`. The corresponding test is `runtime/samples/key-block-post-hydrate`.

~~Fix for issue #6463 is based on the comment https://github.com/sveltejs/svelte/issues/6463#issuecomment-889430684. The corresponding test is `hydration/samples/head-html`.~~
