### PR TITLE
docs: Add a missing 't' to 'forgo'

### DIFF
--- a/documentation/docs/04-compiler-and-api/04-custom-elements-api.md
+++ b/documentation/docs/04-compiler-and-api/04-custom-elements-api.md
@@ -57,7 +57,7 @@ el.name = 'everybody';
 
 ## Component options
 
-When constructing a custom element, you can tailor several aspects by defining `customElement` as an object within `<svelte:options>` since Svelte 4. This object comprises a mandatory `tag` property for the custom element's name, an optional `shadow` property that can be set to `"none"` to forgo shadow root creation (note that styles are then no longer encapsulated, and you can't use slots), and a `props` option, which offers the following settings:
+When constructing a custom element, you can tailor several aspects by defining `customElement` as an object within `<svelte:options>` since Svelte 4. This object comprises a mandatory `tag` property for the custom element's name, an optional `shadow` property that can be set to `"none"` to forgot shadow root creation (note that styles are then no longer encapsulated, and you can't use slots), and a `props` option, which offers the following settings:
 
 - `attribute: string`: To update a custom element's prop, you have two alternatives: either set the property on the custom element's reference as illustrated above or use an HTML attribute. For the latter, the default attribute name is the lowercase property name. Modify this by assigning `attribute: "<desired name>"`.
 - `reflect: boolean`: By default, updated prop values do not reflect back to the DOM. To enable this behavior, set `reflect: true`.


### PR DESCRIPTION
I noticed a typo in the body of [the Component options section of the Custom elements API page](https://svelte.dev/docs/custom-elements-api#component-options):
![Typo Example](https://github.com/sveltejs/svelte/assets/22640284/821666a1-90e0-4b35-a5ce-440320464275)

This PR only fixes this by adding the missing 't' at the end of the 'forgo'.

![Unnecessary Meme](https://github.com/sveltejs/svelte/assets/22640284/28506140-ada5-46fe-acff-c6a8f9d1c125)
