### PR TITLE
[docs] Update 02-template-syntax.md

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1427,8 +1427,6 @@ bind:this={component_instance}
 
 Components also support `bind:this`, allowing you to interact with component instances programmatically.
 
-> Note that we can't do `{cart.empty}` since `cart` is `undefined` when the button is first rendered and throws an error.
-
 ```sv
 <ShoppingCart bind:this={cart}/>
 


### PR DESCRIPTION
Removed: > Note that we can't do `{cart.empty}` since `cart` is `undefined` when the button is first rendered and throws an error.

It fixed in 3.16.7
Issue: https://github.com/sveltejs/svelte/issues/4090