### PR TITLE
[fix] export CompileOptions

### DIFF
--- a/generate-type-definitions.js
+++ b/generate-type-definitions.js
@@ -5,9 +5,20 @@ const { readFileSync, writeFileSync } = require('fs');
 
 execSync('tsc -p src/compiler --emitDeclarationOnly && tsc -p src/runtime --emitDeclarationOnly');
 
-// We need to add these types to the index.d.ts here because if we add them before building, the build will fail,
+// We need to add these types to the .d.ts files here because if we add them before building, the build will fail,
 // because the TS->JS transformation doesn't know these exports are types and produces code that fails at runtime.
 // We can't use `export type` syntax either because the TS version we're on doesn't have this feature yet.
-const path = 'types/runtime/index.d.ts';
-const content = readFileSync(path, 'utf8');
-writeFileSync(path, content.replace('SvelteComponentTyped', 'SvelteComponentTyped, ComponentType, ComponentConstructorOptions, ComponentProps'));
+
+function modify(path, modifyFn) {
+    const content = readFileSync(path, 'utf8');
+    writeFileSync(path, modifyFn(content));
+}
+
+modify(
+    'types/runtime/index.d.ts',
+    content => content.replace('SvelteComponentTyped', 'SvelteComponentTyped, ComponentType, ComponentConstructorOptions, ComponentProps')
+);
+modify(
+    'types/compiler/index.d.ts',
+    content => content + '\nexport { CompileOptions, ModuleFormat, EnableSourcemap, CssHashGetter } from "./interfaces"'
+);

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -4,3 +4,4 @@ export { default as preprocess } from './preprocess/index';
 export { walk } from 'estree-walker';
 
 export const VERSION = '__VERSION__';
+// additional exports added  through generate-type-definitions.js

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -13,5 +13,5 @@ export {
 	createEventDispatcher,
 	SvelteComponentDev as SvelteComponent,
 	SvelteComponentTyped
-	// additional exports added through post-typegen.js
+	// additional exports added through generate-type-definitions.js
 } from 'svelte/internal';


### PR DESCRIPTION
It's are used by SvelteKit and in order to properly use it under the new TS moduleResolution NodeNext it needs to be part of a file that is defined in the exports map

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
