### PR TITLE
Link to sites repository in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm run test -- -g transition
 
 ## svelte.dev
 
-The source code for https://svelte.dev, including all the documentation, lives in the [site](site) directory. The site is built with [SvelteKit](https://kit.svelte.dev).
+The source code for https://svelte.dev, including all the documentation, lives in the [sites](https://github.com/sveltejs/sites) repository. The site is built with [SvelteKit](https://kit.svelte.dev).
 
 ### Is svelte.dev down?
 


### PR DESCRIPTION
Just some oversight, the readme still tells users the site is part of the package itself, while it is not in it's own repository.