### PR TITLE
[chore] fix test flakiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
   },
   "types": "types/runtime/index.d.ts",
   "scripts": {
-    "test": "mocha",
-    "test:unit": "mocha --require sucrase/register --recursive src/**/__test__.ts",
+    "test": "mocha --exit",
+    "test:unit": "mocha --require sucrase/register --recursive src/**/__test__.ts --exit",
     "quicktest": "mocha",
     "precoverage": "c8 mocha",
     "coverage": "c8 report --reporter=text-lcov > coverage.lcov && c8 report --reporter=html",

--- a/test/custom-elements/index.ts
+++ b/test/custom-elements/index.ts
@@ -16,7 +16,7 @@ const page = `
 
 const assert = fs.readFileSync(`${__dirname}/assert.js`, 'utf-8');
 
-describe('custom-elements', function () {
+describe('custom-elements', function() {
 	// Note: Increase the timeout in preparation for restarting Chromium due to SIGSEGV.
 	this.timeout(10000);
 	let svelte;

--- a/test/custom-elements/index.ts
+++ b/test/custom-elements/index.ts
@@ -124,7 +124,7 @@ describe('custom-elements', function () {
 				}
 			}
 
-			// NOTE: Chromium may exit due to SIGSEGV, so retry in that case.
+			// NOTE: Chromium may exit with SIGSEGV, so retry in that case
 			let count = 0;
 			do {
 				count++;

--- a/test/custom-elements/index.ts
+++ b/test/custom-elements/index.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import { rollup } from 'rollup';
 import virtual from '@rollup/plugin-virtual';
 import puppeteer from 'puppeteer';
-import { addLineNumbers, loadConfig, loadSvelte } from '../helpers';
+import { addLineNumbers, loadConfig, loadSvelte, getNewPage } from '../helpers';
 import { deepEqual } from 'assert';
 
 const page = `
@@ -16,9 +16,8 @@ const page = `
 
 const assert = fs.readFileSync(`${__dirname}/assert.js`, 'utf-8');
 
-describe('custom-elements', function() {
+describe('custom-elements', function () {
 	this.timeout(10000);
-
 	let svelte;
 	let server;
 	let browser;
@@ -44,12 +43,16 @@ describe('custom-elements', function() {
 		});
 	}
 
+	async function launchPuppeteer() {
+		return await puppeteer.launch();
+	}
+
 	before(async () => {
 		svelte = loadSvelte();
 		console.log('[custom-element] Loaded Svelte');
 		server = await create_server();
 		console.log('[custom-element] Started server');
-		browser = await puppeteer.launch();
+		browser = await launchPuppeteer();
 		console.log('[custom-element] Launched puppeteer browser');
 	});
 
@@ -108,26 +111,7 @@ describe('custom-elements', function() {
 			const result = await bundle.generate({ format: 'iife', name: 'test' });
 			code = result.output[0].code;
 
-			const page = await browser.newPage();
-
-			page.on('console', (type) => {
-				console[type._type](type._text);
-			});
-
-			page.on('error', error => {
-				console.log('>>> an error happened');
-				console.error(error);
-			});
-
-			try {
-				await page.goto('http://localhost:6789');
-
-				const result = await page.evaluate(() => test(document.querySelector('main')));
-				if (result) console.log(result);
-			} catch (err) {
-				console.log(addLineNumbers(code));
-				throw err;
-			} finally {
+			function assertWarnings() {
 				if (expected_warnings) {
 					deepEqual(warnings.map(w => ({
 						code: w.code,
@@ -138,6 +122,27 @@ describe('custom-elements', function() {
 					})), expected_warnings);
 				}
 			}
+
+			// NOTE: Chromium may exit due to SIGSEGV, so retry in that case.
+			let count = 0;
+			do {
+				count++;
+				try {
+					const page = await getNewPage(browser);
+					await page.goto('http://localhost:6789');
+					const result = await page.evaluate(() => test(document.querySelector('main')));
+					if (result) console.log(result);
+					assertWarnings();
+					break;
+				} catch (err) {
+					if (count === 5 || browser.isConnected()) {
+						console.log(addLineNumbers(code));
+						assertWarnings();
+						throw err;
+					}
+					browser = await launchPuppeteer();
+				}
+			} while (count <= 5);
 		});
 	});
 });

--- a/test/custom-elements/index.ts
+++ b/test/custom-elements/index.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import { rollup } from 'rollup';
 import virtual from '@rollup/plugin-virtual';
 import puppeteer from 'puppeteer';
-import { addLineNumbers, loadConfig, loadSvelte, getNewPage } from '../helpers';
+import { addLineNumbers, loadConfig, loadSvelte, getNewPage, retryAsync } from '../helpers';
 import { deepEqual } from 'assert';
 
 const page = `
@@ -17,6 +17,7 @@ const page = `
 const assert = fs.readFileSync(`${__dirname}/assert.js`, 'utf-8');
 
 describe('custom-elements', function () {
+	// Note: Increase the timeout in preparation for restarting Chromium due to SIGSEGV.
 	this.timeout(10000);
 	let svelte;
 	let server;
@@ -44,7 +45,7 @@ describe('custom-elements', function () {
 	}
 
 	async function launchPuppeteer() {
-		return await puppeteer.launch();
+		return await retryAsync(() => puppeteer.launch());
 	}
 
 	before(async () => {

--- a/test/custom-elements/index.ts
+++ b/test/custom-elements/index.ts
@@ -152,6 +152,8 @@ describe('custom-elements', function () {
 						assertWarnings();
 						throw err;
 					}
+					console.debug(err.stack || err);
+					console.log('RESTARTING Chromium...');
 					browser = await launchPuppeteer();
 				}
 			} while (count <= 5);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -287,7 +287,7 @@ export async function retryAsync<T>(fn: () => Promise<T>, maxAttempts: number = 
 			return await fn();
 		} catch (err) {
 			if (++attempts >= maxAttempts) throw err;
-			new Promise(resolve => setTimeout(resolve, interval));
+			await new Promise(resolve => setTimeout(resolve, interval));
 		}
 	}
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -5,7 +5,6 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as colors from 'kleur';
 export const assert = (assert$1 as unknown) as typeof assert$1 & { htmlEqual: (actual, expected, message?) => void, htmlEqualWithComments: (actual, expected, message?) => void };
-import { Browser, Page } from 'puppeteer';
 
 // for coverage purposes, we need to test source files,
 // but for sanity purposes, we need to test dist files
@@ -279,23 +278,6 @@ export function prettyPrintPuppeteerAssertionError(message) {
 	if (match) {
 		assert.equal(match[1], match[2]);
 	}
-}
-
-export async function getNewPage(browser: Browser): Promise<Page> {
-	const pages = await browser.pages();
-	if (pages.length) return pages[0];
-	const page = await browser.newPage();
-
-	page.on('console', (type) => {
-		console[type._type](type._text);
-	});
-
-	page.on('error', error => {
-		console.log('>>> an error happened');
-		console.error(error);
-	});
-
-	return page;
 }
 
 export async function retryAsync<T>(fn: () => Promise<T>): Promise<T> {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -243,7 +243,7 @@ const original_set_timeout = global.setTimeout;
 export function useFakeTimers() {
 	const callbacks = [];
 
-	global.setTimeout = function (fn) {
+	global.setTimeout = function(fn) {
 		callbacks.push(fn);
 	};
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -280,13 +280,14 @@ export function prettyPrintPuppeteerAssertionError(message) {
 	}
 }
 
-export async function retryAsync<T>(fn: () => Promise<T>, maxAttempts: number = 3): Promise<T> {
+export async function retryAsync<T>(fn: () => Promise<T>, maxAttempts: number = 3, interval: number = 1000): Promise<T> {
 	let attempts = 0;
 	while (attempts <= maxAttempts) {
 		try {
 			return await fn();
 		} catch (err) {
 			if (++attempts >= maxAttempts) throw err;
+			new Promise(resolve => setTimeout(resolve, interval));
 		}
 	}
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -68,7 +68,7 @@ for (const key of Object.getOwnPropertyNames(global)) {
 }
 
 // implement mock scroll
-window.scrollTo = function (pageXOffset, pageYOffset) {
+window.scrollTo = function(pageXOffset, pageYOffset) {
 	window.pageXOffset = pageXOffset;
 	window.pageYOffset = pageYOffset;
 };

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -280,13 +280,13 @@ export function prettyPrintPuppeteerAssertionError(message) {
 	}
 }
 
-export async function retryAsync<T>(fn: () => Promise<T>): Promise<T> {
+export async function retryAsync<T>(fn: () => Promise<T>, maxAttempts: number = 3): Promise<T> {
 	let attempts = 0;
-	while (attempts <= 3) {
+	while (attempts <= maxAttempts) {
 		try {
 			return await fn();
 		} catch (err) {
-			if (++attempts >= 3) throw err;
+			if (++attempts >= maxAttempts) throw err;
 		}
 	}
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -297,3 +297,14 @@ export async function getNewPage(browser: Browser): Promise<Page> {
 
 	return page;
 }
+
+export async function retryAsync<T>(fn: () => Promise<T>): Promise<T> {
+	let attempts = 0;
+	while (attempts <= 3) {
+		try {
+			return await fn();
+		} catch (err) {
+			if (++attempts >= 3) throw err;
+		}
+	}
+}

--- a/test/runtime-puppeteer/index.ts
+++ b/test/runtime-puppeteer/index.ts
@@ -227,7 +227,7 @@ describe('runtime (puppeteer)', function() {
 					throw new Error('Received unexpected warnings');
 				}
 			}
-			// NOTE: Chromium may exit due to SIGSEGV, so retry in that case.
+			// NOTE: Chromium may exit with SIGSEGV, so retry in that case
 			let count = 0;
 			do {
 				count++;

--- a/test/runtime-puppeteer/index.ts
+++ b/test/runtime-puppeteer/index.ts
@@ -10,7 +10,6 @@ import {
 	loadSvelte,
 	mkdirp,
 	prettyPrintPuppeteerAssertionError,
-	getNewPage,
 	retryAsync
 } from '../helpers';
 import { deepEqual } from 'assert';
@@ -233,11 +232,22 @@ describe('runtime (puppeteer)', function () {
 			do {
 				count++;
 				try {
-					const page = await getNewPage(browser);
+					const page = await browser.newPage();
+
+					page.on('console', (type) => {
+						console[type._type](type._text);
+					});
+
+					page.on('error', error => {
+						console.log('>>> an error happened');
+						console.error(error);
+					});
+
 					await page.goto('http://localhost:6789');
 					const result = await page.evaluate(() => test(document.querySelector('main')));
 					if (result) console.log(result);
 					assertWarnings();
+					await page.close();
 					break;
 				} catch (err) {
 					if (count === 5 || browser.isConnected()) {

--- a/test/runtime-puppeteer/index.ts
+++ b/test/runtime-puppeteer/index.ts
@@ -256,6 +256,8 @@ describe('runtime (puppeteer)', function () {
 						assertWarnings();
 						throw err;
 					}
+					console.debug(err.stack || err);
+					console.log('RESTARTING Chromium...');
 					browser = await launchPuppeteer();
 				}
 			} while (count <= 5);

--- a/test/runtime-puppeteer/index.ts
+++ b/test/runtime-puppeteer/index.ts
@@ -55,7 +55,7 @@ async function launchPuppeteer() {
 
 const assert = fs.readFileSync(`${__dirname}/assert.js`, 'utf-8');
 
-describe('runtime (puppeteer)', function () {
+describe('runtime (puppeteer)', function() {
 	// Note: Increase the timeout in preparation for restarting Chromium due to SIGSEGV.
 	this.timeout(10000);
 	before(async () => {

--- a/test/runtime-puppeteer/index.ts
+++ b/test/runtime-puppeteer/index.ts
@@ -10,7 +10,8 @@ import {
 	loadSvelte,
 	mkdirp,
 	prettyPrintPuppeteerAssertionError,
-	getNewPage
+	getNewPage,
+	retryAsync
 } from '../helpers';
 import { deepEqual } from 'assert';
 
@@ -50,12 +51,14 @@ function create_server() {
 }
 
 async function launchPuppeteer() {
-	return await puppeteer.launch();
+	return await retryAsync(() => puppeteer.launch());
 }
 
 const assert = fs.readFileSync(`${__dirname}/assert.js`, 'utf-8');
 
-describe('runtime (puppeteer)', () => {
+describe('runtime (puppeteer)', function () {
+	// Note: Increase the timeout in preparation for restarting Chromium due to SIGSEGV.
+	this.timeout(10000);
 	before(async () => {
 		svelte = loadSvelte(false);
 		console.log('[runtime-puppeteer] Loaded Svelte');

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -203,7 +203,7 @@ describe('runtime', () => {
 					}
 
 					if (config.test) {
-						config.test({
+						return Promise.resolve(config.test({
 							assert,
 							component,
 							mod,
@@ -211,12 +211,13 @@ describe('runtime', () => {
 							window,
 							raf,
 							compileOptions
-						});
-						component.$destroy();
+						})).then(() => {
+							component.$destroy();
 
-						if (unhandled_rejection) {
-							throw unhandled_rejection;
-						}
+							if (unhandled_rejection) {
+								throw unhandled_rejection;
+							}
+						});
 					} else {
 						component.$destroy();
 						assert.htmlEqual(target.innerHTML, '');

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -35,7 +35,7 @@ describe('runtime', () => {
 		svelte = loadSvelte(false);
 		svelte$ = loadSvelte(true);
 
-		require.extensions['.svelte'] = function(module, filename) {
+		require.extensions['.svelte'] = function (module, filename) {
 			const options = Object.assign({
 				filename
 			}, compileOptions);
@@ -65,7 +65,7 @@ describe('runtime', () => {
 		}
 
 		const testName = `${dir} ${hydrate ? `(with hydration${from_ssr_html ? ' from ssr rendered html' : ''})` : ''}`;
-		(config.skip ? it.skip : solo ? it.only : it)(testName, () => {
+		(config.skip ? it.skip : solo ? it.only : it)(testName, (done) => {
 			if (failed.has(dir)) {
 				// this makes debugging easier, by only printing compiled output once
 				throw new Error('skipping test, already failed');
@@ -96,7 +96,7 @@ describe('runtime', () => {
 			glob('**/*.svelte', { cwd }).forEach(file => {
 				if (file[0] === '_') return;
 
-				const dir  = `${cwd}/_output/${hydrate ? 'hydratable' : 'normal'}`;
+				const dir = `${cwd}/_output/${hydrate ? 'hydratable' : 'normal'}`;
 				const out = `${dir}/${file.replace(/\.svelte$/, '.js')}`;
 
 				if (fs.existsSync(out)) {
@@ -120,7 +120,7 @@ describe('runtime', () => {
 				}
 			});
 
-			return Promise.resolve()
+			Promise.resolve()
 				.then(() => {
 					// hack to support transition tests
 					clear_loops();
@@ -203,7 +203,7 @@ describe('runtime', () => {
 					}
 
 					if (config.test) {
-						return Promise.resolve(config.test({
+						config.test({
 							assert,
 							component,
 							mod,
@@ -211,13 +211,12 @@ describe('runtime', () => {
 							window,
 							raf,
 							compileOptions
-						})).then(() => {
-							component.$destroy();
-
-							if (unhandled_rejection) {
-								throw unhandled_rejection;
-							}
 						});
+						component.$destroy();
+
+						if (unhandled_rejection) {
+							throw unhandled_rejection;
+						}
 					} else {
 						component.$destroy();
 						assert.htmlEqual(target.innerHTML, '');
@@ -245,6 +244,7 @@ describe('runtime', () => {
 				.catch(err => {
 					// print a clickable link to open the directory
 					err.stack += `\n\ncmd-click: ${path.relative(process.cwd(), cwd)}/main.svelte`;
+					done();
 					throw err;
 				})
 				.then(() => {
@@ -255,6 +255,7 @@ describe('runtime', () => {
 					flush();
 
 					if (config.after_test) config.after_test();
+					done();
 				});
 		});
 	}

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -35,7 +35,7 @@ describe('runtime', () => {
 		svelte = loadSvelte(false);
 		svelte$ = loadSvelte(true);
 
-		require.extensions['.svelte'] = function (module, filename) {
+		require.extensions['.svelte'] = function(module, filename) {
 			const options = Object.assign({
 				filename
 			}, compileOptions);

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -53,20 +53,22 @@ describe('ssr', () => {
 		}
 
 		(solo ? it.only : it)(dir, (done) => {
-			dir = path.resolve(`${__dirname}/samples`, dir);
-
-			cleanRequireCache();
-
-			const compileOptions = {
-				sveltePath,
-				...config.compileOptions,
-				generate: 'ssr',
-				format: 'cjs'
-			};
-
-			require('../../register')(compileOptions);
 
 			try {
+
+				dir = path.resolve(`${__dirname}/samples`, dir);
+
+				cleanRequireCache();
+
+				const compileOptions = {
+					sveltePath,
+					...config.compileOptions,
+					generate: 'ssr',
+					format: 'cjs'
+				};
+
+				require('../../register')(compileOptions);
+
 				const Component = require(`${dir}/main.svelte`).default;
 
 				const expectedHtml = tryToReadFile(`${dir}/_expected.html`);
@@ -131,8 +133,8 @@ describe('ssr', () => {
 				err.stack += `\n\ncmd-click: ${path.relative(process.cwd(), dir)}/main.svelte`;
 				throw err;
 			} finally {
-				done();
 				set_current_component(null);
+				done();
 			}
 		});
 	});

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -52,7 +52,7 @@ describe('ssr', () => {
 			throw new Error('Forgot to remove `solo: true` from test');
 		}
 
-		(solo ? it.only : it)(dir, () => {
+		(solo ? it.only : it)(dir, (done) => {
 			dir = path.resolve(`${__dirname}/samples`, dir);
 
 			cleanRequireCache();
@@ -131,6 +131,7 @@ describe('ssr', () => {
 				err.stack += `\n\ncmd-click: ${path.relative(process.cwd(), dir)}/main.svelte`;
 				throw err;
 			} finally {
+				done();
 				set_current_component(null);
 			}
 		});


### PR DESCRIPTION
I solved several issues of flaky tests.

## [Solved] `EXC_BAD_ACCESS (SIGSEGV)` occurred in Chrome

Sometimes `EXC_BAD_ACCESS (SIGSEGV)` occurred in Chrome.
To fix this, maybe I need to fix the Chrome code, but that need too much work, so I added the retry process.
Only when Chrome crashes will re-run the tests.

And this problem seems to occur mainly when calling `browser.newPage()`. The cause is probably that there are too many tabs.
Closing the tabs at the end of a test seems to have stopped this error.

In other words, it reduces the error rate and stabilizes the test by retrying when an error occurs.

## [Solved] `Windows shows Terminate batch job (Y/N)?`
On GitHub actions with Windows, sometimes shows `Windows shows Terminate batch job (Y/N)?` and CI is not completed. 
So to handle it, I added [--exit](https://mochajs.org/) options to `mocha`.
(`--exit` option means `Force Mocha to quit after tests complete`.)

## [Solved] `Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.`

I added `done()`.
However, maybe there is still a possibility that this issue still exists.

## [Solved] `Failed to launch the browser process!`

I added a retry process for the Chrome launching process.

## [Not Solved] Failed to download Chromium

It seems that Chrome may fail to download very occasionally.
I'm not sure how to deal with it for now. 
But this is a very rare occurrence and I don't think it will have a big impact without fixing it.

```
ERROR: Failed to download Chromium r722234! Set "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" env variable to skip download.
{ Error: read ECONNRESET
    at TLSWrap.onread (net.js:622:25)
  -- ASYNC --
    at BrowserFetcher.<anonymous> (/Users/runner/work/svelte/svelte/node_modules/puppeteer/lib/helper.js:111:15)
    at Object.<anonymous> (/Users/runner/work/svelte/svelte/node_modules/puppeteer/install.js:66:16)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Function.Module.runMain (module.js:694:10)
    at startup (bootstrap_node.js:204:16)
    at bootstrap_node.js:625:3 errno: 'ECONNRESET', code: 'ECONNRESET', syscall: 'read' }
```

~~## Performance improvement (`browser.newPage`)~~

~~I also noticed that `browser.newPage` is taking a long time. So, to reduce the test execution time.~~
~~I reuse `Page`  if already exists.~~
~~After this improvement, the test run time for `custom-elements` is 1 second. This is 3 times faster compared to before.~~

=> I removed this optimization according to this [PR comment](https://github.com/sveltejs/svelte/pull/7076#discussion_r777020964).

Please continue to let me know if there are any other reasons that make the test unstable!

---

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
