### PR TITLE
chore: Reduce number of lines of expected files

### DIFF
--- a/test/validator/index.ts
+++ b/test/validator/index.ts
@@ -33,13 +33,15 @@ describe('validate', () => {
 					...options
 				});
 
-				assert.deepEqual(warnings.map(w => ({
-					code: w.code,
-					message: w.message,
-					pos: w.pos,
-					start: w.start,
-					end: w.end
-				})), expected_warnings);
+				assert.deepEqual(
+					warnings.map((w) => ({
+						code: w.code,
+						message: w.message,
+						start: { line: w.start.line, column: w.start.column },
+						end: { line: w.end.line, column: w.end.column },
+					})),
+					expected_warnings
+				);
 			} catch (e) {
 				error = e;
 			}
@@ -56,13 +58,17 @@ describe('validate', () => {
 				}
 
 				try {
-					assert.equal(error.code, expected.code);
-					assert.equal(error.message, expected.message);
-					assert.deepEqual(error.start, expected.start);
-					assert.deepEqual(error.end, expected.end);
-					assert.equal(error.pos, expected.pos);
+					assert.deepEqual(
+						{
+							code: error.code,
+							message: error.message,
+							start: { line: error.start.line, column: error.start.column },
+							end: { line: error.end.line, column: error.end.column },
+						},
+						expected
+					);
 				} catch (e) {
-					console.error(error); // eslint-disable-line no-console
+					console.error(error);
 					throw e;
 				}
 			}
@@ -76,6 +82,51 @@ describe('validate', () => {
 				generate: false
 			});
 		}, /options\.name must be a valid identifier/);
+	});
+
+	it("check warning position", () => {
+		const { warnings } = svelte.compile('\n  <img \n src="foo.jpg">\n', {
+			generate: false,
+		});
+
+		assert.deepEqual(
+			warnings.map((w) => {
+				return {
+					code: w.code,
+					frame: w.frame,
+					message: w.message,
+					start: {
+						character: w.start.character,
+						column: w.start.column,
+						line: w.start.line,
+					},
+					end: {
+						character: w.end.character,
+						column: w.end.column,
+						line: w.end.line,
+					},
+					pos: w.pos,
+				};
+			}),
+			[
+				{
+					code: "a11y-missing-attribute",
+					frame: '1: \n2:   <img \n     ^\n3:  src="foo.jpg">\n4: ',
+					message: "A11y: <img> element should have an alt attribute",
+					start: {
+						character: 3,
+						column: 2,
+						line: 2,
+					},
+					end: {
+						character: 24,
+						column: 15,
+						line: 3,
+					},
+					pos: 3,
+				},
+			]
+		);
 	});
 
 	it('warns if options.name is not capitalised', () => {

--- a/test/validator/index.ts
+++ b/test/validator/index.ts
@@ -38,7 +38,7 @@ describe('validate', () => {
 						code: w.code,
 						message: w.message,
 						start: { line: w.start.line, column: w.start.column },
-						end: { line: w.end.line, column: w.end.column },
+						end: { line: w.end.line, column: w.end.column }
 					})),
 					expected_warnings
 				);
@@ -63,7 +63,7 @@ describe('validate', () => {
 							code: error.code,
 							message: error.message,
 							start: { line: error.start.line, column: error.start.column },
-							end: { line: error.end.line, column: error.end.column },
+							end: { line: error.end.line, column: error.end.column }
 						},
 						expected
 					);
@@ -84,9 +84,9 @@ describe('validate', () => {
 		}, /options\.name must be a valid identifier/);
 	});
 
-	it("check warning position", () => {
+	it('check warning position', () => {
 		const { warnings } = svelte.compile('\n  <img \n src="foo.jpg">\n', {
-			generate: false,
+			generate: false
 		});
 
 		assert.deepEqual(
@@ -98,33 +98,33 @@ describe('validate', () => {
 					start: {
 						character: w.start.character,
 						column: w.start.column,
-						line: w.start.line,
+						line: w.start.line
 					},
 					end: {
 						character: w.end.character,
 						column: w.end.column,
-						line: w.end.line,
+						line: w.end.line
 					},
-					pos: w.pos,
+					pos: w.pos
 				};
 			}),
 			[
 				{
-					code: "a11y-missing-attribute",
+					code: 'a11y-missing-attribute',
 					frame: '1: \n2:   <img \n     ^\n3:  src="foo.jpg">\n4: ',
-					message: "A11y: <img> element should have an alt attribute",
+					message: 'A11y: <img> element should have an alt attribute',
 					start: {
 						character: 3,
 						column: 2,
-						line: 2,
+						line: 2
 					},
 					end: {
 						character: 24,
 						column: 15,
-						line: 3,
+						line: 3
 					},
-					pos: 3,
-				},
+					pos: 3
+				}
 			]
 		);
 	});

--- a/test/validator/samples/a11y-alt-text/warnings.json
+++ b/test/validator/samples/a11y-alt-text/warnings.json
@@ -4,62 +4,47 @@
 		"message": "A11y: <img> element should have an alt attribute",
 		"start": {
 			"line": 1,
-			"column": 0,
-			"character": 0
+			"column": 0
 		},
 		"end": {
 			"line": 1,
-			"column": 19,
-			"character": 19
-		},
-		"pos": 0
+			"column": 19
+		}
 	},
-
 	{
 		"code": "a11y-missing-attribute",
 		"message": "A11y: <area> element should have an alt, aria-label or aria-labelledby attribute",
 		"start": {
 			"line": 4,
-			"column": 1,
-			"character": 28
+			"column": 1
 		},
 		"end": {
 			"line": 4,
-			"column": 7,
-			"character": 34
-		},
-		"pos": 28
+			"column": 7
+		}
 	},
-
 	{
 		"code": "a11y-missing-attribute",
 		"message": "A11y: <object> element should have a title, aria-label or aria-labelledby attribute",
 		"start": {
 			"line": 7,
-			"column": 0,
-			"character": 43
+			"column": 0
 		},
 		"end": {
 			"line": 7,
-			"column": 17,
-			"character": 60
-		},
-		"pos": 43
+			"column": 17
+		}
 	},
-
 	{
 		"code": "a11y-missing-attribute",
 		"message": "A11y: <input type=\"image\"> element should have an alt, aria-label or aria-labelledby attribute",
 		"start": {
 			"line": 9,
-			"column": 0,
-			"character": 62
+			"column": 0
 		},
 		"end": {
 			"line": 9,
-			"column": 20,
-			"character": 82
-		},
-		"pos": 62
+			"column": 20
+		}
 	}
 ]

--- a/test/validator/samples/a11y-anchor-has-content/warnings.json
+++ b/test/validator/samples/a11y-anchor-has-content/warnings.json
@@ -3,13 +3,10 @@
 	"message": "A11y: <a> element should have child content",
 	"start": {
 		"line": 1,
-		"column": 0,
-		"character": 0
+		"column": 0
 	},
 	"end": {
 		"line": 1,
-		"column": 19,
-		"character": 19
-	},
-	"pos": 0
+		"column": 19
+	}
 }]

--- a/test/validator/samples/a11y-anchor-in-svg-is-valid/warnings.json
+++ b/test/validator/samples/a11y-anchor-in-svg-is-valid/warnings.json
@@ -4,44 +4,35 @@
 		"message": "A11y: <a> element should have an href attribute",
 		"start": {
 			"line": 1,
-			"column": 11,
-			"character": 11
+			"column": 11
 		},
 		"end": {
 			"line": 1,
-			"column": 37,
-			"character": 37
-		},
-		"pos": 11
+			"column": 37
+		}
 	},
 	{
 		"code": "a11y-invalid-attribute",
 		"message": "A11y: '' is not a valid xlink:href attribute",
 		"start": {
 			"line": 2,
-			"column": 14,
-			"character": 65
+			"column": 14
 		},
 		"end": {
 			"line": 2,
-			"column": 27,
-			"character": 78
-		},
-		"pos": 65
+			"column": 27
+		}
 	},
 	{
 		"code": "a11y-invalid-attribute",
 		"message": "A11y: '#' is not a valid xlink:href attribute",
 		"start": {
 			"line": 3,
-			"column": 14,
-			"character": 130
+			"column": 14
 		},
 		"end": {
 			"line": 3,
-			"column": 28,
-			"character": 144
-		},
-		"pos": 130
+			"column": 28
+		}
 	}
 ]

--- a/test/validator/samples/a11y-anchor-is-valid/warnings.json
+++ b/test/validator/samples/a11y-anchor-is-valid/warnings.json
@@ -4,89 +4,71 @@
 		"message": "A11y: <a> element should have an href attribute",
 		"start": {
 			"line": 1,
-			"column": 0,
-			"character": 0
+			"column": 0
 		},
 		"end": {
 			"line": 1,
-			"column": 26,
-			"character": 26
-		},
-		"pos": 0
+			"column": 26
+		}
 	},
 	{
 		"code": "a11y-invalid-attribute",
 		"message": "A11y: '' is not a valid href attribute",
 		"start": {
 			"line": 2,
-			"column": 3,
-			"character": 30
+			"column": 3
 		},
 		"end": {
 			"line": 2,
-			"column": 10,
-			"character": 37
-		},
-		"pos": 30
+			"column": 10
+		}
 	},
 	{
 		"code": "a11y-invalid-attribute",
 		"message": "A11y: '#' is not a valid href attribute",
 		"start": {
 			"line": 3,
-			"column": 3,
-			"character": 53
+			"column": 3
 		},
 		"end": {
 			"line": 3,
-			"column": 11,
-			"character": 61
-		},
-		"pos": 53
+			"column": 11
+		}
 	},
 	{
 		"code": "a11y-invalid-attribute",
 		"message": "A11y: 'javascript:void(0)' is not a valid href attribute",
 		"start": {
 			"line": 4,
-			"column": 3,
-			"character": 77
+			"column": 3
 		},
 		"end": {
 			"line": 4,
-			"column": 28,
-			"character": 102
-		},
-		"pos": 77
+			"column": 28
+		}
 	},
 	{
 		"code": "a11y-missing-attribute",
 		"message": "A11y: <a> element should have an href attribute",
 		"start": {
 			"line": 5,
-			"column": 0,
-			"character": 115
+			"column": 0
 		},
 		"end": {
 			"line": 5,
-			"column": 22,
-			"character": 137
-		},
-		"pos": 115
+			"column": 22
+		}
 	},
 	{
 		"code": "a11y-missing-attribute",
 		"message": "A11y: <a> element should have an href attribute",
 		"start": {
 			"line": 6,
-			"column": 0,
-			"character": 138
+			"column": 0
 		},
 		"end": {
 			"line": 6,
-			"column": 20,
-			"character": 158
-		},
-		"pos": 138
+			"column": 20
+		}
 	}
 ]

--- a/test/validator/samples/a11y-aria-activedescendant/warnings.json
+++ b/test/validator/samples/a11y-aria-activedescendant/warnings.json
@@ -2,14 +2,11 @@
   {
     "code": "a11y-aria-activedescendant-has-tabindex",
     "end": {
-      "character": 568,
       "column": 36,
       "line": 16
     },
     "message": "A11y: Elements with attribute aria-activedescendant should have tabindex value",
-    "pos": 537,
     "start": {
-      "character": 537,
       "column": 5,
       "line": 16
     }

--- a/test/validator/samples/a11y-aria-props/warnings.json
+++ b/test/validator/samples/a11y-aria-props/warnings.json
@@ -4,30 +4,23 @@
 		"message": "A11y: Unknown aria attribute 'aria-labeledby' (did you mean 'labelledby'?)",
 		"start": {
 			"line": 1,
-			"column": 20,
-			"character": 20
+			"column": 20
 		},
 		"end": {
 			"line": 1,
-			"column": 40,
-			"character": 40
-		},
-		"pos": 20
+			"column": 40
+		}
 	},
-
 	{
 		"code": "a11y-missing-attribute",
 		"message": "A11y: <input type=\"image\"> element should have an alt, aria-label or aria-labelledby attribute",
 		"start": {
 			"column": 0,
-			"line": 1,
-			"character": 0
+			"line": 1
 		},
 		"end": {
 			"line": 1,
-			"column": 41,
-			"character": 41
-		},
-		"pos": 0
+			"column": 41
+		}
 	}
 ]

--- a/test/validator/samples/a11y-aria-proptypes-boolean/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-boolean/warnings.json
@@ -4,29 +4,23 @@
     "message": "A11y: The value of 'aria-disabled' must be exactly one of true or false",
     "start": {
       "line": 5,
-      "column": 8,
-      "character": 51
+      "column": 8
     },
     "end": {
       "line": 5,
-      "column": 27,
-      "character": 70
-    },
-    "pos": 51
+      "column": 27
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-disabled' must be exactly one of true or false",
     "start": {
       "line": 6,
-      "column": 8,
-      "character": 81
+      "column": 8
     },
     "end": {
       "line": 6,
-      "column": 26,
-      "character": 99
-    },
-    "pos": 81
+      "column": 26
+    }
   }
 ]

--- a/test/validator/samples/a11y-aria-proptypes-integer/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-integer/warnings.json
@@ -4,44 +4,35 @@
     "message": "A11y: The value of 'aria-level' must be of type integer",
     "start": {
       "line": 1,
-      "column": 5,
-      "character": 5
+      "column": 5
     },
     "end": {
       "line": 1,
-      "column": 21,
-      "character": 21
-    },
-    "pos": 5
+      "column": 21
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-level' must be of type integer",
     "start": {
       "line": 2,
-      "column": 5,
-      "character": 30
+      "column": 5
     },
     "end": {
       "line": 2,
-      "column": 20,
-      "character": 45
-    },
-    "pos": 30
+      "column": 20
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-level' must be of type integer",
     "start": {
       "line": 5,
-      "column": 5,
-      "character": 107
+      "column": 5
     },
     "end": {
       "line": 5,
-      "column": 15,
-      "character": 117
-    },
-    "pos": 107
+      "column": 15
+    }
   }
 ]

--- a/test/validator/samples/a11y-aria-proptypes-number/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-number/warnings.json
@@ -1,47 +1,38 @@
 [
-  {
-    "code": "a11y-incorrect-aria-attribute-type",
-    "message": "A11y: The value of 'aria-valuemax' must be of type number",
-    "start": {
-      "line": 1,
-      "column": 5,
-      "character": 5
-    },
-    "end": {
-      "line": 1,
-      "column": 24,
-      "character": 24
-    },
-    "pos": 5
-  },
-  {
-    "code": "a11y-incorrect-aria-attribute-type",
-    "message": "A11y: The value of 'aria-valuemax' must be of type number",
-    "start": {
-      "line": 2,
-      "column": 5,
-      "character": 33
-    },
-    "end": {
-      "line": 2,
-      "column": 23,
-      "character": 51
-    },
-    "pos": 33
-  },
-  {
-    "code": "a11y-incorrect-aria-attribute-type",
-    "message": "A11y: The value of 'aria-valuemax' must be of type number",
-    "start": {
-      "line": 5,
-      "column": 5,
-      "character": 119
-    },
-    "end": {
-      "line": 5,
-      "column": 18,
-      "character": 132
-    },
-    "pos": 119
-  }
+	{
+		"code": "a11y-incorrect-aria-attribute-type",
+		"message": "A11y: The value of 'aria-valuemax' must be of type number",
+		"start": {
+			"line": 1,
+			"column": 5
+		},
+		"end": {
+			"line": 1,
+			"column": 24
+		}
+	},
+	{
+		"code": "a11y-incorrect-aria-attribute-type",
+		"message": "A11y: The value of 'aria-valuemax' must be of type number",
+		"start": {
+			"line": 2,
+			"column": 5
+		},
+		"end": {
+			"line": 2,
+			"column": 23
+		}
+	},
+	{
+		"code": "a11y-incorrect-aria-attribute-type",
+		"message": "A11y: The value of 'aria-valuemax' must be of type number",
+		"start": {
+			"line": 5,
+			"column": 5
+		},
+		"end": {
+			"line": 5,
+			"column": 18
+		}
+	}
 ]

--- a/test/validator/samples/a11y-aria-proptypes-string/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-string/warnings.json
@@ -1,17 +1,14 @@
 [
-  {
-    "code": "a11y-incorrect-aria-attribute-type",
-    "message": "A11y: The value of 'aria-label' must be of type string",
-    "start": {
-      "line": 1,
-      "column": 5,
-      "character": 5
-    },
-    "end": {
-      "line": 1,
-      "column": 15,
-      "character": 15
-    },
-    "pos": 5
-  }
+	{
+		"code": "a11y-incorrect-aria-attribute-type",
+		"message": "A11y: The value of 'aria-label' must be of type string",
+		"start": {
+			"line": 1,
+			"column": 5
+		},
+		"end": {
+			"line": 1,
+			"column": 15
+		}
+	}
 ]

--- a/test/validator/samples/a11y-aria-proptypes-token/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-token/warnings.json
@@ -4,59 +4,47 @@
     "message": "A11y: The value of 'aria-sort' must be exactly one of ascending, descending, none, other",
     "start": {
       "line": 1,
-      "column": 5,
-      "character": 5
+      "column": 5
     },
     "end": {
       "line": 1,
-      "column": 17,
-      "character": 17
-    },
-    "pos": 5
+      "column": 17
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-sort' must be exactly one of ascending, descending, none, other",
     "start": {
       "line": 2,
-      "column": 5,
-      "character": 26
+      "column": 5
     },
     "end": {
       "line": 2,
-      "column": 26,
-      "character": 47
-    },
-    "pos": 26
+      "column": 26
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-sort' must be exactly one of ascending, descending, none, other",
     "start": {
       "line": 3,
-      "column": 5,
-      "character": 56
+      "column": 5
     },
     "end": {
       "line": 3,
-      "column": 14,
-      "character": 65
-    },
-    "pos": 56
+      "column": 14
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-sort' must be exactly one of ascending, descending, none, other",
     "start": {
       "line": 6,
-      "column": 5,
-      "character": 127
+      "column": 5
     },
     "end": {
       "line": 6,
-      "column": 37,
-      "character": 159
-    },
-    "pos": 127
+      "column": 37
+    }
   }
 ]

--- a/test/validator/samples/a11y-aria-proptypes-tokenlist/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-tokenlist/warnings.json
@@ -4,74 +4,59 @@
     "message": "A11y: The value of 'aria-relevant' must be a space-separated list of one or more of additions, all, removals, text",
     "start": {
       "line": 1,
-      "column": 5,
-      "character": 5
+      "column": 5
     },
     "end": {
       "line": 1,
-      "column": 21,
-      "character": 21
-    },
-    "pos": 5
+      "column": 21
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-relevant' must be a space-separated list of one or more of additions, all, removals, text",
     "start": {
       "line": 2,
-      "column": 5,
-      "character": 30
+      "column": 5
     },
     "end": {
       "line": 2,
-      "column": 27,
-      "character": 52
-    },
-    "pos": 30
+      "column": 27
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-relevant' must be a space-separated list of one or more of additions, all, removals, text",
     "start": {
       "line": 3,
-      "column": 5,
-      "character": 61
+      "column": 5
     },
     "end": {
       "line": 3,
-      "column": 18,
-      "character": 74
-    },
-    "pos": 61
+      "column": 18
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-relevant' must be a space-separated list of one or more of additions, all, removals, text",
     "start": {
       "line": 6,
-      "column": 5,
-      "character": 144
+      "column": 5
     },
     "end": {
       "line": 6,
-      "column": 40,
-      "character": 179
-    },
-    "pos": 144
+      "column": 40
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-relevant' must be a space-separated list of one or more of additions, all, removals, text",
     "start": {
       "line": 7,
-      "column": 5,
-      "character": 188
+      "column": 5
     },
     "end": {
       "line": 7,
-      "column": 41,
-      "character": 224
-    },
-    "pos": 188
+      "column": 41
+    }
   }
 ]

