### PR TITLE
feat: add optional `compiler-ignore` attribute to `<slot>`

### DIFF
--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1609,6 +1609,14 @@ Named slots can also expose values. The `let:` directive goes on the element wit
 </FancyList>
 ```
 
+---
+
+Svelte can also instructed to ignore a `<slot>` element and treat it in a semantically generic way so that that `<slot>` can retain its default behavior as an HTML Element.
+This is useful if you are rendering your Svelte application to a `shadowRoot` and you wish to have slotted content come from the light DOM outside of the Svelte application
+
+```sv
+<slot name="some-slot" compiler-ignore></slot>
+```
 
 ### `<svelte:self>`
 

--- a/src/compiler/compile/nodes/shared/map_children.ts
+++ b/src/compiler/compile/nodes/shared/map_children.ts
@@ -47,11 +47,22 @@ function get_constructor(type) {
 	}
 }
 
+function should_treat_as_element(child: TemplateNode) {
+	switch (child.type) {
+		case 'Slot':
+			return child.attributes.some((attr) => attr.name === 'compiler-ignore' && attr.value);
+		default: return false;
+	}
+}
+
 export default function map_children(component, parent, scope, children: TemplateNode[]) {
 	let last = null;
 	let ignores = [];
 
-	return children.map(child => {
+	return children.map(child => {		
+		if (should_treat_as_element(child)) {
+			child.type = 'Element';
+		}
 		const constructor = get_constructor(child.type);
 
 		const use_ignores = child.type !== 'Text' && child.type !== 'Comment' && ignores.length;

--- a/test/runtime/samples/$$slot/A.svelte
+++ b/test/runtime/samples/$$slot/A.svelte
@@ -29,3 +29,5 @@ $$slots: {toString($$slots)}
 {:else}
 	Slot b is not available
 {/if}
+
+<slot compiler-ignore name="c"></slot>

--- a/test/runtime/samples/$$slot/_config.js
+++ b/test/runtime/samples/$$slot/_config.js
@@ -4,11 +4,13 @@ export default {
 		<span slot="a">hello world</span>
 		$$slots: {"a":true,"default":true}
 		Slot b is not available
+		<slot compiler-ignore name="c"></slot>
 
 		<span>bye world</span>
 		<span slot="a">hello world</span>
 		$$slots: {"a":true,"b":true,"default":true}
 		<div><span slot="b">hello world</span></div>
+		<slot compiler-ignore name="c"></slot>
 	`,
 
 	async test({ assert, component }) {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

### Reason for existence
Closes #8056.
This PR adds an ability to tell Svelte to not compile a `<slot>` into a `Slot` so that a developer using Svelte can optionally choose to use a `<slot>` with behavioral characteristics as defined in the Web Component spec.
Changes are non-breaking, and test execution should reflect that.
Docs have also been updated.

#### A note on implementation design
There seemed to be a number of places where the `compiler-ignore` Attribute could have been evaluated and operated upon (e.g. during parsing).
To me, it seemed best to do so during compilation, immediately before the selection of the `constructor`, through which a given Node would get compiled.

