### PR TITLE
chore: run fewer CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,17 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [14, 16, 18]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        include:
+          - node-version: 14
+            os: ubuntu-latest
+          - node-version: 14
+            os: windows-latest
+          - node-version: 14
+            os: macOS-latest
+          - node-version: 16
+            os: ubuntu-latest
+          - node-version: 18
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -37,6 +46,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
+        node-version: 14
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We probably don't need to run on every combination of Node version and OS. This cuts the number of test jobs down from 9 to 5 while still making sure that every Node version and OS is tested