--- a/test/validator/samples/a11y-aria-proptypes-tristate/warnings.json
+++ b/test/validator/samples/a11y-aria-proptypes-tristate/warnings.json
@@ -4,29 +4,23 @@
     "message": "A11y: The value of 'aria-checked' must be exactly one of true, false, or mixed",
     "start": {
       "line": 5,
-      "column": 5,
-      "character": 48
+      "column": 5
     },
     "end": {
       "line": 5,
-      "column": 23,
-      "character": 66
-    },
-    "pos": 48
+      "column": 23
+    }
   },
   {
     "code": "a11y-incorrect-aria-attribute-type",
     "message": "A11y: The value of 'aria-checked' must be exactly one of true, false, or mixed",
     "start": {
       "line": 6,
-      "column": 5,
-      "character": 75
+      "column": 5
     },
     "end": {
       "line": 6,
-      "column": 22,
-      "character": 92
-    },
-    "pos": 75
+      "column": 22
+    }
   }
 ]

--- a/test/validator/samples/a11y-aria-role/warnings.json
+++ b/test/validator/samples/a11y-aria-role/warnings.json
@@ -4,29 +4,23 @@
 		"message": "A11y: Unknown role 'toooltip' (did you mean 'tooltip'?)",
 		"start": {
 			"line": 6,
-			"column": 5,
-			"character": 101
+			"column": 5
 		},
 		"end": {
 			"line": 6,
-			"column": 20,
-			"character": 116
-		},
-		"pos": 101
+			"column": 20
+		}
 	},
 	{
 		"code": "a11y-unknown-role",
 		"message": "A11y: Unknown role 'toooltip' (did you mean 'tooltip'?)",
 		"start": {
 			"line": 7,
-			"column": 5,
-			"character": 129
+			"column": 5
 		},
 		"end": {
 			"line": 7,
-			"column": 27,
-			"character": 151
-		},
-		"pos": 129
+			"column": 27
+		}
 	}
 ]

--- a/test/validator/samples/a11y-aria-unsupported-element/warnings.json
+++ b/test/validator/samples/a11y-aria-unsupported-element/warnings.json
@@ -4,30 +4,23 @@
 		"message": "A11y: <meta> should not have aria-* attributes",
 		"start": {
 			"line": 1,
-			"column": 6,
-			"character": 6
+			"column": 6
 		},
 		"end": {
 			"line": 1,
-			"column": 25,
-			"character": 25
-		},
-		"pos": 6
+			"column": 25
+		}
 	},
-
 	{
 		"code": "a11y-misplaced-role",
 		"message": "A11y: <meta> should not have role attribute",
 		"start": {
 			"line": 2,
-			"column": 6,
-			"character": 33
+			"column": 6
 		},
 		"end": {
 			"line": 2,
-			"column": 20,
-			"character": 47
-		},
-		"pos": 33
+			"column": 20
+		}
 	}
 ]

--- a/test/validator/samples/a11y-click-events-have-key-events/warnings.json
+++ b/test/validator/samples/a11y-click-events-have-key-events/warnings.json
@@ -4,104 +4,83 @@
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
 			"line": 12,
-			"column": 0,
-			"character": 190
+			"column": 0
 		},
 		"end": {
 			"line": 12,
-			"column": 23,
-			"character": 213
-		},
-		"pos": 190
+			"column": 23
+		}
 	},
 	{
 		"code": "a11y-click-events-have-key-events",
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
 			"line": 13,
-			"column": 0,
-			"character": 214
+			"column": 0
 		},
 		"end": {
 			"line": 13,
-			"column": 43,
-			"character": 257
-		},
-		"pos": 214
+			"column": 43
+		}
 	},
 	{
 		"code": "a11y-click-events-have-key-events",
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
 			"line": 15,
-			"column": 0,
-			"character": 259
+			"column": 0
 		},
 		"end": {
 			"line": 15,
-			"column": 27,
-			"character": 286
-		},
-		"pos": 259
+			"column": 27
+		}
 	},
 	{
 		"code": "a11y-click-events-have-key-events",
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
 			"line": 16,
-			"column": 0,
-			"character": 287
+			"column": 0
 		},
 		"end": {
 			"line": 16,
-			"column": 24,
-			"character": 311
-		},
-		"pos": 287
+			"column": 24
+		}
 	},
 	{
 		"code": "a11y-click-events-have-key-events",
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
 			"line": 17,
-			"column": 0,
-			"character": 312
+			"column": 0
 		},
 		"end": {
 			"line": 17,
-			"column": 27,
-			"character": 339
-		},
-		"pos": 312
+			"column": 27
+		}
 	},
 	{
 		"code": "a11y-click-events-have-key-events",
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
 			"line": 18,
-			"column": 0,
-			"character": 340
+			"column": 0
 		},
 		"end": {
 			"line": 18,
-			"column": 26,
-			"character": 366
-		},
-		"pos": 340
+			"column": 26
+		}
 	},
 	{
 		"code": "a11y-click-events-have-key-events",
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
 			"line": 19,
-			"column": 0,
-			"character": 367
+			"column": 0
 		},
 		"end": {
 			"line": 19,
-			"column": 26,
-			"character": 393
-		},
-		"pos": 367
+			"column": 26
+		}
 	}
 ]

--- a/test/validator/samples/a11y-contenteditable-element-without-child/errors.json
+++ b/test/validator/samples/a11y-contenteditable-element-without-child/errors.json
@@ -4,14 +4,11 @@
 		"message": "'contenteditable' attribute is required for textContent and innerHTML two-way bindings",
 		"start": {
 			"line": 6,
-			"column": 3,
-			"character": 157
+			"column": 3
 		},
 		"end": {
 			"line": 6,
-			"column": 24,
-			"character": 178
-		},
-		"pos": 157
+			"column": 24
+		}
 	}
 ]

--- a/test/validator/samples/a11y-figcaption-wrong-place/warnings.json
+++ b/test/validator/samples/a11y-figcaption-wrong-place/warnings.json
@@ -4,29 +4,23 @@
 		"message": "A11y: <figcaption> must be first or last child of <figure>",
 		"start": {
 			"line": 4,
-			"column": 1,
-			"character": 44
+			"column": 1
 		},
 		"end": {
 			"line": 6,
-			"column": 14,
-			"character": 102
-		},
-		"pos": 44
+			"column": 14
+		}
 	},
 	{
 		"code": "a11y-structure",
 		"message": "A11y: <figcaption> must be an immediate child of <figure>",
 		"start": {
 			"line": 15,
-			"column": 2,
-			"character": 226
+			"column": 2
 		},
 		"end": {
 			"line": 17,
-			"column": 15,
-			"character": 302
-		},
-		"pos": 226
+			"column": 15
+		}
 	}
 ]

--- a/test/validator/samples/a11y-heading-has-content/warnings.json
+++ b/test/validator/samples/a11y-heading-has-content/warnings.json
@@ -4,30 +4,23 @@
 		"message": "A11y: <h1> element should have child content",
 		"start": {
 			"line": 1,
-			"column": 0,
-			"character": 0
+			"column": 0
 		},
 		"end": {
 			"line": 1,
-			"column": 9,
-			"character": 9
-		},
-		"pos": 0
+			"column": 9
+		}
 	},
-
 	{
 		"code": "a11y-hidden",
 		"message": "A11y: <h2> element should not be hidden",
 		"start": {
 			"line": 2,
-			"column": 4,
-			"character": 14
+			"column": 4
 		},
 		"end": {
 			"line": 2,
-			"column": 15,
-			"character": 25
-		},
-		"pos": 14
+			"column": 15
+		}
 	}
 ]

--- a/test/validator/samples/a11y-html-has-lang/warnings.json
+++ b/test/validator/samples/a11y-html-has-lang/warnings.json
@@ -4,14 +4,11 @@
 		"message": "A11y: <html> element should have a lang attribute",
 		"start": {
 			"column": 0,
-			"line": 9,
-			"character": 124
+			"line": 9
 		},
 		"end": {
 			"line": 9,
-			"column": 13,
-			"character": 137
-		},
-		"pos": 124
+			"column": 13
+		}
 	}
 ]

--- a/test/validator/samples/a11y-iframe-has-title/warnings.json
+++ b/test/validator/samples/a11y-iframe-has-title/warnings.json
@@ -4,14 +4,11 @@
 		"message": "A11y: <iframe> element should have a title attribute",
 		"start": {
 			"line": 5,
-			"column": 0,
-			"character": 37
+			"column": 0
 		},
 		"end": {
 			"line": 5,
-			"column": 27,
-			"character": 64
-		},
-		"pos": 37
+			"column": 27
+		}
 	}
 ]

--- a/test/validator/samples/a11y-img-redundant-alt/warnings.json
+++ b/test/validator/samples/a11y-img-redundant-alt/warnings.json
@@ -3,45 +3,36 @@
 		"code": "a11y-img-redundant-alt",
 		"message": "A11y: Screenreaders already announce <img> elements as an image.",
 		"end": {
-			"character": 173,
 			"column": 49,
 			"line": 3
 		},
 		"start": {
-			"character": 124,
 			"column": 0,
 			"line": 3
-		},
-		"pos": 124
+		}
 	},
 	{
 		"code": "a11y-img-redundant-alt",
 		"message": "A11y: Screenreaders already announce <img> elements as an image.",
 		"end": {
-			"character": 219,
 			"column": 45,
 			"line": 4
 		},
 		"start": {
-			"character": 174,
 			"column": 0,
 			"line": 4
-		},
-		"pos": 174
+		}
 	},
 	{
 		"code": "a11y-img-redundant-alt",
 		"message": "A11y: Screenreaders already announce <img> elements as an image.",
 		"end": {
-			"character": 272,
 			"column": 52,
 			"line": 5
 		},
 		"start": {
-			"character": 220,
 			"column": 0,
 			"line": 5
-		},
-		"pos": 220
+		}
 	}
 ]

--- a/test/validator/samples/a11y-label-has-associated-control/warnings.json
+++ b/test/validator/samples/a11y-label-has-associated-control/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-label-has-associated-control",
 		"end": {
-			"character": 82,
 			"column": 16,
 			"line": 5
 		},
 		"message": "A11y: A form label must be associated with a control.",
-		"pos": 66,
 		"start": {
-			"character": 66,
 			"column": 0,
 			"line": 5
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "a11y-label-has-associated-control",
 		"end": {
-			"character": 215,
 			"column": 30,
 			"line": 10
 		},
 		"message": "A11y: A form label must be associated with a control.",
-		"pos": 185,
 		"start": {
-			"character": 185,
 			"column": 0,
 			"line": 10
 		}

--- a/test/validator/samples/a11y-media-has-caption/warnings.json
+++ b/test/validator/samples/a11y-media-has-caption/warnings.json
@@ -2,14 +2,11 @@
   {
     "code": "a11y-media-has-caption",
     "end": {
-      "character": 55,
       "column": 15,
       "line": 2
     },
     "message": "A11y: <video> elements must have a <track kind=\"captions\">",
-    "pos": 40,
     "start": {
-      "character": 40,
       "column": 0,
       "line": 2
     }
@@ -17,14 +14,11 @@
   {
     "code": "a11y-media-has-caption",
     "end": {
-      "character": 80,
       "column": 24,
       "line": 3
     },
     "message": "A11y: <video> elements must have a <track kind=\"captions\">",
-    "pos": 56,
     "start": {
-      "character": 56,
       "column": 0,
       "line": 3
     }
@@ -32,14 +26,11 @@
   {
     "code": "a11y-media-has-caption",
     "end": {
-      "character": 124,
       "column": 27,
       "line": 5
     },
     "message": "A11y: <video> elements must have a <track kind=\"captions\">",
-    "pos": 97,
     "start": {
-      "character": 97,
       "column": 0,
       "line": 5
     }
@@ -47,14 +38,11 @@
   {
     "code": "a11y-media-has-caption",
     "end": {
-      "character": 160,
       "column": 35,
       "line": 6
     },
     "message": "A11y: <video> elements must have a <track kind=\"captions\">",
-    "pos": 125,
     "start": {
-      "character": 125,
       "column": 0,
       "line": 6
     }

--- a/test/validator/samples/a11y-mouse-events-have-key-events/input.svelte
+++ b/test/validator/samples/a11y-mouse-events-have-key-events/input.svelte
@@ -3,7 +3,7 @@
 	// Props should be passed down explicitly for rule to pass.
 	const otherProps = {
 		onBlur: () => void 0,
-		onFocus: () => void 0,
+		onFocus: () => void 0
 	};
 </script>
 

--- a/test/validator/samples/a11y-mouse-events-have-key-events/warnings.json
+++ b/test/validator/samples/a11y-mouse-events-have-key-events/warnings.json
@@ -2,14 +2,11 @@
     {
         "code": "a11y-mouse-events-have-key-events",
         "end": {
-            "character": 272,
             "column": 35,
             "line": 10
         },
         "message": "A11y: on:mouseover must be accompanied by on:focus",
-        "pos": 237,
         "start": {
-            "character": 237,
             "column": 0,
             "line": 10
         }
@@ -17,14 +14,11 @@
     {
         "code": "a11y-mouse-events-have-key-events",
         "end": {
-            "character": 384,
             "column": 51,
             "line": 12
         },
         "message": "A11y: on:mouseover must be accompanied by on:focus",
-        "pos": 333,
         "start": {
-            "character": 333,
             "column": 0,
             "line": 12
         }
@@ -32,14 +26,11 @@
     {
         "code": "a11y-mouse-events-have-key-events",
         "end": {
-            "character": 419,
             "column": 34,
             "line": 13
         },
         "message": "A11y: on:mouseout must be accompanied by on:blur",
-        "pos": 385,
         "start": {
-            "character": 385,
             "column": 0,
             "line": 13
         }
@@ -47,14 +38,11 @@
     {
         "code": "a11y-mouse-events-have-key-events",
         "end": {
-            "character": 528,
             "column": 50,
             "line": 15
         },
         "message": "A11y: on:mouseout must be accompanied by on:blur",
-        "pos": 478,
         "start": {
-            "character": 478,
             "column": 0,
             "line": 15
         }

--- a/test/validator/samples/a11y-no-abstract-roles/warnings.json
+++ b/test/validator/samples/a11y-no-abstract-roles/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 19,
 			"column": 19,
 			"line": 1
 		},
 		"message": "A11y: Abstract role 'command' is forbidden",
-		"pos": 5,
 		"start": {
-			"character": 5,
 			"column": 5,
 			"line": 1
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 43,
 			"column": 21,
 			"line": 2
 		},
 		"message": "A11y: Abstract role 'composite' is forbidden",
-		"pos": 27,
 		"start": {
-			"character": 27,
 			"column": 5,
 			"line": 2
 		}
@@ -32,14 +26,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 63,
 			"column": 17,
 			"line": 3
 		},
 		"message": "A11y: Abstract role 'input' is forbidden",
-		"pos": 51,
 		"start": {
-			"character": 51,
 			"column": 5,
 			"line": 3
 		}
@@ -47,14 +38,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 86,
 			"column": 20,
 			"line": 4
 		},
 		"message": "A11y: Abstract role 'landmark' is forbidden",
-		"pos": 71,
 		"start": {
-			"character": 71,
 			"column": 5,
 			"line": 4
 		}
@@ -62,14 +50,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 106,
 			"column": 17,
 			"line": 5
 		},
 		"message": "A11y: Abstract role 'range' is forbidden",
-		"pos": 94,
 		"start": {
-			"character": 94,
 			"column": 5,
 			"line": 5
 		}
@@ -77,14 +62,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 129,
 			"column": 20,
 			"line": 6
 		},
 		"message": "A11y: Abstract role 'roletype' is forbidden",
-		"pos": 114,
 		"start": {
-			"character": 114,
 			"column": 5,
 			"line": 6
 		}
@@ -92,14 +74,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 151,
 			"column": 19,
 			"line": 7
 		},
 		"message": "A11y: Abstract role 'section' is forbidden",
-		"pos": 137,
 		"start": {
-			"character": 137,
 			"column": 5,
 			"line": 7
 		}
@@ -107,14 +86,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 177,
 			"column": 23,
 			"line": 8
 		},
 		"message": "A11y: Abstract role 'sectionhead' is forbidden",
-		"pos": 159,
 		"start": {
-			"character": 159,
 			"column": 5,
 			"line": 8
 		}
@@ -122,14 +98,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 198,
 			"column": 18,
 			"line": 9
 		},
 		"message": "A11y: Abstract role 'select' is forbidden",
-		"pos": 185,
 		"start": {
-			"character": 185,
 			"column": 5,
 			"line": 9
 		}
@@ -137,14 +110,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 222,
 			"column": 21,
 			"line": 10
 		},
 		"message": "A11y: Abstract role 'structure' is forbidden",
-		"pos": 206,
 		"start": {
-			"character": 206,
 			"column": 5,
 			"line": 10
 		}
@@ -152,14 +122,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 243,
 			"column": 18,
 			"line": 11
 		},
 		"message": "A11y: Abstract role 'widget' is forbidden",
-		"pos": 230,
 		"start": {
-			"character": 230,
 			"column": 5,
 			"line": 11
 		}
@@ -167,14 +134,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 264,
 			"column": 18,
 			"line": 12
 		},
 		"message": "A11y: Abstract role 'window' is forbidden",
-		"pos": 251,
 		"start": {
-			"character": 251,
 			"column": 5,
 			"line": 12
 		}

--- a/test/validator/samples/a11y-no-access-key/warnings.json
+++ b/test/validator/samples/a11y-no-access-key/warnings.json
@@ -3,13 +3,10 @@
 	"message": "A11y: Avoid using accesskey",
 	"start": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	},
 	"end": {
 		"line": 1,
-		"column": 18,
-		"character": 18
-	},
-	"pos": 5
+		"column": 18
+	}
 }]

--- a/test/validator/samples/a11y-no-autofocus/warnings.json
+++ b/test/validator/samples/a11y-no-autofocus/warnings.json
@@ -3,13 +3,10 @@
 	"message": "A11y: Avoid using autofocus",
 	"start": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	},
 	"end": {
 		"line": 1,
-		"column": 14,
-		"character": 14
-	},
-	"pos": 5
+		"column": 14
+	}
 }]

--- a/test/validator/samples/a11y-no-distracting-elements/warnings.json
+++ b/test/validator/samples/a11y-no-distracting-elements/warnings.json
@@ -4,30 +4,23 @@
 		"message": "A11y: Avoid <marquee> elements",
 		"start": {
 			"line": 1,
-			"column": 0,
-			"character": 0
+			"column": 0
 		},
 		"end": {
 			"line": 1,
-			"column": 10,
-			"character": 10
-		},
-		"pos": 0
+			"column": 10
+		}
 	},
