### PR TITLE
chore: a11y tests cleanup

### DIFF
--- a/packages/svelte/src/compiler/compile/utils/a11y.js
+++ b/packages/svelte/src/compiler/compile/utils/a11y.js
@@ -14,7 +14,8 @@ const non_interactive_roles = new Set(
 				// aria-activedescendant, thus in practice we treat it as a widget.
 				// focusable tabpanel elements are recommended if any panels in a set contain content where the first element in the panel is not focusable.
 				// 'generic' is meant to have no semantic meaning.
-				!['toolbar', 'tabpanel', 'generic'].includes(name) &&
+				// 'cell' is treated as CellRole by the AXObject which is interactive, so we treat 'cell' it as interactive as well.
+				!['toolbar', 'tabpanel', 'generic', 'cell'].includes(name) &&
 				!role.superClass.some((classes) => classes.includes('widget'))
 			);
 		})

--- a/packages/svelte/test/validator/samples/a11y-no-interactive-element-to-noninteractive-role/input.svelte
+++ b/packages/svelte/test/validator/samples/a11y-no-interactive-element-to-noninteractive-role/input.svelte
@@ -21,37 +21,37 @@
 <button role="button">button</button>
 
 <!-- input -->
-<input role="article"/>
-<input role="banner"/>
-<input role="complementary"/>
-<input role="img"/>
-<input role="listitem"/>
-<input role="main"/>
-<input role="region"/>
-<input role="tooltip"/>
-<input role="button"/>
+<input role="article" />
+<input role="banner" />
+<input role="complementary" />
+<input role="img" />
+<input role="listitem" />
+<input role="main" />
+<input role="region" />
+<input role="tooltip" />
+<input role="button" />
 
 <!-- select -->
-<select role="article"/>
-<select role="banner"/>
-<select role="complementary"/>
-<select role="img"/>
-<select role="listitem"/>
-<select role="main"/>
-<select role="region"/>
-<select role="tooltip"/>
-<select role="button"/>
+<select role="article" />
+<select role="banner" />
+<select role="complementary" />
+<select role="img" />
+<select role="listitem" />
+<select role="main" />
+<select role="region" />
+<select role="tooltip" />
+<select role="button" />
 
 <!-- textarea -->
-<textarea role="article"/>
-<textarea role="banner"/>
-<textarea role="complementary"/>
-<textarea role="img"/>
-<textarea role="listitem"/>
-<textarea role="main"/>
-<textarea role="region"/>
-<textarea role="tooltip"/>
-<textarea role="button"/>
+<textarea role="article" />
+<textarea role="banner" />
+<textarea role="complementary" />
+<textarea role="img" />
+<textarea role="listitem" />
+<textarea role="main" />
+<textarea role="region" />
+<textarea role="tooltip" />
+<textarea role="button" />
 
 <!-- HTML elements attributed with an abstract role -->
 <div role="command" />
@@ -99,6 +99,7 @@
 <div role="tab" />
 <div role="textbox" />
 <div role="treeitem" aria-selected={true} />
+<summary role="listitem" />
 
 <!-- HTML elements attributed with a non-interactive role -->
 <div role="alert" />
@@ -143,6 +144,5 @@
 <menuitem role="listitem" />
 <option class="foo" role="listitem" />
 <select class="foo" role="listitem" />
-<summary role="listitem" /> // TODO: https://github.com/sveltejs/svelte/issues/8728
 <textarea class="foo" role="listitem" />
 <tr role="listitem" />

--- a/packages/svelte/test/validator/samples/a11y-no-interactive-element-to-noninteractive-role/warnings.json
+++ b/packages/svelte/test/validator/samples/a11y-no-interactive-element-to-noninteractive-role/warnings.json
@@ -206,7 +206,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 23,
+			"column": 24,
 			"line": 24
 		},
 		"message": "A11y: <input> cannot have role 'article'",
@@ -218,7 +218,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 22,
+			"column": 23,
 			"line": 25
 		},
 		"message": "A11y: <input> cannot have role 'banner'",
@@ -230,7 +230,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 29,
+			"column": 30,
 			"line": 26
 		},
 		"message": "A11y: <input> cannot have role 'complementary'",
@@ -242,7 +242,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 19,
+			"column": 20,
 			"line": 27
 		},
 		"message": "A11y: <input> cannot have role 'img'",
@@ -254,7 +254,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 24,
+			"column": 25,
 			"line": 28
 		},
 		"message": "A11y: <input> cannot have role 'listitem'",
