### PR TITLE
[fix] Fix bug with transition draw when delay is passed

### DIFF
--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -198,7 +198,10 @@ export function draw(node: SVGElement & { getTotalLength(): number }, {
 		delay,
 		duration,
 		easing,
-		css: (t, u) => `stroke-dasharray: ${t * len} ${u * len}`
+		css: (t, u) => `
+			stroke-dasharray: ${len};
+			stroke-dashoffset: ${u * len};
+		`
 	};
 }
 


### PR DESCRIPTION
Signed-off-by: Gus Wezerek <gustav.wezerek@nytimes.com>

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`

closes [#6816](https://github.com/sveltejs/svelte/issues/6816):

**Describe the bug**
When the stroke-linecap is set to something other than "butt," a small dot is visible at the beginning of a path. This is only visible when applying a delay to the transition. This can be a problem if you have multiple paths and want them to be displayed one after the other.

**Proposed solution**
(tested locally) The transition could instead rely on stroke-dashoffset.

Reproduction
https://svelte.dev/repl/5b62eb46687d4e219b970b38154705fa