### PR TITLE
fix: empty value attribute selector doesn't produce "Unused CSS selector" warning

### DIFF
--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -350,7 +350,7 @@ function attribute_matches(node: CssNode, name: string, expected_value: string, 
 	const attr = node.attributes.find((attr: CssNode) => attr.name === name);
 	if (!attr) return false;
 	if (attr.is_true) return operator === null;
-	if (expected_value === null) return true;
+	if (expected_value == null) return true;
 
 	if (attr.chunks.length === 1) {
 		const value = attr.chunks[0];

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -350,7 +350,7 @@ function attribute_matches(node: CssNode, name: string, expected_value: string, 
 	const attr = node.attributes.find((attr: CssNode) => attr.name === name);
 	if (!attr) return false;
 	if (attr.is_true) return operator === null;
-	if (!expected_value) return true;
+	if (expected_value === null) return true;
 
 	if (attr.chunks.length === 1) {
 		const value = attr.chunks[0];

--- a/test/css/samples/unused-selector-empty-attribute/_config.js
+++ b/test/css/samples/unused-selector-empty-attribute/_config.js
@@ -1,0 +1,25 @@
+export default {
+	warnings: [{
+		filename: 'SvelteComponent.svelte',
+		code: 'css-unused-selector',
+		message: 'Unused CSS selector "img[alt=""]"',
+		start: {
+			character: 87,
+			column: 1,
+			line: 8
+		  },
+		end: {
+			character: 98,
+			column: 12,
+			line: 8
+		  },
+		pos: 87,
+		frame: `
+			 6:   }
+			 7:
+			 8:   img[alt=""] {
+			      ^
+			 9:     border: 1px solid red;
+			10:   }`
+	}]
+};

--- a/test/css/samples/unused-selector-empty-attribute/expected.css
+++ b/test/css/samples/unused-selector-empty-attribute/expected.css
@@ -1,0 +1,1 @@
+img[alt].svelte-xyz{border:1px solid green}

--- a/test/css/samples/unused-selector-empty-attribute/expected.html
+++ b/test/css/samples/unused-selector-empty-attribute/expected.html
@@ -1,0 +1,1 @@
+<img alt="a foo" class="svelte-xyz" src="foo.jpg">

--- a/test/css/samples/unused-selector-empty-attribute/input.svelte
+++ b/test/css/samples/unused-selector-empty-attribute/input.svelte
@@ -1,0 +1,11 @@
+<img src="foo.jpg" alt="a foo" />
+
+<style>
+	img[alt] {
+		border: 1px solid green;
+	}
+
+	img[alt=""] {
+		border: 1px solid red;
+	}
+</style>


### PR DESCRIPTION
Long time user, first time contributor

The following code doesn't report a "Unused CSS selector" warning:
```svelte
<img src="foo.jpg" alt="a foo" />

<style>
  img[alt=""] {
    border: 1px solid red;
  }
</style>
```

Fixes: https://github.com/sveltejs/svelte/issues/8042

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`
