### PR TITLE
breaking: remove legacy package.json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased (4.0)
 
 * **breaking** Minimum supported Node version is now Node 14
-* **breaking** Minimum supported TypeScript version is now 5 (it will likely work with lower versions, but we make no guarantess about that)
+* **breaking** Minimum supported webpack version is now webpack 5
+* **breaking** Minimum supported TypeScript version is now TypeScript 5 (it will likely work with lower versions, but we make no guarantees about that)
 * **breaking** Stricter types for `createEventDispatcher` (see PR for migration instructions) ([#7224](https://github.com/sveltejs/svelte/pull/7224))
 * **breaking** Stricter types for `Action` and `ActionReturn` (see PR for migration instructions) ([#7224](https://github.com/sveltejs/svelte/pull/7224))
 * **breaking** Stricter types for `onMount` - now throws a type error when returning a function asynchronously to catch potential mistakes around callback functions (see PR for migration instructions) ([#8136](https://github.com/sveltejs/svelte/pull/8136))

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -90,19 +90,6 @@ export default [
 						}
 
 						fs.writeFileSync(
-							`${dir}/package.json`,
-							JSON.stringify(
-								{
-									main: './index.js',
-									module: './index.mjs',
-									types: './index.d.ts',
-								},
-								null,
-								'  '
-							)
-						);
-
-						fs.writeFileSync(
 							`${dir}/index.d.ts`,
 							`export * from '../types/runtime/${dir}/index.js';`
 						);


### PR DESCRIPTION
Now that we only support newer versions of Node we can simply rely on `exports`.

This is a breaking change because it requires bundlers to be able to handle the `exports` field. This is the case for
- Vite 3/4
- Rollup 2/3 (using `@rollup/plugin-node-resolve`)
- Webpack 5

If you're relying on a bundler that does not know how to deal with export maps, you need to update its version to one that supports it (like webpack 4->5) or switch to another bundler.