@@ -266,7 +266,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 20,
+			"column": 21,
 			"line": 29
 		},
 		"message": "A11y: <input> cannot have role 'main'",
@@ -278,7 +278,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 22,
+			"column": 23,
 			"line": 30
 		},
 		"message": "A11y: <input> cannot have role 'region'",
@@ -290,7 +290,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 23,
+			"column": 24,
 			"line": 31
 		},
 		"message": "A11y: <input> cannot have role 'tooltip'",
@@ -302,7 +302,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 24,
+			"column": 25,
 			"line": 35
 		},
 		"message": "A11y: <select> cannot have role 'article'",
@@ -314,7 +314,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 23,
+			"column": 24,
 			"line": 36
 		},
 		"message": "A11y: <select> cannot have role 'banner'",
@@ -326,7 +326,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 30,
+			"column": 31,
 			"line": 37
 		},
 		"message": "A11y: <select> cannot have role 'complementary'",
@@ -338,7 +338,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 20,
+			"column": 21,
 			"line": 38
 		},
 		"message": "A11y: <select> cannot have role 'img'",
@@ -350,7 +350,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 25,
+			"column": 26,
 			"line": 39
 		},
 		"message": "A11y: <select> cannot have role 'listitem'",
@@ -362,7 +362,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 21,
+			"column": 22,
 			"line": 40
 		},
 		"message": "A11y: <select> cannot have role 'main'",
@@ -374,7 +374,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 23,
+			"column": 24,
 			"line": 41
 		},
 		"message": "A11y: <select> cannot have role 'region'",
@@ -386,7 +386,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 24,
+			"column": 25,
 			"line": 42
 		},
 		"message": "A11y: <select> cannot have role 'tooltip'",
@@ -398,7 +398,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 26,
+			"column": 27,
 			"line": 46
 		},
 		"message": "A11y: <textarea> cannot have role 'article'",
@@ -410,7 +410,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 25,
+			"column": 26,
 			"line": 47
 		},
 		"message": "A11y: <textarea> cannot have role 'banner'",
@@ -422,7 +422,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 32,
+			"column": 33,
 			"line": 48
 		},
 		"message": "A11y: <textarea> cannot have role 'complementary'",
@@ -434,7 +434,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 22,
+			"column": 23,
 			"line": 49
 		},
 		"message": "A11y: <textarea> cannot have role 'img'",
@@ -446,7 +446,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 27,
+			"column": 28,
 			"line": 50
 		},
 		"message": "A11y: <textarea> cannot have role 'listitem'",
@@ -458,7 +458,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 23,
+			"column": 24,
 			"line": 51
 		},
 		"message": "A11y: <textarea> cannot have role 'main'",
@@ -470,7 +470,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 25,
+			"column": 26,
 			"line": 52
 		},
 		"message": "A11y: <textarea> cannot have role 'region'",
@@ -482,7 +482,7 @@
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
-			"column": 26,
+			"column": 27,
 			"line": 53
 		},
 		"message": "A11y: <textarea> cannot have role 'tooltip'",
@@ -639,36 +639,36 @@
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
 			"column": 28,
-			"line": 143
+			"line": 144
 		},
 		"message": "A11y: <menuitem> cannot have role 'listitem'",
 		"start": {
 			"column": 0,
-			"line": 143
+			"line": 144
 		}
 	},
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
 			"column": 38,
