### PR TITLE
[docs] fix warning in examples-09-transitions-06-deferred-transitions 

### DIFF
--- a/site/content/examples/09-transitions/06-deferred-transitions/App.svelte
+++ b/site/content/examples/09-transitions/06-deferred-transitions/App.svelte
@@ -56,8 +56,8 @@
 					>
 
 					<p class='credit'>
-						<a target="_blank" href="https://www.flickr.com/photos/{d.path}">via Flickr</a> &ndash;
-						<a target="_blank" href={d.license.url}>{d.license.name}</a>
+						<a target="_blank" rel="noreferrer" href="https://www.flickr.com/photos/{d.path}">via Flickr</a> &ndash;
+						<a target="_blank" rel="noreferrer" href={d.license.url}>{d.license.name}</a>
 					</p>
 				</div>
 			{/await}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

The following error is displayed upon running the [deferred-transitions example](https://svelte.dev/examples/deferred-transitions)

```
Security: Anchor with "target=_blank" should have rel attribute containing the value "noreferrer" (59:6)
```
![image](https://user-images.githubusercontent.com/84540554/198192218-37e33341-66e8-44e4-9bc9-f5f71f188835.png)

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
