### PR TITLE
[docs] Examples/easing code refactoring

### DIFF
--- a/site/content/examples/11-easing/00-easing/App.svelte
+++ b/site/content/examples/11-easing/00-easing/App.svelte
@@ -7,10 +7,10 @@
 
 	import { easesGroupBy, eases, types } from './eases.js';
 
-	let current_type = easesGroupBy[0];
-	let current_ease = Object.keys(eases)[0];
+	let currentType = easesGroupBy[0];
+	let currentEase = Object.keys(eases)[0];
 	let duration = 2000;
-	let current = eases[current_ease][current_type];
+	let current = eases[currentEase][currentType];
 	let playing = false;
 	let width;
 
@@ -33,7 +33,7 @@
 		playing = false;
 	}
 
-	$: current = eases[current_ease][current_type];
+	$: current = eases[currentEase][currentType];
 	$: current && runAnimations();
 </script>
 
@@ -70,8 +70,8 @@
 		{playing}
 		{width}
 		bind:duration
-		bind:current_ease
-		bind:current_type
+		bind:currentEase
+		bind:currentType
 		on:play={runAnimations}
 	/>
 </div>

--- a/site/content/examples/11-easing/00-easing/App.svelte
+++ b/site/content/examples/11-easing/00-easing/App.svelte
@@ -5,12 +5,12 @@
 	import Grid from './Grid.svelte';
 	import Controls from './Controls.svelte';
 
-	import { eases, types } from './eases.js';
+	import { easesGroupBy, eases, types } from './eases.js';
 
-	let current_type = 'In';
-	let current_ease = 'sine';
+	let current_type = easesGroupBy[0];
+	let current_ease = Object.keys(eases)[0];
 	let duration = 2000;
-	let current = eases.get(current_ease)[current_type];
+	let current = eases[current_ease][current_type];
 	let playing = false;
 	let width;
 
@@ -33,7 +33,7 @@
 		playing = false;
 	}
 
-	$: current = eases.get(current_ease)[current_type];
+	$: current = eases[current_ease][current_type];
 	$: current && runAnimations();
 </script>
 

