### PR TITLE
[docs] Replace double tildes with Math.trunc in tutorials

### DIFF
--- a/site/content/tutorial/10-transitions/04-custom-css-transitions/app-b/App.svelte
+++ b/site/content/tutorial/10-transitions/04-custom-css-transitions/app-b/App.svelte
@@ -13,7 +13,7 @@
 				return `
 					transform: scale(${eased}) rotate(${eased * 1080}deg);
 					color: hsl(
-						${~~(t * 360)},
+						${Math.trunc(t * 360)},
 						${Math.min(100, 1000 - 1000 * t)}%,
 						${Math.min(50, 500 - 500 * t)}%
 					);`

--- a/site/content/tutorial/10-transitions/04-custom-css-transitions/text.md
+++ b/site/content/tutorial/10-transitions/04-custom-css-transitions/text.md
@@ -59,7 +59,7 @@ We can get a lot more creative though. Let's make something truly gratuitous:
 				return `
 					transform: scale(${eased}) rotate(${eased * 1080}deg);
 					color: hsl(
-						${~~(t * 360)},
+						${Math.trunc(t * 360)},
 						${Math.min(100, 1000 - 1000 * t)}%,
 						${Math.min(50, 500 - 500 * t)}%
 					);`

--- a/site/content/tutorial/10-transitions/05-custom-js-transitions/app-b/App.svelte
+++ b/site/content/tutorial/10-transitions/05-custom-js-transitions/app-b/App.svelte
@@ -17,7 +17,7 @@
 		return {
 			duration,
 			tick: t => {
-				const i = ~~(text.length * t);
+				const i = Math.trunc(text.length * t);
 				node.textContent = text.slice(0, i);
 			}
 		};

--- a/site/content/tutorial/10-transitions/05-custom-js-transitions/text.md
+++ b/site/content/tutorial/10-transitions/05-custom-js-transitions/text.md
@@ -21,7 +21,7 @@ function typewriter(node, { speed = 1 }) {
 	return {
 		duration,
 		tick: t => {
-			const i = ~~(text.length * t);
+			const i = Math.trunc(text.length * t);
 			node.textContent = text.slice(0, i);
 		}
 	};


### PR DESCRIPTION
Using double tildes for truncating fractional numbers isn't readable for people who haven't encountered it before. It might lead them into thinking that this is some svelte specific syntax. At the very least, it'll distract learners from the main objective of the lesson while they go look up what it is. `Math.trunc` clearly communicates what it is doing.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
