### PR TITLE
fix: Handle read-only properties on DOM nodes

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -325,7 +325,8 @@ export function set_custom_element_data_map(node, data_map: Record<string, unkno
 }
 
 export function set_custom_element_data(node, prop, value) {
-	if (prop in node) {
+	const descriptor = Object.getOwnPropertyDescriptor(node, prop);
+	if (descriptor && descriptor.writable) {
 		node[prop] = typeof node[prop] === 'boolean' && value === '' ? true : value;
 	} else {
 		attr(node, prop, value);


### PR DESCRIPTION
There might be cases where there are properties that are read-only and setting their value would trigger an exception. Address that by querying the descriptor and figuring out if the property is writable.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
