### PR TITLE
docs: Add way to use regular `<slot>` element

### DIFF
--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1501,6 +1501,8 @@ The content is exposed in the child component using the `<slot>` element, which 
 </Widget>
 ```
 
+Note: If you want to render regular `<slot>` element, You can use `<svelte:element this="slot" />`.
+
 #### `<slot name="`*name*`">`
 
 ---


### PR DESCRIPTION
close: https://github.com/sveltejs/svelte/issues/8056
close: https://github.com/sveltejs/svelte/pull/8057

According to the https://github.com/sveltejs/svelte/pull/8057#issuecomment-1336118413, I updated the document.


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
