### PR TITLE
fix: match `no-redundant-roles` implementation closer to `jsx-eslint`

### DIFF
--- a/src/compiler/compile/nodes/Element.ts
+++ b/src/compiler/compile/nodes/Element.ts
@@ -121,6 +121,7 @@ const a11y_implicit_semantics = new Map([
 	['details', 'group'],
 	['dt', 'term'],
 	['fieldset', 'group'],
+	['figure', 'figure'],
 	['form', 'form'],
 	['h1', 'heading'],
 	['h2', 'heading'],
@@ -132,6 +133,7 @@ const a11y_implicit_semantics = new Map([
 	['img', 'img'],
 	['li', 'listitem'],
 	['link', 'link'],
+	['main', 'main'],
 	['menu', 'list'],
 	['meter', 'progressbar'],
 	['nav', 'navigation'],
@@ -142,6 +144,7 @@ const a11y_implicit_semantics = new Map([
 	['progress', 'progressbar'],
 	['section', 'region'],
 	['summary', 'button'],
+	['table', 'table'],
 	['tbody', 'rowgroup'],
 	['textarea', 'textbox'],
 	['tfoot', 'rowgroup'],
@@ -631,9 +634,7 @@ export default class Element extends Node {
 						}
 
 						// no-redundant-roles
-						const has_redundant_role = current_role === get_implicit_role(this.name, attribute_map);
-
-						if (this.name === current_role || has_redundant_role) {
+						if (current_role === get_implicit_role(this.name, attribute_map)) {
 							component.warn(attribute, compiler_warnings.a11y_no_redundant_roles(current_role));
 						}
 

--- a/test/validator/samples/a11y-no-redundant-roles/input.svelte
+++ b/test/validator/samples/a11y-no-redundant-roles/input.svelte
@@ -42,3 +42,7 @@
 <!-- Tested header/footer not nested in section/article -->
 <header role="banner"></header>
 <footer role="contentinfo"></footer>
+
+<!-- Allowed -->
+<!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+<menu role="menu" />


### PR DESCRIPTION
Deals with the `no-redundant-roles` part of #8529

There was an erroneous check which compares the element name with the current role. This fix brings `no-redundant-roles` closer to the original [implementation](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/no-redundant-roles.js)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
