### PR TITLE
Fix: each block binding with spread syntax

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -344,7 +344,18 @@ function get_event_handler(
 
 	if (context) {
 		const { object, property, store, snippet } = context;
-		lhs = replace_object(lhs, snippet);
+
+		if (snippet.type === 'CallExpression' &&
+		lhs.type === 'MemberExpression' &&
+		snippet.callee.type === 'Identifier' &&
+		snippet.callee.name === '@object_without_properties' &&
+		snippet.arguments.length > 0 &&
+		snippet.arguments[0].type === 'MemberExpression') {
+			lhs.object = snippet.arguments[0];
+		} else {
+			lhs = replace_object(lhs, snippet);
+		}
+
 		contextual_dependencies.add(object.name);
 		contextual_dependencies.add(property.name);
 		contextual_dependencies.delete(name);

--- a/test/runtime/samples/each-block-destructured-object-rest-binding/_config.js
+++ b/test/runtime/samples/each-block-destructured-object-rest-binding/_config.js
@@ -1,0 +1,63 @@
+export default {
+	props: {
+		arr: [{p: 'foo', val: 'val1', id: 'id-1'}, {p: 'bar', val: 'val2', id: 'id-2'}]
+	},
+
+	html: `
+		<input placeholder="foo">
+		{"val":"val1","id":"id-1"}
+		<br>
+		<input placeholder="bar">
+		{"val":"val2","id":"id-2"}
+		<br>
+	`,
+
+	ssrHtml: `
+		<input placeholder="foo" value="val1">
+		{"val":"val1","id":"id-1"}
+		<br>
+		<input placeholder="bar" value="val2">
+		{"val":"val2","id":"id-2"}
+		<br>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const inputs = target.querySelectorAll('input');
+
+		inputs[0].value = 'val3';
+		await inputs[0].dispatchEvent(new window.Event('input'));
+
+		const { arr } = component;
+
+		assert.deepEqual(arr, [
+			{p: 'foo', val: 'val3', id: 'id-1'},
+			{p: 'bar', val: 'val2', id: 'id-2'}
+		]);
+
+		assert.htmlEqual(target.innerHTML, `
+			<input placeholder="foo">
+			{"val":"val3","id":"id-1"}
+			<br>
+			<input placeholder="bar">
+			{"val":"val2","id":"id-2"}
+			<br>
+		`);
+
+		inputs[1].value = 'val4';
+		await inputs[1].dispatchEvent(new window.Event('input'));
+
+		assert.deepEqual(arr, [
+			{p: 'foo', val: 'val3', id: 'id-1'},
+			{p: 'bar', val: 'val4', id: 'id-2'}
+		]);
+
+		assert.htmlEqual(target.innerHTML, `
+			<input placeholder="foo">
+			{"val":"val3","id":"id-1"}
+			<br>
+			<input placeholder="bar">
+			{"val":"val4","id":"id-2"}
+			<br>
+		`);
+	}
+};

--- a/test/runtime/samples/each-block-destructured-object-rest-binding/main.svelte
+++ b/test/runtime/samples/each-block-destructured-object-rest-binding/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	export let arr;
+</script>
+
+{#each arr as {p, ...rest} (rest.id)}
+	<input bind:value={rest.val} placeholder={p}/>
+	{JSON.stringify(rest)}
+	<br>
+{/each}


### PR DESCRIPTION
Fixes: https://github.com/sveltejs/svelte/issues/6860
Reason: https://github.com/sveltejs/svelte/issues/6860#issuecomment-952452854

( this PR target the change in the compiler code to avoid any edge case and additionally during the creation of each block, rest indirectly gets its the value from the array (on which each block will iterate) i.e, `child_ctx[3] = object_without_properties(list[i], ["id"]);` and here if we change the code inside the `object_without_properties` and make it mutable then that means the exclude property will be removed from array also.)

Please suggest some other approach also 👍 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
