### PR TITLE
fix: warning in examples events section

### DIFF
--- a/documentation/examples/04-events/00-dom-events/App.svelte
+++ b/documentation/examples/04-events/00-dom-events/App.svelte
@@ -7,7 +7,7 @@
 	}
 </script>
 
-<div on:mousemove={handleMousemove}>
+<div on:mousemove={handleMousemove} role='button' tabindex='0'>
 	The mouse position is {m.x} x {m.y}
 </div>
 


### PR DESCRIPTION
### What does this PR do

Fixes warning in examples tab dom events section.

![image](https://github.com/sveltejs/svelte/assets/88965204/691c6823-0ef6-4778-8dbc-be8db1718528)
