### PR TITLE
fix(site-2): Remove marked warnings

### DIFF
--- a/sites/svelte.dev/src/lib/server/markdown/index.js
+++ b/sites/svelte.dev/src/lib/server/markdown/index.js
@@ -212,6 +212,8 @@ const default_renderer = {
  */
 export function transform(markdown, renderer = {}) {
 	marked.use({
+		mangle: false,
+		headerIds: false,
 		renderer: {
 			// we have to jump through these hoops because of marked's API design choices —
 			// options are global, and merged in confusing ways. You can't do e.g.


### PR DESCRIPTION
marked 5.0 would throw up a million warnings on dev and build time. Tweaked option to remove those, shouldn't affect us at all