### PR TITLE
fix: send in/out to transition fn

### DIFF
--- a/src/runtime/internal/transitions.ts
+++ b/src/runtime/internal/transitions.ts
@@ -376,8 +376,10 @@ export function create_bidirectional_transition(node: Element & ElementCSSInline
 		run(b: INTRO | OUTRO) {
 			if (is_function(config)) {
 				wait().then(() => {
+					const opts: TransitionOptions = { direction: b ? 'in' : 'out' };
+					
 					// @ts-ignore
-					config = config(options);
+					config = config(opts);
 					go(b);
 				});
 			} else {

--- a/test/runtime/samples/transition-js-deferred-option-direction/_config.js
+++ b/test/runtime/samples/transition-js-deferred-option-direction/_config.js
@@ -4,16 +4,19 @@ export default {
 
 		const div_in = target.querySelector('#in');
 		const div_out = target.querySelector('#out');
-		const div_both = target.querySelector('#both');
+		const div_bothin = target.querySelector('#both-in');
+		const div_bothout = target.querySelector('#both-out');
 
-		assert.equal(div_in.initial, 'in');
-		assert.equal(div_out.initial, 'out');
-		assert.equal(div_both.initial, 'both');
+		assert.equal(div_in.directions, 'in,in');
+		assert.equal(div_out.directions, 'out');
+		assert.equal(div_bothin.directions, 'both');
+		assert.equal(div_bothout.directions, 'both');
 
 		return Promise.resolve().then(() => {
-			assert.equal(div_in.later, 'in');
-			assert.equal(div_out.later, 'out');
-			assert.equal(div_both.later, 'both');
+			assert.equal(div_in.directions, 'in,in');
+			assert.equal(div_out.directions, 'out,out');
+			assert.equal(div_bothin.directions, 'both,in');
+			assert.equal(div_bothout.directions, 'both,out');
 		});
 	}
 };

--- a/test/runtime/samples/transition-js-deferred-option-direction/main.svelte
+++ b/test/runtime/samples/transition-js-deferred-option-direction/main.svelte
@@ -2,10 +2,10 @@
 	export let visible;
 
 	function foo(node, _params, options) {
-		node.initial = options.direction;
+		node.directions = options.direction;
 
 		return (opts) => {
-			node.later = opts.direction;
+			node.directions += "," + opts.direction;
 
 			return {
 				duration: 10
@@ -15,10 +15,11 @@
 </script>
 
 {#if visible}
-	<div id="both" transition:foo></div>
-	<div id="in" in:foo></div>
+	<div id="both-in" transition:foo />
+	<div id="in" in:foo />
 {/if}
 
 {#if !visible}
-	<div id="out" out:foo></div>
+	<div id="out" out:foo />
+	<div id="both-out" transition:foo={{ duration: 500 }} />
 {/if}


### PR DESCRIPTION
After #3918 was fixed by #8068 it was noticed by @robertadamsonsmith that if your transition function and is used as a combined in/out transition, it still got sent `{ direction: 'both' }` when running the function instead of `in` or `out` depending on the direction the transition is going. This severely limits the utility of passing the `direction` value in the first place.

https://github.com/sveltejs/svelte/issues/3918#issuecomment-1367995446

I agree with him that this is a bug in the original version of #8068, so I'm sending this PR in the hopes that we can get that corrected before too long.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
