### PR TITLE
[feat](store): export type `Invalidator`

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -10,7 +10,7 @@ export type Unsubscriber = () => void;
 export type Updater<T> = (value: T) => T;
 
 /** Cleanup logic callback. */
-type Invalidator<T> = (value?: T) => void;
+export type Invalidator<T> = (value?: T) => void;
 
 /** Start and stop notification callbacks. */
 export type StartStopNotifier<T> = (set: Subscriber<T>) => Unsubscriber | void;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

---

I am writing a lib(https://github.com/evillt/svelte-use) that including some enhance for store. e.g. auto unsubscribe on component destroy.

It relies on the `Invalidator` type but `svelte/store` was not exported. So, I duplicated the code [here](https://github.com/evillt/svelte-use/blob/eb8ae17127f236a47d78bc287ebb45469ed99057/packages/shared/writable/index.ts#L13).

It would be better if exported by `svelte/store` itself.
