### PR TITLE
fix: derived store restarting when unsubscribed from another store with a shared ancestor

### DIFF
--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -164,7 +164,7 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 	const auto = fn.length < 2;
 
 	return readable(initial_value, (set) => {
-		let inited = false;
+		let started = false;
 		const values = [];
 
 		let pending = 0;
@@ -188,7 +188,7 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 			(value) => {
 				values[i] = value;
 				pending &= ~(1 << i);
-				if (inited) {
+				if (started) {
 					sync();
 				}
 			},
@@ -197,12 +197,13 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 			})
 		);
 
-		inited = true;
+		started = true;
 		sync();
 
 		return function stop() {
 			run_all(unsubscribers);
 			cleanup();
+			started = false;
 		};
 	});
 }

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -203,6 +203,9 @@ export function derived<T>(stores: Stores, fn: Function, initial_value?: T): Rea
 		return function stop() {
 			run_all(unsubscribers);
 			cleanup();
+			// We need to set this to false because callbacks can still happen despite having unsubscribed:
+			// Callbacks might already be placed in the queue which doesn't know it should no longer
+			// invoke this derived store.
 			started = false;
 		};
 	});

--- a/test/store/index.ts
+++ b/test/store/index.ts
@@ -407,6 +407,25 @@ describe('store', () => {
 			const d = derived(fake_observable, _ => _);
 			assert.equal(get(d), 42);
 		});
+
+		it('doesn\'t restart when unsubscribed from another store with a shared ancestor', () => {
+			const a = writable(true);
+			let b_started = false;
+			const b = derived(a, (_, __) => {
+				b_started = true;
+				return () => {
+					assert.equal(b_started, true);
+					b_started = false;
+				};
+			});
+			const c = derived(a, ($a, set) => {
+				if ($a) return b.subscribe(set);
+			});
+
+			c.subscribe(() => { });
+			a.set(false);
+			assert.equal(b_started, false);
+		});
 	});
 
 	describe('get', () => {


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/8364

When a derived store was unsubscribed from another store sharing a common ancestor, the ancestors update loop would restart the store after it had already been stopped. This PR renames the existing `inited` boolean to `started` to be more clear about its function and resets it to `false` once the store has been stopped so `sync()` isn't  run on a cold store.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
