### PR TITLE
blog: Mark setting-up-your-editor as not draft

### DIFF
--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -3,7 +3,6 @@ title: Setting up your editor
 description: Instructions for configuring linting and syntax highlighting
 author: Rich Harris
 authorURL: https://twitter.com/Rich_Harris
-draft: true
 ---
 
 *__Coming soon__*


### PR DESCRIPTION
<img width="1496" alt="CleanShot 2022-01-29 at 23 49 56@2x" src="https://user-images.githubusercontent.com/47742487/151672774-6c751683-4d3b-4037-82f2-332ee1ed2a8f.png">

This blog post is marked as draft, making it return 404. This PR fixes it