### PR TITLE
feat: loose parsing mode

### DIFF
--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -116,6 +116,7 @@ export interface Ast {
 	css: Style;
 	instance: Script;
 	module: Script;
+	firstError?: any;
 }
 
 export interface Warning {
@@ -170,6 +171,7 @@ export interface CompileOptions {
 export interface ParserOptions {
 	filename?: string;
 	customElement?: boolean;
+	errorMode?: 'throw' | 'warn' | 'loose';
 }
 
 export interface Visitor {


### PR DESCRIPTION
Related to #4818

Adds a `loose` parsing mode which will continue parsing no matter what. In `loose` mode, the first error that is encountered is part of the return in case subsequent analysis of the result cannot be performed and a fallback to the original error is needed.
This would enable https://github.com/sveltejs/language-tools/pull/1177 
It's up to discussion whether the naming is good and whether or not additional parsing fallbacks should be applied in loose mode (this is the simplest implementation as a start for now).

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
