### PR TITLE
fix(perf): use `if` in toggle_class instead of dynamic property access shenanigans

### DIFF
--- a/src/runtime/internal/dom.ts
+++ b/src/runtime/internal/dom.ts
@@ -753,7 +753,11 @@ export const resize_observer_device_pixel_content_box = /* @__PURE__ */ new Resi
 export { ResizeObserverSingleton };
 
 export function toggle_class(element, name, toggle) {
-	element.classList[toggle ? 'add' : 'remove'](name);
+	if (toggle) {
+		element.classList.add(name);
+	} else {
+		element.classList.remove(name);
+	}
 }
 
 export function custom_event<T = any>(type: string, detail?: T, { bubbles = false, cancelable = false } = {}): CustomEvent<T> {


### PR DESCRIPTION
Closes #8629 (is a rework of it).

Following the discussion in #8629 (and an early predecessor #3189), instead of using `.toggle(... force)`, a plain old `if` proves to be about 10% faster in Chrome, likely due to JITs being able to do a better thing.

Micro-benchmark: https://gist.github.com/akx/76818fb782a232b5e08eae785cb3ee97
