### PR TITLE
feat: media query range syntax & single value function support via css-tree extension

### DIFF
--- a/src/compiler/parse/read/css-tree-cq/css_tree_parse.ts
+++ b/src/compiler/parse/read/css-tree-cq/css_tree_parse.ts
@@ -3,12 +3,7 @@
 // `css-tree` Node module directly. This allows the production build of Svelte to work correctly.
 import { fork } from '../../../../../node_modules/css-tree/dist/csstree.esm.js';
 
-import * as Comparison from './node/comparison';
-import * as ContainerFeature from './node/container_feature';
-import * as ContainerFeatureRange from './node/container_feature_range';
-import * as ContainerFeatureStyle from './node/container_feature_style';
-import * as ContainerQuery from './node/container_query';
-import * as QueryCSSFunction from './node/query_css_function';
+import * as node from './node';
 
 /**
  * Extends `css-tree` for container query support by forking and adding new nodes and at-rule support for `@container`.
@@ -30,14 +25,7 @@ const cqSyntax = fork({
 			}
 		}
 	},
-	node: { // extend node types
-		Comparison,
-		ContainerFeature,
-		ContainerFeatureRange,
-		ContainerFeatureStyle,
-		ContainerQuery,
-		QueryCSSFunction
-	}
+	node
 });
 
 export const parse = cqSyntax.parse;

--- a/src/compiler/parse/read/css-tree-cq/node/index.ts
+++ b/src/compiler/parse/read/css-tree-cq/node/index.ts
@@ -1,0 +1,7 @@
+export * as Comparison from './comparison';
+export * as ContainerFeatureStyle from './container_feature_style';
+export * as ContainerQuery from './container_query';
+export * as MediaQuery from './media_query';
+export * as QueryFeature from './query_feature';
+export * as QueryFeatureRange from './query_feature_range';
+export * as QueryCSSFunction from './query_css_function';

--- a/src/compiler/parse/read/css-tree-cq/node/lookahead_is_range.ts
+++ b/src/compiler/parse/read/css-tree-cq/node/lookahead_is_range.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import {
+	EOF,
+	WhiteSpace,
+	Delim,
+	RightParenthesis,
+	LeftCurlyBracket,
+	Colon
+} from 'css-tree/tokenizer';
+
+/**
+ * Looks ahead to determine if query feature is a range query. This involves locating at least one delimiter and no
+ * colon tokens.
+ *
+ * @returns {boolean} Is potential range query.
+ */
+export function lookahead_is_range() {
+	let type;
+	let offset = 0;
+
+	let count = 0;
+	let delim_found = false;
+	let no_colon = true;
+
+	// A range query has maximum 5 tokens when formatted as 'mf-range' /
+	// '<mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value>'. So only look ahead maximum of 6 non-whitespace tokens.
+	do {
+		type = this.lookupNonWSType(offset++);
+		if (type !== WhiteSpace) {
+			count++;
+		}
+		if (type === Delim) {
+			delim_found = true;
+		}
+		if (type === Colon) {
+			no_colon = false;
+		}
+		if (type === LeftCurlyBracket || type === RightParenthesis) {
+			break;
+		}
+	} while (type !== EOF && count <= 6);
+
+	return delim_found && no_colon;
+}

--- a/src/compiler/parse/read/css-tree-cq/node/media_query.ts
+++ b/src/compiler/parse/read/css-tree-cq/node/media_query.ts
@@ -2,43 +2,25 @@
 import {
 	WhiteSpace,
 	Comment,
-	Function,
 	Ident,
 	LeftParenthesis
 } from 'css-tree/tokenizer';
 
 import { lookahead_is_range } from './lookahead_is_range';
 
