### PR TITLE
[fix] hydrate correct elements when using `@html`

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -501,7 +501,7 @@ export function claim_html_tag(nodes) {
 	}
 
 	init_claim_info(nodes);
-	const html_tag_nodes = nodes.splice(start_index, end_index + 1);
+	const html_tag_nodes = nodes.splice(start_index, end_index - start_index + 1);
 	detach(html_tag_nodes[0]);
 	detach(html_tag_nodes[html_tag_nodes.length - 1]);
 	const claimed_nodes = html_tag_nodes.slice(1, html_tag_nodes.length - 1);

--- a/test/hydration/samples/raw-with-empty-line-at-top/_after.html
+++ b/test/hydration/samples/raw-with-empty-line-at-top/_after.html
@@ -1,0 +1,6 @@
+
+<div>before</div>
+<br>
+
+<!-- HTML_TAG_START -->a <!-- HTML_TAG_END --><!-- HTML_TAG_START -->b <!-- HTML_TAG_END --><!-- HTML_TAG_START -->c <!-- HTML_TAG_END -->
+<div>after</div>

--- a/test/hydration/samples/raw-with-empty-line-at-top/_before.html
+++ b/test/hydration/samples/raw-with-empty-line-at-top/_before.html
@@ -1,0 +1,6 @@
+
+<div>before</div>
+<br>
+
+<!-- HTML_TAG_START -->a <!-- HTML_TAG_END --><!-- HTML_TAG_START -->b <!-- HTML_TAG_END --><!-- HTML_TAG_START -->c <!-- HTML_TAG_END -->
+<div>after</div>

--- a/test/hydration/samples/raw-with-empty-line-at-top/main.svelte
+++ b/test/hydration/samples/raw-with-empty-line-at-top/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	let content = ["a ", "b ", "c "];
+</script>
+
+<div>before</div>
+<br>
+
+{#each content as c}
+    {@html c}
+{/each}
+<div>after</div>


### PR DESCRIPTION
fixes https://github.com/sveltejs/svelte/issues/7115

After executing this line from Kit, `nodes` contains (maybe unexpected) `#text` node at the top and end.
https://github.com/sveltejs/svelte/blob/03ef0e46e9bf86ca2fe3800b9accef19070fea44/src/runtime/internal/Component.ts#L161

In this case, `start_index` is more than 0 (mostly 1).
And the second argument of `splice` is delete_count.
Therefore it will splice more than expected.
https://github.com/sveltejs/svelte/blob/03ef0e46e9bf86ca2fe3800b9accef19070fea44/src/runtime/internal/dom.ts#L504

If `start_index` is possibly more than 0, I think it should be modified to look like this PR.

On the other hand, should we prevent containing unexpected `#text` nodes at the top and end?
I think we can not control it because a template file containing `%svelte.body%` can be freely created by a user.

---

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
