### PR TITLE
[fix] Remove likely outdated warning.

### DIFF
--- a/site/content/tutorial/06-bindings/14-component-this/text.md
+++ b/site/content/tutorial/06-bindings/14-component-this/text.md
@@ -19,5 +19,3 @@ Now we can programmatically interact with this component using `field`.
 	Focus field
 </button>
 ```
-
-> Note that we can't do `{field.focus}` since field is undefined when the button is first rendered and throws an error.


### PR DESCRIPTION
Remove the warning that:
"Replacing '() => field.focus()' with '{field.focus}' throws an error"
as it no longer does.

If 'can't do `{field.focus}`' refers to reading that value in the HTML section of the file then there are earlier tutorials where this warning should be placed.

Discussed [on the discord](https://discord.com/channels/457912077277855764/939867760492703744/1023387576415031406)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