-
 	{
 		"code": "a11y-distracting-elements",
 		"message": "A11y: Avoid <blink> elements",
 		"start": {
 			"line": 2,
-			"column": 0,
-			"character": 11
+			"column": 0
 		},
 		"end": {
 			"line": 2,
-			"column": 8,
-			"character": 19
-		},
-		"pos": 11
+			"column": 8
+		}
 	}
 ]

--- a/test/validator/samples/a11y-no-interactive-element-to-noninteractive-role/warnings.json
+++ b/test/validator/samples/a11y-no-interactive-element-to-noninteractive-role/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 49,
 			"column": 38,
 			"line": 2
 		},
 		"message": "A11y: <a> cannot have role 'article'",
-		"pos": 11,
 		"start": {
-			"character": 11,
 			"column": 0,
 			"line": 2
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 87,
 			"column": 37,
 			"line": 3
 		},
 		"message": "A11y: <a> cannot have role 'banner'",
-		"pos": 50,
 		"start": {
-			"character": 50,
 			"column": 0,
 			"line": 3
 		}
@@ -32,14 +26,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 132,
 			"column": 44,
 			"line": 4
 		},
 		"message": "A11y: <a> cannot have role 'complementary'",
-		"pos": 88,
 		"start": {
-			"character": 88,
 			"column": 0,
 			"line": 4
 		}
@@ -47,14 +38,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 167,
 			"column": 34,
 			"line": 5
 		},
 		"message": "A11y: <a> cannot have role 'img'",
-		"pos": 133,
 		"start": {
-			"character": 133,
 			"column": 0,
 			"line": 5
 		}
@@ -62,14 +50,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 207,
 			"column": 39,
 			"line": 6
 		},
 		"message": "A11y: <a> cannot have role 'listitem'",
-		"pos": 168,
 		"start": {
-			"character": 168,
 			"column": 0,
 			"line": 6
 		}
@@ -77,14 +62,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 243,
 			"column": 35,
 			"line": 7
 		},
 		"message": "A11y: <a> cannot have role 'main'",
-		"pos": 208,
 		"start": {
-			"character": 208,
 			"column": 0,
 			"line": 7
 		}
@@ -92,14 +74,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 281,
 			"column": 37,
 			"line": 8
 		},
 		"message": "A11y: <a> cannot have role 'region'",
-		"pos": 244,
 		"start": {
-			"character": 244,
 			"column": 0,
 			"line": 8
 		}
@@ -107,14 +86,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 320,
 			"column": 38,
 			"line": 9
 		},
 		"message": "A11y: <a> cannot have role 'tooltip'",
-		"pos": 282,
 		"start": {
-			"character": 282,
 			"column": 0,
 			"line": 9
 		}
@@ -122,14 +98,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 414,
 			"column": 38,
 			"line": 13
 		},
 		"message": "A11y: <button> cannot have role 'article'",
-		"pos": 376,
 		"start": {
-			"character": 376,
 			"column": 0,
 			"line": 13
 		}
@@ -137,14 +110,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 452,
 			"column": 37,
 			"line": 14
 		},
 		"message": "A11y: <button> cannot have role 'banner'",
-		"pos": 415,
 		"start": {
-			"character": 415,
 			"column": 0,
 			"line": 14
 		}
@@ -152,14 +122,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 497,
 			"column": 44,
 			"line": 15
 		},
 		"message": "A11y: <button> cannot have role 'complementary'",
-		"pos": 453,
 		"start": {
-			"character": 453,
 			"column": 0,
 			"line": 15
 		}
@@ -167,14 +134,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 532,
 			"column": 34,
 			"line": 16
 		},
 		"message": "A11y: <button> cannot have role 'img'",
-		"pos": 498,
 		"start": {
-			"character": 498,
 			"column": 0,
 			"line": 16
 		}
@@ -182,14 +146,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 572,
 			"column": 39,
 			"line": 17
 		},
 		"message": "A11y: <button> cannot have role 'listitem'",
-		"pos": 533,
 		"start": {
-			"character": 533,
 			"column": 0,
 			"line": 17
 		}
@@ -197,14 +158,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 608,
 			"column": 35,
 			"line": 18
 		},
 		"message": "A11y: <button> cannot have role 'main'",
-		"pos": 573,
 		"start": {
-			"character": 573,
 			"column": 0,
 			"line": 18
 		}
@@ -212,14 +170,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 646,
 			"column": 37,
 			"line": 19
 		},
 		"message": "A11y: <button> cannot have role 'region'",
-		"pos": 609,
 		"start": {
-			"character": 609,
 			"column": 0,
 			"line": 19
 		}
@@ -227,14 +182,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 685,
 			"column": 38,
 			"line": 20
 		},
 		"message": "A11y: <button> cannot have role 'tooltip'",
-		"pos": 647,
 		"start": {
-			"character": 647,
 			"column": 0,
 			"line": 20
 		}
@@ -242,14 +194,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 707,
 			"column": 21,
 			"line": 21
 		},
 		"message": "A11y: Redundant role 'button'",
-		"pos": 694,
 		"start": {
-			"character": 694,
 			"column": 8,
 			"line": 21
 		}
@@ -257,14 +206,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 763,
 			"column": 23,
 			"line": 24
 		},
 		"message": "A11y: <input> cannot have role 'article'",
-		"pos": 740,
 		"start": {
-			"character": 740,
 			"column": 0,
 			"line": 24
 		}
@@ -272,14 +218,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 786,
 			"column": 22,
 			"line": 25
 		},
 		"message": "A11y: <input> cannot have role 'banner'",
-		"pos": 764,
 		"start": {
-			"character": 764,
 			"column": 0,
 			"line": 25
 		}
@@ -287,14 +230,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 816,
 			"column": 29,
 			"line": 26
 		},
 		"message": "A11y: <input> cannot have role 'complementary'",
-		"pos": 787,
 		"start": {
-			"character": 787,
 			"column": 0,
 			"line": 26
 		}
@@ -302,14 +242,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 836,
 			"column": 19,
 			"line": 27
 		},
 		"message": "A11y: <input> cannot have role 'img'",
-		"pos": 817,
 		"start": {
-			"character": 817,
 			"column": 0,
 			"line": 27
 		}
@@ -317,14 +254,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 861,
 			"column": 24,
 			"line": 28
 		},
 		"message": "A11y: <input> cannot have role 'listitem'",
-		"pos": 837,
 		"start": {
-			"character": 837,
 			"column": 0,
 			"line": 28
 		}
@@ -332,14 +266,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 882,
 			"column": 20,
 			"line": 29
 		},
 		"message": "A11y: <input> cannot have role 'main'",
-		"pos": 862,
 		"start": {
-			"character": 862,
 			"column": 0,
 			"line": 29
 		}
@@ -347,14 +278,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 905,
 			"column": 22,
 			"line": 30
 		},
 		"message": "A11y: <input> cannot have role 'region'",
-		"pos": 883,
 		"start": {
-			"character": 883,
 			"column": 0,
 			"line": 30
 		}
@@ -362,14 +290,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 929,
 			"column": 23,
 			"line": 31
 		},
 		"message": "A11y: <input> cannot have role 'tooltip'",
-		"pos": 906,
 		"start": {
-			"character": 906,
 			"column": 0,
 			"line": 31
 		}
@@ -377,14 +302,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 994,
 			"column": 24,
 			"line": 35
 		},
 		"message": "A11y: <select> cannot have role 'article'",
-		"pos": 970,
 		"start": {
-			"character": 970,
 			"column": 0,
 			"line": 35
 		}
@@ -392,14 +314,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1018,
 			"column": 23,
 			"line": 36
 		},
 		"message": "A11y: <select> cannot have role 'banner'",
-		"pos": 995,
 		"start": {
-			"character": 995,
 			"column": 0,
 			"line": 36
 		}
@@ -407,14 +326,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1049,
 			"column": 30,
 			"line": 37
 		},
 		"message": "A11y: <select> cannot have role 'complementary'",
-		"pos": 1019,
 		"start": {
-			"character": 1019,
 			"column": 0,
 			"line": 37
 		}
@@ -422,14 +338,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1070,
 			"column": 20,
 			"line": 38
 		},
 		"message": "A11y: <select> cannot have role 'img'",
-		"pos": 1050,
 		"start": {
-			"character": 1050,
 			"column": 0,
 			"line": 38
 		}
@@ -437,14 +350,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1096,
 			"column": 25,
 			"line": 39
 		},
 		"message": "A11y: <select> cannot have role 'listitem'",
-		"pos": 1071,
 		"start": {
-			"character": 1071,
 			"column": 0,
 			"line": 39
 		}
@@ -452,14 +362,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1118,
 			"column": 21,
 			"line": 40
 		},
 		"message": "A11y: <select> cannot have role 'main'",
-		"pos": 1097,
 		"start": {
-			"character": 1097,
 			"column": 0,
 			"line": 40
 		}
@@ -467,14 +374,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1142,
 			"column": 23,
 			"line": 41
 		},
 		"message": "A11y: <select> cannot have role 'region'",
-		"pos": 1119,
 		"start": {
-			"character": 1119,
 			"column": 0,
 			"line": 41
 		}
@@ -482,14 +386,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1167,
 			"column": 24,
 			"line": 42
 		},
 		"message": "A11y: <select> cannot have role 'tooltip'",
-		"pos": 1143,
 		"start": {
-			"character": 1143,
 			"column": 0,
 			"line": 42
 		}
@@ -497,14 +398,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1237,
 			"column": 26,
 			"line": 46
 		},
 		"message": "A11y: <textarea> cannot have role 'article'",
-		"pos": 1211,
 		"start": {
-			"character": 1211,
 			"column": 0,
 			"line": 46
 		}
@@ -512,14 +410,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1263,
 			"column": 25,
 			"line": 47
 		},
 		"message": "A11y: <textarea> cannot have role 'banner'",
-		"pos": 1238,
 		"start": {
-			"character": 1238,
 			"column": 0,
 			"line": 47
 		}
@@ -527,14 +422,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1296,
 			"column": 32,
 			"line": 48
 		},
 		"message": "A11y: <textarea> cannot have role 'complementary'",
-		"pos": 1264,
 		"start": {
-			"character": 1264,
 			"column": 0,
 			"line": 48
 		}
@@ -542,14 +434,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1319,
 			"column": 22,
 			"line": 49
 		},
 		"message": "A11y: <textarea> cannot have role 'img'",
-		"pos": 1297,
 		"start": {
-			"character": 1297,
 			"column": 0,
 			"line": 49
 		}
@@ -557,14 +446,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1347,
 			"column": 27,
 			"line": 50
 		},
 		"message": "A11y: <textarea> cannot have role 'listitem'",
-		"pos": 1320,
 		"start": {
-			"character": 1320,
 			"column": 0,
 			"line": 50
 		}
@@ -572,14 +458,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1371,
 			"column": 23,
 			"line": 51
 		},
 		"message": "A11y: <textarea> cannot have role 'main'",
-		"pos": 1348,
 		"start": {
-			"character": 1348,
 			"column": 0,
 			"line": 51
 		}
@@ -587,14 +470,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1397,
 			"column": 25,
 			"line": 52
 		},
 		"message": "A11y: <textarea> cannot have role 'region'",
-		"pos": 1372,
 		"start": {
-			"character": 1372,
 			"column": 0,
 			"line": 52
 		}
@@ -602,14 +482,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 1424,
 			"column": 26,
 			"line": 53
 		},
 		"message": "A11y: <textarea> cannot have role 'tooltip'",
-		"pos": 1398,
 		"start": {
-			"character": 1398,
 			"column": 0,
 			"line": 53
 		}
@@ -617,14 +494,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1527,
 			"column": 19,
 			"line": 57
 		},
 		"message": "A11y: Abstract role 'command' is forbidden",
-		"pos": 1513,
 		"start": {
-			"character": 1513,
 			"column": 5,
 			"line": 57
 		}
@@ -632,14 +506,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1552,
 			"column": 21,
 			"line": 58
 		},
 		"message": "A11y: Abstract role 'composite' is forbidden",
-		"pos": 1536,
 		"start": {
-			"character": 1536,
 			"column": 5,
 			"line": 58
 		}
@@ -647,14 +518,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1573,
 			"column": 17,
 			"line": 59
 		},
 		"message": "A11y: Abstract role 'input' is forbidden",
-		"pos": 1561,
 		"start": {
-			"character": 1561,
 			"column": 5,
 			"line": 59
 		}
@@ -662,14 +530,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1597,
 			"column": 20,
 			"line": 60
 		},
 		"message": "A11y: Abstract role 'landmark' is forbidden",
-		"pos": 1582,
 		"start": {
-			"character": 1582,
 			"column": 5,
 			"line": 60
 		}
@@ -677,14 +542,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1618,
 			"column": 17,
 			"line": 61
 		},
 		"message": "A11y: Abstract role 'range' is forbidden",
-		"pos": 1606,
 		"start": {
-			"character": 1606,
 			"column": 5,
 			"line": 61
 		}
@@ -692,14 +554,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1642,
 			"column": 20,
 			"line": 62
 		},
 		"message": "A11y: Abstract role 'roletype' is forbidden",
-		"pos": 1627,
 		"start": {
-			"character": 1627,
 			"column": 5,
 			"line": 62
 		}
@@ -707,14 +566,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1665,
 			"column": 19,
 			"line": 63
 		},
 		"message": "A11y: Abstract role 'section' is forbidden",
-		"pos": 1651,
 		"start": {
-			"character": 1651,
 			"column": 5,
 			"line": 63
 		}
@@ -722,14 +578,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1692,
 			"column": 23,
 			"line": 64
 		},
 		"message": "A11y: Abstract role 'sectionhead' is forbidden",
-		"pos": 1674,
 		"start": {
-			"character": 1674,
 			"column": 5,
 			"line": 64
 		}
@@ -737,14 +590,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1714,
 			"column": 18,
 			"line": 65
 		},
 		"message": "A11y: Abstract role 'select' is forbidden",
-		"pos": 1701,
 		"start": {
-			"character": 1701,
 			"column": 5,
 			"line": 65
 		}
@@ -752,14 +602,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1739,
 			"column": 21,
 			"line": 66
 		},
 		"message": "A11y: Abstract role 'structure' is forbidden",
-		"pos": 1723,
 		"start": {
-			"character": 1723,
 			"column": 5,
 			"line": 66
 		}
@@ -767,14 +614,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1851,
 			"column": 18,
 			"line": 71
 		},
 		"message": "A11y: Abstract role 'widget' is forbidden",
-		"pos": 1838,
 		"start": {
-			"character": 1838,
 			"column": 5,
 			"line": 71
 		}
@@ -782,14 +626,11 @@
 	{
 		"code": "a11y-no-abstract-role",
 		"end": {
-			"character": 1873,
 			"column": 18,
 			"line": 72
 		},
 		"message": "A11y: Abstract role 'window' is forbidden",
-		"pos": 1860,
 		"start": {
-			"character": 1860,
 			"column": 5,
 			"line": 72
 		}
@@ -797,14 +638,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 3695,
 			"column": 28,
 			"line": 145
 		},
 		"message": "A11y: <menuitem> cannot have role 'listitem'",
-		"pos": 3667,
 		"start": {
-			"character": 3667,
 			"column": 0,
 			"line": 145
 		}
@@ -812,14 +650,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 3734,
 			"column": 38,
 			"line": 146
 		},
 		"message": "A11y: <option> cannot have role 'listitem'",
-		"pos": 3696,
 		"start": {
-			"character": 3696,
 			"column": 0,
 			"line": 146
 		}
@@ -827,14 +662,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 3773,
 			"column": 38,
 			"line": 147
 		},
 		"message": "A11y: <select> cannot have role 'listitem'",
-		"pos": 3735,
 		"start": {
-			"character": 3735,
 			"column": 0,
 			"line": 147
 		}
@@ -842,14 +674,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 3801,
 			"column": 27,
 			"line": 148
 		},
 		"message": "A11y: <summary> cannot have role 'listitem'",
-		"pos": 3774,
 		"start": {
-			"character": 3774,
 			"column": 0,
 			"line": 148
 		}
@@ -857,14 +686,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 3842,
 			"column": 40,
 			"line": 149
 		},
 		"message": "A11y: <textarea> cannot have role 'listitem'",
-		"pos": 3802,
 		"start": {
-			"character": 3802,
 			"column": 0,
 			"line": 149
 		}
@@ -872,14 +698,11 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"character": 3865,
 			"column": 22,
 			"line": 150
 		},
 		"message": "A11y: <tr> cannot have role 'listitem'",
-		"pos": 3843,
 		"start": {
-			"character": 3843,
 			"column": 0,
 			"line": 150
 		}

--- a/test/validator/samples/a11y-no-noninteractive-tabindex/warnings.json
+++ b/test/validator/samples/a11y-no-noninteractive-tabindex/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-no-noninteractive-tabindex",
 		"end": {
-			"character": 278,
 			"column": 20,
 			"line": 12
 		},
 		"message": "A11y: noninteractive element cannot have nonnegative tabIndex value",
-		"pos": 258,
 		"start": {
-			"character": 258,
 			"column": 0,
 			"line": 12
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "a11y-no-noninteractive-tabindex",
 		"end": {
-			"character": 314,
 			"column": 35,
 			"line": 13
 		},
 		"message": "A11y: noninteractive element cannot have nonnegative tabIndex value",
-		"pos": 279,
 		"start": {
-			"character": 279,
 			"column": 0,
 			"line": 13
 		}
@@ -32,14 +26,11 @@
 	{
 		"code": "a11y-no-noninteractive-tabindex",
 		"end": {
-			"character": 339,
 			"column": 24,
 			"line": 14
 		},
 		"message": "A11y: noninteractive element cannot have nonnegative tabIndex value",
-		"pos": 315,
 		"start": {
-			"character": 315,
 			"column": 0,
 			"line": 14
 		}
@@ -47,14 +38,11 @@
 	{
 		"code": "a11y-no-noninteractive-tabindex",
 		"end": {
-			"character": 366,
 			"column": 26,
 			"line": 15
 		},
 		"message": "A11y: noninteractive element cannot have nonnegative tabIndex value",
-		"pos": 340,
 		"start": {
-			"character": 340,
 			"column": 0,
 			"line": 15
 		}

--- a/test/validator/samples/a11y-no-redundant-roles/warnings.json
+++ b/test/validator/samples/a11y-no-redundant-roles/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 23,
 			"column": 23,
 			"line": 1
 		},
 		"message": "A11y: Redundant role 'link'",
-		"pos": 12,
 		"start": {
-			"character": 12,
 			"column": 12,
 			"line": 1
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 58,
 			"column": 23,
 			"line": 2
 		},
 		"message": "A11y: Redundant role 'article'",
-		"pos": 44,
 		"start": {
-			"character": 44,
 			"column": 9,
 			"line": 2
 		}
@@ -32,14 +26,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 89,
 			"column": 27,
 			"line": 3
 		},
 		"message": "A11y: Redundant role 'complementary'",
-		"pos": 69,
 		"start": {
-			"character": 69,
 			"column": 7,
 			"line": 3
 		}
@@ -47,14 +38,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 114,
 			"column": 21,
 			"line": 4
 		},
 		"message": "A11y: Redundant role 'document'",
