### PR TITLE
chore: upgrade to code-red 1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "agadoo": "^2.0.0",
         "aria-query": "^5.1.1",
         "axobject-query": "^3.1.1",
-        "code-red": "^0.2.5",
+        "code-red": "^1.0.0",
         "css-tree": "^2.2.1",
         "eslint": "^8.26.0",
         "eslint-plugin-import": "^2.26.0",
@@ -381,9 +381,9 @@
       "dev": true
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -655,9 +655,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1111,17 +1111,16 @@
       }
     },
     "node_modules/code-red": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/code-red/-/code-red-0.2.5.tgz",
-      "integrity": "sha512-x+uQyJLNS1v0+74eXqM7FMPoM1fU/fN3tdexGWtCuVjCfxADt1TuuEGIGlFyCC2vhgINDctDb/rgSn8/ZDfJsQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.0.tgz",
+      "integrity": "sha512-x5fNWOBu7Ii38br3iVPuwQcDQM0f2h8ipvqw4qTLlOzYlrFQRz954qR0hPZ8asV5KG/igXNY8CRG6xtDUoKOJQ==",
       "dev": true,
       "dependencies": {
-        "@types/estree": "^0.0.50",
-        "acorn": "^8.0.5",
-        "estree-walker": "^3.0.0",
-        "is-reference": "^3.0.0",
-        "periscopic": "^3.0.4",
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.14",
+        "@types/estree": "^1.0.0",
+        "acorn": "^8.8.2",
+        "estree-walker": "^3.0.3",
+        "periscopic": "^3.1.0"
       }
     },
     "node_modules/color-convert": {
@@ -2292,10 +2291,13 @@
       }
     },
     "node_modules/estree-walker": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
-      "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==",
-      "dev": true
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -4031,11 +4033,12 @@
       "dev": true
     },
     "node_modules/periscopic": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
-      "integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
       "dev": true,
       "dependencies": {
+        "@types/estree": "^1.0.0",
         "estree-walker": "^3.0.0",
         "is-reference": "^3.0.0"
       }
@@ -5577,9 +5580,9 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
     "@types/json-schema": {
@@ -5753,9 +5756,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true
     },
     "acorn-globals": {
@@ -6114,17 +6117,16 @@
       }
     },
     "code-red": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/code-red/-/code-red-0.2.5.tgz",
-      "integrity": "sha512-x+uQyJLNS1v0+74eXqM7FMPoM1fU/fN3tdexGWtCuVjCfxADt1TuuEGIGlFyCC2vhgINDctDb/rgSn8/ZDfJsQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.0.tgz",
+      "integrity": "sha512-x5fNWOBu7Ii38br3iVPuwQcDQM0f2h8ipvqw4qTLlOzYlrFQRz954qR0hPZ8asV5KG/igXNY8CRG6xtDUoKOJQ==",
       "dev": true,
       "requires": {
-        "@types/estree": "^0.0.50",
-        "acorn": "^8.0.5",
-        "estree-walker": "^3.0.0",
-        "is-reference": "^3.0.0",
-        "periscopic": "^3.0.4",
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.14",
+        "@types/estree": "^1.0.0",
+        "acorn": "^8.8.2",
+        "estree-walker": "^3.0.3",
+        "periscopic": "^3.1.0"
       }
     },
     "color-convert": {
@@ -7029,10 +7031,13 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
-      "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==",
-      "dev": true
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "esutils": {
       "version": "2.0.3",
@@ -8351,11 +8356,12 @@
       "dev": true
     },
     "periscopic": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
-      "integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
       "dev": true,
       "requires": {
+        "@types/estree": "^1.0.0",
         "estree-walker": "^3.0.0",
         "is-reference": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "agadoo": "^2.0.0",
     "aria-query": "^5.1.1",
     "axobject-query": "^3.1.1",
-    "code-red": "^0.2.5",
+    "code-red": "^1.0.0",
     "css-tree": "^2.2.1",
     "eslint": "^8.26.0",
     "eslint-plugin-import": "^2.26.0",

--- a/src/compiler/compile/Component.ts
+++ b/src/compiler/compile/Component.ts
@@ -951,7 +951,7 @@ export default class Component {
 		});
 	}
 
-	warn_on_undefined_store_value_references(node: Node, parent: Node, prop: string, scope: Scope) {
+	warn_on_undefined_store_value_references(node: Node, parent: Node, prop: string | number | symbol, scope: Scope) {
 		if (
 			node.type === 'LabeledStatement' &&
 			node.label.name === '$' &&


### PR DESCRIPTION
Modern ESM-only version that replaces `sourcemap-codec` with `@jridgewell/sourcemap-codec`