### PR TITLE
docs: Selecting multiple elements in <select multiple> on MacOS with command key

### DIFF
--- a/site/content/tutorial/06-bindings/07-multiple-select-bindings/text.md
+++ b/site/content/tutorial/06-bindings/07-multiple-select-bindings/text.md
@@ -18,4 +18,4 @@ Returning to our [earlier ice cream example](tutorial/group-inputs), we can repl
 </select>
 ```
 
-> Press and hold the `control` key for selecting multiple options.
+> Press and hold the `control` key (on Windows) or the `command` key (on MacOS) for selecting multiple options.

--- a/site/content/tutorial/06-bindings/07-multiple-select-bindings/text.md
+++ b/site/content/tutorial/06-bindings/07-multiple-select-bindings/text.md
@@ -18,4 +18,4 @@ Returning to our [earlier ice cream example](tutorial/group-inputs), we can repl
 </select>
 ```
 
-> Press and hold the `control` key (on Windows) or the `command` key (on MacOS) for selecting multiple options.
+> Press and hold the `control` key (or the `command` key on MacOS) for selecting multiple options.


### PR DESCRIPTION
### Description
On MacOS, control-clicking an element is the same as right-clicking an element in Windows.
The correct way of multiple selection under MacOS is using the option key ('⌘').

Svelte's [tutorial documentation](https://svelte.dev/tutorial/multiple-select-bindings) is incomplete here.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
