### PR TITLE
feat: add a way to compile from an AST

### DIFF
--- a/packages/svelte/src/compiler/compile/index.js
+++ b/packages/svelte/src/compiler/compile/index.js
@@ -120,6 +120,42 @@ function validate_options(options, warnings) {
 }
 
 /**
+ * `compileAST` takes your component AST, and turns it into a JavaScript module that exports a class.
+ *
+ * @param {object} ast
+ * @param {import('../interfaces.js').CompileOptions} options
+ */
+export function compileAST(ast, options = {}) {
+	options = Object.assign(
+		{ generate: 'dom', dev: false, enableSourcemap: true, css: 'injected' },
+		options
+	);
+	const stats = new Stats();
+	const warnings = [];
+	validate_options(options, warnings);
+	stats.start('parse');
+	stats.stop('parse');
+	stats.start('create component');
+	const component = new Component(
+		ast,
+		null,
+		options.name || get_name_from_filename(options.filename) || 'Component',
+		options,
+		stats,
+		warnings
+	);
+	stats.stop('create component');
+	const result =
+		options.generate === false
+			? null
+			: options.generate === 'ssr'
+			? render_ssr(component, options)
+			: render_dom(component, options);
+	return component.generate(result);
+}
+
+
+/**
  * `compile` takes your component source code, and turns it into a JavaScript module that exports a class.
  *
  * https://svelte.dev/docs/svelte-compiler#svelte-compile

--- a/packages/svelte/src/compiler/compile/index.js
+++ b/packages/svelte/src/compiler/compile/index.js
@@ -133,8 +133,6 @@ export function compileAST(ast, options = {}) {
 	const stats = new Stats();
 	const warnings = [];
 	validate_options(options, warnings);
-	stats.start('parse');
-	stats.stop('parse');
 	stats.start('create component');
 	const component = new Component(
 		ast,

--- a/packages/svelte/src/compiler/compile/index.js
+++ b/packages/svelte/src/compiler/compile/index.js
@@ -122,7 +122,7 @@ function validate_options(options, warnings) {
 /**
  * `compileAST` takes your component AST, and turns it into a JavaScript module that exports a class.
  *
- * @param {object} ast
+ * @param {import('../interfaces.js').Ast} ast
  * @param {import('../interfaces.js').CompileOptions} options
  */
 export function compileAST(ast, options = {}) {

--- a/packages/svelte/src/compiler/compile/index.js
+++ b/packages/svelte/src/compiler/compile/index.js
@@ -152,7 +152,6 @@ export function compileAST(ast, options = {}) {
 	return component.generate(result);
 }
 
-
 /**
  * `compile` takes your component source code, and turns it into a JavaScript module that exports a class.
  *


### PR DESCRIPTION
Allows the developer to compile directly from an AST, returned previously from `svelte.parse`.

There is currently no way to compile a modified AST to source code, this adds a function, `compileAST`, that provides that functionality.

Notes:
- The second argument to `new Component` is currently set to null, this might break something, but for our purposes seems to be working.
- `@param {object}` could be typed better.
- `compile` could call `compileAST` underneath so we don't have to copy/paste code.

Hopefully someone has useful feedback!