### PR TITLE
chore: adding default for disclose version

### DIFF
--- a/.changeset/proud-cycles-hunt.md
+++ b/.changeset/proud-cycles-hunt.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Align disclose-version exports specification
+fix: align `disclose-version` exports specification

--- a/.changeset/proud-cycles-hunt.md
+++ b/.changeset/proud-cycles-hunt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Align disclose-version exports specification

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -58,7 +58,8 @@
       "default": "./src/runtime/store/index.js"
     },
     "./internal/disclose-version": {
-      "import": "./src/runtime/internal/disclose-version/index.js"
+      "import": "./src/runtime/internal/disclose-version/index.js",
+      "default": "./src/runtime/internal/disclose-version/index.js"
     },
     "./transition": {
       "types": "./types/index.d.ts",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -58,7 +58,6 @@
       "default": "./src/runtime/store/index.js"
     },
     "./internal/disclose-version": {
-      "import": "./src/runtime/internal/disclose-version/index.js",
       "default": "./src/runtime/internal/disclose-version/index.js"
     },
     "./transition": {


### PR DESCRIPTION
### Description

This PR allows the built-in nodejs resolver (18.x) to lookup `internal/disclose-version`, otherwise it yields:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './internal/disclose-version' is not defined by "exports" in /Users/lab/Projects/plasmo/examples/with-svelte/node_modules/svelte/package.json
```

The call looks like this:

```
const filePath = require.resolve("svelte/internal", {
        paths: [""]
})

```

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
