### PR TITLE
fix: infinite loop when binding object in key block

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -5,11 +5,13 @@ import { children, detach, start_hydrating, end_hydrating } from './dom';
 import { transition_in } from './transitions';
 import { T$$ } from './types';
 
-export function bind(component, name, callback) {
+export function bind(component, name, callback, runCallback = true) {
 	const index = component.$$.props[name];
 	if (index !== undefined) {
 		component.$$.bound[index] = callback;
-		callback(component.$$.ctx[index]);
+		if (runCallback) {
+			callback(component.$$.ctx[index]);
+		}
 	}
 }
 

--- a/test/runtime/samples/binding-object-in-key-block/Component.svelte
+++ b/test/runtime/samples/binding-object-in-key-block/Component.svelte
@@ -1,0 +1,7 @@
+<script lang='ts'>
+	export let obj;
+</script>
+
+<p>
+	{obj.value}
+</p>

--- a/test/runtime/samples/binding-object-in-key-block/_config.js
+++ b/test/runtime/samples/binding-object-in-key-block/_config.js
@@ -1,0 +1,4 @@
+// fix: https://github.com/sveltejs/svelte/issues/8305
+export default {
+	html: '<p>0</p>'
+};

--- a/test/runtime/samples/binding-object-in-key-block/main.svelte
+++ b/test/runtime/samples/binding-object-in-key-block/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Component from './Component.svelte';
+	let obj = {
+		value: '0'
+	};
+</script>
+
+{#key obj}
+	<Component bind:obj={obj} />
+{/key}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

fix: [#8305](https://github.com/sveltejs/svelte/issues/8305)

The reason of this issue is key block bind's callback will make dirty, and object always safe_not_equal .

So key block will recreate when component bind's callback run, and then binding_callbacks add new callback.

binding_callbacks's length always > 0, can't get out of while loop.

[This example](https://stackblitz.com/edit/vitejs-vite-d572kl?file=src%2FApp.svelte) can freezes page too.
Can paste it into  svelte's repl and observe the reaction.

The solution is run component bind proactively when create a key block only at the first time.

Component bind value use parent value when next key block recreate, don't run callback proactively.



