### PR TITLE
fix: don't break in `attributeChangedCallback` if `$$component` does not exist yet

### DIFF
--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -287,7 +287,7 @@ if (typeof HTMLElement === 'function') {
 				this.$$props_definition,
 				'toProp'
 			);
-			this.$$component.$set({ [attr]: this.$$data[attr] });
+			this.$$component?.$set({ [attr]: this.$$data[attr] });
 		}
 
 		disconnectedCallback() {


### PR DESCRIPTION
Since the custom element class waits one tick before instantiating the `$$component` field, it's possibly undefined when `attributeChangedCallback` is called. This PR fixes that error by optionally chaining the `$$set` call on `$$component`.