### PR TITLE
feat: css units in fly & blur transitions

### DIFF
--- a/site/content/docs/04-run-time.md
+++ b/site/content/docs/04-run-time.md
@@ -670,7 +670,7 @@ Animates a `blur` filter alongside an element's opacity.
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicInOut`) — an [easing function](/docs#run-time-svelte-easing)
 * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
-* `amount` (`number|string`, default 5) - the size of the blur (support css units, for example: "4rem", numbers use px)
+* `amount` (`number | string`, default 5) - the size of the blur. Supports css units (for example: `"4rem"`). The default unit is `px`
 
 ```sv
 <script>
@@ -705,8 +705,8 @@ Animates the x and y positions and the opacity of an element. `in` transitions a
 * `delay` (`number`, default 0) — milliseconds before starting
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicOut`) — an [easing function](/docs#run-time-svelte-easing)
-* `x` (`number|string`, default 0) - the x offset to animate out to and in from
-* `y` (`number|string`, default 0) - the y offset to animate out to and in from
+* `x` (`number | string`, default 0) - the x offset to animate out to and in from
+* `y` (`number | string`, default 0) - the y offset to animate out to and in from
 * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
 
 x and y use `px` by default but support css units, for example `x: '100vw'` or `y: '50%'`.

--- a/site/content/docs/04-run-time.md
+++ b/site/content/docs/04-run-time.md
@@ -670,7 +670,7 @@ Animates a `blur` filter alongside an element's opacity.
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicInOut`) — an [easing function](/docs#run-time-svelte-easing)
 * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
-* `amount` (`number`, default 5) - the size of the blur in pixels
+* `amount` (`number|string`, default 5) - the size of the blur (support css units, for example: "4rem", numbers use px)
 
 ```sv
 <script>
@@ -705,10 +705,11 @@ Animates the x and y positions and the opacity of an element. `in` transitions a
 * `delay` (`number`, default 0) — milliseconds before starting
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicOut`) — an [easing function](/docs#run-time-svelte-easing)
-* `x` (`number`, default 0) - the x offset to animate out to and in from
-* `y` (`number`, default 0) - the y offset to animate out to and in from
+* `x` (`number|string`, default 0) - the x offset to animate out to and in from
+* `y` (`number|string`, default 0) - the y offset to animate out to and in from
 * `opacity` (`number`, default 0) - the opacity value to animate out to and in from
 
+x and y use `px` by default but support css units, for example `x: '100vw'` or `y: '50%'`.
 You can see the `fly` transition in action in the [transition tutorial](/tutorial/adding-parameters-to-transitions).
 
 ```sv

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -191,12 +191,6 @@ export function action_destroyer(action_result) {
 }
 
 export function split_css_unit(value: number | string): [number, string] {
-	if (typeof value === 'number') {
-		return [value, 'px'];
-	}
-	const split = value?.match?.(/^\s*(-?[\d.]+)([^\s]*)\s*$/);
-	if (split) {
-		return [parseFloat(split[1]), split[2] || 'px'];
-	}
-	return [parseFloat(value), 'px'];
+	const split = typeof value === 'string' && value.match(/^\s*(-?[\d.]+)([^\s]*)\s*$/);
+	return split ? [parseFloat(split[1]), split[2] || 'px'] : [value, 'px'];
 }

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -192,5 +192,5 @@ export function action_destroyer(action_result) {
 
 export function split_css_unit(value: number | string): [number, string] {
 	const split = typeof value === 'string' && value.match(/^\s*(-?[\d.]+)([^\s]*)\s*$/);
-	return split ? [parseFloat(split[1]), split[2] || 'px'] : [value, 'px'];
+	return split ? [parseFloat(split[1]), split[2] || 'px'] : [value as number, 'px'];
 }

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -189,3 +189,15 @@ export const has_prop = (obj, prop) => Object.prototype.hasOwnProperty.call(obj,
 export function action_destroyer(action_result) {
 	return action_result && is_function(action_result.destroy) ? action_result.destroy : noop;
 }
+
+export function split_css_unit(value: number | string, fallback = 'px'): [number, string] {
+	if (typeof value === 'number') {
+		return [value, fallback];
+	}
+	const split = value?.match?.(/^\s*(-?[\d.]+)([^\s]*)\s*$/);
+	if (split) {
+		return [parseFloat(split[1]), split[2] || fallback];
+	}
+	console.warn('Failed to split', value);
+	return [parseFloat(value), fallback];
+}

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -190,14 +190,13 @@ export function action_destroyer(action_result) {
 	return action_result && is_function(action_result.destroy) ? action_result.destroy : noop;
 }
 
-export function split_css_unit(value: number | string, fallback = 'px'): [number, string] {
+export function split_css_unit(value: number | string): [number, string] {
 	if (typeof value === 'number') {
-		return [value, fallback];
+		return [value, 'px'];
 	}
 	const split = value?.match?.(/^\s*(-?[\d.]+)([^\s]*)\s*$/);
 	if (split) {
-		return [parseFloat(split[1]), split[2] || fallback];
+		return [parseFloat(split[1]), split[2] || 'px'];
 	}
-	console.warn('Failed to split', value);
-	return [parseFloat(value), fallback];
+	return [parseFloat(value), 'px'];
 }

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -1,5 +1,5 @@
 import { cubicOut, cubicInOut, linear } from 'svelte/easing';
-import { assign, is_function } from 'svelte/internal';
+import { assign, split_css_unit, is_function } from 'svelte/internal';
 
 export type EasingFunction = (t: number) => number;
 
@@ -15,7 +15,7 @@ export interface BlurParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
-	amount?: number;
+	amount?: number | string;
 	opacity?: number;
 }
 
@@ -31,12 +31,12 @@ export function blur(node: Element, {
 	const f = style.filter === 'none' ? '' : style.filter;
 
 	const od = target_opacity * (1 - opacity);
-
+	const [value, unit] = split_css_unit(amount);
 	return {
 		delay,
 		duration,
 		easing,
-		css: (_t, u) => `opacity: ${target_opacity - (od * u)}; filter: ${f} blur(${u * amount}px);`
+		css: (_t, u) => `opacity: ${target_opacity - (od * u)}; filter: ${f} blur(${u * value}${unit});`
 	};
 }
 
@@ -65,8 +65,8 @@ export interface FlyParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
-	x?: number;
-	y?: number;
+	x?: number | string;
+	y?: number | string;
 	opacity?: number;
 }
 
@@ -83,13 +83,14 @@ export function fly(node: Element, {
 	const transform = style.transform === 'none' ? '' : style.transform;
 
 	const od = target_opacity * (1 - opacity);
-
+	const [xValue, xUnit] = split_css_unit(x);
+	const [yValue, yUnit] = split_css_unit(y);
 	return {
 		delay,
 		duration,
 		easing,
 		css: (t, u) => `
-			transform: ${transform} translate(${(1 - t) * x}px, ${(1 - t) * y}px);
+			transform: ${transform} translate(${(1 - t) * xValue}${xUnit}, ${(1 - t) * yValue}${yUnit});
 			opacity: ${target_opacity - (od * u)}`
 	};
 }

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import { trim_start, trim_end } from '../../src/compiler/utils/trim';
+import { split_css_unit } from '../../src/runtime/internal/utils';
 
 describe('utils', () => {
 	describe('trim', () => {
@@ -11,6 +12,43 @@ describe('utils', () => {
 		it('trim_end', () => {
 			const value = trim_end('	\r\n\t svelte content \r\n\t	');
 			assert.equal(value, '	\r\n\t svelte content');
+		});
+	});
+
+	describe('split_css_unit', () => {
+		it('should use px as default', () => {
+			assert.deepEqual(split_css_unit(10), [10, 'px']);
+			assert.deepEqual(split_css_unit('10'), [10, 'px']);
+		});
+
+		it('should use the fallback', () => {
+			assert.deepEqual(split_css_unit(100, '%'), [100, '%']);
+			assert.deepEqual(split_css_unit('100', '%'), [100, '%']);
+		});
+
+		it('should split the css notation into value and unit', () => {
+			assert.deepEqual(split_css_unit('-50%'), [-50, '%']);
+			assert.deepEqual(split_css_unit('0.1rem'), [0.1, 'rem']);
+			assert.deepEqual(split_css_unit('.1rem'), [0.1, 'rem']);
+		});
+
+		it('should complain for invalid input', () => {
+			const warnings = [];
+			const warn = console.warn;
+			console.warn = (...args) => {
+				warnings.push(args);
+			};
+
+			split_css_unit('calc(100vw - 10rem)');
+			split_css_unit(undefined);
+			assert.deepEqual(split_css_unit('100 %'), [100, 'px']);
+			assert.deepEqual(warnings, [
+				['Failed to split', 'calc(100vw - 10rem)'],
+				['Failed to split', undefined],
+				['Failed to split', '100 %']
+			]);
+
+			console.warn = warn;
 		});
 	});
 });

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -21,34 +21,10 @@ describe('utils', () => {
 			assert.deepEqual(split_css_unit('10'), [10, 'px']);
 		});
 
-		it('should use the fallback', () => {
-			assert.deepEqual(split_css_unit(100, '%'), [100, '%']);
-			assert.deepEqual(split_css_unit('100', '%'), [100, '%']);
-		});
-
 		it('should split the css notation into value and unit', () => {
 			assert.deepEqual(split_css_unit('-50%'), [-50, '%']);
 			assert.deepEqual(split_css_unit('0.1rem'), [0.1, 'rem']);
 			assert.deepEqual(split_css_unit('.1rem'), [0.1, 'rem']);
-		});
-
-		it('should complain for invalid input', () => {
-			const warnings = [];
-			const warn = console.warn;
-			console.warn = (...args) => {
-				warnings.push(args);
-			};
-
-			split_css_unit('calc(100vw - 10rem)');
-			split_css_unit(undefined);
-			assert.deepEqual(split_css_unit('100 %'), [100, 'px']);
-			assert.deepEqual(warnings, [
-				['Failed to split', 'calc(100vw - 10rem)'],
-				['Failed to split', undefined],
-				['Failed to split', '100 %']
-			]);
-
-			console.warn = warn;
 		});
 	});
 });


### PR DESCRIPTION
For the `fly` transition, the x & y are passed as numbers and are used are pixel values (px)
This limits the range of what fly can do.

This PR adds support for passing the x & y as strings that can contain CSS units:

You can create an animation that are relative:

```html
<div class="box" in:fly={{x: '100%'}} />
```

`'100%'` is based on the width of the box.

Or based on the viewport:

```html
<div class="modal" in:fly={{y: '50vh'}} />
```

Other units are also supported, we use `rem` a lot,
currently we are calculating the px value or accept that the animation doesn't scale.
With this PR we would be able to write:

```html
<h1 class="title" in:fly={{y: '3rem'}} />
```

As a guideline for the regex I looked at css notation.  
'100%' ✅  
'100 %' ❌

If no unit is provided it falls back to using px. '50' is interpreted as '50px'

Closes #6050

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`
