### PR TITLE
fix: transition slide not smooth with min height and min width

### DIFF
--- a/packages/svelte/src/runtime/transition/index.js
+++ b/packages/svelte/src/runtime/transition/index.js
@@ -84,6 +84,7 @@ export function slide(node, { delay = 0, duration = 400, easing = cubicOut, axis
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
 	const primary_property = axis === 'y' ? 'height' : 'width';
+	const min_primary_property = `min-${primary_property}`;
 	const primary_property_value = parseFloat(style[primary_property]);
 	const secondary_properties = axis === 'y' ? ['top', 'bottom'] : ['left', 'right'];
 	const capitalized_secondary_properties = secondary_properties.map(
@@ -107,6 +108,7 @@ export function slide(node, { delay = 0, duration = 400, easing = cubicOut, axis
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
 			`${primary_property}: ${t * primary_property_value}px;` +
+			`${min_primary_property}: 0;` +
 			`padding-${secondary_properties[0]}: ${t * padding_start_value}px;` +
 			`padding-${secondary_properties[1]}: ${t * padding_end_value}px;` +
 			`margin-${secondary_properties[0]}: ${t * margin_start_value}px;` +

--- a/packages/svelte/test/runtime/samples/class-shortcut-with-transition/_config.js
+++ b/packages/svelte/test/runtime/samples/class-shortcut-with-transition/_config.js
@@ -16,7 +16,7 @@ export default {
 		raf.tick(150);
 		assert.htmlEqual(
 			target.innerHTML,
-			'<p>foo</p><p class="red svelte-1yszte8 border" style="animation: __svelte_1333973250_0 100ms linear 0ms 1 both;">bar</p>'
+			'<p>foo</p><p class="red svelte-1yszte8 border" style="animation: __svelte_567626776_0 100ms linear 0ms 1 both;">bar</p>'
 		);
 
 		component.open = true;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`

closes: #8533

transition slide will become not smooth with min-height and min-width.
https://svelte.dev/repl/90fdf9a3faa645aaa1e18201cf29e9cf?version=4.0.3


transition slide not smooth when with min height or min width.

I think we can set `min-height` or `min-width` to be 0 to keep slide smooth when run animation.

I didn't add a test case because I don't know how to test this case.

I'd be happy to add test cases, if any suggestions can be given.

