### PR TITLE
[docs] Document the effect of the order of bind: and on:

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -606,7 +606,7 @@ On `<input>` elements with `type="file"`, you can use `bind:files` to get the [`
 
 `bind:` can be used together with `on:` directives. The order that they are defined in determines the value of the bound variable when the event handler is called.
 
-```
+```sv
 <script>
 	let value = 'Hello World';
 </script>

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -602,6 +602,22 @@ On `<input>` elements with `type="file"`, you can use `bind:files` to get the [`
 />
 ```
 
+---
+
+`bind:` can be used together with `on:` directives. The order that they are defined in determines the value of the bound variable when the event handler is called.
+
+```
+<script>
+	let value = 'Hello World';
+</script>
+
+<input
+	on:input="{() => console.log('Old value:', value)}"
+	bind:value
+	on:input="{() => console.log('New value:', value)}"
+/>
+```
+
 
 ##### Binding `<select>` value
 


### PR DESCRIPTION
Closes #6197

After reading the maitainers' views on #5166, I think a simple note like this would be sufficient.

on: and bind: have separate sections for components and elements but from a beginner's perspective this seems like the most natural place to have it.

I'm not sure what, if anything would need to be added in any of the tutorials, I'd appreciate some comments on that.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
