### PR TITLE
[feat] improve types for Style interface

### DIFF
--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -118,10 +118,49 @@ export interface Script extends BaseNode {
 	content: Program;
 }
 
+export interface StyleAttribute extends BaseNode {
+  type: 'Attribute';
+  name: string;
+  value: true | MustacheTag | any[];
+}
+
+export interface StyleSelector extends BaseNode {
+  type: 'Selector';
+  children: any[];
+}
+
+export interface StyleDeclarationValue extends BaseNode {
+  type: 'Value';
+  children: any[];
+}
+
+export interface StyleDeclaration extends BaseNode {
+  type: 'Declaration';
+  important: boolean;
+  property: string;
+  value: StyleDeclarationValue;
+}
+
+export interface StyleNode extends BaseNode {
+  type: 'Rule';
+  prelude: {
+    type: 'SelectorList';
+    children: StyleSelector[];
+    start: number;
+    end: number;
+  };
+  block: {
+    type: 'Block';
+    children: StyleDeclaration[];
+    start: number;
+    end: number;
+  }
+}
+
 export interface Style extends BaseNode {
 	type: 'Style';
-	attributes: any[]; // TODO
-	children: any[]; // TODO add CSS node types
+	attributes: StyleAttribute[];
+	children: StyleNode[];
 	content: {
 		start: number;
 		end: number;


### PR DESCRIPTION
This PR aims to improve the types for the `Style` interface.

**Approach**

Types were derived by generating an AST output with the following: 

```svelte
<style attr1="4" attr2 attr3={false} >
	h1, #id {
		color: red;
	}
	
	:global(a, b) {
		font: inherit;
	}
	
	* {}
</style>
```