### PR TITLE
fix: change Typescript to JSDoc in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To watch for changes and continually rebuild the package (this is useful if you'
 pnpm dev
 ```
 
-The compiler is written in JavaScript with JSDoc.
+The compiler is written in JavaScript and uses [JSDoc](https://jsdoc.app/index.html) comments for type-checking.
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To watch for changes and continually rebuild the package (this is useful if you'
 pnpm dev
 ```
 
-The compiler is written in [TypeScript](https://www.typescriptlang.org/), but don't let that put you off — it's basically just JavaScript with type annotations. You'll pick it up in no time. If you're using an editor other than [Visual Studio Code](https://code.visualstudio.com/), you may need to install a plugin in order to get syntax highlighting and code hints, etc.
+The compiler is written in JavaScript with JSDoc.
 
 ### Running Tests
 


### PR DESCRIPTION
I’ve changed the readme so that it no longer says that the compiler uses Typescript, but JS with JSDoc.