### PR TITLE
fix: escape closing script tag

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -602,7 +602,7 @@ export function add_resize_listener(node: HTMLElement, fn: () => void) {
 	let unsubscribe: () => void;
 
 	if (crossorigin) {
-		iframe.src = "data:text/html,<script>onresize=function(){parent.postMessage(0,'*')}</script>";
+		iframe.src = "data:text/html,<script>onresize=function(){parent.postMessage(0,'*')}<\/script>";
 		unsubscribe = listen(window, 'message', (event: MessageEvent) => {
 			if (event.source === iframe.contentWindow) fn();
 		});

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -602,6 +602,7 @@ export function add_resize_listener(node: HTMLElement, fn: () => void) {
 	let unsubscribe: () => void;
 
 	if (crossorigin) {
+		// eslint-disable-next-line no-useless-escape
 		iframe.src = "data:text/html,<script>onresize=function(){parent.postMessage(0,'*')}<\/script>";
 		unsubscribe = listen(window, 'message', (event: MessageEvent) => {
 			if (event.source === iframe.contentWindow) fn();


### PR DESCRIPTION
Hello! Big fan of svelte; thanks for all that you do.

If a svelte app is inlined to a browser (i.e. stuffed in between `<script>...</script>` tags instead of loaded remotely), the string in this patch is parsed as a valid closing script tag.

This is similar to, but not quite the same as #3039 / #3840 / #4406 / #4996 / #5024 / #5237 / sveltejs/rollup-plugin-svelte#133 / #5810 / sveltejs/rollup-plugin-svelte#182 / #6203 / #6366 / maybe others.

In those issues, the errant script tag is in user-land code. In this case it's in svelte core.

tests pass locally for me with this change.