### PR TITLE
docs: fix statement before list of compiler options

### DIFF
--- a/site/content/docs/05-compile-time.md
+++ b/site/content/docs/05-compile-time.md
@@ -33,7 +33,7 @@ const result = svelte.compile(source, {
 });
 ```
 
-The following options can be passed to the compiler. None are required:
+The following options (none of which are required) can be passed to the compiler:
 
 <!-- | option | type | default
 | --- | --- | --- |


### PR DESCRIPTION
The colon should come after the statement about "The following options...", not a subsequent senence saying that none of the options are required.