### PR TITLE
[fix] Incorrect link for Svelte Society community-maintained tools in docs

### DIFF
--- a/site/content/docs/04-compile-time.md
+++ b/site/content/docs/04-compile-time.md
@@ -6,7 +6,7 @@ Typically, you won't interact with the Svelte compiler directly, but will instea
 
 * [rollup-plugin-svelte](https://github.com/sveltejs/rollup-plugin-svelte) for users of [Rollup](https://rollupjs.org)
 * [svelte-loader](https://github.com/sveltejs/svelte-loader) for users of [webpack](https://webpack.js.org)
-* or one of the [community-maintained plugins](https://sveltesociety.dev/tooling)
+* or one of the [community-maintained plugins](https://sveltesociety.dev/tools)
 
 Nonetheless, it's useful to understand how to use the compiler, since bundler plugins generally expose compiler options to you.
 


### PR DESCRIPTION
https://sveltesociety.dev/tooling was incorrect. https://sveltesociety.dev/tools is the correct link.
