### PR TITLE
docs: Clarify when bind:group does not work

### DIFF
--- a/site/content/docs/03-template-syntax.md
+++ b/site/content/docs/03-template-syntax.md
@@ -823,6 +823,8 @@ Inputs that work together can use `bind:group`.
 <input type="checkbox" bind:group={fillings} value="Guac (extra)">
 ```
 
+**Note**: `bind:group` only works if the inputs are in the same Svelte component.
+
 #### bind:this
 
 ```sv


### PR DESCRIPTION
This PR clarifies the documentation around when `bind:group` does and does not work. See issue https://github.com/sveltejs/svelte/issues/2308 for the confusion this can generate. There are decent workarounds available, and understandable complexity were the behaviour were to be changed, but I think an extra sentence in the documentation could save a lot of headaches.
