### PR TITLE
[fix] Max call stack exceeded when large number of components are flushed

### DIFF
--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -51,7 +51,10 @@ export function add_flush_callback(fn) {
 //    function, guarantees this behavior.
 const seen_callbacks = new Set();
 let flushidx = 0;  // Do *not* move this inside the flush() function
+let flushing = false;
 export function flush() {
+	if (flushing) return;
+	flushing = true;
 	const saved_component = current_component;
 
 	do {
@@ -90,7 +93,8 @@ export function flush() {
 	while (flush_callbacks.length) {
 		flush_callbacks.pop()();
 	}
-
+	
+	flushing = false;
 	update_scheduled = false;
 	seen_callbacks.clear();
 	set_current_component(saved_component);


### PR DESCRIPTION
- This is based on the PR in the original Svelte repo made by @[AaronDDM](https://github.com/AaronDDM): [7397](https://github.com/sveltejs/svelte/pull/7397)
