### PR TITLE
[docs] adds jsdoc for most functions in runtime API

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -239,12 +239,12 @@ export class SvelteComponent {
 	$$set?: ($$props: any) => void;
 	/**
 	 * 
-	   * ```ts
-	   * component.$destroy()
-	   * ```
-	   * 
-	   * Removes a component from the DOM and triggers any `onDestroy` handlers.
-	   * 
+	 * ```ts
+	 * component.$destroy()
+	 * ```
+	 * 
+	 * Removes a component from the DOM and triggers any `onDestroy` handlers.
+	 * 
 	 */
 	$destroy() {
 		destroy_component(this, 1);

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -38,7 +38,7 @@ interface T$$ {
 	on_destroy: any[];
 	skip_bound: boolean;
 	on_disconnect: any[];
-	root:Element | ShadowRoot
+	root: Element | ShadowRoot
 }
 
 export function bind(component, name, callback) {
@@ -237,12 +237,43 @@ if (typeof HTMLElement === 'function') {
 export class SvelteComponent {
 	$$: T$$;
 	$$set?: ($$props: any) => void;
-
+	/**
+	 * 
+	   * ```ts
+	   * component.$destroy()
+	   * ```
+	   * 
+	   * Removes a component from the DOM and triggers any `onDestroy` handlers.
+	   * 
+	 */
 	$destroy() {
 		destroy_component(this, 1);
 		this.$destroy = noop;
 	}
-
+	/**
+	 * 
+	 * ```ts
+	 * component.$on(event, callback)
+	 * ```
+	 * 
+	 * ---
+	 * 
+	 * Causes the `callback` function to be called whenever the component dispatches an `event`.
+	 * 
+	 * A function is returned that will remove the event listener when called.
+	 * 
+	 * ```ts
+	 * const off = app.$on('selected', event => {
+	 * 	console.log(event.detail.selection);
+	 * });
+	 * 
+	 * off();
+	 * ```
+	 * 
+	 * @param type 
+	 * @param callback 
+	 * @returns a function  that will remove the event listener when called.
+	 */
 	$on(type, callback) {
 		const callbacks = (this.$$.callbacks[type] || (this.$$.callbacks[type] = []));
 		callbacks.push(callback);
@@ -252,7 +283,23 @@ export class SvelteComponent {
 			if (index !== -1) callbacks.splice(index, 1);
 		};
 	}
-
+	/**
+	 *  * 
+	 * ```ts
+	 * component.$set(props)
+	 * ```
+	 * 
+	 * ---
+	 * 
+	 * Programmatically sets props on an instance. `component.$set({ x: 1 })` is equivalent to `x = 1` inside the component's `<script>` block.
+	 * 
+	 * Calling this method schedules an update for the next microtask — the DOM is *not* updated synchronously.
+	 * 
+	 * ```ts
+	 * component.$set({ answer: 42 });
+	 * ```
+	 * 
+	 */
 	$set($$props) {
 		if (this.$$set && !is_empty($$props)) {
 			this.$$.skip_bound = true;

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -284,7 +284,7 @@ export class SvelteComponent {
 		};
 	}
 	/**
-	 *  * 
+	 * 
 	 * ```ts
 	 * component.$set(props)
 	 * ```

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -272,7 +272,7 @@ export class SvelteComponent {
 	 * 
 	 * @param type 
 	 * @param callback 
-	 * @returns a function  that will remove the event listener when called.
+	 * @returns a function that will remove the event listener when called
 	 */
 	$on(type, callback) {
 		const callbacks = (this.$$.callbacks[type] || (this.$$.callbacks[type] = []));

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -298,7 +298,6 @@ export class SvelteComponent {
 	 * ```ts
 	 * component.$set({ answer: 42 });
 	 * ```
-	 * 
 	 */
 	$set($$props) {
 		if (this.$$set && !is_empty($$props)) {

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -251,13 +251,6 @@ export class SvelteComponent {
 		this.$destroy = noop;
 	}
 	/**
-	 * 
-	 * ```ts
-	 * component.$on(event, callback)
-	 * ```
-	 * 
-	 * ---
-	 * 
 	 * Causes the `callback` function to be called whenever the component dispatches an `event`.
 	 * 
 	 * A function is returned that will remove the event listener when called.
@@ -284,13 +277,6 @@ export class SvelteComponent {
 		};
 	}
 	/**
-	 * 
-	 * ```ts
-	 * component.$set(props)
-	 * ```
-	 * 
-	 * ---
-	 * 
 	 * Programmatically sets props on an instance. `component.$set({ x: 1 })` is equivalent to `x = 1` inside the component's `<script>` block.
 	 * 
 	 * Calling this method schedules an update for the next microtask — the DOM is *not* updated synchronously.

--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -11,12 +11,6 @@ export function get_current_component() {
 	return current_component;
 }
 /**
- * ```ts
- * beforeUpdate(callback: () => void)
- * ```
- * 
- * ---
- * 
  * Schedules a callback to run immediately before the component is updated after any state change.
  * 
  * > The first time the callback runs will be before the initial `onMount`
@@ -37,16 +31,6 @@ export function beforeUpdate(fn: () => any) {
 	get_current_component().$$.before_update.push(fn);
 }
 /**
- * 
- * ```ts
- * onMount(callback: () => void)
- * ```
- * ```ts
- * onMount(callback: () => () => void)
- * ```
- * 
- * ---
- * 
  * The `onMount` function schedules a callback to run as soon as the component has been mounted to the DOM. It must be called during the component's initialisation (but doesn't need to live *inside* the component; it can be called from an external module).
  * 
  * `onMount` does not run inside a [server-side component](https://svelte.dev/docs#run-time-server-side-component-api).
@@ -87,13 +71,6 @@ export function onMount(fn: () => any | (() => any)) {
 	get_current_component().$$.on_mount.push(fn);
 }
 /**
- * 
- * ```ts
- * afterUpdate(callback: () => void)
- * ```
- * 
- * ---
- * 
  * Schedules a callback to run immediately after the component has been updated.
  * 
  * > The first time the callback runs will be after the initial `onMount`
@@ -114,13 +91,6 @@ export function afterUpdate(fn: () => any) {
 	get_current_component().$$.after_update.push(fn);
 }
 /**
- * 
- * ```ts
- * onDestroy(callback: () => void)
- * ```
- * 
- * ---
- * 
  * Schedules a callback to run immediately before the component is unmounted.
  * 
  * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the only one that runs inside a server-side component.
@@ -141,13 +111,6 @@ export function onDestroy(fn: () => any) {
 	get_current_component().$$.on_destroy.push(fn);
 }
 /**
- * 
- * ```ts
- * dispatch: ((name: string, detail?: any) => void) = createEventDispatcher();
- * ```
- * 
- * ---
- * 
  * Creates an event dispatcher that can be used to dispatch [component events](https://svelte.dev/docs#template-syntax-component-directives-on-eventname). Event dispatchers are functions that can take two arguments: `name` and `detail`.
  * 
  * Component events created with `createEventDispatcher` create a [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent). These events do not [bubble](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture) and are not cancellable with `event.preventDefault()`. The `detail` argument corresponds to the [CustomEvent.detail](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail) property and can contain any type of data.
@@ -197,13 +160,6 @@ export function createEventDispatcher<
 	};
 }
 /**
- * 
- * ```ts
- * setContext(key: any, context: any)
- * ```
- * 
- * ---
- * 
  * Associates an arbitrary `context` object with the current component and the specified `key`. The context is then available to children of the component (including slotted content) with `getContext`.
  * 
  * Like lifecycle functions, this must be called during component initialisation.
@@ -225,13 +181,6 @@ export function setContext<T>(key: any, context: T) {
 	get_current_component().$$.context.set(key, context);
 }
 /**
- * 
- * ```ts
- * context: any = getContext(key: any)
- * ```
- * 
- * ---
- * 
  * Retrieves the context that belongs to the closest parent component with the specified `key`. Must be called during component initialisation.
  * 
  * ```html
@@ -249,13 +198,6 @@ export function getContext<T>(key: any): T {
 	return get_current_component().$$.context.get(key);
 }
 /**
- * 
- * ```ts
- * contexts: Map<any, any> = getAllContexts()
- * ```
- * 
- * ---
- * 
  * Retrieves the whole context map that belongs to the closest parent component. Must be called during component initialisation. Useful, for example, if you programmatically create a component and want to pass the existing context to it.
  * 
  * ```html
@@ -272,13 +214,6 @@ export function getAllContexts<T extends Map<any, any> = Map<any, any>>(): T {
 	return get_current_component().$$.context;
 }
 /**
- * 
- * ```ts
- * hasContext: boolean = hasContext(key: any)
- * ```
- * 
- * ---
- * 
  * Checks whether a given `key` has been set in the context of a parent component. Must be called during component initialisation.
  * 
  * ```html

--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -10,23 +10,174 @@ export function get_current_component() {
 	if (!current_component) throw new Error('Function called outside component initialization');
 	return current_component;
 }
-
+/**
+ * ```ts
+ * beforeUpdate(callback: () => void)
+ * ```
+ * 
+ * ---
+ * 
+ * Schedules a callback to run immediately before the component is updated after any state change.
+ * 
+ * > The first time the callback runs will be before the initial `onMount`
+ * 
+ * ```html
+ * <script>
+ * 	import { beforeUpdate } from 'svelte';
+ * 
+ * 	beforeUpdate(() => {
+ * 		console.log('the component is about to update');
+ * 	});
+ * </script>
+ * ```
+ * 
+ * @param fn callback
+ */
 export function beforeUpdate(fn: () => any) {
 	get_current_component().$$.before_update.push(fn);
 }
-
-export function onMount(fn: () => any) {
+/**
+ * 
+ * ```ts
+ * onMount(callback: () => void)
+ * ```
+ * ```ts
+ * onMount(callback: () => () => void)
+ * ```
+ * 
+ * ---
+ * 
+ * The `onMount` function schedules a callback to run as soon as the component has been mounted to the DOM. It must be called during the component's initialisation (but doesn't need to live *inside* the component; it can be called from an external module).
+ * 
+ * `onMount` does not run inside a [server-side component](https://svelte.dev/docs#run-time-server-side-component-api).
+ * 
+ * ```html
+ * <script>
+ * 	import { onMount } from 'svelte';
+ * 
+ * 	onMount(() => {
+ * 		console.log('the component has mounted');
+ * 	});
+ * </script>
+ * ```
+ * 
+ * ---
+ * 
+ * If a function is returned from `onMount`, it will be called when the component is unmounted.
+ * 
+ * ```html
+ * <script>
+ * 	import { onMount } from 'svelte';
+ * 
+ * 	onMount(() => {
+ * 		const interval = setInterval(() => {
+ * 			console.log('beep');
+ * 		}, 1000);
+ * 
+ * 		return () => clearInterval(interval);
+ * 	});
+ * </script>
+ * ```
+ * 
+ * > This behaviour will only work when the function passed to `onMount` *synchronously* returns a value. `async` functions always return a `Promise`, and as such cannot *synchronously* return a function.
+ * 
+ * @param fn callback function
+ */
+export function onMount(fn: () => any | (() => any)) {
 	get_current_component().$$.on_mount.push(fn);
 }
-
+/**
+ * 
+ * ```ts
+ * afterUpdate(callback: () => void)
+ * ```
+ * 
+ * ---
+ * 
+ * Schedules a callback to run immediately after the component has been updated.
+ * 
+ * > The first time the callback runs will be after the initial `onMount`
+ * 
+ * ```html
+ * <script>
+ * 	import { afterUpdate } from 'svelte';
+ * 
+ * 	afterUpdate(() => {
+ * 		console.log('the component just updated');
+ * 	});
+ * </script>
+ * ```
+ * 
+ * @param fn callback function
+ */
 export function afterUpdate(fn: () => any) {
 	get_current_component().$$.after_update.push(fn);
 }
-
+/**
+ * 
+ * ```ts
+ * onDestroy(callback: () => void)
+ * ```
+ * 
+ * ---
+ * 
+ * Schedules a callback to run immediately before the component is unmounted.
+ * 
+ * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the only one that runs inside a server-side component.
+ * 
+ * ```html
+ * <script>
+ * 	import { onDestroy } from 'svelte';
+ * 
+ * 	onDestroy(() => {
+ * 		console.log('the component is being destroyed');
+ * 	});
+ * </script>
+ * ```
+ * 
+ * @param fn callback function
+ */
 export function onDestroy(fn: () => any) {
 	get_current_component().$$.on_destroy.push(fn);
 }
-
+/**
+ * 
+ * ```ts
+ * dispatch: ((name: string, detail?: any) => void) = createEventDispatcher();
+ * ```
+ * 
+ * ---
+ * 
+ * Creates an event dispatcher that can be used to dispatch [component events](https://svelte.dev/docs#template-syntax-component-directives-on-eventname). Event dispatchers are functions that can take two arguments: `name` and `detail`.
+ * 
+ * Component events created with `createEventDispatcher` create a [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent). These events do not [bubble](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture) and are not cancellable with `event.preventDefault()`. The `detail` argument corresponds to the [CustomEvent.detail](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail) property and can contain any type of data.
+ * 
+ * ```html
+ * <script>
+ * 	import { createEventDispatcher } from 'svelte';
+ * 
+ * 	const dispatch = createEventDispatcher();
+ * </script>
+ * 
+ * <button on:click="{() => dispatch('notify', 'detail value')}">Fire Event</button>
+ * ```
+ * 
+ * ---
+ * 
+ * Events dispatched from child components can be listened to in their parent. Any data provided when the event was dispatched is available on the `detail` property of the event object.
+ * 
+ * ```html
+ * <script>
+ * 	function callbackFunction(event) {
+ * 		console.log(`Notify fired! Detail: ${event.detail}`)
+ * 	}
+ * </script>
+ * 
+ * <Child on:notify="{callbackFunction}"/>
+ * ```
+ * 
+ * @returns event dispatcher
+ */
 export function createEventDispatcher<
 	EventMap extends {} = any
 >(): <EventKey extends Extract<keyof EventMap, string>>(type: EventKey, detail?: EventMap[EventKey]) => void {
@@ -45,21 +196,106 @@ export function createEventDispatcher<
 		}
 	};
 }
-
-export function setContext<T>(key, context: T) {
+/**
+ * 
+ * ```ts
+ * setContext(key: any, context: any)
+ * ```
+ * 
+ * ---
+ * 
+ * Associates an arbitrary `context` object with the current component and the specified `key`. The context is then available to children of the component (including slotted content) with `getContext`.
+ * 
+ * Like lifecycle functions, this must be called during component initialisation.
+ * 
+ * ```html
+ * <script>
+ * 	import { setContext } from 'svelte';
+ * 
+ * 	setContext('answer', 42);
+ * </script>
+ * ```
+ * 
+ * > Context is not inherently reactive. If you need reactive values in context then you can pass a store into context, which *will* be reactive.
+ * 
+ * @param key context key (Symbols are recommended)
+ * @param context context value
+ */
+export function setContext<T>(key: any, context: T) {
 	get_current_component().$$.context.set(key, context);
 }
-
-export function getContext<T>(key): T {
+/**
+ * 
+ * ```ts
+ * context: any = getContext(key: any)
+ * ```
+ * 
+ * ---
+ * 
+ * Retrieves the context that belongs to the closest parent component with the specified `key`. Must be called during component initialisation.
+ * 
+ * ```html
+ * <script>
+ * 	import { getContext } from 'svelte';
+ * 
+ * 	const answer = getContext('answer');
+ * </script>
+ * ```
+ * 
+ * @param key context key (Symbols are recommended)
+ * @returns context value
+ */
+export function getContext<T>(key: any): T {
 	return get_current_component().$$.context.get(key);
 }
-
+/**
+ * 
+ * ```ts
+ * contexts: Map<any, any> = getAllContexts()
+ * ```
+ * 
+ * ---
+ * 
+ * Retrieves the whole context map that belongs to the closest parent component. Must be called during component initialisation. Useful, for example, if you programmatically create a component and want to pass the existing context to it.
+ * 
+ * ```html
+ * <script>
+ * 	import { getAllContexts } from 'svelte';
+ * 
+ * 	const contexts = getAllContexts();
+ * </script>
+ * ```
+ * 
+ * @returns whole context map that belongs to the closest parent component
+ */
 export function getAllContexts<T extends Map<any, any> = Map<any, any>>(): T {
 	return get_current_component().$$.context;
 }
-
-export function hasContext(key): boolean {
-	return get_current_component().$$.context.has(key);	
+/**
+ * 
+ * ```ts
+ * hasContext: boolean = hasContext(key: any)
+ * ```
+ * 
+ * ---
+ * 
+ * Checks whether a given `key` has been set in the context of a parent component. Must be called during component initialisation.
+ * 
+ * ```html
+ * <script>
+ * 	import { hasContext } from 'svelte';
+ * 
+ * 	if (hasContext('answer')) {
+ * 		// do something
+ * 	}
+ * </script>
+ * ```
+ * 
+ * @param key context key (Symbols are recommended)
+ * @returns boolean indicates whether the context has been set
+ */
+export function hasContext(key:any): boolean {
+	return get_current_component().$$.context.has(key);
 }
 
 // TODO figure out if we still want to support

--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -17,7 +17,30 @@ export function schedule_update() {
 		resolved_promise.then(flush);
 	}
 }
-
+/**
+ * 
+ * ```ts
+ * promise: Promise = tick()
+ * ```
+ * 
+ * ---
+ * 
+ * Returns a promise that resolves once any pending state changes have been applied, or in the next microtask if there are none.
+ * 
+ * ```html
+ * <script>
+ * 	import { beforeUpdate, tick } from 'svelte';
+ * 
+ * 	beforeUpdate(async () => {
+ * 		console.log('the component is about to update');
+ * 		await tick();
+ * 		console.log('the component just updated');
+ * 	});
+ * </script>
+ * ```
+ *  
+ * @returns a promise that resolves once any pending state changes have been applied, or in the next microtask if there are none
+ */
 export function tick() {
 	schedule_update();
 	return resolved_promise;

--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -18,13 +18,6 @@ export function schedule_update() {
 	}
 }
 /**
- * 
- * ```ts
- * promise: Promise = tick()
- * ```
- * 
- * ---
- * 
  * Returns a promise that resolves once any pending state changes have been applied, or in the next microtask if there are none.
  * 
  * ```html

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -71,7 +71,28 @@ export function subscribe(store, ...callbacks) {
 	const unsub = store.subscribe(...callbacks);
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
-
+/**
+ * 
+ * ```ts
+ * value: any = get(store)
+ * ```
+ * 
+ * ---
+ * 
+ * Generally, you should read the value of a store by subscribing to it and using the value as it changes over time. Occasionally, you may need to retrieve the value of a store to which you're not subscribed. `get` allows you to do so.
+ * 
+ * > This works by creating a subscription, reading the value, then unsubscribing. It's therefore not recommended in hot code paths.
+ * 
+ * ```ts
+ * import { get } from 'svelte/store';
+ * 
+ * const value = get(store);
+ * ```
+ * 
+ * 
+ * @param store 
+ * @returns 
+ */
 export function get_store_value<T>(store: Readable<T>): T {
 	let value;
 	subscribe(store, _ => value = _)();

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -72,13 +72,6 @@ export function subscribe(store, ...callbacks) {
 	return unsub.unsubscribe ? () => unsub.unsubscribe() : unsub;
 }
 /**
- * 
- * ```ts
- * value: any = get(store)
- * ```
- * 
- * ---
- * 
  * Generally, you should read the value of a store by subscribing to it and using the value as it changes over time. Occasionally, you may need to retrieve the value of a store to which you're not subscribed. `get` allows you to do so.
  * 
  * > This works by creating a subscription, reading the value, then unsubscribing. It's therefore not recommended in hot code paths.

--- a/src/runtime/motion/spring.ts
+++ b/src/runtime/motion/spring.ts
@@ -74,11 +74,6 @@ export interface Spring<T> extends Readable<T>{
 	precision: number;
 }
 /**
- * 
- * ```ts
- * store = spring(value: any, options)
- * ```
- * 
  * A `spring` store gradually changes to its target value based on its `stiffness` and `damping` parameters. Whereas `tweened` stores change their values over a fixed duration, `spring` stores change over a duration that is determined by their existing velocity, allowing for more natural-seeming motion in many situations. The following options are available:
  * 
  * * `stiffness` (`number`, default `0.15`) — a value between 0 and 1 where higher means a 'tighter' spring

--- a/src/runtime/motion/tweened.ts
+++ b/src/runtime/motion/tweened.ts
@@ -76,11 +76,6 @@ export interface Tweened<T> extends Readable<T> {
 }
 
 /**
- * 
- * ```ts
- * store = tweened(value: any, options)
- * ```
- * 
  * Tweened stores update their values over a fixed duration. The following options are available:
  * 
  * * `delay` (`number`, default 0) — milliseconds before starting

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -46,13 +46,6 @@ type SubscribeInvalidateTuple<T> = [Subscriber<T>, Invalidator<T>];
 const subscriber_queue = [];
 
 /**
- * 
- * ```ts
- * store = readable(value?: any, start?: (set: (value: any) => void) => () => void)
- * ```
- * 
- * ---
- * 
  * Creates a store whose value cannot be set from 'outside', the first argument is the store's initial value, and the second argument to `readable` is the same as the second argument to `writable`.
  * 
  * ```ts
@@ -80,16 +73,6 @@ export function readable<T>(initialValue?: T, start?: StartStopNotifier<T>): Rea
 }
 
 /**
- * 
- * ```ts
- * store = writable(initial_value?: any)
- * ```
- * ```ts
- * store = writable(initial_value?: any, start?: (set: (value: any) => void) => () => void)
- * ```
- * 
- * ---
- * 
  * Function that creates a store which has values that can be set from 'outside' components. It gets created as an object with additional `set` and `update` methods.
  * 
  * `set` is a method that takes one argument which is the value to be set. The store value gets set to the value of the argument if the store value is not already equal to it.
@@ -192,25 +175,6 @@ type StoresValues<T> = T extends Readable<infer U> ? U :
 	{ [K in keyof T]: T[K] extends Readable<infer U> ? U : never };
 
 /**
- *
- * ```ts
- * store = derived(a, callback: (a: any) => any)
- * ```
- * ---
- * ```ts
- * store = derived(a, callback: (a: any, set: (value: any) => void) => void | () => void, initial_value: any)
- * ```
- * ---
- * ```ts
- * store = derived([a, ...b], callback: ([a: any, ...b: any[]]) => any)
- * ```
- * ---
- * ```ts
- * store = derived([a, ...b], callback: ([a: any, ...b: any[]], set: (value: any) => void) => void | () => void, initial_value: any)
- * ```
- * 
- * ---
- * 
  * Derives a store from one or more other stores. The callback runs initially when the first subscriber subscribes and then whenever the store dependencies change.
  * 
  * In the simplest version, `derived` takes a single store, and the callback returns a derived value.

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -1,6 +1,27 @@
 import { cubicOut, cubicInOut, linear } from 'svelte/easing';
 import { assign, is_function } from 'svelte/internal';
-
+/** 
+ * 
+ * Easing functions specify the rate of change over time and are useful when working with Svelte's built-in transitions and animations as well as the tweened and spring utilities. `svelte/easing` contains 31 named exports, a `linear` ease and 3 variants of 10 different easing functions: `in`, `out` and `inOut`.
+ * 
+ * You can explore the various eases using the [ease visualiser](https://svelte.dev/examples/easing) in the [examples section](https://svelte.dev/examples).
+ * 
+ * 
+ * | ease | in | out | inOut |
+ * | --- | --- | --- | --- |
+ * | **back** | `backIn` | `backOut` | `backInOut` |
+ * | **bounce** | `bounceIn` | `bounceOut` | `bounceInOut` |
+ * | **circ** | `circIn` | `circOut` | `circInOut` |
+ * | **cubic** | `cubicIn` | `cubicOut` | `cubicInOut` |
+ * | **elastic** | `elasticIn` | `elasticOut` | `elasticInOut` |
+ * | **expo** | `expoIn` | `expoOut` | `expoInOut` |
+ * | **quad** | `quadIn` | `quadOut` | `quadInOut` |
+ * | **quart** | `quartIn` | `quartOut` | `quartInOut` |
+ * | **quint** | `quintIn` | `quintOut` | `quintInOut` |
+ * | **sine** | `sineIn` | `sineOut` | `sineInOut` |
+ * 
+ * 
+ */
 export type EasingFunction = (t: number) => number;
 
 export interface TransitionConfig {
@@ -12,13 +33,57 @@ export interface TransitionConfig {
 }
 
 export interface BlurParams {
+	/** (`number`, default 0) — milliseconds before starting */
 	delay?: number;
+	/** (`number`, default 400) — milliseconds the transition lasts */
 	duration?: number;
+	/** (`function`, default `cubicInOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
+	/** (`number`, default 5) - the size of the blur in pixels */
 	amount?: number;
+	/** (`number`, default 0) - the opacity value to animate out to and in from */
 	opacity?: number;
 }
-
+/**
+ * 
+ * ```html
+ * transition:blur={params}
+ * ```
+ * ```html
+ * in:blur={params}
+ * ```
+ * ```html
+ * out:blur={params}
+ * ```
+ * 
+ * ---
+ * 
+ * Animates a `blur` filter alongside an element's opacity.
+ * 
+ * `blur` accepts the following parameters:
+ * 
+ * * `delay` (`number`, default 0) — milliseconds before starting
+ * * `duration` (`number`, default 400) — milliseconds the transition lasts
+ * * `easing` (`function`, default `cubicInOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing)
+ * * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
+ * * `amount` (`number`, default 5) - the size of the blur in pixels
+ * 
+ * ```html
+ * <script>
+ * 	import { blur } from 'svelte/transition';
+ * </script>
+ * 
+ * {#if condition}
+ * 	<div transition:blur="{{amount: 10}}">
+ * 		fades in and out
+ * 	</div>
+ * {/if}
+ * ```
+ * 
+ * @param node 
+ * @param options 
+ * @returns transition config
+ */
 export function blur(node: Element, {
 	delay = 0,
 	duration = 400,
@@ -41,11 +106,52 @@ export function blur(node: Element, {
 }
 
 export interface FadeParams {
+	/** (`number`, default 0) — milliseconds before starting */
 	delay?: number;
+	/** (`number`, default 400) — milliseconds the transition lasts */
 	duration?: number;
+	/** (`function`, default `linear`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
 }
-
+/**
+ * 
+ * ```html
+ * transition:fade={params}
+ * ```
+ * ```html
+ * in:fade={params}
+ * ```
+ * ```html
+ * out:fade={params}
+ * ```
+ * 
+ * ---
+ * 
+ * Animates the opacity of an element from 0 to the current opacity for `in` transitions and from the current opacity to 0 for `out` transitions.
+ * 
+ * `fade` accepts the following parameters:
+ * 
+ * * `delay` (`number`, default 0) — milliseconds before starting
+ * * `duration` (`number`, default 400) — milliseconds the transition lasts
+ * * `easing` (`function`, default `linear`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing)
+ * 
+ * You can see the `fade` transition in action in the [transition tutorial](https://svelte.dev/tutorial/transition).
+ * 
+ * ```html
+ * <script>
+ * 	import { fade } from 'svelte/transition';
+ * </script>
+ * 
+ * {#if condition}
+ * 	<div transition:fade="{{delay: 250, duration: 300}}">
+ * 		fades in and out
+ * 	</div>
+ * {/if}
+ * ```
+ * @param node 
+ * @param param1 
+ * @returns 
+ */
 export function fade(node: Element, {
 	delay = 0,
 	duration = 400,
@@ -62,14 +168,63 @@ export function fade(node: Element, {
 }
 
 export interface FlyParams {
+	/** (`number`, default 0) — milliseconds before starting */
 	delay?: number;
+	/** (`number`, default 400) — milliseconds the transition lasts */
 	duration?: number;
+	/** (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
+	/** (`number`, default 0) - the x offset to animate out to and in from */
 	x?: number;
+	/** (`number`, default 0) - the y offset to animate out to and in from */
 	y?: number;
+	/** (`number`, default 0) - the opacity value to animate out to and in from */
 	opacity?: number;
 }
-
+/**
+ * 
+ * ```html
+ * transition:fly={params}
+ * ```
+ * ```html
+ * in:fly={params}
+ * ```
+ * ```html
+ * out:fly={params}
+ * ```
+ * 
+ * ---
+ * 
+ * Animates the x and y positions and the opacity of an element. `in` transitions animate from an element's current (default) values to the provided values, passed as parameters. `out` transitions animate from the provided values to an element's default values.
+ * 
+ * `fly` accepts the following parameters:
+ * 
+ * * `delay` (`number`, default 0) — milliseconds before starting
+ * * `duration` (`number`, default 400) — milliseconds the transition lasts
+ * * `easing` (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing)
+ * * `x` (`number`, default 0) - the x offset to animate out to and in from
+ * * `y` (`number`, default 0) - the y offset to animate out to and in from
+ * * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
+ * 
+ * You can see the `fly` transition in action in the [transition tutorial](https://svelte.dev/tutorial/adding-parameters-to-transitions).
+ * 
+ * ```html
+ * <script>
+ * 	import { fly } from 'svelte/transition';
+ * 	import { quintOut } from 'svelte/easing';
+ * </script>
+ * 
+ * {#if condition}
+ * 	<div transition:fly="{{delay: 250, duration: 300, x: 100, y: 500, opacity: 0.5, easing: quintOut}}">
+ * 		flies in and out
+ * 	</div>
+ * {/if}
+ * ```
+ * 
+ * @param node 
+ * @param options
+ * @returns transition config
+ */
 export function fly(node: Element, {
 	delay = 0,
 	duration = 400,
@@ -95,11 +250,52 @@ export function fly(node: Element, {
 }
 
 export interface SlideParams {
+	/** (`number`, default 0) — milliseconds before starting */
 	delay?: number;
+	/** (`number`, default 400) — milliseconds the transition lasts */
 	duration?: number;
+	/** (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
 }
-
+/**
+ * 
+ * ```html
+ * transition:slide={params}
+ * ```
+ * ```html
+ * in:slide={params}
+ * ```
+ * ```html
+ * out:slide={params}
+ * ```
+ * 
+ * ---
+ * 
+ * Slides an element in and out.
+ * 
+ * `slide` accepts the following parameters:
+ * 
+ * * `delay` (`number`, default 0) — milliseconds before starting
+ * * `duration` (`number`, default 400) — milliseconds the transition lasts
+ * * `easing` (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing)
+ * 
+ * ```html
+ * <script>
+ * 	import { slide } from 'svelte/transition';
+ * 	import { quintOut } from 'svelte/easing';
+ * </script>
+ * 
+ * {#if condition}
+ * 	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut }}">
+ * 		slides in and out
+ * 	</div>
+ * {/if}
+ * ```
+ * 
+ * @param node 
+ * @param options
+ * @returns transition config
+ */
 export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
@@ -133,13 +329,57 @@ export function slide(node: Element, {
 }
 
 export interface ScaleParams {
+	/** (`number`, default 0) — milliseconds before starting */
 	delay?: number;
+	/** (`number`, default 400) — milliseconds the transition lasts */
 	duration?: number;
+	/** (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
+	/** (`number`, default 0) - the scale value to animate out to and in from */
 	start?: number;
+	/** (`number`, default 0) - the opacity value to animate out to and in from */
 	opacity?: number;
 }
-
+/**
+ * 
+ * ```html
+ * transition:scale={params}
+ * ```
+ * ```html
+ * in:scale={params}
+ * ```
+ * ```html
+ * out:scale={params}
+ * ```
+ * 
+ * ---
+ * 
+ * Animates the opacity and scale of an element. `in` transitions animate from an element's current (default) values to the provided values, passed as parameters. `out` transitions animate from the provided values to an element's default values.
+ * 
+ * `scale` accepts the following parameters:
+ * 
+ * * `delay` (`number`, default 0) — milliseconds before starting
+ * * `duration` (`number`, default 400) — milliseconds the transition lasts
+ * * `easing` (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing)
+ * * `start` (`number`, default 0) - the scale value to animate out to and in from
+ * * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
+ * 
+ * ```html
+ * <script>
+ * 	import { scale } from 'svelte/transition';
+ * 	import { quintOut } from 'svelte/easing';
+ * </script>
+ * 
+ * {#if condition}
+ * 	<div transition:scale="{{duration: 500, delay: 500, opacity: 0.5, start: 0.5, easing: quintOut}}">
+ * 		scales in and out
+ * 	</div>
+ * {/if}
+ * ```
+ * @param node 
+ * @param options
+ * @returns transition config
+ */
 export function scale(node: Element, {
 	delay = 0,
 	duration = 400,
@@ -166,12 +406,68 @@ export function scale(node: Element, {
 }
 
 export interface DrawParams {
+	/** (`number`, default 0) — milliseconds before starting */
 	delay?: number;
+	/** (`number`, default undefined) - the speed of the animation
+	 * 
+	 *  The `speed` parameter is a means of setting the duration of the transition relative to the path's length. It is a modifier that is applied to the length of the path: `duration = length / speed`. A path that is 1000 pixels with a speed of 1 will have a duration of `1000ms`, setting the speed to `0.5` will double that duration and setting it to `2` will halve it 
+	 */
 	speed?: number;
+	/** (`number` | `function`, default 800) — milliseconds the transition lasts */
 	duration?: number | ((len: number) => number);
+	/** (`function`, default `cubicInOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
 }
-
+/**
+ * 
+ * ```html
+ * transition:draw={params}
+ * ```
+ * ```html
+ * in:draw={params}
+ * ```
+ * ```html
+ * out:draw={params}
+ * ```
+ * 
+ * ---
+ * 
+ * Animates the stroke of an SVG element, like a snake in a tube. `in` transitions begin with the path invisible and draw the path to the screen over time. `out` transitions start in a visible state and gradually erase the path. `draw` only works with elements that have a `getTotalLength` method, like `<path>` and `<polyline>`.
+ * 
+ * `draw` accepts the following parameters:
+ * 
+ * * `delay` (`number`, default 0) — milliseconds before starting
+ * * `speed` (`number`, default undefined) - the speed of the animation, see below.
+ * * `duration` (`number` | `function`, default 800) — milliseconds the transition lasts
+ * * `easing` (`function`, default `cubicInOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing)
+ * 
+ * The `speed` parameter is a means of setting the duration of the transition relative to the path's length. It is a modifier that is applied to the length of the path: `duration = length / speed`. A path that is 1000 pixels with a speed of 1 will have a duration of `1000ms`, setting the speed to `0.5` will double that duration and setting it to `2` will halve it.
+ * 
+ * ```html
+ * <script>
+ * 	import { draw } from 'svelte/transition';
+ * 	import { quintOut } from 'svelte/easing';
+ * </script>
+ * 
+ * <svg viewBox="0 0 5 5" xmlns="http://www.w3.org/2000/svg">
+ * 	{#if condition}
+ * 		<path transition:draw="{{duration: 5000, delay: 500, easing: quintOut}}"
+ * 					d="M2 1 h1 v1 h1 v1 h-1 v1 h-1 v-1 h-1 v-1 h1 z"
+ * 					fill="none"
+ * 					stroke="cornflowerblue"
+ * 					stroke-width="0.1px"
+ * 					stroke-linejoin="round"
+ * 		/>
+ * 	{/if}
+ * </svg>
+ * 
+ * ```
+ * 
+ * 
+ * @param node 
+ * @param options
+ * @returns transition config
+ */
 export function draw(node: SVGElement & { getTotalLength(): number }, {
 	delay = 0,
 	speed,
@@ -203,28 +499,65 @@ export function draw(node: SVGElement & { getTotalLength(): number }, {
 }
 
 export interface CrossfadeParams {
+	/** (`number`, default 0) — milliseconds before starting */
 	delay?: number;
+	/** (`number` | `function`, default 800) — milliseconds the transition lasts */
 	duration?: number | ((len: number) => number);
+	/** (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
+	/** (`function`) — A fallback [transition](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) to use for send when there is no matching element being received, and for receive when there is no element being sent.  */
+	fallback?: (node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig;
 }
 
 type ClientRectMap = Map<any, { rect: ClientRect }>;
-
-export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
-	fallback?: (node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig;
-}): [
-  (
-    node: Element,
-    params: CrossfadeParams & {
-      key: any;
-    }
-  ) => () => TransitionConfig,
-  (
-    node: Element,
-    params: CrossfadeParams & {
-      key: any;
-    }
-  ) => () => TransitionConfig
+/**
+ * 
+ * The `crossfade` function creates a pair of [transitions](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.
+ * 
+ * ---
+ * 
+ * `crossfade` accepts the following parameters:
+ * 
+ * * `delay` (`number`, default 0) — milliseconds before starting
+ * * `duration` (`number` | `function`, default 800) — milliseconds the transition lasts
+ * * `easing` (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing)
+ * * `fallback` (`function`) — A fallback [transition](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) to use for send when there is no matching element being received, and for receive when there is no element being sent. 
+ * 
+ * ```html
+ * <script>
+ * 	import { crossfade } from 'svelte/transition';
+ * 	import { quintOut } from 'svelte/easing';
+ * 
+ * 	const [send, receive] = crossfade({
+ * 		duration:1500,
+ * 		easing: quintOut
+ * 	});
+ * </script>
+ * 
+ * {#if condition}
+ * 	<h1 in:send={{key}} out:receive={{key}}>BIG ELEM</h1>
+ * {:else}
+ * 	<small in:send={{key}} out:receive={{key}}>small elem</small>
+ * {/if}
+ * ```
+ * 
+ * 
+ * @param options 
+ * @returns a pair of transitions 
+ */
+export function crossfade({ fallback, ...defaults }: CrossfadeParams): [
+	(
+		node: Element,
+		params: CrossfadeParams & {
+			key: any;
+		}
+	) => () => TransitionConfig,
+	(
+		node: Element,
+		params: CrossfadeParams & {
+			key: any;
+		}
+	) => () => TransitionConfig
 ] {
 	const to_receive: ClientRectMap = new Map();
 	const to_send: ClientRectMap = new Map();

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -510,6 +510,9 @@ export interface CrossfadeParams {
 	duration?: number | ((len: number) => number);
 	/** (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
+}
+
+export interface CrossfadeInput extends CrossfadeParams {
 	/** (`function`) — A fallback [transition](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) to use for send when there is no matching element being received, and for receive when there is no element being sent.  */
 	fallback?: (node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig;
 }
@@ -551,7 +554,7 @@ type ClientRectMap = Map<any, { rect: ClientRect }>;
  * @param options 
  * @returns a pair of transitions 
  */
-export function crossfade({ fallback, ...defaults }: CrossfadeParams): [
+export function crossfade({ fallback, ...defaults }: CrossfadeInput): [
 	(
 		node: Element,
 		params: CrossfadeParams & {

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -1,5 +1,6 @@
 import { cubicOut, cubicInOut, linear } from 'svelte/easing';
 import { assign, is_function } from 'svelte/internal';
+
 /** 
  * 
  * Easing functions specify the rate of change over time and are useful when working with Svelte's built-in transitions and animations as well as the tweened and spring utilities. `svelte/easing` contains 31 named exports, a `linear` ease and 3 variants of 10 different easing functions: `in`, `out` and `inOut`.
@@ -113,6 +114,7 @@ export interface FadeParams {
 	/** (`function`, default `linear`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
 }
+
 /**
  * 
  * ```html
@@ -257,6 +259,7 @@ export interface SlideParams {
 	/** (`function`, default `cubicOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
 }
+
 /**
  * 
  * ```html
@@ -340,6 +343,7 @@ export interface ScaleParams {
 	/** (`number`, default 0) - the opacity value to animate out to and in from */
 	opacity?: number;
 }
+
 /**
  * 
  * ```html
@@ -418,6 +422,7 @@ export interface DrawParams {
 	/** (`function`, default `cubicInOut`) — an [easing function](https://svelte.dev/docs#run-time-svelte-easing) */
 	easing?: EasingFunction;
 }
+
 /**
  * 
  * ```html
@@ -510,6 +515,7 @@ export interface CrossfadeParams {
 }
 
 type ClientRectMap = Map<any, { rect: ClientRect }>;
+
 /**
  * 
  * The `crossfade` function creates a pair of [transitions](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`


#### what happened ? 
this PR adds jsdoc for most functions in runtime API
some parameters are renamed for better readability and more meaningful names
some interfaces are exported ( they were used in public api but didn't exported ) and they are mostly renamed ( it does not cause breaking change because its a new export ) 

additionally the fallback parameter off crossfade is merged into single interface ( it was separated )
#7230 