### PR TITLE
[fix] Improve performance by using trimRight() instead of regex replace

### DIFF
--- a/src/compiler/compile/render_ssr/index.ts
+++ b/src/compiler/compile/render_ssr/index.ts
@@ -237,7 +237,7 @@ function trim(nodes: TemplateNode[]) {
 		const node = nodes[end - 1] as Text;
 		if (node.type !== 'Text') break;
 
-		node.data = node.data.replace(/\s+$/, '');
+		node.data = node.data.trimRight();
 		if (node.data) break;
 	}
 

--- a/src/compiler/parse/index.ts
+++ b/src/compiler/parse/index.ts
@@ -34,7 +34,7 @@ export class Parser {
 			throw new TypeError('Template must be a string');
 		}
 
-		this.template = template.replace(/\s+$/, '');
+		this.template = template.trimRight();
 		this.filename = options.filename;
 		this.customElement = options.customElement;
 


### PR DESCRIPTION


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

close #7675

This PR uses `trimRight()` instead of `replace(/\s+$/, '')` to improve parsing performance.

See the https://github.com/sveltejs/svelte/issues/7675#issuecomment-1179995722 for issues with the original regex.


If you know how to add a test to check performance, please let me know.
I ran the following test locally and I checked that it would improve performance.

```js
import { parse } from '../../compiler.js';
describe('improve performance', () => {
	it('parse', () => {
		parse(`<div>${' '.repeat(1000000)}</div>`);
	});
});
```
