### PR TITLE
[fix] harden attribute escaping during ssr

### DIFF
--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -85,12 +85,12 @@ export function escape(value: unknown, is_attr = false) {
 	let escaped = '';
 	let last = 0;
 
-  while (pattern.test(str)) {
-    const i = pattern.lastIndex - 1;
-    const ch = str[i];
-    escaped += str.substring(last, i) + (ch === '&' ? '&amp;' : (ch === '"' ? '&quot;' : '&lt;'));
-    last = i + 1;
-  }
+	while (pattern.test(str)) {
+		const i = pattern.lastIndex - 1;
+		const ch = str[i];
+		escaped += str.substring(last, i) + (ch === '&' ? '&amp;' : (ch === '"' ? '&quot;' : '&lt;'));
+		last = i + 1;
+	}
 
 	return escaped + str.substring(last);
 }

--- a/src/runtime/internal/ssr.ts
+++ b/src/runtime/internal/ssr.ts
@@ -96,7 +96,9 @@ export function escape(value: unknown, is_attr = false) {
 }
 
 export function escape_attribute_value(value) {
-	return typeof value === 'string' ? escape(value, true) : value;
+	// keep booleans, null, and undefined for the sake of `spread`
+	const should_escape = typeof value === 'string' || (value && typeof value === 'object');
+	return should_escape ? escape(value, true) : value;
 }
 
 export function escape_object(obj) {
@@ -192,7 +194,7 @@ export function create_ssr_component(fn) {
 
 export function add_attribute(name, value, boolean) {
 	if (value == null || (boolean && !value)) return '';
-	const assignment = (boolean && value === true) ? '' : `="${escape_attribute_value(value.toString())}"`;
+	const assignment = (boolean && value === true) ? '' : `="${escape(value, true)}"`;
 	return ` ${name}${assignment}`;
 }
 

--- a/test/server-side-rendering/samples/attribute-escaped-quotes-spread/_expected.html
+++ b/test/server-side-rendering/samples/attribute-escaped-quotes-spread/_expected.html
@@ -2,4 +2,10 @@
 	bar="'></div><script>alert(42)</script>"
 	foo="&quot;></div><script>alert(42)</script>"
 	qux="&amp;&amp;&amp;"
+	quux="&quot;><script>alert(42)</script>"
+></div>
+
+<div
+	foo="foo"
+	unsafe="&quot;><script>alert(42)</script>"
 ></div>

--- a/test/server-side-rendering/samples/attribute-escaped-quotes-spread/main.svelte
+++ b/test/server-side-rendering/samples/attribute-escaped-quotes-spread/main.svelte
@@ -1,10 +1,15 @@
 <script>
+	const safe = { foo: 'foo' };
+	const unsafe = { toString: () => '"><script>alert(42)<\/script>' };
+
 	export let props = {
 		foo: '"></div><script>alert(42)</' + 'script>',
 		bar: "'></div><script>alert(42)</" + 'script>',
 		['"></div><script>alert(42)</' + 'script>']: 'baz',
 		qux: '&&&',
+		quux: unsafe
 	};
 </script>
 
 <div {...props}></div>
+<div {...safe} {unsafe}></div>


### PR DESCRIPTION
Upon reviewing #5701 I noticed we don't escape attributes when using objects during SSR. This introduces a (small) vulnerability where objects with a custom `toString()` implementation turn seemingly safe components into an XSS vector:

```svelte
<!-- SeeminglySafe.svelte -->
<script>
	export let attr = undefined;
	export let attrs = {};

	const safe_attrs = {
		foo: 'foo',
		bar: 'bar'
	};
</script>

{#if attr !== undefined}
	Variant 1: <div {...safe_attrs} {attr}/>
{:else}
	Variant 2: <div {...attrs}/>
{/if}

<!-- Component.svelte -->
<script>
	import ActuallyVulnerable from './SeeminglySafe.svelte';

	export let untrusted = '"><script>alert("xss")<\/script>';

	const model = {
		data: untrusted,

		// I'm so helpful! Don't you _love_ OOP?
		toString() {
			return this.data.toString();
		}
	};
</script>

<ActuallyVulnerable attr={model} />
<ActuallyVulnerable attrs={{ foo: 'foo', bar: model }} />

<!-- SSRed html -->
Variant 1: <div foo="foo" bar="bar" attr=""><script>alert("xss")</script>"></div>
Variant 2: <div foo="foo" bar=""><script>alert("xss")</script>"></div>

```

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
