### PR TITLE
[fix]: strip leading newline characters after 'pre' elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "svelte",
       "version": "3.46.4",
       "license": "MIT",
       "devDependencies": {

--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -84,7 +84,7 @@ export default function tag(parser: Parser) {
 				parser.current().children.length
 			) {
 				parser.error(
-					parser_errors.invalid_element_content(slug, name), 
+					parser_errors.invalid_element_content(slug, name),
 					parser.current().children[0].start
 				);
 			}
@@ -197,6 +197,14 @@ export default function tag(parser: Parser) {
 
 	parser.eat('>', true);
 
+	// A leading newline character immediately following the pre element start tag is stripped
+	// See spec: https://www.w3.org/TR/2011/WD-html5-20110113/grouping-content.html#the-pre-element
+	if (!is_closing_tag && name === 'pre') {
+		if (!parser.eat('\r\n')) {
+			parser.eat('\n');
+		}
+	}
+
 	if (self_closing) {
 		// don't push self-closing elements onto the stack
 		element.end = parser.index;
@@ -258,7 +266,7 @@ function read_tag_name(parser: Parser) {
 		const match = fuzzymatch(name.slice(7), valid_meta_tags);
 
 		parser.error(
-			parser_errors.invalid_tag_name_svelte_element(valid_meta_tags, match), 
+			parser_errors.invalid_tag_name_svelte_element(valid_meta_tags, match),
 			start
 		);
 	}

--- a/test/parser/samples/leading-newline-after-pre-tag/input.svelte
+++ b/test/parser/samples/leading-newline-after-pre-tag/input.svelte
@@ -1,0 +1,3 @@
+<pre>
+test
+</pre>

--- a/test/parser/samples/leading-newline-after-pre-tag/output.json
+++ b/test/parser/samples/leading-newline-after-pre-tag/output.json
@@ -1,0 +1,25 @@
+{
+	"html": {
+		"start": 0,
+		"end": 17,
+		"type": "Fragment",
+		"children": [
+			{
+				"start": 0,
+				"end": 17,
+				"type": "Element",
+				"name": "pre",
+				"attributes": [],
+				"children": [
+					{
+						"start": 6,
+						"end": 11,
+						"type": "Text",
+						"raw": "test\n",
+						"data": "test\n"
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
Close #7264

Strips the leading newline character after 'pre' elements per the spec https://www.w3.org/TR/2011/WD-html5-20110113/grouping-content.html#the-pre-element

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
