### PR TITLE
[fix] only read static value for rel attribute validation

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -620,8 +620,8 @@ export default class Element extends Node {
 
 				if (href_static_value === null || href_static_value.match(/^(https?:)?\/\//i)) {
 					const rel = attribute_map.get('rel');
-					if (rel?.is_static) {
-						const rel_values = rel.get_static_value().split(' ');
+					if (rel == null || rel.is_static) {
+						const rel_values = rel ? rel.get_static_value().split(' ') : [];
 						const expected_values = ['noreferrer'];
 						expected_values.forEach(expected_value => {
 							if (!rel || rel && rel_values.indexOf(expected_value) < 0) {

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -620,7 +620,7 @@ export default class Element extends Node {
 
 				if (href_static_value === null || href_static_value.match(/^(https?:)?\/\//i)) {
 					const rel = attribute_map.get('rel');
-					const rel_values = rel ? rel.get_static_value().split(' ') : [];
+					const rel_values = rel?.is_static ? rel.get_static_value().split(' ') : [];
 					const expected_values = ['noreferrer'];
 
 					expected_values.forEach(expected_value => {

--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -620,17 +620,18 @@ export default class Element extends Node {
 
 				if (href_static_value === null || href_static_value.match(/^(https?:)?\/\//i)) {
 					const rel = attribute_map.get('rel');
-					const rel_values = rel?.is_static ? rel.get_static_value().split(' ') : [];
-					const expected_values = ['noreferrer'];
-
-					expected_values.forEach(expected_value => {
-						if (!rel || rel && rel_values.indexOf(expected_value) < 0) {
-							component.warn(this, {
-								code: `security-anchor-rel-${expected_value}`,
-								message: `Security: Anchor with "target=_blank" should have rel attribute containing the value "${expected_value}"`
-							});
-						}
-					});
+					if (rel?.is_static) {
+						const rel_values = rel.get_static_value().split(' ');
+						const expected_values = ['noreferrer'];
+						expected_values.forEach(expected_value => {
+							if (!rel || rel && rel_values.indexOf(expected_value) < 0) {
+								component.warn(this, {
+									code: `security-anchor-rel-${expected_value}`,
+									message: `Security: Anchor with "target=_blank" should have rel attribute containing the value "${expected_value}"`
+								});
+							}
+						});
+					}
 				}
 			}
 

--- a/test/validator/samples/security-anchor-rel-noreferrer/input.svelte
+++ b/test/validator/samples/security-anchor-rel-noreferrer/input.svelte
@@ -29,3 +29,5 @@
 <a href="HTTPS://svelte.dev" target="_blank" rel="noreferrer noopener">svelte website (valid)</a>
 <a href="//svelte.dev" target="_blank" rel="noreferrer">svelte website (valid)</a>
 <a href="//svelte.dev" target="_blank" rel="noreferrer noopener">svelte website (valid)</a>
+<!-- dynamic rel value should not warn-->
+<a href="//svelte.dev" target="_blank" rel={`${Math.random()}`}>svelte website (valid)</a>


### PR DESCRIPTION
fixes #7994 

~~this always logs the warning for dynamic rel values, if that includes noreferrer, users have to disable the warning with a comment or onwarn handler~~

Alternative would be to only log for static values but that leaves some users unaware if they don't have it in their dynamic value.

edit: switched to warning for static only, see below.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
