### PR TITLE
chore: remove prepare script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - run: pnpm playwright install chromium
       - run: pnpm test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
       - run: pnpm playwright install chromium
       - run: pnpm test
         env:

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "format:check": "prettier . --cache --plugin-search-dir=. --check",
     "test": "vitest run && echo \"manually check that there are no type errors in test/types by opening the files in there\"",
     "build": "rollup -c && npm run tsd",
-    "prepare": "npm run build",
     "dev": "rollup -cw",
     "posttest": "agadoo internal/index.mjs",
     "prepublishOnly": "node check_publish_env.js && npm run lint && npm run build && npm test",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import glob from 'tiny-glob/sync';
 import colors from 'kleur';
 import { assert } from 'vitest';
-import { compile } from '../compiler.js';
+import { compile } from '../src/compiler/index.js';
 import { fileURLToPath } from 'node:url';
 
 export function try_load_json(file) {

--- a/test/server-side-rendering/ssr-2.test.js
+++ b/test/server-side-rendering/ssr-2.test.js
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import glob from 'tiny-glob/sync';
 import { assert, describe, it } from 'vitest';
-import { compile } from '../../compiler.mjs';
+import { compile } from '../../src/compiler/index.js';
 import { create_loader, mkdirp, try_load_config } from '../helpers.js';
 import { assert_html_equal, assert_html_equal_with_options } from '../html_equal.js';
 


### PR DESCRIPTION
It drives me insane that `pnpm install` takes forever because it builds the library. I don't know if there's a reason for this. Maybe @Conduitry knows if there's a reason it needs to be this way?