### PR TITLE
fix: check each_blocks is empty on mount

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/EachBlock.ts
+++ b/src/compiler/compile/render_dom/wrappers/EachBlock.ts
@@ -448,7 +448,9 @@ export default class EachBlockWrapper extends Wrapper {
 
 		block.chunks.mount.push(b`
 			for (let #i = 0; #i < ${view_length}; #i += 1) {
-				${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node});
+				if (${iterations}[#i]) {
+					${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node});
+				}
 			}
 		`);
 
@@ -542,7 +544,9 @@ export default class EachBlockWrapper extends Wrapper {
 
 		block.chunks.mount.push(b`
 			for (let #i = 0; #i < ${view_length}; #i += 1) {
-				${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node});
+				if (${iterations}[#i]) {
+					${iterations}[#i].m(${initial_mount_node}, ${initial_anchor_node});
+				}
 			}
 		`);
 

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -114,7 +114,9 @@ function create_fragment(ctx) {
 		},
 		m: function mount(target, anchor) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				if (each_blocks[i]) {
+					each_blocks[i].m(target, anchor);
+				}
 			}
 
 			insert_dev(target, t0, anchor);

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -108,7 +108,9 @@ function create_fragment(ctx) {
 		},
 		m: function mount(target, anchor) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				if (each_blocks[i]) {
+					each_blocks[i].m(target, anchor);
+				}
 			}
 
 			insert_dev(target, t0, anchor);

