### PR TITLE
chore: update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Before submitting the PR, please make sure you do the following
 - [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
-- [ ] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
+- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
 - [ ] This message body should clearly illustrate what problems it solves.
 - [ ] Ideally, include a test that fails without this PR but passes with it.
 


### PR DESCRIPTION
Thanks to @baseballyama for noticing this. We updated SvelteKit this way to match the dependabot default, go with the more common way, etc.
