### PR TITLE
[docs] fix security warning in tutorial section Logic / Each blocks

### DIFF
--- a/site/content/tutorial/04-logic/04-each-blocks/app-a/App.svelte
+++ b/site/content/tutorial/04-logic/04-each-blocks/app-a/App.svelte
@@ -10,7 +10,7 @@
 
 <ul>
 	<!-- open each block -->
-		<li><a target="_blank" href="https://www.youtube.com/watch?v={cat.id}">
+		<li><a target="_blank" href="https://www.youtube.com/watch?v={cat.id}" rel="noreferrer">
 			{cat.name}
 		</a></li>
 	<!-- close each block -->

--- a/site/content/tutorial/04-logic/04-each-blocks/app-b/App.svelte
+++ b/site/content/tutorial/04-logic/04-each-blocks/app-b/App.svelte
@@ -10,7 +10,7 @@
 
 <ul>
 	{#each cats as { id, name }, i}
-		<li><a target="_blank" href="https://www.youtube.com/watch?v={id}">
+		<li><a target="_blank" href="https://www.youtube.com/watch?v={id}" rel="noreferrer">
 			{i + 1}: {name}
 		</a></li>
 	{/each}

--- a/site/content/tutorial/04-logic/04-each-blocks/text.md
+++ b/site/content/tutorial/04-logic/04-each-blocks/text.md
@@ -7,7 +7,7 @@ If you need to loop over lists of data, use an `each` block:
 ```html
 <ul>
 	{#each cats as cat}
-		<li><a target="_blank" href="https://www.youtube.com/watch?v={cat.id}">
+		<li><a target="_blank" href="https://www.youtube.com/watch?v={cat.id}" rel="noreferrer">
 			{cat.name}
 		</a></li>
 	{/each}
@@ -20,7 +20,7 @@ You can get the current *index* as a second argument, like so:
 
 ```html
 {#each cats as cat, i}
-	<li><a target="_blank" href="https://www.youtube.com/watch?v={cat.id}">
+	<li><a target="_blank" href="https://www.youtube.com/watch?v={cat.id}" rel="noreferrer">
 		{i + 1}: {cat.name}
 	</a></li>
 {/each}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

In the tutorial section "Logic / Each block" there is a warning in the editor: 
`Security: Anchor with "target=_blank" should have rel attribute containing the value "noreferrer" (13:6)`

[Affected page](https://svelte.dev/tutorial/each-blocks)

[REPL showing the fix](https://svelte.dev/repl/3c455d029068488aabcc307c2e7d261d?version=3.52.0)
