### PR TITLE
[docs] set language on FAQ code blocks

### DIFF
--- a/site/content/faq/450-how-do-i-document-my-components.md
+++ b/site/content/faq/450-how-do-i-document-my-components.md
@@ -4,7 +4,7 @@ question: How do I document my components?
 
 In editors which use the Svelte Language Server you can document Components, functions and exports using specially formatted comments.
 
-````svelte
+````sv
 <script>
 	/** What should we call the user? */
 	export let name = 'world';

--- a/site/content/faq/500-what-about-typescript-support.md
+++ b/site/content/faq/500-what-about-typescript-support.md
@@ -6,14 +6,14 @@ You need to install a preprocessor such as [svelte-preprocess](https://github.co
 
 To declare the type of a reactive variable in a Svelte template, you should use the following syntax:
 
-```
+```ts
 let x: number;
 $: x = count + 1;
 ```
 
 To import a type or interface make sure to use [TypeScript's `type` modifier](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export):
 
-```
+```ts
 import type { SomeInterface } from './SomeFile';
 ```
 


### PR DESCRIPTION
The code blocks in the FAQ were either missing languages or had the incorrect language (the API used to parse the markdown [requires](https://github.com/sveltejs/action-deploy-docs/blob/42d39f22a94353de238f9e2382645458e1ebb99f/src/format/code.ts#L18) `sv` for Svelte).

https://github.com/sveltejs/sites/pull/297 should be merged and released first so that the correct styles are applied.

See https://github.com/sveltejs/kit/pull/3794#issuecomment-1033963412 for context

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
