### PR TITLE
[docs] what is rendered when for #await

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -309,7 +309,7 @@ An each block can also have an `{:else}` clause, which is rendered if the list i
 
 ---
 
-Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected.
+Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected. The pending state is rendered initially on both the client and server with the resolved state being updated after hydration.
 
 ```sv
 {#await promise}

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -309,7 +309,7 @@ An each block can also have an `{:else}` clause, which is rendered if the list i
 
 ---
 
-Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected. If using SSR, the server will render the pending state.
+Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected. In SSR mode, only the pending state will be rendered on the server.
 
 ```sv
 {#await promise}

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -309,7 +309,7 @@ An each block can also have an `{:else}` clause, which is rendered if the list i
 
 ---
 
-Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected. The pending state is rendered initially on both the client and server with the resolved state being updated after hydration.
+Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected. If using SSR, the server will render the pending state.
 
 ```sv
 {#await promise}


### PR DESCRIPTION
I was looking at https://github.com/sveltejs/kit/issues/2520 and was a bit unclear on how `{#await}` works exactly. @Conduitry filled me in on some missing details that helped elucidate things. I thought they could be useful to add to the docs