### PR TITLE
[fix] binding member expression should only invalidate the object, not the member property

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -72,7 +72,7 @@ export default class BindingWrapper {
 
 	get_update_dependencies() {
 		const object = get_object(this.node.expression.node).name;
-		const dependencies = new Set();
+		const dependencies = new Set<string>();
 		dependencies.add(object);
 
 

--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -70,6 +70,21 @@ export default class BindingWrapper {
 		return dependencies;
 	}
 
+	get_update_dependencies() {
+		const object = get_object(this.node.expression.node).name;
+		const dependencies = new Set();
+		dependencies.add(object);
+
+
+		const indirect_dependencies = this.parent.renderer.component.indirect_dependencies.get(object);
+		if (indirect_dependencies) {
+			indirect_dependencies.forEach(indirect_dependency => {
+				dependencies.add(indirect_dependency);
+			});
+		}
+		return dependencies;
+	}
+
 	is_readonly_media_attribute() {
 		return this.node.is_readonly_media_attribute();
 	}

--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -71,18 +71,27 @@ export default class BindingWrapper {
 	}
 
 	get_update_dependencies() {
-		const object = get_object(this.node.expression.node).name;
+		const object = this.object;
 		const dependencies = new Set<string>();
-		dependencies.add(object);
-
-
-		const indirect_dependencies = this.parent.renderer.component.indirect_dependencies.get(object);
-		if (indirect_dependencies) {
-			indirect_dependencies.forEach(indirect_dependency => {
-				dependencies.add(indirect_dependency);
-			});
+		if (this.node.expression.template_scope.names.has(object)) {
+			this.node.expression.template_scope.dependencies_for_name
+				.get(object)
+				.forEach((name) => dependencies.add(name));
+		} else {
+			dependencies.add(object);
 		}
-		return dependencies;
+
+		const result = new Set(dependencies);
+		dependencies.forEach((dependency) => {
+			const indirect_dependencies = this.parent.renderer.component.indirect_dependencies.get(dependency);
+			if (indirect_dependencies) {
+				indirect_dependencies.forEach(indirect_dependency => {
+					result.add(indirect_dependency);
+				});
+			}
+		});
+
+		return result;
 	}
 
 	is_readonly_media_attribute() {

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -466,7 +466,7 @@ export default class ElementWrapper extends Wrapper {
 
 		binding_group.bindings.forEach(binding => {
 			// TODO this is a mess
-			add_to_set(dependencies, binding.get_dependencies());
+			add_to_set(dependencies, binding.get_update_dependencies());
 			add_to_set(contextual_dependencies, binding.handler.contextual_dependencies);
 
 			binding.render(block, lock);

--- a/src/compiler/compile/render_dom/wrappers/shared/bind_this.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/bind_this.ts
@@ -12,7 +12,7 @@ export default function bind_this(component: Component, block: Block, binding: B
 	const callee = block.renderer.reference(fn.name);
 
 	const { contextual_dependencies, mutation } = binding.handler;
-	const dependencies = binding.get_dependencies();
+	const dependencies = binding.get_update_dependencies();
 
 	const body = b`
 		${mutation}

--- a/test/runtime/samples/binding-input-member-expression-update/_config.js
+++ b/test/runtime/samples/binding-input-member-expression-update/_config.js
@@ -1,0 +1,18 @@
+// binding member expression shouldn't invalidate the property name
+export default {
+	async test({ assert, component, target, window }) {
+		const input = target.querySelector('input');
+		assert.deepEqual(component.logs.length, 1);
+		assert.equal(input.value, 'abc');
+
+		input.value = 'hij';
+		await input.dispatchEvent(new window.Event('input'));
+
+		assert.deepEqual(component.values.a, 'hij');
+		assert.deepEqual(component.logs.length, 1);
+		
+		component.paths = ['b'];
+		assert.deepEqual(component.logs.length, 2);
+		assert.equal(input.value, 'def');		
+	}
+};

--- a/test/runtime/samples/binding-input-member-expression-update/main.svelte
+++ b/test/runtime/samples/binding-input-member-expression-update/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	export let values = { a: "abc", b: "def" };
+	export let paths = ["a"];
+	export let logs = [];
+
+	$: paths && logs.push("paths updated");
+</script>
+
+<input bind:value={values[paths[0]]} />

--- a/test/runtime/samples/binding-input-member-expression-update/main.svelte
+++ b/test/runtime/samples/binding-input-member-expression-update/main.svelte
@@ -1,9 +1,9 @@
 <script>
-	export let values = { a: "abc", b: "def" };
-	export let paths = ["a"];
+	export let values = { a: 'abc', b: 'def' };
+	export let paths = ['a'];
 	export let logs = [];
 
-	$: paths && logs.push("paths updated");
+	$: paths && logs.push('paths updated');
 </script>
 
 <input bind:value={values[paths[0]]} />

--- a/test/runtime/samples/binding-this-each-key/_config.js
+++ b/test/runtime/samples/binding-this-each-key/_config.js
@@ -1,0 +1,10 @@
+export default {
+	html: '<div>content</div><div>content</div><div>content</div>',
+
+	test({ assert, target, component }) {
+		const divs = target.querySelectorAll('div');
+		assert.equal(component.refs[0], divs[0]);
+		assert.equal(component.refs[1], divs[1]);
+		assert.equal(component.refs[2], divs[2]);
+	}
+};

--- a/test/runtime/samples/binding-this-each-key/main.svelte
+++ b/test/runtime/samples/binding-this-each-key/main.svelte
@@ -3,6 +3,8 @@
 
 	export let refs = [];
 
+	// note that this is NOT data.slice().reverse()
+	// as that wouldn't have triggered an infinite loop
 	$: list = data.reverse();
 </script>
 

--- a/test/runtime/samples/binding-this-each-key/main.svelte
+++ b/test/runtime/samples/binding-this-each-key/main.svelte
@@ -1,13 +1,13 @@
 <script>
-  export let data = [ { id: "1" }, { id: "2" }, { id: "3" } ];
-	
-  export let refs = [];
+	export let data = [ { id: '1' }, { id: '2' }, { id: '3' } ];
 
-  $: list = data.reverse()
+	export let refs = [];
+
+	$: list = data.reverse();
 </script>
 
 {#each list as { id }, index (id)}
-  <div bind:this={refs[index]}>
-    content
-  </div>
+	<div bind:this={refs[index]}>
+		content
+	</div>
 {/each}

--- a/test/runtime/samples/binding-this-each-key/main.svelte
+++ b/test/runtime/samples/binding-this-each-key/main.svelte
@@ -1,0 +1,13 @@
+<script>
+  export let data = [ { id: "1" }, { id: "2" }, { id: "3" } ];
+	
+  export let refs = [];
+
+  $: list = data.reverse()
+</script>
+
+{#each list as { id }, index (id)}
+  <div bind:this={refs[index]}>
+    content
+  </div>
+{/each}

--- a/test/runtime/samples/binding-this-member-expression-update/_config.js
+++ b/test/runtime/samples/binding-this-member-expression-update/_config.js
@@ -1,0 +1,8 @@
+// binding member expression shouldn't invalidate the property name
+export default {
+	test({ assert, component, target }) {
+		const div = target.querySelector('div');
+		assert.equal(div, component.container.a);
+		assert.deepEqual(component.logs.length, 1);
+	}
+};

--- a/test/runtime/samples/binding-this-member-expression-update/main.svelte
+++ b/test/runtime/samples/binding-this-member-expression-update/main.svelte
@@ -1,9 +1,9 @@
 <script>
 	export let container = {};
-	export let paths = ["a"];
+	export let paths = ['a'];
 	export let logs = [];
 
-	$: paths && logs.push("paths updated");
+	$: paths && logs.push('paths updated');
 </script>
 
 <div bind:this={container[paths[0]]} />

--- a/test/runtime/samples/binding-this-member-expression-update/main.svelte
+++ b/test/runtime/samples/binding-this-member-expression-update/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	export let container = {};
+	export let paths = ["a"];
+	export let logs = [];
+
+	$: paths && logs.push("paths updated");
+</script>
+
+<div bind:this={container[paths[0]]} />


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/6921

Previously when binding a member expression `a[b][c]`, Svelte will invalidate all `a`, `b`, `c` whenever the bound value changes.

with the fix, Svelte will only invalidate `a`.

### Before submitting the PR, please make sure you do the following
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
