### PR TITLE
[fix] throw warning instead of error if <svelte:element> is void tag and content exists

### DIFF
--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -117,7 +117,9 @@ export function validate_dynamic_element(tag: unknown) {
 
 export function validate_void_dynamic_element(tag: undefined | string) {
 	if (tag && is_void(tag)) {
-		throw new Error(`<svelte:element this="${tag}"> is self-closing and cannot have content.`);
+		console.warn(
+			`<svelte:element this="${tag}"> is self-closing and cannot have content.`
+		);
 	}
 }
 

--- a/test/runtime/samples/dynamic-element-void-with-content-1/_config.js
+++ b/test/runtime/samples/dynamic-element-void-with-content-1/_config.js
@@ -5,5 +5,5 @@ export default {
 	props: {
 		tag: 'br'
 	},
-	error: '<svelte:element this="br"> is self-closing and cannot have content.'
+	warnings: ['<svelte:element this="br"> is self-closing and cannot have content.']
 };

--- a/test/runtime/samples/dynamic-element-void-with-content-2/_config.js
+++ b/test/runtime/samples/dynamic-element-void-with-content-2/_config.js
@@ -5,5 +5,5 @@ export default {
 	props: {
 		tag: 'br'
 	},
-	error: '<svelte:element this="br"> is self-closing and cannot have content.'
+	warnings: ['<svelte:element this="br"> is self-closing and cannot have content.']
 };

--- a/test/runtime/samples/dynamic-element-void-with-content-3/_config.js
+++ b/test/runtime/samples/dynamic-element-void-with-content-3/_config.js
@@ -5,5 +5,5 @@ export default {
 	props: {
 		tag: 'br'
 	},
-	error: '<svelte:element this="br"> is self-closing and cannot have content.'
+	warnings: ['<svelte:element this="br"> is self-closing and cannot have content.']
 };

--- a/test/runtime/samples/dynamic-element-void-with-content-5/_config.js
+++ b/test/runtime/samples/dynamic-element-void-with-content-5/_config.js
@@ -1,0 +1,6 @@
+export default {
+	compileOptions: {
+		dev: true
+	},
+	warnings: ['<svelte:element this="input"> is self-closing and cannot have content.']
+};

--- a/test/runtime/samples/dynamic-element-void-with-content-5/main.svelte
+++ b/test/runtime/samples/dynamic-element-void-with-content-5/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	const tags = [{ t: 'div', content: 'hello world' }, { t: 'input' }];
+</script>
+
+{#each tags as tag}
+	{tag.t} <br />
+	<svelte:element this={tag.t}>
+		{#if tag.t !== 'input'}{tag.content}{/if}
+	</svelte:element>
+{/each}


### PR DESCRIPTION
fix: https://github.com/sveltejs/svelte/issues/7566

I tried to add check logic for the issue but I didn't get a good idea.
I think the issue is an actual use case, so for now, throwing a warning instead of an error is a reasonable solution.
If you have any ideas, please share us.🙏

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
