### PR TITLE
site: alternate footer design

### DIFF
--- a/sites/svelte.dev/src/routes/+layout.svelte
+++ b/sites/svelte.dev/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import { Icon, Shell } from '@sveltejs/site-kit/components';
-	import { Nav, Separator } from '@sveltejs/site-kit/nav';
+	import { Nav } from '@sveltejs/site-kit/nav';
 	import { Search, SearchBox } from '@sveltejs/site-kit/search';
 	import '@sveltejs/site-kit/styles/index.css';
 

--- a/sites/svelte.dev/src/routes/+page.svelte
+++ b/sites/svelte.dev/src/routes/+page.svelte
@@ -61,20 +61,22 @@
 	<footer>
 		<div class="logo">
 		</div>
-		<div>
+		<div class="links">
 			<h4>resources</h4>
 			<a href="/docs">documentation</a>
 			<a href="/tutorial">tutorial</a>
 			<a href="/examples">examples</a>
 			<a href="/blog">blog</a>
 		</div>
-		<div>
+		<div class="links">
 			<h4>connect</h4>
 			<a href="https://github.com/sveltejs/svelte">github</a>
 			<a href="https://opencollective.com/svelte">open collective</a>
 			<a href="/chat">discord</a>
 			<a href="https://twitter.com/sveltejs">twitter</a>
 		</div>
+		<div class="copyright">© 2023 Svelte</div>
+		<div class="open-source">Svelte is <a href="https://github.com/sveltejs/svelte">free and open source software</a> released under the MIT license</div>
 	</footer>
 </section>
 
@@ -99,6 +101,7 @@
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 		grid-template-rows: 1fr;
+		grid-row-gap: 6rem;
 	}
 
 	footer .logo {
@@ -109,7 +112,24 @@
 		filter: grayscale(100%) opacity(84%);
 	}
 