-		"pos": 99,
 		"start": {
-			"character": 99,
 			"column": 6,
 			"line": 4
 		}
@@ -62,14 +50,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 139,
 			"column": 21,
 			"line": 5
 		},
 		"message": "A11y: Redundant role 'button'",
-		"pos": 126,
 		"start": {
-			"character": 126,
 			"column": 8,
 			"line": 5
 		}
@@ -77,14 +62,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 167,
 			"column": 24,
 			"line": 6
 		},
 		"message": "A11y: Redundant role 'listbox'",
-		"pos": 153,
 		"start": {
-			"character": 153,
 			"column": 10,
 			"line": 6
 		}
@@ -92,14 +74,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 192,
 			"column": 21,
 			"line": 7
 		},
 		"message": "A11y: Redundant role 'definition'",
-		"pos": 175,
 		"start": {
-			"character": 175,
 			"column": 4,
 			"line": 7
 		}
@@ -107,14 +86,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 212,
 			"column": 16,
 			"line": 8
 		},
 		"message": "A11y: Redundant role 'term'",
-		"pos": 201,
 		"start": {
-			"character": 201,
 			"column": 5,
 			"line": 8
 		}
@@ -122,14 +98,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 237,
 			"column": 21,
 			"line": 9
 		},
 		"message": "A11y: Redundant role 'group'",
-		"pos": 225,
 		"start": {
-			"character": 225,
 			"column": 9,
 			"line": 9
 		}
@@ -137,14 +110,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 262,
 			"column": 21,
 			"line": 10
 		},
 		"message": "A11y: Redundant role 'dialog'",
-		"pos": 249,
 		"start": {
-			"character": 249,
 			"column": 8,
 			"line": 10
 		}
@@ -152,14 +122,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 281,
 			"column": 15,
 			"line": 11
 		},
 		"message": "A11y: Redundant role 'term'",
-		"pos": 270,
 		"start": {
-			"character": 270,
 			"column": 4,
 			"line": 11
 		}
@@ -167,14 +134,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 307,
 			"column": 22,
 			"line": 12
 		},
 		"message": "A11y: Redundant role 'group'",
-		"pos": 295,
 		"start": {
-			"character": 295,
 			"column": 10,
 			"line": 12
 		}
@@ -182,14 +146,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 332,
 			"column": 21,
 			"line": 13
 		},
 		"message": "A11y: Redundant role 'figure'",
-		"pos": 319,
 		"start": {
-			"character": 319,
 			"column": 8,
 			"line": 13
 		}
@@ -197,14 +158,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 353,
 			"column": 17,
 			"line": 14
 		},
 		"message": "A11y: Redundant role 'form'",
-		"pos": 342,
 		"start": {
-			"character": 342,
 			"column": 6,
 			"line": 14
 		}
@@ -212,14 +170,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 383,
 			"column": 18,
 			"line": 15
 		},
 		"message": "A11y: Redundant role 'heading'",
-		"pos": 369,
 		"start": {
-			"character": 369,
 			"column": 4,
 			"line": 15
 		}
@@ -227,14 +182,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 415,
 			"column": 18,
 			"line": 16
 		},
 		"message": "A11y: Redundant role 'heading'",
-		"pos": 401,
 		"start": {
-			"character": 401,
 			"column": 4,
 			"line": 16
 		}
@@ -242,14 +194,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 447,
 			"column": 18,
 			"line": 17
 		},
 		"message": "A11y: Redundant role 'heading'",
-		"pos": 433,
 		"start": {
-			"character": 433,
 			"column": 4,
 			"line": 17
 		}
@@ -257,14 +206,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 479,
 			"column": 18,
 			"line": 18
 		},
 		"message": "A11y: Redundant role 'heading'",
-		"pos": 465,
 		"start": {
-			"character": 465,
 			"column": 4,
 			"line": 18
 		}
@@ -272,14 +218,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 511,
 			"column": 18,
 			"line": 19
 		},
 		"message": "A11y: Redundant role 'heading'",
-		"pos": 497,
 		"start": {
-			"character": 497,
 			"column": 4,
 			"line": 19
 		}
@@ -287,14 +230,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 543,
 			"column": 18,
 			"line": 20
 		},
 		"message": "A11y: Redundant role 'heading'",
-		"pos": 529,
 		"start": {
-			"character": 529,
 			"column": 4,
 			"line": 20
 		}
@@ -302,14 +242,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 577,
 			"column": 20,
 			"line": 21
 		},
 		"message": "A11y: Redundant role 'separator'",
-		"pos": 561,
 		"start": {
-			"character": 561,
 			"column": 4,
 			"line": 21
 		}
@@ -317,14 +254,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 600,
 			"column": 19,
 			"line": 22
 		},
 		"message": "A11y: Redundant role 'listitem'",
-		"pos": 585,
 		"start": {
-			"character": 585,
 			"column": 4,
 			"line": 22
 		}
@@ -332,14 +266,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 621,
 			"column": 17,
 			"line": 23
 		},
 		"message": "A11y: Redundant role 'link'",
-		"pos": 610,
 		"start": {
-			"character": 610,
 			"column": 6,
 			"line": 23
 		}
@@ -347,14 +278,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 642,
 			"column": 17,
 			"line": 24
 		},
 		"message": "A11y: Redundant role 'main'",
-		"pos": 631,
 		"start": {
-			"character": 631,
 			"column": 6,
 			"line": 24
 		}
@@ -362,14 +290,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 668,
 			"column": 17,
 			"line": 25
 		},
 		"message": "A11y: Redundant role 'list'",
-		"pos": 657,
 		"start": {
-			"character": 657,
 			"column": 6,
 			"line": 25
 		}
@@ -377,14 +302,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 694,
 			"column": 22,
 			"line": 26
 		},
 		"message": "A11y: Redundant role 'navigation'",
-		"pos": 677,
 		"start": {
-			"character": 677,
 			"column": 5,
 			"line": 26
 		}
@@ -392,14 +314,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 713,
 			"column": 15,
 			"line": 27
 		},
 		"message": "A11y: Redundant role 'list'",
-		"pos": 702,
 		"start": {
-			"character": 702,
 			"column": 4,
 			"line": 27
 		}
@@ -407,14 +326,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 739,
 			"column": 22,
 			"line": 28
 		},
 		"message": "A11y: Redundant role 'group'",
-		"pos": 727,
 		"start": {
-			"character": 727,
 			"column": 10,
 			"line": 28
 		}
@@ -422,14 +338,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 764,
 			"column": 21,
 			"line": 29
 		},
 		"message": "A11y: Redundant role 'option'",
-		"pos": 751,
 		"start": {
-			"character": 751,
 			"column": 8,
 			"line": 29
 		}
@@ -437,14 +350,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 789,
 			"column": 21,
 			"line": 30
 		},
 		"message": "A11y: Redundant role 'status'",
-		"pos": 776,
 		"start": {
-			"character": 776,
 			"column": 8,
 			"line": 30
 		}
@@ -452,14 +362,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 821,
 			"column": 28,
 			"line": 31
 		},
 		"message": "A11y: Redundant role 'progressbar'",
-		"pos": 803,
 		"start": {
-			"character": 803,
 			"column": 10,
 			"line": 31
 		}
@@ -467,14 +374,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 847,
 			"column": 22,
 			"line": 32
 		},
 		"message": "A11y: Redundant role 'region'",
-		"pos": 834,
 		"start": {
-			"character": 834,
 			"column": 9,
 			"line": 32
 		}
@@ -482,14 +386,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 873,
 			"column": 22,
 			"line": 33
 		},
 		"message": "A11y: Redundant role 'button'",
-		"pos": 860,
 		"start": {
-			"character": 860,
 			"column": 9,
 			"line": 33
 		}
@@ -497,14 +398,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 896,
 			"column": 19,
 			"line": 34
 		},
 		"message": "A11y: Redundant role 'table'",
-		"pos": 884,
 		"start": {
-			"character": 884,
 			"column": 7,
 			"line": 34
 		}
@@ -512,14 +410,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 922,
 			"column": 22,
 			"line": 35
 		},
 		"message": "A11y: Redundant role 'rowgroup'",
-		"pos": 907,
 		"start": {
-			"character": 907,
 			"column": 7,
 			"line": 35
 		}
@@ -527,14 +422,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 950,
 			"column": 24,
 			"line": 36
 		},
 		"message": "A11y: Redundant role 'textbox'",
-		"pos": 936,
 		"start": {
-			"character": 936,
 			"column": 10,
 			"line": 36
 		}
@@ -542,14 +434,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 976,
 			"column": 22,
 			"line": 37
 		},
 		"message": "A11y: Redundant role 'rowgroup'",
-		"pos": 961,
 		"start": {
-			"character": 961,
 			"column": 7,
 			"line": 37
 		}
@@ -557,14 +446,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 1002,
 			"column": 22,
 			"line": 38
 		},
 		"message": "A11y: Redundant role 'rowgroup'",
-		"pos": 987,
 		"start": {
-			"character": 987,
 			"column": 7,
 			"line": 38
 		}
@@ -572,14 +458,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 1020,
 			"column": 14,
 			"line": 39
 		},
 		"message": "A11y: Redundant role 'row'",
-		"pos": 1010,
 		"start": {
-			"character": 1010,
 			"column": 4,
 			"line": 39
 		}
@@ -587,14 +470,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 1039,
 			"column": 15,
 			"line": 40
 		},
 		"message": "A11y: Redundant role 'list'",
-		"pos": 1028,
 		"start": {
-			"character": 1028,
 			"column": 4,
 			"line": 40
 		}
@@ -602,14 +482,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 1125,
 			"column": 21,
 			"line": 43
 		},
 		"message": "A11y: Redundant role 'banner'",
-		"pos": 1112,
 		"start": {
-			"character": 1112,
 			"column": 8,
 			"line": 43
 		}
@@ -617,14 +494,11 @@
 	{
 		"code": "a11y-no-redundant-roles",
 		"end": {
-			"character": 1162,
 			"column": 26,
 			"line": 44
 		},
 		"message": "A11y: Redundant role 'contentinfo'",
-		"pos": 1144,
 		"start": {
-			"character": 1144,
 			"column": 8,
 			"line": 44
 		}

--- a/test/validator/samples/a11y-not-on-components/warnings.json
+++ b/test/validator/samples/a11y-not-on-components/warnings.json
@@ -4,14 +4,11 @@
 		"message": "A11y: Avoid using autofocus",
 		"start": {
 			"column": 8,
-			"line": 6,
-			"character": 88
+			"line": 6
 		},
 		"end": {
 			"line": 6,
-			"column": 17,
-			"character": 97
-		},
-		"pos": 88
+			"column": 17
+		}
 	}
 ]

--- a/test/validator/samples/a11y-role-has-required-aria-props/warnings.json
+++ b/test/validator/samples/a11y-role-has-required-aria-props/warnings.json
@@ -4,59 +4,47 @@
 		"message": "A11y: Elements with the ARIA role \"heading\" must have the following attributes defined: \"aria-level\"",
 		"start": {
 			"line": 1,
-			"column": 5,
-			"character": 5
+			"column": 5
 		},
 		"end": {
 			"line": 1,
-			"column": 19,
-			"character": 19
-		},
-		"pos": 5
+			"column": 19
+		}
 	},
 	{
 		"code": "a11y-role-has-required-aria-props",
 		"message": "A11y: Elements with the ARIA role \"checkbox\" must have the following attributes defined: \"aria-checked\"",
 		"start": {
 			"line": 2,
-			"column": 6,
-			"character": 33
+			"column": 6
 		},
 		"end": {
 			"line": 2,
-			"column": 21,
-			"character": 48
-		},
-		"pos": 33
+			"column": 21
+		}
 	},
 	{
 		"code": "a11y-role-has-required-aria-props",
 		"message": "A11y: Elements with the ARIA role \"meter\" must have the following attributes defined: \"aria-valuenow\"",
 		"start": {
 			"line": 3,
-			"column": 5,
-			"character": 62
+			"column": 5
 		},
 		"end": {
 			"line": 3,
-			"column": 17,
-			"character": 74
-		},
-		"pos": 62
+			"column": 17
+		}
 	},
 	{
 		"code": "a11y-role-has-required-aria-props",
 		"message": "A11y: Elements with the ARIA role \"scrollbar\" must have the following attributes defined: \"aria-controls\", \"aria-valuenow\"",
 		"start": {
-			"character": 87,
 			"column": 5,
 			"line": 4
 		},
 		"end": {
-			"character": 103,
 			"column": 21,
 			"line": 4
-		},
-		"pos": 87
+		}
 	}
 ]

--- a/test/validator/samples/a11y-scope/warnings.json
+++ b/test/validator/samples/a11y-scope/warnings.json
@@ -4,14 +4,11 @@
 		"message": "A11y: The scope attribute should only be used with <th> elements",
 		"start": {
 			"line": 1,
-			"column": 5,
-			"character": 5
+			"column": 5
 		},
 		"end": {
 			"line": 1,
-			"column": 10,
-			"character": 10
-		},
-		"pos": 5
+			"column": 10
+		}
 	}
 ]

--- a/test/validator/samples/a11y-tabindex-no-positive/warnings.json
+++ b/test/validator/samples/a11y-tabindex-no-positive/warnings.json
@@ -4,14 +4,11 @@
 		"message": "A11y: avoid tabindex values above zero",
 		"start": {
 			"line": 7,
-			"column": 8,
-			"character": 85
+			"column": 8
 		},
 		"end": {
 			"line": 7,
-			"column": 20,
-			"character": 97
-		},
-		"pos": 85
+			"column": 20
+		}
 	}
 ]

--- a/test/validator/samples/action-invalid/warnings.json
+++ b/test/validator/samples/action-invalid/warnings.json
@@ -1,15 +1,12 @@
 [{
 	"code": "missing-declaration",
 	"message": "'whatever' is not defined. Consider adding a <script> block with 'export let whatever' to declare a prop",
-	"pos": 5,
 	"start": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	},
 	"end": {
 		"line": 1,
-		"column": 17,
-		"character": 17
+		"column": 17
 	}
 }]

--- a/test/validator/samples/action-object/input.svelte
+++ b/test/validator/samples/action-object/input.svelte
@@ -3,7 +3,7 @@
 		foo : "bar",
 		action(element, { leet }) {
 			element.foo = this.foo + leet;
-		},
+		}
 	}
 </script>
 

--- a/test/validator/samples/action-object/warnings.json
+++ b/test/validator/samples/action-object/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "missing-declaration",
 		"end": {
-			"character": 217,
 			"column": 39,
 			"line": 11
 		},
 		"message": "'foo' is not defined",
-		"pos": 186,
 		"start": {
-			"character": 186,
 			"column": 8,
 			"line": 11
 		}

--- a/test/validator/samples/action-on-component/errors.json
+++ b/test/validator/samples/action-on-component/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-action",
 	"message": "Actions can only be applied to DOM elements, not components",
-	"pos": 86,
 	"start": {
 		"line": 7,
-		"column": 8,
-		"character": 86
+		"column": 8
 	},
 	"end": {
 		"line": 7,
-		"column": 15,
-		"character": 93
+		"column": 15
 	}
 }]

--- a/test/validator/samples/animation-duplicate/errors.json
+++ b/test/validator/samples/animation-duplicate/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element can only have one 'animate' directive",
 	"start": {
 		"line": 7,
-		"column": 18,
-		"character": 108
+		"column": 18
 	},
 	"end": {
 		"line": 7,
-		"column": 29,
-		"character": 119
-	},
-	"pos": 108
+		"column": 29
+	}
 }]

--- a/test/validator/samples/animation-missing/warnings.json
+++ b/test/validator/samples/animation-missing/warnings.json
@@ -3,13 +3,10 @@
 	"message": "'foo' is not defined",
 	"start": {
 		"line": 6,
-		"column": 6,
-		"character": 71
+		"column": 6
 	},
 	"end": {
 		"line": 6,
-		"column": 17,
-		"character": 82
-	},
-	"pos": 71
+		"column": 17
+	}
 }]

--- a/test/validator/samples/animation-not-in-each/errors.json
+++ b/test/validator/samples/animation-not-in-each/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element that uses the animate directive must be the immediate child of a keyed each block",
 	"start": {
 		"line": 5,
-		"column": 5,
-		"character": 44
+		"column": 5
 	},
 	"end": {
 		"line": 5,
-		"column": 16,
-		"character": 55
-	},
-	"pos": 44
+		"column": 16
+	}
 }]

--- a/test/validator/samples/animation-not-in-keyed-each/errors.json
+++ b/test/validator/samples/animation-not-in-keyed-each/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element that uses the animate directive must be used inside a keyed each block. Did you forget to add a key to your each block?",
 	"start": {
 		"line": 6,
-		"column": 6,
-		"character": 69
+		"column": 6
 	},
 	"end": {
 		"line": 6,
-		"column": 17,
-		"character": 80
-	},
-	"pos": 69
+		"column": 17
+	}
 }]

--- a/test/validator/samples/animation-siblings/errors.json
+++ b/test/validator/samples/animation-siblings/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element that uses the animate directive must be the sole child of a keyed each block",
 	"start": {
 		"line": 6,
-		"column": 6,
-		"character": 77
+		"column": 6
 	},
 	"end": {
 		"line": 6,
-		"column": 17,
-		"character": 88
-	},
-	"pos": 77
+		"column": 17
+	}
 }]

--- a/test/validator/samples/assignment-to-const-2/errors.json
+++ b/test/validator/samples/assignment-to-const-2/errors.json
@@ -4,14 +4,11 @@
 		"message": "You are assigning to a const",
 		"start": {
 			"line": 13,
-			"column": 24,
-			"character": 282
+			"column": 24
 		},
 		"end": {
 			"line": 13,
-			"column": 35,
-			"character": 293
-		},
-		"pos": 282
+			"column": 35
+		}
 	}
 ]

--- a/test/validator/samples/assignment-to-const-3/errors.json
+++ b/test/validator/samples/assignment-to-const-3/errors.json
@@ -4,14 +4,11 @@
 		"message": "You are assigning to a const",
 		"start": {
 			"line": 14,
-			"column": 3,
-			"character": 172
+			"column": 3
 		},
 		"end": {
 			"line": 14,
-			"column": 10,
-			"character": 179
-		},
-		"pos": 172
+			"column": 10
+		}
 	}
 ]

--- a/test/validator/samples/assignment-to-const-4/errors.json
+++ b/test/validator/samples/assignment-to-const-4/errors.json
@@ -4,14 +4,11 @@
 		"message": "You are assigning to a const",
 		"start": {
 			"line": 17,
-			"column": 2,
-			"character": 189
+			"column": 2
 		},
 		"end": {
 			"line": 17,
-			"column": 9,
-			"character": 196
-		},
-		"pos": 189
+			"column": 9
+		}
 	}
 ]

--- a/test/validator/samples/assignment-to-const/errors.json
+++ b/test/validator/samples/assignment-to-const/errors.json
@@ -4,14 +4,11 @@
 		"message": "You are assigning to a const",
 		"start": {
 			"line": 16,
-			"column": 2,
-			"character": 225
+			"column": 2
 		},
 		"end": {
 			"line": 16,
-			"column": 18,
-			"character": 241
-		},
-		"pos": 225
+			"column": 18
+		}
 	}
 ]

