### PR TITLE
[docs] fix typo in getting started

### DIFF
--- a/site/content/docs/01-getting-started.md
+++ b/site/content/docs/01-getting-started.md
@@ -7,6 +7,7 @@ title: Getting started
 To try Svelte in an interactive online environment you can try [the REPL](https://svelte.dev/repl) or [StackBlitz](https://node.new/svelte).
 
 To create a project locally, run:
+
 ```
 npm create vite@latest myapp -- --template svelte
 cd myapp
@@ -16,6 +17,6 @@ npm run dev
 
 Or use [SvelteKit](https://kit.svelte.dev/), the official application framework from the Svelte team (currently in beta).
 
-See the SvelteSociety website run by the Svelte community for a list of integrations with various [tooling and editots](https://sveltesociety.dev/tools).
+The Svelte team maintains a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode) and the Svelte community has created a list of integrations with various other [tooling and editors](https://sveltesociety.dev/tools).
 
 If you're having trouble, get help on [Discord](https://svelte.dev/chat) or [StackOverflow](https://stackoverflow.com/questions/tagged/svelte).


### PR DESCRIPTION
Fix typo and tweak getting started docs.

@benmccann made this suggestion in https://github.com/sveltejs/svelte/pull/7812#discussion_r957772699, but doesn't look like it made it in.