### PR TITLE
chore: mark Promise.resolve() as pure to appease Agadoo

### DIFF
--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -8,7 +8,7 @@ export const binding_callbacks = [];
 let render_callbacks = [];
 const flush_callbacks = [];
 
-const resolved_promise = Promise.resolve();
+const resolved_promise = /* @__PURE__ */ Promise.resolve();
 let update_scheduled = false;
 
 export function schedule_update() {


### PR DESCRIPTION
This should appease Agadoo's treeshaking test, by marking `Promise.resolve()` as pure, so Rollup can shake it out. It might also have a miniscule benefit for people who are using Rollup to bundle their app but aren't using this promise.

This should fix the local build failure that is currently blocking cutting a new release. I don't think this warrants a changelog entry.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