--- a/test/validator/samples/attribute-expected-equals/errors.json
+++ b/test/validator/samples/attribute-expected-equals/errors.json
@@ -3,13 +3,10 @@
 	"message": "Expected =",
 	"start": {
 		"line": 5,
-		"column": 9,
-		"character": 50
+		"column": 9
 	},
 	"end": {
 		"line": 5,
-		"column": 9,
-		"character": 50
-	},
-	"pos": 50
+		"column": 9
+	}
 }]

--- a/test/validator/samples/attribute-invalid-name-2/errors.json
+++ b/test/validator/samples/attribute-invalid-name-2/errors.json
@@ -3,13 +3,10 @@
 	"message": "'3aa' is not a valid attribute name",
 	"start": {
 		"line": 1,
-		"column": 3,
-		"character": 3
+		"column": 3
 	},
 	"end": {
 		"line": 1,
-		"column": 12,
-		"character": 12
-	},
-	"pos": 3
+		"column": 12
+	}
 }]

--- a/test/validator/samples/attribute-invalid-name-3/errors.json
+++ b/test/validator/samples/attribute-invalid-name-3/errors.json
@@ -3,13 +3,10 @@
 	"message": "'a*a' is not a valid attribute name",
 	"start": {
 		"line": 1,
-		"column": 3,
-		"character": 3
+		"column": 3
 	},
 	"end": {
 		"line": 1,
-		"column": 6,
-		"character": 6
-	},
-	"pos": 3
+		"column": 6
+	}
 }]

--- a/test/validator/samples/attribute-invalid-name-4/errors.json
+++ b/test/validator/samples/attribute-invalid-name-4/errors.json
@@ -3,13 +3,10 @@
 	"message": "'-a' is not a valid attribute name",
 	"start": {
 		"line": 1,
-		"column": 3,
-		"character": 3
+		"column": 3
 	},
 	"end": {
 		"line": 1,
-		"column": 5,
-		"character": 5
-	},
-	"pos": 3
+		"column": 5
+	}
 }]

--- a/test/validator/samples/attribute-invalid-name-5/errors.json
+++ b/test/validator/samples/attribute-invalid-name-5/errors.json
@@ -3,13 +3,10 @@
 	"message": "'a;' is not a valid attribute name",
 	"start": {
 		"line": 1,
-		"column": 3,
-		"character": 3
+		"column": 3
 	},
 	"end": {
 		"line": 1,
-		"column": 11,
-		"character": 11
-	},
-	"pos": 3
+		"column": 11
+	}
 }]

--- a/test/validator/samples/attribute-invalid-name/errors.json
+++ b/test/validator/samples/attribute-invalid-name/errors.json
@@ -3,13 +3,10 @@
 	"message": "'}' is not a valid attribute name",
 	"start": {
 		"line": 1,
-		"column": 3,
-		"character": 3
+		"column": 3
 	},
 	"end": {
 		"line": 1,
-		"column": 4,
-		"character": 4
-	},
-	"pos": 3
+		"column": 4
+	}
 }]

--- a/test/validator/samples/binding-await-catch/errors.json
+++ b/test/validator/samples/binding-await-catch/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-binding",
 		"message": "Cannot bind to a variable declared with {#await ... then} or {:catch} blocks",
-		"pos": 79,
-		"start": { "line": 6, "column": 9, "character": 79 },
-		"end": { "line": 6, "column": 27, "character": 97 }
+		"start": { "line": 6, "column": 9 },
+		"end": { "line": 6, "column": 27 }
 	}
 ]

--- a/test/validator/samples/binding-await-then-2/errors.json
+++ b/test/validator/samples/binding-await-then-2/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-binding",
 		"message": "Cannot bind to a variable declared with {#await ... then} or {:catch} blocks",
-		"pos": 78,
-		"start": { "line": 6, "column": 9, "character": 78 },
-		"end": { "line": 6, "column": 19, "character": 88 }
+		"start": { "line": 6, "column": 9 },
+		"end": { "line": 6, "column": 19 }
 	}
 ]

--- a/test/validator/samples/binding-await-then/errors.json
+++ b/test/validator/samples/binding-await-then/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-binding",
 		"message": "Cannot bind to a variable declared with {#await ... then} or {:catch} blocks",
-		"pos": 75,
-		"start": { "line": 5, "column": 9, "character": 75 },
-		"end": { "line": 5, "column": 19, "character": 85 }
+		"start": { "line": 5, "column": 9 },
+		"end": { "line": 5, "column": 19 }
 	}
 ]

--- a/test/validator/samples/binding-const/errors.json
+++ b/test/validator/samples/binding-const/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-binding",
 	"message": "Cannot bind to a variable which is not writable",
-	"pos": 61,
 	"start": {
 		"line": 5,
-		"column": 19,
-		"character": 61
+		"column": 19
 	},
 	"end": {
 		"line": 5,
-		"column": 24,
-		"character": 66
+		"column": 24
 	}
 }]

--- a/test/validator/samples/binding-dimensions-svg-child/errors.json
+++ b/test/validator/samples/binding-dimensions-svg-child/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-binding",
 	"message": "'offsetWidth' is not a valid binding on SVG elements",
-	"pos": 51,
 	"start": {
 		"line": 6,
-		"column": 7,
-		"character": 51
+		"column": 7
 	},
 	"end": {
 		"line": 6,
-		"column": 23,
-		"character": 67
+		"column": 23
 	}
 }]

--- a/test/validator/samples/binding-dimensions-svg/errors.json
+++ b/test/validator/samples/binding-dimensions-svg/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-binding",
 	"message": "'offsetWidth' is not a valid binding on <svg>. Use 'clientWidth' instead",
-	"pos": 43,
 	"start": {
 		"line": 5,
-		"column": 5,
-		"character": 43
+		"column": 5
 	},
 	"end": {
 		"line": 5,
-		"column": 21,
-		"character": 59
+		"column": 21
 	}
 }]

--- a/test/validator/samples/binding-dimensions-void/errors.json
+++ b/test/validator/samples/binding-dimensions-void/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-binding",
 	"message": "'offsetWidth' is not a valid binding on void elements like <img>. Use a wrapper element instead",
-	"pos": 60,
 	"start": {
 		"line": 5,
-		"column": 22,
-		"character": 60
+		"column": 22
 	},
 	"end": {
 		"line": 5,
-		"column": 38,
-		"character": 76
+		"column": 38
 	}
 }]

--- a/test/validator/samples/binding-input-checked/errors.json
+++ b/test/validator/samples/binding-input-checked/errors.json
@@ -3,13 +3,10 @@
 	"message": "'checked' binding can only be used with <input type=\"checkbox\">",
 	"start": {
 		"line": 5,
-		"column": 7,
-		"character": 37
+		"column": 7
 	},
 	"end": {
 		"line": 5,
-		"column": 25,
-		"character": 55
-	},
-	"pos": 37
+		"column": 25
+	}
 }]

--- a/test/validator/samples/binding-input-type-boolean/errors.json
+++ b/test/validator/samples/binding-input-type-boolean/errors.json
@@ -3,13 +3,10 @@
 	"message": "'type' attribute must be specified",
 	"start": {
 		"line": 5,
-		"column": 24,
-		"character": 54
+		"column": 24
 	},
 	"end": {
 		"line": 5,
-		"column": 28,
-		"character": 58
-	},
-	"pos": 54
+		"column": 28
+	}
 }]

--- a/test/validator/samples/binding-input-type-dynamic/errors.json
+++ b/test/validator/samples/binding-input-type-dynamic/errors.json
@@ -3,13 +3,10 @@
 	"message": "'type' attribute cannot be dynamic if input uses two-way binding",
 	"start": {
 		"line": 6,
-		"column": 24,
-		"character": 70
+		"column": 24
 	},
 	"end": {
 		"line": 6,
-		"column": 40,
-		"character": 86
-	},
-	"pos": 70
+		"column": 40
+	}
 }]

--- a/test/validator/samples/binding-invalid-foreign-namespace/errors.json
+++ b/test/validator/samples/binding-invalid-foreign-namespace/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-binding",
 	"message": "'value' is not a valid binding. Foreign elements only support bind:this",
-	"pos": 81,
 	"start": {
 		"line": 6,
-		"column": 7,
-		"character": 81
+		"column": 7
 	},
 	"end": {
 		"line": 6,
-		"column": 28,
-		"character": 102
+		"column": 28
 	}
 }]

--- a/test/validator/samples/binding-invalid-on-element/errors.json
+++ b/test/validator/samples/binding-invalid-on-element/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-binding",
 	"message": "'value' is not a valid binding on <div> elements",
-	"pos": 37,
 	"start": {
 		"line": 5,
-		"column": 5,
-		"character": 37
+		"column": 5
 	},
 	"end": {
 		"line": 5,
-		"column": 15,
-		"character": 47
+		"column": 15
 	}
 }]

--- a/test/validator/samples/binding-invalid-value-global/errors.json
+++ b/test/validator/samples/binding-invalid-value-global/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "binding-undeclared",
 	"message": "foo is not declared",
-	"pos": 58,
 	"start": {
 		"line": 4,
-		"column": 19,
-		"character": 58
+		"column": 19
 	},
 	"end": {
 		"line": 4,
-		"column": 22,
-		"character": 61
+		"column": 22
 	}
 }]

--- a/test/validator/samples/binding-invalid-value/errors.json
+++ b/test/validator/samples/binding-invalid-value/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "binding-undeclared",
 	"message": "foo is not declared",
-	"pos": 37,
 	"start": {
 		"line": 2,
-		"column": 19,
-		"character": 37
+		"column": 19
 	},
 	"end": {
 		"line": 2,
-		"column": 22,
-		"character": 40
+		"column": 22
 	}
 }]

--- a/test/validator/samples/binding-invalid/errors.json
+++ b/test/validator/samples/binding-invalid/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-binding",
 	"message": "'whatever' is not a valid binding",
-	"pos": 40,
 	"start": {
 		"line": 5,
-		"column": 5,
-		"character": 40
+		"column": 5
 	},
 	"end": {
 		"line": 5,
-		"column": 18,
-		"character": 53
+		"column": 18
 	}
 }]

--- a/test/validator/samples/binding-let/errors.json
+++ b/test/validator/samples/binding-let/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-binding",
 	"message": "Cannot bind to a variable declared with the let: directive",
-	"pos": 52,
 	"start": {
 		"line": 6,
-		"column": 8,
-		"character": 52
+		"column": 8
 	},
 	"end": {
 		"line": 6,
-		"column": 24,
-		"character": 68
+		"column": 24
 	}
 }]

--- a/test/validator/samples/binding-select-multiple-dynamic/errors.json
+++ b/test/validator/samples/binding-select-multiple-dynamic/errors.json
@@ -3,13 +3,10 @@
 	"message": "'multiple' attribute cannot be dynamic if select uses two-way binding",
 	"start": {
 		"line": 6,
-		"column": 19,
-		"character": 66
+		"column": 19
 	},
 	"end": {
 		"line": 6,
-		"column": 29,
-		"character": 76
-	},
-	"pos": 66
+		"column": 29
+	}
 }]

--- a/test/validator/samples/component-dynamic/warnings.json
+++ b/test/validator/samples/component-dynamic/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "reactive-component",
     "message": "<Let/> will not be reactive if Let changes. Use <svelte:component this={Let}/> if you want this reactivity.",
-    "pos": 190,
 		"end": {
-			"character": 197,
 			"column": 7,
 			"line": 15
 		},
 		"start": {
-			"character": 190,
 			"column": 0,
 			"line": 15
 		}
@@ -17,14 +14,11 @@
 	{
     "message": "<ExportLet/> will not be reactive if ExportLet changes. Use <svelte:component this={ExportLet}/> if you want this reactivity.",
 		"code": "reactive-component",
-    "pos": 198,
 		"end": {
-			"character": 211,
 			"column": 13,
 			"line": 16
 		},
 		"start": {
-			"character": 198,
 			"column": 0,
 			"line": 16
 		}
@@ -32,14 +26,11 @@
 	{
     "message": "<Reactive/> will not be reactive if Reactive changes. Use <svelte:component this={Reactive}/> if you want this reactivity.",
 		"code": "reactive-component",
-    "pos": 212,
 		"end": {
-			"character": 224,
 			"column": 12,
 			"line": 17
 		},
 		"start": {
-			"character": 212,
 			"column": 0,
 			"line": 17
 		}

--- a/test/validator/samples/component-event-modifiers-invalid/errors.json
+++ b/test/validator/samples/component-event-modifiers-invalid/errors.json
@@ -3,13 +3,10 @@
 	"code": "invalid-event-modifier",
 	"start": {
 		"line": 6,
-		"column": 8,
-		"character": 93
+		"column": 8
 	},
 	"end": {
 		"line": 6,
-		"column": 40,
-		"character": 125
-	},
-	"pos": 93
+		"column": 40
+	}
 }]

--- a/test/validator/samples/component-invalid-style-directive/errors.json
+++ b/test/validator/samples/component-invalid-style-directive/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-component-style-directive",
 		"message": "Style directives cannot be used on components",
-		"start": { "line": 7, "column": 19, "character": 97 },
-		"end": { "line": 7, "column": 36, "character": 114 },
-		"pos": 97
+		"start": { "line": 7, "column": 19 },
+		"end": { "line": 7, "column": 36 }
 	}
 ]

--- a/test/validator/samples/component-name-lowercase/warnings.json
+++ b/test/validator/samples/component-name-lowercase/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "component-name-lowercase",
 		"message": "<thisShouldWarnMe> will be treated as an HTML element unless it begins with a capital letter",
-		"pos": 121,
 		"start": {
-			"character": 121,
 			"column": 0,
 			"line": 8
 		},
 		"end": {
-			"character": 141,
 			"column": 20,
 			"line": 8
 		}

--- a/test/validator/samples/component-slot-default-duplicate.skip/errors.json
+++ b/test/validator/samples/component-slot-default-duplicate.skip/errors.json
@@ -3,6 +3,5 @@
 	"start": {
 		"line": 2,
 		"column": 0
-	},
-	"pos": 14
+	}
 }]

--- a/test/validator/samples/component-slot-default-reserved/errors.json
+++ b/test/validator/samples/component-slot-default-reserved/errors.json
@@ -3,13 +3,10 @@
 	"message": "default is a reserved word — it cannot be used as a slot name",
 	"start": {
 		"line": 1,
-		"column": 6,
-		"character": 6
+		"column": 6
 	},
 	"end": {
 		"line": 1,
-		"column": 20,
-		"character": 20
-	},
-	"pos": 6
+		"column": 20
+	}
 }]

--- a/test/validator/samples/component-slot-dynamic-attribute/errors.json
+++ b/test/validator/samples/component-slot-dynamic-attribute/errors.json
@@ -3,13 +3,10 @@
 	"message": "slot attribute cannot have a dynamic value",
 	"start": {
 		"line": 6,
-		"column": 9,
-		"character": 77
+		"column": 9
 	},
 	"end": {
 		"line": 6,
-		"column": 19,
-		"character": 87
-	},
-	"pos": 77
+		"column": 19
+	}
 }]

--- a/test/validator/samples/component-slot-dynamic/errors.json
+++ b/test/validator/samples/component-slot-dynamic/errors.json
@@ -3,13 +3,10 @@
 	"message": "<slot> name cannot be dynamic",
 	"start": {
 		"line": 1,
-		"column": 6,
-		"character": 6
+		"column": 6
 	},
 	"end": {
 		"line": 1,
-		"column": 18,
-		"character": 18
-	},
-	"pos": 6
+		"column": 18
+	}
 }]

--- a/test/validator/samples/component-slot-named-duplicate.skip/errors.json
+++ b/test/validator/samples/component-slot-named-duplicate.skip/errors.json
@@ -3,6 +3,5 @@
 	"start": {
 		"line": 2,
 		"column": 6
-	},
-	"pos": 31
+	}
 }]

--- a/test/validator/samples/component-slotted-custom-element-2/errors.json
+++ b/test/validator/samples/component-slotted-custom-element-2/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-slotted-content",
 		"message": "Element with a slot='...' attribute must be a child of a component or a descendant of a custom element",
-		"start": { "line": 10, "column": 9, "character": 138 },
-		"end": { "line": 10, "column": 19, "character": 148 },
-		"pos": 138
+		"start": { "line": 10, "column": 9 },
+		"end": { "line": 10, "column": 19 }
 	}
 ]

--- a/test/validator/samples/component-slotted-each-block/errors.json
+++ b/test/validator/samples/component-slotted-each-block/errors.json
@@ -3,13 +3,10 @@
 	"message": "Element with a slot='...' attribute must be a child of a component or a descendant of a custom element",
 	"start": {
 		"line": 7,
-		"column": 7,
-		"character": 100
+		"column": 7
 	},
 	"end": {
 		"line": 7,
-		"column": 17,
-		"character": 110
-	},
-	"pos": 100
+		"column": 17
+	}
 }]

--- a/test/validator/samples/component-slotted-if-block/errors.json
+++ b/test/validator/samples/component-slotted-if-block/errors.json
@@ -3,13 +3,10 @@
 	"message": "Element with a slot='...' attribute must be a child of a component or a descendant of a custom element",
 	"start": {
 		"line": 7,
-		"column": 7,
-		"character": 88
+		"column": 7
 	},
 	"end": {
 		"line": 7,
-		"column": 17,
-		"character": 98
-	},
-	"pos": 88
+		"column": 17
+	}
 }]

--- a/test/validator/samples/const-tag-conflict-1/errors.json
+++ b/test/validator/samples/const-tag-conflict-1/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-const-declaration",
 		"message": "'a' has already been declared",
-		"start": { "line": 7, "column": 2, "character": 84 },
-		"end": { "line": 7, "column": 19, "character": 101 },
-		"pos": 84
+		"start": { "line": 7, "column": 2 },
+		"end": { "line": 7, "column": 19 }
 	}
 ]

--- a/test/validator/samples/const-tag-conflict-2/errors.json
+++ b/test/validator/samples/const-tag-conflict-2/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-const-declaration",
 		"message": "'item' has already been declared",
-		"start": { "line": 6, "column": 2, "character": 64 },
-		"end": { "line": 6, "column": 21, "character": 83 },
-		"pos": 64
+		"start": { "line": 6, "column": 2 },
+		"end": { "line": 6, "column": 21 }
 	}
 ]

--- a/test/validator/samples/const-tag-cyclical/errors.json
+++ b/test/validator/samples/const-tag-cyclical/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "cyclical-const-tags",
 		"message": "Cyclical dependency detected: b → c → b",
-		"start": { "line": 6, "column": 2, "character": 61 },
-		"end": { "line": 6, "column": 20, "character": 79 },
-		"pos": 61
+		"start": { "line": 6, "column": 2 },
+		"end": { "line": 6, "column": 20 }
 	}
 ]

--- a/test/validator/samples/const-tag-out-of-scope/warnings.json
+++ b/test/validator/samples/const-tag-out-of-scope/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "missing-declaration",
 		"message": "'b' is not defined",
-		"pos": 100,
 		"start": {
-			"character": 100,
 			"column": 1,
 			"line": 10
 		},
 		"end": {
-			"character": 101,
 			"column": 2,
 			"line": 10
 		}

