### PR TITLE
[chore] Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,16 @@ jobs:
         id: download-artifact
         with:
           name: build-assets
+      - name: Get Node version ${{ runner.os }}
+        run: echo "NODE_VERSION=`node --version`" >> $GITHUB_ENV
+        if: runner.os != 'Windows'
+      - name: Get Node version ${{ runner.os }}
+        run: |
+          chcp 65001
+          echo ("NODE_VERSION=$(node --version)") >> $env:GITHUB_ENV
+        if: runner.os == 'Windows'
+      - run: npm install --save-dev puppeteer@13
+        if: ${{ runner.os == 'Linux' && (!startsWith(env.NODE_VERSION, 'v8.') && !startsWith(env.NODE_VERSION, 'v10.')) }}
       - run: npm install
         env:
           SKIP_PREPARE: true

--- a/test/custom-elements/index.ts
+++ b/test/custom-elements/index.ts
@@ -64,6 +64,9 @@ describe('custom-elements', function() {
 
 	fs.readdirSync(`${__dirname}/samples`).forEach(dir => {
 		if (dir[0] === '.') return;
+		// MEMO: puppeteer can not execute Chromium properly with Node8,10 on Linux at GitHub actions.
+		const { version } = process;
+		if ((version.startsWith('v8.') || version.startsWith('v10.')) && process.platform === 'linux') return;
 
 		const solo = /\.solo$/.test(dir);
 		const skip = /\.skip$/.test(dir);

--- a/test/runtime-puppeteer/index.ts
+++ b/test/runtime-puppeteer/index.ts
@@ -77,6 +77,9 @@ describe('runtime (puppeteer)', function() {
 
 	function runTest(dir, hydrate) {
 		if (dir[0] === '.') return;
+		// MEMO: puppeteer can not execute Chromium properly with Node8,10 on Linux at GitHub actions.
+		const { version } = process;
+		if ((version.startsWith('v8.') || version.startsWith('v10.')) && process.platform === 'linux') return;
 
 		const config = loadConfig(`${__dirname}/samples/${dir}/_config.js`);
 		const solo = config.solo || /\.solo/.test(dir);


### PR DESCRIPTION
Last few months, CI on Linux is broken.
I checked the reason and I found that Puppeteer can not run properly with Node8 on Linux.
I couldn't find a way to run it properly, therefore I stop to run Puppeteer tests with Node8 on Linux.
Also after updating Puppeteer, still it doesn't run properly with Node10 on Linux, so I did the same way for Node10 also.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
