### PR TITLE
[feat] add axis option to slide transition

### DIFF
--- a/site/content/docs/04-run-time.md
+++ b/site/content/docs/04-run-time.md
@@ -745,6 +745,7 @@ Slides an element in and out.
 * `delay` (`number`, default 0) — milliseconds before starting
 * `duration` (`number`, default 400) — milliseconds the transition lasts
 * `easing` (`function`, default `cubicOut`) — an [easing function](/docs#run-time-svelte-easing)
+* `axis` (`'x'` | `'y'`, default `'y'`) — direction of the transition
 
 ```sv
 <script>
@@ -753,7 +754,7 @@ Slides an element in and out.
 </script>
 
 {#if condition}
-	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut }}">
+	<div transition:slide="{{delay: 250, duration: 300, easing: quintOut, axis: 'x' }}">
 		slides in and out
 	</div>
 {/if}

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -98,15 +98,45 @@ export interface SlideParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
+	axis?: 'x' | 'y';
 }
 
 export function slide(node: Element, {
 	delay = 0,
 	duration = 400,
-	easing = cubicOut
+	easing = cubicOut,
+	axis = 'y'
 }: SlideParams = {}): TransitionConfig {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
+
+	if (axis === 'x') {
+		const width = parseFloat(style.width);
+		const padding_left = parseFloat(style.paddingLeft);
+		const padding_right = parseFloat(style.paddingRight);
+		const margin_left = parseFloat(style.marginLeft);
+		const margin_right = parseFloat(style.marginRight);
+		const border_left_width = parseFloat(style.borderLeftWidth);
+		const border_right_width = parseFloat(style.borderRightWidth);
+
+		return {
+			delay,
+			duration,
+			easing,
+			css: t =>
+				'white-space: nowrap;' +
+				'overflow: hidden;' +
+				`opacity: ${Math.min(t * 20, 1) * opacity};` +
+				`width: ${t * width}px;` +
+				`padding-left: ${t * padding_left}px;` +
+				`padding-right: ${t * padding_right}px;` +
+				`margin-left: ${t * margin_left}px;` +
+				`margin-right: ${t * margin_right}px;` +
+				`border-left-width: ${t * border_left_width}px;` +
+				`border-right-width: ${t * border_right_width}px;`
+		};
+	}
+
 	const height = parseFloat(style.height);
 	const padding_top = parseFloat(style.paddingTop);
 	const padding_bottom = parseFloat(style.paddingBottom);


### PR DESCRIPTION
Currently, the `slide` transition only animates on the y-axis. It would be nice to support animating on the x-axis. A real world use case would be a side navigation menu.

This PR adds an `axis` parameter to the `slide` transition function. Possible values are `'x'` or `'y'`. `'y'` is the default value for backward compatibility.

### Usage

```svelte
<script>
  import { slide } from "svelte/transition";

  let toggled = false;
</script>

{#if toggled}
  <div transition:slide={{ axis: "x" }} />
{/if}
```

### Demo

Play with the horizontal slide transition in this [Svelte REPL](https://svelte.dev/repl/64757313f2cf46f99633379bfa192232?version=3.49.0).

https://user-images.githubusercontent.com/10718366/183316478-9c68a7a7-ae7a-42b3-8cf3-196606a12ede.mov


### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
