### PR TITLE
[chore] better organize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,13 +24,6 @@ _actual*.*
 _output
 /types
 
-/site/.svelte-kit/
-/site/build/
-/site/.env
-/site/static/svelte-app.json
-/site/static/contributors.jpg
-/site/static/donors.jpg
-/site/static/workers/
-/site/scripts/svelte-app/
-/site/src/routes/_contributors.js
-/site/src/routes/_donors.js
+.svelte-kit/
+build/
+.env

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,7 @@
+/static/svelte-app.json
+/static/contributors.jpg
+/static/donors.jpg
+/static/workers/
+/scripts/svelte-app/
+/src/routes/_contributors.js
+/src/routes/_donors.js


### PR DESCRIPTION
Move common stuff into base project. `svelte.dev` stuff will be in sub-project. See also https://github.com/sveltejs/sites/pull/77 and review together

This will make it so that when I copy over the site to the new repo the correct things are ignored