### PR TITLE
site: Applying DRY principle for keypad buttons in bindings: example 12

### DIFF
--- a/site/content/examples/05-bindings/12-component-bindings/Keypad.svelte
+++ b/site/content/examples/05-bindings/12-component-bindings/Keypad.svelte
@@ -11,15 +11,10 @@
 </script>
 
 <div class="keypad">
-	<button on:click={select(1)}>1</button>
-	<button on:click={select(2)}>2</button>
-	<button on:click={select(3)}>3</button>
-	<button on:click={select(4)}>4</button>
-	<button on:click={select(5)}>5</button>
-	<button on:click={select(6)}>6</button>
-	<button on:click={select(7)}>7</button>
-	<button on:click={select(8)}>8</button>
-	<button on:click={select(9)}>9</button>
+	
+	{#each {length: 9} as _, i}
+		<button on:click={select(i)}>{++i}</button>
+	{/each}
 
 	<button disabled={!value} on:click={clear}>clear</button>
 	<button on:click={select(0)}>0</button>


### PR DESCRIPTION
Not a huge change, but I figured it could be worth changing the 9 lines of `<button>` to an `each` block to show another use case for said `each` block.