### PR TITLE
[fix] Fixes regression in iFrame animations caused by #6570

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -151,7 +151,7 @@ export function get_root_for_style(node: Node): ShadowRoot | Document {
 	if ((root as ShadowRoot).host) {
 		return root as ShadowRoot;
 	}
-	return document;
+	return node.ownerDocument;
 }
 
 export function append_empty_stylesheet(node: Node) {


### PR DESCRIPTION
Which is funny, because #6570 was fixing a regression as well, to do with detached dom nodes.

Styles for transitions and animations need to be added to the document in which the element/node resides, otherwise, the CSS won't apply to it and the transition/animation won't run. This was implemented a while ago but broken recently.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
