### PR TITLE
[fix] do not collapse whitespace-only css vars

### DIFF
--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -145,6 +145,8 @@ class Declaration {
 			? this.node.value.children[0]
 			: this.node.value;
 
+		if (first.type === 'Raw' && /^\s+$/.test(first.value)) return;
+
 		let start = first.start;
 		while (/\s/.test(code.original[start])) start += 1;
 

--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -145,6 +145,8 @@ class Declaration {
 			? this.node.value.children[0]
 			: this.node.value;
 
+		// Don't minify whitespace in custom properties, since some browsers (Chromium < 99)
+		// treat --foo: ; and --foo:; differently
 		if (first.type === 'Raw' && /^\s+$/.test(first.value)) return;
 
 		let start = first.start;

--- a/test/css/samples/css-vars/expected.css
+++ b/test/css/samples/css-vars/expected.css
@@ -1,1 +1,1 @@
-:root{--root-test:20}div.svelte-xyz{--test:10}
+:root{--root-test:20}div.svelte-xyz{--test:10}div.svelte-xyz{--foo: }

--- a/test/css/samples/css-vars/expected.css
+++ b/test/css/samples/css-vars/expected.css
@@ -1,1 +1,1 @@
-:root{--root-test:20}div.svelte-xyz{--test:10}div.svelte-xyz{--foo: }
+:root{--root-test:20}div.svelte-xyz{--test:10}div.svelte-xyz{--foo: ;--bar: !important}

--- a/test/css/samples/css-vars/input.svelte
+++ b/test/css/samples/css-vars/input.svelte
@@ -7,4 +7,8 @@
 	div {
 		--test: 10;
 	}
+
+	div {
+		--foo: ;
+	}
 </style>

--- a/test/css/samples/css-vars/input.svelte
+++ b/test/css/samples/css-vars/input.svelte
@@ -10,5 +10,6 @@
 
 	div {
 		--foo: ;
+		--bar: !important;
 	}
 </style>


### PR DESCRIPTION
Fixes #7152, see also #7288

`--foo:;` used to be an invalid CSS custom property value, while `-foo: ;` was valid. By collapsing the whitespace in these declaration values, we were breaking scenarios where an empty custom property was desired.

Note that the spec was updated to [trim whitespace](https://www.w3.org/TR/css-variables-1/#changes-20151203) and treat these values identically, but Chromium browsers still treat `--foo;` as invalid. This was recently [fixed](https://bugs.chromium.org/p/chromium/issues/detail?id=1220149) and will be released in Chrome 99, but this would still be a good fix to maintain backwards compatibility.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
