### PR TITLE
feat: emit the duplicate key as part of the error message when validating k…

### DIFF
--- a/src/runtime/internal/keyed_each.ts
+++ b/src/runtime/internal/keyed_each.ts
@@ -112,7 +112,7 @@ export function validate_each_keys(ctx, list, get_context, get_key) {
 	for (let i = 0; i < list.length; i++) {
 		const key = get_key(get_context(ctx, list, i));
 		if (keys.has(key)) {
-			throw new Error('Cannot have duplicate keys in a keyed each');
+			throw new Error(`Cannot have duplicate keys in a keyed each: ${key} is a duplicate`);
 		}
 		keys.add(key);
 	}

--- a/test/runtime/samples/keyed-each-dev-unique/_config.js
+++ b/test/runtime/samples/keyed-each-dev-unique/_config.js
@@ -3,5 +3,5 @@ export default {
 		dev: true
 	},
 
-	error: 'Cannot have duplicate keys in a keyed each'
+	error: 'Cannot have duplicate keys in a keyed each: 1 is a duplicate'
 };


### PR DESCRIPTION
…eyed each blocks

Issue: #8410 

Adds the duplicate key in the error message, to allow for easier debugging.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.


### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
