### PR TITLE
[docs] Promote prettier-plugin-svelte

### DIFF
--- a/site/content/faq/425-is-there-a-tool-to-automaticly-format.md
+++ b/site/content/faq/425-is-there-a-tool-to-automaticly-format.md
@@ -1,0 +1,5 @@
+---
+question: Is there a tool to automaticly format my .svelte files?
+---
+
+You can use prettier with the [prettier-plugin-svelte](https://www.npmjs.com/package/prettier-plugin-svelte) plugin maintained by us.

--- a/site/content/faq/425-is-there-a-tool-to-automaticly-format.md
+++ b/site/content/faq/425-is-there-a-tool-to-automaticly-format.md
@@ -1,5 +1,5 @@
 ---
-question: Is there a tool to automaticly format my .svelte files?
+question: Is there a tool to automatically format my .svelte files?
 ---
 
-You can use prettier with the [prettier-plugin-svelte](https://www.npmjs.com/package/prettier-plugin-svelte) plugin maintained by us.
+You can use prettier with the [prettier-plugin-svelte](https://www.npmjs.com/package/prettier-plugin-svelte) plugin.


### PR DESCRIPTION
I wanted to find a tool to reformat my svelte files. Both the FAQ and stackoveflow were unhelpful. I eventually stumbled upon prettier-plugin-svelte. Since this kind of question is off-topic on stackoveflow ("Questions asking us to recommend or find a book, tool, software library, tutorial or other off-site resource are off-topic for Stack Overflow" [quoted from here](https://stackoverflow.com/help/on-topic)) we should add this to the FAQ
<!--
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
-->