### PR TITLE
[fix] onDestroy runs after the component is detached from DOM

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -542,9 +542,15 @@ export default class InlineComponentWrapper extends Wrapper {
 				`);
 			}
 
-			block.chunks.destroy.push(b`
-				@destroy_component(${name}, ${parent_node ? null : 'detaching'});
-			`);
+			if (parent_node) {
+				block.chunks.destroy.unshift(b`
+					@destroy_component(${name}, detaching);
+				`);
+			} else {
+				block.chunks.destroy.push(b`
+					@destroy_component(${name}, ${parent_node ? null : 'detaching'});
+				`);
+			}
 
 			block.chunks.outro.push(
 				b`@transition_out(${name}.$$.fragment, #local);`

--- a/test/runtime/samples/component-detach-destroy/CustomComponent.svelte
+++ b/test/runtime/samples/component-detach-destroy/CustomComponent.svelte
@@ -1,0 +1,10 @@
+<script>
+  import { onDestroy } from "svelte"
+  onDestroy(() => {
+		const el = document.querySelector('#show')
+		console.log(`Element exist ${!!el}`)
+    console.log("Custom component destroyed.")
+  })
+</script>
+
+<p>Hello</p>

--- a/test/runtime/samples/component-detach-destroy/_config.js
+++ b/test/runtime/samples/component-detach-destroy/_config.js
@@ -1,0 +1,27 @@
+let log;
+export default {
+	html: `
+	<button>Show/Hide</button><div id="show"><p>Hello</p></div>
+	`,
+
+	before_test() {
+		log = console.log;
+	},
+	after_test() {
+		console.log = log;
+	},
+
+	async test({ assert, target, window }) {
+		const button = target.querySelector('button');
+		const event = new window.MouseEvent('click');
+		const messages = [];
+		console.log = msg => messages.push(msg);
+		await button.dispatchEvent(event);
+		//This means element gets removed
+		assert.htmlEqual(target.innerHTML, `
+			<button>Show/Hide</button>
+		`);
+		//This means element existed on Destroy gets called
+		assert.deepEqual(messages, ['Element exist true', 'Custom component destroyed.']);
+	}
+};

--- a/test/runtime/samples/component-detach-destroy/main.svelte
+++ b/test/runtime/samples/component-detach-destroy/main.svelte
@@ -1,0 +1,16 @@
+<script>
+  import CustomComponent from './CustomComponent.svelte'
+	let div;
+  let show = true
+</script>
+
+<button on:click={() => {
+	show = !show
+}}>Show/Hide</button>
+
+{#if show}
+  <div id="show">
+    <CustomComponent />
+  </div>
+{/if}
+


### PR DESCRIPTION
Fix: #7888 
The idea is if there is a parent node instead of push, append an item to the first, and in the case of nested components, the last child will be at the first index.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
