### PR TITLE
store subscribers shouldn't get the initial undefined value

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -65,8 +65,11 @@ export function writable<T>(value?: T, start: StartStopNotifier<T> = noop): Writ
 	let stop: Unsubscriber;
 	const subscribers: Set<SubscribeInvalidateTuple<T>> = new Set();
 
+	let runOnSubscribe = value !== undefined;
+
 	function set(new_value: T): void {
 		if (safe_not_equal(value, new_value)) {
+			runOnSubscribe = true;
 			value = new_value;
 			if (stop) { // store is ready
 				const run_queue = !subscriber_queue.length;
@@ -94,7 +97,7 @@ export function writable<T>(value?: T, start: StartStopNotifier<T> = noop): Writ
 		if (subscribers.size === 1) {
 			stop = start(set) || noop;
 		}
-		run(value);
+		if (runOnSubscribe) run(value);
 
 		return () => {
 			subscribers.delete(subscriber);

--- a/test/store/index.ts
+++ b/test/store/index.ts
@@ -22,7 +22,7 @@ describe('store', () => {
 			assert.deepEqual(values, [0, 1, 2]);
 		});
 
-		it('creates an undefined writable store', () => {
+		it('creates an empty writable store', () => {
 			const store = writable();
 			const values = [];
 
@@ -32,8 +32,22 @@ describe('store', () => {
 
 			unsubscribe();
 
-			assert.deepEqual(values, [undefined]);
+			assert.deepEqual(values, []);
 		});
+
+		it('creates a null writable store', () => {
+			const store = writable(null);
+			const values = [];
+
+			const unsubscribe = store.subscribe(value => {
+				values.push(value);
+			});
+
+			unsubscribe();
+
+			assert.deepEqual(values, [null]);
+		});
+
 
 		it('calls provided subscribe handler', () => {
 			let called = 0;
@@ -128,7 +142,7 @@ describe('store', () => {
 			assert.deepEqual(values, [0, 1, 2]);
 		});
 
-		it('creates an undefined readable store', () => {
+		it('creates an empty readable store', () => {
 			const store = readable();
 			const values = [];
 
@@ -138,7 +152,7 @@ describe('store', () => {
 
 			unsubscribe();
 
-			assert.deepEqual(values, [undefined]);
+			assert.deepEqual(values, []);
 		});
 
 		it('creates a readable store without updater', () => {


### PR DESCRIPTION
before this, an empty, uninitialized store would emit an `undefined`
value, even before any value is set. this is quite unexpected and not
the same behaviour as rxjs (for example).

you can still explicitly create a store with undefined with
`writeable(undefined)` or `readable(undefined)`

Previously:
```
> var store = require('./store');
> var w = store.writable();
> w.subscribe(v=>console.log('v:', v));
v: undefined
```

After this commit:
```
> var store = require('./store');
> var w = store.writable();
> w.subscribe(v=>console.log('v:', v));
> w.set('test');
v: test
```

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
