### PR TITLE
fix: more predictable spring behaviour

### DIFF
--- a/src/runtime/motion/spring.ts
+++ b/src/runtime/motion/spring.ts
@@ -115,7 +115,7 @@ export function spring<T=any>(value?: T, opts: SpringOpts = {}): Spring<T> {
 				inv_mass = Math.min(inv_mass + inv_mass_recovery_rate, 1);
 
 				last_time = Math.max(last_time, now - tick * limit);
-				while ( last_time < now ) {
+				while (last_time < now) {
 					const elapsed = Math.min(tick, now - last_time);
 					last_time += elapsed;
 


### PR DESCRIPTION
Fix for bug described here: https://github.com/sveltejs/svelte/issues/7010

The proposed solution is that 'tick' should be added to the spring options. If the elapsed frame time is greater than this, then multiple tick calculations are carried out instead of the usual 1.

To prevent the number of rounds of calculations in a frame from increasing high enough to cause high cpu load (principally from when the user switches tab during a spring animation), it is proposed that there should be a configurable 'limit', which sets a limit on the number of ticks calculated per frame.

As this issue effects all springs, and is unlikely to cause issues with any existing usage, I think it may be appropriate for this to be the standard behaviour with sensible defaults.

I don't know if the proposed variable names are appropriate (it is hard to reduce a complex idea to a simple memorable term without losing some nuance.)

I haven't indented the existing code that should be indented to be in a loop, in order to make the changes clear. I've also not attempted to write any tests until I know that it would be worthwhile. This is my first attempt at submitting a pull request, so please let me know if I'm going about this at all wrong.