### PR TITLE
[feat] skip custom element check if <svelte:element> uses under svg

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/index.ts
@@ -806,12 +806,14 @@ export default class ElementWrapper extends Wrapper {
 		if (this.node.is_dynamic_element) {
 			// call attribute bindings for custom element if tag is custom element
 			const tag = this.node.tag_expr.manipulate(block);
-			const attr_update = b`
-				if (/-/.test(${tag})) {
-					@set_custom_element_data_map(${this.var}, ${data});
-				} else {
-					${fn}(${this.var}, ${data});
-				}`;
+			const attr_update = this.node.namespace === namespaces.svg
+				? b`${fn}(${this.var}, ${data});`
+				: b`
+					if (/-/.test(${tag})) {
+						@set_custom_element_data_map(${this.var}, ${data});
+					} else {
+						${fn}(${this.var}, ${data});
+					}`;
 			block.chunks.hydrate.push(attr_update);
 			block.chunks.update.push(b`
 				${data} = @get_spread_update(${levels}, [${updates}]);

--- a/test/js/samples/svelte-element-svg/expected.js
+++ b/test/js/samples/svelte-element-svg/expected.js
@@ -48,8 +48,10 @@ function create_dynamic_element(ctx) {
 			append(svelte_element1, svelte_element0);
 		},
 		p(ctx, dirty) {
-			set_svg_attributes(svelte_element0, svelte_element0_data = get_spread_update(svelte_element0_levels, [{ xmlns: "http://www.w3.org/2000/svg" }]));
-			set_svg_attributes(svelte_element1, svelte_element1_data = get_spread_update(svelte_element1_levels, [{ xmlns: "http://www.w3.org/2000/svg" }]));
+			svelte_element0_data = get_spread_update(svelte_element0_levels, [{ xmlns: "http://www.w3.org/2000/svg" }]);
+			set_svg_attributes(svelte_element0, svelte_element0_data);
+			svelte_element1_data = get_spread_update(svelte_element1_levels, [{ xmlns: "http://www.w3.org/2000/svg" }]);
+			set_svg_attributes(svelte_element1, svelte_element1_data);
 		},
 		d(detaching) {
 			if (detaching) detach(svelte_element1);

--- a/test/runtime/samples/dynamic-element-svg/_config.js
+++ b/test/runtime/samples/dynamic-element-svg/_config.js
@@ -1,0 +1,10 @@
+export default {
+	html: '<svg xmlns="http://www.w3.org/2000/svg"><path xmlns="http://www.w3.org/2000/svg"></path></svg>',
+
+	test({ assert, target }) {
+		const svg = target.querySelector('svg');
+		const rect = target.querySelector('path');
+		assert.equal(svg.namespaceURI, 'http://www.w3.org/2000/svg');
+		assert.equal(rect.namespaceURI, 'http://www.w3.org/2000/svg');
+	}
+};

--- a/test/runtime/samples/dynamic-element-svg/main.svelte
+++ b/test/runtime/samples/dynamic-element-svg/main.svelte
@@ -1,0 +1,3 @@
+<svelte:element this="svg" xmlns="http://www.w3.org/2000/svg">
+    <svelte:element this="path" xmlns="http://www.w3.org/2000/svg"></svelte:element>
+</svelte:element>


### PR DESCRIPTION
And...

https://github.com/sveltejs/svelte/pull/7766 broke a test what https://github.com/sveltejs/svelte/pull/7695 added.
I think https://github.com/sveltejs/svelte/pull/7695 tests should move to runtime dir for maintainability.
So I moved it.


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
