### PR TITLE
[fix] mark css/instance/module `Ast` properties as optional

### DIFF
--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -131,9 +131,9 @@ export interface Style extends BaseNode {
 
 export interface Ast {
 	html: TemplateNode;
-	css: Style;
-	instance: Script;
-	module: Script;
+	css?: Style;
+	instance?: Script;
+	module?: Script;
 }
 
 export interface Warning {


### PR DESCRIPTION
**Description**

Parsing a Svelte component with only markup will return `undefined` for `css`, `instance`, and `module`.

Currently, all properties in the `Ast` interface are required, which can cause type errors.

https://github.com/sveltejs/svelte/blob/d1b3f462a5cfc29283963ad13741f8ef87ea3631/src/compiler/interfaces.ts#L132-L137

**Repro**

```ts
// parser.ts
import { parse } from "svelte/compiler";

const ast = parse("");

console.log(ast.instance.start);

// TypeError: Cannot read properties of undefined (reading 'start')
```