### PR TITLE
[docs] Tutorial easing equations reference

### DIFF
--- a/site/content/tutorial/09-motion/01-tweened/text.md
+++ b/site/content/tutorial/09-motion/01-tweened/text.md
@@ -28,7 +28,7 @@ Clicking the buttons causes the progress bar to animate to its new value. It's a
 </script>
 ```
 
-> The `svelte/easing` module contains the [Penner easing equations](https://web.archive.org/web/20190805215728/http://robertpenner.com/easing/), or you can supply your own `p => t` function where `p` and `t` are both values between 0 and 1.
+> The `svelte/easing` module contains [easing functions](https://svelte.dev/docs#run-time-svelte-easing) for you to use, or you can supply your own `p => t` function where `p` and `t` are both values between 0 and 1.
 
 The full set of options available to `tweened`:
 


### PR DESCRIPTION
I changed the link because the previous one is a reference to a page that no longer exists. Use Svelte documentation seems better to me