### PR TITLE
[docs] remove beta label from SvelteKit mention

### DIFF
--- a/site/content/faq/900-is-there-a-router.md
+++ b/site/content/faq/900-is-there-a-router.md
@@ -2,7 +2,7 @@
 question: Is there a router?
 ---
 
-The official routing library is [SvelteKit](https://kit.svelte.dev/), which is currently in beta. SvelteKit provides a filesystem router, server-side rendering (SSR), and hot module reloading (HMR) in one easy-to-use package. It shares similarities with Next.js for React.
+The official routing library is [SvelteKit](https://kit.svelte.dev/). SvelteKit provides a filesystem router, server-side rendering (SSR), and hot module reloading (HMR) in one easy-to-use package. It shares similarities with Next.js for React.
 
 However, you can use any router lib you want. A lot of people use [page.js](https://github.com/visionmedia/page.js). There's also [navaid](https://github.com/lukeed/navaid), which is very similar. And [universal-router](https://github.com/kriasoft/universal-router), which is isomorphic with child routes, but without built-in history support.
 


### PR DESCRIPTION
I figured we didn't need to mention the RC as it'd just be one more thing to update when we get to the final version

We should probably update the homepage as well, but that lives in the `sites` repo and would have to be a separate PR