### PR TITLE
WIP: Regression on contenteditable

### DIFF
--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -83,10 +83,14 @@ export function dataset_dev(node: HTMLElement, property: string, value?: any) {
 
 export function set_data_dev(text, data) {
 	data = '' + data;
-	if (text.wholeText === data) return;
+	if (text.data === data) return;
 
-	dispatch_dev('SvelteDOMSetData', { node: text, data });
-	text.data = data;
+	console.log(text.parentNode.hasAttribute('contenteditable'));
+	if (text.parentNode && text.parentNode.hasAttribute('contenteditable')) {
+		text.innerText = data;
+	} else {
+		text.data = data;
+	}
 }
 
 export function validate_each_argument(arg) {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -514,7 +514,13 @@ export function claim_html_tag(nodes) {
 
 export function set_data(text, data) {
 	data = '' + data;
-	if (text.wholeText !== data) text.data = data;
+	if (text.data === data) return;
+
+	if (text.parentNode && text.parentNode.hasAttribute('contenteditable')) {
+		text.innerText = data;
+	} else {
+		text.data = data;
+	}
 }
 
 export function set_input_value(input, value) {


### PR DESCRIPTION
Fixes: https://github.com/sveltejs/svelte/issues/5018
Fixes: https://github.com/sveltejs/svelte/issues/5931

The issue caused because of setting the updated value to the data property of mustache text node, use innerText if parent have contenteditable attribute

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
