### PR TITLE
[fix] Fixes issue #7026 - style_manager transition conflict (a platform use case)

### DIFF
--- a/src/runtime/internal/style_manager.ts
+++ b/src/runtime/internal/style_manager.ts
@@ -9,9 +9,9 @@ const active_docs = new Set<ExtendedDoc>();
 let active = 0;
 
 // A suitable unique ID to create separate style sheets per Svelte runtime. Fixes issue #7026.
-// It is possible a more universal / UUID may be relevant to use instead of `Date.now` in the future.
+// It is possible a more universal / UUID may be relevant to use instead of `Math.random` in the future.
 // Define unique keys to store the style transitions so one Svelte runtime does not clobber the data of another.
-const unique_id = Date.now();
+const unique_id = Math.random();
 const svelte_stylesheet = `__svelte_stylesheet_${unique_id}`;
 const svelte_rules = `__svelte_rules_${unique_id}`;
 
@@ -37,8 +37,8 @@ export function create_rule(node: Element & ElementCSSInlineStyle, a: number, b:
 	const name = `__svelte_${hash(rule)}_${uid}`;
 	const doc = get_root_for_style(node) as ExtendedDoc;
 	active_docs.add(doc);
-	const stylesheet = doc[svelte_stylesheet] || (doc[svelte_stylesheet] = append_empty_stylesheet(node).sheet as CSSStyleSheet);
-	const current_rules = doc[svelte_rules] || (doc[svelte_rules] = {});
+	const stylesheet: CSSStyleSheet = doc[svelte_stylesheet] || (doc[svelte_stylesheet] = append_empty_stylesheet(node).sheet as CSSStyleSheet);
+	const current_rules: Record<string, true> = doc[svelte_rules] || (doc[svelte_rules] = {});
 
 	if (!current_rules[name]) {
 		current_rules[name] = true;
@@ -70,7 +70,7 @@ export function clear_rules() {
 	raf(() => {
 		if (active) return;
 		active_docs.forEach(doc => {
-			const stylesheet = doc[svelte_stylesheet];
+			const stylesheet: CSSStyleSheet = doc[svelte_stylesheet];
 			let i = stylesheet.cssRules.length;
 			while (i--) stylesheet.deleteRule(i);
 			doc[svelte_rules] = {};


### PR DESCRIPTION
Fixes #7026. 

I gave a thorough overview of the problem in the issue, so please refer to [the issue](https://github.com/sveltejs/svelte/issues/7026) and demo repo associated with that issue. 

In short [./src/runtime/internal/style_manager.ts](https://github.com/sveltejs/svelte/blob/master/src/runtime/internal/style_manager.ts) does not take into account multiple Svelte runtimes on the same browser page. There is a single generated stylesheet where transition keyframe rules are added / removed at runtime for transitions. Currently if more than one app / runtime transitions at the same time the first runtime to finish all of its transitions clears out the style sheet which is also holding transition rules for all other Svelte runtimes.

This causes all sorts of visual glitching issues with transitions between separately compiled Svelte apps running on the same browser page. 

The fix is low impact and that is to assign a unique ID key and create temporary / transition style sheets for each Svelte runtime. This is accomplished with `Date.now`, but I am certainly open to suggestions on a better unique ID generation mechanism. 

No new tests are required and all tests pass. 

Below is a gif that shows the transition interruption. The left and right apps are separately compiled Svelte apps. On this platform (FoundryVTT) pressing `esc` closes all apps, so both close at the same time. The left app has a one second scale transition. The right app has a two second scale transition. When the left app finishes at one second it clears out all transition styles and interrupts the right apps transition. The right app will display fully and then disappear after the end of the two second transition when it is removed from the DOM.
![svelte-7026-no-fix](https://user-images.githubusercontent.com/311473/148312094-28cc0780-9532-4f94-8e7a-81b3895b1745.gif)

Apologies if I am pinging the wrong folks. I waited until after the holiday weeks to move this forward. I am including the last two committers to `style_manager.ts`:
- @tanhauhau 
- @ivanhofer 

Also 
@benmccann from our discussion from `#contributing` on Discord.


This issue is a big quality problem for usage of Svelte in platform use cases. I have made a really nice Svelte integration for the Foundry VTT platform and am imminently releasing a library / tool suite for all 3rd party Foundry developers. I certainly appreciate the help in getting this PR merged and am more than willing to modify it according to any advice from the maintainers. 