### PR TITLE
feat: apply inert to outroing elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * **breaking** Error on falsy values instead of stores passed to `derived` ([#7947](https://github.com/sveltejs/svelte/pull/7947))
 * **breaking** Custom store implementers now need to pass an `update` function additionally to the `set` function ([#6750](https://github.com/sveltejs/svelte/pull/6750))
 * **breaking** Change order in which preprocessors are applied ([#8618](https://github.com/sveltejs/svelte/pull/8618))
+* **breaking** apply `inert` to outroing elements ([#8627](https://github.com/sveltejs/svelte/pull/8627))
 * Add a way to modify attributes for script/style preprocessors ([#8618](https://github.com/sveltejs/svelte/pull/8618))
 * Improve hydration speed by adding `data-svelte-h` attribute to detect unchanged HTML elements ([#7426](https://github.com/sveltejs/svelte/pull/7426))
 * Add `a11y no-noninteractive-element-interactions` rule ([#8391](https://github.com/sveltejs/svelte/pull/8391))

--- a/test/runtime/samples/transition-inert/_config.js
+++ b/test/runtime/samples/transition-inert/_config.js
@@ -1,0 +1,28 @@
+export default {
+	async test({ assert, component, target, raf }) {
+		// jsdom doesn't set the inert attribute, and the transition checks if it exists, so set it manually to trigger the inert logic
+		target.querySelector('button.a').inert = false;
+		target.querySelector('button.b').inert = false;
+
+		// check and abort halfway through the outro transition
+		component.visible = false;
+		raf.tick(50);
+		assert.strictEqual(target.querySelector('button.a').inert, true);
+		assert.strictEqual(target.querySelector('button.b').inert, true);
+
+		component.visible = true;
+		assert.strictEqual(target.querySelector('button.a').inert, false);
+		assert.strictEqual(target.querySelector('button.b').inert, false);
+
+		// let it transition out completely and then back in
+		component.visible = false;
+		raf.tick(101);
+		component.visible = true;
+		raf.tick(50);
+		assert.strictEqual(target.querySelector('button.a').inert, false);
+		assert.strictEqual(target.querySelector('button.b').inert, false);
+		raf.tick(51);
+		assert.strictEqual(target.querySelector('button.a').inert, false);
+		assert.strictEqual(target.querySelector('button.b').inert, false);
+	}
+};

--- a/test/runtime/samples/transition-inert/main.svelte
+++ b/test/runtime/samples/transition-inert/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	export let visible = true;
+
+	function slide(_, params) {
+		return params;
+	}
+</script>
+
+{#if visible}
+	<button class="a" transition:slide={{ duration: 100 }}>
+		foo
+	</button>
+	<button class="b" out:slide={{ duration: 100 }}>
+		bar
+	</button>
+{/if}


### PR DESCRIPTION
That way they are invisible to assistive technology and can't be interacted with, which makes sense since the element is already "dead" and only transitioning out at this point. Strictly speaking that's a breaking change, so it's marked as such.

closes #8445


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
