### PR TITLE
Hint matches existing structure and solution

### DIFF
--- a/documentation/tutorial/10-transitions/09-key-blocks/text.md
+++ b/documentation/tutorial/10-transitions/09-key-blocks/text.md
@@ -5,8 +5,10 @@ title: Key blocks
 Key blocks destroy and recreate their contents when the value of an expression changes.
 
 ```svelte
-{#key value}
-	<div transition:fade>{value}</div>
+{#key number}
+  <span style="display: inline-block" in:fade>
+    {number}
+  </span>
 {/key}
 ```
 


### PR DESCRIPTION
In the discussion there's a hint-- a bit of code that, when added to the existing code, gives the solution to the problem. The bit of code in the hint does not match the pre-existing code or the solution in these ways: 1) different variable name-- number vs. value
2) what transition to use
3) whether to use  the transition attribute or the in attribute I have just changed the markup so that the suggested code matches what needs to be added to most quickly arrive at the solution. Otherwise the learner has to also fix/grapple with these other differences.


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
