### PR TITLE
[docs] simplify template literals to string primitives

### DIFF
--- a/site/content/tutorial/02-reactivity/03-reactive-statements/app-b/App.svelte
+++ b/site/content/tutorial/02-reactivity/03-reactive-statements/app-b/App.svelte
@@ -2,7 +2,7 @@
 	let count = 0;
 
 	$: if (count >= 10) {
-		alert(`count is dangerously high!`);
+		alert('count is dangerously high!');
 		count = 9;
 	}
 

--- a/site/content/tutorial/02-reactivity/03-reactive-statements/text.md
+++ b/site/content/tutorial/02-reactivity/03-reactive-statements/text.md
@@ -23,7 +23,7 @@ You can even put the `$:` in front of things like `if` blocks:
 
 ```js
 $: if (count >= 10) {
-	alert(`count is dangerously high!`);
+	alert('count is dangerously high!');
 	count = 9;
 }
 ```

--- a/site/content/tutorial/02-reactivity/03-reactive-statements/text.md
+++ b/site/content/tutorial/02-reactivity/03-reactive-statements/text.md
@@ -8,7 +8,7 @@ We're not limited to declaring reactive *values* — we can also run arbitrary *
 $: console.log(`the count is ${count}`);
 ```
 
-> Did you notice we are using [template literal syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals "MDN Web Docs") here? `the count is ${count}` is enclosed by `` ` `` backticks, **not** `'` quotes. This enables us to substitute it with reactive declarations, `${count}` for example. 
+> This example uses [a template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals "MDN Web Docs").
 
 You can easily group statements together with a block:
 

--- a/site/content/tutorial/02-reactivity/03-reactive-statements/text.md
+++ b/site/content/tutorial/02-reactivity/03-reactive-statements/text.md
@@ -5,17 +5,15 @@ title: Statements
 We're not limited to declaring reactive *values* — we can also run arbitrary *statements* reactively. For example, we can log the value of `count` whenever it changes:
 
 ```js
-$: console.log(`the count is ${count}`);
+$: console.log('the count is ' + count);
 ```
-
-> This example uses [a template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals "MDN Web Docs").
 
 You can easily group statements together with a block:
 
 ```js
 $: {
-	console.log(`the count is ${count}`);
-	alert(`I SAID THE COUNT IS ${count}`);
+	console.log('the count is ' + count);
+	alert('I SAID THE COUNT IS ' + count);
 }
 ```
 

--- a/site/content/tutorial/02-reactivity/03-reactive-statements/text.md
+++ b/site/content/tutorial/02-reactivity/03-reactive-statements/text.md
@@ -8,6 +8,8 @@ We're not limited to declaring reactive *values* — we can also run arbitrary *
 $: console.log(`the count is ${count}`);
 ```
 
+> Did you notice we are using [template literal syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals "MDN Web Docs") here? `the count is ${count}` is enclosed by `` ` `` backticks, **not** `'` quotes. This enables us to substitute it with reactive declarations, `${count}` for example. 
+
 You can easily group statements together with a block:
 
 ```js


### PR DESCRIPTION
Coming from python JS template literal syntax was new to me. This part of the otherwise fantastic tutorial threw me off, because I did not immediately notice the backticks. Like: "Oh, that's an interesting concept. But it doesn't work. Bummer."
Took me a while to figure.