### PR TITLE
[fix] fixes sveltejs/svelte#8214 bind:group to undefined

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
+++ b/src/compiler/compile/render_dom/wrappers/Element/Binding.ts
@@ -264,7 +264,7 @@ function get_dom_updater(
 		const type = node.get_static_attribute_value('type');
 
 		const condition = type === 'checkbox'
-			? x`~${binding.snippet}.indexOf(${element.var}.__value)`
+			? x`~(${binding.snippet} ?? [])?.indexOf(${element.var}.__value)`
 			: x`${element.var}.__value === ${binding.snippet}`;
 
 		return b`${element.var}.checked = ${condition};`;


### PR DESCRIPTION
This fix circumvents a breaking error in cases where a variable bound with bind:group is set to undefined (or boolean, etc.). REPL is here: 
https://svelte.dev/repl/842c52bdb62448d0866785eedc7c4fcd?version=3.55.1

I can't seem to write a test that *fails* without this fix, but it's breaking for me in both FF and Chrome. Sorry if I'm imagining things, but more likely I didn't figure out the testing environments. I tried runtime and runtime-puppeteer, but I'm open to working on it again if you'd like.

REPL is here: https://svelte.dev/repl/842c52bdb62448d0866785eedc7c4fcd?version=3.55.1

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
