### PR TITLE
Fix scroll effect in demo

### DIFF
--- a/site/content/tutorial/16-special-elements/05-svelte-window-bindings/app-a/App.svelte
+++ b/site/content/tutorial/16-special-elements/05-svelte-window-bindings/app-a/App.svelte
@@ -4,7 +4,7 @@
 	let y;
 </script>
 
-<svelte:window/>
+<svelte:window bind:scrollY={y}/>
 
 <a class="parallax-container" href="https://www.firewatchgame.com">
 	{#each layers as layer}


### PR DESCRIPTION
Demo was not actually scrolling because scrollY was not bound. It looks like it is _intended_ to scroll. This fixes the issue and allows users to visually see the demo working.