### PR TITLE
docs: fix `fly` animation description

### DIFF
--- a/site/content/docs/04-run-time.md
+++ b/site/content/docs/04-run-time.md
@@ -698,7 +698,7 @@ out:fly={params}
 
 ---
 
-Animates the x and y positions and the opacity of an element. `in` transitions animate from an element's current (default) values to the provided values, passed as parameters. `out` transitions animate from the provided values to an element's default values.
+Animates the x and y positions and the opacity of an element. `in` transitions animate from the provided values, passed as parameters to the element's default values. `out` transitions animate from the element's default values to the provided values.
 
 `fly` accepts the following parameters:
 


### PR DESCRIPTION
The PR is intended to fix the fly transition definition. It was stated that:

> `in` transitions animate from an element's current (default) values to the provided values, passed as parameters. `out` transitions animate from the provided values to an element's default values.

and 

> * `x` (`number`, default 0) - the x offset to animate out to and in from
> * `y` (`number`, default 0) - the y offset to animate out to and in from
> * `opacity` (`number`, default 0) - the opacity value to animate out to and in from

which are both incompatible. I reversed the definition to:

> `in` transitions animate **from the provided values, passed as parameters to the element's default values**. `out` transitions animate **from the element's default values to the provided values**.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
