### PR TITLE
[docs] align input controls

### DIFF
--- a/site/content/tutorial/06-bindings/02-numeric-inputs/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/02-numeric-inputs/app-a/App.svelte
@@ -14,3 +14,8 @@
 </label>
 
 <p>{a} + {b} = {a + b}</p>
+
+<style>
+	label { display: flex }
+	input, p { margin: 6px }
+</style>

--- a/site/content/tutorial/06-bindings/02-numeric-inputs/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/02-numeric-inputs/app-b/App.svelte
@@ -14,3 +14,8 @@
 </label>
 
 <p>{a} + {b} = {a + b}</p>
+
+<style>
+	label { display: flex }
+	input, p { margin: 6px }
+</style>


### PR DESCRIPTION
Using Firefox 93.0 for macOS, this is how the inputs are displayed in this section of the tutorial (Bindings/Numeric Inputs):

<img width="633" alt="image" src="https://user-images.githubusercontent.com/6943864/136690442-192862a7-64e9-4810-9fef-eb8fd7c6cb34.png">

This is how they should be displayed after the addition of this CSS code:

<img width="639" alt="image" src="https://user-images.githubusercontent.com/6943864/136690456-ff952a7f-5dcf-44fa-b4b8-2a8993dc8207.png">

The style tag has been added to the bottom of the editor, the same way it is added in other sections of the tutorial.

You can of course change the margin value, which I've set to `6px`.