### PR TITLE
fix: improve setup of default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,8 @@
         "import": "./index.mjs",
         "require": "./index.js"
       },
-      "node": {
-        "import": "./ssr.mjs",
-        "require": "./ssr.js"
-      },
-      "import": "./index.mjs",
-      "require": "./index.js"
+      "import": "./ssr.mjs",
+      "require": "./ssr.js"
     },
     "./compiler": {
       "types": "./types/compiler/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -74,11 +74,6 @@
     },
     "./elements": {
       "types": "./elements/index.d.ts"
-    },
-    "./ssr": {
-      "types": "./types/runtime/index.d.ts",
-      "import": "./ssr.mjs",
-      "require": "./ssr.js"
     }
   },
   "engines": {


### PR DESCRIPTION
I also removed `svelte/ssr`. It's a workaround for a bug in Vite 4.0 that was fixed in Vite 4.1. We can release a new version of `vite-plugin-svelte` that uses it only when Svelte 3 is detected in the `package.json`. Then in the Svelte 4 changelog we can say it's only compatible with the newer version of `vite-plugin-svelte` which you can also get by bumping to a certain version of SvelteKit where we've bumped the `vite-plugin-svelte` version.