### PR TITLE
[docs] Remove draft status of setting-up-your-editor blog-entry to fix broken link

### DIFF
--- a/site/content/blog/2019-04-15-setting-up-your-editor.md
+++ b/site/content/blog/2019-04-15-setting-up-your-editor.md
@@ -8,7 +8,7 @@ draft: true
 
 *__Coming soon__*
 
-This post will walk you through setting up your editor so that recognises Svelte files:
+This post will walk you through setting up your editor so that it recognises Svelte files:
 
 * eslint-plugin-svelte3
 * svelte-vscode

--- a/site/content/tutorial/01-introduction/07-making-an-app/text.md
+++ b/site/content/tutorial/01-introduction/07-making-an-app/text.md
@@ -14,7 +14,11 @@ First, you'll need to integrate Svelte with a build tool. There are officially m
 
 Don't worry if you're relatively new to web development and haven't used these tools before. We've prepared a simple step-by-step guide, [Svelte for new developers](/blog/svelte-for-new-developers), which walks you through the process.
 
-You'll also want to configure your text editor. There are [plugins](https://sveltesociety.dev/tools#editor-support) for many popular editors as well as an official [VS Code extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode). If your editor does not have a Svelte plugin then you can follow [this guide](/blog/setting-up-your-editor) to configure your text editor to treat `.svelte` files the same as `.html` for the sake of syntax highlighting.
+You'll also want to configure your text editor. There are [plugins](https://sveltesociety.dev/tools#editor-support) for many popular editors as well as an official [VS Code extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
+<!-- 
+NOTE: Removed until we have better place for setting-up-your-editor guide. See https://github.com/sveltejs/svelte/pull/7310#issuecomment-1049923609
+If your editor does not have a Svelte plugin then you can follow [this guide](/blog/setting-up-your-editor) to configure your text editor to treat `.svelte` files the same as `.html` for the sake of syntax highlighting. -->
 
 Then, once you've got your project set up, using Svelte components is easy. The compiler turns each component into a regular JavaScript class — just import it and instantiate with `new`:
 


### PR DESCRIPTION
With commit bbef991 this blog-entry was marked as a draft, which prevents the page from getting rendered in the svelte-blog. However, over time many contributors added the missing content. Since some pages, e.g. [chapter 1: "Making an app" from the tutorial](https://svelte.dev/tutorial/making-an-app), references to this page, there is a broken link. 
This commit removes the draft-marking which should make the page visible and thus fix the broken links.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
