### PR TITLE
[fix] handle preprocess with empty sourcemaps

### DIFF
--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -79,10 +79,13 @@ function processed_content_to_code(processed: Processed, location: SourceLocatio
 	if (processed.map) {
 		decoded_map = decode_map(processed);
 
-		// offset only segments pointing at original component source
-		const source_index = decoded_map.sources.indexOf(file_basename);
-		if (source_index !== -1) {
-			sourcemap_add_offset(decoded_map, location, source_index);
+		// decoded map may not have sources for empty maps like `{ mappings: '' }`
+		if (decoded_map.sources) {
+			// offset only segments pointing at original component source
+			const source_index = decoded_map.sources.indexOf(file_basename);
+			if (source_index !== -1) {
+				sourcemap_add_offset(decoded_map, location, source_index);
+			}
 		}
 	}
 

--- a/test/preprocess/samples/empty-sourcemap/_config.js
+++ b/test/preprocess/samples/empty-sourcemap/_config.js
@@ -1,0 +1,7 @@
+export default {
+	preprocess: {
+		style: ({ content }) => {
+			return { code: content, map: { mappings: '' } };
+		}
+	}
+};

--- a/test/preprocess/samples/empty-sourcemap/input.svelte
+++ b/test/preprocess/samples/empty-sourcemap/input.svelte
@@ -1,0 +1,7 @@
+<div class="foo">bar</div>
+
+<style>
+	.foo {
+		color: red;
+	}
+</style>

--- a/test/preprocess/samples/empty-sourcemap/output.svelte
+++ b/test/preprocess/samples/empty-sourcemap/output.svelte
@@ -1,0 +1,7 @@
+<div class="foo">bar</div>
+
+<style>
+	.foo {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte-preprocess/issues/412

Handles preprocessors that return empty sourcemaps like `{ mappings: '' }`, which is valid per [rollup documentation](https://rollupjs.org/guide/en/#source-code-transformations).

cc @dominikg 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
