### PR TITLE
[docs] Fix link to webpack-loader

### DIFF
--- a/site/content/faq/1200-how-do-i-do-hmr.md
+++ b/site/content/faq/1200-how-do-i-do-hmr.md
@@ -2,4 +2,4 @@
 question: How do I do hot module reloading?
 ---
 
-We recommend using [SvelteKit](https://kit.svelte.dev/), which supports HMR out of the box and is built on top of [Vite](https://vitejs.dev/) and [svelte-hmr](https://github.com/sveltejs/svelte-hmr). There are also community plugins for [rollup](https://github.com/rixo/rollup-plugin-svelte-hot) and [webpack](https://github.com/rixo/svelte-loader-hot).
+We recommend using [SvelteKit](https://kit.svelte.dev/), which supports HMR out of the box and is built on top of [Vite](https://vitejs.dev/) and [svelte-hmr](https://github.com/sveltejs/svelte-hmr). There are also community plugins for [rollup](https://github.com/rixo/rollup-plugin-svelte-hot) and [webpack](https://github.com/sveltejs/svelte-loader).


### PR DESCRIPTION
Change link for Webpack-loader from svelte-loader-hot, which is deprecated, to official svelte-loader.

