### PR TITLE
[fix] check parentNode exists before removing child

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -203,7 +203,7 @@ export function insert_hydration(target: NodeEx, node: NodeEx, anchor?: NodeEx) 
 }
 
 export function detach(node: Node) {
-	if (node.parentNode){
+	if (node.parentNode) {
 		node.parentNode.removeChild(node);
 	}
 }

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -203,7 +203,9 @@ export function insert_hydration(target: NodeEx, node: NodeEx, anchor?: NodeEx) 
 }
 
 export function detach(node: Node) {
-	node.parentNode.removeChild(node);
+	if (node.parentNode){
+		node.parentNode.removeChild(node);
+	}
 }
 
 export function destroy_each(iterations, detaching) {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`


Fixes #6037 

As mentioned here: https://github.com/sveltejs/svelte/issues/6037#issuecomment-928093190
This bug was fixed in prior versions (https://github.com/sveltejs/svelte/issues/2086#issuecomment-490989491) but brought back when it was caught in a revert (https://github.com/sveltejs/svelte/commit/6d16e9260642b1fcc70fa4a24be9fd49985112d1).

I encountered this bug when trying to write a wrapper over Maplibre-GL, where as a part of the components lifecycle, slots would get cleaned up by the library before svelte unmounted the component, thus throwing this error.
