### PR TITLE
docs: clarify statement about initial values for props

### DIFF
--- a/site/content/docs/02-component-format.md
+++ b/site/content/docs/02-component-format.md
@@ -42,7 +42,7 @@ Svelte uses the `export` keyword to mark a variable declaration as a *property* 
 
 ---
 
-You can specify a default initial value for a prop. It will be used if the component's consumer doesn't specify the prop on the component (or if its initial value is `undefined`) when instantiating the component. Note that whenever a prop is removed by the consumer, its value is set to `undefined` rather than the initial value.
+You can specify a default initial value for a prop. It will be used if the component's consumer doesn't specify the prop on the component (or if its initial value is `undefined`) when instantiating the component. Note that if the values of props are subsequently updated, then any prop whose value is not specified will be set to `undefined` (rather than its initial value).
 
 In development mode (see the [compiler options](/docs#compile-time-svelte-compile)), a warning will be printed if no default initial value is provided and the consumer does not specify a value. To squelch this warning, ensure that a default initial value is specified, even if it is `undefined`.
 


### PR DESCRIPTION
I was initially confused what was meant by "whenever a prop is removed by the consumer", and had to read the PR that added this sentence (PR https://github.com/sveltejs/svelte/pull/4460, a response to Issue https://github.com/sveltejs/svelte/issues/4442).
 