### PR TITLE
fix: account for sourcemap in meta info

### DIFF
--- a/.changeset/silly-ladybugs-marry.md
+++ b/.changeset/silly-ladybugs-marry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: account for preprocessor source maps when calculating meta info

--- a/.prettierrc
+++ b/.prettierrc
@@ -12,7 +12,7 @@
 			}
 		},
 		{
-			"files": ["README.md", "packages/*/README.md"],
+			"files": ["README.md", "packages/*/README.md", "**/package.json"],
 			"options": {
 				"useTabs": false,
 				"tabWidth": 2

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,136 +1,136 @@
 {
-	"name": "svelte",
-	"version": "4.0.0-next.2",
-	"description": "Cybernetically enhanced web apps",
-	"type": "module",
-	"module": "src/runtime/index.js",
-	"main": "src/runtime/index.js",
-	"files": [
-		"src",
-		"types",
-		"compiler.*",
-		"register.js",
-		"index.d.ts",
-		"store.d.ts",
-		"animate.d.ts",
-		"transition.d.ts",
-		"easing.d.ts",
-		"motion.d.ts",
-		"action.d.ts",
-		"elements.d.ts",
-		"README.md"
-	],
-	"exports": {
-		"./package.json": "./package.json",
-		".": {
-			"types": "./types/index.d.ts",
-			"browser": {
-				"import": "./src/runtime/index.js"
-			},
-			"import": "./src/runtime/ssr.js"
-		},
-		"./compiler": {
-			"types": "./types/index.d.ts",
-			"import": "./src/compiler/index.js",
-			"require": "./compiler.cjs"
-		},
-		"./action": {
-			"types": "./types/index.d.ts"
-		},
-		"./animate": {
-			"types": "./types/index.d.ts",
-			"import": "./src/runtime/animate/index.js"
-		},
-		"./easing": {
-			"types": "./types/index.d.ts",
-			"import": "./src/runtime/easing/index.js"
-		},
-		"./internal": {
-			"import": "./src/runtime/internal/index.js"
-		},
-		"./motion": {
-			"types": "./types/index.d.ts",
-			"import": "./src/runtime/motion/index.js"
-		},
-		"./store": {
-			"types": "./types/index.d.ts",
-			"import": "./src/runtime/store/index.js"
-		},
-		"./transition": {
-			"types": "./types/index.d.ts",
-			"import": "./src/runtime/transition/index.js"
-		},
-		"./elements": {
-			"types": "./elements.d.ts"
-		}
-	},
-	"engines": {
-		"node": ">=16"
-	},
-	"types": "types/index.d.ts",
-	"scripts": {
-		"format": "prettier . --cache --plugin-search-dir=. --write",
-		"check": "prettier . --cache --plugin-search-dir=. --check",
-		"test": "vitest run && echo \"manually check that there are no type errors in test/types by opening the files in there\"",
-		"build": "rollup -c && pnpm types",
-		"generate:version": "node ./scripts/generate-version.js",
-		"dev": "rollup -cw",
-		"posttest": "agadoo src/internal/index.js",
-		"prepublishOnly": "pnpm build",
-		"types": "node ./scripts/generate-dts.js",
-		"lint": "eslint \"{src,test}/**/*.{ts,js}\" --cache"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/sveltejs/svelte.git",
-		"directory": "packages/svelte"
-	},
-	"keywords": [
-		"UI",
-		"framework",
-		"templates",
-		"templating"
-	],
-	"author": "Rich Harris",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/sveltejs/svelte/issues"
-	},
-	"homepage": "https://svelte.dev",
-	"dependencies": {
-		"@ampproject/remapping": "^2.2.1",
-		"@jridgewell/sourcemap-codec": "^1.4.15",
-		"@jridgewell/trace-mapping": "^0.3.18",
-		"acorn": "^8.8.2",
-		"aria-query": "^5.2.1",
-		"axobject-query": "^3.2.1",
-		"code-red": "^1.0.3",
-		"css-tree": "^2.3.1",
-		"estree-walker": "^3.0.3",
-		"is-reference": "^3.0.1",
-		"locate-character": "^3.0.0",
-		"magic-string": "^0.30.0",
-		"periscopic": "^3.1.0"
-	},
-	"devDependencies": {
-		"@playwright/test": "^1.34.3",
-		"@rollup/plugin-commonjs": "^24.1.0",
-		"@rollup/plugin-json": "^6.0.0",
-		"@rollup/plugin-node-resolve": "^15.0.2",
-		"@sveltejs/eslint-config": "^6.0.4",
-		"@types/aria-query": "^5.0.1",
-		"@types/estree": "^1.0.1",
-		"@types/node": "^14.14.31",
-		"agadoo": "^3.0.0",
-		"dts-buddy": "^0.1.7",
-		"esbuild": "^0.17.19",
-		"happy-dom": "^9.18.3",
-		"jsdom": "^21.1.1",
-		"kleur": "^4.1.5",
-		"rollup": "^3.20.2",
-		"source-map": "^0.7.4",
-		"tiny-glob": "^0.2.9",
-		"typescript": "^5.0.4",
-		"vitest": "^0.31.1"
-	}
+  "name": "svelte",
+  "version": "4.0.0-next.2",
+  "description": "Cybernetically enhanced web apps",
+  "type": "module",
+  "module": "src/runtime/index.js",
+  "main": "src/runtime/index.js",
+  "files": [
+    "src",
+    "types",
+    "compiler.*",
+    "register.js",
+    "index.d.ts",
+    "store.d.ts",
+    "animate.d.ts",
+    "transition.d.ts",
+    "easing.d.ts",
+    "motion.d.ts",
+    "action.d.ts",
+    "elements.d.ts",
+    "README.md"
+  ],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./types/index.d.ts",
+      "browser": {
+        "import": "./src/runtime/index.js"
+      },
+      "import": "./src/runtime/ssr.js"
+    },
+    "./compiler": {
+      "types": "./types/index.d.ts",
+      "import": "./src/compiler/index.js",
+      "require": "./compiler.cjs"
+    },
+    "./action": {
+      "types": "./types/index.d.ts"
+    },
+    "./animate": {
+      "types": "./types/index.d.ts",
+      "import": "./src/runtime/animate/index.js"
+    },
+    "./easing": {
+      "types": "./types/index.d.ts",
+      "import": "./src/runtime/easing/index.js"
+    },
+    "./internal": {
+      "import": "./src/runtime/internal/index.js"
+    },
+    "./motion": {
+      "types": "./types/index.d.ts",
+      "import": "./src/runtime/motion/index.js"
+    },
+    "./store": {
+      "types": "./types/index.d.ts",
+      "import": "./src/runtime/store/index.js"
+    },
+    "./transition": {
+      "types": "./types/index.d.ts",
+      "import": "./src/runtime/transition/index.js"
+    },
+    "./elements": {
+      "types": "./elements.d.ts"
+    }
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "types": "types/index.d.ts",
+  "scripts": {
+    "format": "prettier . --cache --plugin-search-dir=. --write",
+    "check": "prettier . --cache --plugin-search-dir=. --check",
+    "test": "vitest run && echo \"manually check that there are no type errors in test/types by opening the files in there\"",
+    "build": "rollup -c && pnpm types",
+    "generate:version": "node ./scripts/generate-version.js",
+    "dev": "rollup -cw",
+    "posttest": "agadoo src/internal/index.js",
+    "prepublishOnly": "pnpm build",
+    "types": "node ./scripts/generate-dts.js",
+    "lint": "eslint \"{src,test}/**/*.{ts,js}\" --cache"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sveltejs/svelte.git",
+    "directory": "packages/svelte"
+  },
+  "keywords": [
+    "UI",
+    "framework",
+    "templates",
+    "templating"
+  ],
+  "author": "Rich Harris",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sveltejs/svelte/issues"
+  },
+  "homepage": "https://svelte.dev",
+  "dependencies": {
+    "@ampproject/remapping": "^2.2.1",
+    "@jridgewell/sourcemap-codec": "^1.4.15",
+    "@jridgewell/trace-mapping": "^0.3.18",
+    "acorn": "^8.8.2",
+    "aria-query": "^5.2.1",
+    "axobject-query": "^3.2.1",
+    "code-red": "^1.0.3",
+    "css-tree": "^2.3.1",
+    "estree-walker": "^3.0.3",
+    "is-reference": "^3.0.1",
+    "locate-character": "^3.0.0",
+    "magic-string": "^0.30.0",
+    "periscopic": "^3.1.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.34.3",
+    "@rollup/plugin-commonjs": "^24.1.0",
+    "@rollup/plugin-json": "^6.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.2",
+    "@sveltejs/eslint-config": "^6.0.4",
+    "@types/aria-query": "^5.0.1",
+    "@types/estree": "^1.0.1",
+    "@types/node": "^14.14.31",
+    "agadoo": "^3.0.0",
+    "dts-buddy": "^0.1.7",
+    "esbuild": "^0.17.19",
+    "happy-dom": "^9.18.3",
+    "jsdom": "^21.1.1",
+    "kleur": "^4.1.5",
+    "rollup": "^3.20.2",
+    "source-map": "^0.7.4",
+    "tiny-glob": "^0.2.9",
+    "typescript": "^5.0.4",
+    "vitest": "^0.31.1"
+  }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,135 +1,136 @@
 {
-  "name": "svelte",
-  "version": "4.0.0-next.2",
-  "description": "Cybernetically enhanced web apps",
-  "type": "module",
-  "module": "src/runtime/index.js",
-  "main": "src/runtime/index.js",
-  "files": [
-    "src",
-    "types",
-    "compiler.*",
-    "register.js",
-    "index.d.ts",
-    "store.d.ts",
-    "animate.d.ts",
-    "transition.d.ts",
-    "easing.d.ts",
-    "motion.d.ts",
-    "action.d.ts",
-    "elements.d.ts",
-    "README.md"
-  ],
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./types/index.d.ts",
-      "browser": {
-        "import": "./src/runtime/index.js"
-      },
-      "import": "./src/runtime/ssr.js"
-    },
-    "./compiler": {
-      "types": "./types/index.d.ts",
-      "import": "./src/compiler/index.js",
-      "require": "./compiler.cjs"
-    },
-    "./action": {
-      "types": "./types/index.d.ts"
-    },
-    "./animate": {
-      "types": "./types/index.d.ts",
-      "import": "./src/runtime/animate/index.js"
-    },
-    "./easing": {
-      "types": "./types/index.d.ts",
-      "import": "./src/runtime/easing/index.js"
-    },
-    "./internal": {
-      "import": "./src/runtime/internal/index.js"
-    },
-    "./motion": {
-      "types": "./types/index.d.ts",
-      "import": "./src/runtime/motion/index.js"
-    },
-    "./store": {
-      "types": "./types/index.d.ts",
-      "import": "./src/runtime/store/index.js"
-    },
-    "./transition": {
-      "types": "./types/index.d.ts",
-      "import": "./src/runtime/transition/index.js"
-    },
-    "./elements": {
-      "types": "./elements.d.ts"
-    }
-  },
-  "engines": {
-    "node": ">=16"
-  },
-  "types": "types/index.d.ts",
-  "scripts": {
-    "format": "prettier . --cache --plugin-search-dir=. --write",
-    "check": "prettier . --cache --plugin-search-dir=. --check",
-    "test": "vitest run && echo \"manually check that there are no type errors in test/types by opening the files in there\"",
-    "build": "rollup -c && pnpm types",
-    "generate:version": "node ./scripts/generate-version.js",
-    "dev": "rollup -cw",
-    "posttest": "agadoo src/internal/index.js",
-    "prepublishOnly": "pnpm build",
-    "types": "node ./scripts/generate-dts.js",
-    "lint": "eslint \"{src,test}/**/*.{ts,js}\" --cache"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sveltejs/svelte.git",
-    "directory": "packages/svelte"
-  },
-  "keywords": [
-    "UI",
-    "framework",
-    "templates",
-    "templating"
-  ],
-  "author": "Rich Harris",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/sveltejs/svelte/issues"
-  },
-  "homepage": "https://svelte.dev",
-  "dependencies": {
-    "@ampproject/remapping": "^2.2.1",
-    "@jridgewell/sourcemap-codec": "^1.4.15",
-    "acorn": "^8.8.2",
-    "aria-query": "^5.2.1",
-    "axobject-query": "^3.2.1",
-    "code-red": "^1.0.3",
-    "css-tree": "^2.3.1",
-    "estree-walker": "^3.0.3",
-    "is-reference": "^3.0.1",
-    "locate-character": "^3.0.0",
-    "magic-string": "^0.30.0",
-    "periscopic": "^3.1.0"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.34.3",
-    "@rollup/plugin-commonjs": "^24.1.0",
-    "@rollup/plugin-json": "^6.0.0",
-    "@rollup/plugin-node-resolve": "^15.0.2",
-    "@sveltejs/eslint-config": "^6.0.4",
-    "@types/aria-query": "^5.0.1",
-    "@types/estree": "^1.0.1",
-    "@types/node": "^14.14.31",
-    "agadoo": "^3.0.0",
-    "dts-buddy": "^0.1.7",
-    "esbuild": "^0.17.19",
-    "happy-dom": "^9.18.3",
-    "jsdom": "^21.1.1",
-    "kleur": "^4.1.5",
-    "rollup": "^3.20.2",
-    "source-map": "^0.7.4",
-    "tiny-glob": "^0.2.9",
-    "typescript": "^5.0.4",
-    "vitest": "^0.31.1"
-  }
+	"name": "svelte",
+	"version": "4.0.0-next.2",
+	"description": "Cybernetically enhanced web apps",
+	"type": "module",
+	"module": "src/runtime/index.js",
+	"main": "src/runtime/index.js",
+	"files": [
+		"src",
+		"types",
+		"compiler.*",
+		"register.js",
+		"index.d.ts",
+		"store.d.ts",
+		"animate.d.ts",
+		"transition.d.ts",
+		"easing.d.ts",
+		"motion.d.ts",
+		"action.d.ts",
+		"elements.d.ts",
+		"README.md"
+	],
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./types/index.d.ts",
+			"browser": {
+				"import": "./src/runtime/index.js"
+			},
+			"import": "./src/runtime/ssr.js"
+		},
+		"./compiler": {
+			"types": "./types/index.d.ts",
+			"import": "./src/compiler/index.js",
+			"require": "./compiler.cjs"
+		},
+		"./action": {
+			"types": "./types/index.d.ts"
+		},
+		"./animate": {
+			"types": "./types/index.d.ts",
+			"import": "./src/runtime/animate/index.js"
+		},
+		"./easing": {
+			"types": "./types/index.d.ts",
+			"import": "./src/runtime/easing/index.js"
+		},
+		"./internal": {
+			"import": "./src/runtime/internal/index.js"
+		},
+		"./motion": {
+			"types": "./types/index.d.ts",
+			"import": "./src/runtime/motion/index.js"
+		},
+		"./store": {
+			"types": "./types/index.d.ts",
+			"import": "./src/runtime/store/index.js"
+		},
+		"./transition": {
+			"types": "./types/index.d.ts",
+			"import": "./src/runtime/transition/index.js"
+		},
+		"./elements": {
+			"types": "./elements.d.ts"
+		}
+	},
+	"engines": {
+		"node": ">=16"
+	},
+	"types": "types/index.d.ts",
+	"scripts": {
+		"format": "prettier . --cache --plugin-search-dir=. --write",
+		"check": "prettier . --cache --plugin-search-dir=. --check",
+		"test": "vitest run && echo \"manually check that there are no type errors in test/types by opening the files in there\"",
+		"build": "rollup -c && pnpm types",
+		"generate:version": "node ./scripts/generate-version.js",
+		"dev": "rollup -cw",
+		"posttest": "agadoo src/internal/index.js",
+		"prepublishOnly": "pnpm build",
+		"types": "node ./scripts/generate-dts.js",
+		"lint": "eslint \"{src,test}/**/*.{ts,js}\" --cache"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sveltejs/svelte.git",
+		"directory": "packages/svelte"
+	},
+	"keywords": [
+		"UI",
+		"framework",
+		"templates",
+		"templating"
+	],
+	"author": "Rich Harris",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/sveltejs/svelte/issues"
+	},
+	"homepage": "https://svelte.dev",
+	"dependencies": {
+		"@ampproject/remapping": "^2.2.1",
+		"@jridgewell/sourcemap-codec": "^1.4.15",
+		"@jridgewell/trace-mapping": "^0.3.18",
+		"acorn": "^8.8.2",
+		"aria-query": "^5.2.1",
+		"axobject-query": "^3.2.1",
+		"code-red": "^1.0.3",
+		"css-tree": "^2.3.1",
+		"estree-walker": "^3.0.3",
+		"is-reference": "^3.0.1",
+		"locate-character": "^3.0.0",
+		"magic-string": "^0.30.0",
+		"periscopic": "^3.1.0"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.34.3",
+		"@rollup/plugin-commonjs": "^24.1.0",
+		"@rollup/plugin-json": "^6.0.0",
+		"@rollup/plugin-node-resolve": "^15.0.2",
+		"@sveltejs/eslint-config": "^6.0.4",
+		"@types/aria-query": "^5.0.1",
+		"@types/estree": "^1.0.1",
+		"@types/node": "^14.14.31",
+		"agadoo": "^3.0.0",
+		"dts-buddy": "^0.1.7",
+		"esbuild": "^0.17.19",
+		"happy-dom": "^9.18.3",
+		"jsdom": "^21.1.1",
+		"kleur": "^4.1.5",
+		"rollup": "^3.20.2",
+		"source-map": "^0.7.4",
+		"tiny-glob": "^0.2.9",
+		"typescript": "^5.0.4",
+		"vitest": "^0.31.1"
+	}
 }

