### PR TITLE
[fix] Add URLSearchParams to list of globals

### DIFF
--- a/src/compiler/utils/names.ts
+++ b/src/compiler/utils/names.ts
@@ -60,6 +60,7 @@ export const globals = new Set([
 	'undefined',
 	'URIError',
 	'URL',
+	'URLSearchParams',
 	'window'
 ]);
 


### PR DESCRIPTION
[`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams): it's a real thing!

I couldn't get the tests running locally, so I didn't go looking for a test to change to motivate this, but I saw that the last addition to the list didn't come with a test either, so I decided I was fine with it.