### PR TITLE
[fix] runtime: destroy missing fragment

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -203,7 +203,7 @@ export function insert_hydration(target: NodeEx, node: NodeEx, anchor?: NodeEx) 
 }
 
 export function detach(node: Node) {
-	node.parentNode.removeChild(node);
+	node.parentNode?.removeChild(node);
 }
 
 export function destroy_each(iterations, detaching) {

--- a/test/runtime/samples/destroy-missing-fragment/_config.js
+++ b/test/runtime/samples/destroy-missing-fragment/_config.js
@@ -1,0 +1,5 @@
+export default {
+	test({ component }) {
+		component.$destroy();
+	}
+};

--- a/test/runtime/samples/destroy-missing-fragment/main.svelte
+++ b/test/runtime/samples/destroy-missing-fragment/main.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { onMount } from 'svelte';
+    import { onMount } from 'svelte';
     let e;
     onMount(() => {
         e.remove();

--- a/test/runtime/samples/destroy-missing-fragment/main.svelte
+++ b/test/runtime/samples/destroy-missing-fragment/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { onMount } from 'svelte';
+    let e;
+    onMount(() => {
+        e.remove();
+    })
+</script>
+
+<div bind:this={e} />


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`


### Problem

When manually removing a HTML element from a component, it is trying to be accessed later on in the destroy lifecycle where it throws an error.

This PR adds optional chaining before accessing `removeChild` from the `parentNode` property to prevent the error thrown.

I prepared a REPL where this fails => https://svelte.dev/repl/0d826c0d67c54d8693aeaa1b77ea09ef?version=3.44.2