### PR TITLE
docs: Tutorial body had <svelte:body /> even though <svelte:document /> was the subject

### DIFF
--- a/site/content/tutorial/16-special-elements/06-svelte-document/app-a/App.svelte
+++ b/site/content/tutorial/16-special-elements/06-svelte-document/app-a/App.svelte
@@ -4,7 +4,7 @@
 	const handleSelectionChange = (e) => selection = document.getSelection();
 </script>
 
-<svelte:body />
+<svelte:document />
 
 <p>Select this text to fire events</p>
 <p>Selection: {selection}</p>


### PR DESCRIPTION
Fixed showing <svelte:body /> where <svelte:document /> topic was  the current subjet.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
