### PR TITLE
[docs] fix transition direction options

### DIFF
--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1099,7 +1099,7 @@ Transition functions also receive a third argument, `options`, which contains in
 
 Available values in the `options` object are:
 
-* `direction` - one of `in`, `out`, or `bidirectional` depending on the type of transition
+* `direction` - one of `in`, `out`, or `both` depending on the type of transition
 
 ##### Transition events
 


### PR DESCRIPTION
It's "both", not "bidirectional" (see #8068).

"bidirectional" was suggested as an alternative, but the implementation uses "both".

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
