### PR TITLE
[fix] allow use of document root as target in typescript

### DIFF
--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -129,7 +129,7 @@ export interface SvelteComponentDev {
 	[accessor: string]: any;
 }
 interface IComponentOptions<Props extends Record<string, any> = Record<string, any>> {
-	target: Element | ShadowRoot;
+	target: Element | Document | ShadowRoot;
 	anchor?: Element;
 	props?: Props;
 	context?: Map<any, any>;


### PR DESCRIPTION
It is not possible to use typescript when using `target: document`
during component initialization, because target can only be of type
Element or ShadowRoot. This means that it is not possible to hydrate
the entire document when managing the <html> element as a Svelte
component.

This commit fixes this by allowing documents to be targets.

---

Note that this just fixes the type constraint of the target option in IComponentOptions. Svelte already works well when hydrating the document root with `target: document` in regular javascript, so this just relaxes the type constraint.

### Tests

It is unclear to me how to add a test for this -- this can only work when hydrating and there's no skip_if_not_hydrate in test/runtime.  This fix was hand-tested with the following setup, but I'd appreciate help in turning this into an actual test.

Given the following App.svelte:

```svelte
<script lang="ts">
export let name: string;
</script>

<html lang="en">
<head></head>
<body>Hello, {name}</body>
</html>
```

And the following main.ts:

```typescript
import App from './App.svelte';

const app = new App({
	target: document,
	hydrate: true,
	props: {
		name: 'world'
	}
});

export default app;
```

Building the bundle results in the following error:

```
src/main.ts → build/static/bundle.js...
(!) Plugin typescript: @rollup/plugin-typescript TS2322: Type 'Document' is not assignable to type 'Element | ShadowRoot'.
  Type 'Document' is missing the following properties from type 'ShadowRoot': delegatesFocus, host, mode, slotAssignment, innerHTML
src/main.ts: (5:2)

7  target: document,
   ~~~~~~

  node_modules/svelte/types/runtime/internal/dev.d.ts:28:5
    28     target: Element | ShadowRoot;
           ~~~~~~
    The expected type comes from property 'target' which is declared here on type 'IComponentOptions<Record<string, any>>'
```

With this commit, the error goes away.

### Workaround

The workaround I'm using is adding a `// @ts-nocheck` at the top of main.ts. This is of course horribly sad, since we just throw type checking out the window.