### PR TITLE
[fix] use `Node.parentNode` instead `Node.parentElement` in `dom.ts`.

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -163,7 +163,6 @@ export function append_hydration(target: NodeEx, node: NodeEx) {
 	if (is_hydrating) {
 		init_hydrate(target);
 
-		// Note: It is important to use `Node.parentNode` instead `Node.parentElement` for a simple legacy browsers compatibility.
 		if ((target.actual_end_child === undefined) || ((target.actual_end_child !== null) && (target.actual_end_child.parentNode !== target))) {
 			target.actual_end_child = target.firstChild;
 		}

--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -163,7 +163,8 @@ export function append_hydration(target: NodeEx, node: NodeEx) {
 	if (is_hydrating) {
 		init_hydrate(target);
 
-		if ((target.actual_end_child === undefined) || ((target.actual_end_child !== null) && (target.actual_end_child.parentElement !== target))) {
+		// Note: It is important to use `Node.parentNode` instead `Node.parentElement` for a simple legacy browsers compatibility.
+		if ((target.actual_end_child === undefined) || ((target.actual_end_child !== null) && (target.actual_end_child.parentNode !== target))) {
 			target.actual_end_child = target.firstChild;
 		}
 


### PR DESCRIPTION
Fixes #7723.

This is for a simple legacy browsers compatibility (specifically, IE11).