### PR TITLE
[feat] add `SveltePreprocessor` utility type

### DIFF
--- a/src/compiler/preprocess/types.ts
+++ b/src/compiler/preprocess/types.ts
@@ -40,3 +40,10 @@ export interface PreprocessorGroup {
 	style?: Preprocessor;
 	script?: Preprocessor;
 }
+
+export interface SveltePreprocessor<
+	PreprocessorType extends keyof PreprocessorGroup,
+	Options = any
+> {
+	(options?: Options): Required<Pick<PreprocessorGroup, PreprocessorType>>;
+}


### PR DESCRIPTION
This PR adds a utility to type Svelte preprocessors. It aims to improve the DX for authors writing Svelte preprocessors using TypeScript. It was inspired by https://github.com/sveltejs/svelte/pull/7121, which added a utility `Action` type to strongly type Svelte actions.

**Current DX**

The current workflow is to use the `PreprocessorGroup` type.

```ts
import type { PreprocessorGroup } from "svelte/types/compiler/preprocess";

function preprocessor(): Pick<PreprocessorGroup<"markup">> {
  return {
    markup({ content }) {
      return { code: content };
    },
  };
}
```

However, since a preprocessor is usually a function that returns a function to allow user-provided options, it would be more concise for a utility type to select from the various groups (markup/style/script) and optionally add a generic `options` as the second parameter.

**Proposed DX**

The following examples illustrate basic use cases:

- preprocessor with a single group
- preprocessor with multiple groups
- preprocessor with user-provided options

```ts
import type { SveltePreprocessor } from "svelte/types/compiler/preprocess";

// Markup-only preprocessor without options
const preprocessMarkup: SveltePreprocessor<"markup"> = () => {
  return {
    markup({ content }) {
      return { code: content };
    },
  };
};

// Markup and style preprocessor without options
const preprocessMarkupStyles: SveltePreprocessor<"markup" | "style"> = () => {
  return {
    markup({ content }) {
      return { code: content };
    },
    style({ content }) {
      return { code: content };
    },
  };
};

// Script preprocessor with user options
// Options are passed as the second parameter
const preprocessWithOptions: SveltePreprocessor<"script", { sourcemap?: boolean }> = (options) => {
  const sourcemap = options?.sourcemap === true;

  return {
    script({ content }) {
      return { code: content, map: sourcemap ? "..." : undefined };
    },
  };
};
```