### PR TITLE
fix: correct date input in Chrome

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -619,10 +619,8 @@ export default class ElementWrapper extends Wrapper {
 
 		this.attributes
 			.forEach(attr => {
-				const dependencies = attr.node.get_dependencies();
-
-				const condition = dependencies.length > 0
-					? block.renderer.dirty(dependencies)
+				const condition = attr.node.dependencies.size > 0
+					? block.renderer.dirty(attr.node.get_dependencies())
 					: null;
 
 				if (attr instanceof SpreadAttributeWrapper) {


### PR DESCRIPTION
This PR regards the issue I raised yesterday: https://github.com/sveltejs/svelte/issues/6751

The below fix doesn't break https://github.com/sveltejs/svelte/pull/5004 - the fix to something else that seems to have added this bug.
I got no difference of tests completed before and after the change, so hopefully it didn't break anything. (Changing the second attr.node.get_dependencies() method to New Array (attr.node.dependencies) also worked for my issue, but I wanted to change as little as possible. Didn't check if it didn't break the previous bug again. If it was changed to this, this part of code would be just as the code before PR #5004, but I'm too newbie to know why this part in #5004 was as it was. Here is the link highlitghting the previous change around this place: https://github.com/sveltejs/svelte/commit/0dfcd19629093a25304951c73d1f51ef9b5460b5#diff-d6a6e8b36b1b88c9bd08d5bee1887bfffc7cebb2211ce45591ef59f8d2fc1111R671)

I wanted to write a test, but had no idea how to do a test that would only feature chrome, as the bug only occured there.
Instead of the test I have videos of how the problem looked before and after the commit:

Before:
https://user-images.githubusercontent.com/68644849/134407433-a9b15dba-d19b-4d0a-b576-dcfb7ce71c82.mp4
After:
https://user-images.githubusercontent.com/68644849/134407443-a5630040-db74-4563-93ef-77c5d2a7cfeb.mp4

Both of them work on code from yesterday's issue.

This is my first PR, I tried to follow the guidelines, but I might've done something wrong. If so, I apologise. I'm amazed how long looking for a small bug takes lol. Thank you guys for maintaining it, you're amazing!

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
