### PR TITLE
breaking: deprecate SvelteComponentTyped, add generics to SvelteComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **breaking** Stricter types for `createEventDispatcher` (see PR for migration instructions) ([#7224](https://github.com/sveltejs/svelte/pull/7224))
 * **breaking** Stricter types for `Action` and `ActionReturn` (see PR for migration instructions) ([#7224](https://github.com/sveltejs/svelte/pull/7224))
 * **breaking** Stricter types for `onMount` - now throws a type error when returning a function asynchronously to catch potential mistakes around callback functions (see PR for migration instructions) ([#8136](https://github.com/sveltejs/svelte/pull/8136))
+* **breaking** Deprecate `SvelteComponentTyped`, use `SvelteComponent` instead ([#8512](https://github.com/sveltejs/svelte/pull/8512))
 * Add `a11y no-noninteractive-element-interactions` rule ([#8391](https://github.com/sveltejs/svelte/pull/8391))
 * Add `a11y-no-static-element-interactions`rule ([#8251](https://github.com/sveltejs/svelte/pull/8251))
 * Bind `null` option and input values consistently ([#8312](https://github.com/sveltejs/svelte/issues/8312))

--- a/elements/index.d.ts
+++ b/elements/index.d.ts
@@ -84,9 +84,9 @@ export interface DOMAttributes<T extends EventTarget> {
 	'on:beforeinput'?: EventHandler<InputEvent, T> | undefined | null;
 	'on:input'?: FormEventHandler<T> | undefined | null;
 	'on:reset'?: FormEventHandler<T> | undefined | null;
-	'on:submit'?: EventHandler<Event & { readonly submitter: HTMLElement | null; }, T> | undefined | null; // TODO make this SubmitEvent once we require TS>=4.4
+	'on:submit'?: EventHandler<SubmitEvent, T> | undefined | null;
 	'on:invalid'?: EventHandler<Event, T> | undefined | null;
-	'on:formdata'?: EventHandler<Event & { readonly formData: FormData; }, T> | undefined | null; // TODO make this FormDataEvent once we require TS>=4.4
+	'on:formdata'?: EventHandler<FormDataEvent, T> | undefined | null;
 
 	// Image Events
 	'on:load'?: EventHandler | undefined | null;
@@ -547,9 +547,9 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	'bind:innerText'?: string | undefined | null;
 
 	readonly 'bind:contentRect'?: DOMRectReadOnly | undefined | null;
-	readonly 'bind:contentBoxSize'?: Array<{ blockSize: number; inlineSize: number }> | undefined | null; // TODO make this ResizeObserverSize once we require TS>=4.4
-	readonly 'bind:borderBoxSize'?: Array<{ blockSize: number; inlineSize: number }> | undefined | null; // TODO make this ResizeObserverSize once we require TS>=4.4
-	readonly 'bind:devicePixelContentBoxSize'?: Array<{ blockSize: number; inlineSize: number }> | undefined | null; // TODO make this ResizeObserverSize once we require TS>=4.4
+	readonly 'bind:contentBoxSize'?: Array<ResizeObserverSize> | undefined | null;
+	readonly 'bind:borderBoxSize'?: Array<ResizeObserverSize> | undefined | null;
+	readonly 'bind:devicePixelContentBoxSize'?: Array<ResizeObserverSize> | undefined | null;
 
 	// SvelteKit
 	'data-sveltekit-keepfocus'?: true | '' | 'off' | undefined | null;
@@ -558,6 +558,9 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	'data-sveltekit-preload-data'?: true | '' | 'hover' | 'tap' | 'off' | undefined | null;
 	'data-sveltekit-reload'?: true | '' | 'off' | undefined | null;
 	'data-sveltekit-replacestate'?: true | '' | 'off' | undefined | null;
+
+	// allow any data- attribute
+	[key: `data-${string}`]: any;
 }
 
 export type HTMLAttributeAnchorTarget =

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -157,10 +157,13 @@ export function construct_svelte_component_dev(component, props) {
 	}
 }
 
-type Props = Record<string, any>;
-export interface SvelteComponentDev {
-	$set(props?: Props): void;
-	$on(event: string, callback: ((event: any) => void) | null | undefined): () => void;
+export interface SvelteComponentDev<
+	Props extends Record<string, any> = any,
+	Events extends Record<string, any> = any,
+	Slots extends Record<string, any> = any // eslint-disable-line @typescript-eslint/no-unused-vars
+> {
+	$set(props?: Partial<Props>): void;
+	$on<K extends Extract<keyof Events, string>>(type: K, callback: ((e: Events[K]) => void) | null | undefined): () => void;
 	$destroy(): void;
 	[accessor: string]: any;
 }
@@ -177,8 +180,33 @@ export interface ComponentConstructorOptions<Props extends Record<string, any> =
 
 /**
  * Base class for Svelte components with some minor dev-enhancements. Used when dev=true.
+ * 
+ * Can be used to create strongly typed Svelte components.
+ *
+ * ### Example:
+ *
+ * You have component library on npm called `component-library`, from which
+ * you export a component called `MyComponent`. For Svelte+TypeScript users,
+ * you want to provide typings. Therefore you create a `index.d.ts`:
+ * ```ts
+ * import { SvelteComponent } from "svelte";
+ * export class MyComponent extends SvelteComponent<{foo: string}> {}
+ * ```
+ * Typing this makes it possible for IDEs like VS Code with the Svelte extension
+ * to provide intellisense and to use the component like this in a Svelte file
+ * with TypeScript:
+ * ```svelte
+ * <script lang="ts">
+ * 	import { MyComponent } from "component-library";
+ * </script>
+ * <MyComponent foo={'bar'} />
+ * ```
  */
-export class SvelteComponentDev extends SvelteComponent {
+export class SvelteComponentDev<
+	Props extends Record<string, any> = any,
+	Events extends Record<string, any> = any,
+	Slots extends Record<string, any> = any
+> extends SvelteComponent {
 	/**
 	 * @private
 	 * For type checking capabilities only.
@@ -192,16 +220,16 @@ export class SvelteComponentDev extends SvelteComponent {
 	 * Does not exist at runtime.
 	 * ### DO NOT USE!
 	 */
-	$$events_def: any;
+	$$events_def: Events;
 	/**
 	 * @private
 	 * For type checking capabilities only.
 	 * Does not exist at runtime.
 	 * ### DO NOT USE!
 	 */
-	$$slot_def: any;
+	$$slot_def: Slots;
 
-	constructor(options: ComponentConstructorOptions) {
+	constructor(options: ComponentConstructorOptions<Props>) {
 		if (!options || (!options.target && !options.$$inline)) {
 			throw new Error("'target' is a required option");
 		}
@@ -221,21 +249,15 @@ export class SvelteComponentDev extends SvelteComponent {
 	$inject_state() {}
 }
 
-// TODO https://github.com/microsoft/TypeScript/issues/41770 is the reason
-// why we have to split out SvelteComponentTyped to not break existing usage of SvelteComponent.
-// Try to find a better way for Svelte 4.0.
-
 export interface SvelteComponentTyped<
 	Props extends Record<string, any> = any,
 	Events extends Record<string, any> = any,
-	Slots extends Record<string, any> = any // eslint-disable-line @typescript-eslint/no-unused-vars
-> {
-	$set(props?: Partial<Props>): void;
-	$on<K extends Extract<keyof Events, string>>(type: K, callback: ((e: Events[K]) => void) | null | undefined): () => void;
-	$destroy(): void;
-	[accessor: string]: any;
-}
+	Slots extends Record<string, any> = any
+> extends SvelteComponentDev<Props, Events, Slots> {}
+
 /**
+ * @deprecated Use `SvelteComponent` instead. See PR for more information: https://github.com/sveltejs/svelte/pull/8512
+ * 
  * Base class to create strongly typed Svelte components.
  * This only exists for typing purposes and should be used in `.d.ts` files.
  *
@@ -270,33 +292,7 @@ export class SvelteComponentTyped<
 	Props extends Record<string, any> = any,
 	Events extends Record<string, any> = any,
 	Slots extends Record<string, any> = any
-> extends SvelteComponentDev {
-	/**
-	 * @private
-	 * For type checking capabilities only.
-	 * Does not exist at runtime.
-	 * ### DO NOT USE!
-	 */
-	$$prop_def: Props;
-	/**
-	 * @private
-	 * For type checking capabilities only.
-	 * Does not exist at runtime.
-	 * ### DO NOT USE!
-	 */
-	$$events_def: Events;
-	/**
-	 * @private
-	 * For type checking capabilities only.
-	 * Does not exist at runtime.
-	 * ### DO NOT USE!
-	 */
-	$$slot_def: Slots;
-
-	constructor(options: ComponentConstructorOptions<Props>) {
-		super(options);
-	}
-}
+> extends SvelteComponentDev<Props, Events, Slots> {}
 
 /**
  * Convenience type to get the type of a Svelte component. Useful for example in combination with
@@ -305,21 +301,21 @@ export class SvelteComponentTyped<
  * Example:
  * ```html
  * <script lang="ts">
- * 	import type { ComponentType, SvelteComponentTyped } from 'svelte';
+ * 	import type { ComponentType, SvelteComponent } from 'svelte';
  * 	import Component1 from './Component1.svelte';
  * 	import Component2 from './Component2.svelte';
  *
  * 	const component: ComponentType = someLogic() ? Component1 : Component2;
- * 	const componentOfCertainSubType: ComponentType<SvelteComponentTyped<{ needsThisProp: string }>> = someLogic() ? Component1 : Component2;
+ * 	const componentOfCertainSubType: ComponentType<SvelteComponent<{ needsThisProp: string }>> = someLogic() ? Component1 : Component2;
  * </script>
  *
  * <svelte:component this={component} />
  * <svelte:component this={componentOfCertainSubType} needsThisProp="hello" />
  * ```
  */
-export type ComponentType<Component extends SvelteComponentTyped = SvelteComponentTyped> = new (
+export type ComponentType<Component extends SvelteComponentDev = SvelteComponentDev> = new (
 	options: ComponentConstructorOptions<
-		Component extends SvelteComponentTyped<infer Props> ? Props : Record<string, any>
+		Component extends SvelteComponentDev<infer Props> ? Props : Record<string, any>
 	>
 ) => Component;
 
@@ -334,7 +330,7 @@ export type ComponentType<Component extends SvelteComponentTyped = SvelteCompone
  * </script>
  * ```
  */
-export type ComponentProps<Component extends SvelteComponent> = Component extends SvelteComponentTyped<infer Props>
+export type ComponentProps<Component extends SvelteComponent> = Component extends SvelteComponentDev<infer Props>
 	? Props
 	: never;
 
@@ -354,7 +350,7 @@ export type ComponentProps<Component extends SvelteComponent> = Component extend
  * ```
  */
 export type ComponentEvents<Component extends SvelteComponent> =
-	Component extends SvelteComponentTyped<any, infer Events> ? Events : never;
+	Component extends SvelteComponentDev<any, infer Events> ? Events : never;
 
 export function loop_guard(timeout) {
 	const start = Date.now();

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -249,6 +249,7 @@ export class SvelteComponentDev<
 	$inject_state() {}
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SvelteComponentTyped<
 	Props extends Record<string, any> = any,
 	Events extends Record<string, any> = any,

--- a/src/runtime/internal/dev.ts
+++ b/src/runtime/internal/dev.ts
@@ -258,36 +258,6 @@ export interface SvelteComponentTyped<
 
 /**
  * @deprecated Use `SvelteComponent` instead. See PR for more information: https://github.com/sveltejs/svelte/pull/8512
- * 
- * Base class to create strongly typed Svelte components.
- * This only exists for typing purposes and should be used in `.d.ts` files.
- *
- * ### Example:
- *
- * You have component library on npm called `component-library`, from which
- * you export a component called `MyComponent`. For Svelte+TypeScript users,
- * you want to provide typings. Therefore you create a `index.d.ts`:
- * ```ts
- * import { SvelteComponentTyped } from "svelte";
- * export class MyComponent extends SvelteComponentTyped<{foo: string}> {}
- * ```
- * Typing this makes it possible for IDEs like VS Code with the Svelte extension
- * to provide intellisense and to use the component like this in a Svelte file
- * with TypeScript:
- * ```svelte
- * <script lang="ts">
- * 	import { MyComponent } from "component-library";
- * </script>
- * <MyComponent foo={'bar'} />
- * ```
- *
- * #### Why not make this part of `SvelteComponent(Dev)`?
- * Because
- * ```ts
- * class ASubclassOfSvelteComponent extends SvelteComponent<{foo: string}> {}
- * const component: typeof SvelteComponent = ASubclassOfSvelteComponent;
- * ```
- * will throw a type error, so we need to separate the more strictly typed class.
  */
 export class SvelteComponentTyped<
 	Props extends Record<string, any> = any,


### PR DESCRIPTION
# Breaking change / how to migrate

`SvelteComponent` now has the same capabilities as `SvelteComponenTyped`, which is therefore now deprecated. Use `SvelteComponent` where you've used `SvelteComponentTyped` previously:

```diff
- import { SvelteComponentTyped } from 'svelte';
+ import { SvelteComponent } from 'svelte';

- export class Foo extends SvelteComponentTyped<{ aProp: string }> {}
+ export class Foo extends SvelteComponent<{ aProp: string }> {}
```

In case you've used `SvelteComponent` previously to type "I expect a Svelte component constructor here" by using `typeof SvelteComponent`, you'll now likely get a somewhat opaque TypeScript error.

Code:
```ts
import type { SvelteComponent } from 'svelte';

const a: typeof SvelteComponent = SomeSvelteComponentWithAProp;
```
Error:
```
Type 'typeof SomeSvelteComponentWithAProp' is not assignable to type 'typeof SvelteComponent'.
  Types of construct signatures are incompatible.
    Type 'new (options: ComponentConstructorOptions<{ prop: string; }>) => SomeSvelteComponentWithAProp' is not assignable to type 'new <Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any>(options: ComponentConstructorOptions<Props>) => SvelteComponent<...>'.
      Types of parameters 'options' and 'options' are incompatible.
        Type 'ComponentConstructorOptions<Props>' is not assignable to type 'ComponentConstructorOptions<{ prop: string; }>'.
          Type 'Props' is not assignable to type '{ prop: string; }'.
            Property 'prop' is missing in type 'Record<string, any>' but required in type '{ prop: string; }'.
```

The solution is to either add `<any>` to `typeof SvelteComponent` (which is possible since TypeScript version 4.7) or do `ComponentType<SvelteComponent>` instead:

```ts
import type { SvelteComponent, ComponentType } from 'svelte';

// either
const a: typeof SvelteComponent<any> = SomeSvelteComponentWithAProp;
// or
const b: ComponentType<SvelteComponent> = SomeSvelteComponentWithAProp;
```

## PR description

Deprecate SvelteComponentTyped, add generics to SvelteComponent - reverts the revert in #5738. Also add data- attribute to HTMLAttributes (for https://github.com/sveltejs/language-tools/issues/1825) and use available TS interfaces.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
