### PR TITLE
fix: undefined parent_component in Component.ts

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -97,7 +97,7 @@ export function init(component, options, instance, create_fragment, not_equal, p
 		callbacks: blank_object(),
 		dirty,
 		skip_bound: false,
-		root: options.target || parent_component.$$.root
+		root: options.target || parent_component?.$$.root
 	};
 
 	append_styles && append_styles($$.root);


### PR DESCRIPTION
This change fixes an issue in Component.ts where an error occurs when the parent_component parameter is undefined, causing the following error: "Cannot read properties of undefined (reading '$$')".

The proposed solution is to add a null check to the parent_component parameter before accessing the $$ property. 

This change ensures that the code works even when parent_component is not defined, as is the case when importing a module dynamically.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
