### PR TITLE
[docs] clarified definition of "local transition" in tutorial

### DIFF
--- a/site/content/tutorial/10-transitions/07-local-transitions/text.md
+++ b/site/content/tutorial/10-transitions/07-local-transitions/text.md
@@ -6,7 +6,11 @@ Ordinarily, transitions will play on elements when any container block is added 
 
 Instead, we'd like transitions to play only when individual items are added and removed — in other words, when the user drags the slider.
 
-We can achieve this with a *local* transition, which only plays when the immediate parent block is added or removed:
+We can achieve this with a *local* transition. Local transitions only play when the block they belong to is created or removed, not when parent blocks are created or removed.
+
+
+
+
 
 ```html
 <div transition:slide|local>

--- a/site/content/tutorial/10-transitions/07-local-transitions/text.md
+++ b/site/content/tutorial/10-transitions/07-local-transitions/text.md
@@ -6,7 +6,7 @@ Ordinarily, transitions will play on elements when any container block is added 
 
 Instead, we'd like transitions to play only when individual items are added and removed — in other words, when the user drags the slider.
 
-We can achieve this with a *local* transition. Local transitions only play when the block they belong to is created or removed, not when parent blocks are created or removed.
+We can achieve this with a *local* transition, which only plays when the block with the transition itself is added or removed.
 
 ```html
 <div transition:slide|local>

--- a/site/content/tutorial/10-transitions/07-local-transitions/text.md
+++ b/site/content/tutorial/10-transitions/07-local-transitions/text.md
@@ -6,7 +6,7 @@ Ordinarily, transitions will play on elements when any container block is added 
 
 Instead, we'd like transitions to play only when individual items are added and removed — in other words, when the user drags the slider.
 
-We can achieve this with a *local* transition, which only plays when the block with the transition itself is added or removed.
+We can achieve this with a *local* transition, which only plays when the block with the transition itself is added or removed:
 
 ```html
 <div transition:slide|local>

--- a/site/content/tutorial/10-transitions/07-local-transitions/text.md
+++ b/site/content/tutorial/10-transitions/07-local-transitions/text.md
@@ -8,10 +8,6 @@ Instead, we'd like transitions to play only when individual items are added and 
 
 We can achieve this with a *local* transition. Local transitions only play when the block they belong to is created or removed, not when parent blocks are created or removed.
 
-
-
-
-
 ```html
 <div transition:slide|local>
 	{item}


### PR DESCRIPTION
I was confused while reading the tutorial about local transitions. The tutorial talks about removing items and words the transition in those terms, which makes the transition block a parent. BUT... then it talks about the local directive, which belongs to the block with the transition itself.

To avoid confusion I have pretty much copied the wording from the docs verbatim (https://svelte.dev/docs, search for "Local transitions only play"), since I find the wording in the docs very clear.

I have not created an issue. Please let me know if this would still be helpful or is still needed.