### PR TITLE
fix: test cases should fail when it should fail

### DIFF
--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -245,7 +245,7 @@ describe('runtime', () => {
 				.catch(err => {
 					// print a clickable link to open the directory
 					err.stack += `\n\ncmd-click: ${path.relative(process.cwd(), cwd)}/main.svelte`;
-					done();
+					done(err);
 					throw err;
 				})
 				.then(() => {

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -128,13 +128,13 @@ describe('ssr', () => {
 				}
 
 				if (show) showOutput(dir, { generate: 'ssr', format: 'cjs' });
+				done();
 			} catch (err) {
 				showOutput(dir, { generate: 'ssr', format: 'cjs' });
 				err.stack += `\n\ncmd-click: ${path.relative(process.cwd(), dir)}/main.svelte`;
-				throw err;
+				done(err);
 			} finally {
 				set_current_component(null);
-				done();
 			}
 		});
 	});


### PR DESCRIPTION
https://github.com/sveltejs/svelte/pull/7076 is too good that it doesn't even has error with failed tests

when using async callback with test case, need to call the `done(err)` with error to fail the test.

ref: https://mochajs.org/#asynchronous-code

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
