### PR TITLE
[docs] add inline documentation to svelte runtime functions

### DIFF
--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -15,6 +15,8 @@ export function get_current_component() {
  * Schedules a callback to run immediately before the component is updated after any state change.
  * 
  * The first time the callback runs will be before the initial `onMount`
+ * 
+ * https://svelte.dev/docs#run-time-svelte-beforeupdate
  */
 export function beforeUpdate(fn: () => any) {
 	get_current_component().$$.before_update.push(fn);
@@ -26,6 +28,8 @@ export function beforeUpdate(fn: () => any) {
  * it can be called from an external module).
  * 
  * `onMount` does not run inside a [server-side component](/docs#run-time-server-side-component-api).
+ * 
+ * https://svelte.dev/docs#run-time-svelte-onmount
  */
 export function onMount(fn: () => any) {
 	get_current_component().$$.on_mount.push(fn);
@@ -43,7 +47,10 @@ export function afterUpdate(fn: () => any) {
 /** 
  * Schedules a callback to run immediately before the component is unmounted.
  * 
- * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the only one that runs inside a server-side component.
+ * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the 
+ * only one that runs inside a server-side component.
+ * 
+ * https://svelte.dev/docs#run-time-svelte-ondestroy
  */
 export function onDestroy(fn: () => any) {
 	get_current_component().$$.on_destroy.push(fn);
@@ -62,6 +69,8 @@ export interface DispatchOptions {
  * These events do not [bubble](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture).
  * The `detail` argument corresponds to the [CustomEvent.detail](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail) 
  * property and can contain any type of data. 
+ * 
+ * https://svelte.dev/docs#run-time-svelte-createeventdispatcher
  */
 export function createEventDispatcher<EventMap extends {} = any>(): <
 	EventKey extends Extract<keyof EventMap, string>
@@ -95,6 +104,8 @@ export function createEventDispatcher<EventMap extends {} = any>(): <
  * (including slotted content) with `getContext`.
  * 
  * Like lifecycle functions, this must be called during component initialisation. 
+ * 
+ * https://svelte.dev/docs#run-time-svelte-setcontext
  */
 export function setContext<T>(key, context: T): T {
 	get_current_component().$$.context.set(key, context);
@@ -104,6 +115,8 @@ export function setContext<T>(key, context: T): T {
 /**
  * Retrieves the context that belongs to the closest parent component with the specified `key`. 
  * Must be called during component initialisation. 
+ * 
+ * https://svelte.dev/docs#run-time-svelte-getcontext
  */
 export function getContext<T>(key): T {
 	return get_current_component().$$.context.get(key);
@@ -113,6 +126,8 @@ export function getContext<T>(key): T {
  * Retrieves the whole context map that belongs to the closest parent component. 
  * Must be called during component initialisation. Useful, for example, if you 
  * programmatically create a component and want to pass the existing context to it.
+ * 
+ * https://svelte.dev/docs#run-time-svelte-getallcontexts
  */
 export function getAllContexts<T extends Map<any, any> = Map<any, any>>(): T {
 	return get_current_component().$$.context;
@@ -121,6 +136,8 @@ export function getAllContexts<T extends Map<any, any> = Map<any, any>>(): T {
 /**
  * Checks whether a given `key` has been set in the context of a parent component. 
  * Must be called during component initialisation. 
+ * 
+ * https://svelte.dev/docs#run-time-svelte-hascontext
  */
 export function hasContext(key): boolean {
 	return get_current_component().$$.context.has(key);	

--- a/src/runtime/internal/lifecycle.ts
+++ b/src/runtime/internal/lifecycle.ts
@@ -11,18 +11,40 @@ export function get_current_component() {
 	return current_component;
 }
 
+/**
+ * Schedules a callback to run immediately before the component is updated after any state change.
+ * 
+ * The first time the callback runs will be before the initial `onMount`
+ */
 export function beforeUpdate(fn: () => any) {
 	get_current_component().$$.before_update.push(fn);
 }
 
+/**
+ * The `onMount` function schedules a callback to run as soon as the component has been mounted to the DOM. 
+ * It must be called during the component's initialisation (but doesn't need to live *inside* the component; 
+ * it can be called from an external module).
+ * 
+ * `onMount` does not run inside a [server-side component](/docs#run-time-server-side-component-api).
+ */
 export function onMount(fn: () => any) {
 	get_current_component().$$.on_mount.push(fn);
 }
 
+/**
+ * Schedules a callback to run immediately after the component has been updated.
+ * 
+ * The first time the callback runs will be after the initial `onMount` 
+ */
 export function afterUpdate(fn: () => any) {
 	get_current_component().$$.after_update.push(fn);
 }
 
+/** 
+ * Schedules a callback to run immediately before the component is unmounted.
+ * 
+ * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the only one that runs inside a server-side component.
+ */
 export function onDestroy(fn: () => any) {
 	get_current_component().$$.on_destroy.push(fn);
 }
@@ -31,6 +53,16 @@ export interface DispatchOptions {
 	cancelable?: boolean;
 }
 
+/**
+ * Creates an event dispatcher that can be used to dispatch [component events](/docs#template-syntax-component-directives-on-eventname). 
+ * Event dispatchers are functions that can take two arguments: `name` and `detail`.
+ * 
+ * Component events created with `createEventDispatcher` create a 
+ * [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent). 
+ * These events do not [bubble](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture).
+ * The `detail` argument corresponds to the [CustomEvent.detail](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail) 
+ * property and can contain any type of data. 
+ */
 export function createEventDispatcher<EventMap extends {} = any>(): <
 	EventKey extends Extract<keyof EventMap, string>
 >(
@@ -57,19 +89,39 @@ export function createEventDispatcher<EventMap extends {} = any>(): <
 	};
 }
 
+/**
+ * Associates an arbitrary `context` object with the current component and the specified `key` 
+ * and returns that object. The context is then available to children of the component 
+ * (including slotted content) with `getContext`.
+ * 
+ * Like lifecycle functions, this must be called during component initialisation. 
+ */
 export function setContext<T>(key, context: T): T {
 	get_current_component().$$.context.set(key, context);
 	return context;
 }
 
+/**
+ * Retrieves the context that belongs to the closest parent component with the specified `key`. 
+ * Must be called during component initialisation. 
+ */
 export function getContext<T>(key): T {
 	return get_current_component().$$.context.get(key);
 }
 
+/**
+ * Retrieves the whole context map that belongs to the closest parent component. 
+ * Must be called during component initialisation. Useful, for example, if you 
+ * programmatically create a component and want to pass the existing context to it.
+ */
 export function getAllContexts<T extends Map<any, any> = Map<any, any>>(): T {
 	return get_current_component().$$.context;
 }
 
+/**
+ * Checks whether a given `key` has been set in the context of a parent component. 
+ * Must be called during component initialisation. 
+ */
 export function hasContext(key): boolean {
 	return get_current_component().$$.context.has(key);	
 }


### PR DESCRIPTION
The runtime functions `onMount` etc. have no inline documentation. To improve the DX, I added inline documentation from the (website) docs. VSCode and other IDEs show an explanation of those functions directly in the IDE now. 

**Before**
<img width="431" alt="Screenshot 2022-09-09 at 12 02 15" src="https://user-images.githubusercontent.com/35429197/189325931-3ed74ce5-06b8-4485-8f3f-3d7fd703ee97.png">

**After**
<img width="667" alt="Screenshot 2022-09-09 at 12 02 05" src="https://user-images.githubusercontent.com/35429197/189326051-5ab4424a-349f-4824-9661-a603f3b41fd6.png">