--- a/test/validator/samples/const-tag-placement-1/errors.json
+++ b/test/validator/samples/const-tag-placement-1/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-const-placement",
 		"message": "{@const} must be the immediate child of {#if}, {:else if}, {:else}, {#each}, {:then}, {:catch}, <svelte:fragment> or <Component>",
-		"start": { "line": 5, "column": 0, "character": 36 },
-		"end": { "line": 5, "column": 18, "character": 54 },
-		"pos": 36
+		"start": { "line": 5, "column": 0 },
+		"end": { "line": 5, "column": 18 }
 	}
 ]

--- a/test/validator/samples/const-tag-placement-2/errors.json
+++ b/test/validator/samples/const-tag-placement-2/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-const-placement",
 		"message": "{@const} must be the immediate child of {#if}, {:else if}, {:else}, {#each}, {:then}, {:catch}, <svelte:fragment> or <Component>",
-		"start": { "line": 7, "column": 4, "character": 63 },
-		"end": { "line": 7, "column": 18, "character": 77 },
-		"pos": 63
+		"start": { "line": 7, "column": 4 },
+		"end": { "line": 7, "column": 18 }
 	}
 ]

--- a/test/validator/samples/const-tag-readonly-1/errors.json
+++ b/test/validator/samples/const-tag-readonly-1/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-const-update",
 		"message": "'b' is declared using {@const ...} and is read-only",
-		"start": { "line": 7, "column": 26, "character": 106 },
-		"end": { "line": 7, "column": 30, "character": 110 },
-		"pos": 106
+		"start": { "line": 7, "column": 26 },
+		"end": { "line": 7, "column": 30 }
 	}
 ]

--- a/test/validator/samples/const-tag-readonly-2/errors.json
+++ b/test/validator/samples/const-tag-readonly-2/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-binding",
 		"message": "Cannot bind to a variable declared with {@const ...}",
-		"start": { "line": 7, "column": 9, "character": 89 },
-		"end": { "line": 7, "column": 23, "character": 103 },
-		"pos": 89
+		"start": { "line": 7, "column": 9 },
+		"end": { "line": 7, "column": 23 }
 	}
 ]

--- a/test/validator/samples/contenteditable-dynamic/errors.json
+++ b/test/validator/samples/contenteditable-dynamic/errors.json
@@ -3,13 +3,10 @@
 	"message": "'contenteditable' attribute cannot be dynamic if element uses two-way binding",
 	"start": {
 		"line": 6,
-		"column": 8,
-		"character": 73
+		"column": 8
 	},
 	"end": {
 		"line": 6,
-		"column": 32,
-		"character": 97
-	},
-	"pos": 73
+		"column": 32
+	}
 }]

--- a/test/validator/samples/contenteditable-missing/errors.json
+++ b/test/validator/samples/contenteditable-missing/errors.json
@@ -3,13 +3,10 @@
 	"message": "'contenteditable' attribute is required for textContent and innerHTML two-way bindings",
 	"start": {
 		"line": 4,
-		"column": 8,
-		"character": 48
+		"column": 8
 	},
 	"end": {
 		"line": 4,
-		"column": 31,
-		"character": 71
-	},
-	"pos": 48
+		"column": 31
+	}
 }]

--- a/test/validator/samples/css-invalid-combinator-selector-1/errors.json
+++ b/test/validator/samples/css-invalid-combinator-selector-1/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "css-invalid-selector",
 		"message": "Invalid selector \"> span\"",
-		"start": { "line": 10, "column": 1, "character": 88 },
-		"end": { "line": 10, "column": 7, "character": 94 },
-		"pos": 88
+		"start": { "line": 10, "column": 1 },
+		"end": { "line": 10, "column": 7 }
 	}
 ]

--- a/test/validator/samples/css-invalid-combinator-selector-2/errors.json
+++ b/test/validator/samples/css-invalid-combinator-selector-2/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "css-invalid-selector",
 		"message": "Invalid selector \"+ p\"",
-		"start": { "line": 8, "column": 1, "character": 68 },
-		"end": { "line": 8, "column": 4, "character": 71 },
-		"pos": 68
+		"start": { "line": 8, "column": 1 },
+		"end": { "line": 8, "column": 4 }
 	}
 ]

--- a/test/validator/samples/css-invalid-combinator-selector-3/errors.json
+++ b/test/validator/samples/css-invalid-combinator-selector-3/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "css-invalid-selector",
 		"message": "Invalid selector \"> span\"",
-		"start": { "line": 5, "column": 2, "character": 44 },
-		"end": { "line": 5, "column": 8, "character": 50 },
-		"pos": 44
+		"start": { "line": 5, "column": 2 },
+		"end": { "line": 5, "column": 8 }
 	}
 ]

--- a/test/validator/samples/css-invalid-combinator-selector-4/errors.json
+++ b/test/validator/samples/css-invalid-combinator-selector-4/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "css-invalid-selector",
 		"message": "Invalid selector \"p >\"",
-		"start": { "line": 4, "column": 1, "character": 26 },
-		"end": { "line": 4, "column": 4, "character": 29 },
-		"pos": 26
+		"start": { "line": 4, "column": 1 },
+		"end": { "line": 4, "column": 4 }
 	}
 ]

--- a/test/validator/samples/css-invalid-global-placement-2/errors.json
+++ b/test/validator/samples/css-invalid-global-placement-2/errors.json
@@ -3,13 +3,10 @@
 	"message": ":global(...) can be at the start or end of a selector sequence, but not in the middle",
 	"start": {
 		"line": 2,
-		"column": 6,
-		"character": 14
+		"column": 6
 	},
 	"end": {
 		"line": 2,
-		"column": 19,
-		"character": 27
-	},
-	"pos": 14
+		"column": 19
+	}
 }]

--- a/test/validator/samples/css-invalid-global-placement-3/errors.json
+++ b/test/validator/samples/css-invalid-global-placement-3/errors.json
@@ -3,13 +3,10 @@
 	"message": ":global(...) can be at the start or end of a selector sequence, but not in the middle",
 	"start": {
 		"line": 5,
-		"column": 6,
-		"character": 60
+		"column": 6
 	},
 	"end": {
 		"line": 5,
-		"column": 19,
-		"character": 73
-	},
-	"pos": 60
+		"column": 19
+	}
 }]

--- a/test/validator/samples/css-invalid-global-placement/errors.json
+++ b/test/validator/samples/css-invalid-global-placement/errors.json
@@ -3,13 +3,10 @@
 	"message": ":global(...) can be at the start or end of a selector sequence, but not in the middle",
 	"start": {
 		"line": 2,
-		"column": 6,
-		"character": 14
+		"column": 6
 	},
 	"end": {
 		"line": 2,
-		"column": 19,
-		"character": 27
-	},
-	"pos": 14
+		"column": 19
+	}
 }]

--- a/test/validator/samples/css-invalid-global-selector-2/errors.json
+++ b/test/validator/samples/css-invalid-global-selector-2/errors.json
@@ -4,14 +4,11 @@
 		"message": ":global(...) must contain a single selector",
 		"start": {
 			"line": 11,
-			"column": 5,
-			"character": 156
+			"column": 5
 		},
 		"end": {
 			"line": 11,
-			"column": 29,
-			"character": 180
-		},
-		"pos": 156
+			"column": 29
+		}
 	}
 ]

--- a/test/validator/samples/css-invalid-global-selector-3/errors.json
+++ b/test/validator/samples/css-invalid-global-selector-3/errors.json
@@ -4,14 +4,11 @@
 		"message": ":global(...) must contain a single selector",
 		"start": {
 			"line": 5,
-			"column": 5,
-			"character": 77
+			"column": 5
 		},
 		"end": {
 			"line": 5,
-			"column": 44,
-			"character": 116
-		},
-		"pos": 77
+			"column": 44
+		}
 	}
 ]

--- a/test/validator/samples/css-invalid-global-selector-4/errors.json
+++ b/test/validator/samples/css-invalid-global-selector-4/errors.json
@@ -4,14 +4,11 @@
 		"message": ":global(...) must contain a single selector",
 		"start": {
 			"line": 2,
-			"column": 5,
-			"character": 13
+			"column": 5
 		},
 		"end": {
 			"line": 2,
-			"column": 24,
-			"character": 32
-		},
-		"pos": 13
+			"column": 24
+		}
 	}
 ]

--- a/test/validator/samples/css-invalid-global-selector-5/errors.json
+++ b/test/validator/samples/css-invalid-global-selector-5/errors.json
@@ -4,14 +4,11 @@
 		"message": ":global(...) must contain a single selector",
 		"start": {
 			"line": 5,
-			"column": 1,
-			"character": 54
+			"column": 1
 		},
 		"end": {
 			"line": 5,
-			"column": 20,
-			"character": 73
-		},
-		"pos": 54
+			"column": 20
+		}
 	}
 ]

--- a/test/validator/samples/css-invalid-global-selector-6/errors.json
+++ b/test/validator/samples/css-invalid-global-selector-6/errors.json
@@ -4,14 +4,11 @@
 		"message": ":global(...) must contain a single selector",
 		"start": {
 			"line": 5,
-			"column": 1,
-			"character": 54
+			"column": 1
 		},
 		"end": {
 			"line": 5,
-			"column": 20,
-			"character": 73
-		},
-		"pos": 54
+			"column": 20
+		}
 	}
 ]

--- a/test/validator/samples/css-invalid-global-selector/errors.json
+++ b/test/validator/samples/css-invalid-global-selector/errors.json
@@ -4,14 +4,11 @@
 		"message": ":global(...) must contain a single selector",
 		"start": {
 			"line": 11,
-			"column": 5,
-			"character": 143
+			"column": 5
 		},
 		"end": {
 			"line": 11,
-			"column": 24,
-			"character": 162
-		},
-		"pos": 143
+			"column": 24
+		}
 	}
 ]

--- a/test/validator/samples/debug-invalid-args/errors.json
+++ b/test/validator/samples/debug-invalid-args/errors.json
@@ -3,13 +3,10 @@
 	"message": "{@debug ...} arguments must be identifiers, not arbitrary expressions",
 	"start": {
 		"line": 2,
-		"column": 9,
-		"character": 13
+		"column": 9
 	},
 	"end": {
 		"line": 2,
-		"column": 9,
-		"character": 13
-	},
-	"pos": 13
+		"column": 9
+	}
 }]

--- a/test/validator/samples/default-export-anonymous-class/errors.json
+++ b/test/validator/samples/default-export-anonymous-class/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "default-export",
 	"message": "A component cannot have a default export",
-	"pos": 10,
 	"start": {
 		"line": 2,
-		"column": 1,
-		"character": 10
+		"column": 1
 	},
 	"end": {
 		"line": 2,
-		"column": 30,
-		"character": 39
+		"column": 30
 	}
 }]

--- a/test/validator/samples/default-export-anonymous-function/errors.json
+++ b/test/validator/samples/default-export-anonymous-function/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "default-export",
 	"message": "A component cannot have a default export",
-	"pos": 10,
 	"start": {
 		"line": 2,
-		"column": 1,
-		"character": 10
+		"column": 1
 	},
 	"end": {
 		"line": 2,
-		"column": 24,
-		"character": 33
+		"column": 24
 	}
 }]

--- a/test/validator/samples/default-export/errors.json
+++ b/test/validator/samples/default-export/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "default-export",
 	"message": "A component cannot have a default export",
-	"pos": 10,
 	"start": {
 		"line": 2,
-		"column": 1,
-		"character": 10
+		"column": 1
 	},
 	"end": {
 		"line": 2,
-		"column": 19,
-		"character": 28
+		"column": 19
 	}
 }]

--- a/test/validator/samples/directive-non-expression/errors.json
+++ b/test/validator/samples/directive-non-expression/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-directive-value",
 	"message": "Directive value must be a JavaScript expression enclosed in curly braces",
-	"pos": 15,
 	"start": {
 		"line": 1,
-		"column": 15,
-		"character": 15
+		"column": 15
 	},
 	"end": {
 		"line": 1,
-		"column": 15,
-		"character": 15
+		"column": 15
 	}
 }]

--- a/test/validator/samples/dollar-dollar-global-in-markup/errors.json
+++ b/test/validator/samples/dollar-dollar-global-in-markup/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "illegal-global",
 	"message": "$$billsyall is an illegal variable name",
-	"pos": 1,
 	"start": {
 		"line": 1,
-		"column": 1,
-		"character": 1
+		"column": 1
 	},
 	"end": {
 		"line": 1,
-		"column": 12,
-		"character": 12
+		"column": 12
 	}
 }]

--- a/test/validator/samples/dollar-dollar-global-in-script/errors.json
+++ b/test/validator/samples/dollar-dollar-global-in-script/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "illegal-global",
 	"message": "$$billsyall is an illegal variable name",
-	"pos": 10,
 	"start": {
 		"line": 2,
-		"column": 1,
-		"character": 10
+		"column": 1
 	},
 	"end": {
 		"line": 2,
-		"column": 12,
-		"character": 21
+		"column": 12
 	}
 }]

--- a/test/validator/samples/dollar-global-in-markup/errors.json
+++ b/test/validator/samples/dollar-global-in-markup/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "illegal-global",
 	"message": "$ is an illegal variable name",
-	"pos": 1,
 	"start": {
 		"line": 1,
-		"column": 1,
-		"character": 1
+		"column": 1
 	},
 	"end": {
 		"line": 1,
-		"column": 2,
-		"character": 2
+		"column": 2
 	}
 }]

--- a/test/validator/samples/dollar-global-in-script/errors.json
+++ b/test/validator/samples/dollar-global-in-script/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "illegal-global",
 	"message": "$ is an illegal variable name",
-	"pos": 10,
 	"start": {
 		"line": 2,
-		"column": 1,
-		"character": 10
+		"column": 1
 	},
 	"end": {
 		"line": 2,
-		"column": 2,
-		"character": 11
+		"column": 2
 	}
 }]

--- a/test/validator/samples/dynamic-element-invalid-tag/errors.json
+++ b/test/validator/samples/dynamic-element-invalid-tag/errors.json
@@ -4,14 +4,11 @@
 		"code": "invalid-element-definition",
 		"start": {
 			"line": 2,
-			"column": 17,
-			"character": 23
+			"column": 17
 		},
 		"end": {
 			"line": 2,
-			"column": 17,
-			"character": 23
-		},
-		"pos": 23
+			"column": 17
+		}
 	}
 ]

--- a/test/validator/samples/dynamic-element-missing-tag/errors.json
+++ b/test/validator/samples/dynamic-element-missing-tag/errors.json
@@ -3,13 +3,10 @@
 	"message": "<svelte:element> must have a 'this' attribute",
 	"start": {
 		"line": 2,
-		"column": 1,
-		"character": 7
+		"column": 1
 	},
 	"end": {
 		"line": 2,
-		"column": 1,
-		"character": 7
-	},
-	"pos": 7
+		"column": 1
+	}
 }]

--- a/test/validator/samples/dynamic-element-this/errors.json
+++ b/test/validator/samples/dynamic-element-this/errors.json
@@ -3,13 +3,10 @@
 	"message": "'this' is a reserved word in JavaScript and cannot be used here",
 	"start": {
 		"line": 2,
-		"column": 18,
-		"character": 24
+		"column": 18
 	},
 	"end": {
 		"line": 2,
-		"column": 18,
-		"character": 24
-	},
-	"pos": 24
+		"column": 18
+	}
 	}]

--- a/test/validator/samples/each-block-destructured-object-rest-comma-after/errors.json
+++ b/test/validator/samples/each-block-destructured-object-rest-comma-after/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "parse-error",
 	"message": "Comma is not permitted after the rest element",
-	"pos": 100,
 	"start": {
 		"line": 5,
-		"column": 53,
-		"character": 100
+		"column": 53
 	},
 	"end": {
 		"line": 5,
-		"column": 53,
-		"character": 100
+		"column": 53
 	}
 }]

--- a/test/validator/samples/each-block-invalid-context-destructured-object/errors.json
+++ b/test/validator/samples/each-block-invalid-context-destructured-object/errors.json
@@ -3,13 +3,10 @@
 	"message": "Unexpected keyword 'case'",
 	"start": {
 		"line": 1,
-		"column": 18,
-		"character": 18
+		"column": 18
 	},
 	"end": {
 		"line": 1,
-		"column": 18,
-		"character": 18
-	},
-	"pos": 18
+		"column": 18
+	}
 }]

--- a/test/validator/samples/each-block-invalid-context-destructured/errors.json
+++ b/test/validator/samples/each-block-invalid-context-destructured/errors.json
@@ -3,13 +3,10 @@
 	"message": "Unexpected token",
 	"start": {
 		"line": 1,
-		"column": 17,
-		"character": 17
+		"column": 17
 	},
 	"end": {
 		"line": 1,
-		"column": 17,
-		"character": 17
-	},
-	"pos": 17
+		"column": 17
+	}
 }]

--- a/test/validator/samples/each-block-invalid-context/errors.json
+++ b/test/validator/samples/each-block-invalid-context/errors.json
@@ -3,13 +3,10 @@
 	"message": "'case' is a reserved word in JavaScript and cannot be used here",
 	"start": {
 		"line": 1,
-		"column": 16,
-		"character": 16
+		"column": 16
 	},
 	"end": {
 		"line": 1,
-		"column": 16,
-		"character": 16
-	},
-	"pos": 16
+		"column": 16
+	}
 }]

--- a/test/validator/samples/empty-block/warnings.json
+++ b/test/validator/samples/empty-block/warnings.json
@@ -4,29 +4,23 @@
 		"message": "Empty block",
 		"start": {
 			"line": 5,
-			"column": 0,
-			"character": 38
+			"column": 0
 		},
 		"end": {
 			"line": 7,
-			"column": 7,
-			"character": 70
-		},
-		"pos": 38
+			"column": 7
+		}
 	},
 	{
 		"code": "empty-block",
 		"message": "Empty block",
 		"start": {
 			"line": 9,
-			"column": 0,
-			"character": 72
+			"column": 0
 		},
 		"end": {
 			"line": 9,
-			"column": 30,
-			"character": 102
-		},
-		"pos": 72
+			"column": 30
+		}
 	}
 ]

--- a/test/validator/samples/error-mode-warn/warnings.json
+++ b/test/validator/samples/error-mode-warn/warnings.json
@@ -2,29 +2,23 @@
 	{
 		"code": "invalid-binding",
 		"message": "Cannot bind to a variable which is not writable",
-		"pos": 61,
 		"start": {
 			"line": 5,
-			"column": 19,
-			"character": 61
+			"column": 19
 		},
 		"end": {
 			"line": 5,
-			"column": 24,
-			"character": 66
+			"column": 24
 		}
 	},
 	{
 		"code": "missing-declaration",
 		"message": "'undeclared' is not defined",
-		"pos": 88,
 		"start": {
-			"character": 88,
 			"column": 19,
 			"line": 6
 		},
 		"end": {
-			"character": 98,
 			"column": 29,
 			"line": 6
 		}
@@ -32,14 +26,11 @@
 	{
 		"code": "binding-undeclared",
 		"message": "undeclared is not declared",
-		"pos": 88,
 		"end": {
-			"character": 98,
 			"column": 29,
 			"line": 6
 		},
 		"start": {
-			"character": 88,
 			"column": 19,
 			"line": 6
 		}

--- a/test/validator/samples/event-modifiers-invalid-nonpassive/errors.json
+++ b/test/validator/samples/event-modifiers-invalid-nonpassive/errors.json
@@ -3,13 +3,10 @@
 	"code": "invalid-event-modifier",
 	"start": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	},
 	"end": {
 		"line": 1,
-		"column": 51,
-		"character": 51
-	},
-	"pos": 5
+		"column": 51
+	}
 }]

