### PR TITLE
[feat] add convenience type for `ComponentEvents`

### DIFF
--- a/generate-type-definitions.js
+++ b/generate-type-definitions.js
@@ -16,7 +16,7 @@ function modify(path, modifyFn) {
 
 modify(
     'types/runtime/index.d.ts',
-    content => content.replace('SvelteComponentTyped', 'SvelteComponentTyped, ComponentType, ComponentConstructorOptions, ComponentProps')
+    content => content.replace('SvelteComponentTyped', 'SvelteComponentTyped, ComponentType, ComponentConstructorOptions, ComponentProps, ComponentEvents, ComponentEvent, ComponentSlots')
 );
 modify(
     'types/compiler/index.d.ts',

--- a/generate-type-definitions.js
+++ b/generate-type-definitions.js
@@ -16,7 +16,7 @@ function modify(path, modifyFn) {
 
 modify(
     'types/runtime/index.d.ts',
-    content => content.replace('SvelteComponentTyped', 'SvelteComponentTyped, ComponentType, ComponentConstructorOptions, ComponentProps, ComponentEvents, ComponentEvent')
+    content => content.replace('SvelteComponentTyped', 'SvelteComponentTyped, ComponentType, ComponentConstructorOptions, ComponentProps, ComponentEvents')
 );
 modify(
     'types/compiler/index.d.ts',

--- a/generate-type-definitions.js
+++ b/generate-type-definitions.js
@@ -16,7 +16,7 @@ function modify(path, modifyFn) {
 
 modify(
     'types/runtime/index.d.ts',
-    content => content.replace('SvelteComponentTyped', 'SvelteComponentTyped, ComponentType, ComponentConstructorOptions, ComponentProps, ComponentEvents, ComponentEvent, ComponentSlots')
+    content => content.replace('SvelteComponentTyped', 'SvelteComponentTyped, ComponentType, ComponentConstructorOptions, ComponentProps, ComponentEvents, ComponentEvent')
 );
 modify(
     'types/compiler/index.d.ts',

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -301,6 +301,25 @@ export type ComponentProps<Component extends SvelteComponent> = Component extend
 	? Props
 	: never;
 
+/**
+ * Convenience type to get the events the given component expects. Example:
+ * ```html
+ * <script lang="ts">
+ *    import type { ComponentEvents } from 'svelte';
+ *    import Component from './Component.svelte';
+ *
+ *    type $$Events = ComponentEvent<Component>;
+ * </script>
+ * 
+ * <div class="wrapper">
+ *    <Component on:close />
+ * </div>
+ * ```
+ */
+export type ComponentEvents<Component extends SvelteComponent> = Component extends SvelteComponentTyped<any, infer Events>
+	? Events
+	: never;
+
 export function loop_guard(timeout) {
 	const start = Date.now();
 	return () => {

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -264,18 +264,18 @@ export class SvelteComponentTyped<
 /**
  * Convenience type to get the type of a Svelte component. Useful for example in combination with
  * dynamic components using `<svelte:component>`.
- * 
+ *
  * Example:
  * ```html
  * <script lang="ts">
  * 	import type { ComponentType, SvelteComponentTyped } from 'svelte';
  * 	import Component1 from './Component1.svelte';
  * 	import Component2 from './Component2.svelte';
- * 
+ *
  * 	const component: ComponentType = someLogic() ? Component1 : Component2;
  * 	const componentOfCertainSubType: ComponentType<SvelteComponentTyped<{ needsThisProp: string }>> = someLogic() ? Component1 : Component2;
  * </script>
- * 
+ *
  * <svelte:component this={component} />
  * <svelte:component this={componentOfCertainSubType} needsThisProp="hello" />
  * ```
@@ -292,7 +292,7 @@ export type ComponentType<Component extends SvelteComponentTyped = SvelteCompone
  * <script lang="ts">
  * 	import type { ComponentProps } from 'svelte';
  * 	import Component from './Component.svelte';
- * 
+ *
  * 	const props: ComponentProps<Component> = { foo: 'bar' }; // Errors if these aren't the correct props
  * </script>
  * ```
@@ -308,35 +308,16 @@ export type ComponentProps<Component extends SvelteComponent> = Component extend
  *    import type { ComponentEvents } from 'svelte';
  *    import Component from './Component.svelte';
  *
- *    type $$Events = ComponentEvents<Component>;
+ *    function handleCloseEvent(event: ComponentEvents<Component>['close']) {
+ *       console.log(event.detail);
+ *    };
  * </script>
- * 
- * <div class="wrapper">
- *    <Component on:close />
- * </div>
+ *
+ * <Component on:close={handleCloseEvent} />
  * ```
  */
 export type ComponentEvents<Component extends SvelteComponent> =
 	Component extends SvelteComponentTyped<any, infer Events> ? Events : never;
-
-/**
-* Convenience type to get an event the given component expects. Example:
-* ```html
-* <script lang="ts">
-*    import type { ComponentEvent } from 'svelte';
-*    import Component from './Component.svelte';
-*
-*    function handleCloseEvent(event: ComponentEvent<Component, 'close'>) {
-*       console.log(event.detail);
-*    };
-* </script>
-*
-* <Component on:close={handleCloseEvent} />
-* ```
-*/
-export type ComponentEvent<Component extends SvelteComponent, Name extends string> = Component extends SvelteComponentTyped<any, infer Events>
-	? never extends Events[Name] ? CustomEvent<unknown> : Events[Name]
-	: never;
 
 export function loop_guard(timeout) {
 	const start = Date.now();

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -310,7 +310,7 @@ export type ComponentProps<Component extends SvelteComponent> = Component extend
  *
  *    function handleCloseEvent(event: ComponentEvents<Component>['close']) {
  *       console.log(event.detail);
- *    };
+ *    }
  * </script>
  *
  * <Component on:close={handleCloseEvent} />

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -308,7 +308,7 @@ export type ComponentProps<Component extends SvelteComponent> = Component extend
  *    import type { ComponentEvents } from 'svelte';
  *    import Component from './Component.svelte';
  *
- *    type $$Events = ComponentEvent<Component>;
+ *    type $$Events = ComponentEvents<Component>;
  * </script>
  * 
  * <div class="wrapper">

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -339,10 +339,6 @@ export type ComponentEvent<Component extends SvelteComponent, Name extends strin
 	? never extends Events[Name] ? CustomEvent<unknown> : Events[Name]
 	: never;
 
-export type ComponentSlots<Component extends SvelteComponent> = Component extends SvelteComponentTyped<any, any, infer Slots>
-	? {} extends Slots ? never : Slots
-	: never;
-  
 export function loop_guard(timeout) {
 	const start = Date.now();
 	return () => {

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -316,9 +316,8 @@ export type ComponentProps<Component extends SvelteComponent> = Component extend
  * </div>
  * ```
  */
-export type ComponentEvents<Component extends SvelteComponent> = Component extends SvelteComponentTyped<any, infer Events>
-	? Events
-	: never;
+export type ComponentEvents<Component extends SvelteComponent> =
+	Component extends SvelteComponentTyped<any, infer Events> ? Events : never;
 
 /**
 * Convenience type to get an event the given component expects. Example:

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -339,6 +339,10 @@ export type ComponentEvent<Component extends SvelteComponent, Name extends strin
 	? never extends Events[Name] ? CustomEvent<unknown> : Events[Name]
 	: never;
 
+export type ComponentSlots<Component extends SvelteComponent> = Component extends SvelteComponentTyped<any, any, infer Slots>
+	? {} extends Slots ? never : Slots
+	: never;
+  
 export function loop_guard(timeout) {
 	const start = Date.now();
 	return () => {

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -320,6 +320,25 @@ export type ComponentEvents<Component extends SvelteComponent> = Component exten
 	? Events
 	: never;
 
+/**
+* Convenience type to get an event the given component expects. Example:
+* ```html
+* <script lang="ts">
+*    import type { ComponentEvent } from 'svelte';
+*    import Component from './Component.svelte';
+*
+*    function handleCloseEvent(event: ComponentEvents<Component, 'close'>) {
+*       console.log(event.detail);
+*    };
+* </script>
+*
+* <Component on:close={handleCloseEvent} />
+* ```
+*/
+export type ComponentEvent<Component extends SvelteComponent, Name extends string> = Component extends SvelteComponentTyped<any, infer Events>
+	? never extends Events[Name] ? CustomEvent<unknown> : Events[Name]
+	: never;
+
 export function loop_guard(timeout) {
 	const start = Date.now();
 	return () => {

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -327,7 +327,7 @@ export type ComponentEvents<Component extends SvelteComponent> = Component exten
 *    import type { ComponentEvent } from 'svelte';
 *    import Component from './Component.svelte';
 *
-*    function handleCloseEvent(event: ComponentEvents<Component, 'close'>) {
+*    function handleCloseEvent(event: ComponentEvent<Component, 'close'>) {
 *       console.log(event.detail);
 *    };
 * </script>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

This extends the convenience types of #6770 with
 - `ComponentEvents` to get all events of a component
    use-case: wrapping a component and re-declaring its events
    https://github.com/ivanhofer/sveltekit-typescript-showcase/blob/main/src/03-events/04-%24%24Events/Component.svelte
 - `ComponentEvent` to get the type of a single event of a component
    use-case: typing an event handler
    https://github.com/ivanhofer/sveltekit-typescript-showcase/blob/main/src/03-events/02-typed-event-details/Usage.svelte
 - `ComponentSlots` to get all slots of a component
    use-case: none, that I currently can think of, but it makes sense to also provide this type helper

