### PR TITLE
[fix] ensure truthy non-boolean attributes are rendered correctly in SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Fix non-boolean attribute rendering in SSR to render truthy values as is, making it consistent with DOM rendering.
+* Fix non-boolean attribute rendering in SSR to render truthy values as is, making it consistent with DOM rendering. ([#6121](https://github.com/sveltejs/svelte/issues/6121))
 
 ## 3.44.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Svelte changelog
 
+## unreleased
+
+* Fix non-boolean attribute rendering in SSR to render truthy values as is, making it consistent with DOM rendering.
+
 ## 3.44.3
 
 * Fix `bind:this` binding inside `onMount` for manually instantiated component ([#6760](https://github.com/sveltejs/svelte/issues/6760))

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -141,7 +141,7 @@ export function create_ssr_component(fn) {
 
 export function add_attribute(name, value, boolean) {
 	if (value == null || (boolean && !value)) return '';
-	return ` ${name}${value === true ? '' : `=${typeof value === 'string' ? JSON.stringify(escape(value)) : `"${value}"`}`}`;
+	return ` ${name}${value === true && boolean_attributes.has(name) ? '' : `=${typeof value === 'string' ? JSON.stringify(escape(value)) : `"${value}"`}`}`;
 }
 
 export function add_classes(classes) {

--- a/test/runtime/samples/attribute-boolean-true/_config.js
+++ b/test/runtime/samples/attribute-boolean-true/_config.js
@@ -1,8 +1,8 @@
 export default {
 	html: '<textarea readonly data-attr="true"></textarea>',
 	test({ assert, target }) {
-		const textarea = target.querySelector("textarea");
-		assert.equal(textarea.dataset.attr, "true");
+		const textarea = target.querySelector('textarea');
+		assert.equal(textarea.dataset.attr, 'true');
 		assert.ok(textarea.readOnly);
-	},
+	}
 };

--- a/test/runtime/samples/attribute-boolean-true/_config.js
+++ b/test/runtime/samples/attribute-boolean-true/_config.js
@@ -1,7 +1,8 @@
 export default {
-	html: '<textarea readonly></textarea>',
+	html: '<textarea readonly data-attr="true"></textarea>',
 	test({ assert, target }) {
-		const textarea = target.querySelector('textarea');
+		const textarea = target.querySelector("textarea");
+		assert.equal(textarea.dataset.attr, "true");
 		assert.ok(textarea.readOnly);
-	}
+	},
 };

--- a/test/runtime/samples/attribute-boolean-true/main.svelte
+++ b/test/runtime/samples/attribute-boolean-true/main.svelte
@@ -1,1 +1,1 @@
-<textarea readonly="{true}"></textarea>
+<textarea readonly={true} data-attr={true} />


### PR DESCRIPTION
Fixes #6121.

Added an additional test for this case using the example in #6121.