### PR TITLE
[fix] ensure style manager instances don't conflict with each other

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -157,7 +157,7 @@ export function get_root_for_style(node: Node): ShadowRoot | Document {
 export function append_empty_stylesheet(node: Node) {
 	const style_element = element('style') as HTMLStyleElement;
 	append_stylesheet(get_root_for_style(node), style_element);
-	return style_element;
+	return style_element.sheet as CSSStyleSheet;
 }
 
 function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement) {

--- a/src/runtime/internal/style_manager.ts
+++ b/src/runtime/internal/style_manager.ts
@@ -18,11 +18,11 @@ function hash(str: string) {
 	return hash >>> 0;
 }
 
-const create_style_information = (doc: Document | ShadowRoot, node: Element & ElementCSSInlineStyle) => {
+function create_style_information(doc: Document | ShadowRoot, node: Element & ElementCSSInlineStyle) {
 	const info = { stylesheet: append_empty_stylesheet(node), rules: {} };
 	active_docs.set(doc, info);
 	return info;
-};
+}
 
 export function create_rule(node: Element & ElementCSSInlineStyle, a: number, b: number, duration: number, delay: number, ease: (t: number) => number, fn: (t: number, u: number) => string, uid: number = 0) {
 	const step = 16.666 / duration;

--- a/src/runtime/internal/style_manager.ts
+++ b/src/runtime/internal/style_manager.ts
@@ -6,6 +6,8 @@ interface StyleInformation {
 	rules: Record<string, true>;
 }
 
+// we need to store the information for multiple documents because a Svelte application could also contain iframes
+// https://github.com/sveltejs/svelte/issues/3624
 const managed_styles = new Map<Document | ShadowRoot, StyleInformation>();
 let active = 0;
 


### PR DESCRIPTION
**fixes animations with multiple independent Svelte apps running at the same time.**

This is an alternative approach to #7107.

Closes #7107
Fixes #7026

Instead of storing the style information directly on the `node` via a random property name, here the information get's stored inside a locale varable within the `style_manager`.
