### PR TITLE
chore: switch to @jridgewell/sourcemap-codec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@ampproject/remapping": "^0.3.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14",
         "@rollup/plugin-commonjs": "^11.0.0",
         "@rollup/plugin-json": "^4.0.1",
         "@rollup/plugin-node-resolve": "^11.2.1",
@@ -44,7 +45,6 @@
         "rollup": "^1.27.14",
         "source-map": "^0.7.4",
         "source-map-support": "^0.5.21",
-        "sourcemap-codec": "^1.4.8",
         "tiny-glob": "^0.2.9",
         "tslib": "^2.4.1",
         "typescript": "^3.7.5",
@@ -161,6 +161,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5371,6 +5377,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
       "integrity": "sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
   "homepage": "https://svelte.dev",
   "devDependencies": {
     "@ampproject/remapping": "^0.3.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14",
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-json": "^4.0.1",
     "@rollup/plugin-node-resolve": "^11.2.1",
@@ -154,7 +155,6 @@
     "rollup": "^1.27.14",
     "source-map": "^0.7.4",
     "source-map-support": "^0.5.21",
-    "sourcemap-codec": "^1.4.8",
     "tiny-glob": "^0.2.9",
     "tslib": "^2.4.1",
     "typescript": "^3.7.5",

--- a/src/compiler/preprocess/decode_sourcemap.ts
+++ b/src/compiler/preprocess/decode_sourcemap.ts
@@ -1,4 +1,4 @@
-import { decode as decode_mappings } from 'sourcemap-codec';
+import { decode as decode_mappings } from '@jridgewell/sourcemap-codec';
 import { Processed } from './types';
 
 /**


### PR DESCRIPTION
`sourcemap-codec` has been archived in favor of `@jridgewell/sourcemap-codec`

As follow-ups, we will also need to merge:
- https://github.com/Rich-Harris/code-red/pull/74

And upgrade:
- @ampproject/remapping (causes `generate-type-definitions` to fail - may need to happen as part of Svelte 4?)
- magic-string (causes a sourcemap test to fail - better to do this separately to investigate)