### PR TITLE
[fix] parent_component is undefined

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -38,7 +38,7 @@ interface T$$ {
 	on_destroy: any[];
 	skip_bound: boolean;
 	on_disconnect: any[];
-	root:Element | ShadowRoot
+	root: Element | ShadowRoot
 }
 
 export function bind(component, name, callback) {
@@ -130,7 +130,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 		callbacks: blank_object(),
 		dirty,
 		skip_bound: false,
-		root: options.target || parent_component.$$.root
+		root: options.target || parent_component?.$$.root
 	};
 
 	append_styles && append_styles($$.root);


### PR DESCRIPTION
This bug was introduced in https://github.com/sveltejs/svelte/pull/5870
When a svelte file is imported into another svelte file that has been compiled into js, the parent_component will be undefined