### PR TITLE
[fix] When intro was triggered before the outro, that outro was canceled

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -897,6 +897,7 @@ export default class ElementWrapper extends Wrapper {
 
 			const intro_block = b`
 				@add_render_callback(() => {
+					if (!#current) return;
 					if (!${name}) ${name} = @create_bidirectional_transition(${this.var}, ${fn}, ${snippet}, true);
 					${name}.run(1);
 				});
@@ -942,6 +943,7 @@ export default class ElementWrapper extends Wrapper {
 				if (outro) {
 					intro_block = b`
 						@add_render_callback(() => {
+							if (!#current) return;
 							if (${outro_name}) ${outro_name}.end(1);
 							${intro_name} = @create_in_transition(${this.var}, ${fn}, ${snippet});
 							${intro_name}.start();


### PR DESCRIPTION
**The issue**

1. When the block.i (intro) is called it registers a callback (via add_render_callback)
2. Then the block.o (outro) is called and start the outro and adds a callback to detach on outroend
3. The render callback from the intro is executed, starts the intro and cancels the outro animation

This causes components that should've been destroyed to stay on the page.

#6152
#6812 

**The fix in this PR**

Inside the intro render callback it checks if it is still `current` and if it isn't (because an outro was triggered) it won't start the intro animation.
