### PR TITLE
[fix] Fix img overflow in "Who’s using Svelte ?" on Safari

### DIFF
--- a/site/src/routes/_components/WhosUsingSvelte.svelte
+++ b/site/src/routes/_components/WhosUsingSvelte.svelte
@@ -46,6 +46,7 @@
 		height: 100%;
 		padding: 5px 10px;
 		transition: transform 0.2s;
+		min-width:  0; /* Avoid image overflow in Safari */
 	}
 	picture:hover,
 	img:hover {


### PR DESCRIPTION
## Problem : 

In the "Who’s using Svelte ?" part, on the Svelte’s website using Safari, images overflowing.

## Solution : 

Add a `min-with: 0`  🤷

---

### Before : 

<img width="1116" alt="Capture d’écran 2021-10-02 à 14 14 39" src="https://user-images.githubusercontent.com/56537238/135718594-24d92f70-5a8c-4889-8da9-7ef7cb63d9fb.png">


<img width="315" alt="Capture d’écran 2021-10-02 à 14 16 12" src="https://user-images.githubusercontent.com/56537238/135718604-593bc893-f522-407f-8155-642d49678427.png">


### After : 

<img width="1116" alt="Capture d’écran 2021-10-02 à 14 14 47" src="https://user-images.githubusercontent.com/56537238/135718619-6f59b255-cc17-4567-891d-92242b62f6d0.png">


<img width="315" alt="Capture d’écran 2021-10-02 à 14 16 21" src="https://user-images.githubusercontent.com/56537238/135718628-65a68ad6-9220-423f-8375-db5c21bfb2c1.png">


