### PR TITLE
[docs] Show recommended method to use TypeScript

### DIFF
--- a/site/content/blog/2020-07-17-svelte-and-typescript.md
+++ b/site/content/blog/2020-07-17-svelte-and-typescript.md
@@ -5,6 +5,9 @@ author: Orta Therox
 authorURL: https://twitter.com/orta
 ---
 
+*This blog post is outdated. The recommended way to create a Svelte project with TypeScript is using [Vite](https://vitejs.dev). 
+Run `npm create vite@latest myapp -- --template svelte-ts` for Vite to scaffold a project.*
+
 It's been by far the most requested feature for a while, and it's finally here: Svelte officially supports TypeScript.
 
 We think it'll give you a much nicer development experience — one that also scales beautifully to larger Svelte code bases — regardless of whether you use TypeScript or JavaScript.


### PR DESCRIPTION
### Problem
When searching "svelte typescript" on a search engine (tested on Google/DuckDuckGo/Bing), the first result is [this svelte blog post](https://svelte.dev/blog/svelte-and-typescript). The post is slightly outdated as the best way to scaffold a TypeScript Svelte project now is using ViteJS. 

### Solution 
This PR adds a note at the top of the post stating that it is outdated and suggests the recommend method to create a project.

---

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