-const CONTAINER_QUERY_KEYWORDS = new Set(['none', 'and', 'not', 'or']);
-
-export const name = 'ContainerQuery';
+export const name = 'MediaQuery';
 export const structure = {
-	name: 'Identifier',
 	children: [[
 		'Identifier',
 		'QueryFeature',
 		'QueryFeatureRange',
-		'ContainerFeatureStyle',
 		'WhiteSpace'
 	]]
 };
 
 export function parse() {
-	const start = this.tokenStart;
 	const children = this.createList();
 	let child = null;
-	let name = null;
-
-	// Parse potential container name.
-	if (this.tokenType === Ident) {
-		const container_name = this.substring(this.tokenStart, this.tokenEnd);
-
-		// Container name doesn't match a query keyword, so assign it as container name.
-		if (!CONTAINER_QUERY_KEYWORDS.has(container_name.toLowerCase())) {
-			name = container_name;
-			this.eatIdent(container_name);
-		}
-	}
 
 	this.skipSC();
 
@@ -52,10 +34,6 @@ export function parse() {
 
 				case Ident:
 					child = this.Identifier();
-					break;
-
-				case Function:
-					child = this.ContainerFeatureStyle();
 					break;
 
 				case LeftParenthesis:
@@ -75,18 +53,12 @@ export function parse() {
 	}
 
 	return {
-		type: 'ContainerQuery',
-		loc: this.getLocation(start, this.tokenStart - 1),
-		name,
+		type: 'MediaQuery',
+		loc: this.getLocationFromList(children),
 		children
 	};
 }
 
 export function generate(node) {
-	if (typeof node.name === 'string') {
-		this.token(Ident, node.name);
-	}
-
 	this.children(node);
 }
-

--- a/src/compiler/parse/read/css-tree-cq/node/query_feature.ts
+++ b/src/compiler/parse/read/css-tree-cq/node/query_feature.ts
@@ -10,7 +10,7 @@ import {
 	Delim
 } from 'css-tree/tokenizer';
 
-export const name = 'ContainerFeature';
+export const name = 'QueryFeature';
 export const structure = {
 	name: String,
 	value: ['Identifier', 'Number', 'Dimension', 'QueryCSSFunction', 'Ratio', null]
@@ -62,7 +62,7 @@ export function parse() {
 	this.eat(RightParenthesis);
 
 	return {
-		type: 'ContainerFeature',
+		type: 'QueryFeature',
 		loc: this.getLocation(start, this.tokenStart),
 		name,
 		value

--- a/src/compiler/parse/read/css-tree-cq/node/query_feature_range.ts
+++ b/src/compiler/parse/read/css-tree-cq/node/query_feature_range.ts
@@ -10,7 +10,7 @@ import {
 	WhiteSpace
 } from 'css-tree/tokenizer';
 
-export const name = 'ContainerFeatureRange';
+export const name = 'QueryFeatureRange';
 export const structure = {
 	name: String,
 	value: ['Identifier', 'Number', 'Comparison', 'Dimension', 'QueryCSSFunction', 'Ratio', null]
@@ -30,6 +30,7 @@ function lookup_non_WS_type_and_value(offset, type, referenceStr) {
 }
 
 export function parse() {
+	const start = this.tokenStart;
 	const children = this.createList();
 	let child = null;
 
@@ -75,8 +76,8 @@ export function parse() {
 	this.eat(RightParenthesis);
 
 	return {
-		type: 'ContainerFeatureRange',
-		loc: this.getLocationFromList(children),
+		type: 'QueryFeatureRange',
+		loc: this.getLocation(start, this.tokenStart),
 		children
 	};
 }

--- a/test/css/samples/media-query/expected.css
+++ b/test/css/samples/media-query/expected.css
@@ -1,1 +1,1 @@
-@media(min-width: 400px){.large-screen.svelte-xyz{display:block}}
+@media(min-width: 400px){.large-screen.svelte-xyz{display:block}}@media(min-width: calc(400px + 1px)){.large-screen.svelte-xyz{display:block}}@media(width >= 600px){.large-screen.svelte-xyz{display:block}}@media(400px <= width <= 1000px){.large-screen.svelte-xyz{display:block}}@media(width < clamp(200px, 40%, 400px)){.large-screen.svelte-xyz{display:block}}@media(calc(400px + 1px) <= width <= calc(1000px + 1px)){.large-screen.svelte-xyz{display:block}}

--- a/test/css/samples/media-query/input.svelte
+++ b/test/css/samples/media-query/input.svelte
@@ -6,4 +6,34 @@
 			display: block;
 		}
 	}
+
+	@media (min-width: calc(400px + 1px)) {
+		.large-screen {
+			display: block;
+		}
+	}
+
+	@media (width >= 600px) {
+		.large-screen {
+			display: block;
+		}
+	}
+
+	@media (400px <= width <= 1000px) {
+		.large-screen {
+			display: block;
+		}
+	}
+
+	@media (width < clamp(200px, 40%, 400px)) {
+		.large-screen {
+			display: block;
+		}
+	}
+
+	@media (calc(400px + 1px) <= width <= calc(1000px + 1px)) {
+		.large-screen {
+			display: block;
+		}
+	}
 </style>


### PR DESCRIPTION
Closes #5876. As discussed there, `css-tree` is not updated for the latest CSS syntax including the ability to use [single value functions (calc, etc.)](https://chromestatus.com/feature/5643732019838976) in media queries. `css-tree` also does not yet support [media query range syntax](https://developer.chrome.com/blog/media-query-range-syntax/) that is part of the media query level 4 specification. 

This PR broadly helps the entire Svelte ecosystem including SvelteKit.

Given the acceptance of the container query PR (#8275) to extend `css-tree` to support container queries I was able to refactor this extension support repurposing the range syntax support to apply to both container & media queries. At the same time the single value function support implemented for container queries also applies to media queries. 

Changes
src/compiler/parse/read/css-tree-cq/css_tree_parse.ts: cleanup new AST node import / assignment.

src/compiler/parse/read/css-tree-cq/node/index.ts: added for convenience to export all nodes cleanly.

src/compiler/parse/read/css-tree-cq/node/lookahead_is_range.ts: separated utility function out to be used by CQ / MQ.

src/compiler/parse/read/css-tree-cq/node/media_query.ts: provides new media query node implementation.

src/compiler/parse/read/css-tree-cq/node/query_feature.ts: renamed from container_feature.ts

src/compiler/parse/read/css-tree-cq/node/query_range_feature.ts: renamed from container_range_feature.ts

test/css/samples/media-query: Updated parsing test case with range syntax and single value function use cases.

Impact
No downsides that I'm aware of regarding these changes. Simply that Svelte can now ship with updated media query syntax support. I have thoroughly tested the code and updated the media query parsing test accordingly. Because the fork capability of css-tree is used to extend it the css-tree version can keep being bumped if new versions come out without updated MQ support. However, when the unified queries support is added to `css-tree` the local extensions can be removed and an easy swap back to the official css-tree parse capability is trivial.

Testing
The media query parsing test has been updated for range syntax and single value function use cases.

css-tree Extension
The bulk of this PR is a refactor of the container query implementation to share the range syntax and single value function support added in the CQ PR between both media and container queries via local extension of css-tree using the fork capability of css-tree to just modify how the `MediaQuery` node is parsed. The benefit of taking this approach is that the temporary modifications necessary to extend css-tree are committed to the Svelte repo and a separate hard fork of css-tree isn't necessary. The css-tree version can continue to be bumped as necessary and when css-tree supports modern query syntax the local extension can be removed.

It is unknown when css-tree will be updated to support modern query support. However, when css-tree does offer support a one line change and removal of the extensions provided in this PR is trivial.

