### PR TITLE
[docs] Fix a minor bug in binding tutorial

### DIFF
--- a/site/content/tutorial/06-bindings/12-bind-this/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/12-bind-this/app-a/App.svelte
@@ -15,7 +15,7 @@
 			for (let p = 0; p < imageData.data.length; p += 4) {
 				const i = p / 4;
 				const x = i % canvas.width;
-				const y = i / canvas.height >>> 0;
+				const y = i / canvas.width >>> 0;
 
 				const r = 64 + (128 * x / canvas.width) + (64 * Math.sin(t / 1000));
 				const g = 64 + (128 * y / canvas.height) + (64 * Math.cos(t / 1000));

--- a/site/content/tutorial/06-bindings/12-bind-this/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/12-bind-this/app-b/App.svelte
@@ -15,7 +15,7 @@
 			for (let p = 0; p < imageData.data.length; p += 4) {
 				const i = p / 4;
 				const x = i % canvas.width;
-				const y = i / canvas.height >>> 0;
+				const y = i / canvas.width >>> 0;
 
 				const r = 64 + (128 * x / canvas.width) + (64 * Math.sin(t / 1000));
 				const g = 64 + (128 * y / canvas.height) + (64 * Math.cos(t / 1000));


### PR DESCRIPTION
To calculate y coordinate of `imageData`, we should divide the index with
`canvas.width` not with `canvas.height`. The current code works because the
shape of canvas is square.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
