### PR TITLE
[docs] update outdated SvelteKit release info

### DIFF
--- a/site/content/tutorial/01-introduction/07-making-an-app/text.md
+++ b/site/content/tutorial/01-introduction/07-making-an-app/text.md
@@ -12,7 +12,7 @@ npm create vite@latest my-app -- --template svelte
 
 ...or one of the [community-maintained integrations](https://sveltesociety.dev/tools).
 
-> [SvelteKit](https://kit.svelte.dev) is the official application framework from the Svelte team. It's currently in development, but if you don't mind using pre-1.0 software then it's the recommended way to build Svelte apps.
+> [SvelteKit](https://kit.svelte.dev) is the official application framework from the Svelte team. It [reached version 1.0](https://svelte.dev/blog/announcing-sveltekit-1.0) on December 14, 2022 and is now the recommended way to built Svelte apps of all shapes and sizes.
 
 Don't worry if you're relatively new to web development and haven't used these tools before. We've prepared a simple step-by-step guide, [Svelte for new developers](/blog/svelte-for-new-developers), which walks you through the process.
 

--- a/site/content/tutorial/01-introduction/07-making-an-app/text.md
+++ b/site/content/tutorial/01-introduction/07-making-an-app/text.md
@@ -4,15 +4,13 @@ title: Making an app
 
 This tutorial is designed to get you familiar with the process of writing components. But at some point, you'll want to start writing components in the comfort of your own text editor.
 
-First, you'll need to integrate Svelte with a build tool. We recommend using [Vite](https://vitejs.dev/) with [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte/)...
+First, you'll need to integrate Svelte with a build tool. We recommend using [SvelteKit](https://kit.svelte.dev), which sets up [Vite](https://vitejs.dev/) with [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte/) for you...
 
 ```bash
-npm create vite@latest my-app -- --template svelte
+npm create svelte@latest myapp
 ```
 
-...or one of the [community-maintained integrations](https://sveltesociety.dev/tools).
-
-> [SvelteKit](https://kit.svelte.dev) is the official application framework from the Svelte team. It [reached version 1.0](https://svelte.dev/blog/announcing-sveltekit-1.0) on December 14, 2022 and is now the recommended way to build Svelte apps of all shapes and sizes.
+There are also a number of [community-maintained integrations](https://sveltesociety.dev/tools).
 
 Don't worry if you're relatively new to web development and haven't used these tools before. We've prepared a simple step-by-step guide, [Svelte for new developers](/blog/svelte-for-new-developers), which walks you through the process.
 

--- a/site/content/tutorial/01-introduction/07-making-an-app/text.md
+++ b/site/content/tutorial/01-introduction/07-making-an-app/text.md
@@ -12,7 +12,7 @@ npm create vite@latest my-app -- --template svelte
 
 ...or one of the [community-maintained integrations](https://sveltesociety.dev/tools).
 
-> [SvelteKit](https://kit.svelte.dev) is the official application framework from the Svelte team. It [reached version 1.0](https://svelte.dev/blog/announcing-sveltekit-1.0) on December 14, 2022 and is now the recommended way to built Svelte apps of all shapes and sizes.
+> [SvelteKit](https://kit.svelte.dev) is the official application framework from the Svelte team. It [reached version 1.0](https://svelte.dev/blog/announcing-sveltekit-1.0) on December 14, 2022 and is now the recommended way to build Svelte apps of all shapes and sizes.
 
 Don't worry if you're relatively new to web development and haven't used these tools before. We've prepared a simple step-by-step guide, [Svelte for new developers](/blog/svelte-for-new-developers), which walks you through the process.
 


### PR DESCRIPTION
## Problem solved

The Svelte [_Tutorial > Introduction > Making an app_](https://svelte.dev/tutorial/making-an-app) page implies SvelteKit is still pre-1.0. Now that SvelteKit 1.0 has been released, this should be updated.

## Checklist

### Before submitting the PR, please make sure you do the following
- [ ] N/A - It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] N/A - Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] N/A - Run the tests with `npm test` and lint the project with `npm run lint`
