### PR TITLE
navigation arrows in tutorial site centered

### DIFF
--- a/site/src/routes/tutorial/[slug]/_TableOfContents.svelte
+++ b/site/src/routes/tutorial/[slug]/_TableOfContents.svelte
@@ -61,10 +61,14 @@
 		cursor: pointer;
 		-webkit-appearance: none;
 	}
+	
+	.arrows {
+		padding: 15px;
+	}
 </style>
 
 <nav>
-	<a rel="prefetch" aria-label="Previous tutorial step" class="no-underline" href="tutorial/{(selected.prev || selected).slug}" class:disabled={!selected.prev}>
+	<a rel="prefetch" aria-label="Previous tutorial step" class="no-underline arrows" href="tutorial/{(selected.prev || selected).slug}" class:disabled={!selected.prev}>
 		<Icon name="arrow-left" />
 	</a>
 
@@ -88,7 +92,7 @@
 		</select>
 	</div>
 
-	<a rel="prefetch" aria-label="Next tutorial step" class="no-underline" href="tutorial/{(selected.next || selected).slug}" class:disabled={!selected.next}>
+	<a rel="prefetch" aria-label="Next tutorial step" class="no-underline arrows" href="tutorial/{(selected.next || selected).slug}" class:disabled={!selected.next}>
 		<Icon name="arrow-right" />
 	</a>
 </nav>


### PR DESCRIPTION
fixes #6624

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

Navigation arrows in the tutorial site was centered.  

### Output
![image](https://user-images.githubusercontent.com/24916780/130408734-c8aa72bc-aef1-4f02-9a0d-ba4177a5310d.png)

