### PR TITLE
docs: Mention the interactivity of the installer

### DIFF
--- a/site/content/docs/01-getting-started.md
+++ b/site/content/docs/01-getting-started.md
@@ -13,6 +13,7 @@ cd myapp
 npm install
 npm run dev
 ```
+*The installer is interactive, so when prompted use your arrow keys to make your selections.*
 
 SvelteKit will handle calling [the Svelte compiler](https://www.npmjs.com/package/svelte) to convert your `.svelte` files into `.js` files that create the DOM and `.css` files that style it. It also provides all the other pieces you need to build a web application such as a development server, routing, and deployment. [SvelteKit](https://kit.svelte.dev/) utilizes [Vite](https://vitejs.dev/) to build your code and handle server-side rendering (SSR). There are [plugins for all the major web bundlers](https://sveltesociety.dev/tools#bundling) to handle Svelte compilation, which will output `.js` and `.css` that you can insert into your HTML, but most others won't handle SSR.
 


### PR DESCRIPTION
Having never installed Svelte before today, I was waiting for a long time at the initial prompt for it to... do something.  It never did.  Not because it was broken, but because the fact I needed to use my arrow keys was not obvious at all.  It asked what template I wanted to use, but didn't explain how to make the selection.  Once I figured it out (after asking in Discord) it was blatantly obvious, but for a very first time user and after having installed other similar products that don't use this type of interactivity but start with effectively identical commands, it was anything but obvious.  Almost made me cross Svelte off my evaluation list.
