### PR TITLE
[docs] Update introduction/dynamic-attributes

### DIFF
--- a/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
+++ b/site/content/tutorial/01-introduction/03-dynamic-attributes/text.md
@@ -2,9 +2,9 @@
 title: Dynamic attributes
 ---
 
-Just like you can use curly braces to control text, you can use them to control element attributes.
+You can use curly braces to control element attributes, just like you use them to control text.
 
-Our image is missing a `src` — let's add one:
+Our image is missing a `src` attribute — let's add one:
 
 ```html
 <img src={src}>
@@ -24,7 +24,6 @@ In this case, we're missing the `alt` attribute that describes the image for peo
 
 We can use curly braces *inside* attributes. Try changing it to `"{name} dances."` — remember to declare a `name` variable in the `<script>` block.
 
-
 ## Shorthand attributes
 
 It's not uncommon to have an attribute where the name and value are the same, like `src={src}`. Svelte gives us a convenient shorthand for these cases:
@@ -32,4 +31,3 @@ It's not uncommon to have an attribute where the name and value are the same, li
 ```html
 <img {src} alt="A man dances.">
 ```
-


### PR DESCRIPTION
1. Noticed the awkward sentence "Just like you can use curly braces to control text, you can use them to control element attributes". Changed it to a sentence easier to understand
2. `src` is an attribute and when the doc referred to attributes, it always puts '~ attribute', so added the 'attribute' description after `src`
3. Removed unnecessary spaces

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
