### PR TITLE
[docs] Add missing parent <div> element to code example in each block bindings tutorial

### DIFF
--- a/site/content/tutorial/06-bindings/09-each-block-bindings/text.md
+++ b/site/content/tutorial/06-bindings/09-each-block-bindings/text.md
@@ -6,15 +6,17 @@ You can even bind to properties inside an `each` block.
 
 ```html
 {#each todos as todo}
-	<input
-		type=checkbox
-		bind:checked={todo.done}
-	>
+	<div class:done={todo.done}>
+		<input
+			type=checkbox
+			bind:checked={todo.done}
+		>
 
-	<input
-		placeholder="What needs to be done?"
-		bind:value={todo.text}
-	>
+		<input
+			placeholder="What needs to be done?"
+			bind:value={todo.text}
+		>
+	</div>
 {/each}
 ```
 


### PR DESCRIPTION
This PR makes a small correction to the ["each block bindings" tutorial](https://svelte.dev/tutorial/each-block-bindings). I believe this PR is in line with the contribution guidelines, but I'm new here, so apologies if anything's off.

I'm working through the Svelte tutorial -- which is great, by the way! -- and noticed a small inconsistency between the displayed example code and the "after" code state that's intended. This PR updates the example code to match the expected result. 

In the previous commit on this file, the missing `{#each}` tags were restored to this example code, which is helpful -- but it left out the `<div>` that wraps the `<input>`s. If a reader were copying from the example into the workspace, they would notice the styles breaking as a result. This change is intended to clarify that the parent `<div>` element should remain intact.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
