### PR TITLE
chore: simplify Svelte 4 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,42 +6,7 @@ on:
 permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
-  Setup:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: npm
-      - run: npm install
-        env:
-          SKIP_PREPARE: true
-      - run: npm run build
-        env:
-          PUBLISH: true
-      - name: Upload build assets
-        id: upload-artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: build-assets
-          path: |
-            index.*
-            compiler.*
-            ssr.*
-            action/
-            animate/
-            easing/
-            internal/
-            motion/
-            store/
-            transition/
-            types/
   Tests:
-    needs: Setup
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -54,11 +19,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - name: Download build assets
-        uses: actions/download-artifact@v3
-        id: download-artifact
-        with:
-          name: build-assets
       - run: npm install
         env:
           SKIP_PREPARE: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm install
-        env:
-          SKIP_PREPARE: true
       - run: npm run test:integration
         env:
           CI: true

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "test:unit": "mocha --config .mocharc.unit.js --exit",
     "quicktest": "mocha --exit",
     "build": "rollup -c && npm run tsd",
-    "prepare": "node scripts/skip_in_ci.js npm run build",
+    "prepare": "npm run build",
     "dev": "rollup -cw",
     "posttest": "agadoo internal/index.mjs",
     "prepublishOnly": "node check_publish_env.js && npm run lint && npm run build && npm test",

--- a/scripts/skip_in_ci.js
+++ b/scripts/skip_in_ci.js
@@ -1,7 +1,0 @@
-if (process.env.SKIP_PREPARE) {
-  console.log('Skipped "prepare" script');
-} else {
-	const { execSync } = require("child_process");
-	const command = process.argv.slice(2).join(" ");
-	execSync(command, { stdio: "inherit" });
-}


### PR DESCRIPTION
The `Setup` job was to work around old Node versions, which we no longer have to support :tada: 