### PR TITLE
docs: Fix TypeScript event name typos

### DIFF
--- a/documentation/docs/05-misc/03-typescript.md
+++ b/documentation/docs/05-misc/03-typescript.md
@@ -102,12 +102,12 @@ Events can be typed with `createEventDispatcher`:
 	}>();
 
 	function handleClick() {
-		dispatch('even');
+		dispatch('event');
 		dispatch('click', 'hello');
 	}
 
 	function handleType() {
-		dispatch('even');
+		dispatch('event');
 		dispatch('type', Math.random() > 0.5 ? 'world' : null);
 	}
 </script>


### PR DESCRIPTION
The dispatched event name should match the type declaration.