--- a/packages/svelte/src/compiler/compile/Component.js
+++ b/packages/svelte/src/compiler/compile/Component.js
@@ -144,13 +144,15 @@ export default class Component {
 	file;
 
 	/**
-	 * Use this for source mappings. Use `meta_locate` for the meta data on the dom elements.
+	 * Use this for stack traces. It is 1-based and acts on pre-processed sources.
+	 * Use `meta_locate` for metadata on DOM elements.
 	 * @type {(c: number) => { line: number; column: number }}
 	 */
 	locate;
 
 	/**
-	 * Use this for the meta data on the dom elements. Use `locate` for source mappings.
+	 * Use this for metadata on DOM elements. It is 1-based and acts on sources that have not been pre-processed.
+	 * Use `locate` for source mappings.
 	 * @type {(c: number) => { line: number; column: number }}
 	 */
 	meta_locate;

--- a/packages/svelte/src/compiler/compile/Component.js
+++ b/packages/svelte/src/compiler/compile/Component.js
@@ -214,11 +214,15 @@ export default class Component {
 
 		// line numbers in stack trace frames are 1-based. source maps are 0-based
 		this.locate = getLocator(this.source, { offsetLine: 1 });
-		// @ts-expect-error - fix the type of CompileOptions.sourcemap
-		const tracer = compile_options.sourcemap ? new TraceMap(compile_options.sourcemap) : undefined;
+		/** @type {TraceMap | null | undefined} initialise lazy because only used in dev mode */
+		let tracer;
 		this.meta_locate = (c) => {
 			/** @type {{ line: number, column: number }} */
 			let location = this.locate(c);
+			if (tracer === undefined) {
+				// @ts-expect-error - fix the type of CompileOptions.sourcemap
+				tracer = compile_options.sourcemap ? new TraceMap(compile_options.sourcemap) : null;
+			}
 			if (tracer) {
 				// originalPositionFor returns 1-based lines like locator
 				location = originalPositionFor(tracer, location);

--- a/packages/svelte/src/compiler/compile/render_dom/Renderer.js
+++ b/packages/svelte/src/compiler/compile/render_dom/Renderer.js
@@ -62,10 +62,18 @@ export default class Renderer {
 	/** @type {import('estree').Identifier} */
 	file_var;
 
-	/** @type {(c: number) => { line: number; column: number }} */
+	/**
+	 * Use this for stack traces. It is 1-based and acts on pre-processed sources.
+	 * Use `meta_locate` for metadata on DOM elements.
+	 * @type {(c: number) => { line: number; column: number }}
+	 */
 	locate;
 
-	/** @type {(c: number) => { line: number; column: number }} */
+	/**
+	 * Use this for metadata on DOM elements. It is 1-based and acts on sources that have not been pre-processed.
+	 * Use `locate` for source mappings.
+	 * @type {(c: number) => { line: number; column: number }}
+	 */
 	meta_locate;
 
 	/**

--- a/packages/svelte/src/compiler/compile/render_dom/Renderer.js
+++ b/packages/svelte/src/compiler/compile/render_dom/Renderer.js
@@ -65,6 +65,9 @@ export default class Renderer {
 	/** @type {(c: number) => { line: number; column: number }} */
 	locate;
 
+	/** @type {(c: number) => { line: number; column: number }} */
+	meta_locate;
+
 	/**
 	 * @param {import('../Component.js').default} component
 	 * @param {import('../../interfaces.js').CompileOptions} options
@@ -73,6 +76,7 @@ export default class Renderer {
 		this.component = component;
 		this.options = options;
 		this.locate = component.locate; // TODO messy
+		this.meta_locate = component.meta_locate; // TODO messy
 		this.file_var = options.dev && this.component.get_unique_name('file');
 		component.vars
 			.filter((v) => !v.hoistable || (v.export_name && !v.module))

--- a/packages/svelte/src/compiler/compile/render_dom/wrappers/Element/index.js
+++ b/packages/svelte/src/compiler/compile/render_dom/wrappers/Element/index.js
@@ -588,6 +588,8 @@ export default class ElementWrapper extends Wrapper {
 			const loc = renderer.meta_locate(this.node.start);
 			block.chunks.hydrate.push(
 				b`@add_location(${this.var}, ${renderer.file_var}, ${loc.line - 1}, ${loc.column}, ${
+					// TODO this.node.start isn't correct if there's a source map. But since we don't know how the
+					// original source file looked, there's not much we can do.
 					this.node.start
 				});`
 			);

--- a/packages/svelte/src/compiler/compile/render_dom/wrappers/Element/index.js
+++ b/packages/svelte/src/compiler/compile/render_dom/wrappers/Element/index.js
@@ -585,7 +585,7 @@ export default class ElementWrapper extends Wrapper {
 			);
 		}
 		if (renderer.options.dev) {
-			const loc = renderer.locate(this.node.start);
+			const loc = renderer.meta_locate(this.node.start);
 			block.chunks.hydrate.push(
 				b`@add_location(${this.var}, ${renderer.file_var}, ${loc.line - 1}, ${loc.column}, ${
 					this.node.start

--- a/packages/svelte/test/runtime/samples/element-source-location-preprocessed/_config.js
+++ b/packages/svelte/test/runtime/samples/element-source-location-preprocessed/_config.js
@@ -27,7 +27,7 @@ export default {
 			file: path.relative(process.cwd(), path.resolve(__dirname, 'main.svelte')),
 			line: 5, // line 4 in main.svelte, but that's the preprocessed code, the original code is above in the fake preprocessor
 			column: 1, // line 0 in main.svelte, but that's the preprocessed code, the original code is above in the fake preprocessor
-			char: 38 // TODO this is wrong but we can't backtrace it due to limitations, see meta_locate function comment for more info
+			char: 38 // TODO this is wrong but we can't backtrace it due to limitations, see add_location function usage comment for more info
 		});
 	}
 };

--- a/packages/svelte/test/runtime/samples/element-source-location-preprocessed/_config.js
+++ b/packages/svelte/test/runtime/samples/element-source-location-preprocessed/_config.js
@@ -1,0 +1,33 @@
+import MagicString from 'magic-string';
+import * as path from 'node:path';
+
+// fake preprocessor by doing transforms on the source
+const str = new MagicString(
+	`<script>
+type Foo = 'foo';
+let foo = 'foo';
+</script>
+
+ <h1>{foo}</h1>
+`.replace(/\r\n/g, '\n')
+);
+str.remove(8, 26); // remove line type Foo = ...
+str.remove(55, 56); // remove whitespace before <h1>
+
+export default {
+	compileOptions: {
+		dev: true,
+		sourcemap: str.generateMap({ hires: true })
+	},
+
+	test({ assert, target }) {
+		const h1 = target.querySelector('h1');
+
+		assert.deepEqual(h1.__svelte_meta.loc, {
+			file: path.relative(process.cwd(), path.resolve(__dirname, 'main.svelte')),
+			line: 5, // line 4 in main.svelte, but that's the preprocessed code, the original code is above in the fake preprocessor
+			column: 1, // line 0 in main.svelte, but that's the preprocessed code, the original code is above in the fake preprocessor
+			char: 38 // TODO this is wrong but we can't backtrace it due to limitations, see meta_locate function comment for more info
+		});
+	}
+};

--- a/packages/svelte/test/runtime/samples/element-source-location-preprocessed/main.svelte
+++ b/packages/svelte/test/runtime/samples/element-source-location-preprocessed/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	let foo = 'foo';
+</script>
+
+<h1>{foo}</h1>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.4.15
         version: 1.4.15
+      '@jridgewell/trace-mapping':
+        specifier: ^0.3.18
+        version: 0.3.18
       acorn:
         specifier: ^8.8.2
         version: 8.8.2


### PR DESCRIPTION
We need to use a different method for getting the meta info because `locate` is used to help construct the source map that references the preprocessed Svelte file. If we would now add source maps to that `locate` function it would go the the original source directly which means skipping potentially intermediate source maps which we would need in other situations.

Also adds a new dependency, cc @benmccann that might affect the blog post

fixes #8360
closes #8362

TODO:
- [x] think one more time if there really isn't a way to reuse the other stuff (_didn't find a better way_)
- [ ] needs to also convert the character (_update: limitation we can't solve, noted in a TODO_)
- [x] tests

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
