### PR TITLE
[docs] Add clarification on how reactivity works

### DIFF
--- a/site/content/docs/02-component-format.md
+++ b/site/content/docs/02-component-format.md
@@ -193,7 +193,7 @@ Total: {total}
 ```
 
 ---
-Is important to note that the reactive blocks are ordered via simple static analysis at compile time, and all the compiler looks at are the variables that are assigned to and used within the block itself, not in any functions called by them. This means that `yDependant` will not be updated in the following example:
+It is important to note that the reactive blocks are ordered via simple static analysis at compile time, and all the compiler looks at are the variables that are assigned to and used within the block itself, not in any functions called by them. This means that `yDependent` will not be updated when `x` is updated in the following example:
 
 ```sv
 <script>
@@ -204,12 +204,12 @@ Is important to note that the reactive blocks are ordered via simple static anal
 		y = value;
 	}
 	
-	$: yDependant = y;
+	$: yDependent = y;
 	$: setY(x);
 </script>
 ```
 
-Moving the line `$: yDependant = y` bellow `$: setY(x)` will update `yDependant`.
+Moving the line `$: yDependent = y` bellow `$: setY(x)` will cause `yDependent` to be updated when `x` is updated.
 
 ---
 

--- a/site/content/docs/02-component-format.md
+++ b/site/content/docs/02-component-format.md
@@ -193,6 +193,25 @@ Total: {total}
 ```
 
 ---
+Is important to note that the reactive blocks are ordered via simple static analysis at compile time, and all the compiler looks at are the variables that are assigned to and used within the block itself, not in any functions called by them. This means that `yDependant` will not be updated in the following example:
+
+```sv
+<script>
+	let x = 0;
+	let y = 0;
+	
+	const setY = (value) => {
+		y = value;
+	}
+	
+	$: yDependant = y;
+	$: setY(x);
+</script>
+```
+
+Moving the line `$: yDependant = y` bellow `$: setY(x)` will update `yDependant`.
+
+---
 
 If a statement consists entirely of an assignment to an undeclared variable, Svelte will inject a `let` declaration on your behalf.
 


### PR DESCRIPTION
Based on the fact that multiple issues were opened related to a perceived bug on the reactive variables, I thought it would be good to add a clarification on the docs. Part of the text is taken from [this comment](https://github.com/sveltejs/svelte/issues/7818#issuecomment-1230374639) that I found super useful.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
