### PR TITLE
docs: update dialog example

### DIFF
--- a/site/content/examples/15-composition/05-modal/App.svelte
+++ b/site/content/examples/15-composition/05-modal/App.svelte
@@ -1,21 +1,14 @@
 <script>
 	import Modal from './Modal.svelte';
 
-	let button; // HTMLButtonElement
 	let showModal = false;
 </script>
 
-<button bind:this={button} on:click={() => (showModal = true)}>
+<button on:click={() => (showModal = true)}>
 	show modal
 </button>
 
-<Modal
-	{showModal}
-	on:close={() => {
-		showModal = false;
-		button.focus();
-	}}
->
+<Modal bind:showModal>
 	<h2 slot="header">
 		modal
 		<small><em>adjective</em> mod·al \ˈmō-dəl\</small>

--- a/site/content/examples/15-composition/05-modal/App.svelte
+++ b/site/content/examples/15-composition/05-modal/App.svelte
@@ -1,29 +1,36 @@
 <script>
 	import Modal from './Modal.svelte';
 
+	let button; // HTMLButtonElement
 	let showModal = false;
 </script>
 
-<button on:click="{() => showModal = true}">
+<button bind:this={button} on:click={() => (showModal = true)}>
 	show modal
 </button>
 
-{#if showModal}
-	<Modal on:close="{() => showModal = false}">
-		<h2 slot="header">
-			modal
-			<small><em>adjective</em>  mod·al \ˈmō-dəl\</small>
-		</h2>
+<Modal
+	{showModal}
+	on:close={() => {
+		showModal = false;
+		button.focus();
+	}}
+>
+	<h2 slot="header">
+		modal
+		<small><em>adjective</em> mod·al \ˈmō-dəl\</small>
+	</h2>
 
-		<ol class="definition-list">
-			<li>of or relating to modality in logic</li>
-			<li>containing provisions as to the mode of procedure or the manner of taking effect —used of a contract or legacy</li>
-			<li>of or relating to a musical mode</li>
-			<li>of or relating to structure as opposed to substance</li>
-			<li>of, relating to, or constituting a grammatical form or category characteristically indicating predication</li>
-			<li>of or relating to a statistical mode</li>
-		</ol>
+	<ol class="definition-list">
+		<li>of or relating to modality in logic</li>
+		<li>
+			containing provisions as to the mode of procedure or the manner of taking effect —used of a contract or legacy
+		</li>
+		<li>of or relating to a musical mode</li>
+		<li>of or relating to structure as opposed to substance</li>
+		<li>of, relating to, or constituting a grammatical form or category characteristically indicating predication</li>
+		<li>of or relating to a statistical mode</li>
+	</ol>
 
-		<a href="https://www.merriam-webster.com/dictionary/modal">merriam-webster.com</a>
-	</Modal>
-{/if}
+	<a href="https://www.merriam-webster.com/dictionary/modal">merriam-webster.com</a>
+</Modal>

--- a/site/content/examples/15-composition/05-modal/Modal.svelte
+++ b/site/content/examples/15-composition/05-modal/Modal.svelte
@@ -1,80 +1,58 @@
 <script>
-	import { createEventDispatcher, onDestroy } from 'svelte';
+	export let showModal; // boolean
 
-	const dispatch = createEventDispatcher();
-	const close = () => dispatch('close');
+	let dialog; // HTMLDialogElement
 
-	let modal;
-
-	const handle_keydown = e => {
-		if (e.key === 'Escape') {
-			close();
-			return;
-		}
-
-		if (e.key === 'Tab') {
-			// trap focus
-			const nodes = modal.querySelectorAll('*');
-			const tabbable = Array.from(nodes).filter(n => n.tabIndex >= 0);
-
-			let index = tabbable.indexOf(document.activeElement);
-			if (index === -1 && e.shiftKey) index = 0;
-
-			index += tabbable.length + (e.shiftKey ? -1 : 1);
-			index %= tabbable.length;
-
-			tabbable[index].focus();
-			e.preventDefault();
-		}
-	};
-
-	const previously_focused = typeof document !== 'undefined' && document.activeElement;
-
-	if (previously_focused) {
-		onDestroy(() => {
-			previously_focused.focus();
-		});
-	}
+	$: if (dialog && showModal) dialog.showModal();
 </script>
 
-<svelte:window on:keydown={handle_keydown}/>
-
-<div class="modal-background" on:click={close}></div>
-
-<div class="modal" role="dialog" aria-modal="true" bind:this={modal}>
-	<slot name="header"></slot>
-	<hr>
-	<slot></slot>
-	<hr>
-
-	<!-- svelte-ignore a11y-autofocus -->
-	<button autofocus on:click={close}>close modal</button>
-</div>
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<dialog bind:this={dialog} on:close on:click|self={() => dialog.close()}>
+	<div on:click|stopPropagation>
+		<slot name="header" />
+		<hr />
+		<slot />
+		<hr />
+		<!-- svelte-ignore a11y-autofocus -->
+		<button autofocus on:click={() => dialog.close()}>close modal</button>
+	</div>
+</dialog>
 
 <style>
-	.modal-background {
-		position: fixed;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		background: rgba(0,0,0,0.3);
-	}
-
-	.modal {
-		position: absolute;
-		left: 50%;
-		top: 50%;
-		width: calc(100vw - 4em);
+	dialog {
 		max-width: 32em;
-		max-height: calc(100vh - 4em);
-		overflow: auto;
-		transform: translate(-50%,-50%);
-		padding: 1em;
 		border-radius: 0.2em;
-		background: white;
+		border: none;
+		padding: 0;
 	}
-
+	dialog::backdrop {
+		background: rgba(0, 0, 0, 0.3);
+	}
+	dialog > div {
+		padding: 1em;
+	}
+	dialog[open] {
+		animation: zoom 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	@keyframes zoom {
+		from {
+			transform: scale(0.95);
+		}
+		to {
+			transform: scale(1);
+		}
+	}
+	dialog[open]::backdrop {
+		animation: fade 0.2s ease-out;
+	}
+	@keyframes fade {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
 	button {
 		display: block;
 	}

--- a/site/content/examples/15-composition/05-modal/Modal.svelte
+++ b/site/content/examples/15-composition/05-modal/Modal.svelte
@@ -7,7 +7,11 @@
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<dialog bind:this={dialog} on:close on:click|self={() => dialog.close()}>
+<dialog
+	bind:this={dialog}
+	on:close={() => (showModal = false)}
+	on:click|self={() => dialog.close()}
+>
 	<div on:click|stopPropagation>
 		<slot name="header" />
 		<hr />


### PR DESCRIPTION
The [modal](https://svelte.dev/examples/modal) example is based on `<div>` elements.

Since the `<dialog>` element is now [widely supported](https://caniuse.com/dialog), I propose a rewrite.

The following features are supported. Please check the [demo](https://svelte.dev/repl/bbe203121c094add9de669f3e5d35d8b?version=3.55.1).

- close modal by clicking on the modal's backdrop
- focus on the `show modal` button when closed
- press `esc` key to close modal - `<dialog>` feat.
- keep tab focus inside the modal - `<dialog>` feat.
- (optional) show animation on `.showModal()`

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
