### PR TITLE
[docs] use new export import for marked 4 in examples

### DIFF
--- a/site/content/examples/05-bindings/04-textarea-inputs/App.svelte
+++ b/site/content/examples/05-bindings/04-textarea-inputs/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import marked from 'marked';
+	import { marked } from 'marked';
 	let text = `Some words are *italic*, some are **bold**`;
 </script>
 

--- a/site/content/tutorial/06-bindings/05-textarea-inputs/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/05-textarea-inputs/app-a/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import marked from 'marked';
+	import { marked } from 'marked';
 	let value = `Some words are *italic*, some are **bold**`;
 </script>
 

--- a/site/content/tutorial/06-bindings/05-textarea-inputs/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/05-textarea-inputs/app-b/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import marked from 'marked';
+	import { marked } from 'marked';
 	let value = `Some words are *italic*, some are **bold**`;
 </script>
 


### PR DESCRIPTION
Fixes #6892. We need to use the named export from `marked` that Marked 4 now has.

Question: Should we make these examples use `marked@4` to reduce future issues like this?

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
