### PR TITLE
[fix] Update utils.ts

### DIFF
--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -89,7 +89,7 @@ export function create_slot(definition, ctx, $$scope, fn) {
 	}
 }
 
-function get_slot_context(definition, ctx, $$scope, fn) {
+export function get_slot_context(definition, ctx, $$scope, fn) {
 	return definition[1] && fn
 		? assign($$scope.ctx.slice(), definition[1](fn(ctx)))
 		: $$scope.ctx;


### PR DESCRIPTION
Some libraries such as https://github.com/hperrin/svelte-material-ui depend on the "get_slot_context" being exported, but it was not any more, having them break on build.