### PR TITLE
[docs] fix `#each` in window-bindings example

### DIFF
--- a/site/content/examples/17-special-elements/03-svelte-window-bindings/App.svelte
+++ b/site/content/examples/17-special-elements/03-svelte-window-bindings/App.svelte
@@ -7,7 +7,7 @@
 <svelte:window bind:scrollY={y}/>
 
 <a class="parallax-container" href="https://www.firewatchgame.com">
-	{#each [0, 1, 2, 3, 4, 5, 6, 7, 8] as layer}
+	{#each layers as layer}
 		<img
 			style="transform: translate(0,{-y * layer / (layers.length - 1)}px)"
 			src="https://www.firewatchgame.com/images/parallax/parallax{layer}.png"


### PR DESCRIPTION
The #each should use the layers as defined in the <script> section so that the parallax works correctly when the layers array is changed

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
