### PR TITLE
[fix] style shorthand lost in production mode

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -219,6 +219,7 @@ export default class ElementWrapper extends Wrapper {
 				node.classes.length > 0 ||
 				node.intro || node.outro ||
 				node.handlers.length > 0 ||
+				node.styles.length > 0 ||
 				this.node.name === 'option' ||
 				renderer.options.dev
 			) {

--- a/test/runtime/samples/inline-style-directive/_config.js
+++ b/test/runtime/samples/inline-style-directive/_config.js
@@ -1,6 +1,8 @@
 export default {
 	html: `
-		<p style="color: red;"></p>
+		<div>
+			<p style="color: red;"></p>
+		</div>
 	`,
 
 	test({ assert, target, window }) {

--- a/test/runtime/samples/inline-style-directive/main.svelte
+++ b/test/runtime/samples/inline-style-directive/main.svelte
@@ -2,4 +2,6 @@
 	export let myColor = "red";
 </script>
 
-<p style:color={myColor} />
+<div>
+	<p style:color={myColor} />
+</div>

--- a/test/runtime/samples/inline-style/_config.js
+++ b/test/runtime/samples/inline-style/_config.js
@@ -4,9 +4,9 @@ export default {
 	`,
 
 	test({ assert, component, target, window }) {
-		const p = target.querySelector('div');
+		const div = target.querySelector('div');
 
-		const styles = window.getComputedStyle(p);
+		const styles = window.getComputedStyle(div);
 		assert.equal(styles.color, 'red');
 	}
 };


### PR DESCRIPTION
See #7386 for context, but essentially elements using the `style:<prop>` shorthand are not generating an update function in production mode due to the `innerHTML` optimization being applied incorrectly.

So this fixes #7386 by adding a new condition to check for when opting out of the `.innerHTML` optimization in prod mode. Also modifies an existing test so that it'll demonstrate the bug and fail without the logic fix.

Huge thanks to @dummdidumm for pointing to literally the exact line that needed changing.