-	@media (min-width: 400px) {
+	footer h4 {
+		font-size: var(--sk-text-m);
+		padding-bottom: 1rem;
+	}
+
+	.links a {
+		color: var(--sk-text-2);
+		font-size: var(--sk-text-s);
+		display: block;
+		line-height: 1.8;
+	}
+
+	.open-source {
+		display: none;
+		grid-column: span 2;
+	}
+
+	@media (min-width: 500px) {
 		footer {
 			grid-template-columns: repeat(3, 1fr);
 		}
@@ -117,17 +137,9 @@
 		footer .logo {
 			display: block;
 		}
-	}
 
-	footer h4 {
-		font-size: var(--sk-text-m);
-		padding-bottom: 1rem;
-	}
-
-	footer a {
-		color: var(--sk-text-2);
-		font-size: var(--sk-text-s);
-		display: block;
-		line-height: 1.8;
+		.open-source {
+			display: block;
+		}
 	}
 </style>

--- a/sites/svelte.dev/src/routes/+page.svelte
+++ b/sites/svelte.dev/src/routes/+page.svelte
@@ -57,39 +57,66 @@
 
 <Supporters />
 
-{#if $theme.current === 'light'}
-	<Image lazy src={CollectiveLight} alt="The Svelte logo in a ball pit" />
-{:else}
-	<Image lazy src={CollectiveDark} alt="The Svelte logo in a ball pit" />
-{/if}
-
-<footer>
-	<a href="/tutorial">Tutorial</a>
-	<a href="/docs">Docs</a>
-	<a href="/examples">Examples</a>
-	<a href="/blog">Blog</a>
-	<a href="https://opencollective.com/svelte">Open Collective</a>
-</footer>
+<section>
+	<footer>
+		<div class="logo">
+		</div>
+		<div>
+			<h4>resources</h4>
+			<a href="/docs">documentation</a>
+			<a href="/tutorial">tutorial</a>
+			<a href="/examples">examples</a>
+			<a href="/blog">blog</a>
+		</div>
+		<div>
+			<h4>connect</h4>
+			<a href="https://github.com/sveltejs/svelte">github</a>
+			<a href="https://opencollective.com/svelte">open collective</a>
+			<a href="/chat">discord</a>
+			<a href="https://twitter.com/sveltejs">twitter</a>
+		</div>
+	</footer>
+</section>
 
 <style>
 	h2 {
 		line-height: 1.05;
 	}
 
+	p {
+		font-size: var(--sk-text-m);
+	}
+
+	section {
+		background: var(--sk-back-4);
+		padding: 10rem 0;
+	}
+
 	footer {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
-		padding: 4rem;
+		max-width: 120rem;
+		padding: 0 var(--sk-page-padding-side);
+		margin: 0 auto;
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		grid-template-rows: 1fr;
+	}
+
+	footer .logo {
+		background: url('@sveltejs/site-kit/branding/svelte-logo.svg');
+		background-repeat: no-repeat;
+		background-size: 8rem;
+		filter: grayscale(100%) opacity(84%);
+	}
+
+	footer h4 {
+		font-size: var(--sk-text-m);
+		padding-bottom: 1rem;
 	}
 
 	footer a {
 		color: var(--sk-text-2);
-		padding: 0.5rem 1rem;
+		font-size: var(--sk-text-s);
 		display: block;
-	}
-
-	p {
-		font-size: var(--sk-text-m);
+		line-height: 1.8;
 	}
 </style>

--- a/sites/svelte.dev/src/routes/+page.svelte
+++ b/sites/svelte.dev/src/routes/+page.svelte
@@ -75,7 +75,7 @@
 			<a href="/chat">discord</a>
 			<a href="https://twitter.com/sveltejs">twitter</a>
 		</div>
-		<div class="copyright">© 2023 Svelte</div>
+		<div class="copyright">© 2023 <a href="https://github.com/sveltejs/svelte/graphs/contributors">Svelte contributors</a></div>
 		<div class="open-source">Svelte is <a href="https://github.com/sveltejs/svelte">free and open source software</a> released under the MIT license</div>
 	</footer>
 </section>

--- a/sites/svelte.dev/src/routes/+page.svelte
+++ b/sites/svelte.dev/src/routes/+page.svelte
@@ -97,15 +97,26 @@
 		padding: 0 var(--sk-page-padding-side);
 		margin: 0 auto;
 		display: grid;
-		grid-template-columns: repeat(3, 1fr);
+		grid-template-columns: repeat(2, 1fr);
 		grid-template-rows: 1fr;
 	}
 
 	footer .logo {
+		display: none;
 		background: url('@sveltejs/site-kit/branding/svelte-logo.svg');
 		background-repeat: no-repeat;
 		background-size: 8rem;
 		filter: grayscale(100%) opacity(84%);
+	}
+
+	@media (min-width: 400px) {
+		footer {
+			grid-template-columns: repeat(3, 1fr);
+		}
+
+		footer .logo {
+			display: block;
+		}
 	}
 
 	footer h4 {

--- a/sites/svelte.dev/src/routes/_components/Supporters/index.svelte
+++ b/sites/svelte.dev/src/routes/_components/Supporters/index.svelte
@@ -6,7 +6,7 @@
 
 <Section --background="var(--sk-back-2">
 	<p class="intro">
-		Svelte is free and open source software, made possible by the work of hundreds of supporters.
+		Svelte is made possible by the work of hundreds of supporters.
 	</p>
 
 	<div class="layout">

--- a/sites/svelte.dev/src/routes/_components/Try.svelte
+++ b/sites/svelte.dev/src/routes/_components/Try.svelte
@@ -70,11 +70,6 @@
 		font-size: var(--sk-text-xl);
 	}
 
-	a {
-		color: inherit;
-		text-decoration: underline;
-	}
-
 	@media (min-width: 900px) {
 		.grid {
 			grid-template-columns: repeat(var(--columns), 1fr);


### PR DESCRIPTION
I wanted to experiment with the footer design. The Svelte balls image is super cool, but has always felt a bit disconnected from the rest of the design to me. I think we should definitely make use of it prominently though. E.g. we should probably switch out the header image on https://twitter.com/sveltejs/ for the Svelte balls.

**master**

![Screenshot from 2023-06-20 22-04-09](https://github.com/sveltejs/svelte/assets/322311/38e5ffbb-b99e-4dcd-803e-bf12372a5d7e)

**this PR**

![Screenshot from 2023-06-20 22-10-56](https://github.com/sveltejs/svelte/assets/322311/67ab8173-b951-4df5-88ab-7d84eafb07c8)
