### PR TITLE
[fix] textContent should not be set for <template> element.

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -288,11 +288,12 @@ export default class ElementWrapper extends Wrapper {
 		}
 
 		// insert static children with textContent or innerHTML
+		// skip textcontent for <template>.  append nodes to TemplateElement.content instead
 		const can_use_textcontent = this.can_use_textcontent();
-		const isTemplate = this.node.name == 'template';
-		// skip textcontent logic for <template>. should append to the template .content 
-		const isTemplateWithTextContent = isTemplate && can_use_textcontent;
-		if (!isTemplateWithTextContent && !this.node.namespace && (this.can_use_innerhtml || can_use_textcontent) && this.fragment.nodes.length > 0) {
+		const is_template = this.node.name === 'template';
+		const is_template_with_text_content = is_template && can_use_textcontent;
+
+		if (!is_template_with_text_content && !this.node.namespace && (this.can_use_innerhtml || can_use_textcontent) && this.fragment.nodes.length > 0) {
 			if (this.fragment.nodes.length === 1 && this.fragment.nodes[0].node.type === 'Text') {
 				block.chunks.create.push(
 					b`${node}.textContent = ${string_literal((this.fragment.nodes[0] as TextWrapper).data)};`
@@ -323,7 +324,7 @@ export default class ElementWrapper extends Wrapper {
 			this.fragment.nodes.forEach((child: Wrapper) => {
 				child.render(
 					block,
-					this.node.name === 'template' ? x`${node}.content` : node,
+					is_template ? x`${node}.content` : node,
 					nodes
 				);
 			});

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -289,7 +289,10 @@ export default class ElementWrapper extends Wrapper {
 
 		// insert static children with textContent or innerHTML
 		const can_use_textcontent = this.can_use_textcontent();
-		if (!this.node.namespace && (this.can_use_innerhtml || can_use_textcontent) && this.fragment.nodes.length > 0) {
+		const isTemplate = this.node.name == 'template';
+		// skip textcontent logic for <template>. should append to the template .content 
+		const isTemplateWithTextContent = isTemplate && can_use_textcontent;
+		if (!isTemplateWithTextContent && !this.node.namespace && (this.can_use_innerhtml || can_use_textcontent) && this.fragment.nodes.length > 0) {
 			if (this.fragment.nodes.length === 1 && this.fragment.nodes[0].node.type === 'Text') {
 				block.chunks.create.push(
 					b`${node}.textContent = ${string_literal((this.fragment.nodes[0] as TextWrapper).data)};`

--- a/test/runtime/samples/template/_config.js
+++ b/test/runtime/samples/template/_config.js
@@ -8,16 +8,23 @@ export default {
 	`,
 
 	test({ assert, target }) {
-		const template = target.querySelector('template');
-
+		
+		const template = target.querySelector('#t1');
 		assert.htmlEqual(template.innerHTML, `
-			<div>foo</div>
-		`);
-
+		<div>foo</div>
+   	    `);
 		const content = template.content.cloneNode(true);
 		const div = content.children[0];
 		assert.htmlEqual(div.outerHTML, `
 			<div>foo</div>
 		`);
+
+
+		const template2 = target.querySelector('#t2');
+		assert.equal(template2.childNodes.length, 0); 
+		assert.equal(template2.content.childNodes.length, 1);
+		assert.equal(template2.content.firstChild.textContent, '123');
+		assert.htmlEqual(template2.innerHTML, '123');
+
 	}
 };

--- a/test/runtime/samples/template/_config.js
+++ b/test/runtime/samples/template/_config.js
@@ -2,9 +2,10 @@ export default {
 	// solo: 1,
 
 	html: `
-		<template>
-			<div>foo</div>
-		</template>
+	<template id="t1">
+	    <div>foo</div>
+	</template>
+	<template id="t2">123</template>
 	`,
 
 	test({ assert, target }) {

--- a/test/runtime/samples/template/main.svelte
+++ b/test/runtime/samples/template/main.svelte
@@ -1,3 +1,4 @@
-<template>
+<template id="t1">
 	<div>foo</div>
 </template>
+<template id="t2">123</template>


### PR DESCRIPTION
fix inconsistent rendering of template tags, where text only content is not inserted in the fragment (`.content`) 
elements directly under a template element is non standard, and may break some functionality
for example  `$(template).innerHTML` will be empty when elements are not part of the fragment.

### current behavior 

```html
A)<template>123</template>

B)<template>1+2={1+2}</template>

C)<template><b>inside</b></template>
```
![image](https://user-images.githubusercontent.com/8693091/154920767-0608242d-0c23-47a3-bdff-1d55c8cf8182.png)


for `A`, `B` content is not part of the template fragment(`.content`)



