### PR TITLE
[docs] Update 03-template-syntax.md - on:click on:click emits twice to parents - explanation

### DIFF
--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -572,6 +572,13 @@ It's possible to have multiple event listeners for the same event:
 <button on:click={increment} on:click={track}>Click me!</button>
 ```
 
+But also this is possible:
+```sv
+<button on:click on:click>
+	This component  will emit the click event TWICE to its parent!!
+</button>
+```
+
 #### bind:*property*
 
 ```sv


### PR DESCRIPTION
Added explanation on double event handlers that propagate to the parent. To make sure the developer understands the true power of adding multiple handlers. (and I have been in a situation forgetting about this, which took me a while to figure out).

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
