### PR TITLE
[docs] explain initial value for bind scroll

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1608,6 +1608,7 @@ All except `scrollX` and `scrollY` are readonly.
 <svelte:window bind:scrollY={y}/>
 ```
 
+> Note that only subsequent changes to the bound variable of `scrollX` and `scrollY` will be scrolled automatically. To scroll initially, use `scrollTo()` in `onMount()`.
 
 ### `<svelte:body>`
 

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1608,7 +1608,7 @@ All except `scrollX` and `scrollY` are readonly.
 <svelte:window bind:scrollY={y}/>
 ```
 
-> Note that only subsequent changes to the bound variable of `scrollX` and `scrollY` will cause scrolling automatically. The initial value will not cause scrolling as it brings accessibility issues. However if the scrolling behaviour is desired, call `scrollTo()` in `onMount()` instead.
+> Note that the page will not be scrolled to the initial value to avoid accessibility issues. Only subsequent changes to the bound variable of `scrollX` and `scrollY` will cause scrolling. However, if the scrolling behaviour is desired, call `scrollTo()` in `onMount()`.
 
 ### `<svelte:body>`
 

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1608,7 +1608,7 @@ All except `scrollX` and `scrollY` are readonly.
 <svelte:window bind:scrollY={y}/>
 ```
 
-> Note that only subsequent changes to the bound variable of `scrollX` and `scrollY` will be scrolled automatically. To scroll initially, use `scrollTo()` in `onMount()`.
+> Note that only subsequent changes to the bound variable of `scrollX` and `scrollY` will cause scrolling automatically. The initial value will not cause scrolling as it brings accessibility issues. However if the scrolling behaviour is desired, call `scrollTo()` in `onMount()` instead.
 
 ### `<svelte:body>`
 


### PR DESCRIPTION
Closes #2724

The initial value of `bind:scrollX={x}` (and `scrollY`) will not be automatically scrolled on initial bound, which makes sense as to not interfere with potential router behaviour. Fixing it might also cause a breaking change. Note this in the docs instead.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
