### PR TITLE
[fix] prefer context from constructor options

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -124,7 +124,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 		on_disconnect: [],
 		before_update: [],
 		after_update: [],
-		context: new Map(parent_component ? parent_component.$$.context : options.context || []),
+		context: new Map(options.context || (parent_component ? parent_component.$$.context : [])),
 
 		// everything else
 		callbacks: blank_object(),

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -91,7 +91,7 @@ export function create_ssr_component(fn) {
 
 		const $$ = {
 			on_destroy,
-			context: new Map(parent_component ? parent_component.$$.context : context || []),
+			context: new Map(context || (parent_component ? parent_component.$$.context : [])),
 
 			// these will be immediately discarded
 			on_mount: [],

--- a/test/runtime/samples/constructor-prefer-passed-context/ChildComponent.svelte
+++ b/test/runtime/samples/constructor-prefer-passed-context/ChildComponent.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { getContext } from 'svelte';
+	const value = getContext('foo');
+</script>
+
+<div>Value in child component: {value}</div>

--- a/test/runtime/samples/constructor-prefer-passed-context/_config.js
+++ b/test/runtime/samples/constructor-prefer-passed-context/_config.js
@@ -1,0 +1,6 @@
+export default {
+	skip_if_ssr: true,
+	html: `
+		<div><div>Value in child component: undefined</div></div>
+	`
+};

--- a/test/runtime/samples/constructor-prefer-passed-context/main.svelte
+++ b/test/runtime/samples/constructor-prefer-passed-context/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	import { setContext } from 'svelte';
+	import ChildComponent from './ChildComponent.svelte';
+
+	setContext('foo', true);
+
+	function render(node) {
+		new ChildComponent({
+			target: node,
+			context: new Map()
+		});
+	}
+</script>
+
+<div use:render />

--- a/test/server-side-rendering/samples/constructor-prefer-passed-context/ChildComponent.svelte
+++ b/test/server-side-rendering/samples/constructor-prefer-passed-context/ChildComponent.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { getContext } from 'svelte';
+	const value = getContext('foo');
+</script>
+
+<div>Value in child component: {value}</div>

--- a/test/server-side-rendering/samples/constructor-prefer-passed-context/_expected.html
+++ b/test/server-side-rendering/samples/constructor-prefer-passed-context/_expected.html
@@ -1,0 +1,1 @@
+<div><div>Value in child component: undefined</div></div>

--- a/test/server-side-rendering/samples/constructor-prefer-passed-context/main.svelte
+++ b/test/server-side-rendering/samples/constructor-prefer-passed-context/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { setContext } from 'svelte';
+	import ChildComponent from './ChildComponent.svelte';
+
+	setContext('foo', true);
+
+	const content = ChildComponent.render({}, { context: new Map() }).html;
+</script>
+
+<div>{@html content}</div>


### PR DESCRIPTION
This fixes #6753 and also fixes it for SSR so that the passed `context` is preferred, even when we have a `parent_component`. Browser and SSR are implemented as separate tests, because the process of synchronously creating a child component outside of Svelte's jurisdiction is rather different in the two cases.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `npm test` and lint the project with `npm run lint`