-			"line": 144
+			"line": 145
 		},
 		"message": "A11y: <option> cannot have role 'listitem'",
 		"start": {
 			"column": 0,
-			"line": 144
+			"line": 145
 		}
 	},
 	{
 		"code": "a11y-no-interactive-element-to-noninteractive-role",
 		"end": {
 			"column": 38,
-			"line": 145
+			"line": 146
 		},
 		"message": "A11y: <select> cannot have role 'listitem'",
 		"start": {
 			"column": 0,
-			"line": 145
+			"line": 146
 		}
 	},
 	{

--- a/packages/svelte/test/validator/samples/a11y-no-noninteractive-element-to-interactive-role/input.svelte
+++ b/packages/svelte/test/validator/samples/a11y-no-noninteractive-element-to-interactive-role/input.svelte
@@ -2,7 +2,6 @@
 <article role="button" />
 <aside role="checkbox" aria-checked={false} />
 <blockquote role="columnheader" />
-<body role="combobox" aria-controls={[]} aria-expanded /> // TODO: https://github.com/sveltejs/svelte/issues/8728
 <br role="grid" />
 <caption role="gridcell" />
 <dd role="link" />
@@ -13,14 +12,13 @@
 <dt role="menuitemcheckbox" aria-checked />
 <fieldset role="menuitemradio" aria-checked />
 <figure>
-  <figcaption role="menuitemradio" aria-checked />
+	<figcaption role="menuitemradio" aria-checked />
 </figure>
 <figure role="option" aria-selected />
 <footer role="radio" aria-checked />
 <form role="radiogroup" />
-<frame role="row" /> // TODO: https://github.com/sveltejs/svelte/issues/8728
 <h1 role="rowheader">Button</h1>
-<h2 role="scrollbar" aria-controls={[]} aria-valuenow={0} >Button</h2>
+<h2 role="scrollbar" aria-controls={[]} aria-valuenow={0}>Button</h2>
 <h3 role="searchbox">Button</h3>
 <h4 role="slider" aria-valuenow={0}>Button</h4>
 <h5 role="spinbutton">Button</h5>
@@ -46,7 +44,6 @@
 <section role="radio" aria-label="radio" aria-checked />
 <table role="menu" />
 <tbody role="searchbox" />
-<td role="button" />  // TODO: https://github.com/sveltejs/svelte/issues/8728
 <tfoot role="listbox" />
 <thead role="slider" aria-valuenow={0} />
 <time role="doc-backlink" />
@@ -73,7 +70,7 @@
 <li role="row" />
 <li role="treeitem" aria-selected={false} />
 
-<!-- VALID: div elements assigned an interactive role. -->
+<!-- VALID: elements assigned an interactive role. -->
 <div role="button" />
 <div role="checkbox" aria-checked={true} />
 <div role="columnheader" />
@@ -101,9 +98,12 @@
 <div role="tab" />
 <div role="textbox" />
 <div role="treeitem" aria-selected={true} />
+<body role="combobox" aria-controls={[]} aria-expanded />
+<td role="button" />
 
 <!-- VALID: HTML elements attributed with a non-interactive role -->
 <div role="alert" />
 <div role="document" />
 <div role="separator" />
 <div role="timer" />
+<frame role="row" />

--- a/packages/svelte/test/validator/samples/a11y-no-noninteractive-element-to-interactive-role/warnings.json
+++ b/packages/svelte/test/validator/samples/a11y-no-noninteractive-element-to-interactive-role/warnings.json
@@ -1,590 +1,296 @@
 [
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 25,
-			"line": 2
-		},
 		"message": "A11y: Non-interactive element <article> cannot have interactive role 'button'",
-		"start": {
-			"column": 0,
-			"line": 2
-		}
+		"start": { "line": 2, "column": 0 },
+		"end": { "line": 2, "column": 25 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 46,
-			"line": 3
-		},
 		"message": "A11y: Non-interactive element <aside> cannot have interactive role 'checkbox'",
-		"start": {
-			"column": 0,
-			"line": 3
-		}
+		"start": { "line": 3, "column": 0 },
+		"end": { "line": 3, "column": 46 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 34,
-			"line": 4
-		},
 		"message": "A11y: Non-interactive element <blockquote> cannot have interactive role 'columnheader'",
-		"start": {
-			"column": 0,
-			"line": 4
-		}
+		"start": { "line": 4, "column": 0 },
+		"end": { "line": 4, "column": 34 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 18,
-			"line": 6
-		},
 		"message": "A11y: Non-interactive element <br> cannot have interactive role 'grid'",
-		"start": {
-			"column": 0,
-			"line": 6
-		}
+		"start": { "line": 5, "column": 0 },
+		"end": { "line": 5, "column": 18 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 27,
-			"line": 7
-		},
 		"message": "A11y: Non-interactive element <caption> cannot have interactive role 'gridcell'",
-		"start": {
-			"column": 0,
-			"line": 7
-		}
+		"start": { "line": 6, "column": 0 },
+		"end": { "line": 6, "column": 27 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 18,
-			"line": 8
-		},
 		"message": "A11y: Non-interactive element <dd> cannot have interactive role 'link'",
-		"start": {
-			"column": 0,
-			"line": 8
-		}
+		"start": { "line": 7, "column": 0 },
+		"end": { "line": 7, "column": 18 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 26,
-			"line": 9
-		},
 		"message": "A11y: Non-interactive element <details> cannot have interactive role 'listbox'",
-		"start": {
-			"column": 0,
-			"line": 9
-		}
+		"start": { "line": 8, "column": 0 },
+		"end": { "line": 8, "column": 26 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 19,
-			"line": 10
-		},
 		"message": "A11y: Non-interactive element <dir> cannot have interactive role 'menu'",
-		"start": {
-			"column": 0,
-			"line": 10
-		}
+		"start": { "line": 9, "column": 0 },
+		"end": { "line": 9, "column": 19 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 21,
-			"line": 11
-		},
 		"message": "A11y: Non-interactive element <dl> cannot have interactive role 'menubar'",
-		"start": {
-			"column": 0,
-			"line": 11
-		}
+		"start": { "line": 10, "column": 0 },
+		"end": { "line": 10, "column": 21 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 23,
-			"line": 12
-		},
 		"message": "A11y: Non-interactive element <dfn> cannot have interactive role 'menuitem'",
-		"start": {
-			"column": 0,
-			"line": 12
-		}
+		"start": { "line": 11, "column": 0 },
+		"end": { "line": 11, "column": 23 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 43,
-			"line": 13
-		},
 		"message": "A11y: Non-interactive element <dt> cannot have interactive role 'menuitemcheckbox'",
-		"start": {
-			"column": 0,
-			"line": 13
-		}
+		"start": { "line": 12, "column": 0 },
+		"end": { "line": 12, "column": 43 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 46,
-			"line": 14
-		},
 		"message": "A11y: Non-interactive element <fieldset> cannot have interactive role 'menuitemradio'",
-		"start": {
-			"column": 0,
-			"line": 14
-		}
+		"start": { "line": 13, "column": 0 },
+		"end": { "line": 13, "column": 46 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 50,
-			"line": 16
-		},
 		"message": "A11y: Non-interactive element <figcaption> cannot have interactive role 'menuitemradio'",
-		"start": {
-			"column": 2,
-			"line": 16
-		}
+		"start": { "line": 15, "column": 1 },
+		"end": { "line": 15, "column": 49 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 38,
-			"line": 18
-		},
 		"message": "A11y: Non-interactive element <figure> cannot have interactive role 'option'",
-		"start": {
-			"column": 0,
-			"line": 18
-		}
+		"start": { "line": 17, "column": 0 },
+		"end": { "line": 17, "column": 38 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 36,
-			"line": 19
-		},
 		"message": "A11y: Non-interactive element <footer> cannot have interactive role 'radio'",
-		"start": {
-			"column": 0,
-			"line": 19
-		}
+		"start": { "line": 18, "column": 0 },
+		"end": { "line": 18, "column": 36 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 26,
-			"line": 20
-		},
 		"message": "A11y: Non-interactive element <form> cannot have interactive role 'radiogroup'",
-		"start": {
-			"column": 0,
-			"line": 20
-		}
+		"start": { "line": 19, "column": 0 },
+		"end": { "line": 19, "column": 26 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 32,
-			"line": 22
-		},
 		"message": "A11y: Non-interactive element <h1> cannot have interactive role 'rowheader'",
-		"start": {
-			"column": 0,
-			"line": 22
-		}
+		"start": { "line": 20, "column": 0 },
+		"end": { "line": 20, "column": 32 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 70,
-			"line": 23
-		},
 		"message": "A11y: Non-interactive element <h2> cannot have interactive role 'scrollbar'",
-		"start": {
-			"column": 0,
-			"line": 23
-		}
+		"start": { "line": 21, "column": 0 },
+		"end": { "line": 21, "column": 69 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 32,
-			"line": 24
-		},
 		"message": "A11y: Non-interactive element <h3> cannot have interactive role 'searchbox'",
-		"start": {
-			"column": 0,
-			"line": 24
-		}
+		"start": { "line": 22, "column": 0 },
+		"end": { "line": 22, "column": 32 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 47,
-			"line": 25
-		},
 		"message": "A11y: Non-interactive element <h4> cannot have interactive role 'slider'",
-		"start": {
-			"column": 0,
-			"line": 25
-		}
+		"start": { "line": 23, "column": 0 },
+		"end": { "line": 23, "column": 47 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 33,
-			"line": 26
-		},
 		"message": "A11y: Non-interactive element <h5> cannot have interactive role 'spinbutton'",
-		"start": {
-			"column": 0,
-			"line": 26
-		}
+		"start": { "line": 24, "column": 0 },
+		"end": { "line": 24, "column": 33 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 42,
-			"line": 27
-		},
 		"message": "A11y: Non-interactive element <h6> cannot have interactive role 'switch'",
-		"start": {
-			"column": 0,
-			"line": 27
-		}
+		"start": { "line": 25, "column": 0 },
+		"end": { "line": 25, "column": 42 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 17,
-			"line": 28
-		},
 		"message": "A11y: Non-interactive element <hr> cannot have interactive role 'tab'",
-		"start": {
-			"column": 0,
-			"line": 28
-		}
+		"start": { "line": 26, "column": 0 },
+		"end": { "line": 26, "column": 17 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 38,
-			"line": 29
-		},
 		"message": "A11y: Non-interactive element <img> cannot have interactive role 'tabpanel'",
-		"start": {
-			"column": 0,
-			"line": 29
-		}
+		"start": { "line": 27, "column": 0 },
+		"end": { "line": 27, "column": 38 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 24,
-			"line": 30
-		},
 		"message": "A11y: Non-interactive element <label> cannot have interactive role 'textbox'",
-		"start": {
-			"column": 0,
-			"line": 30
-		}
+		"start": { "line": 28, "column": 0 },
+		"end": { "line": 28, "column": 24 }
 	},
 	{
 		"code": "a11y-label-has-associated-control",
-		"end": {
-			"column": 24,
-			"line": 30
-		},
 		"message": "A11y: A form label must be associated with a control.",
-		"start": {
-			"column": 0,
-			"line": 30
-		}
+		"start": { "line": 28, "column": 0 },
+		"end": { "line": 28, "column": 24 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 25,
-			"line": 31
-		},
 		"message": "A11y: Non-interactive element <legend> cannot have interactive role 'toolbar'",
-		"start": {
-			"column": 0,
-			"line": 31
-		}
+		"start": { "line": 29, "column": 0 },
+		"end": { "line": 29, "column": 25 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 18,
-			"line": 32
-		},
 		"message": "A11y: Non-interactive element <li> cannot have interactive role 'tree'",
-		"start": {
-			"column": 0,
-			"line": 32
-		}
+		"start": { "line": 30, "column": 0 },
+		"end": { "line": 30, "column": 18 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 24,
-			"line": 33
-		},
 		"message": "A11y: Non-interactive element <main> cannot have interactive role 'treegrid'",
-		"start": {
-			"column": 0,
-			"line": 33
-		}
+		"start": { "line": 31, "column": 0 },
+		"end": { "line": 31, "column": 24 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 38,
-			"line": 34
-		},
 		"message": "A11y: Non-interactive element <mark> cannot have interactive role 'treeitem'",
-		"start": {
-			"column": 0,
-			"line": 34
-		}
+		"start": { "line": 32, "column": 0 },
+		"end": { "line": 32, "column": 38 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 31,
-			"line": 35
-		},
 		"message": "A11y: Non-interactive element <marquee> cannot have interactive role 'doc-backlink'",
-		"start": {
-			"column": 0,
-			"line": 35
-		}
+		"start": { "line": 33, "column": 0 },
+		"end": { "line": 33, "column": 31 }
 	},
 	{
 		"code": "a11y-distracting-elements",
-		"end": {
-			"column": 31,
-			"line": 35
-		},
 		"message": "A11y: Avoid <marquee> elements",
-		"start": {
-			"column": 0,
-			"line": 35
-		}
+		"start": { "line": 33, "column": 0 },
+		"end": { "line": 33, "column": 31 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 29,
-			"line": 36
-		},
 		"message": "A11y: Non-interactive element <menu> cannot have interactive role 'doc-biblioref'",
-		"start": {
-			"column": 0,
-			"line": 36
-		}
+		"start": { "line": 34, "column": 0 },
+		"end": { "line": 34, "column": 29 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 29,
-			"line": 37
-		},
 		"message": "A11y: Non-interactive element <meter> cannot have interactive role 'doc-glossref'",
-		"start": {
-			"column": 0,
-			"line": 37
-		}
+		"start": { "line": 35, "column": 0 },
+		"end": { "line": 35, "column": 29 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 26,
-			"line": 38
-		},
 		"message": "A11y: Non-interactive element <nav> cannot have interactive role 'doc-noteref'",
-		"start": {
-			"column": 0,
-			"line": 38
-		}
+		"start": { "line": 36, "column": 0 },
+		"end": { "line": 36, "column": 26 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 20,
-			"line": 39
-		},
 		"message": "A11y: Non-interactive element <ol> cannot have interactive role 'button'",
-		"start": {
-			"column": 0,
-			"line": 39
-		}
+		"start": { "line": 37, "column": 0 },
+		"end": { "line": 37, "column": 20 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 42,
-			"line": 40
-		},
 		"message": "A11y: Non-interactive element <optgroup> cannot have interactive role 'treeitem'",
-		"start": {
-			"column": 0,
-			"line": 40
-		}
+		"start": { "line": 38, "column": 0 },
+		"end": { "line": 38, "column": 42 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 26,
-			"line": 41
-		},
 		"message": "A11y: Non-interactive element <output> cannot have interactive role 'treegrid'",
-		"start": {
-			"column": 0,
-			"line": 41
-		}
+		"start": { "line": 39, "column": 0 },
+		"end": { "line": 39, "column": 26 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 25,
-			"line": 42
-		},
 		"message": "A11y: Non-interactive element <p> cannot have interactive role 'columnheader'",
-		"start": {
-			"column": 0,
-			"line": 42
-		}
+		"start": { "line": 40, "column": 0 },
+		"end": { "line": 40, "column": 25 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 19,
-			"line": 43
-		},
 		"message": "A11y: Non-interactive element <pre> cannot have interactive role 'tree'",
-		"start": {
-			"column": 0,
-			"line": 43
-		}
+		"start": { "line": 41, "column": 0 },
+		"end": { "line": 41, "column": 19 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 61,
-			"line": 44
-		},
 		"message": "A11y: Non-interactive element <progress> cannot have interactive role 'combobox'",
-		"start": {
-			"column": 0,
-			"line": 44
-		}
+		"start": { "line": 42, "column": 0 },
+		"end": { "line": 42, "column": 61 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 23,
-			"line": 45
-		},
 		"message": "A11y: Non-interactive element <ruby> cannot have interactive role 'toolbar'",
-		"start": {
-			"column": 0,
-			"line": 45
-		}
+		"start": { "line": 43, "column": 0 },
+		"end": { "line": 43, "column": 23 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 56,
-			"line": 46
-		},
 		"message": "A11y: Non-interactive element <section> cannot have interactive role 'radio'",
-		"start": {
-			"column": 0,
-			"line": 46
-		}
+		"start": { "line": 44, "column": 0 },
+		"end": { "line": 44, "column": 56 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 21,
-			"line": 47
-		},
 		"message": "A11y: Non-interactive element <table> cannot have interactive role 'menu'",
-		"start": {
-			"column": 0,
-			"line": 47
-		}
+		"start": { "line": 45, "column": 0 },
+		"end": { "line": 45, "column": 21 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 26,
-			"line": 48
-		},
 		"message": "A11y: Non-interactive element <tbody> cannot have interactive role 'searchbox'",
-		"start": {
-			"column": 0,
-			"line": 48
-		}
+		"start": { "line": 46, "column": 0 },
+		"end": { "line": 46, "column": 26 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 24,
-			"line": 50
-		},
 		"message": "A11y: Non-interactive element <tfoot> cannot have interactive role 'listbox'",
-		"start": {
-			"column": 0,
-			"line": 50
-		}
+		"start": { "line": 47, "column": 0 },
+		"end": { "line": 47, "column": 24 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 41,
-			"line": 51
-		},
 		"message": "A11y: Non-interactive element <thead> cannot have interactive role 'slider'",
-		"start": {
-			"column": 0,
-			"line": 51
-		}
+		"start": { "line": 48, "column": 0 },
+		"end": { "line": 48, "column": 41 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 28,
-			"line": 52
-		},
 		"message": "A11y: Non-interactive element <time> cannot have interactive role 'doc-backlink'",
-		"start": {
-			"column": 0,
-			"line": 52
-		}
+		"start": { "line": 49, "column": 0 },
+		"end": { "line": 49, "column": 28 }
 	},
 	{
 		"code": "a11y-no-noninteractive-element-to-interactive-role",
-		"end": {
-			"column": 24,
-			"line": 53
-		},
 		"message": "A11y: Non-interactive element <ul> cannot have interactive role 'spinbutton'",
-		"start": {
-			"column": 0,
-			"line": 53
-		}
+		"start": { "line": 50, "column": 0 },
+		"end": { "line": 50, "column": 24 }
 	}
 ]


### PR DESCRIPTION
closes #8728
Turns out all the removed previous test failures are indeed correct to be removed, according to the test adjustments in https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/937

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
