### PR TITLE
[docs] fix redirects from legacy /repl page

### DIFF
--- a/site/src/routes/repl/index.svelte
+++ b/site/src/routes/repl/index.svelte
@@ -1,13 +1,14 @@
 <script context="module">
-	export function load({ page: { query }}) {
-		const { gist, example, version } = query;
+	export function load({ page: { query } }) {
+		const gist = query.get('gist');
+		const example = query.get('example');
+		const version = query.get('version');
 
 		// redirect to v2 REPL if appropriate
 		if (/^[^>]?[12]/.test(version)) {
-			const q = Object.keys(query).map(key => `${key}=${query[key]}`).join('&');
 			return {
 				status: 302,
-				redirect: `https://v2.svelte.dev/repl?${q}`
+				redirect: `https://v2.svelte.dev/repl?${query}`
 			};
 		}
 


### PR DESCRIPTION
The legacy `/repl` page wasn't correctly updated for SvelteKit - it was assuming that `query` was an object of keys and values, rather than a `URLSearchParams` instance.

I'm not sure why one of the redirects is a 301 and the other is a 302, but that seems to predate the SvelteKit conversion. This also means that anyone who get an invalid redirect to the new REPL (rather than to the old v2 site) will have a bad redirect stuck in their cache. There's nothing we can do about that now, but maybe it would make sense to make these both be 302s?

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
