### PR TITLE
chore: deindent cjs output for compiler

### DIFF
--- a/.changeset/smart-kangaroos-tell.md
+++ b/.changeset/smart-kangaroos-tell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: deindent cjs output for compiler

--- a/packages/svelte/rollup.config.js
+++ b/packages/svelte/rollup.config.js
@@ -42,7 +42,8 @@ export default [
 			file: 'compiler.cjs',
 			format: 'umd',
 			name: 'svelte',
-			sourcemap: false
+			sourcemap: false,
+			indent: false,
 		},
 		external: []
 	}

--- a/packages/svelte/rollup.config.js
+++ b/packages/svelte/rollup.config.js
@@ -43,7 +43,7 @@ export default [
 			format: 'umd',
 			name: 'svelte',
 			sourcemap: false,
-			indent: false,
+			indent: false
 		},
 		external: []
 	}


### PR DESCRIPTION
Removes a level of indentation inside the UMD wrapper. It's not much but -40KiB unpacked and about -6KiB gzipped (lol)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
