### PR TITLE
[docs] Improve clarity of 2 files to edit and improve learning

### DIFF
--- a/site/content/tutorial/01-introduction/05-nested-components/text.md
+++ b/site/content/tutorial/01-introduction/05-nested-components/text.md
@@ -6,7 +6,7 @@ It would be impractical to put your entire app in a single component. Instead, w
 
 We now present you 2 files in the editor on the right (upper bar) to click on, `App.svelte` and `Nested.svelte`.
 
-Each component is a reusable self-contained block of code that encapsulates HTML, CSS, and JavaScript that belong together, written into a `.svelte` file.
+Each `.svelte` file holds a component that is a reusable self-contained block of code that encapsulates HTML, CSS, and JavaScript that belong together.
 
 Let's add a `<script>` tag to `App.svelte` that imports the file (our component) `Nested.svelte` into our app...
 

--- a/site/content/tutorial/01-introduction/05-nested-components/text.md
+++ b/site/content/tutorial/01-introduction/05-nested-components/text.md
@@ -2,9 +2,13 @@
 title: Nested components
 ---
 
-It would be impractical to put your entire app in a single component. Instead, we can import components from other files and include them as though we were including elements.
+It would be impractical to put your entire app in a single component. Instead, we can import components from other files and then use them as though we were including elements.
 
-Add a `<script>` tag that imports `Nested.svelte`...
+NOTE: Remember that in Svelte, an application is composed from one or more components and each component is a reusable self-contained block of code that encapsulates HTML, CSS, and JavaScript that belong together, written into a `.svelte` file.
+
+We now present you 2 files in the editor on the right (upper bar) to click on, `App.svelte` and `Nested.svelte`.
+
+Let's add a `<script>` tag to `App.svelte` that imports the file and our component `Nested.svelte` to our app...
 
 ```html
 <script>
@@ -12,7 +16,7 @@ Add a `<script>` tag that imports `Nested.svelte`...
 </script>
 ```
 
-...then add it to the markup:
+...then add the component `Nested` to use it in the app markup:
 
 ```html
 <p>This is a paragraph.</p>

--- a/site/content/tutorial/01-introduction/05-nested-components/text.md
+++ b/site/content/tutorial/01-introduction/05-nested-components/text.md
@@ -4,9 +4,9 @@ title: Nested components
 
 It would be impractical to put your entire app in a single component. Instead, we can import components from other files and then use them as though we were including elements.
 
-NOTE: Remember that in Svelte, an application is composed from one or more components and each component is a reusable self-contained block of code that encapsulates HTML, CSS, and JavaScript that belong together, written into a `.svelte` file.
-
 We now present you 2 files in the editor on the right (upper bar) to click on, `App.svelte` and `Nested.svelte`.
+
+Each component is a reusable self-contained block of code that encapsulates HTML, CSS, and JavaScript that belong together, written into a `.svelte` file.
 
 Let's add a `<script>` tag to `App.svelte` that imports the file and our component `Nested.svelte` to our app...
 

--- a/site/content/tutorial/01-introduction/05-nested-components/text.md
+++ b/site/content/tutorial/01-introduction/05-nested-components/text.md
@@ -8,7 +8,7 @@ We now present you 2 files in the editor on the right (upper bar) to click on, `
 
 Each component is a reusable self-contained block of code that encapsulates HTML, CSS, and JavaScript that belong together, written into a `.svelte` file.
 
-Let's add a `<script>` tag to `App.svelte` that imports the file and our component `Nested.svelte` to our app...
+Let's add a `<script>` tag to `App.svelte` that imports the file (our component) `Nested.svelte` into our app...
 
 ```html
 <script>

--- a/site/content/tutorial/01-introduction/05-nested-components/text.md
+++ b/site/content/tutorial/01-introduction/05-nested-components/text.md
@@ -16,7 +16,7 @@ Let's add a `<script>` tag to `App.svelte` that imports the file (our component)
 </script>
 ```
 
-...then add the component `Nested` to use it in the app markup:
+...then use component `Nested` in the app markup:
 
 ```html
 <p>This is a paragraph.</p>


### PR DESCRIPTION
While going through the tutorial, I didn't notice the 2nd file to edit in the tutorial or the way that Svelte directly uses a component and by this stage in the tutorial had forgot what exactly components themselves are. (They are only mentioned in the intro basics at the very bottom).  Repetition is the key to reinforcement learning, so let's repeat what components are at this critical point of learning.
This fixes all 3 issues and importantly reaffirms what components are.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
