### PR TITLE
[fix/docs] Remove invalid statement in onMount tutorial

### DIFF
--- a/site/content/tutorial/07-lifecycle/01-onmount/text.md
+++ b/site/content/tutorial/07-lifecycle/01-onmount/text.md
@@ -4,7 +4,7 @@ title: onMount
 
 Every component has a *lifecycle* that starts when it is created, and ends when it is destroyed. There are a handful of functions that allow you to run code at key moments during that lifecycle.
 
-The one you'll use most frequently is `onMount`, which runs after the component is first rendered to the DOM. We briefly encountered it [earlier](/tutorial/bind-this) when we needed to interact with a `<canvas>` element after it had been rendered.
+The one you'll use most frequently is `onMount`, which runs after the component is first rendered to the DOM.
 
 We'll add an `onMount` handler that loads some data over the network:
 


### PR DESCRIPTION
Removes an old reference in the onMount tutorial as the reference has been moved to the advanced section and is no longer before this part.

See: https://learn.svelte.dev/tutorial/onmount (Part 1 / Lifecycle / onMount)
Removed section points to https://learn.svelte.dev/tutorial/bind-this (Part 3 / Advanced bindings / This) as "before"

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
