### PR TITLE
chore: fix CI setup for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,7 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
       - uses: actions/setup-node@v3
         with:
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install
-        env:
-          SKIP_PREPARE: true
       - run: pnpm test:unit


### PR DESCRIPTION
@Conduitry with his eagle eyes noticed that the CI jobs aren't running on the specified Node versions: https://github.com/sveltejs/svelte/pull/8528#issuecomment-1519388031