### PR TITLE
[docs] Use symbols instead of empty object literals for context keys in tutorial

### DIFF
--- a/site/content/tutorial/15-context/01-context-api/app-a/mapbox.js
+++ b/site/content/tutorial/15-context/01-context-api/app-a/mapbox.js
@@ -3,6 +3,6 @@ import mapbox from 'mapbox-gl';
 // https://docs.mapbox.com/help/glossary/access-token/
 mapbox.accessToken = MAPBOX_ACCESS_TOKEN;
 
-const key = {};
+const key = Symbol();
 
 export { mapbox, key };

--- a/site/content/tutorial/15-context/01-context-api/app-b/mapbox.js
+++ b/site/content/tutorial/15-context/01-context-api/app-b/mapbox.js
@@ -3,6 +3,6 @@ import mapbox from 'mapbox-gl';
 // https://docs.mapbox.com/help/glossary/access-token/
 mapbox.accessToken = MAPBOX_ACCESS_TOKEN;
 
-const key = {};
+const key = Symbol();
 
 export { mapbox, key };

--- a/site/content/tutorial/15-context/01-context-api/text.md
+++ b/site/content/tutorial/15-context/01-context-api/text.md
@@ -40,10 +40,10 @@ The markers can now add themselves to the map.
 In `mapbox.js` you'll see this line:
 
 ```js
-const key = {};
+const key = Symbol();
 ```
 
-We can use anything as a key — we could do `setContext('mapbox', ...)` for example. The downside of using a string is that different component libraries might accidentally use the same one; using an object literal means the keys are guaranteed not to conflict in any circumstance (since an object only has referential equality to itself, i.e. `{} !== {}` whereas `"x" === "x"`), even when you have multiple different contexts operating across many component layers.
+Technically, we can use any value as a key — we could do `setContext('mapbox', ...)` for example. The downside of using a string is that different component libraries might accidentally use the same one; using [symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol), on the other hand, means that the keys are guaranteed not to conflict in any circumstance, even when you have multiple different contexts operating across many component layers, since a symbol is essentially a unique identifier.
 
 ## Contexts vs. stores
 


### PR DESCRIPTION
Closes #6870
In the section "[Context API](https://svelte.dev/tutorial/context-api)" of the official tutorial, it's recommended to use empty object literals as context keys since they are guaranteed to be unique, which will prevent any conflict that could otherwise occur if different components use the same string value, for example, as context key.
However, as was explained in the linked issue above, [JavaScript symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) are a more semantically correct construct to use in this case, as cases like this are exactly what symbols are for.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
