### PR TITLE
chore: Remove the need for `node:process`

### DIFF
--- a/packages/svelte/src/compiler/Stats.js
+++ b/packages/svelte/src/compiler/Stats.js
@@ -1,10 +1,4 @@
-const now =
-	typeof process !== 'undefined' && process.hrtime
-		? () => {
-				const t = process.hrtime();
-				return t[0] * 1e3 + t[1] / 1e6;
-		  }
-		: () => self.performance.now();
+const now = () => performance.now();
 
 /** @param {any} timings */
 function collapse_timings(timings) {


### PR DESCRIPTION
By replacing conditional logic with `performance.now()`, this patch ensures improved compatibility across other environments. It avoids unnecessary polyfills triggered by seeing global `process` being used in code by other bundlers/CDN that don't know if they are optional or not, leading to cleaner code.

`performance.now()` exist in all env.