### PR TITLE
[chore]: store regexp as variable instead of defining it inline

### DIFF
--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -48,6 +48,8 @@ interface ComponentOptions {
 }
 
 const regex_leading_directory_separator = /^[/\\]/;
+const regex_starts_with_Export = /^Export/;
+const regex_contains_Function = /Function/;
 
 export default class Component {
 	stats: Stats;
@@ -640,7 +642,7 @@ export default class Component {
 				body.splice(i, 1);
 			}
 
-			if (/^Export/.test(node.type)) {
+			if (regex_starts_with_Export.test(node.type)) {
 				const replacement = this.extract_exports(node, true);
 				if (replacement) {
 					body[i] = replacement;
@@ -797,7 +799,7 @@ export default class Component {
 					return this.skip();
 				}
 
-				if (/^Export/.test(node.type)) {
+				if (regex_starts_with_Export.test(node.type)) {
 					const replacement = component.extract_exports(node);
 					if (replacement) {
 						this.replace(replacement);
@@ -920,7 +922,7 @@ export default class Component {
 				}
 
 				if (name[1] !== '$' && scope.has(name.slice(1)) && scope.find_owner(name.slice(1)) !== this.instance_scope) {
-					if (!((/Function/.test(parent.type) && prop === 'params') || (parent.type === 'VariableDeclarator' && prop === 'id'))) {
+					if (!((regex_contains_Function.test(parent.type) && prop === 'params') || (parent.type === 'VariableDeclarator' && prop === 'id'))) {
 						return this.error(node as any, compiler_errors.contextual_store);
 					}
 				}
@@ -967,7 +969,7 @@ export default class Component {
 
 		walk(this.ast.instance.content, {
 			enter(node: Node) {
-				if (/Function/.test(node.type)) {
+				if (regex_contains_Function.test(node.type)) {
 					return this.skip();
 				}
 
@@ -1462,6 +1464,8 @@ export default class Component {
 	}
 }
 
+const regex_valid_tag_name = /^[a-zA-Z][a-zA-Z0-9]*-[a-zA-Z0-9-]+$/;
+
 function process_component_options(component: Component, nodes) {
 	const component_options: ComponentOptions = {
 		immutable: component.compile_options.immutable || false,
@@ -1507,7 +1511,7 @@ function process_component_options(component: Component, nodes) {
 							return component.error(attribute, compiler_errors.invalid_tag_attribute);
 						}
 
-						if (tag && !/^[a-zA-Z][a-zA-Z0-9]*-[a-zA-Z0-9-]+$/.test(tag)) {
+						if (tag && !regex_valid_tag_name.test(tag)) {
 							return component.error(attribute, compiler_errors.invalid_tag_property);
 						}
 

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -48,8 +48,8 @@ interface ComponentOptions {
 }
 
 const regex_leading_directory_separator = /^[/\\]/;
-const regex_starts_with_Export = /^Export/;
-const regex_contains_Function = /Function/;
+const regex_starts_with_term_export = /^Export/;
+const regex_contains_term_function = /Function/;
 
 export default class Component {
 	stats: Stats;
@@ -642,7 +642,7 @@ export default class Component {
 				body.splice(i, 1);
 			}
 
-			if (regex_starts_with_Export.test(node.type)) {
+			if (regex_starts_with_term_export.test(node.type)) {
 				const replacement = this.extract_exports(node, true);
 				if (replacement) {
 					body[i] = replacement;
@@ -799,7 +799,7 @@ export default class Component {
 					return this.skip();
 				}
 
-				if (regex_starts_with_Export.test(node.type)) {
+				if (regex_starts_with_term_export.test(node.type)) {
 					const replacement = component.extract_exports(node);
 					if (replacement) {
 						this.replace(replacement);
@@ -922,7 +922,7 @@ export default class Component {
 				}
 
 				if (name[1] !== '$' && scope.has(name.slice(1)) && scope.find_owner(name.slice(1)) !== this.instance_scope) {
-					if (!((regex_contains_Function.test(parent.type) && prop === 'params') || (parent.type === 'VariableDeclarator' && prop === 'id'))) {
+					if (!((regex_contains_term_function.test(parent.type) && prop === 'params') || (parent.type === 'VariableDeclarator' && prop === 'id'))) {
 						return this.error(node as any, compiler_errors.contextual_store);
 					}
 				}
@@ -969,7 +969,7 @@ export default class Component {
 
 		walk(this.ast.instance.content, {
 			enter(node: Node) {
-				if (regex_contains_Function.test(node.type)) {
+				if (regex_contains_term_function.test(node.type)) {
 					return this.skip();
 				}
 

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -47,6 +47,8 @@ interface ComponentOptions {
 	preserveWhitespace?: boolean;
 }
 
+const regex_leading_directory_separator = /^[/\\]/;
+
 export default class Component {
 	stats: Stats;
 	warnings: Warning[];
@@ -136,7 +138,7 @@ export default class Component {
 			(typeof process !== 'undefined'
 				? compile_options.filename
 					.replace(process.cwd(), '')
-					.replace(/^[/\\]/, '')
+				.replace(regex_leading_directory_separator, '')
 				: compile_options.filename);
 		this.locate = getLocator(this.source, { offsetLine: 1 });
 

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -138,7 +138,7 @@ export default class Component {
 			(typeof process !== 'undefined'
 				? compile_options.filename
 					.replace(process.cwd(), '')
-				.replace(regex_leading_directory_separator, '')
+					.replace(regex_leading_directory_separator, '')
 				: compile_options.filename);
 		this.locate = getLocator(this.source, { offsetLine: 1 });
 
@@ -1091,7 +1091,7 @@ export default class Component {
 
 						this.replace(b`
 							${node.declarations.length ? node : null}
-							${ props.length > 0 && b`let { ${ props } } = $$props;`}
+							${ props.length > 0 && b`let { ${props} } = $$props;`}
 							${inserts}
 						` as any);
 						return this.skip();
@@ -1475,7 +1475,7 @@ function process_component_options(component: Component, nodes) {
 
 	const node = nodes.find(node => node.name === 'svelte:options');
 
-	function get_value(attribute, {code, message}) {
+	function get_value(attribute, { code, message }) {
 		const { value } = attribute;
 		const chunk = value[0];
 

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -281,12 +281,14 @@ function apply_selector(blocks: Block[], node: Element, to_encapsulate: Array<{ 
 	return true;
 }
 
+const regex_backslash_and_following_character = /\\(.)/g;
+
 function block_might_apply_to_node(block: Block, node: Element): BlockAppliesToNode {
 	let i = block.selectors.length;
 
 	while (i--) {
 		const selector = block.selectors[i];
-		const name = typeof selector.name === 'string' && selector.name.replace(/\\(.)/g, '$1');
+		const name = typeof selector.name === 'string' && selector.name.replace(regex_backslash_and_following_character, '$1');
 
 		if (selector.type === 'PseudoClassSelector' && (name === 'host' || name === 'root')) {
 			return BlockAppliesToNode.NotPossible;

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -25,6 +25,8 @@ const whitelist_attribute_selector = new Map([
 	['dialog', new Set(['open'])]
 ]);
 
+const regex_is_single_css_selector = /[^\\],(?!([^([]+[^\\]|[^([\\])[)\]])/;
+
 export default class Selector {
 	node: CssNode;
 	stylesheet: Stylesheet;
@@ -157,7 +159,7 @@ export default class Selector {
 		for (const block of this.blocks) {
 			for (const selector of block.selectors) {
 				if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
-					if (/[^\\],(?!([^([]+[^\\]|[^([\\])[)\]])/.test(selector.children[0].value)) {
+					if (regex_is_single_css_selector.test(selector.children[0].value)) {
 						component.error(selector, compiler_errors.css_invalid_global_selector);
 					}
 				}
@@ -338,6 +340,9 @@ function test_attribute(operator, expected_value, case_insensitive, value) {
 	}
 }
 
+const regex_starts_with_whitespace = /^\s/;
+const regex_ends_with_whitespace = /\s$/;
+
 function attribute_matches(node: CssNode, name: string, expected_value: string, operator: string, case_insensitive: boolean) {
 	const spread = node.attributes.find(attr => attr.type === 'Spread');
 	if (spread) return true;
@@ -373,7 +378,7 @@ function attribute_matches(node: CssNode, name: string, expected_value: string, 
 			const start_with_space = [];
 			const remaining = [];
 			current_possible_values.forEach((current_possible_value: string) => {
-				if (/^\s/.test(current_possible_value)) {
+				if (regex_starts_with_whitespace.test(current_possible_value)) {
 					start_with_space.push(current_possible_value);
 				} else {
 					remaining.push(current_possible_value);
@@ -394,7 +399,7 @@ function attribute_matches(node: CssNode, name: string, expected_value: string, 
 				prev_values = combined;
 
 				start_with_space.forEach((value: string) => {
-					if (/\s$/.test(value)) {
+					if (regex_ends_with_whitespace.test(value)) {
 						possible_values.add(value);
 					} else {
 						prev_values.push(value);
@@ -408,7 +413,7 @@ function attribute_matches(node: CssNode, name: string, expected_value: string, 
 		}
 
 		current_possible_values.forEach((current_possible_value: string) => {
-			if (/\s$/.test(current_possible_value)) {
+			if (regex_ends_with_whitespace.test(current_possible_value)) {
 				possible_values.add(current_possible_value);
 			} else {
 				prev_values.push(current_possible_value);

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -9,6 +9,7 @@ import EachBlock from '../nodes/EachBlock';
 import IfBlock from '../nodes/IfBlock';
 import AwaitBlock from '../nodes/AwaitBlock';
 import compiler_errors from '../compiler_errors';
+import { regex_starts_with_whitespace, regex_ends_with_whitespace } from '../../utils/patterns';
 
 enum BlockAppliesToNode {
 	NotPossible,
@@ -339,9 +340,6 @@ function test_attribute(operator, expected_value, case_insensitive, value) {
 		default: throw new Error("this shouldn't happen");
 	}
 }
-
-const regex_starts_with_whitespace = /^\s/;
-const regex_ends_with_whitespace = /\s$/;
 
 function attribute_matches(node: CssNode, name: string, expected_value: string, operator: string, case_insensitive: boolean) {
 	const spread = node.attributes.find(attr => attr.type === 'Spread');

--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -10,8 +10,10 @@ import compiler_warnings from '../compiler_warnings';
 import { extract_ignores_above_position } from '../../utils/extract_svelte_ignore';
 import { push_array } from '../../utils/push_array';
 
+const regex_css_browser_prefix = /^-((webkit)|(moz)|(o)|(ms))-/;
+
 function remove_css_prefix(name: string): string {
-	return name.replace(/^-((webkit)|(moz)|(o)|(ms))-/, '');
+	return name.replace(regex_css_browser_prefix, '');
 }
 
 const is_keyframes_node = (node: CssNode) =>

--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -118,6 +118,9 @@ class Rule {
 	}
 }
 
+const regex_only_whitespace = /^\s+$/;
+const regex_whitespace = /\s/;
+
 class Declaration {
 	node: CssNode;
 
@@ -149,10 +152,10 @@ class Declaration {
 
 		// Don't minify whitespace in custom properties, since some browsers (Chromium < 99)
 		// treat --foo: ; and --foo:; differently
-		if (first.type === 'Raw' && /^\s+$/.test(first.value)) return;
+		if (first.type === 'Raw' && regex_only_whitespace.test(first.value)) return;
 
 		let start = first.start;
-		while (/\s/.test(code.original[start])) start += 1;
+		while (regex_whitespace.test(code.original[start])) start += 1;
 
 		if (start - c > 1) {
 			code.overwrite(c, start, ':');

--- a/src/compiler/compile/css/Stylesheet.ts
+++ b/src/compiler/compile/css/Stylesheet.ts
@@ -9,6 +9,7 @@ import hash from '../utils/hash';
 import compiler_warnings from '../compiler_warnings';
 import { extract_ignores_above_position } from '../../utils/extract_svelte_ignore';
 import { push_array } from '../../utils/push_array';
+import { regex_only_whitespaces, regex_whitespace } from '../../utils/patterns';
 
 const regex_css_browser_prefix = /^-((webkit)|(moz)|(o)|(ms))-/;
 
@@ -118,9 +119,6 @@ class Rule {
 	}
 }
 
-const regex_only_whitespace = /^\s+$/;
-const regex_whitespace = /\s/;
-
 class Declaration {
 	node: CssNode;
 
@@ -152,7 +150,7 @@ class Declaration {
 
 		// Don't minify whitespace in custom properties, since some browsers (Chromium < 99)
 		// treat --foo: ; and --foo:; differently
-		if (first.type === 'Raw' && regex_only_whitespace.test(first.value)) return;
+		if (first.type === 'Raw' && regex_only_whitespaces.test(first.value)) return;
 
 		let start = first.start;
 		while (regex_whitespace.test(code.original[start])) start += 1;

--- a/src/compiler/compile/index.ts
+++ b/src/compiler/compile/index.ts
@@ -35,6 +35,9 @@ const valid_options = [
 	'cssHash'
 ];
 
+const regex_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
+const regex_starts_with_lowercase_character = /^[a-z]/;
+
 function validate_options(options: CompileOptions, warnings: Warning[]) {
 	const { name, filename, loopGuardTimeout, dev, namespace } = options;
 
@@ -48,11 +51,11 @@ function validate_options(options: CompileOptions, warnings: Warning[]) {
 		}
 	});
 
-	if (name && !/^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test(name)) {
+	if (name && !regex_valid_identifier.test(name)) {
 		throw new Error(`options.name must be a valid identifier (got '${name}')`);
 	}
 
-	if (name && /^[a-z]/.test(name)) {
+	if (name && regex_starts_with_lowercase_character.test(name)) {
 		const message = 'options.name should be capitalised';
 		warnings.push({
 			code: 'options-lowercase-name',

--- a/src/compiler/compile/nodes/Binding.ts
+++ b/src/compiler/compile/nodes/Binding.ts
@@ -3,7 +3,7 @@ import get_object from '../utils/get_object';
 import Expression from './shared/Expression';
 import Component from '../Component';
 import TemplateScope from './shared/TemplateScope';
-import {dimensions} from '../../utils/patterns';
+import { regex_dimensions } from '../../utils/patterns';
 import { Node as ESTreeNode } from 'estree';
 import { TemplateNode } from '../../interfaces';
 import Element from './Element';
@@ -88,7 +88,7 @@ export default class Binding extends Node {
 		const type = parent.get_static_attribute_value('type');
 
 		this.is_readonly =
-			dimensions.test(this.name) ||
+			regex_dimensions.test(this.name) ||
 			(isElement(parent) &&
 				((parent.is_media_node() && read_only_media_attributes.has(this.name)) ||
 					(parent.name === 'input' && type === 'file')) /* TODO others? */);

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -11,7 +11,7 @@ import StyleDirective from './StyleDirective';
 import Text from './Text';
 import { namespaces } from '../../utils/namespaces';
 import map_children from './shared/map_children';
-import { regex_dimensions, regex_start_newline } from '../../utils/patterns';
+import { regex_dimensions, regex_starts_with_newline, regex_non_whitespace_character } from '../../utils/patterns';
 import fuzzymatch from '../../utils/fuzzymatch';
 import list from '../../utils/list';
 import Let from './Let';
@@ -206,7 +206,6 @@ function is_valid_aria_attribute_value(schema: ARIAPropertyDefinition, value: st
 const regex_any_repeated_whitespaces = /[\s]+/g;
 const regex_heading_tags = /^h[1-6]$/;
 const regex_illegal_attribute_character = /(^[0-9-.])|[\^$@%&#?!|()[\]{}^*+~;]/;
-const regex_non_whitespace_characters = /\S/;
 
 export default class Element extends Node {
 	type: 'Element';
@@ -258,7 +257,7 @@ export default class Element extends Node {
 					// places if there's another newline afterwards.
 					// see https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 					// see https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element
-					first.data = first.data.replace(regex_start_newline, '');
+					first.data = first.data.replace(regex_starts_with_newline, '');
 				}
 			}
 
@@ -734,7 +733,7 @@ export default class Element extends Node {
 		if (this.name === 'figure') {
 			const children = this.children.filter(node => {
 				if (node.type === 'Comment') return false;
-				if (node.type === 'Text') return regex_non_whitespace_characters.test(node.data);
+				if (node.type === 'Text') return regex_non_whitespace_character.test(node.data);
 				return true;
 			});
 

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -203,7 +203,7 @@ function is_valid_aria_attribute_value(schema: ARIAPropertyDefinition, value: st
 	}
 }
 
-const regex_any_repeated_whitespace = /[\s\n\t]+/g;
+const regex_any_repeated_whitespace = /[\s]+/g;
 
 export default class Element extends Node {
 	type: 'Element';

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -203,6 +203,8 @@ function is_valid_aria_attribute_value(schema: ARIAPropertyDefinition, value: st
 	}
 }
 
+const regex_any_repeated_whitespace = /[\s\n\t]+/g;
+
 export default class Element extends Node {
 	type: 'Element';
 	name: string;
@@ -1001,8 +1003,6 @@ export default class Element extends Node {
 		});
 	}
 }
-
-const regex_any_repeated_whitespace = /[\s\n\t]+/g;
 
 const regex_starts_with_vovel = /^[aeiou]/;
 

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -988,7 +988,7 @@ export default class Element extends Node {
 			if (attribute && !attribute.is_true) {
 				attribute.chunks.forEach((chunk, index) => {
 					if (chunk.type === 'Text') {
-						let data = chunk.data.replace(/[\s\n\t]+/g, ' ');
+						let data = chunk.data.replace(regex_any_repeated_whitespace, ' ');
 						if (index === 0) {
 							data = data.trimLeft();
 						} else if (index === attribute.chunks.length - 1) {
@@ -1002,12 +1002,16 @@ export default class Element extends Node {
 	}
 }
 
+const regex_any_repeated_whitespace = /[\s\n\t]+/g;
+
+const regex_starts_with_vovel = /^[aeiou]/;
+
 function should_have_attribute(
 	node,
 	attributes: string[],
 	name = node.name
 ) {
-	const article = /^[aeiou]/.test(attributes[0]) ? 'an' : 'a';
+	const article = regex_starts_with_vovel.test(attributes[0]) ? 'an' : 'a';
 	const sequence = attributes.length > 1 ?
 		attributes.slice(0, -1).join(', ') + ` or ${attributes[attributes.length - 1]}` :
 		attributes[0];

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -11,7 +11,7 @@ import StyleDirective from './StyleDirective';
 import Text from './Text';
 import { namespaces } from '../../utils/namespaces';
 import map_children from './shared/map_children';
-import { dimensions, start_newline } from '../../utils/patterns';
+import { regex_dimensions, regex_start_newline } from '../../utils/patterns';
 import fuzzymatch from '../../utils/fuzzymatch';
 import list from '../../utils/list';
 import Let from './Let';
@@ -258,7 +258,7 @@ export default class Element extends Node {
 					// places if there's another newline afterwards.
 					// see https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 					// see https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element
-					first.data = first.data.replace(start_newline, '');
+					first.data = first.data.replace(regex_start_newline, '');
 				}
 			}
 
@@ -866,7 +866,7 @@ export default class Element extends Node {
 				if (this.name !== 'video') {
 					return component.error(binding, compiler_errors.invalid_binding_element_with('<video>', name));
 				}
-			} else if (dimensions.test(name)) {
+			} else if (regex_dimensions.test(name)) {
 				if (this.name === 'svg' && (name === 'offsetWidth' || name === 'offsetHeight')) {
 					return component.error(binding, compiler_errors.invalid_binding_on(binding.name, `<svg>. Use '${name.replace('offset', 'client')}' instead`));
 				} else if (is_svg(this.name)) {

--- a/src/compiler/compile/nodes/EventHandler.ts
+++ b/src/compiler/compile/nodes/EventHandler.ts
@@ -6,7 +6,7 @@ import { Identifier } from 'estree';
 import TemplateScope from './shared/TemplateScope';
 import { TemplateNode } from '../../interfaces';
 
-const regex_FunctionExpression = /FunctionExpression/;
+const regex_contains_FunctionExpression = /FunctionExpression/;
 
 export default class EventHandler extends Node {
 	type: 'EventHandler';
@@ -27,7 +27,7 @@ export default class EventHandler extends Node {
 			this.expression = new Expression(component, this, template_scope, info.expression);
 			this.uses_context = this.expression.uses_context;
 
-			if (regex_FunctionExpression.test(info.expression.type) && info.expression.params.length === 0) {
+			if (regex_contains_FunctionExpression.test(info.expression.type) && info.expression.params.length === 0) {
 				// TODO make this detection more accurate — if `event.preventDefault` isn't called, and
 				// `event` is passed to another function, we can make it passive
 				this.can_make_passive = true;
@@ -57,7 +57,7 @@ export default class EventHandler extends Node {
 		}
 		const node = this.expression.node;
 
-		if (regex_FunctionExpression.test(node.type)) {
+		if (regex_contains_FunctionExpression.test(node.type)) {
 			return false;
 		}
 

--- a/src/compiler/compile/nodes/EventHandler.ts
+++ b/src/compiler/compile/nodes/EventHandler.ts
@@ -6,7 +6,7 @@ import { Identifier } from 'estree';
 import TemplateScope from './shared/TemplateScope';
 import { TemplateNode } from '../../interfaces';
 
-const regex_contains_FunctionExpression = /FunctionExpression/;
+const regex_contains_term_function_expression = /FunctionExpression/;
 
 export default class EventHandler extends Node {
 	type: 'EventHandler';
@@ -27,7 +27,7 @@ export default class EventHandler extends Node {
 			this.expression = new Expression(component, this, template_scope, info.expression);
 			this.uses_context = this.expression.uses_context;
 
-			if (regex_contains_FunctionExpression.test(info.expression.type) && info.expression.params.length === 0) {
+			if (regex_contains_term_function_expression.test(info.expression.type) && info.expression.params.length === 0) {
 				// TODO make this detection more accurate — if `event.preventDefault` isn't called, and
 				// `event` is passed to another function, we can make it passive
 				this.can_make_passive = true;
@@ -57,7 +57,7 @@ export default class EventHandler extends Node {
 		}
 		const node = this.expression.node;
 
-		if (regex_contains_FunctionExpression.test(node.type)) {
+		if (regex_contains_term_function_expression.test(node.type)) {
 			return false;
 		}
 

--- a/src/compiler/compile/nodes/EventHandler.ts
+++ b/src/compiler/compile/nodes/EventHandler.ts
@@ -6,6 +6,8 @@ import { Identifier } from 'estree';
 import TemplateScope from './shared/TemplateScope';
 import { TemplateNode } from '../../interfaces';
 
+const regex_FunctionExpression = /FunctionExpression/;
+
 export default class EventHandler extends Node {
 	type: 'EventHandler';
 	name: string;
@@ -25,7 +27,7 @@ export default class EventHandler extends Node {
 			this.expression = new Expression(component, this, template_scope, info.expression);
 			this.uses_context = this.expression.uses_context;
 
-			if (/FunctionExpression/.test(info.expression.type) && info.expression.params.length === 0) {
+			if (regex_FunctionExpression.test(info.expression.type) && info.expression.params.length === 0) {
 				// TODO make this detection more accurate — if `event.preventDefault` isn't called, and
 				// `event` is passed to another function, we can make it passive
 				this.can_make_passive = true;
@@ -55,7 +57,7 @@ export default class EventHandler extends Node {
 		}
 		const node = this.expression.node;
 
-		if (/FunctionExpression/.test(node.type)) {
+		if (regex_FunctionExpression.test(node.type)) {
 			return false;
 		}
 

--- a/src/compiler/compile/nodes/Head.ts
+++ b/src/compiler/compile/nodes/Head.ts
@@ -5,8 +5,7 @@ import Component from '../Component';
 import TemplateScope from './shared/TemplateScope';
 import { TemplateNode } from '../../interfaces';
 import compiler_errors from '../compiler_errors';
-
-const regex_non_whitespace_characters = /\S/;
+import { regex_non_whitespace_character } from '../../utils/patterns';
 
 export default class Head extends Node {
 	type: 'Head';
@@ -22,7 +21,7 @@ export default class Head extends Node {
 		}
 
 		this.children = map_children(component, parent, scope, info.children.filter(child => {
-			return (child.type !== 'Text' || regex_non_whitespace_characters.test(child.data));
+			return (child.type !== 'Text' || regex_non_whitespace_character.test(child.data));
 		}));
 
 		if (this.children.length > 0) {

--- a/src/compiler/compile/nodes/Head.ts
+++ b/src/compiler/compile/nodes/Head.ts
@@ -6,6 +6,8 @@ import TemplateScope from './shared/TemplateScope';
 import { TemplateNode } from '../../interfaces';
 import compiler_errors from '../compiler_errors';
 
+const regex_non_whitespace_characters = /\S/;
+
 export default class Head extends Node {
 	type: 'Head';
 	children: any[]; // TODO
@@ -20,7 +22,7 @@ export default class Head extends Node {
 		}
 
 		this.children = map_children(component, parent, scope, info.children.filter(child => {
-			return (child.type !== 'Text' || /\S/.test(child.data));
+			return (child.type !== 'Text' || regex_non_whitespace_characters.test(child.data));
 		}));
 
 		if (this.children.length > 0) {

--- a/src/compiler/compile/nodes/InlineComponent.ts
+++ b/src/compiler/compile/nodes/InlineComponent.ts
@@ -73,10 +73,10 @@ export default class InlineComponent extends Node {
 
 				case 'Transition':
 					return component.error(node, compiler_errors.invalid_transition);
-				
+
 				case 'StyleDirective':
 					return component.error(node, compiler_errors.invalid_component_style_directive);
-	
+
 				default:
 					throw new Error(`Not implemented: ${node.type}`);
 			}
@@ -164,8 +164,10 @@ export default class InlineComponent extends Node {
 	}
 }
 
+const regex_only_whitespace = /^\s+$/;
+
 function not_whitespace_text(node) {
-	return !(node.type === 'Text' && /^\s+$/.test(node.data));
+	return !(node.type === 'Text' && regex_only_whitespace.test(node.data));
 }
 
 function get_namespace(parent: Node, explicit_namespace: string) {

--- a/src/compiler/compile/nodes/InlineComponent.ts
+++ b/src/compiler/compile/nodes/InlineComponent.ts
@@ -10,6 +10,7 @@ import TemplateScope from './shared/TemplateScope';
 import { INode } from './interfaces';
 import { TemplateNode } from '../../interfaces';
 import compiler_errors from '../compiler_errors';
+import { regex_only_whitespaces } from '../../utils/patterns';
 
 export default class InlineComponent extends Node {
 	type: 'InlineComponent';
@@ -164,10 +165,8 @@ export default class InlineComponent extends Node {
 	}
 }
 
-const regex_only_whitespace = /^\s+$/;
-
 function not_whitespace_text(node) {
-	return !(node.type === 'Text' && regex_only_whitespace.test(node.data));
+	return !(node.type === 'Text' && regex_only_whitespaces.test(node.data));
 }
 
 function get_namespace(parent: Node, explicit_namespace: string) {

--- a/src/compiler/compile/nodes/Text.ts
+++ b/src/compiler/compile/nodes/Text.ts
@@ -16,6 +16,9 @@ const elements_without_text = new Set([
 	'video'
 ]);
 
+const regex_ends_with_svg = /svg$/;
+const regex_non_whitespace_characters = /\S/;
+
 export default class Text extends Node {
 	type: 'Text';
 	data: string;
@@ -28,7 +31,7 @@ export default class Text extends Node {
 	}
 
 	should_skip() {
-		if (/\S/.test(this.data)) return false;
+		if (regex_non_whitespace_characters.test(this.data)) return false;
 
 		const parent_element = this.find_nearest(/(?:Element|InlineComponent|SlotTemplate|Head)/);
 		if (!parent_element) return false;
@@ -37,7 +40,7 @@ export default class Text extends Node {
 		if (parent_element.type === 'InlineComponent') return parent_element.children.length === 1 && this === parent_element.children[0];
 
 		// svg namespace exclusions
-		if (/svg$/.test(parent_element.namespace)) {
+		if (regex_ends_with_svg.test(parent_element.namespace)) {
 			if (this.prev && this.prev.type === 'Element' && this.prev.name === 'tspan') return false;
 		}
 

--- a/src/compiler/compile/nodes/Text.ts
+++ b/src/compiler/compile/nodes/Text.ts
@@ -3,6 +3,7 @@ import Component from '../Component';
 import TemplateScope from './shared/TemplateScope';
 import { INode } from './interfaces';
 import { TemplateNode } from '../../interfaces';
+import { regex_non_whitespace_character } from '../../utils/patterns';
 
 // Whitespace inside one of these elements will not result in
 // a whitespace node being created in any circumstances. (This
@@ -17,7 +18,6 @@ const elements_without_text = new Set([
 ]);
 
 const regex_ends_with_svg = /svg$/;
-const regex_non_whitespace_characters = /\S/;
 
 export default class Text extends Node {
 	type: 'Text';
@@ -31,7 +31,7 @@ export default class Text extends Node {
 	}
 
 	should_skip() {
-		if (regex_non_whitespace_characters.test(this.data)) return false;
+		if (regex_non_whitespace_character.test(this.data)) return false;
 
 		const parent_element = this.find_nearest(/(?:Element|InlineComponent|SlotTemplate|Head)/);
 		if (!parent_element) return false;

--- a/src/compiler/compile/nodes/shared/AbstractBlock.ts
+++ b/src/compiler/compile/nodes/shared/AbstractBlock.ts
@@ -4,6 +4,8 @@ import Node from './Node';
 import { INode } from '../interfaces';
 import compiler_warnings from '../../compiler_warnings';
 
+const regex_non_whitespace_characters = /\S/;
+
 export default class AbstractBlock extends Node {
 	block: Block;
 	children: INode[];
@@ -17,7 +19,7 @@ export default class AbstractBlock extends Node {
 
 		const child = this.children[0];
 
-		if (!child || (child.type === 'Text' && !/[^\s]/.test(child.data))) {
+		if (!child || (child.type === 'Text' && !regex_non_whitespace_characters.test(child.data))) {
 			this.component.warn(this, compiler_warnings.empty_block);
 		}
 	}

--- a/src/compiler/compile/nodes/shared/AbstractBlock.ts
+++ b/src/compiler/compile/nodes/shared/AbstractBlock.ts
@@ -17,7 +17,7 @@ export default class AbstractBlock extends Node {
 
 		const child = this.children[0];
 
-		if (!child || (child.type === 'Text' && !/[^ \r\n\f\v\t]/.test(child.data))) {
+		if (!child || (child.type === 'Text' && !/[^\s]/.test(child.data))) {
 			this.component.warn(this, compiler_warnings.empty_block);
 		}
 	}

--- a/src/compiler/compile/nodes/shared/AbstractBlock.ts
+++ b/src/compiler/compile/nodes/shared/AbstractBlock.ts
@@ -4,7 +4,7 @@ import Node from './Node';
 import { INode } from '../interfaces';
 import compiler_warnings from '../../compiler_warnings';
 
-const regex_non_whitespace_characters = /\S/;
+const regex_non_whitespace_characters = /[^ \r\n\f\v\t]/;
 
 export default class AbstractBlock extends Node {
 	block: Block;

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -21,6 +21,8 @@ import compiler_errors from '../../compiler_errors';
 
 type Owner = INode;
 
+const regex_FunctionExpression = /FunctionExpression/;
+
 export default class Expression {
 	type: 'Expression' = 'Expression';
 	component: Component;
@@ -72,7 +74,7 @@ export default class Expression {
 					scope = map.get(node);
 				}
 
-				if (!function_expression && /FunctionExpression/.test(node.type)) {
+				if (!function_expression && regex_FunctionExpression.test(node.type)) {
 					function_expression = node;
 				}
 

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -21,7 +21,7 @@ import compiler_errors from '../../compiler_errors';
 
 type Owner = INode;
 
-const regex_contains_FunctionExpression = /FunctionExpression/;
+const regex_contains_term_function_expression = /FunctionExpression/;
 
 export default class Expression {
 	type: 'Expression' = 'Expression';
@@ -74,7 +74,7 @@ export default class Expression {
 					scope = map.get(node);
 				}
 
-				if (!function_expression && regex_contains_FunctionExpression.test(node.type)) {
+				if (!function_expression && regex_contains_term_function_expression.test(node.type)) {
 					function_expression = node;
 				}
 

--- a/src/compiler/compile/nodes/shared/Expression.ts
+++ b/src/compiler/compile/nodes/shared/Expression.ts
@@ -21,7 +21,7 @@ import compiler_errors from '../../compiler_errors';
 
 type Owner = INode;
 
-const regex_FunctionExpression = /FunctionExpression/;
+const regex_contains_FunctionExpression = /FunctionExpression/;
 
 export default class Expression {
 	type: 'Expression' = 'Expression';
@@ -74,7 +74,7 @@ export default class Expression {
 					scope = map.get(node);
 				}
 
-				if (!function_expression && regex_FunctionExpression.test(node.type)) {
+				if (!function_expression && regex_contains_FunctionExpression.test(node.type)) {
 					function_expression = node;
 				}
 

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -23,6 +23,8 @@ export interface BlockOptions {
 	dependencies?: Set<string>;
 }
 
+const regex_double_quotes = /"/g;
+
 export default class Block {
 	parent?: Block;
 	renderer: Renderer;
@@ -415,7 +417,7 @@ export default class Block {
 						block: ${block},
 						id: ${this.name || 'create_fragment'}.name,
 						type: "${this.type}",
-						source: "${this.comment ? this.comment.replace(/"/g, '\\"') : ''}",
+						source: "${this.comment ? this.comment.replace(regex_double_quotes, '\\"') : ''}",
 						ctx: #ctx
 					});
 					return ${block};`

--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -3,6 +3,7 @@ import Wrapper from './wrappers/shared/Wrapper';
 import { b, x } from 'code-red';
 import { Node, Identifier, ArrayPattern } from 'estree';
 import { is_head } from './wrappers/shared/is_head';
+import { regex_double_quotes } from '../../utils/patterns';
 
 export interface Bindings {
 	object: Identifier;
@@ -22,8 +23,6 @@ export interface BlockOptions {
 	bindings?: Map<string, Bindings>;
 	dependencies?: Set<string>;
 }
-
-const regex_double_quotes = /"/g;
 
 export default class Block {
 	parent?: Block;

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -13,6 +13,8 @@ import { flatten } from '../../utils/flatten';
 import check_enable_sourcemap from '../utils/check_enable_sourcemap';
 import { push_array } from '../../utils/push_array';
 
+const regex_backslash = /\\/g;
+
 export default function dom(
 	component: Component,
 	options: CompileOptions
@@ -530,7 +532,7 @@ export default function dom(
 				constructor(options) {
 					super();
 
-					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(/\\/g, '\\\\')}${css_sourcemap_enabled && options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
+					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(regex_backslash, '\\\\')}${css_sourcemap_enabled && options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
 
 					@init(this, { target: this.shadowRoot, props: ${init_props}, customElement: true }, ${definition}, ${has_create_fragment ? 'create_fragment' : 'null'}, ${not_equal}, ${prop_indexes}, null, ${dirty});
 

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -13,7 +13,7 @@ import { flatten } from '../../utils/flatten';
 import check_enable_sourcemap from '../utils/check_enable_sourcemap';
 import { push_array } from '../../utils/push_array';
 
-const regex_backslash = /\\/g;
+const regex_backslashes = /\\/g;
 
 export default function dom(
 	component: Component,
@@ -532,7 +532,7 @@ export default function dom(
 				constructor(options) {
 					super();
 
-					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(regex_backslash, '\\\\')}${css_sourcemap_enabled && options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
+					${css.code && b`this.shadowRoot.innerHTML = \`<style>${css.code.replace(regex_backslashes, '\\\\')}${css_sourcemap_enabled && options.dev ? `\n/*# sourceMappingURL=${css.map.toUrl()} */` : ''}</style>\`;`}
 
 					@init(this, { target: this.shadowRoot, props: ${init_props}, customElement: true }, ${definition}, ${has_create_fragment ? 'create_fragment' : 'null'}, ${not_equal}, ${prop_indexes}, null, ${dirty});
 

--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -12,8 +12,7 @@ import { RawSourceMap, DecodedSourceMap } from '@ampproject/remapping/dist/types
 import { flatten } from '../../utils/flatten';
 import check_enable_sourcemap from '../utils/check_enable_sourcemap';
 import { push_array } from '../../utils/push_array';
-
-const regex_backslashes = /\\/g;
+import { regex_backslashes } from '../../utils/patterns';
 
 export default function dom(
 	component: Component,

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -46,6 +46,8 @@ export class BaseAttributeWrapper {
 }
 
 const regex_minus_sign = /-/;
+const regex_invalid_variable_identifier_characters = /[^a-zA-Z_$]/g; // is 0-9 missing?
+const regex_double_quotes = /"/g;
 
 export default class AttributeWrapper extends BaseAttributeWrapper {
 	node: Attribute;
@@ -198,7 +200,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 
 	get_init(block: Block, value) {
 		this.last = this.should_cache && block.get_unique_name(
-			`${this.parent.var.name}_${this.name.replace(/[^a-zA-Z_$]/g, '_')}_value`
+			`${this.parent.var.name}_${this.name.replace(regex_invalid_variable_identifier_characters, '_')}_value`
 		);
 
 		if (this.should_cache) block.add_variable(this.last);
@@ -315,7 +317,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 
 		return `="${value.map(chunk => {
 			return chunk.type === 'Text'
-				? chunk.data.replace(/"/g, '\\"')
+				? chunk.data.replace(regex_double_quotes, '\\"')
 				: `\${${chunk.manipulate()}}`;
 		}).join('')}"`;
 	}

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -42,7 +42,7 @@ export class BaseAttributeWrapper {
 		}
 	}
 
-	render(_block: Block) {}
+	render(_block: Block) { }
 }
 
 const regex_minus_sign = /-/;
@@ -385,13 +385,14 @@ function should_cache(attribute: AttributeWrapper) {
 	return attribute.is_src || attribute.node.should_cache();
 }
 
+const regex_checked_or_group = /checked|group/;
+
 function is_indirectly_bound_value(attribute: AttributeWrapper) {
 	const element = attribute.parent;
 	return attribute.name === 'value' &&
 		(element.node.name === 'option' || // TODO check it's actually bound
 			(element.node.name === 'input' &&
 				element.node.bindings.some(
-					(binding) =>
-						/checked|group/.test(binding.name)
+					(binding) => regex_checked_or_group.test(binding.name)
 				)));
 }

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -45,6 +45,8 @@ export class BaseAttributeWrapper {
 	render(_block: Block) {}
 }
 
+const regex_minus_sign = /-/;
+
 export default class AttributeWrapper extends BaseAttributeWrapper {
 	node: Attribute;
 	parent: ElementWrapper;
@@ -115,7 +117,7 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 		// xlink is a special case... we could maybe extend this to generic
 		// namespaced attributes but I'm not sure that's applicable in
 		// HTML5?
-		const method = /-/.test(element.node.name)
+		const method = regex_minus_sign.test(element.node.name)
 			? '@set_custom_element_data'
 			: name.slice(0, 6) === 'xlink:'
 				? '@xlink_attr'

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -10,6 +10,7 @@ import handle_select_value_binding from './handle_select_value_binding';
 import { Identifier, Node } from 'estree';
 import { namespaces } from '../../../../utils/namespaces';
 import { boolean_attributes } from '../../../../../shared/boolean_attributes';
+import { regex_double_quotes } from '../../../../utils/patterns';
 
 const non_textlike_input_types = new Set([
 	'button',
@@ -47,7 +48,6 @@ export class BaseAttributeWrapper {
 
 const regex_minus_sign = /-/;
 const regex_invalid_variable_identifier_characters = /[^a-zA-Z_$]/g;
-const regex_double_quotes = /"/g;
 
 export default class AttributeWrapper extends BaseAttributeWrapper {
 	node: Attribute;

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -46,7 +46,7 @@ export class BaseAttributeWrapper {
 }
 
 const regex_minus_sign = /-/;
-const regex_invalid_variable_identifier_characters = /[^a-zA-Z_$]/g; // is 0-9 missing?
+const regex_invalid_variable_identifier_characters = /[^a-zA-Z_$]/g;
 const regex_double_quotes = /"/g;
 
 export default class AttributeWrapper extends BaseAttributeWrapper {
@@ -385,7 +385,7 @@ function should_cache(attribute: AttributeWrapper) {
 	return attribute.is_src || attribute.node.should_cache();
 }
 
-const regex_checked_or_group = /checked|group/;
+const regex_contains_checked_or_group = /checked|group/;
 
 function is_indirectly_bound_value(attribute: AttributeWrapper) {
 	const element = attribute.parent;
@@ -393,6 +393,6 @@ function is_indirectly_bound_value(attribute: AttributeWrapper) {
 		(element.node.name === 'option' || // TODO check it's actually bound
 			(element.node.name === 'input' &&
 				element.node.bindings.some(
-					(binding) => regex_checked_or_group.test(binding.name)
+					(binding) => regex_contains_checked_or_group.test(binding.name)
 				)));
 }

--- a/src/compiler/compile/render_dom/wrappers/Element/StyleAttribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/StyleAttribute.ts
@@ -108,6 +108,8 @@ function optimize_style(value: Array<Text | Expression>) {
 	return props;
 }
 
+const regex_important_flag = /\s*!important\s*$/;
+
 function get_style_value(chunks: Array<Text | Expression>) {
 	const value: Array<Text | Expression> = [];
 
@@ -174,9 +176,9 @@ function get_style_value(chunks: Array<Text | Expression>) {
 	let important = false;
 
 	const last_chunk = value[value.length - 1];
-	if (last_chunk && last_chunk.type === 'Text' && /\s*!important\s*$/.test(last_chunk.data)) {
+	if (last_chunk && last_chunk.type === 'Text' && regex_important_flag.test(last_chunk.data)) {
 		important = true;
-		last_chunk.data = last_chunk.data.replace(/\s*!important\s*$/, '');
+		last_chunk.data = last_chunk.data.replace(regex_important_flag, '');
 		if (!last_chunk.data) value.pop();
 	}
 

--- a/src/compiler/compile/render_dom/wrappers/Element/StyleAttribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/StyleAttribute.ts
@@ -69,6 +69,8 @@ export default class StyleAttributeWrapper extends AttributeWrapper {
 	}
 }
 
+const regex_style_prop_key = /^\s*([\w-]+):\s*/;
+
 function optimize_style(value: Array<Text | Expression>) {
 	const props: StyleProp[] = [];
 	let chunks = value.slice();
@@ -78,7 +80,7 @@ function optimize_style(value: Array<Text | Expression>) {
 
 		if (chunk.type !== 'Text') return null;
 
-		const key_match = /^\s*([\w-]+):\s*/.exec(chunk.data);
+		const key_match = regex_style_prop_key.exec(chunk.data);
 		if (!key_match) return null;
 
 		const key = key_match[1];

--- a/src/compiler/compile/render_dom/wrappers/Element/StyleAttribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/StyleAttribute.ts
@@ -109,7 +109,7 @@ function optimize_style(value: Array<Text | Expression>) {
 }
 
 const regex_important_flag = /\s*!important\s*$/;
-const regex_semicolon_or_Whitespace = /[;\s]/;
+const regex_semicolon_or_whitespace = /[;\s]/;
 
 function get_style_value(chunks: Array<Text | Expression>) {
 	const value: Array<Text | Expression> = [];
@@ -156,7 +156,7 @@ function get_style_value(chunks: Array<Text | Expression>) {
 				} as Text);
 			}
 
-			while (regex_semicolon_or_Whitespace.test(chunk.data[c])) c += 1;
+			while (regex_semicolon_or_whitespace.test(chunk.data[c])) c += 1;
 			const remaining_data = chunk.data.slice(c);
 
 			if (remaining_data) {

--- a/src/compiler/compile/render_dom/wrappers/Element/StyleAttribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/StyleAttribute.ts
@@ -109,6 +109,7 @@ function optimize_style(value: Array<Text | Expression>) {
 }
 
 const regex_important_flag = /\s*!important\s*$/;
+const regex_semicolon_or_Whitespace = /[;\s]/;
 
 function get_style_value(chunks: Array<Text | Expression>) {
 	const value: Array<Text | Expression> = [];
@@ -155,7 +156,7 @@ function get_style_value(chunks: Array<Text | Expression>) {
 				} as Text);
 			}
 
-			while (/[;\s]/.test(chunk.data[c])) c += 1;
+			while (regex_semicolon_or_Whitespace.test(chunk.data[c])) c += 1;
 			const remaining_data = chunk.data.slice(c);
 
 			if (remaining_data) {

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -12,7 +12,7 @@ import { namespaces } from '../../../../utils/namespaces';
 import AttributeWrapper from './Attribute';
 import StyleAttributeWrapper from './StyleAttribute';
 import SpreadAttributeWrapper from './SpreadAttribute';
-import { dimensions, start_newline } from '../../../../utils/patterns';
+import { regex_dimensions, regex_start_newline } from '../../../../utils/patterns';
 import Binding from './Binding';
 import add_to_set from '../../../utils/add_to_set';
 import { add_event_handler } from '../shared/add_event_handlers';
@@ -67,7 +67,7 @@ const events = [
 	{
 		event_names: ['elementresize'],
 		filter: (_node: Element, name: string) =>
-			dimensions.test(name)
+			regex_dimensions.test(name)
 	},
 
 	// media events
@@ -1203,7 +1203,7 @@ function to_html(wrappers: Array<ElementWrapper | TextWrapper | MustacheTagWrapp
 					// Two or more leading newlines are required to restore the leading newline immediately after `<pre>`.
 					// see https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element
 					const first = wrapper.fragment.nodes[0];
-					if (first && first.node.type === 'Text' && start_newline.test(first.node.data)) {
+					if (first && first.node.type === 'Text' && regex_start_newline.test(first.node.data)) {
 						state.quasi.value.raw += '\n';
 					}
 				}
@@ -1215,7 +1215,7 @@ function to_html(wrappers: Array<ElementWrapper | TextWrapper | MustacheTagWrapp
 						// Two or more leading newlines are required to restore the leading newline immediately after `<textarea>`.
 						// see https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 						const first = value_attribute.node.chunks[0];
-						if (first && first.type === 'Text' && start_newline.test(first.data)) {
+						if (first && first.type === 'Text' && regex_start_newline.test(first.data)) {
 							state.quasi.value.raw += '\n';
 						}
 						to_html_for_attr_value(value_attribute, block, literal, state);

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -12,7 +12,7 @@ import { namespaces } from '../../../../utils/namespaces';
 import AttributeWrapper from './Attribute';
 import StyleAttributeWrapper from './StyleAttribute';
 import SpreadAttributeWrapper from './SpreadAttribute';
-import { regex_dimensions, regex_start_newline } from '../../../../utils/patterns';
+import { regex_dimensions, regex_starts_with_newline, regex_backslashes } from '../../../../utils/patterns';
 import Binding from './Binding';
 import add_to_set from '../../../utils/add_to_set';
 import { add_event_handler } from '../shared/add_event_handlers';
@@ -1145,7 +1145,6 @@ export default class ElementWrapper extends Wrapper {
 	}
 }
 
-const regex_backslashes = /\\/g;
 const regex_backticks = /`/g;
 const regex_dollar_signs = /\$/g;
 
@@ -1203,7 +1202,7 @@ function to_html(wrappers: Array<ElementWrapper | TextWrapper | MustacheTagWrapp
 					// Two or more leading newlines are required to restore the leading newline immediately after `<pre>`.
 					// see https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element
 					const first = wrapper.fragment.nodes[0];
-					if (first && first.node.type === 'Text' && regex_start_newline.test(first.node.data)) {
+					if (first && first.node.type === 'Text' && regex_starts_with_newline.test(first.node.data)) {
 						state.quasi.value.raw += '\n';
 					}
 				}
@@ -1215,7 +1214,7 @@ function to_html(wrappers: Array<ElementWrapper | TextWrapper | MustacheTagWrapp
 						// Two or more leading newlines are required to restore the leading newline immediately after `<textarea>`.
 						// see https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 						const first = value_attribute.node.chunks[0];
-						if (first && first.type === 'Text' && regex_start_newline.test(first.data)) {
+						if (first && first.type === 'Text' && regex_starts_with_newline.test(first.data)) {
 							state.quasi.value.raw += '\n';
 						}
 						to_html_for_attr_value(value_attribute, block, literal, state);

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -34,12 +34,16 @@ interface BindingGroup {
 	bindings: Binding[];
 }
 
+const regex_radio_or_checkbox_or_file = /radio|checkbox|file/;
+const regex_radio_or_checkbox_or_range_or_file = /radio|checkbox|range|file/;
+
 const events = [
 	{
 		event_names: ['input'],
 		filter: (node: Element, _name: string) =>
 			node.name === 'textarea' ||
-			node.name === 'input' && !/radio|checkbox|range|file/.test(node.get_static_attribute_value('type') as string)
+			node.name === 'input' &&
+			!regex_radio_or_checkbox_or_range_or_file.test(node.get_static_attribute_value('type') as string)
 	},
 	{
 		event_names: ['input'],
@@ -51,7 +55,8 @@ const events = [
 		event_names: ['change'],
 		filter: (node: Element, _name: string) =>
 			node.name === 'select' ||
-			node.name === 'input' && /radio|checkbox|file/.test(node.get_static_attribute_value('type') as string)
+			node.name === 'input' &&
+			regex_radio_or_checkbox_or_file.test(node.get_static_attribute_value('type') as string)
 	},
 	{
 		event_names: ['change', 'input'],

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -34,8 +34,8 @@ interface BindingGroup {
 	bindings: Binding[];
 }
 
-const regex_radio_or_checkbox_or_file = /radio|checkbox|file/;
-const regex_radio_or_checkbox_or_range_or_file = /radio|checkbox|range|file/;
+const regex_contains_radio_or_checkbox_or_file = /radio|checkbox|file/;
+const regex_contains_radio_or_checkbox_or_range_or_file = /radio|checkbox|range|file/;
 
 const events = [
 	{
@@ -43,7 +43,7 @@ const events = [
 		filter: (node: Element, _name: string) =>
 			node.name === 'textarea' ||
 			node.name === 'input' &&
-			!regex_radio_or_checkbox_or_range_or_file.test(node.get_static_attribute_value('type') as string)
+			!regex_contains_radio_or_checkbox_or_range_or_file.test(node.get_static_attribute_value('type') as string)
 	},
 	{
 		event_names: ['input'],
@@ -56,7 +56,7 @@ const events = [
 		filter: (node: Element, _name: string) =>
 			node.name === 'select' ||
 			node.name === 'input' &&
-			regex_radio_or_checkbox_or_file.test(node.get_static_attribute_value('type') as string)
+			regex_contains_radio_or_checkbox_or_file.test(node.get_static_attribute_value('type') as string)
 	},
 	{
 		event_names: ['change', 'input'],
@@ -1145,6 +1145,10 @@ export default class ElementWrapper extends Wrapper {
 	}
 }
 
+const regex_backslashes = /\\/g;
+const regex_backticks = /`/g;
+const regex_dollar_signs = /\$/g;
+
 function to_html(wrappers: Array<ElementWrapper | TextWrapper | MustacheTagWrapper | RawMustacheTagWrapper>, block: Block, literal: any, state: any, can_use_raw_text?: boolean) {
 	wrappers.forEach(wrapper => {
 		if (wrapper instanceof TextWrapper) {
@@ -1160,10 +1164,6 @@ function to_html(wrappers: Array<ElementWrapper | TextWrapper | MustacheTagWrapp
 				parent.name === 'style' ||
 				can_use_raw_text
 			);
-
-			const regex_backslashes = /\\/g;
-			const regex_backticks = /`/g;
-			const regex_dollar_signs = /\$/g;
 
 			state.quasi.value.raw += (raw ? wrapper.data : escape_html(wrapper.data))
 				.replace(regex_backslashes, '\\\\')

--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -322,19 +322,19 @@ export default class ElementWrapper extends Wrapper {
 				}
 			} else if (${previous_tag}) {
 				${
-			has_transitions
-				? b`
+					has_transitions
+						? b`
 							@group_outros();
 							@transition_out(${this.var}, 1, 1, () => {
 								${this.var} = null;
 							});
 							@check_outros();
 						`
-			: b`
+						: b`
 							${this.var}.d(1);
 							${this.var} = null;
 						`
-			}
+				}
 			}
 			${previous_tag} = ${tag};
 		`);
@@ -676,9 +676,9 @@ export default class ElementWrapper extends Wrapper {
 			function ${handler}(${params}) {
 				${binding_group.bindings.map(b => b.handler.mutation)}
 				${Array.from(dependencies)
-			.filter(dep => dep[0] !== '$')
-			.filter(dep => !contextual_dependencies.has(dep))
-			.map(dep => b`${this.renderer.invalidate(dep)};`)}
+					.filter(dep => dep[0] !== '$')
+					.filter(dep => !contextual_dependencies.has(dep))
+					.map(dep => b`${this.renderer.invalidate(dep)};`)}
 			}
 		`);
 

--- a/src/compiler/compile/render_dom/wrappers/Fragment.ts
+++ b/src/compiler/compile/render_dom/wrappers/Fragment.ts
@@ -21,6 +21,7 @@ import Block from '../Block';
 import { trim_start, trim_end } from '../../../utils/trim';
 import { link } from '../../../utils/link';
 import { Identifier } from 'estree';
+import { regex_starts_with_whitespace } from '../../../utils/patterns';
 
 const wrappers = {
 	AwaitBlock,
@@ -49,8 +50,6 @@ function trimmable_at(child: INode, next_sibling: Wrapper): boolean {
 	// The next sibling's previous node is an each block
 	return (next_sibling.node.find_nearest(/EachBlock/) === child.find_nearest(/EachBlock/)) || next_sibling.node.prev.type === 'EachBlock';
 }
-
-const regex_starts_with_whitespace = /^\s/;
 
 export default class FragmentWrapper {
 	nodes: Wrapper[];

--- a/src/compiler/compile/render_dom/wrappers/Fragment.ts
+++ b/src/compiler/compile/render_dom/wrappers/Fragment.ts
@@ -50,6 +50,8 @@ function trimmable_at(child: INode, next_sibling: Wrapper): boolean {
 	return (next_sibling.node.find_nearest(/EachBlock/) === child.find_nearest(/EachBlock/)) || next_sibling.node.prev.type === 'EachBlock';
 }
 
+const regex_starts_with_whitespace = /^\s/;
+
 export default class FragmentWrapper {
 	nodes: Wrapper[];
 
@@ -92,7 +94,7 @@ export default class FragmentWrapper {
 				// *unless* there is no whitespace between this node and its next sibling
 				if (this.nodes.length === 0) {
 					const should_trim = (
-						next_sibling ? (next_sibling.node.type === 'Text' && /^\s/.test(next_sibling.node.data) && trimmable_at(child, next_sibling)) : !child.has_ancestor('EachBlock')
+						next_sibling ? (next_sibling.node.type === 'Text' && regex_starts_with_whitespace.test(next_sibling.node.data) && trimmable_at(child, next_sibling)) : !child.has_ancestor('EachBlock')
 					);
 
 					if (should_trim && !child.keep_space()) {

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -24,6 +24,8 @@ import { namespaces } from '../../../../utils/namespaces';
 
 type SlotDefinition = { block: Block; scope: TemplateScope; get_context?: Node; get_changes?: Node };
 
+const regex_invalid_variable_identifier_characters = /[^a-zA-Z_$]/g; // is 0-9 missing?
+
 export default class InlineComponentWrapper extends Wrapper {
 	var: Identifier;
 	slots: Map<string, SlotDefinition> = new Map();
@@ -596,7 +598,7 @@ export default class InlineComponentWrapper extends Wrapper {
 		this.node.css_custom_properties.forEach((attr) => {
 			const dependencies = attr.get_dependencies();
 			const should_cache = attr.should_cache();
-			const last = should_cache &&	block.get_unique_name(`${attr.name.replace(/[^a-zA-Z_$]/g, '_')}_last`);
+			const last = should_cache &&	block.get_unique_name(`${attr.name.replace(regex_invalid_variable_identifier_characters, '_')}_last`);
 			if (should_cache) block.add_variable(last);
 			const value = attr.get_value(block);
 			const init = should_cache ? x`${last} = ${value}` : value;

--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -24,7 +24,7 @@ import { namespaces } from '../../../../utils/namespaces';
 
 type SlotDefinition = { block: Block; scope: TemplateScope; get_context?: Node; get_changes?: Node };
 
-const regex_invalid_variable_identifier_characters = /[^a-zA-Z_$]/g; // is 0-9 missing?
+const regex_invalid_variable_identifier_characters = /[^a-zA-Z_$]/g;
 
 export default class InlineComponentWrapper extends Wrapper {
 	var: Identifier;

--- a/src/compiler/compile/render_dom/wrappers/Text.ts
+++ b/src/compiler/compile/render_dom/wrappers/Text.ts
@@ -5,6 +5,8 @@ import Wrapper from './shared/Wrapper';
 import { x } from 'code-red';
 import { Identifier } from 'estree';
 
+const regex_non_whitespace_characters = /[\S\u00A0]/;
+
 export default class TextWrapper extends Wrapper {
 	node: Text;
 	data: string;
@@ -27,7 +29,7 @@ export default class TextWrapper extends Wrapper {
 
 	use_space() {
 		if (this.renderer.component.component_options.preserveWhitespace) return false;
-		if (/[\S\u00A0]/.test(this.data)) return false;
+		if (regex_non_whitespace_characters.test(this.data)) return false;
 
 		return !this.node.within_pre();
 	}

--- a/src/compiler/compile/render_dom/wrappers/shared/add_actions.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/add_actions.ts
@@ -12,6 +12,8 @@ export default function add_actions(
 	actions.forEach(action => add_action(block, target, action));
 }
 
+const regex_invalid_variable_identifier_characters = /[^a-zA-Z0-9_$]/g;
+
 export function add_action(block: Block, target: string | Expression, action: Action) {
 	const { expression, template_scope } = action;
 	let snippet;
@@ -23,7 +25,7 @@ export function add_action(block: Block, target: string | Expression, action: Ac
 	}
 
 	const id = block.get_unique_name(
-		`${action.name.replace(/[^a-zA-Z0-9_$]/g, '_')}_action`
+		`${action.name.replace(regex_invalid_variable_identifier_characters, '_')}_action`
 	);
 
 	block.add_variable(id);

--- a/src/compiler/compile/render_dom/wrappers/shared/create_debugging_comment.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/create_debugging_comment.ts
@@ -1,7 +1,7 @@
 import Component from '../../../Component';
 import { INode } from '../../../nodes/interfaces';
+import { regex_whitespace_characters } from '../../../../utils/patterns';
 
-const regex_whitespace_characters = /\s/g;
 
 export default function create_debugging_comment(
 	node: INode,

--- a/src/compiler/compile/render_dom/wrappers/shared/create_debugging_comment.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/create_debugging_comment.ts
@@ -1,6 +1,8 @@
 import Component from '../../../Component';
 import { INode } from '../../../nodes/interfaces';
 
+const regex_whitespace_characters = /\s/g;
+
 export default function create_debugging_comment(
 	node: INode,
 	component: Component
@@ -36,5 +38,5 @@ export default function create_debugging_comment(
 	const start = locate(c);
 	const loc = `(${start.line}:${start.column})`;
 
-	return `${loc} ${source.slice(c, d)}`.replace(/\s/g, ' ');
+	return `${loc} ${source.slice(c, d)}`.replace(regex_whitespace_characters, ' ');
 }

--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -8,7 +8,7 @@ import Expression from '../../nodes/shared/Expression';
 import remove_whitespace_children from './utils/remove_whitespace_children';
 import fix_attribute_casing from '../../render_dom/wrappers/Element/fix_attribute_casing';
 import { namespaces } from '../../../utils/namespaces';
-import { start_newline } from '../../../utils/patterns';
+import { regex_start_newline } from '../../../utils/patterns';
 import { Node, Expression as ESExpression } from 'estree';
 
 export default function (node: Element, renderer: Renderer, options: RenderOptions) {
@@ -173,7 +173,7 @@ export default function (node: Element, renderer: Renderer, options: RenderOptio
 				const value_attribute = node.attributes.find(({ name }) => name === 'value');
 				if (value_attribute) {
 					const first = value_attribute.chunks[0];
-					if (first && first.type === 'Text' && start_newline.test(first.data)) {
+					if (first && first.type === 'Text' && regex_start_newline.test(first.data)) {
 						renderer.add_string('\n');
 					}
 				}
@@ -188,7 +188,7 @@ export default function (node: Element, renderer: Renderer, options: RenderOptio
 			// see https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element
 			// see https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 			const first = children[0];
-			if (first && first.type === 'Text' && start_newline.test(first.data)) {
+			if (first && first.type === 'Text' && regex_start_newline.test(first.data)) {
 				renderer.add_string('\n');
 			}
 		}

--- a/src/compiler/compile/render_ssr/handlers/Element.ts
+++ b/src/compiler/compile/render_ssr/handlers/Element.ts
@@ -8,7 +8,7 @@ import Expression from '../../nodes/shared/Expression';
 import remove_whitespace_children from './utils/remove_whitespace_children';
 import fix_attribute_casing from '../../render_dom/wrappers/Element/fix_attribute_casing';
 import { namespaces } from '../../../utils/namespaces';
-import { regex_start_newline } from '../../../utils/patterns';
+import { regex_starts_with_newline } from '../../../utils/patterns';
 import { Node, Expression as ESExpression } from 'estree';
 
 export default function (node: Element, renderer: Renderer, options: RenderOptions) {
@@ -173,7 +173,7 @@ export default function (node: Element, renderer: Renderer, options: RenderOptio
 				const value_attribute = node.attributes.find(({ name }) => name === 'value');
 				if (value_attribute) {
 					const first = value_attribute.chunks[0];
-					if (first && first.type === 'Text' && regex_start_newline.test(first.data)) {
+					if (first && first.type === 'Text' && regex_starts_with_newline.test(first.data)) {
 						renderer.add_string('\n');
 					}
 				}
@@ -188,7 +188,7 @@ export default function (node: Element, renderer: Renderer, options: RenderOptio
 			// see https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element
 			// see https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 			const first = children[0];
-			if (first && first.type === 'Text' && regex_start_newline.test(first.data)) {
+			if (first && first.type === 'Text' && regex_starts_with_newline.test(first.data)) {
 				renderer.add_string('\n');
 			}
 		}

--- a/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.ts
+++ b/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.ts
@@ -15,13 +15,15 @@ export function get_class_attribute_value(attribute: Attribute): ESTreeExpressio
 	return get_attribute_value(attribute);
 }
 
+const regex_double_quotes = /"/g;
+
 export function get_attribute_value(attribute: Attribute): ESTreeExpression {
 	if (attribute.chunks.length === 0) return x`""`;
 
 	return attribute.chunks
 		.map((chunk) => {
 			return chunk.type === 'Text'
-				? string_literal(chunk.data.replace(/"/g, '&quot;')) as ESTreeExpression
+				? string_literal(chunk.data.replace(regex_double_quotes, '&quot;')) as ESTreeExpression
 				: x`@escape(${chunk.node}, true)`;
 		})
 		.reduce((lhs, rhs) => x`${lhs} + ${rhs}`);

--- a/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.ts
+++ b/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.ts
@@ -4,6 +4,7 @@ import Text from '../../../nodes/Text';
 import { x } from 'code-red';
 import Expression from '../../../nodes/shared/Expression';
 import { Expression as ESTreeExpression } from 'estree';
+import { regex_double_quotes } from '../../../../utils/patterns';
 
 export function get_class_attribute_value(attribute: Attribute): ESTreeExpression {
 	// handle special case — `class={possiblyUndefined}` with scoped CSS
@@ -14,8 +15,6 @@ export function get_class_attribute_value(attribute: Attribute): ESTreeExpressio
 
 	return get_attribute_value(attribute);
 }
-
-const regex_double_quotes = /"/g;
 
 export function get_attribute_value(attribute: Attribute): ESTreeExpression {
 	if (attribute.chunks.length === 0) return x`""`;

--- a/src/compiler/compile/render_ssr/handlers/utils/remove_whitespace_children.ts
+++ b/src/compiler/compile/render_ssr/handlers/utils/remove_whitespace_children.ts
@@ -1,8 +1,7 @@
 import { INode } from '../../../nodes/interfaces';
 import { trim_end, trim_start } from '../../../../utils/trim';
 import { link } from '../../../../utils/link';
-
-const regex_starts_with_whitespace = /^\s/;
+import { regex_starts_with_whitespace } from '../../../../utils/patterns';
 
 // similar logic from `compile/render_dom/wrappers/Fragment`
 // We want to remove trailing whitespace inside an element/component/block,

--- a/src/compiler/compile/render_ssr/handlers/utils/remove_whitespace_children.ts
+++ b/src/compiler/compile/render_ssr/handlers/utils/remove_whitespace_children.ts
@@ -2,6 +2,8 @@ import { INode } from '../../../nodes/interfaces';
 import { trim_end, trim_start } from '../../../../utils/trim';
 import { link } from '../../../../utils/link';
 
+const regex_starts_with_whitespace = /^\s/;
+
 // similar logic from `compile/render_dom/wrappers/Fragment`
 // We want to remove trailing whitespace inside an element/component/block,
 // *unless* there is no whitespace between this node and its next sibling
@@ -22,7 +24,7 @@ export default function remove_whitespace_children(children: INode[], next?: INo
 			if (nodes.length === 0) {
 				const should_trim = next
 					? next.type === 'Text' &&
-					  /^\s/.test(next.data) &&
+					regex_starts_with_whitespace.test(next.data) &&
 					  trimmable_at(child, next)
 					: !child.has_ancestor('EachBlock');
 

--- a/src/compiler/compile/utils/get_name_from_filename.ts
+++ b/src/compiler/compile/utils/get_name_from_filename.ts
@@ -1,3 +1,10 @@
+const regex_percentage_characters = /%/g;
+const regex_file_ending = /\.[^.]+$/;
+const regex_repeated_invalid_variable_identifier_characters = /[^a-zA-Z_$0-9]+/g;
+const regex_starts_with_underscore = /^_/;
+const regex_ends_with_underscore = /_$/;
+const regex_starts_with_digit = /^(\d)/;
+
 export default function get_name_from_filename(filename: string) {
 	if (!filename) return null;
 
@@ -12,12 +19,12 @@ export default function get_name_from_filename(filename: string) {
 	}
 
 	const base = parts.pop()
-		.replace(/%/g, 'u')
-		.replace(/\.[^.]+$/, '')
-		.replace(/[^a-zA-Z_$0-9]+/g, '_')
-		.replace(/^_/, '')
-		.replace(/_$/, '')
-		.replace(/^(\d)/, '_$1');
+		.replace(regex_percentage_characters, 'u')
+		.replace(regex_file_ending, '')
+		.replace(regex_repeated_invalid_variable_identifier_characters, '_')
+		.replace(regex_starts_with_underscore, '')
+		.replace(regex_ends_with_underscore, '')
+		.replace(regex_starts_with_digit, '_$1');
 
 	if (!base) {
 		throw new Error(`Could not derive component name from file ${filename}`);

--- a/src/compiler/compile/utils/get_name_from_filename.ts
+++ b/src/compiler/compile/utils/get_name_from_filename.ts
@@ -1,8 +1,8 @@
+import { regex_starts_with_underscore, regex_ends_with_underscore } from '../../utils/patterns';
+
 const regex_percentage_characters = /%/g;
 const regex_file_ending = /\.[^.]+$/;
 const regex_repeated_invalid_variable_identifier_characters = /[^a-zA-Z_$0-9]+/g;
-const regex_starts_with_underscore = /^_/;
-const regex_ends_with_underscore = /_$/;
 const regex_starts_with_digit = /^(\d)/;
 
 export default function get_name_from_filename(filename: string) {

--- a/src/compiler/compile/utils/hash.ts
+++ b/src/compiler/compile/utils/hash.ts
@@ -1,6 +1,9 @@
 // https://github.com/darkskyapp/string-hash/blob/master/index.js
+
+const const_return_characters = /\r/g;
+
 export default function hash(str: string): string {
-	str = str.replace(/\r/g, '');
+	str = str.replace(const_return_characters, '');
 	let hash = 5381;
 	let i = str.length;
 

--- a/src/compiler/compile/utils/hash.ts
+++ b/src/compiler/compile/utils/hash.ts
@@ -1,9 +1,9 @@
 // https://github.com/darkskyapp/string-hash/blob/master/index.js
 
-const const_return_characters = /\r/g;
+const regex_return_characters = /\r/g;
 
 export default function hash(str: string): string {
-	str = str.replace(const_return_characters, '');
+	str = str.replace(regex_return_characters, '');
 	let hash = 5381;
 	let i = str.length;
 

--- a/src/compiler/compile/utils/stringify.ts
+++ b/src/compiler/compile/utils/stringify.ts
@@ -19,10 +19,14 @@ const escaped = {
 	'>': '&gt;'
 };
 
+const regex_html_characters_to_escape = /["'&<>]/g;
+
 export function escape_html(html) {
-	return String(html).replace(/["'&<>]/g, match => escaped[match]);
+	return String(html).replace(regex_html_characters_to_escape, match => escaped[match]);
 }
 
+const regex_template_characters_to_escape = /(\${|`|\\)/g;
+
 export function escape_template(str) {
-	return str.replace(/(\${|`|\\)/g, '\\$1');
+	return str.replace(regex_template_characters_to_escape, '\\$1');
 }

--- a/src/compiler/parse/index.ts
+++ b/src/compiler/parse/index.ts
@@ -15,6 +15,8 @@ interface LastAutoClosedTag {
 	depth: number;
 }
 
+const regex_position_indicator = / \(\d+:\d+\)$/;
+
 export class Parser {
 	readonly template: string;
 	readonly filename?: string;
@@ -93,7 +95,7 @@ export class Parser {
 	acorn_error(err: any) {
 		this.error({
 			code: 'parse-error',
-			message: err.message.replace(/ \(\d+:\d+\)$/, '')
+			message: err.message.replace(regex_position_indicator, '')
 		}, err.pos);
 	}
 

--- a/src/compiler/parse/index.ts
+++ b/src/compiler/parse/index.ts
@@ -1,6 +1,6 @@
 import { isIdentifierStart, isIdentifierChar } from 'acorn';
 import fragment from './state/fragment';
-import { whitespace } from '../utils/patterns';
+import { regex_whitespace } from '../utils/patterns';
 import { reserved } from '../utils/names';
 import full_char_code_at from '../utils/full_char_code_at';
 import { TemplateNode, Ast, ParserOptions, Fragment, Style, Script } from '../interfaces';
@@ -76,10 +76,10 @@ export class Parser {
 
 		if (this.html.children.length) {
 			let start = this.html.children[0].start;
-			while (whitespace.test(template[start])) start += 1;
+			while (regex_whitespace.test(template[start])) start += 1;
 
 			let end = this.html.children[this.html.children.length - 1].end;
-			while (whitespace.test(template[end - 1])) end -= 1;
+			while (regex_whitespace.test(template[end - 1])) end -= 1;
 
 			this.html.start = start;
 			this.html.end = end;
@@ -140,7 +140,7 @@ export class Parser {
 	allow_whitespace() {
 		while (
 			this.index < this.template.length &&
-			whitespace.test(this.template[this.index])
+			regex_whitespace.test(this.template[this.index])
 		) {
 			this.index++;
 		}
@@ -202,7 +202,7 @@ export class Parser {
 	}
 
 	require_whitespace() {
-		if (!whitespace.test(this.template[this.index])) {
+		if (!regex_whitespace.test(this.template[this.index])) {
 			this.error({
 				code: 'missing-whitespace',
 				message: 'Expected whitespace'

--- a/src/compiler/parse/read/context.ts
+++ b/src/compiler/parse/read/context.ts
@@ -10,8 +10,7 @@ import {
 import { parse_expression_at } from '../acorn';
 import { Pattern } from 'estree';
 import parser_errors from '../errors';
-
-const regex_not_newline_characters = /[^\n]/g;
+import { regex_not_newline_characters } from '../../utils/patterns';
 
 export default function read_context(
 	parser: Parser

--- a/src/compiler/parse/read/context.ts
+++ b/src/compiler/parse/read/context.ts
@@ -11,6 +11,8 @@ import { parse_expression_at } from '../acorn';
 import { Pattern } from 'estree';
 import parser_errors from '../errors';
 
+const regex_not_newline_characters = /[^\n]/g;
+
 export default function read_context(
 	parser: Parser
 ): Pattern & { start: number; end: number } {
@@ -65,7 +67,7 @@ export default function read_context(
 		// so we offset it by removing 1 character in the `space_with_newline`
 		// to achieve that, we remove the 1st space encountered,
 		// so it will not affect the `column` of the node
-		let space_with_newline = parser.template.slice(0, start).replace(/[^\n]/g, ' ');
+		let space_with_newline = parser.template.slice(0, start).replace(regex_not_newline_characters, ' ');
 		const first_space = space_with_newline.indexOf(' ');
 		space_with_newline = space_with_newline.slice(0, first_space) + space_with_newline.slice(first_space + 1);
 

--- a/src/compiler/parse/read/expression.ts
+++ b/src/compiler/parse/read/expression.ts
@@ -1,7 +1,7 @@
 import { parse_expression_at } from '../acorn';
 import { Parser } from '../index';
 import { Node } from 'estree';
-import { whitespace } from '../../utils/patterns';
+import { regex_whitespace } from '../../utils/patterns';
 import parser_errors from '../errors';
 
 export default function read_expression(parser: Parser): Node {
@@ -20,7 +20,7 @@ export default function read_expression(parser: Parser): Node {
 
 			if (char === ')') {
 				num_parens -= 1;
-			} else if (!whitespace.test(char)) {
+			} else if (!regex_whitespace.test(char)) {
 				parser.error(parser_errors.unexpected_token(')'), index);
 			}
 

--- a/src/compiler/parse/read/script.ts
+++ b/src/compiler/parse/read/script.ts
@@ -3,8 +3,8 @@ import { Parser } from '../index';
 import { Script } from '../../interfaces';
 import { Node, Program } from 'estree';
 import parser_errors from '../errors';
+import { regex_not_newline_characters } from '../../utils/patterns';
 
-const regex_not_newline_characters = /[^\n]/g;
 const regex_closing_script_tag = /<\/script\s*>/;
 
 function get_context(parser: Parser, attributes: any[], start: number): string {

--- a/src/compiler/parse/read/script.ts
+++ b/src/compiler/parse/read/script.ts
@@ -4,6 +4,9 @@ import { Script } from '../../interfaces';
 import { Node, Program } from 'estree';
 import parser_errors from '../errors';
 
+const regex_not_newline_characters = /[^\n]/g;
+const regex_closing_script_tag = /<\/script\s*>/;
+
 function get_context(parser: Parser, attributes: any[], start: number): string {
 	const context = attributes.find(attribute => attribute.name === 'context');
 	if (!context) return 'default';
@@ -23,13 +26,13 @@ function get_context(parser: Parser, attributes: any[], start: number): string {
 
 export default function read_script(parser: Parser, start: number, attributes: Node[]): Script {
 	const script_start = parser.index;
-	const data = parser.read_until(/<\/script\s*>/, parser_errors.unclosed_script);
+	const data = parser.read_until(regex_closing_script_tag, parser_errors.unclosed_script);
 	if (parser.index >= parser.template.length) {
 		parser.error(parser_errors.unclosed_script);
 	}
 
-	const source = parser.template.slice(0, script_start).replace(/[^\n]/g, ' ') + data;
-	parser.read(/<\/script\s*>/);
+	const source = parser.template.slice(0, script_start).replace(regex_not_newline_characters, ' ') + data;
+	parser.read(regex_closing_script_tag);
 
 	let ast: Program;
 

--- a/src/compiler/parse/read/style.ts
+++ b/src/compiler/parse/read/style.ts
@@ -5,10 +5,12 @@ import { Node } from 'estree';
 import { Style } from '../../interfaces';
 import parser_errors from '../errors';
 
+const regex_closing_style_tag = /<\/style\s*>/;
+
 export default function read_style(parser: Parser, start: number, attributes: Node[]): Style {
 	const content_start = parser.index;
 
-	const styles = parser.read_until(/<\/style\s*>/, parser_errors.unclosed_style);
+	const styles = parser.read_until(regex_closing_style_tag, parser_errors.unclosed_style);
 
 	if (parser.index >= parser.template.length) {
 		parser.error(parser_errors.unclosed_style);
@@ -67,7 +69,7 @@ export default function read_style(parser: Parser, start: number, attributes: No
 		}
 	});
 
-	parser.read(/<\/style\s*>/);
+	parser.read(regex_closing_style_tag);
 	const end = parser.index;
 
 	return {

--- a/src/compiler/parse/state/mustache.ts
+++ b/src/compiler/parse/state/mustache.ts
@@ -33,6 +33,8 @@ function trim_whitespace(block: TemplateNode, trim_before: boolean, trim_after: 
 	}
 }
 
+const regex_whitespace_with_closing_curly_brace = /\s*}/;
+
 export default function mustache(parser: Parser) {
 	const start = parser.index;
 	parser.index += 1;
@@ -106,8 +108,8 @@ export default function mustache(parser: Parser) {
 			const block = parser.current();
 			if (block.type !== 'IfBlock') {
 				parser.error(
-					parser.stack.some(block => block.type === 'IfBlock') 
-						? parser_errors.invalid_elseif_placement_unclosed_block(to_string(block)) 
+					parser.stack.some(block => block.type === 'IfBlock')
+						? parser_errors.invalid_elseif_placement_unclosed_block(to_string(block))
 						: parser_errors.invalid_elseif_placement_outside_if
 				);
 			}
@@ -141,8 +143,8 @@ export default function mustache(parser: Parser) {
 			const block = parser.current();
 			if (block.type !== 'IfBlock' && block.type !== 'EachBlock') {
 				parser.error(
-					parser.stack.some(block => block.type === 'IfBlock' || block.type === 'EachBlock') 
-						? parser_errors.invalid_else_placement_unclosed_block(to_string(block)) 
+					parser.stack.some(block => block.type === 'IfBlock' || block.type === 'EachBlock')
+						? parser_errors.invalid_else_placement_unclosed_block(to_string(block))
 						: parser_errors.invalid_else_placement_outside_if
 				);
 			}
@@ -167,15 +169,15 @@ export default function mustache(parser: Parser) {
 			if (block.type !== 'PendingBlock') {
 				parser.error(
 					parser.stack.some(block => block.type === 'PendingBlock')
-						? parser_errors.invalid_then_placement_unclosed_block(to_string(block)) 
-						: parser_errors.invalid_then_placement_without_await 
+						? parser_errors.invalid_then_placement_unclosed_block(to_string(block))
+						: parser_errors.invalid_then_placement_without_await
 				);
 			}
 		} else {
 			if (block.type !== 'ThenBlock' && block.type !== 'PendingBlock') {
 				parser.error(parser.stack.some(block => block.type === 'ThenBlock' || block.type === 'PendingBlock')
-						? parser_errors.invalid_catch_placement_unclosed_block(to_string(block)) 
-						: parser_errors.invalid_catch_placement_without_await 
+					? parser_errors.invalid_catch_placement_unclosed_block(to_string(block))
+					: parser_errors.invalid_catch_placement_without_await
 				);
 			}
 		}
@@ -290,7 +292,7 @@ export default function mustache(parser: Parser) {
 
 		const await_block_shorthand = type === 'AwaitBlock' && parser.eat('then');
 		if (await_block_shorthand) {
-			if (parser.match_regex(/\s*}/)) {
+			if (parser.match_regex(regex_whitespace_with_closing_curly_brace)) {
 				parser.allow_whitespace();
 			} else {
 				parser.require_whitespace();
@@ -301,7 +303,7 @@ export default function mustache(parser: Parser) {
 
 		const await_block_catch_shorthand = !await_block_shorthand && type === 'AwaitBlock' && parser.eat('catch');
 		if (await_block_catch_shorthand) {
-			if (parser.match_regex(/\s*}/)) {
+			if (parser.match_regex(regex_whitespace_with_closing_curly_brace)) {
 				parser.allow_whitespace();
 			} else {
 				parser.require_whitespace();
@@ -350,7 +352,7 @@ export default function mustache(parser: Parser) {
 		let identifiers;
 
 		// Implies {@debug} which indicates "debug all"
-		if (parser.read(/\s*}/)) {
+		if (parser.read(regex_whitespace_with_closing_curly_brace)) {
 			identifiers = [];
 		} else {
 			const expression = read_expression(parser);

--- a/src/compiler/parse/state/mustache.ts
+++ b/src/compiler/parse/state/mustache.ts
@@ -1,7 +1,7 @@
 import read_context from '../read/context';
 import read_expression from '../read/expression';
 import { closing_tag_omitted } from '../utils/html';
-import { whitespace } from '../../utils/patterns';
+import { regex_whitespace } from '../../utils/patterns';
 import { trim_start, trim_end } from '../../utils/trim';
 import { to_string } from '../utils/node';
 import { Parser } from '../index';
@@ -89,8 +89,8 @@ export default function mustache(parser: Parser) {
 		// strip leading/trailing whitespace as necessary
 		const char_before = parser.template[block.start - 1];
 		const char_after = parser.template[parser.index];
-		const trim_before = !char_before || whitespace.test(char_before);
-		const trim_after = !char_after || whitespace.test(char_after);
+		const trim_before = !char_before || regex_whitespace.test(char_before);
+		const trim_after = !char_after || regex_whitespace.test(char_after);
 
 		trim_whitespace(block, trim_before, trim_after);
 

--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -53,13 +53,16 @@ function parent_is_head(stack) {
 	return false;
 }
 
+const regex_closing_textarea_tag = /^<\/textarea(\s[^>]*)?>/i;
+const regex_closing_comment = /-->/;
+
 export default function tag(parser: Parser) {
 	const start = parser.index++;
 
 	let parent = parser.current();
 
 	if (parser.eat('!--')) {
-		const data = parser.read_until(/-->/);
+		const data = parser.read_until(regex_closing_comment);
 		parser.eat('-->', true, parser_errors.unclosed_comment);
 
 		parser.current().children.push({
@@ -218,11 +221,10 @@ export default function tag(parser: Parser) {
 		// special case
 		element.children = read_sequence(
 			parser,
-			() =>
-				/^<\/textarea(\s[^>]*)?>/i.test(parser.template.slice(parser.index)),
+			() => regex_closing_textarea_tag.test(parser.template.slice(parser.index)),
 			'inside <textarea>'
 		);
-		parser.read(/^<\/textarea(\s[^>]*)?>/i);
+		parser.read(regex_closing_textarea_tag);
 		element.end = parser.index;
 	} else if (name === 'script' || name === 'style') {
 		// special case
@@ -236,6 +238,8 @@ export default function tag(parser: Parser) {
 		parser.stack.push(element);
 	}
 }
+
+const regex_whitespace_or_slash_or_closing_tag = /(\s|\/|>)/;
 
 function read_tag_name(parser: Parser) {
 	const start = parser.index;
@@ -266,7 +270,7 @@ function read_tag_name(parser: Parser) {
 
 	if (parser.read(SLOT)) return 'svelte:fragment';
 
-	const name = parser.read_until(/(\s|\/|>)/);
+	const name = parser.read_until(regex_whitespace_or_slash_or_closing_tag);
 
 	if (meta_tags.has(name)) return name;
 
@@ -285,6 +289,10 @@ function read_tag_name(parser: Parser) {
 
 	return name;
 }
+
+// eslint-disable-next-line no-useless-escape
+const regex_token_ending_character = /[\s=\/>"']/;
+const regex_quote_characters = /["']/;
 
 function read_attribute(parser: Parser, unique_names: Set<string>) {
 	const start = parser.index;
@@ -344,8 +352,7 @@ function read_attribute(parser: Parser, unique_names: Set<string>) {
 		}
 	}
 
-	// eslint-disable-next-line no-useless-escape
-	const name = parser.read_until(/[\s=\/>"']/);
+	const name = parser.read_until(regex_token_ending_character);
 	if (!name) return null;
 
 	let end = parser.index;
@@ -360,7 +367,7 @@ function read_attribute(parser: Parser, unique_names: Set<string>) {
 		parser.allow_whitespace();
 		value = read_attribute_value(parser);
 		end = parser.index;
-	} else if (parser.match_regex(/["']/)) {
+	} else if (parser.match_regex(regex_quote_characters)) {
 		parser.error(parser_errors.unexpected_token('='), parser.index);
 	}
 

--- a/src/compiler/parse/state/tag.ts
+++ b/src/compiler/parse/state/tag.ts
@@ -55,6 +55,7 @@ function parent_is_head(stack) {
 
 const regex_closing_textarea_tag = /^<\/textarea(\s[^>]*)?>/i;
 const regex_closing_comment = /-->/;
+const regex_capital_letter = /[A-Z]/;
 
 export default function tag(parser: Parser) {
 	const start = parser.index++;
@@ -107,7 +108,7 @@ export default function tag(parser: Parser) {
 
 	const type = meta_tags.has(name)
 		? meta_tags.get(name)
-		: (/[A-Z]/.test(name[0]) || name === 'svelte:self' || name === 'svelte:component') ? 'InlineComponent'
+		: (regex_capital_letter.test(name[0]) || name === 'svelte:self' || name === 'svelte:component') ? 'InlineComponent'
 			: name === 'svelte:fragment' ? 'SlotTemplate'
 				: name === 'title' && parent_is_head(parser.stack) ? 'Title'
 					: name === 'slot' && !parser.customElement ? 'Slot' : 'Element';

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -4,6 +4,7 @@ import { MappedCode, SourceLocation, parse_attached_sourcemap, sourcemap_add_off
 import { decode_map } from './decode_sourcemap';
 import { replace_in_code, slice_source } from './replace_in_code';
 import { MarkupPreprocessor, Source, Preprocessor, PreprocessorGroup, Processed } from './types';
+import { regex_whitespaces } from '../utils/patterns';
 
 export * from './types';
 
@@ -122,13 +123,12 @@ function processed_tag_to_code(
 	return tag_open_code.concat(content_code).concat(tag_close_code);
 }
 
-const regex_whitespace = /\s+/;
 const regex_quoted_value = /^['"](.*)['"]$/;
 
 function parse_tag_attributes(str: string) {
 	// note: won't work with attribute values containing spaces.
 	return str
-		.split(regex_whitespace)
+		.split(regex_whitespaces)
 		.filter(Boolean)
 		.reduce((attrs, attr) => {
 			const i = attr.indexOf('=');

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -123,7 +123,7 @@ function processed_tag_to_code(
 }
 
 const regex_whitespace = /\s+/;
-const regex_unquoted_value = /^['"](.*)['"]$/;
+const regex_quoted_value = /^['"](.*)['"]$/;
 
 function parse_tag_attributes(str: string) {
 	// note: won't work with attribute values containing spaces.
@@ -133,7 +133,7 @@ function parse_tag_attributes(str: string) {
 		.reduce((attrs, attr) => {
 			const i = attr.indexOf('=');
 			const [key, value] = i > 0 ? [attr.slice(0, i), attr.slice(i + 1)] : [attr];
-			const [, unquoted] = (value && value.match(regex_unquoted_value)) || [];
+			const [, unquoted] = (value && value.match(regex_quoted_value)) || [];
 
 			return { ...attrs, [key]: unquoted ?? value ?? true };
 		}, {});

--- a/src/compiler/preprocess/index.ts
+++ b/src/compiler/preprocess/index.ts
@@ -13,8 +13,10 @@ interface SourceUpdate {
 	dependencies?: string[];
 }
 
+const regex_filepath_separator = /[/\\]/;
+
 function get_file_basename(filename: string) {
-	return filename.split(/[/\\]/).pop();
+	return filename.split(regex_filepath_separator).pop();
 }
 
 /**
@@ -120,19 +122,26 @@ function processed_tag_to_code(
 	return tag_open_code.concat(content_code).concat(tag_close_code);
 }
 
+const regex_whitespace = /\s+/;
+const regex_unquoted_value = /^['"](.*)['"]$/;
+
 function parse_tag_attributes(str: string) {
 	// note: won't work with attribute values containing spaces.
 	return str
-		.split(/\s+/)
+		.split(regex_whitespace)
 		.filter(Boolean)
 		.reduce((attrs, attr) => {
 			const i = attr.indexOf('=');
 			const [key, value] = i > 0 ? [attr.slice(0, i), attr.slice(i + 1)] : [attr];
-			const [, unquoted] = (value && value.match(/^['"](.*)['"]$/)) || [];
+			const [, unquoted] = (value && value.match(regex_unquoted_value)) || [];
 
 			return { ...attrs, [key]: unquoted ?? value ?? true };
 		}, {});
 }
+
+
+const regex_style_tags = /<!--[^]*?-->|<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gi;
+const regex_script_tags = /<!--[^]*?-->|<script(\s[^]*?)?(?:>([^]*?)<\/script>|\/>)/gi;
 
 /**
  * Calculate the updates required to process all instances of the specified tag.
@@ -143,10 +152,7 @@ async function process_tag(
 	source: Source
 ): Promise<SourceUpdate> {
 	const { filename, source: markup } = source;
-	const tag_regex =
-		tag_name === 'style'
-			? /<!--[^]*?-->|<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gi
-			: /<!--[^]*?-->|<script(\s[^]*?)?(?:>([^]*?)<\/script>|\/>)/gi;
+	const tag_regex = tag_name === 'style' ? regex_style_tags : regex_script_tags;
 
 	const dependencies: string[] = [];
 
@@ -190,7 +196,7 @@ async function process_markup(process: MarkupPreprocessor, source: Source) {
 			string: processed.code,
 			map: processed.map
 				? // TODO: can we use decode_sourcemap?
-				  typeof processed.map === 'string'
+				typeof processed.map === 'string'
 					? JSON.parse(processed.map)
 					: processed.map
 				: undefined,

--- a/src/compiler/utils/extract_svelte_ignore.ts
+++ b/src/compiler/utils/extract_svelte_ignore.ts
@@ -1,13 +1,12 @@
 import { TemplateNode } from '../interfaces';
 import { flatten } from './flatten';
+import { regex_whitespace } from './patterns';
 
-const pattern = /^\s*svelte-ignore\s+([\s\S]+)\s*$/m;
-
-const regex_whitespace_characters = /\s/;
+const regex_svelte_ignore = /^\s*svelte-ignore\s+([\s\S]+)\s*$/m;
 
 export function extract_svelte_ignore(text: string): string[] {
-	const match = pattern.exec(text);
-	return match ? match[1].split(regex_whitespace_characters).map(x => x.trim()).filter(Boolean) : [];
+	const match = regex_svelte_ignore.exec(text);
+	return match ? match[1].split(regex_whitespace).map(x => x.trim()).filter(Boolean) : [];
 }
 
 export function extract_svelte_ignore_from_comments<Node extends { leadingComments?: Array<{value: string}> }>(node: Node): string[] {

--- a/src/compiler/utils/extract_svelte_ignore.ts
+++ b/src/compiler/utils/extract_svelte_ignore.ts
@@ -3,9 +3,11 @@ import { flatten } from './flatten';
 
 const pattern = /^\s*svelte-ignore\s+([\s\S]+)\s*$/m;
 
+const regex_no_whitespace_character = /[^\S]/;
+
 export function extract_svelte_ignore(text: string): string[] {
 	const match = pattern.exec(text);
-	return match ? match[1].split(/[^\S]/).map(x => x.trim()).filter(Boolean) : [];
+	return match ? match[1].split(regex_no_whitespace_character).map(x => x.trim()).filter(Boolean) : [];
 }
 
 export function extract_svelte_ignore_from_comments<Node extends { leadingComments?: Array<{value: string}> }>(node: Node): string[] {

--- a/src/compiler/utils/extract_svelte_ignore.ts
+++ b/src/compiler/utils/extract_svelte_ignore.ts
@@ -3,11 +3,11 @@ import { flatten } from './flatten';
 
 const pattern = /^\s*svelte-ignore\s+([\s\S]+)\s*$/m;
 
-const regex_no_whitespace_character = /[^\S]/;
+const regex_whitespace_characters = /\s/;
 
 export function extract_svelte_ignore(text: string): string[] {
 	const match = pattern.exec(text);
-	return match ? match[1].split(regex_no_whitespace_character).map(x => x.trim()).filter(Boolean) : [];
+	return match ? match[1].split(regex_whitespace_characters).map(x => x.trim()).filter(Boolean) : [];
 }
 
 export function extract_svelte_ignore_from_comments<Node extends { leadingComments?: Array<{value: string}> }>(node: Node): string[] {

--- a/src/compiler/utils/get_code_frame.ts
+++ b/src/compiler/utils/get_code_frame.ts
@@ -1,5 +1,7 @@
+const regex_tabs = /^\t+/;
+
 function tabs_to_spaces(str: string) {
-	return str.replace(/^\t+/, match => match.split('\t').join('  '));
+	return str.replace(regex_tabs, match => match.split('\t').join('  '));
 }
 
 export default function get_code_frame(

--- a/src/compiler/utils/mapped_code.ts
+++ b/src/compiler/utils/mapped_code.ts
@@ -182,6 +182,8 @@ export class MappedCode {
 		return new MappedCode(string, map);
 	}
 
+	private static regex_line_token = /([^\d\w\s]|\s+)/g;
+
 	static from_source({ source, file_basename, get_location }: Source): MappedCode {
 		let offset: SourceLocation = get_location(0);
 
@@ -195,7 +197,7 @@ export class MappedCode {
 		const line_list = source.split('\n');
 		for (let line = 0; line < line_list.length; line++) {
 			map.mappings.push([]);
-			const token_list = line_list[line].split(/([^\d\w\s]|\s+)/g);
+			const token_list = line_list[line].split(this.regex_line_token);
 			for (let token = 0, column = 0; token < token_list.length; token++) {
 				if (token_list[token] == '') continue;
 				map.mappings[line].push([column, 0, offset.line + line, column]);
@@ -245,7 +247,7 @@ export function combine_sourcemaps(
 	if (!map.file) delete map.file; // skip optional field `file`
 
 	// When source maps are combined and the leading map is empty, sources is not set.
-	// Add the filename to the empty array in this case. 
+	// Add the filename to the empty array in this case.
 	// Further improvements to remapping may help address this as well https://github.com/ampproject/remapping/issues/116
 	if (!map.sources.length) map.sources = [filename];
 
@@ -289,6 +291,8 @@ export function apply_preprocessor_sourcemap(filename: string, svelte_map: Sourc
 	return result_map as SourceMap;
 }
 
+const regex_data_uri = /data:(?:application|text)\/json;(?:charset[:=]\S+?;)?base64,(\S*)/;
+
 // parse attached sourcemap in processed.code
 export function parse_attached_sourcemap(processed: Processed, tag_name: 'script' | 'style'): void {
 	const r_in = '[#@]\\s*sourceMappingURL\\s*=\\s*(\\S*)';
@@ -302,7 +306,7 @@ export function parse_attached_sourcemap(processed: Processed, tag_name: 'script
 	}
 	processed.code = processed.code.replace(regex, (_, match1, match2) => {
 		const map_url = (tag_name == 'script') ? (match1 || match2) : match1;
-		const map_data = (map_url.match(/data:(?:application|text)\/json;(?:charset[:=]\S+?;)?base64,(\S*)/) || [])[1];
+		const map_data = (map_url.match(regex_data_uri) || [])[1];
 		if (map_data) {
 			// sourceMappingURL is data URL
 			if (processed.map) {

--- a/src/compiler/utils/mapped_code.ts
+++ b/src/compiler/utils/mapped_code.ts
@@ -61,6 +61,8 @@ function merge_tables<T>(this_table: T[], other_table: T[]): [T[], number[], boo
 	return [new_table, idx_map, val_changed, idx_changed];
 }
 
+const regex_line_token = /([^\d\w\s]|\s+)/g;
+
 export class MappedCode {
 	string: string;
 	map: DecodedSourceMap;
@@ -182,8 +184,6 @@ export class MappedCode {
 		return new MappedCode(string, map);
 	}
 
-	private static regex_line_token = /([^\d\w\s]|\s+)/g;
-
 	static from_source({ source, file_basename, get_location }: Source): MappedCode {
 		let offset: SourceLocation = get_location(0);
 
@@ -197,7 +197,7 @@ export class MappedCode {
 		const line_list = source.split('\n');
 		for (let line = 0; line < line_list.length; line++) {
 			map.mappings.push([]);
-			const token_list = line_list[line].split(this.regex_line_token);
+			const token_list = line_list[line].split(regex_line_token);
 			for (let token = 0, column = 0; token < token_list.length; token++) {
 				if (token_list[token] == '') continue;
 				map.mappings[line].push([column, 0, offset.line + line, column]);

--- a/src/compiler/utils/names.ts
+++ b/src/compiler/utils/names.ts
@@ -1,5 +1,6 @@
 import { isIdentifierStart, isIdentifierChar } from 'acorn';
 import full_char_code_at from './full_char_code_at';
+import { regex_starts_with_underscore, regex_ends_with_underscore } from './patterns';
 
 export const reserved = new Set([
 	'arguments',
@@ -66,8 +67,6 @@ export function is_valid(str: string): boolean {
 }
 
 const regex_non_standard_characters = /[^a-zA-Z0-9_]+/g;
-const regex_starts_with_underscore = /^_/;
-const regex_ends_with_underscore = /_$/;
 const regex_starts_with_number = /^[0-9]/;
 
 export function sanitize(name: string) {

--- a/src/compiler/utils/names.ts
+++ b/src/compiler/utils/names.ts
@@ -65,10 +65,15 @@ export function is_valid(str: string): boolean {
 	return true;
 }
 
+const regex_non_standard_characters = /[^a-zA-Z0-9_]+/g;
+const regex_starts_with_underscore = /^_/;
+const regex_ends_with_underscore = /_$/;
+const regex_starts_with_number = /^[0-9]/;
+
 export function sanitize(name: string) {
 	return name
-		.replace(/[^a-zA-Z0-9_]+/g, '_')
-		.replace(/^_/, '')
-		.replace(/_$/, '')
-		.replace(/^[0-9]/, '_$&');
+		.replace(regex_non_standard_characters, '_')
+		.replace(regex_starts_with_underscore, '')
+		.replace(regex_ends_with_underscore, '')
+		.replace(regex_starts_with_number, '_$&');
 }

--- a/src/compiler/utils/patterns.ts
+++ b/src/compiler/utils/patterns.ts
@@ -1,7 +1,9 @@
 export const regex_whitespace = /\s/;
 export const regex_whitespaces = /\s+/;
 export const regex_starts_with_whitespace = /^\s/;
+export const regex_starts_with_whitespaces = /^[ \t\r\n]*/;
 export const regex_ends_with_whitespace = /\s$/;
+export const regex_ends_with_whitespaces = /[ \t\r\n]*$/;
 export const regex_only_whitespaces = /^\s+$/;
 
 export const regex_whitespace_characters = /\s/g;

--- a/src/compiler/utils/patterns.ts
+++ b/src/compiler/utils/patterns.ts
@@ -1,6 +1,22 @@
-export const regex_whitespace = /[ \t\r\n]/;
-export const regex_start_whitespace = /^[ \t\r\n]*/;
-export const regex_end_whitespace = /[ \t\r\n]*$/;
-export const regex_start_newline = /^\r?\n/;
+export const regex_whitespace = /\s/;
+export const regex_whitespaces = /\s+/;
+export const regex_starts_with_whitespace = /^\s/;
+export const regex_ends_with_whitespace = /\s$/;
+export const regex_only_whitespaces = /^\s+$/;
+
+export const regex_whitespace_characters = /\s/g;
+export const regex_non_whitespace_character = /\S/;
+
+export const regex_starts_with_newline = /^\r?\n/;
+export const regex_not_newline_characters = /[^\n]/g;
+
+export const regex_double_quotes = /"/g;
+
+export const regex_backslashes = /\\/g;
+
+export const regex_starts_with_underscore = /^_/;
+export const regex_ends_with_underscore = /_$/;
+
+export const regex_invalid_variable_identifier_characters = /[^a-zA-Z0-9_$]/g;
 
 export const regex_dimensions = /^(?:offset|client)(?:Width|Height)$/;

--- a/src/compiler/utils/patterns.ts
+++ b/src/compiler/utils/patterns.ts
@@ -1,6 +1,6 @@
-export const whitespace = /[ \t\r\n]/;
-export const start_whitespace = /^[ \t\r\n]*/;
-export const end_whitespace = /[ \t\r\n]*$/;
-export const start_newline = /^\r?\n/;
+export const regex_whitespace = /[ \t\r\n]/;
+export const regex_start_whitespace = /^[ \t\r\n]*/;
+export const regex_end_whitespace = /[ \t\r\n]*$/;
+export const regex_start_newline = /^\r?\n/;
 
-export const dimensions = /^(?:offset|client)(?:Width|Height)$/;
+export const regex_dimensions = /^(?:offset|client)(?:Width|Height)$/;

--- a/src/compiler/utils/trim.ts
+++ b/src/compiler/utils/trim.ts
@@ -1,9 +1,9 @@
-import { regex_starts_with_whitespace, regex_ends_with_whitespace } from './patterns';
+import { regex_starts_with_whitespaces, regex_ends_with_whitespaces } from './patterns';
 
 export function trim_start(str: string) {
-	return str.replace(regex_starts_with_whitespace, '');
+	return str.replace(regex_starts_with_whitespaces, '');
 }
 
 export function trim_end(str: string) {
-	return str.replace(regex_ends_with_whitespace, '');
+	return str.replace(regex_ends_with_whitespaces, '');
 }

--- a/src/compiler/utils/trim.ts
+++ b/src/compiler/utils/trim.ts
@@ -1,9 +1,9 @@
-import { regex_start_whitespace, regex_end_whitespace } from './patterns';
+import { regex_starts_with_whitespace, regex_ends_with_whitespace } from './patterns';
 
 export function trim_start(str: string) {
-	return str.replace(regex_start_whitespace, '');
+	return str.replace(regex_starts_with_whitespace, '');
 }
 
 export function trim_end(str: string) {
-	return str.replace(regex_end_whitespace, '');
+	return str.replace(regex_ends_with_whitespace, '');
 }

--- a/src/compiler/utils/trim.ts
+++ b/src/compiler/utils/trim.ts
@@ -1,9 +1,9 @@
-import { start_whitespace, end_whitespace } from './patterns';
+import { regex_start_whitespace, regex_end_whitespace } from './patterns';
 
 export function trim_start(str: string) {
-	return str.replace(start_whitespace, '');
+	return str.replace(regex_start_whitespace, '');
 }
 
 export function trim_end(str: string) {
-	return str.replace(end_whitespace, '');
+	return str.replace(regex_end_whitespace, '');
 }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

I was looking through the code of the `preprocessor` feature and I saw that all regular expression are inlined in the code.
Storing a regex in a variable instead can increase the [performance by 5-20%](https://stackoverflow.com/questions/9750338/dynamic-vs-inline-regexp-performance-in-javascript/32523333#32523333) for subsequent runs.

I tried to find good names for the regular expressions. The "downside" of re-locating the regular expressins is the small overhead to jump around when reading code. But with regular expressions in general it is not that easy to reason about when reading them. So a good variable name may also be easier to understand than the expression itself ^^.

There are also other places in the code where this can be applied. But I want to see if this type of PR get's accepted before I change more parts :)
