### PR TITLE
[fix] Max call stack exceeded when large number of components are flushed 

### DIFF
--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -51,7 +51,9 @@ export function add_flush_callback(fn) {
 //    function, guarantees this behavior.
 const seen_callbacks = new Set();
 let flushidx = 0;  // Do *not* move this inside the flush() function
+let flushing = false;
 export function flush() {
+	if (flushing) return;
 	const saved_component = current_component;
 
 	do {
@@ -91,6 +93,7 @@ export function flush() {
 		flush_callbacks.pop()();
 	}
 
+	flushing = false;
 	update_scheduled = false;
 	seen_callbacks.clear();
 	set_current_component(saved_component);


### PR DESCRIPTION
This PR is in reference to the discussion here: https://github.com/sveltejs/svelte/issues/7032

Without this check, `flush()` is being invoked multiple times, even if the previous run has not yet completed. This occurs if/when you have a large number of components. Eventually, this repeated invocation results in a max call stack exceeded error.

(I shall add a test for the original issue ASAP, get a test/pass based on the change)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
