### PR TITLE
fix: transition slide not smooth with min-height and min-widt

### DIFF
--- a/src/runtime/internal/Component.ts
+++ b/src/runtime/internal/Component.ts
@@ -5,11 +5,13 @@ import { children, detach, start_hydrating, end_hydrating } from './dom';
 import { transition_in } from './transitions';
 import { T$$ } from './types';
 
-export function bind(component, name, callback) {
+export function bind(component, name, callback, runCallback = true) {
 	const index = component.$$.props[name];
 	if (index !== undefined) {
 		component.$$.bound[index] = callback;
-		callback(component.$$.ctx[index]);
+		if (runCallback) {
+			callback(component.$$.ctx[index]);
+		}
 	}
 }
 

--- a/src/runtime/transition/index.ts
+++ b/src/runtime/transition/index.ts
@@ -111,6 +111,7 @@ export function slide(node: Element, {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
 	const primary_property = axis === 'y' ? 'height' : 'width';
+	const min_primary_property = `min-${primary_property}`;
 	const primary_property_value = parseFloat(style[primary_property]);
 	const secondary_properties = axis === 'y' ? ['top', 'bottom'] : ['left', 'right'];
 	const capitalized_secondary_properties = secondary_properties.map((e) => `${e[0].toUpperCase()}${e.slice(1)}`);
@@ -128,6 +129,7 @@ export function slide(node: Element, {
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
 			`${primary_property}: ${t * primary_property_value}px;` +
+			`${min_primary_property}: 0;` +
 			`padding-${secondary_properties[0]}: ${t * padding_start_value}px;` +
 			`padding-${secondary_properties[1]}: ${t * padding_end_value}px;` +
 			`margin-${secondary_properties[0]}: ${t * margin_start_value}px;` +

--- a/test/runtime/samples/binding-object-in-key-block/Component.svelte
+++ b/test/runtime/samples/binding-object-in-key-block/Component.svelte
@@ -1,0 +1,7 @@
+<script lang='ts'>
+	export let obj;
+</script>
+
+<p>
+	{obj.value}
+</p>

--- a/test/runtime/samples/binding-object-in-key-block/_config.js
+++ b/test/runtime/samples/binding-object-in-key-block/_config.js
@@ -1,0 +1,4 @@
+// fix: https://github.com/sveltejs/svelte/issues/8305
+export default {
+	html: '<p>0</p>'
+};

--- a/test/runtime/samples/binding-object-in-key-block/main.svelte
+++ b/test/runtime/samples/binding-object-in-key-block/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Component from './Component.svelte';
+	let obj = {
+		value: '0'
+	};
+</script>
+
+{#key obj}
+	<Component bind:obj={obj} />
+{/key}

--- a/test/runtime/samples/class-shortcut-with-transition/_config.js
+++ b/test/runtime/samples/class-shortcut-with-transition/_config.js
@@ -17,7 +17,7 @@ export default {
 		raf.tick(150);
 		assert.htmlEqual(
 			target.innerHTML,
-			'<p>foo</p><p class="red svelte-1yszte8 border" style="animation: __svelte_1333973250_0 100ms linear 0ms 1 both;">bar</p>'
+			'<p>foo</p><p class="red svelte-1yszte8 border" style="animation: __svelte_567626776_0 100ms linear 0ms 1 both;">bar</p>'
 		);
 
 		component.open = true;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

closes: https://github.com/sveltejs/svelte/issues/8533

transition slide will become not smooth with min-height and min-width.
https://svelte.dev/repl/b2fc23f665c341cbbe99d964b0c6e696?version=3.57.0

I think we can add ```min-height: 0``` or ```min-width: 0``` to resolve this problem.
