### PR TITLE
chore: update locate-character

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -109,7 +109,7 @@
     "css-tree": "^2.3.1",
     "estree-walker": "^3.0.3",
     "is-reference": "^3.0.1",
-    "locate-character": "^2.0.5",
+    "locate-character": "^3.0.0",
     "magic-string": "^0.30.0",
     "periscopic": "^3.1.0"
   },

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -123,7 +123,7 @@
     "@types/estree": "^1.0.1",
     "@types/node": "^14.14.31",
     "agadoo": "^3.0.0",
-    "dts-buddy": "^0.1.4",
+    "dts-buddy": "^0.1.7",
     "esbuild": "^0.17.19",
     "happy-dom": "^9.18.3",
     "jsdom": "^21.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       dts-buddy:
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: ^0.1.7
+        version: 0.1.7
       esbuild:
         specifier: ^0.17.19
         version: 0.17.19
@@ -1587,15 +1587,15 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /dts-buddy@0.1.4:
-    resolution: {integrity: sha512-kwWFPmpCFgQRW9U1zdg8ZAIx/KcyhPgvrP9k/apMGNl/LzmL1+PEWevJ6cBBwTW6zckfw9sHHziFK47IoBGX7g==}
+  /dts-buddy@0.1.7:
+    resolution: {integrity: sha512-zqKumjFt/RXVTPV3DT/L7NBDuc763NeAZEIJATicoSvxDnOnCFzV0WUc4JV8KZB3cwMCAktmEtL6ERXz+jJMrA==}
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.3
       '@jridgewell/sourcemap-codec': 1.4.15
       globrex: 0.1.2
       kleur: 4.1.5
-      locate-character: 2.0.5
+      locate-character: 3.0.0
       magic-string: 0.30.0
       sade: 1.8.1
       tiny-glob: 0.2.9
@@ -2690,13 +2690,8 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /locate-character@2.0.5:
-    resolution: {integrity: sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==}
-    dev: true
-
   /locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
-    dev: false
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       locate-character:
-        specifier: ^2.0.5
-        version: 2.0.5
+        specifier: ^3.0.0
+        version: 3.0.0
       magic-string:
         specifier: ^0.30.0
         version: 0.30.0
@@ -2692,6 +2692,11 @@ packages:
 
   /locate-character@2.0.5:
     resolution: {integrity: sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==}
+    dev: true
+
+  /locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+    dev: false
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}


### PR DESCRIPTION
`locate-character` version 2 is still pulled in as a `devDependency` until there's a new release of `dts-buddy` with https://github.com/Rich-Harris/dts-buddy/commit/25fc187109377d4be3699d5dffab1fb9e022725a

However, this is enough to get the new version as a production `dependency`, which will make learn.svelte.dev load ever so slightly faster since the new version of `locate-character` is ESM-only.