### PR TITLE
Replace sveltejs/integrations with sveltesociety.dev

### DIFF
--- a/site/content/blog/2021-04-01-whats-new-in-svelte-april-2021.md
+++ b/site/content/blog/2021-04-01-whats-new-in-svelte-april-2021.md
@@ -54,7 +54,7 @@ Want to learn more about how to get started, what's different compared to Sapper
 - [Sapper Netlify](https://www.npmjs.com/package/sapper-netlify) is a Sapper project that can run on a Netlify function.
 
 
-**Looking for a particular starter?** Check out [svelte-adders](https://github.com/svelte-add/svelte-adders) and a number of other integration examples at [sveltejs/integrations](https://github.com/sveltejs/integrations)
+**Looking for a particular starter?** Check out [svelte-adders](https://github.com/svelte-add/svelte-adders) and a number of other template examples at the community site [sveltesociety.dev](https://sveltesociety.dev/templates/)
 
 **Learning Resources**
 - [How to Build a Website with Svelte and SvelteKit](https://prismic.io/blog/svelte-sveltekit-tutorial) is a step-by-step tutorial walking through the new SvelteKit setup.

--- a/site/content/blog/2021-05-01-whats-new-in-svelte-may-2021.md
+++ b/site/content/blog/2021-05-01-whats-new-in-svelte-may-2021.md
@@ -57,7 +57,7 @@ Last week, Svelte Summit blew us away with a mountain of content! [Check out the
 - [Adds Supabase to Svelte](https://github.com/joshnuss/svelte-supabase) is an experimental command to run to add Supabase to your SvelteKit project
 - [svelte-babylon](https://github.com/SectorXUSA/svelte-babylon) lets you use BabylonJS like A-Frame through reactive Svelte Components
 
-**Looking for a starter or integration?** Check out [svelte-adders](https://github.com/svelte-add/svelte-adders) and a number of other integration examples at [sveltejs/integrations](https://github.com/sveltejs/integrations)
+**Looking for a starter or integration?** Check out [svelte-adders](https://github.com/svelte-add/svelte-adders) and a number of other template examples at the community site [sveltesociety.dev](https://sveltesociety.dev/templates)
 
 
 **Learning Resources**

--- a/site/content/blog/2021-08-01-whats-new-in-svelte-august-2021.md
+++ b/site/content/blog/2021-08-01-whats-new-in-svelte-august-2021.md
@@ -63,7 +63,7 @@ To see all updates to SvelteKit, check out the [SvelteKit changelog](https://git
 - [Kahi UI](https://github.com/novacbn/kahi-ui) is a Svelte-first UI kit with Dark Mode built-in.
 - [typesafe-i18n](https://github.com/ivanhofer/typesafe-i18n) is an opinionated, fully type-safe, lightweight localization library for TypeScript and JavaScript projects with no external dependencies.
 
-Check out [sveltejs/integrations](https://github.com/sveltejs/integrations) for more templates, adders and adapters from across the Svelte ecosystem.
+Check out the community site [sveltesociety.dev](https://sveltesociety.dev/templates/) for more templates, adders and adapters from across the Svelte ecosystem.
 
 
 ## See you next month!

--- a/site/content/docs/04-compile-time.md
+++ b/site/content/docs/04-compile-time.md
@@ -6,7 +6,7 @@ Typically, you won't interact with the Svelte compiler directly, but will instea
 
 * [rollup-plugin-svelte](https://github.com/sveltejs/rollup-plugin-svelte) for users of [Rollup](https://rollupjs.org)
 * [svelte-loader](https://github.com/sveltejs/svelte-loader) for users of [webpack](https://webpack.js.org)
-* or one of the [community-maintained plugins](https://github.com/sveltejs/integrations#bundler-plugins)
+* or one of the [community-maintained plugins](https://sveltesociety.dev/tooling)
 
 Nonetheless, it's useful to understand how to use the compiler, since bundler plugins generally expose compiler options to you.
 

--- a/site/content/tutorial/01-introduction/07-making-an-app/text.md
+++ b/site/content/tutorial/01-introduction/07-making-an-app/text.md
@@ -10,7 +10,7 @@ First, you'll need to integrate Svelte with a build tool. There are officially m
 * [rollup-plugin-svelte](https://github.com/sveltejs/rollup-plugin-svelte)
 * [svelte-loader](https://github.com/sveltejs/svelte-loader)
 
-...and a variety of [community-maintained ones](https://github.com/sveltejs/integrations#bundler-plugins).
+...and a variety of [community-maintained ones](https://sveltesociety.dev/tooling).
 
 Don't worry if you're relatively new to web development and haven't used these tools before. We've prepared a simple step-by-step guide, [Svelte for new developers](blog/svelte-for-new-developers), which walks you through the process.
 


### PR DESCRIPTION
I'd like to replace https://github.com/sveltejs/integrations with https://sveltesociety.dev and retire the former. It's confusing to have this information spread across two sources right now and there's much more info on the latter. I also think that a full-featured webpage is a better format for this stuff because you can do things like sort templates by number of Github stars, automatically remove archive and unmaintained templates, etc. I don't especially want to be in the business of judging whether a template is high enough quality to add to sveltejs/integrations. Having a directory that can be sorted by stars means anyone can add theirs and if it's not popular it will fall to the bottom and if it goes unmaintained we can detect that there's been no commits for some very extended period time and surface that or remove the entry