### PR TITLE
[docs] fix inconsistent margin in svelte/motion spring tutorial

### DIFF
--- a/site/content/tutorial/09-motion/02-spring/app-b/App.svelte
+++ b/site/content/tutorial/09-motion/02-spring/app-b/App.svelte
@@ -33,6 +33,7 @@
 	svg {
 		width: 100%;
 		height: 100%;
+		margin: -8px;
 	}
 	circle {
 		fill: #ff3e00;


### PR DESCRIPTION
This fixes an inconsistency I found in the svelte/motion spring tutorial where app-a has `margin: -8px` on the svg but app-b doesn't.