### PR TITLE
[docs] Fix key-blocks instruction to be aligned with code

### DIFF
--- a/site/content/tutorial/10-transitions/09-key-blocks/text.md
+++ b/site/content/tutorial/10-transitions/09-key-blocks/text.md
@@ -6,7 +6,7 @@ Key blocks destroy and recreate their contents when the value of an expression c
 
 ```html
 {#key value}
-	<div transition:fade>{value}</div>
+	<span style="display: inline-block" in:fly={{ y: -30 }}>
 {/key}
 ```
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

This commit changes the instruction to match the code.

### Tests
-  Visit https://svelte.dev/tutorial/key-blocks 
- Notice the instruction on the left uses `transition:fade` while the code on the right uses `in:fly`