### PR TITLE
fix: Update 06-accessibility-warnings.md

### DIFF
--- a/site/content/docs/06-accessibility-warnings.md
+++ b/site/content/docs/06-accessibility-warnings.md
@@ -55,7 +55,7 @@ Enforce that `autofocus` is not used on elements. Autofocusing elements can caus
 
 ### `a11y-click-events-have-key-events`
 
-Enforce `on:click` is accompanied by at least one of the following: `onKeyUp`, `onKeyDown`, `onKeyPress`. Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and screenreader users. 
+Enforce `on:click` is accompanied by at least one of the following: `on:keyup`, `on:keydown`, `on:keypress`. Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and screenreader users.
 
 This does not apply for interactive or hidden elements.
 
@@ -63,6 +63,8 @@ This does not apply for interactive or hidden elements.
 <!-- A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event. -->
 <div on:click={() => {}} />
 ```
+
+Note that the `keypress` event is now deprecated, so it is officially recommended to use either the `keyup` or `keydown` event instead, accordingly.
 
 ---
 


### PR DESCRIPTION
Convert recommended events to use Svelte syntax, and include deprecation warning re https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event