### PR TITLE
[docs] improve actions tutorial presentation

### DIFF
--- a/site/content/examples/13-actions/00-actions/App.svelte
+++ b/site/content/examples/13-actions/00-actions/App.svelte
@@ -20,6 +20,9 @@
 		height: var(--height);
 		left: calc(50% - var(--width) / 2);
 		top: calc(50% - var(--height) / 2);
+		display: flex;
+		align-items: center;
+		padding: 8px;
 		border-radius: 4px;
 		background-color: #ff3e00;
 		color: #fff;

--- a/site/content/tutorial/12-actions/01-actions/app-a/App.svelte
+++ b/site/content/tutorial/12-actions/01-actions/app-a/App.svelte
@@ -20,6 +20,9 @@
 		height: var(--height);
 		left: calc(50% - var(--width) / 2);
 		top: calc(50% - var(--height) / 2);
+		display: flex;
+		align-items: center;
+		padding: 8px;
 		border-radius: 4px;
 		background-color: #ff3e00;
 		color: #fff;

--- a/site/content/tutorial/12-actions/01-actions/app-b/App.svelte
+++ b/site/content/tutorial/12-actions/01-actions/app-b/App.svelte
@@ -20,6 +20,9 @@
 		height: var(--height);
 		left: calc(50% - var(--width) / 2);
 		top: calc(50% - var(--height) / 2);
+		display: flex;
+		align-items: center;
+		padding: 8px;
 		border-radius: 4px;
 		background-color: #ff3e00;
 		color: #fff;


### PR DESCRIPTION
This commit will improve the presentation of the actions tutorial example at https://svelte.dev/tutorial/actions

Current presentation:

![image](https://user-images.githubusercontent.com/481687/154577039-cb3708a1-f6a9-47e6-be44-7d8149296e49.png)

After proposed changes:

![image](https://user-images.githubusercontent.com/481687/154577068-d0e58e97-8171-4f87-b3a6-6919f7a60165.png)
