### PR TITLE
[docs] Improve wording for `animate` docs, refs #6807

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1132,7 +1132,7 @@ DOMRect {
 
 ---
 
-An animation is triggered when the contents of a [keyed each block](docs#each) are re-ordered. Animations do not run when an element is removed, only when the each block's data is reordered. Animate directives must be on an element that is an *immediate* child of a keyed each block.
+An animation is triggered when an element inside a [keyed each block](docs#each) changes its position. Animations do not run for newly added or removed elements. They only run when the data of an existing element changes position within the each block's data. Animate directives must be on an element that is an *immediate* child of a keyed each block.
 
 Animations can be used with Svelte's [built-in animation functions](docs#svelte_animate) or [custom animation functions](docs#Custom_animation_functions).
 


### PR DESCRIPTION
Quoting #6807

> Usually when you add or remove an item from a list, you don't consider this a "re-order". Yes, technically all elements after the new/removed element change their position within the list, but the order is exactly the same. If you stand in line for coffee and the person in front of you gets a call and leaves you wouldn't say the order of the line changed. I'm not a native speaker though shrug

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.