### PR TITLE
docs: fix white text on white BG in examples(docs)

### DIFF
--- a/documentation/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
+++ b/documentation/tutorial/04-logic/05-keyed-each-blocks/app-a/Thing.svelte
@@ -34,6 +34,7 @@
 		padding: 0.2em 1em 0.3em;
 		text-align: center;
 		border-radius: 0.2em;
+		color:#333333;
 		background-color: #ffdfd3;
 	}
 </style>

--- a/documentation/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
+++ b/documentation/tutorial/04-logic/05-keyed-each-blocks/app-b/Thing.svelte
@@ -34,6 +34,7 @@
 		padding: 0.2em 1em 0.3em;
 		text-align: center;
 		border-radius: 0.2em;
+		color:#333333;
 		background-color: #ffdfd3;
 	}
 </style>


### PR DESCRIPTION
### What does this PR do

Fixes of white text on white bg in examples [Docs](https://svelte.dev/tutorial/keyed-each-blocks)

Color changed from white to black (#333333).

Issue Number : #8816 