### PR TITLE
[fix] added "browser" conditional to "exports" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "import": "./index.mjs",
+        "require": "./index.js"
+      },
       "node": {
         "import": "./ssr.mjs",
         "require": "./ssr.js"


### PR DESCRIPTION
fixes: #6877

This will allow electron renderers to avoid loading `ssr.mjs` when importing `svelte` and instead load `index.mjs` like a normal browser would.  Electron renderers are like normal browsers, but they also can access node functions, which is why both the "node", and "browser" conditionals are present when resolving module names using package.json's "exports" feature.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
