### PR TITLE
fix: enable renaming object keys in destructured slot variables

### DIFF
--- a/test/runtime/samples/component-slot-destructuring/Nested.svelte
+++ b/test/runtime/samples/component-slot-destructuring/Nested.svelte
@@ -1,0 +1,1 @@
+<slot data={{ foo: 'foo', bar: { baz: 'baz' } }} />

--- a/test/runtime/samples/component-slot-destructuring/_config.js
+++ b/test/runtime/samples/component-slot-destructuring/_config.js
@@ -1,0 +1,6 @@
+export default {
+	html: `
+		<p>foo</p>
+		<p>baz</p>
+	`
+};

--- a/test/runtime/samples/component-slot-destructuring/main.svelte
+++ b/test/runtime/samples/component-slot-destructuring/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Nested from './Nested.svelte';
+</script>
+
+<Nested let:data={{ foo: fooRenamed, bar: { baz: bazRenamed } }}>
+	<p>{fooRenamed}</p>
+	<p>{bazRenamed}</p>
+</Nested>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/8556.

When an object key is renamed, the `names` array contains both the previous name and the new name while `context_lookup` only contains the new name. This fix ensures that the lookup succeeds with the new key. 

With this fix, all the examples in this repl now work: https://svelte.dev/repl/98917cf206794f20a4d3c45d012583be?version=3.58.0.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
