### PR TITLE
docs: corrects syntax error in transition code sample

### DIFF
--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1313,7 +1313,7 @@ A custom animation function can also return a `tick` function, which is called *
 		tick: (t, u) =>
 			Object.assign(node.style, {
 				color: t > 0.5 ? 'Pink' : 'Blue'
-			});
+			}),
 	};
 	}
 </script>

--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1307,14 +1307,12 @@ A custom animation function can also return a `tick` function, which is called *
 		const d = Math.sqrt(dx * dx + dy * dy);
 
 		return {
-		delay: 0,
-		duration: Math.sqrt(d) * 120,
-		easing: cubicOut,
-		tick: (t, u) =>
-			Object.assign(node.style, {
-				color: t > 0.5 ? 'Pink' : 'Blue'
-			}),
-	};
+			delay: 0,
+			duration: Math.sqrt(d) * 120,
+			easing: cubicOut,
+			tick: (t, u) =>
+				Object.assign(node.style, { color: t > 0.5 ? 'Pink' : 'Blue' })
+		};
 	}
 </script>
 


### PR DESCRIPTION
There was a small typo in the docs animation docs, where there's a semi-colon mid-way through the object, causing an error (`Expected "}" but found ";"`). This PR corrects that, by replacing it with the expected comma.

For reference, this was in the docs, [here](https://svelte.dev/docs#template-syntax-element-directives-animate-fn-custom-animation-functions) - under Template Syntax --> Element Directives --> animate:fn --> Custom animation functions

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`
