### PR TITLE
[fix] Maximum call stack size exceeded (#4694)

### DIFF
--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -1,3 +1,4 @@
+import { push_array } from '../../utils/push_array';
 import MagicString from 'magic-string';
 import { walk } from 'estree-walker';
 import Selector from './Selector';
@@ -351,7 +352,7 @@ export default class Stylesheet {
 							const at_rule_declarations = node.block.children
 								.filter(node => node.type === 'Declaration')
 								.map(node => new Declaration(node));
-							atrule.declarations.push(...at_rule_declarations);
+							push_array(atrule.declarations, at_rule_declarations);
 						}
 
 						current_atrule = atrule;

--- a/src/compiler/compile/nodes/shared/map_children.ts
+++ b/src/compiler/compile/nodes/shared/map_children.ts
@@ -1,3 +1,4 @@
+import { push_array } from '../../../utils/push_array';
 import AwaitBlock from '../AwaitBlock';
 import Body from '../Body';
 import Comment from '../Comment';
@@ -58,7 +59,7 @@ export default function map_children(component, parent, scope, children: Templat
 		if (use_ignores) component.pop_ignores(), ignores = [];
 
 		if (node.type === 'Comment' && node.ignores.length) {
-			ignores.push(...node.ignores);
+			push_array(ignores, node.ignores);
 		}
 
 		if (last) last.next = node;

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -1,3 +1,4 @@
+import { push_array } from '../../../../utils/push_array';
 import Renderer from '../../Renderer';
 import Element from '../../../nodes/Element';
 import Wrapper from '../shared/Wrapper';
@@ -596,7 +597,7 @@ export default class ElementWrapper extends Wrapper {
 		this.attributes.forEach((attribute) => {
 			if (attribute.node.name === 'class') {
 				const dependencies = attribute.node.get_dependencies();
-				this.class_dependencies.push(...dependencies);
+				push_array(this.class_dependencies, dependencies);
 			}
 		});
 

--- a/src/compiler/compile/render_dom/wrappers/IfBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/IfBlock.ts
@@ -1,3 +1,4 @@
+import { push_array } from '../../../utils/push_array';
 import Wrapper from './shared/Wrapper';
 import Renderer from '../Renderer';
 import Block from '../Block';
@@ -166,7 +167,7 @@ export default class IfBlockWrapper extends Wrapper {
 			block.has_outro_method = has_outros;
 		});
 
-		renderer.blocks.push(...blocks);
+		push_array(renderer.blocks, blocks);
 	}
 
 	render(

--- a/src/compiler/preprocess/decode_sourcemap.ts
+++ b/src/compiler/preprocess/decode_sourcemap.ts
@@ -1,3 +1,4 @@
+import { push_array } from '../utils/push_array';
 import { decode as decode_mappings } from 'sourcemap-codec';
 import { Processed } from './types';
 
@@ -50,7 +51,7 @@ function decoded_sourcemap_from_generator(generator: any) {
 		result_segment = result_line[result_line.length - 1];
 
 		if (mapping.source != null) {
-			result_segment.push(...[
+			push_array(result_segment, [
 				source_idx[mapping.source],
 				mapping.originalLine - 1, // line is one-based
 				mapping.originalColumn

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -1,3 +1,4 @@
+import { push_array } from '../utils/push_array';
 import { RawSourceMap, DecodedSourceMap } from '@ampproject/remapping/dist/types/types';
 import { getLocator } from 'locate-character';
 import { MappedCode, SourceLocation, parse_attached_sourcemap, sourcemap_add_offset, combine_sourcemaps } from '../utils/mapped_code';
@@ -48,7 +49,7 @@ class PreprocessResult implements Source {
 		}
 
 		if (dependencies) {
-			this.dependencies.push(...dependencies);
+			push_array(this.dependencies, dependencies);
 		}
 	}
 
@@ -165,7 +166,7 @@ async function process_tag(
 		});
 
 		if (!processed) return no_change();
-		if (processed.dependencies) dependencies.push(...processed.dependencies);
+		if (processed.dependencies) push_array(dependencies, processed.dependencies);
 		if (!processed.map && processed.code === content) return no_change();
 
 		return processed_tag_to_code(processed, tag_name, attributes, slice_source(content, tag_offset, source));

--- a/src/compiler/utils/push_array.ts
+++ b/src/compiler/utils/push_array.ts
@@ -1,0 +1,11 @@
+export function push_array(thisArray: any[], ...otherList: any[]) {
+  let count = 0;
+  for (let a = 0; a < otherList.length; a++) {
+    const other = otherList[a];
+    for (let i = 0; i < other.length; i++) {
+      thisArray.push(other[i]);
+    }
+    count += other.length;
+  }
+  return count;
+}


### PR DESCRIPTION
draft

start fixing #4694

```js
// problem
[].push(...Array.from({ length: 1000*1000 })) // ... = spread operator
// Uncaught RangeError: Maximum call stack size exceeded
```

```ts
// solution
function pushArray(thisArray: any[], ...otherArrayList: any[]) {
  let count = 0;
  for (let a = 0; a < otherArrayList.length; a++) {
    const otherArray = otherArrayList[a];
    for (let i = 0; i < otherArray.length; i++) {
      thisArray.push(otherArray[i]);
    }
    count += otherArray.length;
  }
  return count;
};

pushArray(someArray, otherArray1, otherArray2, [otherItem])
```

the patch was generated with https://github.com/milahu/random/tree/master/svelte/patch-svelte-compiler-sources

ideally, the patch script would be implemented in eslint or [putout](https://github.com/coderaiser/putout/issues/78)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

### alternatives to pushArray

[a very simple benchmark](https://jsbench.me/7wkta1bhrl/1) suggests that concat is faster than push
but performance depends on input data
todo: compare different methods with real-world data

to use `dst = dst.concat(src)`, we must [transform `const dst` to `let dst`](https://github.com/milahu/random/blob/14c6715413f6cb8a232d132d8263a4f54d7728d1/svelte/patch-svelte-compiler-sources/index.js#L327)

