### PR TITLE
docs: fix CSS pseudo-class in 06-dom-event-forwarding

### DIFF
--- a/site/content/tutorial/05-events/06-dom-event-forwarding/app-a/CustomButton.svelte
+++ b/site/content/tutorial/05-events/06-dom-event-forwarding/app-a/CustomButton.svelte
@@ -15,7 +15,7 @@
 		background: #CBD5E1;
 		color: #475569;
 	}
-	button:focus {
+	button:active {
 		background: #94A3B8;
 		color: #F1F5F9;
 	}

--- a/site/content/tutorial/05-events/06-dom-event-forwarding/app-b/CustomButton.svelte
+++ b/site/content/tutorial/05-events/06-dom-event-forwarding/app-b/CustomButton.svelte
@@ -15,7 +15,7 @@
 		background: #CBD5E1;
 		color: #475569;
 	}
-	button:focus {
+	button:active {
 		background: #94A3B8;
 		color: #F1F5F9;
 	}


### PR DESCRIPTION
Changed CSS pseudo-class of CustomButton from "focus" to "active" to promote desired behavior on click.

# The issue

CustomButton component had a CSS selector for a pseudo-class of "focus", meaning the button would still look like it was actively being clicked on even after the user stopped holding the mouse button (and therefore looked like it was in an active state, even though that was not the case). The replacement "active" pseudo-class eliminates this issue, because it only activates when (in this context) the user click the button.