### PR TITLE
chore(test): use esm output for svelte files

### DIFF
--- a/test/css/css.test.js
+++ b/test/css/css.test.js
@@ -34,15 +34,9 @@ describe('css', () => {
 
 			const expected_warnings = (config.warnings || []).map(normalize_warning);
 
-			const dom = svelte.compile(
-				input,
-				Object.assign({}, config.compileOptions || {}, { format: 'cjs' })
-			);
+			const dom = svelte.compile(input, Object.assign({}, config.compileOptions || {}));
 
-			const ssr = svelte.compile(
-				input,
-				Object.assign({}, config.compileOptions || {}, { format: 'cjs', generate: 'ssr' })
-			);
+			const ssr = svelte.compile(input, Object.assign({}, config.compileOptions || {}));
 
 			assert.equal(dom.css.code, ssr.css.code);
 
@@ -75,7 +69,7 @@ describe('css', () => {
 
 			// we do this here, rather than in the expected.html !== null
 			// block, to verify that valid code was generated
-			const load = create_loader({ ...(config.compileOptions || {}), format: 'cjs' }, cwd);
+			const load = create_loader({ ...(config.compileOptions || {}) }, cwd);
 			try {
 				ClientComponent = (await load('input.svelte')).default;
 			} catch (err) {
@@ -83,10 +77,7 @@ describe('css', () => {
 				throw err;
 			}
 
-			const load_ssr = create_loader(
-				{ ...(config.compileOptions || {}), generate: 'ssr', format: 'cjs' },
-				cwd
-			);
+			const load_ssr = create_loader({ ...(config.compileOptions || {}), generate: 'ssr' }, cwd);
 			try {
 				ServerComponent = (await load_ssr('input.svelte')).default;
 			} catch (err) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -143,6 +143,9 @@ export function create_loader(compileOptions, cwd) {
 
 			const exports = [];
 
+			// We can't use Node's or Vitest's loaders cause we compile with different options
+			// we need to rewrite the imports into function calls that we can intercept to transform any imported
+			// svelte components as well
 			let transformed = compiled.js.code
 				.replace(
 					/^import \* as (\w+) from ['"]([^'"]+)['"];?/gm,
@@ -189,7 +192,9 @@ export function create_loader(compileOptions, cwd) {
 				transformed += `\n__exports.${name} = ${name};`;
 			});
 
-			const __exports = {};
+			const __exports = {
+				[Symbol.toStringTag]: 'Module',
+			};
 			try {
 				const fn = new AsyncFunction('__import', '__exports', transformed);
 				await fn(__import, __exports);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -114,8 +114,7 @@ export function create_loader(compileOptions, cwd) {
 		if (file.endsWith('.svelte')) {
 			const options = {
 				...compileOptions,
-				filename: file,
-				format: 'esm'
+				filename: file
 			};
 
 			const compiled = compile(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -193,7 +193,7 @@ export function create_loader(compileOptions, cwd) {
 			});
 
 			const __exports = {
-				[Symbol.toStringTag]: 'Module',
+				[Symbol.toStringTag]: 'Module'
 			};
 			try {
 				const fn = new AsyncFunction('__import', '__exports', transformed);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -143,9 +143,10 @@ export function create_loader(compileOptions, cwd) {
 
 			const exports = [];
 
-			// We can't use Node's or Vitest's loaders cause we compile with different options
-			// we need to rewrite the imports into function calls that we can intercept to transform any imported
-			// svelte components as well
+			// We can't use Node's or Vitest's loaders cause we compile with different options.
+			// We need to rewrite the imports into function calls that we can intercept to transform
+			// any imported Svelte components as well. A few edge cases aren't handled but also
+			// currently unused in the tests, for example `export * from`and live bindings.
 			let transformed = compiled.js.code
 				.replace(
 					/^import \* as (\w+) from ['"]([^'"]+)['"];?/gm,

--- a/test/hydration/hydration.test.js
+++ b/test/hydration/hydration.test.js
@@ -21,7 +21,6 @@ describe('hydration', async () => {
 
 			const compileOptions = Object.assign({}, config.compileOptions, {
 				accessors: 'accessors' in config ? config.accessors : true,
-				format: 'cjs',
 				hydratable: true
 			});
 

--- a/test/runtime/runtime.shared.js
+++ b/test/runtime/runtime.shared.js
@@ -56,7 +56,6 @@ async function run_test(dir) {
 		const cwd = path.resolve(`${__dirname}/samples/${dir}`);
 
 		const compileOptions = Object.assign({}, config.compileOptions || {}, {
-			format: 'cjs',
 			hydratable: hydrate,
 			immutable: config.immutable,
 			accessors: 'accessors' in config ? config.accessors : true

--- a/test/runtime/runtime_base.test.js
+++ b/test/runtime/runtime_base.test.js
@@ -3,7 +3,7 @@
 import { create_loader } from '../helpers';
 import { assert, it } from 'vitest';
 
-const load = create_loader({ generate: 'dom', dev: true,  }, __dirname);
+const load = create_loader({ generate: 'dom', dev: true }, __dirname);
 const { default: App } = await load('App.svelte');
 
 it('fails if options.target is missing in dev mode', async () => {

--- a/test/runtime/runtime_base.test.js
+++ b/test/runtime/runtime_base.test.js
@@ -3,7 +3,7 @@
 import { create_loader } from '../helpers';
 import { assert, it } from 'vitest';
 
-const load = create_loader({ generate: 'dom', dev: true, format: 'cjs' }, __dirname);
+const load = create_loader({ generate: 'dom', dev: true,  }, __dirname);
 const { default: App } = await load('App.svelte');
 
 it('fails if options.target is missing in dev mode', async () => {

--- a/test/server-side-rendering/ssr-1.test.js
+++ b/test/server-side-rendering/ssr-1.test.js
@@ -30,7 +30,7 @@ describe('ssr', async () => {
 
 			const compileOptions = {
 				...config.compileOptions,
-				generate: 'ssr',
+				generate: 'ssr'
 			};
 
 			const load = create_loader(compileOptions, dir);

--- a/test/server-side-rendering/ssr-1.test.js
+++ b/test/server-side-rendering/ssr-1.test.js
@@ -31,7 +31,6 @@ describe('ssr', async () => {
 			const compileOptions = {
 				...config.compileOptions,
 				generate: 'ssr',
-				format: 'cjs'
 			};
 
 			const load = create_loader(compileOptions, dir);

--- a/test/server-side-rendering/ssr-2.test.js
+++ b/test/server-side-rendering/ssr-2.test.js
@@ -33,7 +33,7 @@ function run_runtime_samples(suite) {
 		it_fn(dir, async () => {
 			const compileOptions = {
 				...config.compileOptions,
-				generate: 'ssr',
+				generate: 'ssr'
 			};
 
 			const load = create_loader(compileOptions, cwd);

--- a/test/server-side-rendering/ssr-2.test.js
+++ b/test/server-side-rendering/ssr-2.test.js
@@ -34,7 +34,6 @@ function run_runtime_samples(suite) {
 			const compileOptions = {
 				...config.compileOptions,
 				generate: 'ssr',
-				format: 'cjs'
 			};
 
 			const load = create_loader(compileOptions, cwd);


### PR DESCRIPTION
# HEADS UP: BIG RESTRUCTURING UNDERWAY

The Svelte repo is currently in the process of heavy restructuring for Svelte 4. After that, work on Svelte 5 will likely change a lot on the compiler aswell. For that reason, please don't open PRs that are large in scope, touch more than a couple of files etc. In other words, bug fixes are fine, but feature PRs will likely not be merged.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
