### PR TITLE
fix: correct FLIP animations in scaled parent

### DIFF
--- a/src/runtime/animate/index.ts
+++ b/src/runtime/animate/index.ts
@@ -21,8 +21,12 @@ export function flip(node: Element, { from, to }: { from: DOMRect; to: DOMRect }
 	const transform = style.transform === 'none' ? '' : style.transform;
 
 	const [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
-	const dx = (from.left + from.width * ox / to.width) - (to.left + ox);
-	const dy = (from.top + from.height * oy / to.height) - (to.top + oy);
+	const scale = {
+		x: to.width / node.clientWidth,
+		y: to.height / node.clientHeight
+	};
+	const dx = ((from.left / scale.x) + (from.width / scale.x) * ox / (to.width / scale.x)) - ((to.left / scale.x) + ox);
+	const dy = ((from.top / scale.y) + (from.height / scale.y) * oy / (to.height / scale.y)) - ((to.top / scale.y) + oy);
 
 	const {
 		delay = 0,

--- a/src/runtime/animate/index.ts
+++ b/src/runtime/animate/index.ts
@@ -21,12 +21,8 @@ export function flip(node: Element, { from, to }: { from: DOMRect; to: DOMRect }
 	const transform = style.transform === 'none' ? '' : style.transform;
 
 	const [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
-	const scale = {
-		x: to.width / node.clientWidth,
-		y: to.height / node.clientHeight
-	};
-	const dx = ((from.left / scale.x) + (from.width / scale.x) * ox / (to.width / scale.x)) - ((to.left / scale.x) + ox);
-	const dy = ((from.top / scale.y) + (from.height / scale.y) * oy / (to.height / scale.y)) - ((to.top / scale.y) + oy);
+	const dx = ((from.left - to.left) * node.clientWidth + from.width * ox) / to.width - ox;
+	const dy = ((from.top - to.top) * node.clientHeight + from.height * oy) / to.height - oy;
 
 	const {
 		delay = 0,


### PR DESCRIPTION
The issue #7205 describes how FLIP animations occurring inside a parent with `transform: scale(n)` are wonky, this PR resolves that issue by;
- Geting the scale factor by comparing against node.clientWidth
- Dividing all the positions/dimensions by the scale to get the correct deltas

---

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.

### Tests
- [x] Run the tests with `npm test` and lint the project with `npm run lint`
- [ ] Ideally, include a test that fails without this PR but passes with it.

_(I haven't added a test, as I don't really understand how the animate tests are working, and I couldn't find an example in the #6658 commit which caused this regression. If anyone wants to walk me through creating a test, or help append a test to this PR, please let me know! :))_

---

- resolves #7205
- fixes regression from #6658
