### PR TITLE
fix: CSS adjacent and general sibling combinator treats slots as if they don't exist

### DIFF
--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -470,7 +470,11 @@ function get_element_parent(node: Element): Element | null {
 	return parent as Element | null;
 }
 
-function find_previous_sibling_ignoring_slots(node: INode): INode {
+function find_previous_sibling_considering_slots(node: INode): INode {
+	if (node.component.compile_options.customElement) {
+		return node.prev;
+	}
+
 	let current_node: INode = node;
 	do { 
 		// @ts-ignore
@@ -497,7 +501,7 @@ function find_previous_sibling_ignoring_slots(node: INode): INode {
 function get_possible_element_siblings(node: INode, adjacent_only: boolean): Map<Element, NodeExist> {
 	const result: Map<Element, NodeExist> = new Map();
 	let prev: INode = node;
-	while (prev = find_previous_sibling_ignoring_slots(prev)) {
+	while (prev = find_previous_sibling_considering_slots(prev)) {
 		if (prev.type === 'Element') {
 			if (!prev.attributes.find(attr => attr.type === 'Attribute' && attr.name.toLowerCase() === 'slot')) {
 				result.set(prev, NodeExist.Definitely);

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -483,11 +483,11 @@ function find_previous_sibling_ignoring_slots(node: INode): INode {
 		}
 
 		// @ts-ignore
-		if (!current_node.prev && current_node.parent.type === 'Slot') {
-			current_node = current_node.parent.prev;
-		} else {
-			current_node = current_node.prev;
+		while (!current_node.prev && current_node.parent && current_node.parent.type === 'Slot') {
+			current_node = current_node.parent;
 		}
+		current_node = current_node.prev;
+
 	// @ts-ignore
 	} while (current_node && current_node.type === 'Slot');
 

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -470,10 +470,34 @@ function get_element_parent(node: Element): Element | null {
 	return parent as Element | null;
 }
 
+function find_previous_sibling_ignoring_slots(node: INode): INode {
+	let current_node: INode = node;
+	do { 
+		// @ts-ignore
+		if (current_node.type === 'Slot') {
+			const slot_children = (current_node as Element).children;
+			if (slot_children.length > 0) {
+				current_node = slot_children.slice(-1)[0]; // go to its last child first
+				continue;
+			}
+		}
+
+		// @ts-ignore
+		if (!current_node.prev && current_node.parent.type === 'Slot') {
+			current_node = current_node.parent.prev;
+		} else {
+			current_node = current_node.prev;
+		}
+	// @ts-ignore
+	} while (current_node && current_node.type === 'Slot');
+
+	return current_node;
+}
+
 function get_possible_element_siblings(node: INode, adjacent_only: boolean): Map<Element, NodeExist> {
 	const result: Map<Element, NodeExist> = new Map();
 	let prev: INode = node;
-	while (prev = prev.prev) {
+	while (prev = find_previous_sibling_ignoring_slots(prev)) {
 		if (prev.type === 'Element') {
 			if (!prev.attributes.find(attr => attr.type === 'Attribute' && attr.name.toLowerCase() === 'slot')) {
 				result.set(prev, NodeExist.Definitely);

--- a/src/compiler/compile/css/Selector.ts
+++ b/src/compiler/compile/css/Selector.ts
@@ -470,29 +470,43 @@ function get_element_parent(node: Element): Element | null {
 	return parent as Element | null;
 }
 
-function find_previous_sibling_considering_slots(node: INode): INode {
+/**
+	* Finds the given node's previous sibling in the DOM
+	*	
+	* Unless the component is a custom element (web component), which in this
+	* case, the <slot> element is actually real, the Svelte <slot> is just a 
+	* placeholder and is not actually real. Any children nodes in <slot>
+	* are 'flattened' and considered as the same level as the <slot>'s siblings
+	*
+	* e.g.
+	* <h1>Heading 1</h1>
+	* <slot>
+	*   <h2>Heading 2</h2>
+	* </slot>
+	*
+	* is considered to look like:
+	* <h1>Heading 1</h1>
+	* <h2>Heading 2</h2>
+	*/
+function find_previous_sibling(node: INode): INode {
 	if (node.component.compile_options.customElement) {
 		return node.prev;
 	}
 
 	let current_node: INode = node;
 	do { 
-		// @ts-ignore
 		if (current_node.type === 'Slot') {
-			const slot_children = (current_node as Element).children;
+			const slot_children = current_node.children;
 			if (slot_children.length > 0) {
 				current_node = slot_children.slice(-1)[0]; // go to its last child first
 				continue;
 			}
 		}
 
-		// @ts-ignore
 		while (!current_node.prev && current_node.parent && current_node.parent.type === 'Slot') {
 			current_node = current_node.parent;
 		}
 		current_node = current_node.prev;
-
-	// @ts-ignore
 	} while (current_node && current_node.type === 'Slot');
 
 	return current_node;
@@ -501,7 +515,7 @@ function find_previous_sibling_considering_slots(node: INode): INode {
 function get_possible_element_siblings(node: INode, adjacent_only: boolean): Map<Element, NodeExist> {
 	const result: Map<Element, NodeExist> = new Map();
 	let prev: INode = node;
-	while (prev = find_previous_sibling_considering_slots(prev)) {
+	while (prev = find_previous_sibling(prev)) {
 		if (prev.type === 'Element') {
 			if (!prev.attributes.find(attr => attr.type === 'Attribute' && attr.name.toLowerCase() === 'slot')) {
 				result.set(prev, NodeExist.Definitely);

--- a/src/compiler/compile/nodes/Slot.ts
+++ b/src/compiler/compile/nodes/Slot.ts
@@ -7,7 +7,8 @@ import { TemplateNode } from '../../interfaces';
 import compiler_errors from '../compiler_errors';
 
 export default class Slot extends Element {
-	type: 'Element';
+	// @ts-ignore Slot elements have the 'Slot' type, but TypeScript doesn't allow us to have 'Slot' when it extends Element 
+	type: 'Slot';
 	name: string;
 	children: INode[];
 	slot_name: string;

--- a/test/css/samples/general-siblings-combinator-former-element-in-slot/expected.css
+++ b/test/css/samples/general-siblings-combinator-former-element-in-slot/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz~p.svelte-xyz{color:red}

--- a/test/css/samples/general-siblings-combinator-former-element-in-slot/input.svelte
+++ b/test/css/samples/general-siblings-combinator-former-element-in-slot/input.svelte
@@ -1,0 +1,12 @@
+<slot>
+  <h1>Heading 1</h1>
+</slot>
+<span>Span 1</span>
+<span>Span 2</span>
+<p>Paragraph 2</p>
+
+<style>
+  h1 ~ p {
+    color: red;
+  }
+</style>

--- a/test/css/samples/general-siblings-combinator-nested-slots-flattened/expected.css
+++ b/test/css/samples/general-siblings-combinator-nested-slots-flattened/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz~p.svelte-xyz{color:red}

--- a/test/css/samples/general-siblings-combinator-nested-slots-flattened/input.svelte
+++ b/test/css/samples/general-siblings-combinator-nested-slots-flattened/input.svelte
@@ -1,0 +1,7 @@
+<slot><slot><h1>Heading 1</h1></slot></slot><span>Span 1</span><span>Span 2</span><slot><slot><p>Paragraph 2</p></slot></slot>
+
+<style>
+  h1 ~ p {
+    color: red;
+  }
+</style>

--- a/test/css/samples/general-siblings-combinator-nested-slots/expected.css
+++ b/test/css/samples/general-siblings-combinator-nested-slots/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz~p.svelte-xyz{color:red}

--- a/test/css/samples/general-siblings-combinator-nested-slots/input.svelte
+++ b/test/css/samples/general-siblings-combinator-nested-slots/input.svelte
@@ -1,0 +1,18 @@
+<slot>
+	<slot>
+		<h1>Heading 1</h1>
+	</slot>
+</slot>
+<span>Span 1</span>
+<span>Span 2</span>
+<slot>
+	<slot>
+		<p>Paragraph 2</p>
+	</slot>
+</slot>
+
+<style>
+  h1 ~ p {
+    color: red;
+  }
+</style>

--- a/test/css/samples/general-siblings-combinator-selects-slot-fallback/expected.css
+++ b/test/css/samples/general-siblings-combinator-selects-slot-fallback/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz~p.svelte-xyz{color:red}

--- a/test/css/samples/general-siblings-combinator-selects-slot-fallback/input.svelte
+++ b/test/css/samples/general-siblings-combinator-selects-slot-fallback/input.svelte
@@ -1,0 +1,12 @@
+<h1>Heading 1</h1>
+<span>Span 1</span>
+<span>Span 2</span>
+<slot>
+  <p>Paragraph 2</p>
+</slot>
+
+<style>
+  h1 ~ p {
+    color: red;
+  }
+</style>

--- a/test/css/samples/general-siblings-combinator-slots-between/expected.css
+++ b/test/css/samples/general-siblings-combinator-slots-between/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz~p.svelte-xyz{color:red}

--- a/test/css/samples/general-siblings-combinator-slots-between/expected.css
+++ b/test/css/samples/general-siblings-combinator-slots-between/expected.css
@@ -1,1 +1,1 @@
-h1.svelte-xyz~p.svelte-xyz{color:red}
+h1.svelte-xyz~span.svelte-xyz{color:green}h1.svelte-xyz~p.svelte-xyz{color:red}span.svelte-xyz~p.svelte-xyz{color:blue}

--- a/test/css/samples/general-siblings-combinator-slots-between/input.svelte
+++ b/test/css/samples/general-siblings-combinator-slots-between/input.svelte
@@ -1,0 +1,14 @@
+<h1>Heading 1</h1>
+<slot>
+  <span>Span 1</span>
+</slot>
+<slot>
+  <span>Span 2</span>
+</slot>
+<p>Paragraph 2</p>
+
+<style>
+  h1 ~ p {
+    color: red;
+  }
+</style>

--- a/test/css/samples/general-siblings-combinator-slots-between/input.svelte
+++ b/test/css/samples/general-siblings-combinator-slots-between/input.svelte
@@ -8,7 +8,15 @@
 <p>Paragraph 2</p>
 
 <style>
+	h1 ~ span {
+		color: green;
+	}
+
   h1 ~ p {
     color: red;
   }
+
+	span ~ p {
+		color: blue;
+	}
 </style>

--- a/test/css/samples/siblings-combinator-former-element-in-slot/expected.css
+++ b/test/css/samples/siblings-combinator-former-element-in-slot/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz+span.svelte-xyz{color:red}

--- a/test/css/samples/siblings-combinator-former-element-in-slot/input.svelte
+++ b/test/css/samples/siblings-combinator-former-element-in-slot/input.svelte
@@ -1,0 +1,10 @@
+<slot>
+  <h1>test</h1>
+</slot>
+<span>Hello</span>
+
+<style>
+  h1 + span {
+    color: red;
+  }
+</style>

--- a/test/css/samples/siblings-combinator-nested-slots-flattened/expected.css
+++ b/test/css/samples/siblings-combinator-nested-slots-flattened/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz+span.svelte-xyz{color:red}

--- a/test/css/samples/siblings-combinator-nested-slots-flattened/input.svelte
+++ b/test/css/samples/siblings-combinator-nested-slots-flattened/input.svelte
@@ -1,0 +1,7 @@
+<slot><slot><slot><h1>test</h1></slot></slot></slot><slot><slot><span>Hello</span></slot></slot>
+
+<style>
+  h1 + span {
+    color: red;
+  }
+</style>

--- a/test/css/samples/siblings-combinator-nested-slots/expected.css
+++ b/test/css/samples/siblings-combinator-nested-slots/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz+span.svelte-xyz{color:red}

--- a/test/css/samples/siblings-combinator-nested-slots/input.svelte
+++ b/test/css/samples/siblings-combinator-nested-slots/input.svelte
@@ -1,0 +1,18 @@
+<slot>
+  <slot>
+    <slot>
+      <h1>test</h1>
+    </slot>
+  </slot>
+</slot>
+<slot>
+  <slot>
+    <span>Hello</span>
+  </slot>
+</slot>
+
+<style>
+  h1 + span {
+    color: red;
+  }
+</style>

--- a/test/css/samples/siblings-combinator-selects-slot-fallback/expected.css
+++ b/test/css/samples/siblings-combinator-selects-slot-fallback/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz+span.svelte-xyz{color:red}

--- a/test/css/samples/siblings-combinator-selects-slot-fallback/input.svelte
+++ b/test/css/samples/siblings-combinator-selects-slot-fallback/input.svelte
@@ -1,0 +1,10 @@
+<h1>test</h1>
+<slot>
+  <span>Hello</span>
+</slot>
+
+<style>
+  h1 + span {
+    color: red;
+  }
+</style>

--- a/test/css/samples/siblings-combinator-slots-between/expected.css
+++ b/test/css/samples/siblings-combinator-slots-between/expected.css
@@ -1,0 +1,1 @@
+h1.svelte-xyz+span.svelte-xyz{color:red}

--- a/test/css/samples/siblings-combinator-slots-between/input.svelte
+++ b/test/css/samples/siblings-combinator-slots-between/input.svelte
@@ -1,0 +1,11 @@
+<h1>test</h1>
+<slot name="a"></slot>
+<slot name="b"></slot>
+<slot name="c"></slot>
+<span>Hello</span>
+
+<style>
+  h1 + span {
+    color: red;
+  }
+</style>

--- a/test/validator/samples/general-siblings-combinator-in-custom-element-selects-slot-fallback/_config.js
+++ b/test/validator/samples/general-siblings-combinator-in-custom-element-selects-slot-fallback/_config.js
@@ -1,0 +1,3 @@
+export default {
+	customElement: true
+};

--- a/test/validator/samples/general-siblings-combinator-in-custom-element-selects-slot-fallback/input.svelte
+++ b/test/validator/samples/general-siblings-combinator-in-custom-element-selects-slot-fallback/input.svelte
@@ -1,0 +1,20 @@
+<svelte:options tag="my-element" />
+
+<h1>Heading 1</h1>
+<span>Span 1</span>
+<span>Span 2</span>
+<slot>
+	<p>Paragraph 2</p>
+</slot>
+
+<style>
+	/* This will not get picked up */
+	h1 ~ p {
+		color: red;
+	}
+
+	/* This will be picked up */
+	h1 ~ slot > p {
+		color: red;
+	}
+</style>

--- a/test/validator/samples/general-siblings-combinator-in-custom-element-selects-slot-fallback/warnings.json
+++ b/test/validator/samples/general-siblings-combinator-in-custom-element-selects-slot-fallback/warnings.json
@@ -1,0 +1,14 @@
+[
+  {
+    "code": "css-unused-selector",
+    "message": "Unused CSS selector \"h1 ~ p\"",
+    "start": {
+      "column": 1,
+      "line": 12
+    },
+    "end": {
+      "column": 7,
+      "line": 12
+    }
+  }
+]

--- a/test/validator/samples/siblings-combinator-in-custom-element-selects-slot-fallback/_config.js
+++ b/test/validator/samples/siblings-combinator-in-custom-element-selects-slot-fallback/_config.js
@@ -1,0 +1,3 @@
+export default {
+	customElement: true
+};

--- a/test/validator/samples/siblings-combinator-in-custom-element-selects-slot-fallback/input.svelte
+++ b/test/validator/samples/siblings-combinator-in-custom-element-selects-slot-fallback/input.svelte
@@ -1,0 +1,18 @@
+<svelte:options tag="custom-element" />
+
+<h1>test</h1>
+<slot>
+  <span>Hello</span>
+</slot>
+
+<style>
+	/* This will not be picked up */
+  h1 + span {
+    color: red;
+  }
+
+	/* This will be picked up */
+	h1 + slot > span {
+		color: red;
+	}
+</style>

--- a/test/validator/samples/siblings-combinator-in-custom-element-selects-slot-fallback/warnings.json
+++ b/test/validator/samples/siblings-combinator-in-custom-element-selects-slot-fallback/warnings.json
@@ -1,0 +1,14 @@
+[
+  {
+    "code": "css-unused-selector",
+    "end": {
+      "column": 11,
+      "line": 10
+    },
+    "message": "Unused CSS selector \"h1 + span\"",
+    "start": {
+      "column": 2,
+      "line": 10
+    }
+  }
+]


### PR DESCRIPTION
Fixes #8284.

The problem is that the `<slot>` element is treated as an actual element, and for this purpose, we have to treat them as if they don't exist. More specifically, we treat all slot fallback children nodes on the same level as the slot's non-slot siblings.

[edit: I wasn't aware of the `<slot>` element in web components before, so I added a check that if the node belongs to a web component, we still treat slots as if they exist.]

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`
