### PR TITLE
docs: Don't recommend TypeScript type assertions for reactive declarations

### DIFF
--- a/documentation/docs/05-misc/03-typescript.md
+++ b/documentation/docs/05-misc/03-typescript.md
@@ -176,13 +176,11 @@ You cannot type your reactive declarations with TypeScript in the way you type a
 </script>
 ```
 
-You cannot add a `: TYPE` because it's invalid syntax in this position. Instead, you can use the `as` or move the definition to a `let` statement just above:
+You cannot add a `: TYPE` because it's invalid syntax in this position. Instead, you can move the definition to a `let` statement just above:
 
 ```svelte
 <script lang="ts">
 	let count = 0;
-
-	$: option1 = (count * 2) as number;
 
 	let option2: number;
 	$: option2 = count * 2;

--- a/documentation/docs/05-misc/03-typescript.md
+++ b/documentation/docs/05-misc/03-typescript.md
@@ -182,8 +182,8 @@ You cannot add a `: TYPE` because it's invalid syntax in this position. Instead,
 <script lang="ts">
 	let count = 0;
 
-	let option2: number;
-	$: option2 = count * 2;
+	let doubled: number;
+	$: doubled = count * 2;
 </script>
 ```
 


### PR DESCRIPTION
The docs currently recommend using type assertions with `as` as a means of assigning types to reactive declarations in lieu of being able to add type annotations directly. 

Given the docs are suggesting the alternative to using type annotations, to me it makes sense to only recommend the type annotation approach using `let variable: Type`.

Generally speaking it's also good practice to use type annotations over assertions where possible as well, as assertions provide weaker type checking.

For example:
```ts
type Person = {
	firstName: string;
	lastName: string;
}

let person1: Person = {
	firstName: 'Erlich',
	lastName: 'Bachman',
	occupation: 'Chief Evangelist Officer',
//  ^❌ Type '{ firstName: string; lastName: string; occupation: string; }' is not assignable to type 'Person'. Object literal may only specify known properties, and 'occupation' does not exist in type 'Person'.ts(2322)
};

let person2 = {
	firstName: 'Erlich',
	lastName: 'Bachman',
	occupation: 'Chief Evangelist Officer',
//  ^✅ No error detected despite not being a property of `Person`
} as Person;
```
