### PR TITLE
[fix] Better handling of inert attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "svelte",
-      "version": "3.49.0",
+      "version": "3.51.0",
       "license": "MIT",
       "devDependencies": {
         "@ampproject/remapping": "^0.3.0",

--- a/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts
@@ -345,6 +345,7 @@ const attribute_lookup = {
 	formnovalidate: { property_name: 'formNoValidate', applies_to: ['button', 'input'] },
 	hidden: {},
 	indeterminate: { applies_to: ['input'] },
+	inert: {},
 	ismap: { property_name: 'isMap', applies_to: ['img'] },
 	loop: { applies_to: ['audio', 'bgsound', 'video'] },
 	multiple: { applies_to: ['input', 'select'] },


### PR DESCRIPTION
Currently the `inert` boolean attribute is not handled properly: like the `disabled` attribute it should not be set when false. But inspecting the DOM reveals it's set as `inert="false"` which is wrong for a [boolean attribute](https://html.spec.whatwg.org/#boolean-attribute)

```js
<script>
let disabled = false;
let inert = false;
</script>

<button {disabled}>click me</button>

<div {inert}>some div <button>click</button></div>

<style>
[inert] {
    opacity: 50%
}
</style>
```

I'm not too familiar with the code base so I just added the keyword to the `attribute_lookup`. Like the `hidden` attribute, `inert` can apply to [any](https://html.spec.whatwg.org/#inert-subtrees) HTMLElement. Sorry if my fix is partial, let me know how to improve it.

Also mentioned [here](https://github.com/sveltejs/svelte/issues/7500#issuecomment-1126693103)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