--- a/test/validator/samples/event-modifiers-invalid-passive/errors.json
+++ b/test/validator/samples/event-modifiers-invalid-passive/errors.json
@@ -3,13 +3,10 @@
 	"code": "invalid-event-modifier",
 	"start": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	},
 	"end": {
 		"line": 1,
-		"column": 50,
-		"character": 50
-	},
-	"pos": 5
+		"column": 50
+	}
 }]

--- a/test/validator/samples/event-modifiers-invalid/errors.json
+++ b/test/validator/samples/event-modifiers-invalid/errors.json
@@ -3,13 +3,10 @@
 	"code": "invalid-event-modifier",
 	"start": {
 		"line": 1,
-		"column": 8,
-		"character": 8
+		"column": 8
 	},
 	"end": {
 		"line": 1,
-		"column": 34,
-		"character": 34
-	},
-	"pos": 8
+		"column": 34
+	}
 }]

--- a/test/validator/samples/event-modifiers-legacy/errors.json
+++ b/test/validator/samples/event-modifiers-legacy/errors.json
@@ -3,13 +3,10 @@
 	"code": "invalid-event-modifier",
 	"start": {
 		"line": 1,
-		"column": 8,
-		"character": 8
+		"column": 8
 	},
 	"end": {
 		"line": 1,
-		"column": 37,
-		"character": 37
-	},
-	"pos": 8
+		"column": 37
+	}
 }]

--- a/test/validator/samples/event-modifiers-redundant/warnings.json
+++ b/test/validator/samples/event-modifiers-redundant/warnings.json
@@ -4,29 +4,23 @@
 		"code": "redundant-event-modifier",
 		"start": {
 			"line": 11,
-			"column": 8,
-			"character": 110
+			"column": 8
 		},
 		"end": {
 			"line": 11,
-			"column": 40,
-			"character": 142
-		},
-		"pos": 110
+			"column": 40
+		}
 	},
 	{
 		"message": "Touch event handlers that don't use the 'event' object are passive by default",
 		"code": "redundant-event-modifier",
 		"start": {
 			"line": 12,
-			"column": 5,
-			"character": 158
+			"column": 5
 		},
 		"end": {
 			"line": 12,
-			"column": 47,
-			"character": 200
-		},
-		"pos": 158
+			"column": 47
+		}
 	}
 ]

--- a/test/validator/samples/html-block-in-attribute/errors.json
+++ b/test/validator/samples/html-block-in-attribute/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-tag-placement",
 		"message": "{@html} tag cannot be in attribute value",
-		"start": { "line": 1, "column": 12, "character": 12 },
-		"end": { "line": 1, "column": 12, "character": 12 },
-		"pos": 12
+		"start": { "line": 1, "column": 12 },
+		"end": { "line": 1, "column": 12 }
 	}
 ]

--- a/test/validator/samples/html-block-in-textarea/errors.json
+++ b/test/validator/samples/html-block-in-textarea/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-tag-placement",
 		"message": "{@html} tag cannot be inside <textarea>",
-		"start": { "line": 2, "column": 1, "character": 12 },
-		"end": { "line": 2, "column": 1, "character": 12 },
-		"pos": 12
+		"start": { "line": 2, "column": 1 },
+		"end": { "line": 2, "column": 1 }
 	}
 ]

--- a/test/validator/samples/ignore-warning/warnings.json
+++ b/test/validator/samples/ignore-warning/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-distracting-elements",
 		"end": {
-			"character": 131,
 			"column": 49,
 			"line": 4
 		},
 		"message": "A11y: Avoid <marquee> elements",
-		"pos": 83,
 		"start": {
-			"character": 83,
 			"column": 1,
 			"line": 4
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "a11y-missing-attribute",
 		"end": {
-			"character": 162,
 			"column": 22,
 			"line": 7
 		},
 		"message": "A11y: <img> element should have an alt attribute",
-		"pos": 140,
 		"start": {
-			"character": 140,
 			"column": 0,
 			"line": 7
 		}

--- a/test/validator/samples/ignore-warnings-cumulative/warnings.json
+++ b/test/validator/samples/ignore-warnings-cumulative/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-distracting-elements",
 		"end": {
-			"character": 161,
 			"column": 12,
 			"line": 7
 		},
 		"message": "A11y: Avoid <marquee> elements",
-		"pos": 104,
 		"start": {
-			"character": 104,
 			"column": 2,
 			"line": 5
 		}

--- a/test/validator/samples/ignore-warnings-newline/warnings.json
+++ b/test/validator/samples/ignore-warnings-newline/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-missing-attribute",
 		"end": {
-			"character": 207,
 			"column": 22,
 			"line": 8
 		},
 		"message": "A11y: <img> element should have an alt attribute",
-		"pos": 185,
 		"start": {
-			"character": 185,
 			"column": 0,
 			"line": 8
 		}

--- a/test/validator/samples/ignore-warnings-stacked/warnings.json
+++ b/test/validator/samples/ignore-warnings-stacked/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-missing-attribute",
 		"end": {
-			"character": 211,
 			"column": 22,
 			"line": 8
 		},
 		"message": "A11y: <img> element should have an alt attribute",
-		"pos": 189,
 		"start": {
-			"character": 189,
 			"column": 0,
 			"line": 8
 		}

--- a/test/validator/samples/ignore-warnings/warnings.json
+++ b/test/validator/samples/ignore-warnings/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "a11y-missing-attribute",
 		"end": {
-			"character": 188,
 			"column": 22,
 			"line": 7
 		},
 		"message": "A11y: <img> element should have an alt attribute",
-		"pos": 166,
 		"start": {
-			"character": 166,
 			"column": 0,
 			"line": 7
 		}

--- a/test/validator/samples/illegal-variable-declaration/errors.json
+++ b/test/validator/samples/illegal-variable-declaration/errors.json
@@ -4,14 +4,11 @@
 		"message": "Cannot declare same variable name which is imported inside <script context=\"module\">",
 		"start": {
 			"line": 6,
-			"column": 1,
-			"character": 86
+			"column": 1
 		},
 		"end": {
 			"line": 6,
-			"column": 9,
-			"character": 94
-		},
-		"pos": 86
+			"column": 9
+		}
 	}
 ]

--- a/test/validator/samples/invalid-empty-css-declaration/errors.json
+++ b/test/validator/samples/invalid-empty-css-declaration/errors.json
@@ -2,11 +2,9 @@
 	"code": "invalid-declaration",
 	"message": "Declaration cannot be empty",
 	"start": {
-		"line": 11, "column": 0, "character": 93
+		"line": 11, "column": 0
 	},
-  	"end": {
-		"line": 11, "column": 0, "character": 93
-	},
-	"pos": 93,
-	"frame": " 9:     color: blue;\n10:   }\n11: </style>\n    ^"
+  "end": {
+		"line": 11, "column": 0
+	}
 }]

--- a/test/validator/samples/logic-block-in-attribute/errors.json
+++ b/test/validator/samples/logic-block-in-attribute/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-logic-block-placement",
 		"message": "{#if} logic block cannot be in attribute value",
-		"start": { "line": 1, "column": 12, "character": 12 },
-		"end": { "line": 1, "column": 12, "character": 12 },
-		"pos": 12
+		"start": { "line": 1, "column": 12 },
+		"end": { "line": 1, "column": 12 }
 	}
 ]

--- a/test/validator/samples/logic-block-in-textarea/errors.json
+++ b/test/validator/samples/logic-block-in-textarea/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-logic-block-placement",
 		"message": "{#each} logic block cannot be inside <textarea>",
-		"start": { "line": 2, "column": 1, "character": 12 },
-		"end": { "line": 2, "column": 1, "character": 12 },
-		"pos": 12
+		"start": { "line": 2, "column": 1 },
+		"end": { "line": 2, "column": 1 }
 	}
 ]

--- a/test/validator/samples/missing-component-global/warnings.json
+++ b/test/validator/samples/missing-component-global/warnings.json
@@ -3,13 +3,10 @@
 	"message": "'String' is not defined. Consider adding a <script> block with 'export let String' to declare a prop",
 	"start": {
 		"line": 2,
-		"column": 1,
-		"character": 7
+		"column": 1
 	},
 	"end": {
 		"line": 2,
-		"column": 10,
-		"character": 16
-	},
-	"pos": 7
+		"column": 10
+	}
 }]

--- a/test/validator/samples/missing-component/warnings.json
+++ b/test/validator/samples/missing-component/warnings.json
@@ -3,13 +3,10 @@
 	"message": "'Widget' is not defined. Consider adding a <script> block with 'export let Widget' to declare a prop",
 	"start": {
 		"line": 2,
-		"column": 1,
-		"character": 7
+		"column": 1
 	},
 	"end": {
 		"line": 2,
-		"column": 10,
-		"character": 16
-	},
-	"pos": 7
+		"column": 10
+	}
 }]

--- a/test/validator/samples/missing-custom-element-compile-options/warnings.json
+++ b/test/validator/samples/missing-custom-element-compile-options/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "missing-custom-element-compile-options",
 		"end": {
-			"character": 36,
 			"column": 36,
 			"line": 1
 		},
 		"message": "The 'tag' option is used when generating a custom element. Did you forget the 'customElement: true' compile option?",
-		"pos": 16,
 		"start": {
-			"character": 16,
 			"column": 16,
 			"line": 1
 		}

--- a/test/validator/samples/module-script-reactive-declaration/warnings.json
+++ b/test/validator/samples/module-script-reactive-declaration/warnings.json
@@ -1,7 +1,6 @@
 [{
 	"message": "$: has no effect in a module script",
 	"code": "module-script-reactive-declaration",
-	"start": { "line": 4, "column": 1, "character": 54 },
-	"end": { "line": 4, "column": 23, "character": 76 },
-	"pos": 54
+	"start": { "line": 4, "column": 1 },
+	"end": { "line": 4, "column": 23 }
 }]

--- a/test/validator/samples/multiple-script-default-context/errors.json
+++ b/test/validator/samples/multiple-script-default-context/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-script",
 	"message": "A component can only have one instance-level <script> element",
-	"pos": 30,
 	"start": {
 		"line": 5,
-		"column": 0,
-		"character": 30
+		"column": 0
 	},
 	"end": {
 		"line": 5,
-		"column": 0,
-		"character": 30
+		"column": 0
 	}
 }]

--- a/test/validator/samples/multiple-script-module-context/errors.json
+++ b/test/validator/samples/multiple-script-module-context/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-script",
 	"message": "A component can only have one <script context=\"module\"> element",
-	"pos": 47,
 	"start": {
 		"line": 5,
-		"column": 0,
-		"character": 47
+		"column": 0
 	},
 	"end": {
 		"line": 5,
-		"column": 0,
-		"character": 47
+		"column": 0
 	}
 }]

--- a/test/validator/samples/namespace-invalid-unguessable/errors.json
+++ b/test/validator/samples/namespace-invalid-unguessable/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-namespace-property",
 	"message": "Invalid namespace 'lol'",
-	"pos": 16,
 	"start": {
 		"line": 1,
-		"column": 16,
-		"character": 16
+		"column": 16
 	},
 	"end": {
 		"line": 1,
-		"column": 31,
-		"character": 31
+		"column": 31
 	}
 }]

--- a/test/validator/samples/namespace-invalid/errors.json
+++ b/test/validator/samples/namespace-invalid/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-namespace-property",
 	"message": "Invalid namespace 'http://www.w3.org/1999/svg' (did you mean 'http://www.w3.org/2000/svg'?)",
-	"pos": 16,
 	"start": {
 		"line": 1,
-		"column": 16,
-		"character": 16
+		"column": 16
 	},
 	"end": {
 		"line": 1,
-		"column": 54,
-		"character": 54
+		"column": 54
 	}
 }]

--- a/test/validator/samples/namespace-non-literal/errors.json
+++ b/test/validator/samples/namespace-non-literal/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-namespace-attribute",
 	"message": "The 'namespace' attribute must be a string literal representing a valid namespace",
-	"pos": 16,
 	"start": {
 		"line": 1,
-		"column": 16,
-		"character": 16
+		"column": 16
 	},
 	"end": {
 		"line": 1,
-		"column": 30,
-		"character": 30
+		"column": 30
 	}
 }]

--- a/test/validator/samples/reactive-declaration-cyclical/errors.json
+++ b/test/validator/samples/reactive-declaration-cyclical/errors.json
@@ -1,7 +1,6 @@
 [{
 	"message": "Cyclical dependency detected: a → b → a",
 	"code": "cyclical-reactive-declaration",
-	"start": { "line": 5, "column": 1, "character": 35 },
-	"end": { "line": 5, "column": 14, "character": 48 },
-	"pos": 35
+	"start": { "line": 5, "column": 1 },
+	"end": { "line": 5, "column": 14 }
 }]

--- a/test/validator/samples/reactive-declaration-non-top-level/warnings.json
+++ b/test/validator/samples/reactive-declaration-non-top-level/warnings.json
@@ -1,7 +1,6 @@
 [{
 	"message": "$: has no effect outside of the top-level",
 	"code": "non-top-level-reactive-declaration",
-	"start": { "line": 6, "column": 2, "character": 71 },
-	"end": { "line": 6, "column": 22, "character": 91 },
-	"pos": 71
+	"start": { "line": 6, "column": 2 },
+	"end": { "line": 6, "column": 22 }
 }]

--- a/test/validator/samples/reactive-module-variable/warnings.json
+++ b/test/validator/samples/reactive-module-variable/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "module-script-reactive-declaration",
 		"message": "\"foo\" is declared in a module script and will not be reactive",
-		"pos": 59,
 		"start": {
-			"character": 59,
 			"column": 4,
 			"line": 5
 		},
 		"end": {
-			"character": 69,
 			"column": 14,
 			"line": 5
 		}

--- a/test/validator/samples/ref-not-supported-in-css/errors.json
+++ b/test/validator/samples/ref-not-supported-in-css/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-ref-selector",
 	"message": "ref selectors are no longer supported",
-	"pos": 68,
 	"start": {
 		"line": 8,
-		"column": 1,
-		"character": 68
+		"column": 1
 	},
 	"end": {
 		"line": 8,
-		"column": 1,
-		"character": 68
+		"column": 1
 	}
 }]

--- a/test/validator/samples/ref-not-supported/errors.json
+++ b/test/validator/samples/ref-not-supported/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-ref-directive",
 	"message": "The ref directive is no longer supported — use `bind:this={foo}` instead",
-	"pos": 5,
 	"start": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	},
 	"end": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	}
 }]

--- a/test/validator/samples/rest-eachblock-binding-2/warnings.json
+++ b/test/validator/samples/rest-eachblock-binding-2/warnings.json
@@ -2,8 +2,7 @@
   {
     "code": "invalid-rest-eachblock-binding",
     "message": "...rest operator will create a new object and binding propagation with original object will not work",
-		"pos": 102,
-    "start": { "line": 8, "column": 24, "character": 102 },
-		"end": { "line": 8, "column": 31, "character": 109 }
+    "start": { "line": 8, "column": 24 },
+		"end": { "line": 8, "column": 31 }
   }
 ]

--- a/test/validator/samples/rest-eachblock-binding-3/warnings.json
+++ b/test/validator/samples/rest-eachblock-binding-3/warnings.json
@@ -2,8 +2,7 @@
   {
     "code": "invalid-rest-eachblock-binding",
     "message": "...rest operator will create a new object and binding propagation with original object will not work",
-		"pos": 168,
-    "start": { "line": 5, "column": 32, "character": 168 },
-		"end": { "line": 5, "column": 39, "character": 175 }
+    "start": { "line": 5, "column": 32 },
+		"end": { "line": 5, "column": 39 }
   }
 ]

--- a/test/validator/samples/rest-eachblock-binding/warnings.json
+++ b/test/validator/samples/rest-eachblock-binding/warnings.json
@@ -2,8 +2,7 @@
   {
     "code": "invalid-rest-eachblock-binding",
     "message": "...rest operator will create a new object and binding propagation with original object will not work",
-		"pos": 143,
-		"start": { "line": 5, "column": 25, "character": 143 },
-    "end": { "line": 5, "column": 32, "character": 150 }
+		"start": { "line": 5, "column": 25 },
+    "end": { "line": 5, "column": 32 }
   }
 ]

--- a/test/validator/samples/script-invalid-context/errors.json
+++ b/test/validator/samples/script-invalid-context/errors.json
@@ -1,15 +1,12 @@
 [{
 	"code": "invalid-script",
 	"message": "If the context attribute is supplied, its value must be \"module\"",
-	"pos": 8,
 	"start": {
 		"line": 1,
-		"column": 8,
-		"character": 8
+		"column": 8
 	},
 	"end": {
 		"line": 1,
-		"column": 8,
-		"character": 8
+		"column": 8
 	}
 }]

--- a/test/validator/samples/security-anchor-rel-noreferer-legacy/warnings.json
+++ b/test/validator/samples/security-anchor-rel-noreferer-legacy/warnings.json
@@ -3,13 +3,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 73,
 			"column": 73,
 			"line": 1
 		},
-		"pos": 0,
 		"start": {
-			"character": 0,
 			"column": 0,
 			"line": 1
 		}
@@ -18,13 +15,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 154,
 			"column": 80,
 			"line": 2
 		},
-		"pos": 74,
 		"start": {
-			"character": 74,
 			"column": 0,
 			"line": 2
 		}
@@ -33,13 +27,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 243,
 			"column": 88,
 			"line": 3
 		},
-		"pos": 155,
 		"start": {
-			"character": 155,
 			"column": 0,
 			"line": 3
 		}
@@ -48,13 +39,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 319,
 			"column": 75,
 			"line": 4
 		},
-		"pos": 244,
 		"start": {
-			"character": 244,
 			"column": 0,
 			"line": 4
 		}
@@ -63,13 +51,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 402,
 			"column": 82,
 			"line": 5
 		},
-		"pos": 320,
 		"start": {
-			"character": 320,
 			"column": 0,
 			"line": 5
 		}
@@ -78,13 +63,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 493,
 			"column": 90,
 			"line": 6
 		},
-		"pos": 403,
 		"start": {
-			"character": 403,
 			"column": 0,
 			"line": 6
 		}
@@ -93,13 +75,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 561,
 			"column": 67,
 			"line": 7
 		},
-		"pos": 494,
 		"start": {
-			"character": 494,
 			"column": 0,
 			"line": 7
 		}
@@ -108,13 +87,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 636,
 			"column": 74,
 			"line": 8
 		},
-		"pos": 562,
 		"start": {
-			"character": 562,
 			"column": 0,
 			"line": 8
 		}
@@ -123,13 +99,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 719,
 			"column": 82,
 			"line": 9
 		},
-		"pos": 637,
 		"start": {
-			"character": 637,
 			"column": 0,
 			"line": 9
 		}
