### PR TITLE
fix: update onMount type to allow async to return any

### DIFF
--- a/packages/svelte/src/runtime/internal/lifecycle.js
+++ b/packages/svelte/src/runtime/internal/lifecycle.js
@@ -26,6 +26,12 @@ export function beforeUpdate(fn) {
 }
 
 /**
+ * Anything except a function
+ * @template T
+ * @typedef {T extends Function ? never : T} NotFunction
+ */
+
+/**
  * The `onMount` function schedules a callback to run as soon as the component has been mounted to the DOM.
  * It must be called during the component's initialisation (but doesn't need to live *inside* the component;
  * it can be called from an external module).
@@ -36,9 +42,7 @@ export function beforeUpdate(fn) {
  *
  * https://svelte.dev/docs#run-time-svelte-onmount
  * @template T
- * @param {() => T extends Promise<() => any>
- * 		? "Returning a function asynchronously from onMount won't call that function on destroy"
- * 		: T} fn
+ * @param {() => NotFunction<T> | Promise<NotFunction<T>> | (() => any)} fn
  * @returns {void}
  */
 export function onMount(fn) {

--- a/packages/svelte/src/runtime/internal/lifecycle.js
+++ b/packages/svelte/src/runtime/internal/lifecycle.js
@@ -26,12 +26,6 @@ export function beforeUpdate(fn) {
 }
 
 /**
- * Anything except a function
- * @template T
- * @typedef {T extends Function ? never : T} NotFunction
- */
-
-/**
  * The `onMount` function schedules a callback to run as soon as the component has been mounted to the DOM.
  * It must be called during the component's initialisation (but doesn't need to live *inside* the component;
  * it can be called from an external module).
@@ -42,7 +36,7 @@ export function beforeUpdate(fn) {
  *
  * https://svelte.dev/docs#run-time-svelte-onmount
  * @template T
- * @param {() => NotFunction<T> | Promise<NotFunction<T>> | (() => any)} fn
+ * @param {() => import('./private.js').NotFunction<T> | Promise<import('./private.js').NotFunction<T>> | (() => any)} fn
  * @returns {void}
  */
 export function onMount(fn) {

--- a/packages/svelte/src/runtime/internal/private.d.ts
+++ b/packages/svelte/src/runtime/internal/private.d.ts
@@ -123,3 +123,8 @@ export interface Task {
 	abort(): void;
 	promise: Promise<void>;
 }
+
+/**
+ * Anything except a function
+ */
+type NotFunction<T> = T extends Function ? never : T;

--- a/packages/svelte/test/types/on-mount.ts
+++ b/packages/svelte/test/types/on-mount.ts
@@ -51,8 +51,15 @@ onMount(async () => {
 	};
 });
 
-// @ts-expect-error async and return any
+// async and return any
 onMount(async () => {
 	const a: any = null as any;
+	return a;
+});
+
+// async and return function casted to any
+// can't really catch this without also catching above
+onMount(async () => {
+	const a: any = (() => {}) as any;
 	return a;
 });


### PR DESCRIPTION
Building off #8136, the current type `onMount` definition is a bit unfriendly in VS Code tooltip. There was also an additional concern by dummdidumm prior to it being merged: https://github.com/sveltejs/svelte/issues/8136#issuecomment-1508921417

> If you return any from onMount, it's an error.

This updated type definition solves both of these concerns:

- VS Code now shows the following onMount type signature:
    ```ts
    function onMount<T>(
        fn: () => NotFunction<T> | Promise<NotFunction<T>> | (() => any)
    ): void
    ```
    This is a lot more readable for humans compared to the previous one, since it's clearer what type we're trying to exclude.
- Any async function that returns any is no longer a type error.

This does also mean that explicitly typecasting a `function` into `any` will be allowed, but as per Conduitry's comments on the matter https://github.com/sveltejs/svelte/pull/8136#issuecomment-1508934533:

> If someone really has a good/weird reason for going that, they can add a ts-ignore.

It's not a big problem to allow explicit opt-outs anyway.

---

I have opted to *not* add a changelog entry, because the current breaking change entry pointing to #8136 is very much still adequate to cover the changes from this PR. This PR technically even loosens the type definition to allow `any`-returning async functions inside onMount.

---

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
