### PR TITLE
[feat] export FlipParams interface from "svelte/animate"

### DIFF
--- a/src/runtime/animate/index.ts
+++ b/src/runtime/animate/index.ts
@@ -10,7 +10,7 @@ export interface AnimationConfig {
 	tick?: (t: number, u: number) => void;
 }
 
-interface FlipParams {
+export interface FlipParams {
 	delay?: number;
 	duration?: number | ((len: number) => number);
 	easing?: (t: number) => number;


### PR DESCRIPTION
Fixes #7103 

Make the `FlipParams` interface importable from "svelte/animate."