### PR TITLE
chore: improve parser performance

### DIFF
--- a/src/compiler/parse/index.ts
+++ b/src/compiler/parse/index.ts
@@ -132,6 +132,10 @@ export class Parser {
 		return this.template.slice(this.index, this.index + str.length) === str;
 	}
 
+	/**
+	 * Match a regex at the current index
+	 * @param pattern Should have a ^ anchor at the start so the regex doesn't search past the beginning, resulting in worse performance
+	 */
 	match_regex(pattern: RegExp) {
 		const match = pattern.exec(this.template.slice(this.index));
 		if (!match || match.index !== 0) return null;
@@ -148,6 +152,10 @@ export class Parser {
 		}
 	}
 
+	/**
+	 * Search for a regex starting at the current index and return the result if it matches
+	 * @param pattern Should have a ^ anchor at the start so the regex doesn't search past the beginning, resulting in worse performance
+	 */
 	read(pattern: RegExp) {
 		const result = this.match_regex(pattern);
 		if (result) this.index += result.length;

--- a/src/compiler/parse/read/script.ts
+++ b/src/compiler/parse/read/script.ts
@@ -6,6 +6,7 @@ import parser_errors from '../errors';
 import { regex_not_newline_characters } from '../../utils/patterns';
 
 const regex_closing_script_tag = /<\/script\s*>/;
+const regex_starts_with_closing_script_tag = /^<\/script\s*>/;
 
 function get_context(parser: Parser, attributes: any[], start: number): string {
 	const context = attributes.find(attribute => attribute.name === 'context');
@@ -32,7 +33,7 @@ export default function read_script(parser: Parser, start: number, attributes: N
 	}
 
 	const source = parser.template.slice(0, script_start).replace(regex_not_newline_characters, ' ') + data;
-	parser.read(regex_closing_script_tag);
+	parser.read(regex_starts_with_closing_script_tag);
 
 	let ast: Program;
 

--- a/src/compiler/parse/read/style.ts
+++ b/src/compiler/parse/read/style.ts
@@ -7,6 +7,7 @@ import { Style } from '../../interfaces';
 import parser_errors from '../errors';
 
 const regex_closing_style_tag = /<\/style\s*>/;
+const regex_starts_with_closing_style_tag = /<\/style\s*>/;
 
 export default function read_style(parser: Parser, start: number, attributes: Node[]): Style {
 	const content_start = parser.index;
@@ -21,7 +22,7 @@ export default function read_style(parser: Parser, start: number, attributes: No
 
 	// discard styles when css is disabled
 	if (parser.css_mode === 'none') {
-		parser.read(regex_closing_style_tag);
+		parser.read(regex_starts_with_closing_style_tag);
 		return null;
 	}
 
@@ -76,7 +77,7 @@ export default function read_style(parser: Parser, start: number, attributes: No
 		}
 	});
 
-	parser.read(regex_closing_style_tag);
+	parser.read(regex_starts_with_closing_style_tag);
   
 	const end = parser.index;
 

--- a/src/compiler/parse/read/style.ts
+++ b/src/compiler/parse/read/style.ts
@@ -7,7 +7,7 @@ import { Style } from '../../interfaces';
 import parser_errors from '../errors';
 
 const regex_closing_style_tag = /<\/style\s*>/;
-const regex_starts_with_closing_style_tag = /<\/style\s*>/;
+const regex_starts_with_closing_style_tag = /^<\/style\s*>/;
 
 export default function read_style(parser: Parser, start: number, attributes: Node[]): Style {
 	const content_start = parser.index;

--- a/src/compiler/parse/state/mustache.ts
+++ b/src/compiler/parse/state/mustache.ts
@@ -33,7 +33,7 @@ function trim_whitespace(block: TemplateNode, trim_before: boolean, trim_after: 
 	}
 }
 
-const regex_whitespace_with_closing_curly_brace = /\s*}/;
+const regex_whitespace_with_closing_curly_brace = /^\s*}/;
 
 export default function mustache(parser: Parser) {
 	const start = parser.index;


### PR DESCRIPTION
- fast path for attribute quote marks common case
- all regexes exclusively passed into read or match_regex which are only successful if matched at the beginning are altered so that the regex has this condition built in, preventing it from searching past the start index

closes #7663 - huge thanks to @MathiasWP for starting this thought process. the changes in there are not necessary to that extent to get the perf improvements, it's enough to handle the common case of quote marks and having a regex with the additional `^` condition.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
