### PR TITLE
feat: Pass changed boolean array to derived callbacks

### DIFF
--- a/packages/svelte/test/store/store.test.js
+++ b/packages/svelte/test/store/store.test.js
@@ -379,11 +379,11 @@ describe('store', () => {
 			const count = writable(0);
 			const values = [];
 
-			const a = derived(count, $count => {
+			const a = derived(count, ($count) => {
 				return 'a' + $count;
 			});
 
-			const b = derived(count, $count => {
+			const b = derived(count, ($count) => {
 				return 'b' + $count;
 			});
 
@@ -400,7 +400,7 @@ describe('store', () => {
 				}
 			});
 
-			const unsubscribe = combined.subscribe(v => {
+			const unsubscribe = combined.subscribe((v) => {
 				values.push(v);
 			});
 

--- a/packages/svelte/test/store/store.test.js
+++ b/packages/svelte/test/store/store.test.js
@@ -375,6 +375,45 @@ describe('store', () => {
 			unsubscribe();
 		});
 
+		it('provides a boolean array to easily tell what changed', () => {
+			const count = writable(0);
+			const values = [];
+
+			const a = derived(count, $count => {
+				return 'a' + $count;
+			});
+
+			const b = derived(count, $count => {
+				return 'b' + $count;
+			});
+
+			const c = writable(0);
+
+			const combined = derived([a, b, c], ([a, b, c], set, _u, changes) => {
+				const [aChanged, bChanged, cChanged] = changes;
+				if (aChanged && bChanged) {
+					set(a + b);
+				} else if (cChanged) {
+					set('c' + c);
+				} else {
+					set('a or b changed without the other one changing');
+				}
+			});
+
+			const unsubscribe = combined.subscribe(v => {
+				values.push(v);
+			});
+
+			assert.deepEqual(values, ['a0b0']);
+
+			c.set(2);
+			count.set(1);
+
+			assert.deepEqual(values, ['a0b0', 'c2', 'a1b1']);
+
+			unsubscribe();
+		});
+
 		it('derived dependency does not update and shared ancestor updates', () => {
 			const root = writable({ a: 0, b: 0 });
 			const values = [];

--- a/site/content/docs/04-run-time.md
+++ b/site/content/docs/04-run-time.md
@@ -383,7 +383,7 @@ store = derived(a, callback: (a: any, set: (value: any) => void, update: (fn: an
 store = derived([a, ...b], callback: ([a: any, ...b: any[]]) => any)
 ```
 ```js
-store = derived([a, ...b], callback: ([a: any, ...b: any[]], set: (value: any) => void, update: (fn: any => any) => void) => void | () => void, initial_value: any)
+store = derived([a, ...b], callback: ([a: any, ...b: any[]], set: (value: any) => void, update: (fn: any => any) => void, changed: boolean[]) => void | () => void, initial_value: any)
 ```
 
 ---
@@ -439,7 +439,7 @@ const tick = derived(frequency, ($frequency, set) => {
 
 ---
 
-In both cases, an array of arguments can be passed as the first argument instead of a single store.
+In both cases, an array of arguments can be passed as the first argument instead of a single store. In this case, the callback can optionally take a fourth argument, `changed`, which will be an array of Booleans describing which store value(s) changed since the last time the callback was called. (In the single-store case, the `changed` array would be pointless since it would always be equal to `[true]`.)
 
 ```js
 import { derived } from 'svelte/store';
@@ -448,6 +448,19 @@ const summed = derived([a, b], ([$a, $b]) => $a + $b);
 
 const delayed = derived([a, b], ([$a, $b], set) => {
 	setTimeout(() => set($a + $b), 1000);
+});
+
+const loggingSum = derived([a, b], ([$a, $b], set, _, changed) => {
+	const [aChanged, bChanged] = changed;
+	if (aChanged) console.log('New value of a', $a);
+	if (bChanged) console.log('New value of b', $b);
+	set($a + $b);
+});
+
+const complexLogic = derived([a, b], ([$a, $b], set, update, changed) => {
+	const [aChanged, bChanged] = changed;
+	if (aChanged) set($a + $b);
+	if (bChanged) update(n => n * 2 - $b);
 });
 ```
 


### PR DESCRIPTION
This allows the callbacks to easily run complex update logic based on which store changed most recently.

Fixes #6777.

This replaces PR #6786, which was targeting Svelte 3.

# HEADS UP: BIG RESTRUCTURING UNDERWAY

The Svelte repo is currently in the process of heavy restructuring for Svelte 4. After that, work on Svelte 5 will likely change a lot on the compiler aswell. For that reason, please don't open PRs that are large in scope, touch more than a couple of files etc. In other words, bug fixes are fine, but feature PRs will likely not be merged.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [X] Run the tests with `npm test` and lint the project with `npm run lint`
