### PR TITLE
[feat] pre-build before testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,40 @@ on: [push, pull_request]
 permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
+  Setup:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: npm
+      - run: npm install --ignore-scripts
+      - run: npm run build
+        env:
+          PUBLISH: true
+      - uses: actions/cache@v3
+        with:
+          # cache key based on OS as the full path for each OS may be different
+          # and windows is not able to reuse the cache from ubuntu
+          key: output-${{ github.run_id }}-${{ matrix.os }}
+          path: |
+            index.*
+            compiler.*
+            ssr.*
+            action/
+            animate/
+            easing/
+            internal/
+            motion/
+            store/
+            transition/
+            types/
   Tests:
+    needs: Setup
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -16,7 +49,22 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: npm install
+      - uses: actions/cache@v3
+        with:
+          key: output-${{ github.run_id }}-${{ matrix.os }}
+          path: |
+            index.*
+            compiler.*
+            ssr.*
+            action/
+            animate/
+            easing/
+            internal/
+            motion/
+            store/
+            transition/
+            types/
+      - run: npm install --ignore-scripts
       - run: npm test
         env:
           CI: true
@@ -40,4 +88,5 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           cache: npm
-      - run: 'npm i && npm run test:unit'
+      - run: npm install --ignore-scripts
+      - run: npm run test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - run: npm install
         env:
           SKIP_PREPARE: true
-      - run: npm test
+      - run: npm run test:integration
         env:
           CI: true
   Lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           node-version: 16
           cache: npm
-      - run: npm install --ignore-scripts
+      - run: npm install
+        env:
+          SKIP_PREPARE: true
       - run: npm run build
         env:
           PUBLISH: true
@@ -64,7 +66,9 @@ jobs:
             store/
             transition/
             types/
-      - run: npm install --ignore-scripts
+      - run: npm install
+        env:
+          SKIP_PREPARE: true
       - run: npm test
         env:
           CI: true
@@ -88,5 +92,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           cache: npm
-      - run: npm install --ignore-scripts
+      - run: npm install
+        env:
+          SKIP_PREPARE: true
       - run: npm run test:unit

--- a/.mocharc.unit.js
+++ b/.mocharc.unit.js
@@ -1,10 +1,11 @@
-const is_unit_test = process.env.UNIT_TEST;
-
 module.exports = {
-	file: is_unit_test ? [] : ['test/test.ts'],
+	spec: [
+		'src/**/__test__.ts',
+	],
 	require: [
 		'sucrase/register'
-	]
+	],
+	recursive: true,
 };
 
 // add coverage options when running 'npx c8 mocha'

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
   },
   "types": "types/runtime/index.d.ts",
   "scripts": {
-    "test": "mocha --exit",
+    "test": "npm run test:integration && npm run test:unit",
+    "test:integration": "mocha --exit",
     "test:unit": "mocha --config .mocharc.unit.js --exit",
     "quicktest": "mocha --exit",
     "build": "rollup -c && npm run tsd",

--- a/package.json
+++ b/package.json
@@ -87,14 +87,13 @@
   "types": "types/runtime/index.d.ts",
   "scripts": {
     "test": "mocha --exit",
-    "test:unit": "mocha --require sucrase/register --recursive src/**/__test__.ts --exit",
-    "quicktest": "mocha",
+    "test:unit": "mocha --config .mocharc.unit.js --exit",
+    "quicktest": "mocha --exit",
     "build": "rollup -c && npm run tsd",
     "prepare": "npm run build",
     "dev": "rollup -cw",
-    "pretest": "npm run build",
     "posttest": "agadoo internal/index.mjs",
-    "prepublishOnly": "node check_publish_env.js && npm run lint && npm test",
+    "prepublishOnly": "node check_publish_env.js && npm run lint && npm run build && npm test",
     "tsd": "node ./generate-type-definitions.js",
     "lint": "eslint \"{src,test}/**/*.{ts,js}\""
   },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "test:unit": "mocha --config .mocharc.unit.js --exit",
     "quicktest": "mocha --exit",
     "build": "rollup -c && npm run tsd",
-    "prepare": "npm run build",
+    "prepare": "node scripts/skip_in_ci.js npm run build",
     "dev": "rollup -cw",
     "posttest": "agadoo internal/index.mjs",
     "prepublishOnly": "node check_publish_env.js && npm run lint && npm run build && npm test",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "types": "types/runtime/index.d.ts",
   "scripts": {
-    "test": "npm run test:integration && npm run test:unit",
+    "test": "npm run test:unit && npm run test:integration",
     "test:integration": "mocha --exit",
     "test:unit": "mocha --config .mocharc.unit.js --exit",
     "quicktest": "mocha --exit",

--- a/scripts/skip_in_ci.js
+++ b/scripts/skip_in_ci.js
@@ -1,0 +1,7 @@
+if (process.env.SKIP_PREPARE) {
+  console.log('Skipped "prepare" script');
+} else {
+	const { execSync } = require("child_process");
+	const command = process.argv.slice(2).join(" ");
+	execSync(command, { stdio: "inherit" });
+}


### PR DESCRIPTION
- updates the CI script
  - runs a `Setup` job which prebuilds the svelte compiler before running the tests on each node version
  - specify `SKIP_PREPARE=true` in `install` commands, since we already pre-build.
    - as it will run `prepare` to build again
    - previously tried `--ignore-scripts` but that will ignore all scripts, including the `postinstall` in the dependencies, as such the browser tests failed as `puppeteer` uses `postinstall` to download the browser
- fix the `test:unit` script
  - I am assuming the script is meant to just run the unit tests, therefore it is run as a separate pipeline as the `Test` job
  - however the command also runs the `Tests`, that's because it is sharing the same `.mocharc.js`
- removes `pretest` that does `npm run build`
  - since `test` is mainly 
    - run by CI (which already pre-build)
    - run in `prepublishOnly` (which already run `npm run build`) before hand

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`