--- a/site/content/examples/11-easing/00-easing/Controls.svelte
+++ b/site/content/examples/11-easing/00-easing/Controls.svelte
@@ -44,7 +44,7 @@
 			<h3>Type</h3>
 			{#if mobile }
 				<select bind:value={currentType}>
-					{#each types as {name, type}}
+					{#each types as [name, type]}
 						<option
 							value={type}
 						>
@@ -54,7 +54,7 @@
 				</select>
 			{:else}
 				<ul>
-					{#each types as {name, type}}
+					{#each types as [name, type]}
 						<li
 							class:selected={type === currentType}
 							on:click={() => currentType = type}

--- a/site/content/examples/11-easing/00-easing/Controls.svelte
+++ b/site/content/examples/11-easing/00-easing/Controls.svelte
@@ -19,7 +19,7 @@
 			<h3>Ease</h3>
 			{#if mobile}
 				<select bind:value={current_ease}>
-					{#each [...eases] as [name]}
+					{#each Object.keys(eases) as name}
 						<option
 							value={name}
 							class:selected={name === current_ease}
@@ -30,7 +30,7 @@
 				</select>
 			{:else}
 				<ul>
-					{#each [...eases] as [name]}
+					{#each Object.keys(eases) as name}
 						<li
 							class:selected={name === current_ease}
 							on:click={() => current_ease = name}
@@ -43,7 +43,7 @@
 			<h3>Type</h3>
 			{#if mobile }
 				<select bind:value={current_type}>
-					{#each types as [name, type]}
+					{#each types as {name, type}}
 						<option
 							value={type}
 						>
@@ -53,7 +53,7 @@
 				</select>
 			{:else}
 				<ul>
-					{#each types as [name, type]}
+					{#each types as {name, type}}
 						<li
 							class:selected={type === current_type}
 							on:click={() => current_type = type}

--- a/site/content/examples/11-easing/00-easing/Controls.svelte
+++ b/site/content/examples/11-easing/00-easing/Controls.svelte
@@ -1,8 +1,8 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
 
-	export let current_ease;
-	export let current_type;
+	export let currentEase;
+	export let currentType;
 	export let eases;
 	export let types;
 	export let duration;
@@ -18,11 +18,11 @@
 		<div class="easing-types">
 			<h3>Ease</h3>
 			{#if mobile}
-				<select bind:value={current_ease}>
+				<select bind:value={currentEase}>
 					{#each Object.keys(eases) as name}
 						<option
 							value={name}
-							class:selected={name === current_ease}
+							class:selected={name === currentEase}
 						>
 							{name}
 						</option>
@@ -32,17 +32,18 @@
 				<ul>
 					{#each Object.keys(eases) as name}
 						<li
-							class:selected={name === current_ease}
-							on:click={() => current_ease = name}
+							class:selected={name === currentEase}
+							on:click={() => currentEase = name}
 						>
 							{name}
 						</li>
 					{/each}
 				</ul>
 			{/if}
+
 			<h3>Type</h3>
 			{#if mobile }
-				<select bind:value={current_type}>
+				<select bind:value={currentType}>
 					{#each types as {name, type}}
 						<option
 							value={type}
@@ -55,8 +56,8 @@
 				<ul>
 					{#each types as {name, type}}
 						<li
-							class:selected={type === current_type}
-							on:click={() => current_type = type}
+							class:selected={type === currentType}
+							on:click={() => currentType = type}
 						>
 							{name}
 					</li>

--- a/site/content/examples/11-easing/00-easing/eases.js
+++ b/site/content/examples/11-easing/00-easing/eases.js
@@ -32,9 +32,9 @@ export const easesGroupBy = ['In', 'InOut', 'Out'];
 export const processedEases = getEasesGroupBy(easesGroupBy);
 
 export const types = [
-    { name: 'Ease In', type: easesGroupBy[0] },
-    { name: 'Ease Out', type: easesGroupBy[1] },
-    { name: 'Ease In Out', type: easesGroupBy[2] },
+    ['Ease In', easesGroupBy[0]],
+    ['Ease Out', easesGroupBy[1]],
+    ['Ease In Out', easesGroupBy[2]],
 ];
 
 export { processedEases as eases };

--- a/site/content/examples/11-easing/00-easing/eases.js
+++ b/site/content/examples/11-easing/00-easing/eases.js
@@ -1,43 +1,40 @@
 import * as eases from 'svelte/easing';
 
-const processed_eases = {};
-
-for (const ease in eases) {
-	if (ease === "linear") {
-		processed_eases.linear = eases.linear;
-	} else {
-		const name = ease.replace(/In$|InOut$|Out$/, '');
-		const type = ease.match(/In$|InOut$|Out$/)[0];
-
-		if (!(name in processed_eases)) processed_eases[name] = {};
-		processed_eases[name][type] = {};
-		processed_eases[name][type].fn = eases[ease];
-
-		let shape = 'M0 1000';
-		for (let i = 1; i <= 1000; i++) {
-			shape = `${shape} L${(i / 1000) * 1000} ${1000 - eases[ease](i / 1000) * 1000} `;
-			processed_eases[name][type].shape = shape;
-		}
-	}
+function calculateShape (easeFn) {
+    let result = 'M0 1000';
+    for (let i = 1; i <= 1000; i++) {
+        result = `${result} L${(i / 1000) * 1000} ${1000 - easeFn(i / 1000) * 1000} `;
+    }
+    return result;
 }
 
-const sorted_eases = new Map([
-	['sine', processed_eases.sine],
-	['quad', processed_eases.quad],
-	['cubic', processed_eases.cubic],
-	['quart', processed_eases.quart],
-	['quint', processed_eases.quint],
-	['expo', processed_eases.expo],
-	['circ', processed_eases.circ],
-	['back', processed_eases.back],
-	['elastic', processed_eases.elastic],
-	['bounce', processed_eases.bounce],
-]);
+function getEasesGroupBy (endings) {
+	const result = {};
+
+	for (const ease in eases) {
+		const ending = endings.find((ending) => ease.endsWith(ending));
+		if (!ending) continue;
+	
+		const key = ending;
+		const name = ease.substring(0, ease.length - ending.length);
+		const fn = eases[ease];
+		const shape = calculateShape(fn);
+	
+		result[name] = result[name] || {};
+		result[name][key] = { fn, shape };
+	}
+
+	return result;
+}
+
+export const easesGroupBy = ['In', 'InOut', 'Out'];
+
+export const processedEases = getEasesGroupBy(easesGroupBy);
 
 export const types = [
-	['Ease In', 'In'],
-	['Ease Out', 'Out'],
-	['Ease In Out', 'InOut']
+    { name: 'Ease In', type: easesGroupBy[0] },
+    { name: 'Ease Out', type: easesGroupBy[1] },
+    { name: 'Ease In Out', type: easesGroupBy[2] },
 ];
 
-export { sorted_eases as eases };
+export { processedEases as eases };


### PR DESCRIPTION
I decided to do a little refactoring of the Examples/easing code.
What was done:
- variable names replaced from `snake_case` to `camelCase`;
- removed hidden dependencies between files (for example `current_type` and `current_ease` default values, `ease` filtering by ending, etc);
- decomposition: new functions for `shape` calculation and a new one for grouping `eases` by names and timing-type (Ease In, Ease Out, Ease In Out);
- eases `Map` replaced to simple object to reduce complexity;

I will be happy to discuss all changes and I will be glad to see your comments!