### PR TITLE
[docs] Updated link to the ease visualizer in the docs

### DIFF
--- a/site/content/blog/2021-03-01-whats-new-in-svelte-march-2021.md
+++ b/site/content/blog/2021-03-01-whats-new-in-svelte-march-2021.md
@@ -10,7 +10,7 @@ Lots to cover this month with releases from across the Svelte ecosystem. Most im
 Let's dive into the news 🐬
 
 ## What's new in `sveltejs/svelte`
-* SSR store handling has been reworked to subscribe and unsubscribe as in DOM mode. SSR stores should work much more consistently now (**3.31.2**, see [custom stores](https://svelte.dev/examples#custom-stores) and [Server-side component API ](https://svelte.dev/docs#run-time-server-side-component-api))
+* SSR store handling has been reworked to subscribe and unsubscribe as in DOM mode. SSR stores should work much more consistently now (**3.31.2**, see [custom stores](https://svelte.dev/examples/custom-stores) and [Server-side component API ](https://svelte.dev/docs#run-time-server-side-component-api))
 * Multiple instances of the same action are now allowed on an element (**3.32.0**, [example](https://svelte.dev/repl/01a14375951749dab9579cb6860eccde?version=3.32.0))
 * The new `foreign` namespace should make it easier for alternative compile targets (like Svelte Native and SvelteGUI) by disabling certain HTML5-specific behaviour and checks (**3.32.0**, [more info](https://github.com/sveltejs/svelte/pull/5652))
 * Support for inline comment sourcemaps in code from preprocessors (**3.32.0**)

--- a/site/content/docs/03-run-time.md
+++ b/site/content/docs/03-run-time.md
@@ -879,7 +879,7 @@ You can see a full example on the [animations tutorial](/tutorial/animate)
 
 Easing functions specify the rate of change over time and are useful when working with Svelte's built-in transitions and animations as well as the tweened and spring utilities. `svelte/easing` contains 31 named exports, a `linear` ease and 3 variants of 10 different easing functions: `in`, `out` and `inOut`.
 
-You can explore the various eases using the [ease visualiser](/examples#easing) in the [examples section](/examples).
+You can explore the various eases using the [ease visualiser](/examples/easing) in the [examples section](/examples).
 
 
 | ease | in | out | inOut |


### PR DESCRIPTION
The docs had a broken link, pointing to `/examples#easing` instead of `/examples/easing`.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
