### PR TITLE
[docs] update intro sentence of reactive declarations tutorial

### DIFF
--- a/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
+++ b/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
@@ -2,9 +2,7 @@
 title: Declarations
 ---
 
-Svelte automatically updates the DOM when your component's state changes. Often, some parts of a component's state depends on *other* parts. For example, you may want to have `fullname` derived from `firstname` and `lastname` and also want to recompute `fullname` when `firstname` and/or `lastname` changes. 
-
-For these, we have *reactive declarations*. They look like this:
+Svelte's reactivity not only keeps the DOM in sync with your application's variables as shown in the previous section, it can also keep variables in sync with each other using reactive declarations. They look like this:
 
 ```js
 let count = 0;

--- a/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
+++ b/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
@@ -2,7 +2,7 @@
 title: Declarations
 ---
 
-Svelte automatically updates the DOM when your component's state changes. Often, some parts of a component's state need to be computed from *other* parts (such as a `fullname` derived from a `firstname` and a `lastname`), and recomputed whenever they change.
+Svelte automatically updates the DOM when your component's state changes. Often, some parts of a component's state depends on *other* parts. For example, you may want to have `fullname` derived from `firstname` and `lastname` and also want to recompute `fullname` when `firstname` and/or `lastname` changes. 
 
 For these, we have *reactive declarations*. They look like this:
 


### PR DESCRIPTION
The sentence "Often, some parts of a component's state need to be computed from other parts (such as a fullname derived from a firstname and a lastname), and recomputed whenever they change." was very confusing and also grammatically incorrect because "and recomputed whenever they change" is a dependent clause.

According to Grammarly, "A dependent clause is a clause that cannot stand as a sentence in its own right, such as before I left the parking lot. When a complex sentence contains a dependent clause like this one, a comma is not used unless the dependent clause comes before the independent clause."

https://www.grammarly.com/blog/comma-in-complex-sentences/#:~:text=A%20dependent%20clause%20is%20a,comes%20before%20the%20independent%20clause.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
