### PR TITLE
[fix] attribute values are incorrectly escaped during ssr

### DIFF
--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -177,7 +177,8 @@ export function create_ssr_component(fn) {
 
 export function add_attribute(name, value, boolean) {
 	if (value == null || (boolean && !value)) return '';
-	return ` ${name}${value === true && boolean_attributes.has(name) ? '' : `=${typeof value === 'string' ? JSON.stringify(escape(value)) : `"${value}"`}`}`;
+	const assignment = (boolean && value === true) ? '' : `="${escape_attribute_value(value.toString())}"`;
+	return ` ${name}${assignment}`;
 }
 
 export function add_classes(classes) {

--- a/test/server-side-rendering/samples/attribute-escaped-quotes/_expected.html
+++ b/test/server-side-rendering/samples/attribute-escaped-quotes/_expected.html
@@ -1,3 +1,3 @@
 <div
-	foo="&#34;></div><script>alert(42)</script>"
+	foo="&#34;></div>\<script>alert(42)</script>"
 ></div>

--- a/test/server-side-rendering/samples/attribute-escaped-quotes/_expected.html
+++ b/test/server-side-rendering/samples/attribute-escaped-quotes/_expected.html
@@ -1,3 +1,4 @@
 <div
 	foo="&#34;></div>\<script>alert(42)</script>"
+	bar="&#34;></div>\<script>alert(42)</script>"
 ></div>

--- a/test/server-side-rendering/samples/attribute-escaped-quotes/main.svelte
+++ b/test/server-side-rendering/samples/attribute-escaped-quotes/main.svelte
@@ -1,5 +1,6 @@
 <script>
 	export let foo = '"></div>\\<script>alert(42)</' + 'script>';
+	export let bar = { toString: () => '"></div>\\<script>alert(42)<\/script>' };
 </script>
 
-<div foo={foo}></div>
+<div foo={foo} bar={bar}></div>

--- a/test/server-side-rendering/samples/attribute-escaped-quotes/main.svelte
+++ b/test/server-side-rendering/samples/attribute-escaped-quotes/main.svelte
@@ -1,5 +1,5 @@
 <script>
-	export let foo = '"></div><script>alert(42)</' + 'script>';
+	export let foo = '"></div>\\<script>alert(42)</' + 'script>';
 </script>
 
 <div foo={foo}></div>


### PR DESCRIPTION
Fixes #7327 and a related security issue.

Attribute values were being `JSON.stringify`ed after being escaped, resulting in escaped characters like `\\` and `\n` to show up in the HTML. The browser _doesn't_ `JSON.parse` attribute values, so the attributes end up with the wrong value.

Succinctly: `<el attr={'\\'}>` renders `<el attr="\\">` gives `el.getAttribute('attr') === '\\\\'`.

The security issue is that objects, on the other hand, were rendered directly to attribute values as unescaped strings. This means an object with a custom `toString()` can result in raw html injection.

See modified tests for more details.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
