### PR TITLE
[fix] update preprocessor types

### DIFF
--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -30,7 +30,7 @@ class PreprocessResult implements Source {
 
 	get_location: ReturnType<typeof getLocator>;
 
-	constructor(public source: string, public filename: string) {
+	constructor(public source: string, public filename?: string) {
 		this.update_source({ string: source });
 
 		// preprocess source must be relative to itself or equal null
@@ -179,10 +179,10 @@ async function process_tag(
 	return { string, map, dependencies };
 }
 
-async function process_markup(filename: string, process: MarkupPreprocessor, source: Source) {
+async function process_markup(process: MarkupPreprocessor, source: Source) {
 	const processed = await process({
 		content: source.source,
-		filename
+		filename: source.filename
 	});
 
 	if (processed) {
@@ -206,8 +206,7 @@ export default async function preprocess(
 	preprocessor: PreprocessorGroup | PreprocessorGroup[],
 	options?: { filename?: string }
 ): Promise<Processed> {
-	// @ts-ignore todo: doublecheck
-	const filename = (options && options.filename) || preprocessor.filename; // legacy
+	const filename: string | undefined = (options && options.filename) || (preprocessor as any).filename; // legacy
 
 	const preprocessors = preprocessor ? (Array.isArray(preprocessor) ? preprocessor : [preprocessor]) : [];
 
@@ -221,7 +220,7 @@ export default async function preprocess(
 	// to make debugging easier = detect low-resolution sourcemaps in fn combine_mappings
 
 	for (const process of markup) {
-		result.update_source(await process_markup(filename, process, result));
+		result.update_source(await process_markup(process, result));
 	}
 
 	for (const process of script) {

--- a/src/compiler/preprocess/types.ts
+++ b/src/compiler/preprocess/types.ts
@@ -19,8 +19,8 @@ export interface Processed {
 
 export type MarkupPreprocessor = (options: {
 	content: string;
-	filename: string;
-}) => Processed | Promise<Processed>;
+	filename?: string;
+}) => Processed | void | Promise<Processed | void>;
 
 export type Preprocessor = (options: {
 	/**
@@ -33,7 +33,7 @@ export type Preprocessor = (options: {
 	 */
 	markup: string;
 	filename?: string;
-}) => Processed | Promise<Processed>;
+}) => Processed | void | Promise<Processed | void>;
 
 export interface PreprocessorGroup {
 	markup?: MarkupPreprocessor;

--- a/src/compiler/preprocess/types.ts
+++ b/src/compiler/preprocess/types.ts
@@ -7,7 +7,7 @@ export interface Source {
 	source: string;
 	get_location: (search: number) => Location;
 	file_basename: string;
-	filename: string;
+	filename?: string;
 }
 
 export interface Processed {


### PR DESCRIPTION
Fix preprocessor types:
- Allow `Preprocessor` to return void
- Make `MarkupPreprocessor` `filename` arg optional (always has been optional)

Refactor `src/compiler/preprocess/index.ts` too ensuring `filename` is nullable.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
