### PR TITLE
fix: allow boolean in tweened instead of throwing an error

### DIFF
--- a/src/runtime/motion/tweened.ts
+++ b/src/runtime/motion/tweened.ts
@@ -11,6 +11,8 @@ function get_interpolator(a, b) {
 	if (type !== typeof b || Array.isArray(a) !== Array.isArray(b)) {
 		throw new Error('Cannot interpolate values of different type');
 	}
+	
+	if (type === 'boolean') return () => b;
 
 	if (Array.isArray(a)) {
 		const arr = b.map((bi, i) => {


### PR DESCRIPTION
When tweening arrays of objects, boolean properties can be useful (e.g. for toggling classes), and it makes no sense (in my opinion) to prevent developers from using boolean values in tweened stores.

This simple fix simply updates any boolean value without trying to interpolate it or throwing a `Cannot interpolate boolean values` error.

See issue: https://github.com/sveltejs/svelte/issues/7543
