### PR TITLE
[docs] Fixed typo in Context API Tutorial

### DIFF
--- a/site/content/tutorial/15-context/01-context-api/text.md
+++ b/site/content/tutorial/15-context/01-context-api/text.md
@@ -11,7 +11,7 @@ There are two halves to the context API — `setContext` and `getContext`. If a 
 Let's set the context first. In `Map.svelte`, import `setContext` from `svelte` and `key` from `mapbox.js` and call `setContext`:
 
 ```js
-import { onMount, setContext } from 'svelte';
+import { onDestroy, setContext } from 'svelte';
 import { mapbox, key } from './mapbox.js';
 
 setContext(key, {


### PR DESCRIPTION
The [Context API](https://svelte.dev/tutorial/context-api) Tutorial gives instructions to import a couple of dependencies in `Map.svelte`. The example code has `onMount` as one of the existing dependencies of `Map.svelte`, however, the actual code is importing `onDestroy` instead of `onMount` (see screenshot below). This PR fixes the inconsistency.

![CleanShot 2021-12-27 at 12 33 36@2x](https://user-images.githubusercontent.com/44473/147505625-2f6496ad-64a6-4fc1-950a-903fcf637b57.png)


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
