### PR TITLE
fix: exclude generated code from code coverage instrumentation

### DIFF
--- a/src/compiler/compile/render_dom/Block.ts
+++ b/src/compiler/compile/render_dom/Block.ts
@@ -319,6 +319,7 @@ export default class Block {
 
 				properties.update = x`function #update(${ctx}, ${dirty}) {
 					${this.maintain_context && b`#ctx = ${ctx};`}
+					/* istanbul ignore next */
 					${this.chunks.update}
 				}`;
 			}

--- a/test/js/samples/action-custom-event-handler/expected.js
+++ b/test/js/samples/action-custom-event-handler/expected.js
@@ -31,6 +31,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (foo_action && is_function(foo_action.update) && dirty & /*bar*/ 1) foo_action.update.call(null, /*foo_function*/ ctx[1]);
 		},
 		i: noop,

--- a/test/js/samples/bind-open/expected.js
+++ b/test/js/samples/bind-open/expected.js
@@ -30,6 +30,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*open*/ 1) {
 				details.open = /*open*/ ctx[0];
 			}

--- a/test/js/samples/capture-inject-dev-only/expected.js
+++ b/test/js/samples/capture-inject-dev-only/expected.js
@@ -43,6 +43,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*foo*/ 1) set_data(t0, /*foo*/ ctx[0]);
 
 			if (dirty & /*foo*/ 1 && input.value !== /*foo*/ ctx[0]) {

--- a/test/js/samples/capture-inject-state/expected.js
+++ b/test/js/samples/capture-inject-state/expected.js
@@ -68,7 +68,9 @@ function create_fragment(ctx) {
 			append_dev(p, t10);
 		},
 		p: function update(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*prop*/ 1) set_data_dev(t0, /*prop*/ ctx[0]);
+
 			if (dirty & /*realName*/ 2) set_data_dev(t2, /*realName*/ ctx[1]);
 			if (dirty & /*$prop*/ 4) set_data_dev(t8, /*$prop*/ ctx[2]);
 		},

--- a/test/js/samples/collapse-element-class-name/expected.js
+++ b/test/js/samples/collapse-element-class-name/expected.js
@@ -53,6 +53,7 @@ function create_fragment(ctx) {
 			current = true;
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (!current || dirty & /*size, theme, $$restProps*/ 7 && div_class_value !== (div_class_value = "button button--size--" + /*size*/ ctx[0] + " button--theme--" + /*theme*/ ctx[1] + " " + (/*$$restProps*/ ctx[2].class || ''))) {
 				attr(div, "class", div_class_value);
 			}

--- a/test/js/samples/collapses-text-around-comments/expected.js
+++ b/test/js/samples/collapses-text-around-comments/expected.js
@@ -33,6 +33,7 @@ function create_fragment(ctx) {
 			append(p, t);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*foo*/ 1) set_data(t, /*foo*/ ctx[0]);
 		},
 		i: noop,

--- a/test/js/samples/component-static-var/expected.js
+++ b/test/js/samples/component-static-var/expected.js
@@ -54,7 +54,9 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			const bar_changes = {};
+
 			if (dirty & /*z*/ 1) bar_changes.x = /*z*/ ctx[0];
 			bar.$set(bar_changes);
 

--- a/test/js/samples/component-store-access-invalidate/expected.js
+++ b/test/js/samples/component-store-access-invalidate/expected.js
@@ -29,6 +29,7 @@ function create_fragment(ctx) {
 			append(h1, t);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*$foo*/ 1) set_data(t, /*$foo*/ ctx[0]);
 		},
 		i: noop,

--- a/test/js/samples/component-store-reassign-invalidate/expected.js
+++ b/test/js/samples/component-store-reassign-invalidate/expected.js
@@ -45,6 +45,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*$foo*/ 2) set_data(t0, /*$foo*/ ctx[1]);
 		},
 		i: noop,

--- a/test/js/samples/custom-svelte-path/expected.js
+++ b/test/js/samples/custom-svelte-path/expected.js
@@ -34,6 +34,7 @@ function create_fragment(ctx) {
 			append(h1, t2);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*name*/ 1) set_data(t1, /*name*/ ctx[0]);
 		},
 		i: noop,

--- a/test/js/samples/data-attribute/expected.js
+++ b/test/js/samples/data-attribute/expected.js
@@ -30,6 +30,7 @@ function create_fragment(ctx) {
 			insert(target, div1, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*bar*/ 1) {
 				attr(div1, "data-foo", /*bar*/ ctx[0]);
 			}

--- a/test/js/samples/debug-empty/expected.js
+++ b/test/js/samples/debug-empty/expected.js
@@ -46,7 +46,9 @@ function create_fragment(ctx) {
 			insert_dev(target, t3, anchor);
 		},
 		p: function update(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*name*/ 1) set_data_dev(t1, /*name*/ ctx[0]);
+
 			debugger;
 		},
 		i: noop,

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -56,6 +56,7 @@ function create_each_block(ctx) {
 			insert_dev(target, t1, anchor);
 		},
 		p: function update(ctx, dirty) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1 && t0_value !== (t0_value = /*thing*/ ctx[4].name + "")) set_data_dev(t0, t0_value);
 
 			if (dirty & /*foo, bar, baz, things*/ 15) {
@@ -123,6 +124,7 @@ function create_fragment(ctx) {
 			append_dev(p, t2);
 		},
 		p: function update(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1) {
 				each_value = /*things*/ ctx[0];
 				validate_each_argument(each_value);

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -53,6 +53,7 @@ function create_each_block(ctx) {
 			insert_dev(target, t1, anchor);
 		},
 		p: function update(ctx, dirty) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1 && t0_value !== (t0_value = /*thing*/ ctx[2].name + "")) set_data_dev(t0, t0_value);
 
 			if (dirty & /*foo*/ 2) {
@@ -117,6 +118,7 @@ function create_fragment(ctx) {
 			append_dev(p, t2);
 		},
 		p: function update(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1) {
 				each_value = /*things*/ ctx[0];
 				validate_each_argument(each_value);

--- a/test/js/samples/debug-hoisted/expected.js
+++ b/test/js/samples/debug-hoisted/expected.js
@@ -25,6 +25,7 @@ function create_fragment(ctx) {
 		},
 		m: noop,
 		p: function update(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*obj, kobzol*/ 3) {
 				const obj = /*obj*/ ctx[0];
 				const kobzol = /*kobzol*/ ctx[1];

--- a/test/js/samples/debug-no-dependencies/expected.js
+++ b/test/js/samples/debug-no-dependencies/expected.js
@@ -92,6 +92,7 @@ function create_fragment(ctx) {
 			insert_dev(target, each_1_anchor, anchor);
 		},
 		p: function update(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 0) {
 				each_value = things;
 				validate_each_argument(each_value);

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -36,6 +36,7 @@ function create_each_block(ctx) {
 			append(span, t);
 		},
 		p(ctx, dirty) {
+			/* istanbul ignore next */
 			if (dirty & /*createElement*/ 1 && t_value !== (t_value = /*node*/ ctx[1] + "")) set_data(t, t_value);
 		},
 		d(detaching) {
@@ -69,6 +70,7 @@ function create_fragment(ctx) {
 			insert(target, each_1_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*createElement*/ 1) {
 				each_value = /*createElement*/ ctx[0];
 				let i;

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -43,7 +43,9 @@ function create_fragment(ctx) {
 			append_dev(p, t2);
 		},
 		p: function update(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*foo*/ 1 && t0_value !== (t0_value = Math.max(0, /*foo*/ ctx[0]) + "")) set_data_dev(t0, t0_value);
+
 			if (dirty & /*bar*/ 2) set_data_dev(t2, /*bar*/ ctx[1]);
 		},
 		i: noop,

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -36,6 +36,7 @@ function create_each_block(ctx) {
 			append(span, t);
 		},
 		p(ctx, dirty) {
+			/* istanbul ignore next */
 			if (dirty & /*a, b, c, d, e*/ 31 && t_value !== (t_value = /*num*/ ctx[5] + "")) set_data(t, t_value);
 		},
 		d(detaching) {
@@ -69,6 +70,7 @@ function create_fragment(ctx) {
 			insert(target, each_1_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*a, b, c, d, e*/ 31) {
 				each_value = [/*a*/ ctx[0], /*b*/ ctx[1], /*c*/ ctx[2], /*d*/ ctx[3], /*e*/ ctx[4]];
 				let i;

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -71,7 +71,9 @@ function create_each_block(ctx) {
 			html_tag.m(raw_value, div);
 		},
 		p(ctx, dirty) {
+			/* istanbul ignore next */
 			if (dirty & /*comments*/ 1 && t2_value !== (t2_value = /*comment*/ ctx[4].author + "")) set_data(t2, t2_value);
+
 			if (dirty & /*elapsed, comments, time*/ 7 && t4_value !== (t4_value = /*elapsed*/ ctx[1](/*comment*/ ctx[4].time, /*time*/ ctx[2]) + "")) set_data(t4, t4_value);
 			if (dirty & /*comments*/ 1 && raw_value !== (raw_value = /*comment*/ ctx[4].html + "")) html_tag.p(raw_value);
 		},
@@ -112,6 +114,7 @@ function create_fragment(ctx) {
 			append(p, t1);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*comments, elapsed, time*/ 7) {
 				each_value = /*comments*/ ctx[0];
 				let i;

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -45,6 +45,8 @@ function create_each_block(key_1, ctx) {
 		},
 		p(new_ctx, dirty) {
 			ctx = new_ctx;
+
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1 && t_value !== (t_value = /*thing*/ ctx[1].name + "")) set_data(t, t_value);
 		},
 		r() {
@@ -93,6 +95,7 @@ function create_fragment(ctx) {
 			insert(target, each_1_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1) {
 				each_value = /*things*/ ctx[0];
 				for (let i = 0; i < each_blocks.length; i += 1) each_blocks[i].r();

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -41,6 +41,8 @@ function create_each_block(key_1, ctx) {
 		},
 		p(new_ctx, dirty) {
 			ctx = new_ctx;
+
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1 && t_value !== (t_value = /*thing*/ ctx[1].name + "")) set_data(t, t_value);
 		},
 		d(detaching) {
@@ -78,6 +80,7 @@ function create_fragment(ctx) {
 			insert(target, each_1_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1) {
 				each_value = /*things*/ ctx[0];
 				each_blocks = update_keyed_each(each_blocks, dirty, get_key, 1, ctx, each_value, each_1_lookup, each_1_anchor.parentNode, destroy_block, create_each_block, each_1_anchor, get_each_context);

--- a/test/js/samples/event-handler-dynamic/expected.js
+++ b/test/js/samples/event-handler-dynamic/expected.js
@@ -69,6 +69,8 @@ function create_fragment(ctx) {
 		},
 		p(new_ctx, [dirty]) {
 			ctx = new_ctx;
+
+			/* istanbul ignore next */
 			if (dirty & /*number*/ 2) set_data(t4, /*number*/ ctx[1]);
 		},
 		i: noop,

--- a/test/js/samples/if-block-no-update/expected.js
+++ b/test/js/samples/if-block-no-update/expected.js
@@ -66,6 +66,7 @@ function create_fragment(ctx) {
 			insert(target, if_block_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (current_block_type !== (current_block_type = select_block_type(ctx, dirty))) {
 				if_block.d(1);
 				if_block = current_block_type(ctx);

--- a/test/js/samples/if-block-simple/expected.js
+++ b/test/js/samples/if-block-simple/expected.js
@@ -41,6 +41,7 @@ function create_fragment(ctx) {
 			insert(target, if_block_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (/*foo*/ ctx[0]) {
 				if (if_block) {
 					

--- a/test/js/samples/inline-style-optimized-multiple/expected.js
+++ b/test/js/samples/inline-style-optimized-multiple/expected.js
@@ -23,6 +23,7 @@ function create_fragment(ctx) {
 			insert(target, div, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*color*/ 1) {
 				set_style(div, "color", /*color*/ ctx[0]);
 			}

--- a/test/js/samples/inline-style-optimized-url/expected.js
+++ b/test/js/samples/inline-style-optimized-url/expected.js
@@ -22,6 +22,7 @@ function create_fragment(ctx) {
 			insert(target, div, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*data*/ 1) {
 				set_style(div, "background", "url(data:image/png;base64," + /*data*/ ctx[0] + ")");
 			}

--- a/test/js/samples/inline-style-optimized/expected.js
+++ b/test/js/samples/inline-style-optimized/expected.js
@@ -22,6 +22,7 @@ function create_fragment(ctx) {
 			insert(target, div, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*color*/ 1) {
 				set_style(div, "color", /*color*/ ctx[0]);
 			}

--- a/test/js/samples/inline-style-unoptimized/expected.js
+++ b/test/js/samples/inline-style-unoptimized/expected.js
@@ -31,6 +31,7 @@ function create_fragment(ctx) {
 			insert(target, div1, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*style*/ 1) {
 				attr(div0, "style", /*style*/ ctx[0]);
 			}

--- a/test/js/samples/input-no-initial-value/expected.js
+++ b/test/js/samples/input-no-initial-value/expected.js
@@ -50,6 +50,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*test*/ 1 && input.value !== /*test*/ ctx[0]) {
 				set_input_value(input, /*test*/ ctx[0]);
 			}

--- a/test/js/samples/input-range/expected.js
+++ b/test/js/samples/input-range/expected.js
@@ -38,6 +38,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*value*/ 1) {
 				set_input_value(input, /*value*/ ctx[0]);
 			}

--- a/test/js/samples/input-value/expected.js
+++ b/test/js/samples/input-value/expected.js
@@ -249,6 +249,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*name*/ 1 && input0.value !== /*name*/ ctx[0]) {
 				input0.value = /*name*/ ctx[0];
 			}

--- a/test/js/samples/input-without-blowback-guard/expected.js
+++ b/test/js/samples/input-without-blowback-guard/expected.js
@@ -31,6 +31,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*foo*/ 1) {
 				input.checked = /*foo*/ ctx[0];
 			}

--- a/test/js/samples/instrumentation-script-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-script-if-no-block/expected.js
@@ -45,6 +45,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*x*/ 1) set_data(t3, /*x*/ ctx[0]);
 		},
 		i: noop,

--- a/test/js/samples/instrumentation-script-main-block/expected.js
+++ b/test/js/samples/instrumentation-script-main-block/expected.js
@@ -29,6 +29,7 @@ function create_fragment(ctx) {
 			append(p, t1);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*x*/ 1) set_data(t1, /*x*/ ctx[0]);
 		},
 		i: noop,

--- a/test/js/samples/instrumentation-script-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-script-x-equals-x/expected.js
@@ -46,6 +46,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1 && t3_value !== (t3_value = /*things*/ ctx[0].length + "")) set_data(t3, t3_value);
 		},
 		i: noop,

--- a/test/js/samples/instrumentation-template-if-no-block/expected.js
+++ b/test/js/samples/instrumentation-template-if-no-block/expected.js
@@ -45,6 +45,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*x*/ 1) set_data(t3, /*x*/ ctx[0]);
 		},
 		i: noop,

--- a/test/js/samples/instrumentation-template-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-template-x-equals-x/expected.js
@@ -46,6 +46,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*things*/ 1 && t3_value !== (t3_value = /*things*/ ctx[0].length + "")) set_data(t3, t3_value);
 		},
 		i: noop,

--- a/test/js/samples/media-bindings/expected.js
+++ b/test/js/samples/media-bindings/expected.js
@@ -75,6 +75,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (!audio_updating && dirty & /*currentTime*/ 8 && !isNaN(/*currentTime*/ ctx[3])) {
 				audio.currentTime = /*currentTime*/ ctx[3];
 			}

--- a/test/js/samples/optional-chaining/expected.js
+++ b/test/js/samples/optional-chaining/expected.js
@@ -92,7 +92,9 @@ function create_fragment(ctx) {
 			current = true;
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if ((!current || dirty & /*a*/ 1) && t0_value !== (t0_value = /*a*/ ctx[0].normal + "")) set_data(t0, t0_value);
+
 			if ((!current || dirty & /*b*/ 2) && t1_value !== (t1_value = /*b*/ ctx[1]?.optional + "")) set_data(t1, t1_value);
 			if ((!current || dirty & /*c*/ 4) && t3_value !== (t3_value = /*c*/ ctx[2]['computed'] + "")) set_data(t3, t3_value);
 			if ((!current || dirty & /*d*/ 8) && t4_value !== (t4_value = /*d*/ ctx[3]?.['computed_optional'] + "")) set_data(t4, t4_value);

--- a/test/js/samples/reactive-class-optimized/expected.js
+++ b/test/js/samples/reactive-class-optimized/expected.js
@@ -83,6 +83,7 @@ function create_fragment(ctx) {
 			insert(target, div8, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*reactiveModuleVar*/ 0) {
 				toggle_class(div0, "update1", reactiveModuleVar);
 			}

--- a/test/js/samples/select-dynamic-value/expected.js
+++ b/test/js/samples/select-dynamic-value/expected.js
@@ -35,6 +35,7 @@ function create_fragment(ctx) {
 			select_option(select, /*current*/ ctx[0]);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*current*/ 1) {
 				select_option(select, /*current*/ ctx[0]);
 			}

--- a/test/js/samples/src-attribute-check-in-foreign/expected.js
+++ b/test/js/samples/src-attribute-check-in-foreign/expected.js
@@ -38,6 +38,7 @@ function create_fragment(ctx) {
 			append_hydration(svg, img);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*url*/ 1) {
 				attr(img, "src", /*url*/ ctx[0]);
 			}

--- a/test/js/samples/src-attribute-check-in-svg/expected.js
+++ b/test/js/samples/src-attribute-check-in-svg/expected.js
@@ -39,6 +39,7 @@ function create_fragment(ctx) {
 			append_hydration(svg, img);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*url*/ 1) {
 				attr(img, "src", /*url*/ ctx[0]);
 			}

--- a/test/js/samples/src-attribute-check/expected.js
+++ b/test/js/samples/src-attribute-check/expected.js
@@ -46,6 +46,7 @@ function create_fragment(ctx) {
 			insert_hydration(target, img1, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*url*/ 1 && !src_url_equal(img0.src, img0_src_value = /*url*/ ctx[0])) {
 				attr(img0, "src", img0_src_value);
 			}

--- a/test/js/samples/svelte-element-event-handlers/expected.js
+++ b/test/js/samples/svelte-element-event-handlers/expected.js
@@ -70,6 +70,7 @@ function create_dynamic_element(ctx) {
 			}
 		},
 		p(ctx, dirty) {
+			/* istanbul ignore next */
 			svelte_element0_data = get_spread_update(svelte_element0_levels, [{ class: "inner" }]);
 
 			if ((/-/).test(span)) {
@@ -109,6 +110,7 @@ function create_fragment(ctx) {
 			insert(target, svelte_element_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (a) {
 				if (!previous_tag) {
 					svelte_element = create_dynamic_element(ctx);

--- a/test/js/samples/svelte-element-svg/expected.js
+++ b/test/js/samples/svelte-element-svg/expected.js
@@ -43,7 +43,9 @@ function create_dynamic_element(ctx) {
 			append(svelte_element1, svelte_element0);
 		},
 		p(ctx, dirty) {
+			/* istanbul ignore next */
 			svelte_element0_data = get_spread_update(svelte_element0_levels, [{ xmlns: "http://www.w3.org/2000/svg" }]);
+
 			set_svg_attributes(svelte_element0, svelte_element0_data);
 			svelte_element1_data = get_spread_update(svelte_element1_levels, [{ xmlns: "http://www.w3.org/2000/svg" }]);
 			set_svg_attributes(svelte_element1, svelte_element1_data);
@@ -69,6 +71,7 @@ function create_fragment(ctx) {
 			insert(target, svelte_element_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (/*tag*/ ctx[0].svg) {
 				if (!previous_tag) {
 					svelte_element = create_dynamic_element(ctx);

--- a/test/js/samples/title/expected.js
+++ b/test/js/samples/title/expected.js
@@ -9,6 +9,7 @@ function create_fragment(ctx) {
 		c: noop,
 		m: noop,
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*custom*/ 1 && title_value !== (title_value = "a " + /*custom*/ ctx[0] + " title")) {
 				document.title = title_value;
 			}

--- a/test/js/samples/transition-local/expected.js
+++ b/test/js/samples/transition-local/expected.js
@@ -27,6 +27,7 @@ function create_if_block(ctx) {
 			insert(target, if_block_anchor, anchor);
 		},
 		p(ctx, dirty) {
+			/* istanbul ignore next */
 			if (/*y*/ ctx[1]) {
 				if (if_block) {
 					if (dirty & /*y*/ 2) {
@@ -94,6 +95,7 @@ function create_fragment(ctx) {
 			insert(target, if_block_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (/*x*/ ctx[0]) {
 				if (if_block) {
 					if_block.p(ctx, dirty);

--- a/test/js/samples/transition-repeated-outro/expected.js
+++ b/test/js/samples/transition-repeated-outro/expected.js
@@ -62,6 +62,7 @@ function create_fragment(ctx) {
 			current = true;
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (/*num*/ ctx[0] < 5) {
 				if (if_block) {
 					if (dirty & /*num*/ 1) {

--- a/test/js/samples/unchanged-expression/expected.js
+++ b/test/js/samples/unchanged-expression/expected.js
@@ -57,6 +57,7 @@ function create_fragment(ctx) {
 			append(p3, t9);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*world3*/ 1) set_data(t9, /*world3*/ ctx[0]);
 		},
 		i: noop,

--- a/test/js/samples/unreferenced-state-not-invalidated/expected.js
+++ b/test/js/samples/unreferenced-state-not-invalidated/expected.js
@@ -28,6 +28,7 @@ function create_fragment(ctx) {
 			append(p, t);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*y*/ 1) set_data(t, /*y*/ ctx[0]);
 		},
 		i: noop,

--- a/test/js/samples/use-elements-as-anchors/expected.js
+++ b/test/js/samples/use-elements-as-anchors/expected.js
@@ -156,6 +156,7 @@ function create_fragment(ctx) {
 			insert(target, if_block4_anchor, anchor);
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (/*a*/ ctx[0]) {
 				if (if_block0) {
 					

--- a/test/js/samples/video-bindings/expected.js
+++ b/test/js/samples/video-bindings/expected.js
@@ -53,6 +53,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (!video_updating && dirty & /*currentTime*/ 1 && !isNaN(/*currentTime*/ ctx[0])) {
 				video.currentTime = /*currentTime*/ ctx[0];
 			}

--- a/test/js/samples/window-binding-scroll/expected.js
+++ b/test/js/samples/window-binding-scroll/expected.js
@@ -52,6 +52,7 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
+			/* istanbul ignore next */
 			if (dirty & /*y*/ 1 && !scrolling) {
 				scrolling = true;
 				clearTimeout(scrolling_timeout);


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

Fixes #7824.

For more context I recommend to read the issue description of #7824 and test out the reproduction setup from https://github.com/AriPerkkio/svelte-istanbul-reproduction/blob/main/debug-svelte-sourcemaps.mjs.

There hasn't been much action on the issue itself so I'm not sure whether this approach is accepted. Though I think this is the only possible approach as the lines cannot be excluded from source maps either - described in the linked issue in more details. Feel free to reject and suggest alternative solution. I have had no experience with Svelte compiler before.

Before:
<img width="592" alt="Screenshot 2023-01-25 at 14 27 54" src="https://user-images.githubusercontent.com/14806298/214566152-48b1d401-2fc4-4473-a587-070d831e6e44.png">


After:
<img width="572" alt="Screenshot 2023-01-25 at 14 27 08" src="https://user-images.githubusercontent.com/14806298/214566219-7de186b3-9517-4685-8a0e-936a1115d152.png">

