### PR TITLE
[fix] Removal of empty stylesheets created from transitions

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -154,14 +154,9 @@ export function get_root_for_style(node: Node): ShadowRoot | Document {
 	return node.ownerDocument;
 }
 
-export function append_empty_stylesheet(node: Node) {
-	const style_element = element('style') as HTMLStyleElement;
-	append_stylesheet(get_root_for_style(node), style_element);
-	return style_element.sheet as CSSStyleSheet;
-}
-
-function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement) {
+export function append_stylesheet(node: ShadowRoot | Document, style: HTMLStyleElement) {
 	append((node as Document).head || node, style);
+	return style.sheet as CSSStyleSheet;
 }
 
 export function append_hydration(target: NodeEx, node: NodeEx) {

--- a/test/runtime/samples/style_manager-cleanup/_config.js
+++ b/test/runtime/samples/style_manager-cleanup/_config.js
@@ -1,0 +1,14 @@
+export default {
+	skip_if_ssr: true,
+	skip_if_hydrate: true,
+	skip_if_hydrate_from_ssr: true,
+	test({ raf, assert, component, window }) {
+		component.visible = true;
+		raf.tick(100);
+		component.visible = false;
+		raf.tick(200);
+		raf.tick(0);
+
+		assert.htmlEqual(window.document.head.innerHTML, '');
+	}
+};

--- a/test/runtime/samples/style_manager-cleanup/main.svelte
+++ b/test/runtime/samples/style_manager-cleanup/main.svelte
@@ -1,0 +1,14 @@
+<script>
+    export let visible = false;
+    
+    function foo() {
+        return {
+            duration: 100,
+            css: () => ''
+        };
+    }
+    </script>
+    
+    {#if visible}
+        <div transition:foo></div>
+    {/if}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`

### Closes
- https://github.com/sveltejs/svelte/issues/4801
- https://github.com/sveltejs/svelte/issues/7164

## What has been changed?
The `style_manager` "cleaned up" the stylesheets it made by only clearing their rules. After clearing them, it removed them from its internal map by running `managed_styles.clear()`. This cleanup was not optimal - it left the style elements empty in the dom.

The proposed change is to remove style-elements created by `style_manager`, instead of making them empty and letting them stay in the DOM without any references. I also refactored some of the methods from the `runtime/internal/dom.ts` file that were only used by the `style_manager` or in the `dom.ts file` itself.

If you want to reverse-engineer this bug yourself, then start with the `append_empty_stylesheet` method in the `dom.ts` file. As long as `append_empty_stylesheet` is used, there will be bugs related to empty stylesheets. It does the following:
1. Creates an empty style-element
2. Appends it to the dom
3. Returns only the sheet of the new style-element, leaving the style-tag totally unreferenced by any code