### PR TITLE
docs(tutorial): fix syntax err in composition slot prop app-a

### DIFF
--- a/documentation/tutorial/14-composition/05-slot-props/app-a/App.svelte
+++ b/documentation/tutorial/14-composition/05-slot-props/app-a/App.svelte
@@ -1,5 +1,6 @@
 <script>
 	import Hoverable from './Hoverable.svelte';
+	let hovering = false;
 </script>
 
 <Hoverable>

--- a/documentation/tutorial/14-composition/05-slot-props/app-a/Hoverable.svelte
+++ b/documentation/tutorial/14-composition/05-slot-props/app-a/Hoverable.svelte
@@ -10,6 +10,6 @@
 	}
 </script>
 
-<div on:mouseenter={enter} on:mouseleave={leave}>
+<div on:mouseenter={enter} on:mouseleave={leave} role="banner">
 	<slot />
 </div>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Description 
doc for composition - slot prop (app a) contain error, so it is not rendering in [tutorial section](https://svelte.dev/tutorial/slot-props) 