### PR TITLE
[doc] fixed seemingly erroneous capitalization of noun

### DIFF
--- a/site/content/faq/100-im-new-to-svelte.md
+++ b/site/content/faq/100-im-new-to-svelte.md
@@ -2,6 +2,6 @@
 question: I'm new to Svelte. Where should I start?
 ---
 
-We think the best way to get started is playing through the interactive [Tutorial](/tutorial). Each step there is mainly focused on one specific aspect and is easy to follow. You'll be editing and running real Svelte components right in your browser.
+We think the best way to get started is playing through the interactive [tutorial](/tutorial). Each step there is mainly focused on one specific aspect and is easy to follow. You'll be editing and running real Svelte components right in your browser.
 
 Five to ten minutes should be enough to get you up and running. An hour and a half should get you through the entire tutorial.


### PR DESCRIPTION
Fixed the seemingly erroneous capitalization of "tutorial" in `faq/100-im-new-to-svelte.md`.

Tutorial -> tutorial.
