### PR TITLE
[chore] Increase workflow timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   Tests:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [8, 10, 12, 14, 16]


### PR DESCRIPTION
I've noticed that CI tests will hit the 15 minute timeout and fail. Perhaps we just need to increase the timeout?

<img width="750" alt="Screen Shot 2021-12-02 at 10 58 16 AM" src="https://user-images.githubusercontent.com/688617/144457819-064d3fba-b4e2-425c-a5e6-e86bd5840669.png">

