### PR TITLE
chore: change to the example: bindings -> group-inputs

### DIFF
--- a/site/content/examples/05-bindings/03-group-inputs/App.svelte
+++ b/site/content/examples/05-bindings/03-group-inputs/App.svelte
@@ -1,6 +1,12 @@
 <script>
 	let scoops = 1;
 	let flavours = ['Mint choc chip'];
+	
+	let radios = new Map();
+	radios.set('One', 1);
+	radios.set('Two', 2);
+	radios.set('Three', 3);
+	
 
 	let menu = [
 		'Cookies and cream',
@@ -16,20 +22,12 @@
 
 <h2>Size</h2>
 
+{#each radios as [number, value]}
 <label>
-	<input type=radio bind:group={scoops} value={1}>
-	One scoop
+	<input type=radio bind:group={scoops} value={value}>
+	{number} scoop
 </label>
-
-<label>
-	<input type=radio bind:group={scoops} value={2}>
-	Two scoops
-</label>
-
-<label>
-	<input type=radio bind:group={scoops} value={3}>
-	Three scoops
-</label>
+{/each}
 
 <h2>Flavours</h2>
 


### PR DESCRIPTION
In a nutshell: Added {#each} while intentionally using map to show that each only iterates over array-like objects.

I replaced existing code for radio buttons with {#each}, each radio button requires two dynamic values so I thought of creating an object. This video, https://youtu.be/dB_YjuAMH3o?t=224 by Rich Harris himself, addressing the quirk where {#each} only iterates over array-like objects. So I tried it and got the following, beautifully written, compile error:
{#each} only iterates over array-like objects. You can use a spread to convert this iterable into an array.

The thought process here is that if someone sees the example using:
for [...radios] as radio instead of, for radios as radio, they will tinker around to see why that is the case and if they try doing otherwise repl will give the above mentioned error to let them know the reason, helping them understand the quirks of svelte.

I understand that this might not turn out to be the appropriate way of showing the quirk, so if that's the case, I do request having a seperate example for this.