### PR TITLE
chore: remove prepare script

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -75,7 +75,6 @@
     "check": "prettier . --cache --plugin-search-dir=. --check",
     "test": "vitest run && echo \"manually check that there are no type errors in test/types by opening the files in there\"",
     "build": "rollup -c && pnpm types",
-    "prepare": "pnpm build",
     "generate:version": "node ./scripts/generate-version.js",
     "dev": "rollup -cw",
     "posttest": "agadoo src/internal/index.js",


### PR DESCRIPTION
@Conduitry suggested earlier that we shouldn't remove it (https://github.com/sveltejs/svelte/pull/8609#issuecomment-1557050720), but I think that it doesn't work anyway now that `svelte` lives within a subdirectory of this repository

This will possibly fix our release issues as well: https://github.com/sveltejs/svelte/actions/runs/5215485544/jobs/9413074053