### PR TITLE
[fix] Relative URL for svelte-logo-mask.svg doesn't work

### DIFF
--- a/site/content/examples/05-bindings/11-bind-this/App.svelte
+++ b/site/content/examples/05-bindings/11-bind-this/App.svelte
@@ -49,7 +49,7 @@
 		width: 100%;
 		height: 100%;
 		background-color: #666;
-		-webkit-mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
-		mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
+		-webkit-mask: url(/svelte-logo-mask.svg) 50% 50% no-repeat;
+		mask: url(/svelte-logo-mask.svg) 50% 50% no-repeat;
 	}
 </style>

--- a/site/content/tutorial/06-bindings/12-bind-this/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/12-bind-this/app-a/App.svelte
@@ -46,7 +46,7 @@
 		width: 100%;
 		height: 100%;
 		background-color: #666;
-		-webkit-mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
-		mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
+		-webkit-mask: url(/svelte-logo-mask.svg) 50% 50% no-repeat;
+		mask: url(/svelte-logo-mask.svg) 50% 50% no-repeat;
 	}
 </style>

--- a/site/content/tutorial/06-bindings/12-bind-this/app-b/App.svelte
+++ b/site/content/tutorial/06-bindings/12-bind-this/app-b/App.svelte
@@ -47,7 +47,7 @@
 		width: 100%;
 		height: 100%;
 		background-color: #666;
-		-webkit-mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
-		mask: url(svelte-logo-mask.svg) 50% 50% no-repeat;
+		-webkit-mask: url(/svelte-logo-mask.svg) 50% 50% no-repeat;
+		mask: url(/svelte-logo-mask.svg) 50% 50% no-repeat;
 	}
 </style>


### PR DESCRIPTION
`https://svelte.dev/svelte-logo-mask.svg` is available, but `https://svelte.dev/tutorial/svelte-logo-mask.svg` results in a 500 error.

This resulted in a white page instead of showing the colored Svelte logo.