### PR TITLE
[fix] duplicate meta tags during hydration

### DIFF
--- a/src/compiler/compile/render_ssr/handlers/Head.ts
+++ b/src/compiler/compile/render_ssr/handlers/Head.ts
@@ -1,6 +1,7 @@
 import Renderer, { RenderOptions } from '../Renderer';
 import Head from '../../nodes/Head';
 import { x } from 'code-red';
+import { Node } from 'estree';
 
 export default function(node: Head, renderer: Renderer, options: RenderOptions) {
 	const head_options = {
@@ -11,6 +12,12 @@ export default function(node: Head, renderer: Renderer, options: RenderOptions) 
 	renderer.push();
 	renderer.render(node.children, head_options);
 	const result = renderer.pop();
+	let expression: Node = result;
+	if (options.hydratable) {
+		const start_comment = `HEAD_${node.id}_START`;
+		const end_comment = `HEAD_${node.id}_END`;
+		expression = x`'<!-- ${start_comment} -->' + ${expression} + '<!-- ${end_comment} -->'`;
+	}
 
-	renderer.add_expression(x`$$result.head += '<!-- HEAD_${node.id}_START -->' + ${result} + '<!-- HEAD_${node.id}_END -->', ""`);
+	renderer.add_expression(x`$$result.head += ${expression}, ""`);
 }

--- a/test/server-side-rendering/index.ts
+++ b/test/server-side-rendering/index.ts
@@ -117,7 +117,9 @@ describe('ssr', () => {
 					fs.writeFileSync(`${dir}/_actual-head.html`, head);
 
 					try {
-						assert.htmlEqual(
+						(compileOptions.hydratable
+							? assert.htmlEqualWithComments
+							: assert.htmlEqual)(
 							head,
 							fs.readFileSync(`${dir}/_expected-head.html`, 'utf-8')
 						);

--- a/test/server-side-rendering/samples/head-meta-hydrate-duplicate/_config.js
+++ b/test/server-side-rendering/samples/head-meta-hydrate-duplicate/_config.js
@@ -1,5 +1,6 @@
 export default {
 	compileOptions: {
 		hydratable: true
-	}
+	},
+	withoutNormalizeHtml: true
 };


### PR DESCRIPTION
In the server-side-rendering test, we did not assert compare for the comments
so even though the generated comments looks different, the test didnt fail.

the bug arises when using 

```js
x`'foo_${variable}_something'`
```

the generated code dropped what comes after `${variable}`.

leading to

```js
x`'foo_xxx'
```

this is obviously a code-red bug, but this PR is a temporary workaround the issue

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
