### PR TITLE
Update homepage with survey results

### DIFF
--- a/site/src/routes/index.svelte
+++ b/site/src/routes/index.svelte
@@ -70,7 +70,7 @@
 
 		<p>Instead of using techniques like virtual DOM diffing, Svelte writes code that surgically updates the DOM when the state of your app changes.</p>
 
-		<p><a href="blog/svelte-3-rethinking-reactivity">Read the introductory blog post</a> to learn more.</p>
+		<p>We're proud that Svelte was recently voted the <a href="https://insights.stackoverflow.com/survey/2021#section-most-loved-dreaded-and-wanted-web-frameworks">most loved web framework</a> with the <a href="https://2020.stateofjs.com/en-US/technologies/front-end-frameworks/">most satisfied developers</a> in a pair of industry surveys. We think you'll love it too. <a href="blog/svelte-3-rethinking-reactivity">Read the introductory blog post</a> to learn more.</p>
 	</div>
 
 	<div style="grid-area: start; display: flex; flex-direction: column; min-width: 0" slot="how">


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/6791

First link goes to the Stack Overflow developer survey results and the second goes to the State of JS survey results. This would make the homepage diverge slightly from pngwn's branch, but we can copy it over there pretty easily if this gets merged

![Screenshot from 2021-09-29 20-02-15](https://user-images.githubusercontent.com/322311/135379242-74f718fd-9fab-4cd6-8c20-54c658bf61db.png)
