### PR TITLE
Potentially missing @html tag in <pre> element

### DIFF
--- a/site/content/tutorial/06-bindings/08-contenteditable-bindings/app-a/App.svelte
+++ b/site/content/tutorial/06-bindings/08-contenteditable-bindings/app-a/App.svelte
@@ -4,7 +4,7 @@
 
 <div contenteditable="true"></div>
 
-<pre>{html}</pre>
+<pre>{@html html}</pre>
 
 <style>
 	[contenteditable] {


### PR DESCRIPTION
Tutorial page rendered the <p></p> tags as plaintext in the html body. Seems an @html tag would solve the issue.

