### PR TITLE
[fix]: missing null value of append_styles in init function

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -584,7 +584,7 @@ export default function dom(
 			class ${name} extends ${superclass} {
 				constructor(options) {
 					super(${options.dev && 'options'});
-					@init(this, options, ${definition}, ${has_create_fragment ? 'create_fragment' : 'null'}, ${not_equal}, ${prop_indexes}, ${optional_parameters});
+					@init(this, options, ${definition}, ${has_create_fragment ? 'create_fragment' : 'null'}, ${not_equal}, ${prop_indexes}, null, ${optional_parameters});
 					${options.dev && b`@dispatch_dev("SvelteRegisterComponent", { component: this, tagName: "${name.name}", options, id: create_fragment.name });`}
 
 					${dev_props_check}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`

Hi. When I was using svelte-navigator, I encountered this issue: `Uncaught TypeError: append_styles is not a function` and there was an issue created in svelte-navigator here: https://github.com/mefechoel/svelte-navigator/issues/47

![image](https://user-images.githubusercontent.com/8545277/136667485-84728c6c-d874-4875-a5d4-15253727fdde.png)


Here is the repo to reproduce the issue: https://github.com/ZhiyueYi/web-toolbox

I think the issue was introduced by this MR: https://github.com/sveltejs/svelte/pull/5870 which didn't handle default case of append_styles well at src/compiler/compile/render_dom/index.ts#L546 in this MR
