### PR TITLE
docs: Remove old redundant text

### DIFF
--- a/documentation/tutorial/05-events/02-inline-handlers/text.md
+++ b/documentation/tutorial/05-events/02-inline-handlers/text.md
@@ -10,6 +10,4 @@ You can also declare event handlers inline:
 </div>
 ```
 
-The quote marks are optional, but they're helpful for syntax highlighting in some environments.
-
 > In some frameworks you may see recommendations to avoid inline event handlers for performance reasons, particularly inside loops. That advice doesn't apply to Svelte — the compiler will always do the right thing, whichever form you choose.


### PR DESCRIPTION
The quote marks were removed in db2d07f2360191b68022ba3e64a86401edd15296

![Screenshot_20230702_174046](https://github.com/sveltejs/svelte/assets/911799/85d03b50-ad3b-4d63-ae87-cc400b10aeb0)

If they aren't coming back, then this text is out-of-date and confusing.