### PR TITLE
docs: update SvelteKit alternatives section

### DIFF
--- a/documentation/content/docs/01-getting-started/01-introduction.md
+++ b/documentation/content/docs/01-getting-started/01-introduction.md
@@ -27,7 +27,7 @@ SvelteKit will handle calling [the Svelte compiler](https://www.npmjs.com/packag
 
 ### Alternatives to SvelteKit
 
-If you don't want to use SvelteKit for some reason, you can also use Svelte with Vite (but without SvelteKit) by running `npm init vite` and selecting the `svelte` option. With this, `npm run build` will generate HTML, JS and CSS files inside the `dist` directory.
+If you don't want to use SvelteKit for some reason, you can also use Svelte with Vite (but without SvelteKit) by running `npm init vite` and selecting the `svelte` option. With this, `npm run build` will generate HTML, JS and CSS files inside the `dist` directory. In most cases, you will probably need to [choose a routing library](/faq#is-there-a-router) as well.
 
 ## Differences from SvelteKit
 

--- a/documentation/content/docs/01-getting-started/01-introduction.md
+++ b/documentation/content/docs/01-getting-started/01-introduction.md
@@ -27,12 +27,7 @@ SvelteKit will handle calling [the Svelte compiler](https://www.npmjs.com/packag
 
 ### Alternatives to SvelteKit
 
-If you don't need a full-fledged app framework and instead want to build a simple frontend-only site/app, you can also use Svelte (without Kit) with Vite by running `npm init vite` and selecting the `svelte` option. With this, `npm run build` will generate HTML, JS and CSS files inside the `dist` directory.
-
-Notable Mentions:
-
-- [Routify](https://www.routify.dev/)
-- [Elder.js](https://elderjs.com/)
+If you don't want to use SvelteKit for some reason, you can also use Svelte with Vite (but without SvelteKit) by running `npm init vite` and selecting the `svelte` option. With this, `npm run build` will generate HTML, JS and CSS files inside the `dist` directory.
 
 ## Differences from SvelteKit
 

--- a/documentation/content/faq/900-is-there-a-router.md
+++ b/documentation/content/faq/900-is-there-a-router.md
@@ -4,10 +4,12 @@ question: Is there a router?
 
 The official routing library is [SvelteKit](https://kit.svelte.dev/). SvelteKit provides a filesystem router, server-side rendering (SSR), and hot module reloading (HMR) in one easy-to-use package. It shares similarities with Next.js for React.
 
-However, you can use any router lib you want. A lot of people use [page.js](https://github.com/visionmedia/page.js). There's also [navaid](https://github.com/lukeed/navaid), which is very similar. And [universal-router](https://github.com/kriasoft/universal-router), which is isomorphic with child routes, but without built-in history support.
+However, you can use any router library. A lot of people use [page.js](https://github.com/visionmedia/page.js). There's also [navaid](https://github.com/lukeed/navaid), which is very similar. And [universal-router](https://github.com/kriasoft/universal-router), which is isomorphic with child routes, but without built-in history support.
 
 If you prefer a declarative HTML approach, there's the isomorphic [svelte-routing](https://github.com/EmilTholin/svelte-routing) library and a fork of it called [svelte-navigator](https://github.com/mefechoel/svelte-navigator) containing some additional functionality.
 
 If you need hash-based routing on the client side, check out [svelte-spa-router](https://github.com/ItalyPaleAle/svelte-spa-router) or [abstract-state-router](https://github.com/TehShrike/abstract-state-router/).
 
 [Routify](https://routify.dev) is another filesystem-based router, similar to SvelteKit's router. Version 3 supports Svelte's native SSR.
+
+You can see a [community-maintained list of routers on sveltesociety.dev](https://sveltesociety.dev/components#routers).


### PR DESCRIPTION
I'm not sure we should mention Routify and Elder.js as we usually avoid endorsing non-official projects and I believe Elder.js is no longer maintained or looking to be handed over to someone else. We do have a routing FAQ that folks can refer to

I also wanted to change the first sentence which sounds a bit like you should use Vite without SvelteKit if you want to do something simple, but I hope SvelteKit would be the simpler option for most folks as it avoids them having to answer questions like how to do routing.