### PR TITLE
[fix] call onDestroy in SSR

### DIFF
--- a/src/runtime/ssr.ts
+++ b/src/runtime/ssr.ts
@@ -1,4 +1,5 @@
 export {
+	onDestroy,
 	setContext,
 	getContext,
 	getAllContexts,
@@ -10,6 +11,5 @@ export {
 } from './index';
 
 export function onMount() {}
-export function onDestroy() {}
 export function beforeUpdate() {}
 export function afterUpdate() {}


### PR DESCRIPTION
Via #6416, lifecycle hooks became noops for SvelteKit. But onDestroy is said to be called suring SSR according to the docs.

Fixes #6676

This PR goes this "fix" route of #6676 . Whether we switch that to "works as designed" for SvelteKit is up for discussion, therefore marking this PR as draft for now.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
