### PR TITLE
[docs] Fix broken link to "The Svelte Handbook"

### DIFF
--- a/site/content/faq/250-are-there-any-books.md
+++ b/site/content/faq/250-are-there-any-books.md
@@ -4,6 +4,6 @@ question: Are there any books?
 
 There are a few books:
 
-- [Svelte Handbook](https://flaviocopes.com/page/download-svelte-handbook/) by Flavio Copes
+- [Svelte Handbook](https://flaviocopes.com/page/svelte-handbook/) by Flavio Copes
 - [Svelte 3 Up and Running](https://www.amazon.com/dp/B08D6T6BKS/) by Alessandro Segala
 - [Svelte and Sapper in Action](https://www.manning.com/books/svelte-and-sapper-in-action) by R. Mark Volkmann


### PR DESCRIPTION
The existing link to "The Svelte Handbook" is broken, this PR fixes it.