--- a/test/js/samples/debug-no-dependencies/expected.js
+++ b/test/js/samples/debug-no-dependencies/expected.js
@@ -86,7 +86,9 @@ function create_fragment(ctx) {
 		},
 		m: function mount(target, anchor) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				if (each_blocks[i]) {
+					each_blocks[i].m(target, anchor);
+				}
 			}
 
 			insert_dev(target, each_1_anchor, anchor);

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -63,7 +63,9 @@ function create_fragment(ctx) {
 		},
 		m(target, anchor) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				if (each_blocks[i]) {
+					each_blocks[i].m(target, anchor);
+				}
 			}
 
 			insert(target, each_1_anchor, anchor);

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -63,7 +63,9 @@ function create_fragment(ctx) {
 		},
 		m(target, anchor) {
 			for (let i = 0; i < 5; i += 1) {
-				each_blocks[i].m(target, anchor);
+				if (each_blocks[i]) {
+					each_blocks[i].m(target, anchor);
+				}
 			}
 
 			insert(target, each_1_anchor, anchor);

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -104,7 +104,9 @@ function create_fragment(ctx) {
 		},
 		m(target, anchor) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				if (each_blocks[i]) {
+					each_blocks[i].m(target, anchor);
+				}
 			}
 
 			insert(target, t0, anchor);

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -87,7 +87,9 @@ function create_fragment(ctx) {
 		},
 		m(target, anchor) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				if (each_blocks[i]) {
+					each_blocks[i].m(target, anchor);
+				}
 			}
 
 			insert(target, each_1_anchor, anchor);

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -72,7 +72,9 @@ function create_fragment(ctx) {
 		},
 		m(target, anchor) {
 			for (let i = 0; i < each_blocks.length; i += 1) {
-				each_blocks[i].m(target, anchor);
+				if (each_blocks[i]) {
+					each_blocks[i].m(target, anchor);
+				}
 			}
 
 			insert(target, each_1_anchor, anchor);

--- a/test/runtime/samples/component-binding-each-remount-keyed/Child.svelte
+++ b/test/runtime/samples/component-binding-each-remount-keyed/Child.svelte
@@ -1,21 +1,21 @@
 <script>
-    import InnerChild from './InnerChild.svelte';
+	import InnerChild from './InnerChild.svelte';
 
-    export let id = 1;
-    export let count;
-    export let increment;
+	export let id = 1;
+	export let count;
+	export let increment;
 
-    let list;
-    $: {
-        list = [];
-        for (let i = 0; i < count; ++i) {
-            list.push(i);
-        }
-    }
+	let list;
+	$: {
+		list = [];
+		for (let i = 0; i < count; ++i) {
+			list.push(i);
+		}
+	}
 </script>
 
 <div data-id={id}>
-    {#each list as item (item)}
-        <InnerChild val={item} {increment} />
-    {/each}
+	{#each list as item (item)}
+		<InnerChild val={item} {increment} />
+	{/each}
 </div>

--- a/test/runtime/samples/component-binding-each-remount-keyed/Child.svelte
+++ b/test/runtime/samples/component-binding-each-remount-keyed/Child.svelte
@@ -1,0 +1,21 @@
+<script>
+    import InnerChild from './InnerChild.svelte';
+
+    export let id = 1;
+    export let count;
+    export let increment;
+
+    let list;
+    $: {
+        list = [];
+        for (let i = 0; i < count; ++i) {
+            list.push(i);
+        }
+    }
+</script>
+
+<div data-id={id}>
+    {#each list as item (item)}
+        <InnerChild val={item} {increment} />
+    {/each}
+</div>

--- a/test/runtime/samples/component-binding-each-remount-keyed/InnerChild.svelte
+++ b/test/runtime/samples/component-binding-each-remount-keyed/InnerChild.svelte
@@ -1,14 +1,14 @@
 <script>
-    import { afterUpdate } from 'svelte';
+	import { afterUpdate } from 'svelte';
 
-    export let val = 1;
-    export let increment;
+	export let val = 1;
+	export let increment;
 
-    afterUpdate(() => {
-        increment();
-    });
+	afterUpdate(() => {
+		increment();
+	});
 </script>
 
 <inner>
-    {val}
+	{val}
 </inner>

--- a/test/runtime/samples/component-binding-each-remount-keyed/InnerChild.svelte
+++ b/test/runtime/samples/component-binding-each-remount-keyed/InnerChild.svelte
@@ -1,0 +1,14 @@
+<script>
+    import { afterUpdate } from 'svelte';
+
+    export let val = 1;
+    export let increment;
+
+    afterUpdate(() => {
+        increment();
+    });
+</script>
+
+<inner>
+    {val}
+</inner>

--- a/test/runtime/samples/component-binding-each-remount-keyed/_config.js
+++ b/test/runtime/samples/component-binding-each-remount-keyed/_config.js
@@ -1,0 +1,39 @@
+export default {
+	html: `
+		<div data-id="1">
+			<inner>0</inner>
+			<inner>1</inner>
+		</div>
+		<div data-id="2">
+			<inner>0</inner>
+			<inner>1</inner>
+		</div>
+		<div data-id="3">
+			<inner>0</inner>
+			<inner>1</inner>
+		</div>
+	`,
+
+	ssrHtml: `
+		<div data-id="1">
+			<inner>0</inner>
+			<inner>1</inner>
+			<inner>2</inner>
+		</div>
+		<div data-id="2">
+			<inner>0</inner>
+			<inner>1</inner>
+			<inner>2</inner>
+		</div>
+		<div data-id="3">
+			<inner>0</inner>
+			<inner>1</inner>
+			<inner>2</inner>
+		</div>
+	`,
+
+	async test({ assert, component }) {
+		await component.done;
+		assert.equal(component.getCounter(), 13);
+	}
+};

--- a/test/runtime/samples/component-binding-each-remount-keyed/_config.js
+++ b/test/runtime/samples/component-binding-each-remount-keyed/_config.js
@@ -32,8 +32,22 @@ export default {
 		</div>
 	`,
 
-	async test({ assert, component }) {
+	async test({ assert, component, target }) {
 		await component.done;
 		assert.equal(component.getCounter(), 13);
+		assert.htmlEqual(target.innerHTML, `
+			<div data-id="3">
+				<inner>0</inner>
+				<inner>1</inner>
+			</div>
+			<div data-id="2">
+				<inner>0</inner>
+				<inner>1</inner>
+			</div>
+			<div data-id="1">
+				<inner>0</inner>
+				<inner>1</inner>
+			</div>
+		`);
 	}
 };

--- a/test/runtime/samples/component-binding-each-remount-keyed/main.svelte
+++ b/test/runtime/samples/component-binding-each-remount-keyed/main.svelte
@@ -1,35 +1,35 @@
 <script>
-    import { onMount } from 'svelte';
-    import Child from './Child.svelte';
+	import { onMount } from 'svelte';
+	import Child from './Child.svelte';
 
-    let updateCounter = 0;
-    let promiseResolve;
-    export const done = new Promise(resolve => {
-        promiseResolve = resolve;
-    });
-    export const getCounter = () => {
-        return updateCounter;
-    };
+	let updateCounter = 0;
+	let promiseResolve;
+	export const done = new Promise(resolve => {
+		promiseResolve = resolve;
+	});
+	export const getCounter = () => {
+		return updateCounter;
+	};
 
-    let vals = [1, 2, 3];
-    const instances = [];
-    let count = 3;
+	let vals = [1, 2, 3];
+	const instances = [];
+	let count = 3;
 
-    const increment = () => {
+	const increment = () => {
 		++updateCounter;
-    };
+	};
 
-    onMount(() => {
-        count = 2;
+	onMount(() => {
+		count = 2;
 
-        setTimeout(() => {
-            vals = vals.reverse();
+		setTimeout(() => {
+			vals = vals.reverse();
 
-            setTimeout(promiseResolve);
-        });
-    });
+			setTimeout(promiseResolve);
+		});
+	});
 </script>
 
 {#each vals as val, index (val)}
-    <Child bind:this={instances[index]} id={val} {count} {increment} />
+	<Child bind:this={instances[index]} id={val} {count} {increment} />
 {/each}

--- a/test/runtime/samples/component-binding-each-remount-keyed/main.svelte
+++ b/test/runtime/samples/component-binding-each-remount-keyed/main.svelte
@@ -1,0 +1,37 @@
+<script>
+    import { onMount } from 'svelte';
+    import Child from './Child.svelte';
+
+    let updateCounter = 0;
+    let promiseResolve;
+    export const done = new Promise(resolve => {
+        promiseResolve = resolve;
+    });
+    export const getCounter = () => {
+        return updateCounter;
+    };
+
+    let vals = [1, 2, 3];
+    let instances = [];
+    let count = 3;
+
+    let increment = () => {
+		++updateCounter;
+    };
+
+    onMount(() => {
+        console.log(instances);
+
+        count = 2;
+
+        setTimeout(() => {
+            vals = vals.reverse();
+
+            setTimeout(promiseResolve);
+        });
+    });
+</script>
+
+{#each vals as val, index (val)}
+    <Child bind:this={instances[index]} id={val} {count} {increment} />
+{/each}

--- a/test/runtime/samples/component-binding-each-remount-keyed/main.svelte
+++ b/test/runtime/samples/component-binding-each-remount-keyed/main.svelte
@@ -12,16 +12,14 @@
     };
 
     let vals = [1, 2, 3];
-    let instances = [];
+    const instances = [];
     let count = 3;
 
-    let increment = () => {
+    const increment = () => {
 		++updateCounter;
     };
 
     onMount(() => {
-        console.log(instances);
-
         count = 2;
 
         setTimeout(() => {

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/Child.svelte
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/Child.svelte
@@ -1,0 +1,21 @@
+<script>
+    import InnerChild from './InnerChild.svelte';
+
+    export let id = 1;
+    export let count;
+    export let increment;
+
+    let list;
+    $: {
+        list = [];
+        for (let i = 0; i < count; ++i) {
+            list.push(i);
+        }
+    }
+</script>
+
+<div data-id={id}>
+    {#each list as item}
+        <InnerChild val={item} {increment} />
+    {/each}
+</div>

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/Child.svelte
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/Child.svelte
@@ -1,21 +1,21 @@
 <script>
-    import InnerChild from './InnerChild.svelte';
+	import InnerChild from './InnerChild.svelte';
 
-    export let id = 1;
-    export let count;
-    export let increment;
+	export let id = 1;
+	export let count;
+	export let increment;
 
-    let list;
-    $: {
-        list = [];
-        for (let i = 0; i < count; ++i) {
-            list.push(i);
-        }
-    }
+	let list;
+	$: {
+		list = [];
+		for (let i = 0; i < count; ++i) {
+			list.push(i);
+		}
+	}
 </script>
 
 <div data-id={id}>
-    {#each list as item}
-        <InnerChild val={item} {increment} />
-    {/each}
+	{#each list as item}
+		<InnerChild val={item} {increment} />
+	{/each}
 </div>

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/InnerChild.svelte
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/InnerChild.svelte
@@ -1,14 +1,14 @@
 <script>
-    import { afterUpdate } from 'svelte';
+	import { afterUpdate } from 'svelte';
 
-    export let val = 1;
-    export let increment;
+	export let val = 1;
+	export let increment;
 
-    afterUpdate(() => {
-        increment();
-    });
+	afterUpdate(() => {
+		increment();
+	});
 </script>
 
 <inner>
-    {val}
+	{val}
 </inner>

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/InnerChild.svelte
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/InnerChild.svelte
@@ -1,0 +1,14 @@
+<script>
+    import { afterUpdate } from 'svelte';
+
+    export let val = 1;
+    export let increment;
+
+    afterUpdate(() => {
+        increment();
+    });
+</script>
+
+<inner>
+    {val}
+</inner>

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/_config.js
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/_config.js
@@ -1,0 +1,39 @@
+export default {
+	html: `
+		<div data-id="1">
+			<inner>0</inner>
+			<inner>1</inner>
+		</div>
+		<div data-id="2">
+			<inner>0</inner>
+			<inner>1</inner>
+		</div>
+		<div data-id="3">
+			<inner>0</inner>
+			<inner>1</inner>
+		</div>
+	`,
+
+	ssrHtml: `
+		<div data-id="1">
+			<inner>0</inner>
+			<inner>1</inner>
+			<inner>2</inner>
+		</div>
+		<div data-id="2">
+			<inner>0</inner>
+			<inner>1</inner>
+			<inner>2</inner>
+		</div>
+		<div data-id="3">
+			<inner>0</inner>
+			<inner>1</inner>
+			<inner>2</inner>
+		</div>
+	`,
+
+	async test({ assert, component }) {
+		await component.done;
+		assert.equal(component.getCounter(), 13);
+	}
+};

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/_config.js
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/_config.js
@@ -32,8 +32,22 @@ export default {
 		</div>
 	`,
 
-	async test({ assert, component }) {
+	async test({ assert, component, target }) {
 		await component.done;
 		assert.equal(component.getCounter(), 13);
+		assert.htmlEqual(target.innerHTML, `
+			<div data-id="3">
+				<inner>0</inner>
+				<inner>1</inner>
+			</div>
+			<div data-id="2">
+				<inner>0</inner>
+				<inner>1</inner>
+			</div>
+			<div data-id="1">
+				<inner>0</inner>
+				<inner>1</inner>
+			</div>
+		`);
 	}
 };

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/main.svelte
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/main.svelte
@@ -1,35 +1,35 @@
 <script>
-    import { onMount } from 'svelte';
-    import Child from './Child.svelte';
+	import { onMount } from 'svelte';
+	import Child from './Child.svelte';
 
-    let updateCounter = 0;
-    let promiseResolve;
-    export const done = new Promise(resolve => {
-        promiseResolve = resolve;
-    });
-    export const getCounter = () => {
-        return updateCounter;
-    };
+	let updateCounter = 0;
+	let promiseResolve;
+	export const done = new Promise(resolve => {
+		promiseResolve = resolve;
+	});
+	export const getCounter = () => {
+		return updateCounter;
+	};
 
-    let vals = [1, 2, 3];
-    const instances = [];
-    let count = 3;
+	let vals = [1, 2, 3];
+	const instances = [];
+	let count = 3;
 
-    const increment = () => {
+	const increment = () => {
 		++updateCounter;
-    };
+	};
 
-    onMount(() => {
-        count = 2;
+	onMount(() => {
+		count = 2;
 
-        setTimeout(() => {
-            vals = vals.reverse();
+		setTimeout(() => {
+			vals = vals.reverse();
 
-            setTimeout(promiseResolve);
-        });
-    });
+			setTimeout(promiseResolve);
+		});
+	});
 </script>
 
 {#each vals as val, index (val)}
-    <Child bind:this={instances[index]} id={val} {count} {increment} />
+	<Child bind:this={instances[index]} id={val} {count} {increment} />
 {/each}

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/main.svelte
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/main.svelte
@@ -1,0 +1,37 @@
+<script>
+    import { onMount } from 'svelte';
+    import Child from './Child.svelte';
+
+    let updateCounter = 0;
+    let promiseResolve;
+    export const done = new Promise(resolve => {
+        promiseResolve = resolve;
+    });
+    export const getCounter = () => {
+        return updateCounter;
+    };
+
+    let vals = [1, 2, 3];
+    let instances = [];
+    let count = 3;
+
+    let increment = () => {
+		++updateCounter;
+    };
+
+    onMount(() => {
+        console.log(instances);
+
+        count = 2;
+
+        setTimeout(() => {
+            vals = vals.reverse();
+
+            setTimeout(promiseResolve);
+        });
+    });
+</script>
+
+{#each vals as val, index (val)}
+    <Child bind:this={instances[index]} id={val} {count} {increment} />
+{/each}

--- a/test/runtime/samples/component-binding-each-remount-unkeyed/main.svelte
+++ b/test/runtime/samples/component-binding-each-remount-unkeyed/main.svelte
@@ -12,16 +12,14 @@
     };
 
     let vals = [1, 2, 3];
-    let instances = [];
+    const instances = [];
     let count = 3;
 
-    let increment = () => {
+    const increment = () => {
 		++updateCounter;
     };
 
     onMount(() => {
-        console.log(instances);
-
         count = 2;
 
         setTimeout(() => {


### PR DESCRIPTION
fix: https://github.com/sveltejs/svelte/issues/8282

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

----------------------------------

## This pr fixes the bug

Bug can be seen in console https://svelte.dev/repl/1c3da5d4744c4820a1e9187f23fc6bbe?version=3.48.0
In my case, Firefox says `TypeError: can't access property "m", each_blocks[i] is null`

## What happens in code sample?

Several conditions and steps required:

* There must be UNKEYED each block with component binding
* Later on an array should be updated with lesser length, so holes would be produced
* Somehow remount children, e.g. wrap all with keyed each and update it
* This produces the code `each_blocks[i].m(...)`  without "is not null" check and it fails

## Some thoughts about the changes

* I've added 2 test cases, one with keyed each (passes on master) and similar without key (fails on master)
* I've added 2 same changes, both in keyed code generation and in unkeyed. This is for similarity, but maybe code size is more important here? If so, changes in keyed each can be reverted