### PR TITLE
docs: clarify let: directives

### DIFF
--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1600,22 +1600,26 @@ Note that explicitly passing in an empty named slot will add that slot's name to
 
 ---
 
-Slots can be rendered zero or more times and can pass values *back* to the parent using props. The parent exposes the values to the slot template using the `let:` directive.
+Slots can be rendered zero or more times.
 
+The `let:` directive gives a slot template access to variables defined in the component that uses them.
 The usual shorthand rules apply — `let:item` is equivalent to `let:item={item}`, and `<slot {item}>` is equivalent to `<slot item={item}>`.
 
 ```sv
 <!-- FancyList.svelte -->
+<!-- This component passes data to its child slot using the `itemData` prop -->
 <ul>
 	{#each items as item}
 		<li class="fancy">
-			<slot prop={item}></slot>
+			<slot itemData={item}></slot>
 		</li>
 	{/each}
 </ul>
 
 <!-- App.svelte -->
-<FancyList {items} let:prop={thing}>
+<!-- the `let:itemData={thing}` directive makes the value that `FancyList` pases as the `itemData` prop
+     available to the slot template as the `thing` variable -->
+<FancyList {items} let:itemData={thing}>
 	<div>{thing.text}</div>
 </FancyList>
 ```

--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1602,7 +1602,7 @@ Note that explicitly passing in an empty named slot will add that slot's name to
 
 Slots can be rendered zero or more times.
 
-The `let:` directive gives a slot template access to variables defined in the component that uses them.
+The `let:` directive gives a slot template access to variables defined in the component that they are provided to.
 The usual shorthand rules apply — `let:item` is equivalent to `let:item={item}`, and `<slot {item}>` is equivalent to `<slot item={item}>`.
 
 ```sv
@@ -1618,7 +1618,7 @@ The usual shorthand rules apply — `let:item` is equivalent to `let:item={item}
 
 <!-- App.svelte -->
 <!-- the `let:itemData={thing}` directive makes the value that `FancyList` pases as the `itemData` prop
-     available to the slot template as the `thing` variable -->
+     available to the slot template as a variable called `thing` -->
 <FancyList {items} let:itemData={thing}>
 	<div>{thing.text}</div>
 </FancyList>

--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1617,7 +1617,7 @@ The usual shorthand rules apply — `let:item` is equivalent to `let:item={item}
 </ul>
 
 <!-- App.svelte -->
-<!-- the `let:itemData={thing}` directive makes the value that `FancyList` pases as the `itemData` prop
+<!-- the `let:itemData={thing}` directive makes the value that `FancyList` passes as the `itemData` prop
      available to the slot template as a variable called `thing` -->
 <FancyList {items} let:itemData={thing}>
 	<div>{thing.text}</div>

--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -1617,8 +1617,12 @@ The usual shorthand rules apply — `let:item` is equivalent to `let:item={item}
 </ul>
 
 <!-- App.svelte -->
-<!-- the `let:itemData={thing}` directive makes the value that `FancyList` passes as the `itemData` prop
-     available to the slot template as a variable called `thing` -->
+<!-- `itemData` can now be used in the content you pass into the slot using `let:itemData` -->
+<FancyList {items} let:itemData>
+	<div>{itemData.text}</div>
+</FancyList>
+
+<!-- You can also rename it using the `let:itemData={thing}` syntax. -->
 <FancyList {items} let:itemData={thing}>
 	<div>{thing.text}</div>
 </FancyList>


### PR DESCRIPTION
This tries to clarify the explanation of `let:` directives through 3 changes:

* use a name other than `prop` for the specific prop in the example. Using the generic name `prop` might make a reader wonder if this is a keyword or magic name choice that needs to be used
* add some comments to the example 
* re-phrases the explanation to avoid the reader having to think about which direction is backwards

I found the statement "Slots can be rendered zero or more times and can pass values *back* to the parent" initially unclear because there are two dfferent child-parent relationships to consider  (a component definition with a child `<slot>`, and a use of the component with a child slot template).

I think these changes are helpful because this syntax is inherently somewhat confusing: as noted in https://github.com/sveltejs/svelte/pull/4125, `let:foo={bar}` defines `bar` to be a new variable set to the value of `foo`, which is counter-intuitive.