### PR TITLE
Update text.md on site/content/tutorial/01-introduction/07-making-an-app

### DIFF
--- a/site/content/tutorial/01-introduction/07-making-an-app/text.md
+++ b/site/content/tutorial/01-introduction/07-making-an-app/text.md
@@ -7,7 +7,7 @@ This tutorial is designed to get you familiar with the process of writing compon
 First, you'll need to integrate Svelte with a build tool. We recommend using [Vite](https://vitejs.dev/) with [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte/)...
 
 ```bash
-npm init vite my-app -- --template svelte
+npm create vite my-app -- --template svelte
 ```
 
 ...or one of the [community-maintained integrations](https://sveltesociety.dev/tools).


### PR DESCRIPTION
to have a consistency with what's shown at https://kit.svelte.dev/ like below

```
npm create svelte my-app
cd my-app
npm install
npm run dev -- --open
```

also it feels more natural with `create` than `init`
