### PR TITLE
[feat] add `Action` as a type for `use:action`

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -11,6 +11,7 @@ export {
 	hasContext,
 	tick,
 	createEventDispatcher,
+	Action,
 	SvelteComponentDev as SvelteComponent,
 	SvelteComponentTyped
 } from 'svelte/internal';

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -734,7 +734,7 @@ export function get_custom_elements_slots(element: HTMLElement) {
 }
 
 
-type ActionWithParams<Node extends HTMLElement = HTMLElement, Params extends any = any> = (
+type ActionWithParams<Node extends HTMLElement = HTMLElement, Params = any> = (
 	node: Node,
 	options: Params
 ) => {
@@ -746,6 +746,6 @@ type ActionWithoutParams<Node extends HTMLElement = HTMLElement> = (node: Node) 
 	destroy?: () => void
 }
 
-export type Action<Node extends HTMLElement = HTMLElement, Params extends any = void> = void extends Params
+export type Action<Node extends HTMLElement = HTMLElement, Params = void> = void extends Params
 	? ActionWithoutParams<Node>
 	: ActionWithParams<Node, Params>

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -732,3 +732,20 @@ export function get_custom_elements_slots(element: HTMLElement) {
 	});
 	return result;
 }
+
+
+type ActionWithParams<Node extends HTMLElement = HTMLElement, Params extends any = any> = (
+	node: Node,
+	options: Params
+) => {
+	update?: (params: Params) => void
+	destroy?: () => void
+}
+
+type ActionWithoutParams<Node extends HTMLElement = HTMLElement> = (node: Node) => {
+	destroy?: () => void
+}
+
+export type Action<Node extends HTMLElement = HTMLElement, Params extends any = void> = void extends Params
+	? ActionWithoutParams<Node>
+	: ActionWithParams<Node, Params>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

Currently there is no type definition for a Svelte action defined. This PR adds a new `Action` type that get's exposed by the `svelte` package.

This can be used to type actions that are declared outside of a `Svelte` component.

_`action.ts`_
```ts
import type { Action } from 'svelte'

export const myAction: Action<HTMLTextAreaElement, boolean> (node, param) => {
   // `node` and `param` are typed 
   return {
      update: (param) => void 0
      destroy: () => void 0
   }
}

export const myOtherAction: Action<HTMLTextAreaElement> (node) => {
   return {
      destroy: () => void 0
   }
}
```

The benefit of this type is that you will get an error if you define something wrong. e.g. you misspelled `'update'` as `'updates'`.

The Svelte VS Code extension already throws an error if you try to apply the action `use:myAction`, but only if you have opened that file that uses the action. You won't see an error if you only open the `action.ts` file in your IDE.