### PR TITLE
[fix] don't run binding init unnecessarily

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -393,7 +393,7 @@ export default class InlineComponentWrapper extends Wrapper {
 
 			component.partly_hoisted.push(body);
 
-			return b`@binding_callbacks.push(() => @bind(${this.var}, '${binding.name}', ${id}));`;
+			return b`@binding_callbacks.push(() => @bind(${this.var}, '${binding.name}', ${id}, ${snippet}));`;
 		});
 
 		const munged_handlers = this.node.handlers.map(handler => {

--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -5,11 +5,13 @@ import { children, detach, start_hydrating, end_hydrating } from './dom';
 import { transition_in } from './transitions';
 import { T$$ } from './types';
 
-export function bind(component, name, callback) {
+export function bind(component, name, callback, value) {
 	const index = component.$$.props[name];
 	if (index !== undefined) {
 		component.$$.bound[index] = callback;
-		callback(component.$$.ctx[index]);
+		if (value === undefined) {
+			callback(component.$$.ctx[index]);
+		}
 	}
 }
 

--- a/test/runtime/samples/binding-no-unnecessary-invalidation/Tab.svelte
+++ b/test/runtime/samples/binding-no-unnecessary-invalidation/Tab.svelte
@@ -1,0 +1,3 @@
+<script>
+	export let tab;
+</script>

--- a/test/runtime/samples/binding-no-unnecessary-invalidation/_config.js
+++ b/test/runtime/samples/binding-no-unnecessary-invalidation/_config.js
@@ -1,0 +1,7 @@
+export default {
+	async test({ assert, target }) {
+		assert.htmlEqual(target.innerHTML, `
+			<p>0</p>
+		`);
+	}
+};

--- a/test/runtime/samples/binding-no-unnecessary-invalidation/main.svelte
+++ b/test/runtime/samples/binding-no-unnecessary-invalidation/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { writable } from "svelte/store";
+	import Tab from "./Tab.svelte";
+
+	let i = 0;
+	const { set, subscribe } = writable({ id: 1, name: "tab1" });
+	const tab = {
+		set(value) {
+			i++;
+			set(value);
+		},
+		subscribe,
+	};
+</script>
+
+<Tab bind:tab={$tab} />
+<p>{i}</p>


### PR DESCRIPTION
Fixes part of #7032
Fixes #6298

I'm honestly not sure how this didn't cause a "variable defined in parent component gets set to undefined by child" bug previously - does this hint at a deeper problem?

While testing I noticed another infinite loop, which happens when I add `<div bind:this={row.div}>foo</div>` to the each loop in [this reproducible](https://svelte.dev/repl/86b8b83f2e2b475e8e92aaa4df9c7da2?version=3.44.3). The problem is the bind this binding invalidating the component, causing another flush, causing another each-loop traversal, causing another binding invalidation, etc. I don't know how to fix this right now so I left that out.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
