### PR TITLE
docs: fix broken fragment in link

### DIFF
--- a/site/content/tutorial/05-events/03-event-modifiers/text.md
+++ b/site/content/tutorial/05-events/03-event-modifiers/text.md
@@ -22,7 +22,7 @@ The full list of modifiers:
 * `stopPropagation` — calls `event.stopPropagation()`, preventing the event reaching the next element
 * `passive` — improves scrolling performance on touch/wheel events (Svelte will add it automatically where it's safe to do so)
 * `nonpassive` — explicitly set `passive: false`
-* `capture` — fires the handler during the *capture* phase instead of the *bubbling* phase ([MDN docs](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture))
+* `capture` — fires the handler during the [*capture*](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_capture) phase instead of the [*bubbling*](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling) phase
 * `once` — remove the handler after the first time it runs
 * `self` — only trigger handler if event.target is the element itself
 * `trusted` — only trigger handler if `event.isTrusted` is `true`. I.e. if the event is triggered by a user action.


### PR DESCRIPTION
It looks like the following URL fragment doesn't exist anymore

<https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture>

So while users used to get navigated to the section specifically on bubbling and capture - now they just see the entire Event page.  Which honestly, isn't bad reading, but the event page as a whole is relevant to pretty much every other item in the event modifiers section.  Instead, this inlines links directly to  sections on bubbling vs capture.

