### PR TITLE
[fix] ssr remove css map

### DIFF
--- a/src/compiler/compile/render_ssr/index.ts
+++ b/src/compiler/compile/render_ssr/index.ts
@@ -1,7 +1,6 @@
 import { b } from 'code-red';
 import Component from '../Component';
 import { CompileOptions, CssResult } from '../../interfaces';
-import { string_literal } from '../utils/stringify';
 import Renderer from './Renderer';
 import { INode as TemplateNode } from '../nodes/interfaces'; // TODO
 import Text from '../nodes/Text';
@@ -200,11 +199,14 @@ export default function ssr(
 		main
 	].filter(Boolean);
 
+	// TODO: support css.map
+	// NOTE: inlining sourcemaps may cause issues for code replacements since
+	// `sourcesContent` contains the raw source code wrapped in double quotes
 	const js = b`
 		${css.code ? b`
 		const #css = {
 			code: "${css.code}",
-			map: ${css.map ? string_literal(css.map.toString()) : 'null'}
+			map: null
 		};` : null}
 
 		${component.extract_javascript(component.ast.module)}

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -129,7 +129,7 @@ export function create_ssr_component(fn) {
 				html,
 				css: {
 					code: Array.from(result.css).map(css => css.code).join('\n'),
-					map: null // TODO
+					map: null // TODO: support css.map
 				},
 				head: result.title + result.head
 			};


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/720.

The inline sourcemap's `sourcesContent` was interfering with Vite's production replacement, since they are applied near the end of the build process (after svelte has been compiled). So we remove the sourcemap instead since it wasn't actually being used.

[REPL](https://svelte.dev/repl/f62a84d81d904e97a50ab66b00117d4f?version=3.42.6) to show css map issue. (Compile to `ssr`)

See https://github.com/sveltejs/kit/issues/720#issuecomment-922336782 for more info.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
