### PR TITLE
[fix] Update A11y no noninteractive element with positive tabindex warning to ignore tabpanel role.

### DIFF
--- a/src/compiler/compile/utils/a11y.ts
+++ b/src/compiler/compile/utils/a11y.ts
@@ -43,7 +43,9 @@ const interactive_roles = new Set(
 		.concat(
 			// 'toolbar' does not descend from widget, but it does support
 			// aria-activedescendant, thus in practice we treat it as a widget.
-			'toolbar'
+			'toolbar',
+			//focusable tabpanel elements are recommended if any panels in a set contain content where the first element in the panel is not focusable.
+			'tabpanel'
 		)
 );
 

--- a/src/compiler/compile/utils/a11y.ts
+++ b/src/compiler/compile/utils/a11y.ts
@@ -7,17 +7,17 @@ import {
 import { AXObjects, AXObjectRoles, elementAXObjects } from 'axobject-query';
 import Attribute from '../nodes/Attribute';
 
-const roles = [...roles_map.keys()];
+const non_abstract_roles = [...roles_map.keys()].filter((name) => !roles_map.get(name).abstract);
 
 const non_interactive_roles = new Set(
-	roles
+	non_abstract_roles
 		.filter((name) => {
 			const role = roles_map.get(name);
 			return (
-				!roles_map.get(name).abstract &&
 				// 'toolbar' does not descend from widget, but it does support
 				// aria-activedescendant, thus in practice we treat it as a widget.
-				name !== 'toolbar' &&
+				// focusable tabpanel elements are recommended if any panels in a set contain content where the first element in the panel is not focusable.
+				!['toolbar', 'tabpanel'].includes(name) &&
 				!role.superClass.some((classes) => classes.includes('widget'))
 			);
 		})
@@ -29,24 +29,7 @@ const non_interactive_roles = new Set(
 );
 
 const interactive_roles = new Set(
-	roles
-		.filter((name) => {
-			const role = roles_map.get(name);
-			return (
-				!role.abstract &&
-				// The `progressbar` is descended from `widget`, but in practice, its
-				// value is always `readonly`, so we treat it as a non-interactive role.
-				name !== 'progressbar' &&
-				role.superClass.some((classes) => classes.includes('widget'))
-			);
-		})
-		.concat(
-			// 'toolbar' does not descend from widget, but it does support
-			// aria-activedescendant, thus in practice we treat it as a widget.
-			'toolbar',
-			//focusable tabpanel elements are recommended if any panels in a set contain content where the first element in the panel is not focusable.
-			'tabpanel'
-		)
+	non_abstract_roles.filter((name) => !non_interactive_roles.has(name))
 );
 
 export function is_non_interactive_roles(role: ARIARoleDefintionKey) {

--- a/test/validator/samples/a11y-no-nointeractive-tabindex/input.svelte
+++ b/test/validator/samples/a11y-no-nointeractive-tabindex/input.svelte
@@ -7,8 +7,11 @@
 <div role='button' tabindex='0' />
 <div role='article' tabindex='-1' />
 <article tabindex='-1' />
+<div role="tabpanel" tabindex='0' />
 <!-- invalid -->
 <div tabindex='0' />
 <div role='article' tabindex='0' />
 <article tabindex='0' />
 <article tabindex='{0}' />
+
+

--- a/test/validator/samples/a11y-no-nointeractive-tabindex/input.svelte
+++ b/test/validator/samples/a11y-no-nointeractive-tabindex/input.svelte
@@ -13,5 +13,3 @@
 <div role='article' tabindex='0' />
 <article tabindex='0' />
 <article tabindex='{0}' />
-
-

--- a/test/validator/samples/a11y-no-nointeractive-tabindex/warnings.json
+++ b/test/validator/samples/a11y-no-nointeractive-tabindex/warnings.json
@@ -2,44 +2,29 @@
 	{
 		"code": "a11y-no-noninteractive-tabindex",
 		"end": {
-			"character": 241,
-			"column": 20,
-			"line": 11
-		},
-		"message": "A11y: noninteractive element cannot have positive tabIndex value",
-		"pos": 221,
-		"start": {
-			"character": 221,
-			"column": 0,
-			"line": 11
-		}
-	},
-	{
-		"code": "a11y-no-noninteractive-tabindex",
-		"end": {
-			"character": 277,
-			"column": 35,
-			"line": 12
-		},
-		"message": "A11y: noninteractive element cannot have positive tabIndex value",
-		"pos": 242,
-		"start": {
-			"character": 242,
-			"column": 0,
-			"line": 12
-		}
-	},
-	{
-		"code": "a11y-no-noninteractive-tabindex",
-		"end": {
-			"character": 302,
-			"column": 24,
-			"line": 13
-		},
-		"message": "A11y: noninteractive element cannot have positive tabIndex value",
-		"pos": 278,
-		"start": {
 			"character": 278,
+			"column": 20,
+			"line": 12
+		},
+		"message": "A11y: noninteractive element cannot have positive tabIndex value",
+		"pos": 258,
+		"start": {
+			"character": 258,
+			"column": 0,
+			"line": 12
+		}
+	},
+	{
+		"code": "a11y-no-noninteractive-tabindex",
+		"end": {
+			"character": 314,
+			"column": 35,
+			"line": 13
+		},
+		"message": "A11y: noninteractive element cannot have positive tabIndex value",
+		"pos": 279,
+		"start": {
+			"character": 279,
 			"column": 0,
 			"line": 13
 		}
@@ -47,16 +32,31 @@
 	{
 		"code": "a11y-no-noninteractive-tabindex",
 		"end": {
-			"character": 329,
-			"column": 26,
+			"character": 339,
+			"column": 24,
 			"line": 14
 		},
 		"message": "A11y: noninteractive element cannot have positive tabIndex value",
-		"pos": 303,
+		"pos": 315,
 		"start": {
-			"character": 303,
+			"character": 315,
 			"column": 0,
 			"line": 14
+		}
+	},
+	{
+		"code": "a11y-no-noninteractive-tabindex",
+		"end": {
+			"character": 366,
+			"column": 26,
+			"line": 15
+		},
+		"message": "A11y: noninteractive element cannot have positive tabIndex value",
+		"pos": 340,
+		"start": {
+			"character": 340,
+			"column": 0,
+			"line": 15
 		}
 	}
 ]


### PR DESCRIPTION
## Description
[This comment](https://github.com/sveltejs/svelte/pull/6693#issuecomment-1277580534) on the original PR for the feature explains the issue. Elements with the role `tabpanel` are a special exception to the rule of noninteractive elements having a positive tab index. It is recommended that tab panels have a positive tabindex when their first element is not focusable. 

- [Link to relevant section in Aria docs](https://w3c.github.io/aria-practices/#keyboard-interaction-21)
- [This Example](https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-automatic) in the Aria Authoring guides also recommends allowing a positive tabindex for tab panels. 

Adding this will get rid of annoying error for people who are trying to implement accessible tab panels in their code.

### Tests
- Updated the unit test for this rule to check for tabpanel role also. Tested with the script and it passed.
