### PR TITLE
[docs] changed wording "finished" to "refined" for a better reading experience

### DIFF
--- a/site/content/tutorial/15-context/01-context-api/text.md
+++ b/site/content/tutorial/15-context/01-context-api/text.md
@@ -33,7 +33,7 @@ const map = getMap();
 
 The markers can now add themselves to the map.
 
-> A more finished version of `<MapMarker>` would also handle removal and prop changes, but we're only demonstrating context here.
+> A more refined version of `<MapMarker>` would also handle removal and prop changes, but we're only demonstrating context here.
 
 ## Context keys
 


### PR DESCRIPTION
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.


Changed wording "finished" to "refined" for a better reading experience in "context api" example