### PR TITLE
[fix] handle AssignmentPattern with ObjectPattern in rewrite_identifier

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -1044,7 +1044,11 @@ export default class Component {
 											break;
 
 										case 'AssignmentPattern':
-											param.left = get_new_name(param.left);
+											if (param.left.type === 'Identifier') {
+												param.left = get_new_name(param.left);
+											} else {
+												rename_identifiers(param.left);
+											}
 											break;
 									}
 								}

--- a/test/runtime/samples/destructured-assignment-pattern-with-object-pattern/_config.js
+++ b/test/runtime/samples/destructured-assignment-pattern-with-object-pattern/_config.js
@@ -1,0 +1,6 @@
+export default {
+	html: `
+		<div>hello undefined</div>
+		<div>hello bar2</div>
+	`
+};

--- a/test/runtime/samples/destructured-assignment-pattern-with-object-pattern/main.svelte
+++ b/test/runtime/samples/destructured-assignment-pattern-with-object-pattern/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	const hoge = {};
+	const { foo: { bar } = {} } = hoge;
+
+
+	const hoge2 = {};
+	const { foo2: { bar2 } = { bar2: "bar2" } } = hoge2;
+</script>
+
+<div>hello {bar}</div>
+<div>hello {bar2}</div>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

## Motivation

fix #6699 

Hi team!  
There is a lack of consideration in handling `export` props with destructure assignment. 
In transforming the left of destructure assignment with AssignmentPattern (such as `let { bar = "hoge"  }` in `let { bar = "hoge" } = {}`) , compiler handle only the case declaration's type is Identifier, but declaration's type in destructuring assignment with AssignmentPattern could be ObjectPattern, RestElement, ArrayPattern, AssignmentPattern. This lack of consideration caused #6699 error because such a pattern was handled as Identifier.

I fixed it (and add the test about it).
