### PR TITLE
[docs] A reference of the field variable is missing in the sidebar

### DIFF
--- a/site/content/tutorial/06-bindings/14-component-this/text.md
+++ b/site/content/tutorial/06-bindings/14-component-this/text.md
@@ -5,6 +5,10 @@ title: Binding to component instances
 Just as you can bind to DOM elements, you can bind to component instances themselves. For example, we can bind the instance of `<InputField>` to a prop named `field` in the same way we did when binding DOM Elements
 
 ```html
+<script>
+	let field;
+</script>
+
 <InputField bind:this={field} />
 ```
 

--- a/site/content/tutorial/06-bindings/14-component-this/text.md
+++ b/site/content/tutorial/06-bindings/14-component-this/text.md
@@ -2,7 +2,7 @@
 title: Binding to component instances
 ---
 
-Just as you can bind to DOM elements, you can bind to component instances themselves. For example, we can bind the instance of `<InputField>` to a prop named `field` in the same way we did when binding DOM Elements
+Just as you can bind to DOM elements, you can bind to component instances themselves. For example, we can bind the instance of `<InputField>` to a variable named `field` in the same way we did when binding DOM Elements
 
 ```html
 <script>


### PR DESCRIPTION
If I just add the code on the sidebar the console says that the field variable is undefined, so I've included a reference with the variable in  the initial code block as to make it clear to the user.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
