### PR TITLE
[docs] update docs/Component-format script-markup-style order

### DIFF
--- a/site/content/docs/01-component-format.md
+++ b/site/content/docs/01-component-format.md
@@ -13,11 +13,11 @@ All three sections — script, styles and markup — are optional.
 	// logic goes here
 </script>
 
+<!-- markup (zero or more items) goes here -->
+
 <style>
 	/* styles go here */
 </style>
-
-<!-- markup (zero or more items) goes here -->
 ```
 
 ### &lt;script&gt;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

### Motivation

fix: #6681 

> The https://svelte.dev/docs#Component_format docs currently present the example snippet in script-style-markup order. But the default order used by prettier-plugin-svelte is script-markup-style (technically options-script-markup-style, but the https://svelte.dev/docs#Component_format docs don't show options), and my subjective impression is that script-markup-style order is more common in real-world code than script-style-markup. (I haven't done any kind of formal survey). I suspect most people write Svelte code in that order because in most components, the markup is tied to the script, and the style is tied closely to the markup, but the style is not closely tied to the script. And so for those components, script-markup-style is the most natural order.

I checked whether is there not the other wrong `script-markup-style` order in docs, examples, and tutorials manually. I found there is no other wrong order. (I’m sorry if there is a leak).