### PR TITLE
[docs] remove confusing assignment from stores tutorial

### DIFF
--- a/site/content/tutorial/08-stores/01-writable-stores/app-b/App.svelte
+++ b/site/content/tutorial/08-stores/01-writable-stores/app-b/App.svelte
@@ -6,7 +6,7 @@
 
 	let count_value;
 
-	const unsubscribe = count.subscribe(value => {
+	count.subscribe(value => {
 		count_value = value;
 	});
 </script>


### PR DESCRIPTION
Tutorial on writable stores contains unexplained and unused assignment
which might cause confusion.

Proper explanations on `unsubscribe` is in the next step of the tutorial.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
