### PR TITLE
[docs] ensure `onmouseleave` event fires in hoverable example

### DIFF
--- a/site/content/examples/15-composition/03-slot-props/App.svelte
+++ b/site/content/examples/15-composition/03-slot-props/App.svelte
@@ -43,4 +43,8 @@
 		background-color: #ff3e00;
 		color: white;
 	}
+	
+	p {
+		pointer-events: none;
+	}
 </style>


### PR DESCRIPTION
Fixes the browser-quirk-related issue described in #6520 and #7867, based on a [suggestion](https://github.com/sveltejs/svelte/issues/7867#issuecomment-1248993436) by @Prinzhorn.

Tested in the editable example area on the Svelte site: https://svelte.dev/examples/slot-props

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
