### PR TITLE
[fix] do not generate unused-export-let inside <script context="module">

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -519,7 +519,7 @@ export default class Component {
 		return result;
 	}
 
-	private _extract_exports(node: ExportDefaultDeclaration | ExportNamedDeclaration | ExportAllDeclaration, module_script) {
+	private _extract_exports(node: ExportDefaultDeclaration | ExportNamedDeclaration | ExportAllDeclaration, module_script: boolean) {
 		if (node.type === 'ExportDefaultDeclaration') {
 			return this.error(node as any, compiler_errors.default_export);
 		}
@@ -539,7 +539,7 @@ export default class Component {
 						extract_names(declarator.id).forEach(name => {
 							const variable = this.var_lookup.get(name);
 							variable.export_name = name;
-							if (variable.writable && !(variable.referenced || variable.referenced_from_script || variable.subscribable)) {
+							if (!module_script && variable.writable && !(variable.referenced || variable.referenced_from_script || variable.subscribable)) {
 								this.warn(declarator as any, compiler_warnings.unused_export_let(this.name.name, name));
 							}
 						});
@@ -559,7 +559,7 @@ export default class Component {
 					if (variable) {
 						variable.export_name = specifier.exported.name;
 
-						if (variable.writable && !(variable.referenced || variable.referenced_from_script || variable.subscribable)) {
+						if (!module_script && variable.writable && !(variable.referenced || variable.referenced_from_script || variable.subscribable)) {
 							this.warn(specifier as any, compiler_warnings.unused_export_let(this.name.name, specifier.exported.name));
 						}
 					}

--- a/test/validator/samples/unreferenced-variables/input.svelte
+++ b/test/validator/samples/unreferenced-variables/input.svelte
@@ -1,25 +1,48 @@
-<script>
-  var a = 1;
-  let b = 1;
-  const c = 1;
-  var d = 1;
-  let e = 1;
-  const f = 1;
-  export { d, e, f};
-  export var g = 1;
-  export let h = 1;
-  export const i = 1;
-  export let j = () => {};
-  export const k = () => {};
-  export function l() {};
-  var m = 1;
-  let n = 1;
-  const o = 1;
-  function foo() {
-    return m + n + o;
+<script context="module">
+  var a1 = 1;
+  let b1 = 1;
+  const c1 = 1;
+  var d1 = 1;
+  let e1 = 1;
+  const f1 = 1;
+  export { d1, e1, f1};
+  export var g1 = 1;
+  export let h1 = 1;
+  export const i1 = 1;
+  export let j1 = () => {};
+  export const k1 = () => {};
+  export function l1() {};
+  var m1 = 1;
+  let n1 = 1;
+  const o1 = 1;
+  function foo1() {
+    return m1 + n1 + o1;
   }
-  export let p;
-  export let q;
-  $p;
+  export let p1;
 </script>
-{$q}
+
+<script>
+  var a2 = 1;
+  let b2 = 1;
+  const c2 = 1;
+  var d2 = 1;
+  let e2 = 1;
+  const f2 = 1;
+  export { d2, e2, f2};
+  export var g2 = 1;
+  export let h2 = 1;
+  export const i2 = 1;
+  export let j2 = () => {};
+  export const k2 = () => {};
+  export function l2() {};
+  var m2 = 1;
+  let n2 = 1;
+  const o2 = 1;
+  function foo2() {
+    return m2 + n2 + o2;
+  }
+  export let p2;
+  export let q2;
+  $p2;
+</script>
+{$q2}

--- a/test/validator/samples/unreferenced-variables/warnings.json
+++ b/test/validator/samples/unreferenced-variables/warnings.json
@@ -2,76 +2,76 @@
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 103,
-			"column": 12,
-			"line": 8
+			"character": 519,
+			"column": 13,
+			"line": 31
 		},
-		"message": "Component has unused export property 'd'. If it is for external reference only, please consider using `export const d`",
-		"pos": 102,
+		"message": "Component has unused export property 'd2'. If it is for external reference only, please consider using `export const d2`",
+		"pos": 517,
 		"start": {
-			"character": 102,
+			"character": 517,
 			"column": 11,
-			"line": 8
+			"line": 31
 		}
 	},
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 106,
+			"character": 523,
+			"column": 17,
+			"line": 31
+		},
+		"message": "Component has unused export property 'e2'. If it is for external reference only, please consider using `export const e2`",
+		"pos": 521,
+		"start": {
+			"character": 521,
 			"column": 15,
-			"line": 8
-		},
-		"message": "Component has unused export property 'e'. If it is for external reference only, please consider using `export const e`",
-		"pos": 105,
-		"start": {
-			"character": 105,
-			"column": 14,
-			"line": 8
+			"line": 31
 		}
 	},
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 130,
-			"column": 18,
-			"line": 9
+			"character": 549,
+			"column": 19,
+			"line": 32
 		},
-		"message": "Component has unused export property 'g'. If it is for external reference only, please consider using `export const g`",
-		"pos": 125,
+		"message": "Component has unused export property 'g2'. If it is for external reference only, please consider using `export const g2`",
+		"pos": 543,
 		"start": {
-			"character": 125,
+			"character": 543,
 			"column": 13,
-			"line": 9
+			"line": 32
 		}
 	},
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 150,
-			"column": 18,
-			"line": 10
+			"character": 570,
+			"column": 19,
+			"line": 33
 		},
-		"message": "Component has unused export property 'h'. If it is for external reference only, please consider using `export const h`",
-		"pos": 145,
+		"message": "Component has unused export property 'h2'. If it is for external reference only, please consider using `export const h2`",
+		"pos": 564,
 		"start": {
-			"character": 145,
+			"character": 564,
 			"column": 13,
-			"line": 10
+			"line": 33
 		}
 	},
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 199,
-			"column": 25,
-			"line": 12
+			"character": 621,
+			"column": 26,
+			"line": 35
 		},
-		"message": "Component has unused export property 'j'. If it is for external reference only, please consider using `export const j`",
-		"pos": 187,
+		"message": "Component has unused export property 'j2'. If it is for external reference only, please consider using `export const j2`",
+		"pos": 608,
 		"start": {
-			"character": 187,
+			"character": 608,
 			"column": 13,
-			"line": 12
+			"line": 35
 		}
 	}
 ]


### PR DESCRIPTION
Fixes #7055

I think this might be the best way to fix the linked issue, and I think it's a reasonable change. Since code inside `<script context="module">` is basically just regular JS, warnings like this can be delegated to userland tools--I don't think it needs to be the Svelte compiler's business especially when these compiler warnings cannot be ignored inline.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
