### PR TITLE
feat: Add -replacestate/-keepfocus to SvelteKit anchor tag props

### DIFF
--- a/elements/index.d.ts
+++ b/elements/index.d.ts
@@ -540,6 +540,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	'bind:textContent'?: string | undefined | null;
 
 	// SvelteKit
+	'data-sveltekit-keepfocus'?: true | '' | 'off' | undefined | null;
 	'data-sveltekit-noscroll'?: true | '' | 'off' | undefined | null;
 	'data-sveltekit-preload-code'?: true | '' | 'eager' | 'viewport' | 'hover' | 'tap' | 'off' | undefined | null;
 	'data-sveltekit-preload-data'?: true | '' | 'hover' | 'tap' | 'off' | undefined | null;

--- a/elements/index.d.ts
+++ b/elements/index.d.ts
@@ -544,6 +544,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	'data-sveltekit-preload-code'?: true | '' | 'eager' | 'viewport' | 'hover' | 'tap' | 'off' | undefined | null;
 	'data-sveltekit-preload-data'?: true | '' | 'hover' | 'tap' | 'off' | undefined | null;
 	'data-sveltekit-reload'?: true | '' | 'off' | undefined | null;
+	'data-sveltekit-replacestate'?: true | '' | 'off' | undefined | null;
 }
 
 export type HTMLAttributeAnchorTarget =


### PR DESCRIPTION
Corresponding changes for data-sveltekit-replacestate addition within SvelteKit: https://github.com/sveltejs/kit/pull/9019

Also related: https://github.com/sveltejs/language-tools/pull/1865

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
