### PR TITLE
[fix] Removal of empty stylesheets created from transitions

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -154,7 +154,7 @@ export function get_root_for_style(node: Node): ShadowRoot | Document {
 	return node.ownerDocument;
 }
 
-export function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement): CSSStyleSheet {
+export function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement) {
 	append((node as Document).head || node, style);
 	return style.sheet;
 }

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -156,7 +156,7 @@ export function get_root_for_style(node: Node): ShadowRoot | Document {
 
 export function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement) {
 	append((node as Document).head || node, style);
-	return style.sheet;
+	return style.sheet as CSSStyleSheet;
 }
 
 export function append_hydration(target: NodeEx, node: NodeEx) {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -154,14 +154,9 @@ export function get_root_for_style(node: Node): ShadowRoot | Document {
 	return node.ownerDocument;
 }
 
-export function append_empty_stylesheet(node: Node) {
-	const style_element = element('style') as HTMLStyleElement;
-	append_stylesheet(get_root_for_style(node), style_element);
-	return style_element.sheet as CSSStyleSheet;
-}
-
-function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement) {
+export function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement): CSSStyleSheet {
 	append((node as Document).head || node, style);
+	return style.sheet
 }
 
 export function append_hydration(target: NodeEx, node: NodeEx) {

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -156,7 +156,7 @@ export function get_root_for_style(node: Node): ShadowRoot | Document {
 
 export function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement): CSSStyleSheet {
 	append((node as Document).head || node, style);
-	return style.sheet
+	return style.sheet;
 }
 
 export function append_hydration(target: NodeEx, node: NodeEx) {

--- a/src/runtime/internal/style_manager.ts
+++ b/src/runtime/internal/style_manager.ts
@@ -1,8 +1,8 @@
-import { append_empty_stylesheet, get_root_for_style } from './dom';
+import { append_stylesheet, detach, element, get_root_for_style } from './dom';
 import { raf } from './environment';
 
 interface StyleInformation {
-	stylesheet: CSSStyleSheet;
+	style_element: HTMLStyleElement;
 	rules: Record<string, true>;
 }
 
@@ -20,8 +20,8 @@ function hash(str: string) {
 	return hash >>> 0;
 }
 
-function create_style_information(doc: Document | ShadowRoot, node: Element & ElementCSSInlineStyle) {
-	const info = { stylesheet: append_empty_stylesheet(node), rules: {} };
+function create_style_information(doc: Document | ShadowRoot) {
+	const info = { style_element: element('style'), rules: {} };
 	managed_styles.set(doc, info);
 	return info;
 }
@@ -39,9 +39,10 @@ export function create_rule(node: Element & ElementCSSInlineStyle, a: number, b:
 	const name = `__svelte_${hash(rule)}_${uid}`;
 	const doc = get_root_for_style(node);
 
-	const { stylesheet, rules } = managed_styles.get(doc) || create_style_information(doc, node);
-
+	const { style_element, rules } = managed_styles.get(doc) || create_style_information(doc);
+	
 	if (!rules[name]) {
+		const stylesheet = append_stylesheet(doc, style_element)
 		rules[name] = true;
 		stylesheet.insertRule(`@keyframes ${name} ${rule}`, stylesheet.cssRules.length);
 	}
@@ -50,6 +51,7 @@ export function create_rule(node: Element & ElementCSSInlineStyle, a: number, b:
 	node.style.animation = `${animation ? `${animation}, ` : ''}${name} ${duration}ms linear ${delay}ms 1 both`;
 
 	active += 1;
+
 	return name;
 }
 
@@ -71,9 +73,8 @@ export function clear_rules() {
 	raf(() => {
 		if (active) return;
 		managed_styles.forEach(info => {
-			const { stylesheet } = info;
-			let i = stylesheet.cssRules.length;
-			while (i--) stylesheet.deleteRule(i);
+			const { style_element } = info;
+			detach(style_element)
 			info.rules = {};
 		});
 		managed_styles.clear();

--- a/src/runtime/internal/style_manager.ts
+++ b/src/runtime/internal/style_manager.ts
@@ -42,7 +42,7 @@ export function create_rule(node: Element & ElementCSSInlineStyle, a: number, b:
 	const { style_element, rules } = managed_styles.get(doc) || create_style_information(doc);
 	
 	if (!rules[name]) {
-		const stylesheet = append_stylesheet(doc, style_element)
+		const stylesheet = append_stylesheet(doc, style_element);
 		rules[name] = true;
 		stylesheet.insertRule(`@keyframes ${name} ${rule}`, stylesheet.cssRules.length);
 	}
@@ -74,7 +74,7 @@ export function clear_rules() {
 		if (active) return;
 		managed_styles.forEach(info => {
 			const { style_element } = info;
-			detach(style_element)
+			detach(style_element);
 			info.rules = {};
 		});
 		managed_styles.clear();

--- a/test/runtime/samples/style_manager-cleanup/_config.js
+++ b/test/runtime/samples/style_manager-cleanup/_config.js
@@ -8,7 +8,7 @@ export default {
 		raf.tick(100);
 		component.visible = false;
 		raf.tick(200);
-		raf.tick(60);
+		raf.tick(0);
 
 		assert.htmlEqual(
 			window.document.head.innerHTML,

--- a/test/runtime/samples/style_manager-cleanup/_config.js
+++ b/test/runtime/samples/style_manager-cleanup/_config.js
@@ -5,10 +5,10 @@ export default {
 
 	async test({ raf, assert, component, window }) {
 		component.visible = true;
-		raf.tick(100)
+		raf.tick(100);
 		component.visible = false;
-		raf.tick(200)
-		raf.tick(60)
+		raf.tick(200);
+		raf.tick(60);
 
 		assert.htmlEqual(
 			window.document.head.innerHTML,

--- a/test/runtime/samples/style_manager-cleanup/_config.js
+++ b/test/runtime/samples/style_manager-cleanup/_config.js
@@ -1,0 +1,18 @@
+export default {
+	skip_if_ssr: true,
+	skip_if_hydrate: true,
+	skip_if_hydrate_from_ssr: true,
+
+	async test({ raf, assert, component, window }) {
+		component.visible = true;
+		raf.tick(100)
+		component.visible = false;
+		raf.tick(200)
+		raf.tick(60)
+
+		assert.htmlEqual(
+			window.document.head.innerHTML,
+			''
+		);
+	}
+};

--- a/test/runtime/samples/style_manager-cleanup/main.svelte
+++ b/test/runtime/samples/style_manager-cleanup/main.svelte
@@ -1,5 +1,5 @@
 <script>
-export let visible = true;
+export let visible = false;
 
 function foo(node, params) {
 	return {

--- a/test/runtime/samples/style_manager-cleanup/main.svelte
+++ b/test/runtime/samples/style_manager-cleanup/main.svelte
@@ -1,0 +1,14 @@
+<script>
+export let visible = true;
+
+function foo(node, params) {
+	return {
+		duration: 100,
+		css: () => ''
+	};
+}
+</script>
+
+{#if visible}
+	<div transition:foo></div>
+{/if}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`

### Closes
- https://github.com/sveltejs/svelte/issues/4801
- https://github.com/sveltejs/svelte/issues/7164

## What has been changed?
The `style_manager` "cleaned up" the stylesheets it made by only clearing their rules. After clearing them, it removed them from its internal map by running `managed_styles.clear()`. This cleanup was not optimal - it left the style elements empty in the dom.

The proposed change is to remove style-elements created by `style_manager`, instead of making them empty and letting them stay in the DOM without any references. I also refactored some of the methods from the `runtime/internal/dom.ts` file that were only used by the `style_manager` or in the `dom.ts file` itself.

If you want to reverse-engineer this bug yourself, then start with the `append_empty_stylesheet` method in the `dom.ts` file. As long as `append_empty_stylesheet` is used, there will be bugs related to empty stylesheets. It does the following:
1. Creates an empty style-element
2. Appends it to the dom
3. Returns only the sheet of the new style-element, leaving the style-tag totally unreferenced by any code