### PR TITLE
[fix] add CustomEvent as a known global

### DIFF
--- a/src/compiler/utils/names.ts
+++ b/src/compiler/utils/names.ts
@@ -10,6 +10,7 @@ export const globals = new Set([
 	'clearTimeout',
 	'confirm',
 	'console',
+	'CustomEvent',
 	'Date',
 	'decodeURI',
 	'decodeURIComponent',


### PR DESCRIPTION
Trying to dispatch a `new CustomEvent` without warning. Not sure if we need to add [the other types of events](https://developer.mozilla.org/en-US/docs/Web/API/Event#interfaces_based_on_event) to the list, it's probably rare to do a `new MouseEvent`.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
