### PR TITLE
[fix] say "nonnegative" instead of "positive" tabIndex

### DIFF
--- a/site/content/docs/06-accessibility-warnings.md
+++ b/site/content/docs/06-accessibility-warnings.md
@@ -268,7 +268,7 @@ Some HTML elements have default ARIA roles. Giving these elements an ARIA role t
 Tab key navigation should be limited to elements on the page that can be interacted with.
 
 ```sv
-<!-- A11y: noninteractive element cannot have positive tabIndex value -->
+<!-- A11y: noninteractive element cannot have nonnegative tabIndex value -->
 <div tabindex='0' />
 ```
 

--- a/src/compiler/compile/compiler_warnings.ts
+++ b/src/compiler/compile/compiler_warnings.ts
@@ -185,7 +185,7 @@ export default {
 	}),
 	a11y_no_noninteractive_tabindex: {
 		code: 'a11y-no-noninteractive-tabindex',
-		message: 'A11y: noninteractive element cannot have positive tabIndex value'
+		message: 'A11y: noninteractive element cannot have nonnegative tabIndex value'
 	},
 	redundant_event_modifier_for_touch: {
 		code: 'redundant-event-modifier',

--- a/test/validator/samples/a11y-no-nointeractive-tabindex/warnings.json
+++ b/test/validator/samples/a11y-no-nointeractive-tabindex/warnings.json
@@ -6,7 +6,7 @@
 			"column": 20,
 			"line": 12
 		},
-		"message": "A11y: noninteractive element cannot have positive tabIndex value",
+		"message": "A11y: noninteractive element cannot have nonnegative tabIndex value",
 		"pos": 258,
 		"start": {
 			"character": 258,
@@ -21,7 +21,7 @@
 			"column": 35,
 			"line": 13
 		},
-		"message": "A11y: noninteractive element cannot have positive tabIndex value",
+		"message": "A11y: noninteractive element cannot have nonnegative tabIndex value",
 		"pos": 279,
 		"start": {
 			"character": 279,
@@ -36,7 +36,7 @@
 			"column": 24,
 			"line": 14
 		},
-		"message": "A11y: noninteractive element cannot have positive tabIndex value",
+		"message": "A11y: noninteractive element cannot have nonnegative tabIndex value",
 		"pos": 315,
 		"start": {
 			"character": 315,
@@ -51,7 +51,7 @@
 			"column": 26,
 			"line": 15
 		},
-		"message": "A11y: noninteractive element cannot have positive tabIndex value",
+		"message": "A11y: noninteractive element cannot have nonnegative tabIndex value",
 		"pos": 340,
 		"start": {
 			"character": 340,


### PR DESCRIPTION
`a11y-no-noninteractive-tabindex` says "noninteractive element cannot have positive tabIndex value" but denies a tabIndex value of zero, and zero is not positive. "Nonnegative" (or similar) is more correct wording.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
