### PR TITLE
[docs] document details binding

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -651,6 +651,19 @@ Elements with the `contenteditable` attribute support `innerHTML` and `textConte
 <div contenteditable="true" bind:innerHTML={html}></div>
 ```
 
+---
+
+`<details>` elements support binding to the `open` property.
+
+```sv
+<details bind:open={isOpen}>
+	<summary>Details</summary>
+	<p>
+		Something small enough to escape casual notice.
+	</p>
+</details>
+```
+
 ##### Media element bindings
 
 ---


### PR DESCRIPTION
I'm not sure when this was added, but I discovered that's it's possible to bind to the `open` state of a `<details>` element. This PR updates the docs accordingly.

Should there be a new tutorial section for this as well?

### Before submitting the PR, please make sure you do the following
- ~[ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs~
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- ~[ ] Ideally, include a test that fails without this PR but passes with it.~

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
