### PR TITLE
fix: correct parent component link for web components

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -104,8 +104,24 @@ function make_dirty(component, i) {
 	component.$$.dirty[(i / 31) | 0] |= (1 << (i % 31));
 }
 
-export function init(component, options, instance, create_fragment, not_equal, props, append_styles, dirty = [-1]) {
-	const parent_component = current_component;
+function is_svelte_element(component) {
+  while (component) {
+    if (component.constructor === SvelteElement)
+      return true;
+    component = Object.getPrototypeOf(component);
+  }
+  return false;
+}
+
+function find_containing_component(component) {
+  while (component && !is_svelte_element(component)) {
+    component = component.parentNode;
+  }
+  return component;
+}
+
+function init(component, options, instance, create_fragment, not_equal, props, append_styles, dirty = [-1]) {
+  const parent_component = options.customElement ? find_containing_component(component.parentNode) : current_component;
 	set_current_component(component);
 
 	const $$: T$$ = component.$$ = {

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -120,7 +120,7 @@ function find_containing_component(component) {
   return component;
 }
 
-function init(component, options, instance, create_fragment, not_equal, props, append_styles, dirty = [-1]) {
+export function init(component, options, instance, create_fragment, not_equal, props, append_styles, dirty = [-1]) {
   const parent_component = options.customElement ? find_containing_component(component.parentNode) : current_component;
 	set_current_component(component);
 


### PR DESCRIPTION
This is a proof of concept for fixing the parent component link for nested web components, e.g. when using 
```
   <my-parent-component>
      <my-child-component></my-child-component>
  </my-parent-component
```
we want the child to have a parent component link set appropriately, so that e.g. the context API (see #3422)  works correctly. The test itself is a bit rough and likely can be optimized by checking for the $$ property first, but I'd like to get idea out first.