### PR TITLE
[docs] fix css in js embed

### DIFF
--- a/site/content/examples/99-embeds/20181225-blog-svelte-css-in-js/styles.js
+++ b/site/content/examples/99-embeds/20181225-blog-svelte-css-in-js/styles.js
@@ -1,4 +1,4 @@
-import emotion from '@emotion/css/dist/emotion-css.umd.min.js';
+import emotion from '@emotion/css@11.1.3/dist/emotion-css.umd.min.js';
 
 const { css } = emotion;
 

--- a/site/content/examples/99-embeds/20181225-blog-svelte-css-in-js/styles.js
+++ b/site/content/examples/99-embeds/20181225-blog-svelte-css-in-js/styles.js
@@ -1,4 +1,4 @@
-import emotion from 'emotion/dist/emotion.umd.min.js';
+import emotion from '@emotion/css/dist/emotion-css.umd.min.js';
 
 const { css } = emotion;
 


### PR DESCRIPTION
The REPL embed on the [Using CSS-in-JS with Svelte](https://svelte.dev/blog/svelte-css-in-js) blog post is currently broken.

![image](https://user-images.githubusercontent.com/4992896/130103697-9701da3d-83f7-4a8f-a18f-096e1deb8c4e.png)

This PR updates the import so it works again. In addition, I pinned the emotion version so that further updates to the package won't break the example.

Result:
![image](https://user-images.githubusercontent.com/4992896/130103856-9f397312-f468-4f29-bc1a-f37c84e49721.png)


### Before submitting the PR, please make sure you do the following
- [ ] ~It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs~
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] ~Ideally, include a test that fails without this PR but passes with it.~

### Tests
-  [ ] ~Run the tests with `npm test` and lint the project with `npm run lint`~
