### PR TITLE
fix: improve source map support for code coverage tools

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/shared/Tag.ts
+++ b/src/compiler/compile/render_dom/wrappers/shared/Tag.ts
@@ -45,13 +45,17 @@ export default class Tag extends Wrapper {
 				condition = x`!#current || ${condition}`;
 			}
 
-			const update_cached_value = x`${value} !== (${value} = ${snippet})`;
-
 			if (this.node.should_cache) {
-				condition = x`${condition} && ${update_cached_value}`;
+				block.chunks.update.push(b`
+					if (${condition}) {
+						if (${value} !== (${value} = ${snippet})) {
+							${update(content as Node)}
+						}
+					}`
+				);
+			} else {
+				block.chunks.update.push(b`if (${condition}) ${update(content as Node)}`);
 			}
-
-			block.chunks.update.push(b`if (${condition}) ${update(content as Node)}`);
 		}
 
 		return { init: content };

--- a/test/js/samples/debug-foo-bar-baz-things/expected.js
+++ b/test/js/samples/debug-foo-bar-baz-things/expected.js
@@ -56,7 +56,11 @@ function create_each_block(ctx) {
 			insert_dev(target, t1, anchor);
 		},
 		p: function update(ctx, dirty) {
-			if (dirty & /*things*/ 1 && t0_value !== (t0_value = /*thing*/ ctx[4].name + "")) set_data_dev(t0, t0_value);
+			if (dirty & /*things*/ 1) {
+				if (t0_value !== (t0_value = /*thing*/ ctx[4].name + "")) {
+					set_data_dev(t0, t0_value);
+				}
+			}
 
 			if (dirty & /*foo, bar, baz, things*/ 15) {
 				const foo = /*foo*/ ctx[1];

--- a/test/js/samples/debug-foo/expected.js
+++ b/test/js/samples/debug-foo/expected.js
@@ -53,7 +53,11 @@ function create_each_block(ctx) {
 			insert_dev(target, t1, anchor);
 		},
 		p: function update(ctx, dirty) {
-			if (dirty & /*things*/ 1 && t0_value !== (t0_value = /*thing*/ ctx[2].name + "")) set_data_dev(t0, t0_value);
+			if (dirty & /*things*/ 1) {
+				if (t0_value !== (t0_value = /*thing*/ ctx[2].name + "")) {
+					set_data_dev(t0, t0_value);
+				}
+			}
 
 			if (dirty & /*foo*/ 2) {
 				const foo = /*foo*/ ctx[1];

--- a/test/js/samples/deconflict-builtins/expected.js
+++ b/test/js/samples/deconflict-builtins/expected.js
@@ -36,7 +36,11 @@ function create_each_block(ctx) {
 			append(span, t);
 		},
 		p(ctx, dirty) {
-			if (dirty & /*createElement*/ 1 && t_value !== (t_value = /*node*/ ctx[1] + "")) set_data(t, t_value);
+			if (dirty & /*createElement*/ 1) {
+				if (t_value !== (t_value = /*node*/ ctx[1] + "")) {
+					set_data(t, t_value);
+				}
+			}
 		},
 		d(detaching) {
 			if (detaching) detach(span);

--- a/test/js/samples/dev-warning-missing-data-computed/expected.js
+++ b/test/js/samples/dev-warning-missing-data-computed/expected.js
@@ -43,7 +43,12 @@ function create_fragment(ctx) {
 			append_dev(p, t2);
 		},
 		p: function update(ctx, [dirty]) {
-			if (dirty & /*foo*/ 1 && t0_value !== (t0_value = Math.max(0, /*foo*/ ctx[0]) + "")) set_data_dev(t0, t0_value);
+			if (dirty & /*foo*/ 1) {
+				if (t0_value !== (t0_value = Math.max(0, /*foo*/ ctx[0]) + "")) {
+					set_data_dev(t0, t0_value);
+				}
+			}
+
 			if (dirty & /*bar*/ 2) set_data_dev(t2, /*bar*/ ctx[1]);
 		},
 		i: noop,

--- a/test/js/samples/each-block-array-literal/expected.js
+++ b/test/js/samples/each-block-array-literal/expected.js
@@ -36,7 +36,11 @@ function create_each_block(ctx) {
 			append(span, t);
 		},
 		p(ctx, dirty) {
-			if (dirty & /*a, b, c, d, e*/ 31 && t_value !== (t_value = /*num*/ ctx[5] + "")) set_data(t, t_value);
+			if (dirty & /*a, b, c, d, e*/ 31) {
+				if (t_value !== (t_value = /*num*/ ctx[5] + "")) {
+					set_data(t, t_value);
+				}
+			}
 		},
 		d(detaching) {
 			if (detaching) detach(span);

--- a/test/js/samples/each-block-changed-check/expected.js
+++ b/test/js/samples/each-block-changed-check/expected.js
@@ -71,9 +71,23 @@ function create_each_block(ctx) {
 			html_tag.m(raw_value, div);
 		},
 		p(ctx, dirty) {
-			if (dirty & /*comments*/ 1 && t2_value !== (t2_value = /*comment*/ ctx[4].author + "")) set_data(t2, t2_value);
-			if (dirty & /*elapsed, comments, time*/ 7 && t4_value !== (t4_value = /*elapsed*/ ctx[1](/*comment*/ ctx[4].time, /*time*/ ctx[2]) + "")) set_data(t4, t4_value);
-			if (dirty & /*comments*/ 1 && raw_value !== (raw_value = /*comment*/ ctx[4].html + "")) html_tag.p(raw_value);
+			if (dirty & /*comments*/ 1) {
+				if (t2_value !== (t2_value = /*comment*/ ctx[4].author + "")) {
+					set_data(t2, t2_value);
+				}
+			}
+
+			if (dirty & /*elapsed, comments, time*/ 7) {
+				if (t4_value !== (t4_value = /*elapsed*/ ctx[1](/*comment*/ ctx[4].time, /*time*/ ctx[2]) + "")) {
+					set_data(t4, t4_value);
+				}
+			}
+
+			if (dirty & /*comments*/ 1) {
+				if (raw_value !== (raw_value = /*comment*/ ctx[4].html + "")) {
+					html_tag.p(raw_value);
+				}
+			}
 		},
 		d(detaching) {
 			if (detaching) detach(div);

--- a/test/js/samples/each-block-keyed-animated/expected.js
+++ b/test/js/samples/each-block-keyed-animated/expected.js
@@ -45,7 +45,12 @@ function create_each_block(key_1, ctx) {
 		},
 		p(new_ctx, dirty) {
 			ctx = new_ctx;
-			if (dirty & /*things*/ 1 && t_value !== (t_value = /*thing*/ ctx[1].name + "")) set_data(t, t_value);
+
+			if (dirty & /*things*/ 1) {
+				if (t_value !== (t_value = /*thing*/ ctx[1].name + "")) {
+					set_data(t, t_value);
+				}
+			}
 		},
 		r() {
 			rect = div.getBoundingClientRect();

--- a/test/js/samples/each-block-keyed/expected.js
+++ b/test/js/samples/each-block-keyed/expected.js
@@ -41,7 +41,12 @@ function create_each_block(key_1, ctx) {
 		},
 		p(new_ctx, dirty) {
 			ctx = new_ctx;
-			if (dirty & /*things*/ 1 && t_value !== (t_value = /*thing*/ ctx[1].name + "")) set_data(t, t_value);
+
+			if (dirty & /*things*/ 1) {
+				if (t_value !== (t_value = /*thing*/ ctx[1].name + "")) {
+					set_data(t, t_value);
+				}
+			}
 		},
 		d(detaching) {
 			if (detaching) detach(div);

--- a/test/js/samples/instrumentation-script-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-script-x-equals-x/expected.js
@@ -46,7 +46,11 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
-			if (dirty & /*things*/ 1 && t3_value !== (t3_value = /*things*/ ctx[0].length + "")) set_data(t3, t3_value);
+			if (dirty & /*things*/ 1) {
+				if (t3_value !== (t3_value = /*things*/ ctx[0].length + "")) {
+					set_data(t3, t3_value);
+				}
+			}
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/instrumentation-template-x-equals-x/expected.js
+++ b/test/js/samples/instrumentation-template-x-equals-x/expected.js
@@ -46,7 +46,11 @@ function create_fragment(ctx) {
 			}
 		},
 		p(ctx, [dirty]) {
-			if (dirty & /*things*/ 1 && t3_value !== (t3_value = /*things*/ ctx[0].length + "")) set_data(t3, t3_value);
+			if (dirty & /*things*/ 1) {
+				if (t3_value !== (t3_value = /*things*/ ctx[0].length + "")) {
+					set_data(t3, t3_value);
+				}
+			}
 		},
 		i: noop,
 		o: noop,

--- a/test/js/samples/optional-chaining/expected.js
+++ b/test/js/samples/optional-chaining/expected.js
@@ -92,12 +92,41 @@ function create_fragment(ctx) {
 			current = true;
 		},
 		p(ctx, [dirty]) {
-			if ((!current || dirty & /*a*/ 1) && t0_value !== (t0_value = /*a*/ ctx[0].normal + "")) set_data(t0, t0_value);
-			if ((!current || dirty & /*b*/ 2) && t1_value !== (t1_value = /*b*/ ctx[1]?.optional + "")) set_data(t1, t1_value);
-			if ((!current || dirty & /*c*/ 4) && t3_value !== (t3_value = /*c*/ ctx[2]['computed'] + "")) set_data(t3, t3_value);
-			if ((!current || dirty & /*d*/ 8) && t4_value !== (t4_value = /*d*/ ctx[3]?.['computed_optional'] + "")) set_data(t4, t4_value);
-			if ((!current || dirty & /*e*/ 16) && t6_value !== (t6_value = /*e*/ ctx[4]() + "")) set_data(t6, t6_value);
-			if ((!current || dirty & /*f*/ 32) && t7_value !== (t7_value = /*f*/ ctx[5]?.() + "")) set_data(t7, t7_value);
+			if (!current || dirty & /*a*/ 1) {
+				if (t0_value !== (t0_value = /*a*/ ctx[0].normal + "")) {
+					set_data(t0, t0_value);
+				}
+			}
+
+			if (!current || dirty & /*b*/ 2) {
+				if (t1_value !== (t1_value = /*b*/ ctx[1]?.optional + "")) {
+					set_data(t1, t1_value);
+				}
+			}
+
+			if (!current || dirty & /*c*/ 4) {
+				if (t3_value !== (t3_value = /*c*/ ctx[2]['computed'] + "")) {
+					set_data(t3, t3_value);
+				}
+			}
+
+			if (!current || dirty & /*d*/ 8) {
+				if (t4_value !== (t4_value = /*d*/ ctx[3]?.['computed_optional'] + "")) {
+					set_data(t4, t4_value);
+				}
+			}
+
+			if (!current || dirty & /*e*/ 16) {
+				if (t6_value !== (t6_value = /*e*/ ctx[4]() + "")) {
+					set_data(t6, t6_value);
+				}
+			}
+
+			if (!current || dirty & /*f*/ 32) {
+				if (t7_value !== (t7_value = /*f*/ ctx[5]?.() + "")) {
+					set_data(t7, t7_value);
+				}
+			}
 
 			if (!current || dirty & /*a*/ 1 && div_a_value !== (div_a_value = /*a*/ ctx[0].normal)) {
 				attr(div, "a", div_a_value);


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`


Fixes #7824.

This change adjusts the generated update part of `create_each_block` so that [`istanbul-lib-source-maps`](https://github.com/istanbuljs/istanbuljs/blob/master/packages/istanbul-lib-source-maps/lib/get-mapping.js) will exclude it from coverage report when re-mapping the source maps using `source-map` package. Now `istanbul-lib-source-maps` will not find the `loc.end` for the if-statement and decides to exclude it from report. This is better approach than using ignore hints as attempted in #8226. Reproduction available at https://github.com/AriPerkkio/svelte-istanbul-reproduction/blob/main/debug-svelte-sourcemaps.mjs.

Before:

<img src="https://user-images.githubusercontent.com/14806298/217796118-0f220bd0-31f4-4c8b-a85e-6e1c17dfd3fb.png" height="450px" />

After:

<img src="https://user-images.githubusercontent.com/14806298/217796299-6144eada-c729-414d-ac74-d7f5c15deca1.png" height="450px" />

This does not fix the uncovered statement of line 12's `each `. It is caused by this hacky solution:

https://github.com/sveltejs/svelte/blob/82d2982845df188631993db6b18c2842e3613acf/src/compiler/compile/render_dom/wrappers/EachBlock.ts#L116-L126
