### PR TITLE
[chore] improve illegal declaration error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.41.0",
+      "version": "3.42.5",
       "license": "MIT",
       "devDependencies": {
         "@ampproject/remapping": "^0.3.0",

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -587,7 +587,7 @@ export default class Component {
 
 		scope.declarations.forEach((node, name) => {
 			if (name[0] === '$') {
-				return this.error(node as any, compiler_errors.illegal_declaration);
+				return this.error(node as any, compiler_errors.illegal_declaration(name));
 			}
 
 			const writable = node.type === 'VariableDeclaration' && (node.kind === 'var' || node.kind === 'let');
@@ -660,7 +660,7 @@ export default class Component {
 
 		instance_scope.declarations.forEach((node, name) => {
 			if (name[0] === '$') {
-				return this.error(node as any, compiler_errors.illegal_declaration);
+				return this.error(node as any, compiler_errors.illegal_declaration(name));
 			}
 
 			const writable = node.type === 'VariableDeclaration' && (node.kind === 'var' || node.kind === 'let');

--- a/src/compiler/compile/compiler_errors.ts
+++ b/src/compiler/compile/compiler_errors.ts
@@ -174,10 +174,10 @@ export default {
 		code: 'default-export',
 		message: 'A component cannot have a default export'
 	},
-	illegal_declaration: {
+	illegal_declaration: (name: string) => ({
 		code: 'illegal-declaration',
-		message: 'The $ prefix is reserved, and cannot be used for variable and import names'
-	},
+		message: `The $ prefix is reserved, and cannot be used for variable and import names, but found ${name}`
+	}),
 	illegal_subscription: {
 		code: 'illegal-subscription',
 		message: 'Cannot reference store value inside <script context="module">'

--- a/test/runtime/samples/store-prevent-user-declarations/_config.js
+++ b/test/runtime/samples/store-prevent-user-declarations/_config.js
@@ -5,5 +5,5 @@ export default {
 		count: writable(0)
 	},
 
-	error: 'The $ prefix is reserved, and cannot be used for variable and import names'
+	error: 'The $ prefix is reserved, and cannot be used for variable and import names, but found $count'
 };


### PR DESCRIPTION
`svelte-preprocess` started failing in 4.9.0 when running the `svelte-jester` test suite. I couldn't figure out where the error message was coming from at first, but updating the error message helped me track it down. The root cause of that issue is being fixed in https://github.com/sveltejs/svelte-preprocess/pull/407

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`