### PR TITLE
[feat] export svelte/ssr in node

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "browser": {
-        "import": "./index.mjs",
-        "require": "./index.js"
+      "node": {
+        "import": "./ssr.mjs",
+        "require": "./ssr.js"
       },
-      "import": "./ssr.mjs",
-      "require": "./ssr.js"
+      "import": "./index.mjs",
+      "require": "./index.js"
     },
     "./compiler": {
       "import": "./compiler.mjs",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
         "import": "./index.mjs",
         "require": "./index.js"
       },
-      "default": {
-        "import": "./ssr.mjs",
-        "require": "./ssr.js"
-      }
+      "import": "./ssr.mjs",
+      "require": "./ssr.js"
     },
     "./compiler": {
       "import": "./compiler.mjs",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "import": "./index.mjs",
         "require": "./index.js"
       },
-      "node": {
+      "default": {
         "import": "./ssr.mjs",
         "require": "./ssr.js"
       }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,14 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./index.mjs",
-      "require": "./index.js"
+      "browser": {
+        "import": "./index.mjs",
+        "require": "./index.js"
+      },
+      "node": {
+        "import": "./ssr.mjs",
+        "require": "./ssr.js"
+      }
     },
     "./compiler": {
       "import": "./compiler.mjs",


### PR DESCRIPTION
Credit to @benmccann for the idea. This prevents the need for bundlers to bundle external dependencies that imports `svelte` in order to resolve them to `svelte/ssr`.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
