### PR TITLE
[docs] Fix statement about the order of bind: and on:

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -641,7 +641,7 @@ If you're using `bind:` directives together with `on:` directives, the order tha
 />
 ```
 
-Here we were binding to the value of a text input, which uses the `input` event internally. Bindings on other elements may use different events such as `change`.
+Here we were binding to the value of a text input, which uses the `input` event. Bindings on other elements may use different events such as `change`.
 
 ##### Binding `<select>` value
 

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -651,7 +651,7 @@ Bindings use event handlers internally to sync the values. The event that is lis
 </div>
 ```
 
-The `1st` input handler will be called before the binding updates the value, so it'll log the old value, whereas `3rd` will log the new value. However, the `change` event only fires when you let go of the slider, so even though the change handler is declared before the input handlers, it'll always be triggered last.
+In the above example, the `1st` input handler will be called before the binding updates the value, so it'll log the old value, whereas `3rd` will log the new value. However, the `change` event only fires when you let go of the slider, so even though the change handler is declared before the input handlers, it'll always be triggered last.
 
 ##### Binding `<select>` value
 

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -627,31 +627,21 @@ On `<input>` elements with `type="file"`, you can use `bind:files` to get the [`
 
 ---
 
-Bindings use event handlers internally to sync the values. The event that is listened for will differ based on the element and the type of binding used. Therefore, the order of `bind:` and `on:` directives can have consequences.
+If you're using `bind:` directives together with `on:` directives, their order can affect what value the bound variable has when the event handler is called.
 
 ```sv
 <script>
-	let value = 50;
-	
-	$: console.log("2nd", value)
+	let value = 'Hello World';
 </script>
 
-
-<div on:input="{() => console.log('4th', value)}">
-	<!--bind:value on range inputs listens to the 'input' event-->
-	<input
-		type="range"
-
-		on:change="{() => console.log('5th', value)}"
-		
-		on:input="{() => console.log('1st', value)}"
-		bind:value
-		on:input="{() => console.log('3rd', value)}"
-	/>
-</div>
+<input
+	on:input="{() => console.log('Old value:', value)}"
+	bind:value
+	on:input="{() => console.log('New value:', value)}"
+/>
 ```
 
-In the above example, the `1st` input handler will be called before the binding updates the value, so it'll log the old value, whereas `3rd` will log the new value. However, the `change` event only fires when you let go of the slider, so even though the change handler is declared before the input handlers, it'll always be triggered last.
+Here we were binding to the value of a text input, which uses the `input` event internally. Bindings on other elements may use different events such as `change`.
 
 ##### Binding `<select>` value
 

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -627,7 +627,7 @@ On `<input>` elements with `type="file"`, you can use `bind:files` to get the [`
 
 ---
 
-If you're using `bind:` directives together with `on:` directives, their order can affect what value the bound variable has when the event handler is called.
+If you're using `bind:` directives together with `on:` directives, the order that they're defined in affects the value of the bound variable when the event handler is called.
 
 ```sv
 <script>

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -627,20 +627,31 @@ On `<input>` elements with `type="file"`, you can use `bind:files` to get the [`
 
 ---
 
-`bind:` can be used together with `on:` directives. The order that they are defined in determines the value of the bound variable when the event handler is called.
+Bindings use event handlers internally to sync the values. The event that is listened for will differ based on the element and the type of binding used. Therefore, the order of `bind:` and `on:` directives can have consequences.
 
 ```sv
 <script>
-	let value = 'Hello World';
+	let value = 50;
+	
+	$: console.log("2nd", value)
 </script>
 
-<input
-	on:input="{() => console.log('Old value:', value)}"
-	bind:value
-	on:input="{() => console.log('New value:', value)}"
-/>
+
+<div on:input="{() => console.log('4th', value)}">
+	<!--bind:value on range inputs listens to the 'input' event-->
+	<input
+		type="range"
+
+		on:change="{() => console.log('5th', value)}"
+		
+		on:input="{() => console.log('1st', value)}"
+		bind:value
+		on:input="{() => console.log('3rd', value)}"
+	/>
+</div>
 ```
 
+The `1st` input handler will be called before the binding updates the value, so it'll log the old value, whereas `3rd` will log the new value. However, the `change` event only fires when you let go of the slider, so even though the change handler is declared before the input handlers, it'll always be triggered last.
 
 ##### Binding `<select>` value
 


### PR DESCRIPTION
Turns out I kinda lied in #6887 (oops). The order of definition only affects things when the binding is based on the same event (see #7212). Hopefully it should be clear enough now.

Caveat: according to [this SO thread](https://stackoverflow.com/a/9512645), it'll not hold true in old (pre IE8) browsers, but we don't really have to care about that do we?

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
