### PR TITLE
warn on boolean compilerOptions.css

### DIFF
--- a/.changeset/stale-cougars-wink.md
+++ b/.changeset/stale-cougars-wink.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+warn on boolean compilerOptions.css

--- a/packages/svelte/src/compiler/compile/index.js
+++ b/packages/svelte/src/compiler/compile/index.js
@@ -37,6 +37,7 @@ const regex_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 const regex_starts_with_lowercase_character = /^[a-z]/;
 
 let warned_of_format = false;
+let warned_boolean_css = false;
 
 /**
  * @param {import('../interfaces.js').CompileOptions} options
@@ -86,23 +87,23 @@ function validate_options(options, warnings) {
 			toString: () => message
 		});
 	}
-	if (valid_css_values.indexOf(css) === -1) {
-		throw new Error(
-			`options.css must be true, false, 'injected', 'external', or 'none' (got '${css}')`
-		);
-	}
+
 	if (css === true || css === false) {
 		options.css = css === true ? 'injected' : 'external';
-		// possibly show this warning once we decided how Svelte 4 looks like
-		// const message = `options.css as a boolean is deprecated. Use '${options.css}' instead of ${css}.`;
-		// warnings.push({
-		// 	code: 'options-css-boolean-deprecated',
-		// 	message,
-		// 	filename,
-		// 	toString: () => message
-		// });
-		// }
+		if (!warned_boolean_css) {
+			console.warn(
+				`compilerOptions.css as a boolean is deprecated. Use '${options.css}' instead of ${css}.`
+			);
+			warned_boolean_css = true;
+		}
 	}
+
+	if (!valid_css_values.includes(options.css)) {
+		throw new Error(
+			`compilerOptions.css must be 'injected', 'external' or 'none' (got '${options.css}').`
+		);
+	}
+
 	if (namespace && valid_namespaces.indexOf(namespace) === -1) {
 		const match = fuzzymatch(namespace, valid_namespaces);
 		if (match) {


### PR DESCRIPTION
closes #8706 

# HEADS UP: BIG RESTRUCTURING UNDERWAY

The Svelte repo is currently in the process of heavy restructuring for Svelte 4. After that, work on Svelte 5 will likely change a lot on the compiler aswell. For that reason, please don't open PRs that are large in scope, touch more than a couple of files etc. In other words, bug fixes are fine, but feature PRs will likely not be merged.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
