### PR TITLE
[docs] Correct default port on blog posts

### DIFF
--- a/site/content/blog/2017-08-07-the-easiest-way-to-get-started.md
+++ b/site/content/blog/2017-08-07-the-easiest-way-to-get-started.md
@@ -31,8 +31,7 @@ npm install
 npm run dev
 ```
 
-This will serve your app on [localhost:5000](http://localhost:5000) and rebuild it with [Rollup](https://rollupjs.org) every time you make a change to the files in `svelte-app/src`.
-
+This will serve your app on [localhost:8080](http://localhost:8080) and rebuild it with [Rollup](https://rollupjs.org) every time you make a change to the files in `svelte-app/src`.
 
 ## 2. Use degit
 
@@ -50,7 +49,7 @@ npm install
 npm run dev
 ```
 
-This will create a new project in the `my-svelte-project` directory, install its dependencies, and start a server on http://localhost:5000.
+This will create a new project in the `my-svelte-project` directory, install its dependencies, and start a server on http://localhost:8080.
 
 You can find more information about using TypeScript [here](/blog/svelte-and-typescript).
 

--- a/site/content/blog/2019-04-16-svelte-for-new-developers.md
+++ b/site/content/blog/2019-04-16-svelte-for-new-developers.md
@@ -78,7 +78,7 @@ npm run dev
 
 Running the `dev` script starts a program called [Rollup](https://rollupjs.org/guide/en/). Rollup's job is to take your application's source files (so far, just `src/main.js` and `src/App.svelte`), pass them to other programs (including Svelte, in our case) and convert them into the code that will actually run when you open the application in a browser.
 
-Speaking of which, open a browser and navigate to http://localhost:5000. This is your application running on a local *web server* (hence 'localhost') on port 5000.
+Speaking of which, open a browser and navigate to http://localhost:8080. This is your application running on a local *web server* (hence 'localhost') on port 8080.
 
 Try changing `src/App.svelte` and saving it. The application will reload with your changes.
 
@@ -99,7 +99,7 @@ Your `public` directory now contains a compressed `bundle.js` file containing yo
 npm run start
 ```
 
-This will run the app on http://localhost:5000.
+This will run the app on http://localhost:8080.
 
 
 ## Next steps


### PR DESCRIPTION
Default port is now 8080, instead of 5000.

Resolves #7354 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
