### PR TITLE
[docs] a variable doubled is used without a declaration? 

### DIFF
--- a/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
+++ b/site/content/tutorial/02-reactivity/02-reactive-declarations/text.md
@@ -6,6 +6,7 @@ Svelte's reactivity not only keeps the DOM in sync with your application's varia
 
 ```js
 let count = 0;
+let doubled ;
 $: doubled = count * 2;
 ```
 


### PR DESCRIPTION
I am a bit confused as to how doubled is recognized as a variable even though there is no declaration. should we not declare doubled before using it? Is a global variable created automatically using var? 

P.S. I am new to Svelte - I am not sure how to raise this issue. I looked through the open source contributing guide and felt that editing the tutorial is the right way to point out the issue. If I should create an issue, please let me know