### PR TITLE
[chore] configure Dependabot to update GitHub Actions dependencies daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
Hello,

I've noticed that the version of `actions/checkout` being used in CI is a bit dated(running: `v1`, latest: `v2.4.0`) and thought about opening a simple `[chore]` PR to update just that, but first wanted to see if the maintainers are open to adding a Dependabot to handle dependency updates for `github-actions` packages.

This change adds the Dependabot for `github-actions` dependencies and will run daily (weekdays) to check for updates.

Here's an example(on my fork) of what would initially be updated: https://github.com/jmherbst/svelte/pull/3

Re: #1 down below -- I couldn't find any previous Issues or PRs related to dependabot+github-actions (only for npm stuff, and security fixes).  


### Before submitting the PR, please make sure you do the following

1. [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
2. [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
