### PR TITLE
fix: svelte-ignore doesn't work with reactive-component 

### DIFF
--- a/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
+++ b/src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts
@@ -21,6 +21,7 @@ import SlotTemplate from '../../../nodes/SlotTemplate';
 import { is_head } from '../shared/is_head';
 import compiler_warnings from '../../../compiler_warnings';
 import { namespaces } from '../../../../utils/namespaces';
+import { extract_ignores_above_node } from '../../../../utils/extract_svelte_ignore';
 
 type SlotDefinition = { block: Block; scope: TemplateScope; get_context?: Node; get_changes?: Node };
 
@@ -111,9 +112,12 @@ export default class InlineComponentWrapper extends Wrapper {
 			return;
 		}
 
+    const ignores = extract_ignores_above_node(this.node);  
+    this.renderer.component.push_ignores(ignores);
 		if (variable.reassigned || variable.export_name || variable.is_reactive_dependency) {
 			this.renderer.component.warn(this.node, compiler_warnings.reactive_component(name));
 		}
+    this.renderer.component.pop_ignores();
 	}
 
 	render(

--- a/src/compiler/utils/extract_svelte_ignore.ts
+++ b/src/compiler/utils/extract_svelte_ignore.ts
@@ -36,8 +36,12 @@ export function extract_ignores_above_position(position: number, template_nodes:
 	return [];
 }
 
-export function extract_ignores_above_node(node: Node): string[] {
-  // We traverse along nodes on the same array as the node we pass in
+export function extract_ignores_above_node(node: INode): string[] {
+  /**
+    * This utilizes the fact that node has a prev and a next attribute
+    * which means that it can find svelte-ignores along
+    * the nodes on the same level as itself who share the same parent. 
+    */
   let cur_node: INode | undefined = node.prev;
   while (cur_node) {
     if (cur_node.type !== 'Comment' && cur_node.type !== 'Text') {

--- a/src/compiler/utils/extract_svelte_ignore.ts
+++ b/src/compiler/utils/extract_svelte_ignore.ts
@@ -1,6 +1,8 @@
 import { TemplateNode } from '../interfaces';
 import { flatten } from './flatten';
 import { regex_whitespace } from './patterns';
+import Node from '../compile/nodes/shared/Node';
+import { INode } from '../compile/nodes/interfaces';
 
 const regex_svelte_ignore = /^\s*svelte-ignore\s+([\s\S]+)\s*$/m;
 
@@ -32,4 +34,22 @@ export function extract_ignores_above_position(position: number, template_nodes:
 	}
 
 	return [];
+}
+
+export function extract_ignores_above_node(node: Node): string[] {
+  // We traverse along nodes on the same array as the node we pass in
+  let cur_node: INode | undefined = node.prev;
+  while (cur_node) {
+    if (cur_node.type !== 'Comment' && cur_node.type !== 'Text') {
+      return [];
+	  }
+
+	  if (cur_node.type === 'Comment' && cur_node.ignores.length) {
+      return cur_node.ignores;
+	  }
+
+    cur_node = cur_node.prev;
+  }
+
+  return [];
 }

--- a/src/compiler/utils/extract_svelte_ignore.ts
+++ b/src/compiler/utils/extract_svelte_ignore.ts
@@ -1,7 +1,6 @@
 import { TemplateNode } from '../interfaces';
 import { flatten } from './flatten';
 import { regex_whitespace } from './patterns';
-import Node from '../compile/nodes/shared/Node';
 import { INode } from '../compile/nodes/interfaces';
 
 const regex_svelte_ignore = /^\s*svelte-ignore\s+([\s\S]+)\s*$/m;
@@ -42,7 +41,7 @@ export function extract_ignores_above_node(node: INode): string[] {
     * which means that it can find svelte-ignores along
     * the nodes on the same level as itself who share the same parent. 
     */
-  let cur_node: INode | undefined = node.prev;
+  let cur_node = node.prev;
   while (cur_node) {
     if (cur_node.type !== 'Comment' && cur_node.type !== 'Text') {
       return [];

--- a/test/validator/samples/component-dynamic/input.svelte
+++ b/test/validator/samples/component-dynamic/input.svelte
@@ -16,3 +16,15 @@
 <ExportLet />
 <Reactive />
 <svelte:component this={Let} />
+
+<!-- Here, we test to see if svelte-ignore works with reactive-component -->
+<!-- svelte-ignore reactive-component -->
+<Let />
+<div>
+  <!-- svelte-ignore reactive-component -->
+  <ExportLet />
+  <div>
+    <!-- svelte-ignore reactive-component -->
+    <Reactive />
+  </div>
+</div>


### PR DESCRIPTION
Fixes #8082, where svelte-ignore somehow does not pick up the reactive-component warning.

The issue on this problem is that the `map_children` function suppresses warnings and errors while traversing AST nodes as `src/compiler/compile/nodes` classes. However, the `reactive-component` warning is called in `src/compiler/compile/render_dom/wrappers/InlineComponent/index.ts`, and its warnings are not suppressed in `map_children`. Thus, we need to extract ignores and suppress here separately.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
