### PR TITLE
[fix] More correct syntax

### DIFF
--- a/site/content/tutorial/05-events/04-component-events/app-b/App.svelte
+++ b/site/content/tutorial/05-events/04-component-events/app-b/App.svelte
@@ -2,7 +2,7 @@
 	import Inner from './Inner.svelte';
 
 	function handleMessage(event) {
-		alert(event.detail.text);
+		alert(event.target.text);
 	}
 </script>
 


### PR DESCRIPTION
Corrected some code in Events chapter for people who using typescript

More correct and relevant syntax, so people don't confuse it with event.target (which is basically same as event.detail) when using TypeScript