### PR TITLE
[fix] util polyfill to make compiler self-contained

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,8 @@
         "sourcemap-codec": "^1.4.8",
         "tiny-glob": "^0.2.9",
         "tslib": "^2.4.0",
-        "typescript": "^3.7.5"
+        "typescript": "^3.7.5",
+        "util": "^0.12.5"
       },
       "engines": {
         "node": ">= 8"
@@ -3070,6 +3071,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4933,6 +4949,19 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -7565,6 +7594,15 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -9022,6 +9060,19 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "periscopic": "^3.0.4",
     "puppeteer": "^2.0.0",
     "rollup": "^1.27.14",
+    "util": "^0.12.5",
     "source-map": "^0.7.4",
     "source-map-support": "^0.5.21",
     "sourcemap-codec": "^1.4.8",

--- a/package.json
+++ b/package.json
@@ -148,12 +148,12 @@
     "periscopic": "^3.0.4",
     "puppeteer": "^2.0.0",
     "rollup": "^1.27.14",
-    "util": "^0.12.5",
     "source-map": "^0.7.4",
     "source-map-support": "^0.5.21",
     "sourcemap-codec": "^1.4.8",
     "tiny-glob": "^0.2.9",
     "tslib": "^2.4.1",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "util": "^0.12.5"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -108,8 +108,18 @@ export default [
 		input: 'src/compiler/index.ts',
 		plugins: [
 			replace({
-				__VERSION__: pkg.version
+				__VERSION__: pkg.version,
+				'process.env.NODE_DEBUG': false // appears inside the util package
 			}),
+			{
+				resolveId(id) {
+					// util is a built-in module in Node.js, but we want a self-contained compiler bundle
+					// that also works in the browser, so we load its polyfill instead
+					if (id === 'util') {
+						return require.resolve('./node_modules/util'); // just 'utils' would resolve this to the built-in module
+					}
+				}
+			},
 			resolve(),
 			commonjs({
 				include: ['node_modules/**']


### PR DESCRIPTION
this is needed for running the Svelte compiler in the browser again. Some package requires the builtin 'node' package which isn't bundled but also not available in the browser, so the REPL is broken. This slipped in through some dependency bump I guess.
Fixes #8010

I decided against using `rollup-plugin-node-builtins` because that one's quite outdated and ships a bunch of stuff we don't need

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
