### PR TITLE
[fix] All players can be played simultaneously

### DIFF
--- a/site/content/tutorial/17-module-context/02-module-exports/app-a/AudioPlayer.svelte
+++ b/site/content/tutorial/17-module-context/02-module-exports/app-a/AudioPlayer.svelte
@@ -17,12 +17,6 @@
 		elements.add(audio);
 		return () => elements.delete(audio);
 	});
-
-	function stopOthers() {
-		elements.forEach(element => {
-			if (element !== audio) element.pause();
-		});
-	}
 </script>
 
 <article class:playing={!paused}>
@@ -32,7 +26,6 @@
 	<audio
 		bind:this={audio}
 		bind:paused
-		on:play={stopOthers}
 		controls
 		{src}
 	></audio>

--- a/site/content/tutorial/17-module-context/02-module-exports/app-b/AudioPlayer.svelte
+++ b/site/content/tutorial/17-module-context/02-module-exports/app-b/AudioPlayer.svelte
@@ -23,12 +23,6 @@
 		elements.add(audio);
 		return () => elements.delete(audio);
 	});
-
-	function stopOthers() {
-		elements.forEach(element => {
-			if (element !== audio) element.pause();
-		});
-	}
 </script>
 
 <article class:playing={!paused}>
@@ -38,7 +32,6 @@
 	<audio
 		bind:this={audio}
 		bind:paused
-		on:play={stopOthers}
 		controls
 		{src}
 	></audio>


### PR DESCRIPTION
### Problem it fixes:
`stopOthers` function is stopping two or more players to play simultaneously.
Since users need to see `stopAll` function working two or more audio players need to play simultaneously.