### PR TITLE
fix: export types needed for defining custom stores

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -10,7 +10,7 @@ export type Unsubscriber = () => void;
 export type Updater<T> = (value: T) => T;
 
 /** Cleanup logic callback. */
-type Invalidator<T> = (value?: T) => void;
+export type Invalidator<T> = (value?: T) => void;
 
 /** Start and stop notification callbacks. */
 export type StartStopNotifier<T> = (set: Subscriber<T>) => Unsubscriber | void;
@@ -41,7 +41,7 @@ export interface Writable<T> extends Readable<T> {
 }
 
 /** Pair of subscriber and invalidator. */
-type SubscribeInvalidateTuple<T> = [Subscriber<T>, Invalidator<T>];
+export type SubscribeInvalidateTuple<T> = [Subscriber<T>, Invalidator<T>];
 
 const subscriber_queue = [];
 
@@ -109,10 +109,10 @@ export function writable<T>(value?: T, start: StartStopNotifier<T> = noop): Writ
 }
 
 /** One or more `Readable`s. */
-type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>;
+export type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>;
 
 /** One or more values from `Readable` stores. */
-type StoresValues<T> = T extends Readable<infer U> ? U :
+export type StoresValues<T> = T extends Readable<infer U> ? U :
 	{ [K in keyof T]: T[K] extends Readable<infer U> ? U : never };
 
 /**


### PR DESCRIPTION
I wrote a custom store to have a more flexible `derived` store. The function signatures looks like:

```typescript
export function derivedWritable<S extends Stores, T>(
  stores: S,
  fn: (values: StoresValues<S>, set: (value: T) => void) => Unsubscriber | void,
  initial_value?: T
): Writable<T> { ... }
```

Both `Stores` and `StoresValues` are not exported in `svelte/store`. I had to copy paste the type definition from this file and duplicate code. Unless I'm using TypeScript wrong (I'm still quite new to it), I think these types plus few others should be exported.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
