### PR TITLE
[docs] fix sentence of `<svelte:element>`

### DIFF
--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1635,11 +1635,11 @@ If `this` is falsy, no component is rendered.
 
 ---
 
-The `<svelte:element>` element lets you render an element of a dynamically specified type. This is useful for example when rich text content from a CMS. If the tag is changed, the children will be preserved unless there's a transition attached to the element. Any properties and event listeners present will be applied to the element.
+The `<svelte:element>` element lets you render an element of a dynamically specified type. This is useful for example when rich text content from a CMS. Any properties and event listeners present will be applied to the element.
 
 The only supported binding is `bind:this`, since the element type specific bindings that Svelte does at build time (e.g. `bind:value` for input elements) does not work with a dynamic tag type.
 
-If `this` has a nullish value, a warning will be logged in development mode.
+If `this` has a nullish value, element and its children are not displayed.
 
 ```sv
 <script>

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1639,7 +1639,7 @@ The `<svelte:element>` element lets you render an element of a dynamically speci
 
 The only supported binding is `bind:this`, since the element type specific bindings that Svelte does at build time (e.g. `bind:value` for input elements) does not work with a dynamic tag type.
 
-If `this` has a nullish value, element and its children are not displayed.
+If `this` has a nullish value, the element and its children will not be rendered.
 
 ```sv
 <script>

--- a/site/content/docs/02-template-syntax.md
+++ b/site/content/docs/02-template-syntax.md
@@ -1635,7 +1635,7 @@ If `this` is falsy, no component is rendered.
 
 ---
 
-The `<svelte:element>` element lets you render an element of a dynamically specified type. This is useful for example when rich text content from a CMS. Any properties and event listeners present will be applied to the element.
+The `<svelte:element>` element lets you render an element of a dynamically specified type. This is useful for example when displaying rich text content from a CMS. Any properties and event listeners present will be applied to the element.
 
 The only supported binding is `bind:this`, since the element type specific bindings that Svelte does at build time (e.g. `bind:value` for input elements) does not work with a dynamic tag type.
 


### PR DESCRIPTION
> If the tag is changed, the children will be preserved unless there's a transition attached to the element.

Child elements are always regenerated when tag is changed. So I removed this sentence.

> If `this` has a nullish value, a warning will be logged in development mode.

Now the warning is not showing. nullish value is officially supported.
So I updated the sentence.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
