### PR TITLE
docs: fix link to changelog

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -27,7 +27,7 @@ See [the SvelteKit documentation](https://kit.svelte.dev/docs) to learn more.
 
 ## Changelog
 
-[The Changelog for this package is available on GitHub](https://github.com/sveltejs/kit/blob/master/packages/kit/CHANGELOG.md).
+[The Changelog for this package is available on GitHub](https://github.com/sveltejs/svelte/blob/master/packages/svelte/CHANGELOG.md).
 
 ## Supporting Svelte
 


### PR DESCRIPTION
Minor DX feedback. When looking for the link to the changelog in the `svelte` [README](https://www.npmjs.com/package/svelte), I was not expecting it to direct to the changelog for SvelteKit.

I think this is a typo since the [link for SvelteKit](https://www.npmjs.com/package/@sveltejs/kit) points to the same location.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