@@ -138,13 +111,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 792,
 			"column": 72,
 			"line": 10
 		},
-		"pos": 720,
 		"start": {
-			"character": 720,
 			"column": 0,
 			"line": 10
 		}
@@ -153,13 +123,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 872,
 			"column": 79,
 			"line": 11
 		},
-		"pos": 793,
 		"start": {
-			"character": 793,
 			"column": 0,
 			"line": 11
 		}
@@ -168,13 +135,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 960,
 			"column": 87,
 			"line": 12
 		},
-		"pos": 873,
 		"start": {
-			"character": 873,
 			"column": 0,
 			"line": 12
 		}
@@ -183,13 +147,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 1033,
 			"column": 72,
 			"line": 13
 		},
-		"pos": 961,
 		"start": {
-			"character": 961,
 			"column": 0,
 			"line": 13
 		}
@@ -198,13 +159,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 1113,
 			"column": 79,
 			"line": 14
 		},
-		"pos": 1034,
 		"start": {
-			"character": 1034,
 			"column": 0,
 			"line": 14
 		}
@@ -213,13 +171,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 1201,
 			"column": 87,
 			"line": 15
 		},
-		"pos": 1114,
 		"start": {
-			"character": 1114,
 			"column": 0,
 			"line": 15
 		}
@@ -228,13 +183,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 1277,
 			"column": 75,
 			"line": 16
 		},
-		"pos": 1202,
 		"start": {
-			"character": 1202,
 			"column": 0,
 			"line": 16
 		}
@@ -243,13 +195,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 1360,
 			"column": 82,
 			"line": 17
 		},
-		"pos": 1278,
 		"start": {
-			"character": 1278,
 			"column": 0,
 			"line": 17
 		}
@@ -258,13 +207,10 @@
 		"code": "security-anchor-rel-noreferrer",
 		"message": "Security: Anchor with \"target=_blank\" should have rel attribute containing the value \"noreferrer\"",
 		"end": {
-			"character": 1451,
 			"column": 90,
 			"line": 18
 		},
-		"pos": 1361,
 		"start": {
-			"character": 1361,
 			"column": 0,
 			"line": 18
 		}

--- a/test/validator/samples/slot-attribute-invalid/errors.json
+++ b/test/validator/samples/slot-attribute-invalid/errors.json
@@ -3,13 +3,10 @@
 	"message": "Element with a slot='...' attribute must be a child of a component or a descendant of a custom element",
 	"start": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	},
 	"end": {
 		"line": 1,
-		"column": 15,
-		"character": 15
-	},
-	"pos": 5
+		"column": 15
+	}
 }]

--- a/test/validator/samples/slot-warning/warnings.json
+++ b/test/validator/samples/slot-warning/warnings.json
@@ -3,15 +3,12 @@
 		"code": "a11y-click-events-have-key-events",
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
-			"character": 78,
 			"column": 1,
 			"line": 6
 		},
 		"end": {
-			"character": 112,
 			"column": 35,
 			"line": 6
-		},
-		"pos": 78
+		}
 	}
 ]

--- a/test/validator/samples/slot-warning2/warnings.json
+++ b/test/validator/samples/slot-warning2/warnings.json
@@ -3,15 +3,12 @@
 		"code": "a11y-click-events-have-key-events",
 		"message": "A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.",
 		"start": {
-			"character": 120,
 			"column": 1,
 			"line": 7
 		},
 		"end": {
-			"character": 154,
 			"column": 35,
 			"line": 7
-		},
-		"pos": 120
+		}
 	}
 ]

--- a/test/validator/samples/style-directive-modifiers-invalid/errors.json
+++ b/test/validator/samples/style-directive-modifiers-invalid/errors.json
@@ -3,13 +3,10 @@
 	"code": "invalid-style-directive-modifier",
 	"start": {
 		"line": 1,
-		"column": 8,
-		"character": 8
+		"column": 8
 	},
 	"end": {
 		"line": 1,
-		"column": 29,
-		"character": 29
-	},
-	"pos": 8
+		"column": 29
+	}
 }]

--- a/test/validator/samples/svelte-fragment-placement-2/errors.json
+++ b/test/validator/samples/svelte-fragment-placement-2/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-slotted-content",
 		"message": "<svelte:fragment> must be a child of a component",
-		"start": { "line": 5, "column": 0, "character": 59 },
-		"end": { "line": 7, "column": 18, "character": 112 },
-		"pos": 59
+		"start": { "line": 5, "column": 0 },
+		"end": { "line": 7, "column": 18 }
 	}
 ]

--- a/test/validator/samples/svelte-fragment-placement/errors.json
+++ b/test/validator/samples/svelte-fragment-placement/errors.json
@@ -2,8 +2,7 @@
 	{
 		"code": "invalid-slotted-content",
 		"message": "<svelte:fragment> must be a child of a component",
-		"start": { "line": 7, "column": 2, "character": 77 },
-		"end": { "line": 9, "column": 20, "character": 134 },
-		"pos": 77
+		"start": { "line": 7, "column": 2 },
+		"end": { "line": 9, "column": 20 }
 	}
 ]

--- a/test/validator/samples/tag-custom-element-options-missing/warnings.json
+++ b/test/validator/samples/tag-custom-element-options-missing/warnings.json
@@ -3,13 +3,10 @@
 		"message": "The 'tag' option is used when generating a custom element. Did you forget the 'customElement: true' compile option?",
 		"start": {
 				"line": 1,
-				"column": 16,
-				"character": 16
+				"column": 16
 		},
 		"end": {
 				"line": 1,
-				"column": 36,
-				"character": 36
-		},
-		"pos": 16
+				"column": 36
+		}
 }]

--- a/test/validator/samples/tag-invalid/errors.json
+++ b/test/validator/samples/tag-invalid/errors.json
@@ -3,13 +3,10 @@
 	"message": "tag name must be two or more words joined by the '-' character",
 	"start": {
 		"line": 1,
-		"column": 16,
-		"character": 16
+		"column": 16
 	},
 	"end": {
 		"line": 1,
-		"column": 29,
-		"character": 29
-	},
-	"pos": 16
+		"column": 29
+	}
 }]

--- a/test/validator/samples/tag-non-string/errors.json
+++ b/test/validator/samples/tag-non-string/errors.json
@@ -3,13 +3,10 @@
 	"message": "'tag' must be a string literal",
 	"start": {
 		"line": 1,
-		"column": 16,
-		"character": 16
+		"column": 16
 	},
 	"end": {
 		"line": 1,
-		"column": 24,
-		"character": 24
-	},
-	"pos": 16
+		"column": 24
+	}
 }]

--- a/test/validator/samples/textarea-value-children/errors.json
+++ b/test/validator/samples/textarea-value-children/errors.json
@@ -3,13 +3,10 @@
 	"message": "A <textarea> can have either a value attribute or (equivalently) child content, but not both",
 	"start": {
 		"line": 1,
-		"column": 10,
-		"character": 10
+		"column": 10
 	},
 	"end": {
 		"line": 1,
-		"column": 23,
-		"character": 23
-	},
-	"pos": 10
+		"column": 23
+	}
 }]

--- a/test/validator/samples/title-no-attributes/errors.json
+++ b/test/validator/samples/title-no-attributes/errors.json
@@ -3,13 +3,10 @@
 	"message": "<title> cannot have attributes",
 	"start": {
 		"line": 2,
-		"column": 8,
-		"character": 22
+		"column": 8
 	},
 	"end": {
 		"line": 2,
-		"column": 25,
-		"character": 39
-	},
-	"pos": 22
+		"column": 25
+	}
 }]

--- a/test/validator/samples/title-no-children/errors.json
+++ b/test/validator/samples/title-no-children/errors.json
@@ -3,13 +3,10 @@
 	"message": "<title> can only contain text and {tags}",
 	"start": {
 		"line": 2,
-		"column": 11,
-		"character": 25
+		"column": 11
 	},
 	"end": {
 		"line": 2,
-		"column": 35,
-		"character": 49
-	},
-	"pos": 25
+		"column": 35
+	}
 }]

--- a/test/validator/samples/transition-duplicate-in-transition/errors.json
+++ b/test/validator/samples/transition-duplicate-in-transition/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element cannot have both an 'in' directive and a 'transition' directive",
 	"start": {
 		"line": 6,
-		"column": 12,
-		"character": 70
+		"column": 12
 	},
 	"end": {
 		"line": 6,
-		"column": 26,
-		"character": 84
-	},
-	"pos": 70
+		"column": 26
+	}
 }]

--- a/test/validator/samples/transition-duplicate-in/errors.json
+++ b/test/validator/samples/transition-duplicate-in/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element can only have one 'in' directive",
 	"start": {
 		"line": 6,
-		"column": 12,
-		"character": 70
+		"column": 12
 	},
 	"end": {
 		"line": 6,
-		"column": 18,
-		"character": 76
-	},
-	"pos": 70
+		"column": 18
+	}
 }]

--- a/test/validator/samples/transition-duplicate-out-transition/errors.json
+++ b/test/validator/samples/transition-duplicate-out-transition/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element cannot have both an 'out' directive and a 'transition' directive",
 	"start": {
 		"line": 6,
-		"column": 13,
-		"character": 71
+		"column": 13
 	},
 	"end": {
 		"line": 6,
-		"column": 27,
-		"character": 85
-	},
-	"pos": 71
+		"column": 27
+	}
 }]

--- a/test/validator/samples/transition-duplicate-out/errors.json
+++ b/test/validator/samples/transition-duplicate-out/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element can only have one 'out' directive",
 	"start": {
 		"line": 6,
-		"column": 13,
-		"character": 71
+		"column": 13
 	},
 	"end": {
 		"line": 6,
-		"column": 20,
-		"character": 78
-	},
-	"pos": 71
+		"column": 20
+	}
 }]

--- a/test/validator/samples/transition-duplicate-transition-in/errors.json
+++ b/test/validator/samples/transition-duplicate-transition-in/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element cannot have both a 'transition' directive and an 'in' directive",
 	"start": {
 		"line": 6,
-		"column": 20,
-		"character": 78
+		"column": 20
 	},
 	"end": {
 		"line": 6,
-		"column": 26,
-		"character": 84
-	},
-	"pos": 78
+		"column": 26
+	}
 }]

--- a/test/validator/samples/transition-duplicate-transition-out/errors.json
+++ b/test/validator/samples/transition-duplicate-transition-out/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element cannot have both a 'transition' directive and an 'out' directive",
 	"start": {
 		"line": 6,
-		"column": 20,
-		"character": 78
+		"column": 20
 	},
 	"end": {
 		"line": 6,
-		"column": 27,
-		"character": 85
-	},
-	"pos": 78
+		"column": 27
+	}
 }]

--- a/test/validator/samples/transition-duplicate-transition/errors.json
+++ b/test/validator/samples/transition-duplicate-transition/errors.json
@@ -3,13 +3,10 @@
 	"message": "An element can only have one 'transition' directive",
 	"start": {
 		"line": 6,
-		"column": 20,
-		"character": 78
+		"column": 20
 	},
 	"end": {
 		"line": 6,
-		"column": 34,
-		"character": 92
-	},
-	"pos": 78
+		"column": 34
+	}
 }]

--- a/test/validator/samples/transition-missing/warnings.json
+++ b/test/validator/samples/transition-missing/warnings.json
@@ -3,13 +3,10 @@
 	"message": "'foo' is not defined. Consider adding a <script> block with 'export let foo' to declare a prop",
 	"start": {
 		"line": 1,
-		"column": 5,
-		"character": 5
+		"column": 5
 	},
 	"end": {
 		"line": 1,
-		"column": 11,
-		"character": 11
-	},
-	"pos": 5
+		"column": 11
+	}
 }]

--- a/test/validator/samples/transition-on-component/errors.json
+++ b/test/validator/samples/transition-on-component/errors.json
@@ -3,13 +3,10 @@
 	"message": "Transitions can only be applied to DOM elements, not components",
 	"start": {
 		"line": 7,
-		"column": 8,
-		"character": 87
+		"column": 8
 	},
 	"end": {
 		"line": 7,
-		"column": 14,
-		"character": 93
-	},
-	"pos": 87
+		"column": 14
+	}
 }]

--- a/test/validator/samples/undefined-value-global/warnings.json
+++ b/test/validator/samples/undefined-value-global/warnings.json
@@ -1,15 +1,12 @@
 [{
 	"code": "missing-declaration",
 	"message": "'potato' is not defined",
-	"pos": 46,
 	"start": {
 		"line": 5,
-		"column": 4,
-		"character": 46
+		"column": 4
 	},
 	"end": {
 		"line": 5,
-		"column": 10,
-		"character": 52
+		"column": 10
 	}
 }]

--- a/test/validator/samples/undefined-value/warnings.json
+++ b/test/validator/samples/undefined-value/warnings.json
@@ -1,15 +1,12 @@
 [{
 	"code": "missing-declaration",
 	"message": "'potato' is not defined. Consider adding a <script> block with 'export let potato' to declare a prop",
-	"pos": 4,
 	"start": {
 		"line": 1,
-		"column": 4,
-		"character": 4
+		"column": 4
 	},
 	"end": {
 		"line": 1,
-		"column": 10,
-		"character": 10
+		"column": 10
 	}
 }]

--- a/test/validator/samples/unreferenced-variables-each/warnings.json
+++ b/test/validator/samples/unreferenced-variables-each/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "unused-export-let",
 		"message": "Component_1 has unused export property 'default_value_5'. If it is for external reference only, please consider using `export const default_value_5`",
-		"pos": 172,
 		"start": {
-			"character": 172,
 			"column": 12,
 			"line": 8
 		},
 		"end": {
-			"character": 187,
 			"column": 27,
 			"line": 8
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "unused-export-let",
 		"message": "Component_1 has unused export property 'default_value_6'. If it is for external reference only, please consider using `export const default_value_6`",
-		"pos": 201,
 		"start": {
-			"character": 201,
 			"column": 12,
 			"line": 9
 		},
 		"end": {
-			"character": 216,
 			"column": 27,
 			"line": 9
 		}

--- a/test/validator/samples/unreferenced-variables/warnings.json
+++ b/test/validator/samples/unreferenced-variables/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 519,
 			"column": 13,
 			"line": 31
 		},
 		"message": "Component has unused export property 'd2'. If it is for external reference only, please consider using `export const d2`",
-		"pos": 517,
 		"start": {
-			"character": 517,
 			"column": 11,
 			"line": 31
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 523,
 			"column": 17,
 			"line": 31
 		},
 		"message": "Component has unused export property 'e2'. If it is for external reference only, please consider using `export const e2`",
-		"pos": 521,
 		"start": {
-			"character": 521,
 			"column": 15,
 			"line": 31
 		}
@@ -32,14 +26,11 @@
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 549,
 			"column": 19,
 			"line": 32
 		},
 		"message": "Component has unused export property 'g2'. If it is for external reference only, please consider using `export const g2`",
-		"pos": 543,
 		"start": {
-			"character": 543,
 			"column": 13,
 			"line": 32
 		}
@@ -47,14 +38,11 @@
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 570,
 			"column": 19,
 			"line": 33
 		},
 		"message": "Component has unused export property 'h2'. If it is for external reference only, please consider using `export const h2`",
-		"pos": 564,
 		"start": {
-			"character": 564,
 			"column": 13,
 			"line": 33
 		}
@@ -62,14 +50,11 @@
 	{
 		"code": "unused-export-let",
 		"end": {
-			"character": 621,
 			"column": 26,
 			"line": 35
 		},
 		"message": "Component has unused export property 'j2'. If it is for external reference only, please consider using `export const j2`",
-		"pos": 608,
 		"start": {
-			"character": 608,
 			"column": 13,
 			"line": 35
 		}

--- a/test/validator/samples/use-the-platform/warnings.json
+++ b/test/validator/samples/use-the-platform/warnings.json
@@ -2,14 +2,11 @@
 	{
 		"code": "invalid-html-attribute",
 		"message": "'className' is not a valid HTML attribute. Did you mean 'class'?",
-		"pos": 5,
 		"start": {
-			"character": 5,
 			"column": 5,
 			"line": 1
 		},
 		"end": {
-			"character": 20,
 			"column": 20,
 			"line": 1
 		}
@@ -17,14 +14,11 @@
 	{
 		"code": "invalid-html-attribute",
 		"message": "'htmlFor' is not a valid HTML attribute. Did you mean 'for'?",
-		"pos": 35,
 		"start": {
-			"character": 35,
 			"column": 7,
 			"line": 2
 		},
 		"end": {
-			"character": 46,
 			"column": 18,
 			"line": 2
 		}

--- a/test/validator/samples/window-binding-invalid-innerwidth/errors.json
+++ b/test/validator/samples/window-binding-invalid-innerwidth/errors.json
@@ -3,13 +3,10 @@
 	"message": "'innerwidth' is not a valid binding on <svelte:window> (did you mean 'innerWidth'?)",
 	"start": {
 		"line": 1,
-		"column": 15,
-		"character": 15
+		"column": 15
 	},
 	"end": {
 		"line": 1,
-		"column": 34,
-		"character": 34
-	},
-	"pos": 15
+		"column": 34
+	}
 }]

--- a/test/validator/samples/window-binding-invalid-value/errors.json
+++ b/test/validator/samples/window-binding-invalid-value/errors.json
@@ -3,13 +3,10 @@
 	"message": "Bindings on <svelte:window> must be to top-level properties, e.g. 'baz' rather than 'foo.bar.baz'",
 	"start": {
 		"line": 1,
-		"column": 32,
-		"character": 32
+		"column": 32
 	},
 	"end": {
 		"line": 1,
-		"column": 43,
-		"character": 43
-	},
-	"pos": 32
+		"column": 43
+	}
 }]

--- a/test/validator/samples/window-binding-invalid-width/errors.json
+++ b/test/validator/samples/window-binding-invalid-width/errors.json
@@ -3,13 +3,10 @@
 	"message": "'width' is not a valid binding on <svelte:window> (did you mean 'innerWidth'?)",
 	"start": {
 		"line": 1,
-		"column": 15,
-		"character": 15
+		"column": 15
 	},
 	"end": {
 		"line": 1,
-		"column": 29,
-		"character": 29
-	},
-	"pos": 15
+		"column": 29
+	}
 }]

--- a/test/validator/samples/window-binding-invalid/errors.json
+++ b/test/validator/samples/window-binding-invalid/errors.json
@@ -3,13 +3,10 @@
 	"message": "'potato' is not a valid binding on <svelte:window> — valid bindings are innerWidth, innerHeight, outerWidth, outerHeight, scrollX, scrollY or online",
 	"start": {
 		"line": 1,
-		"column": 15,
-		"character": 15
+		"column": 15
 	},
 	"end": {
 		"line": 1,
-		"column": 32,
-		"character": 32
-	},
-	"pos": 15
+		"column": 32
+	}
 }]


### PR DESCRIPTION
I updated validator tests to reduce number of lines of expected files.

I thought I remove `line` and `column`, but it's difficult to recognize that reported position is ok or not from `character`. So I removed `character` and `pos`.

And at the same time, to check consistency between `character` and `line`/`column`, and `pos` and `start.character`, I added a test to check this.

refer: https://github.com/sveltejs/svelte/pull/8195#pullrequestreview-1309302602

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
