### PR TITLE
docs: fix contrast for component-binding example

### DIFF
--- a/documentation/examples/05-bindings/12-component-bindings/App.svelte
+++ b/documentation/examples/05-bindings/12-component-bindings/App.svelte
@@ -9,6 +9,21 @@
 	}
 </script>
 
-<h1 style="color: {pin ? '#333' : '#ccc'}">{view}</h1>
+<h1 class:pin>{view}</h1>
 
 <Keypad bind:value={pin} on:submit={handleSubmit} />
+
+<style>
+	h1 {
+		color: #ccc;
+	}
+	h1.pin {
+		color: #333;
+	}
+	:global(body.dark) h1 {
+		color: #444;
+	}
+	:global(body.dark) h1.pin {
+		color: #fff;
+	}
+</style>


### PR DESCRIPTION
fixing the contrast for the component binding example

before:
<img width="272" alt="Screenshot 2023-07-06 at 9 00 15 AM" src="https://github.com/sveltejs/svelte/assets/2338632/80e0f336-c525-4714-b5ec-747621e25266">

after:
<img width="275" alt="Screenshot 2023-07-06 at 9 00 05 AM" src="https://github.com/sveltejs/svelte/assets/2338632/47f642f0-ae99-4407-907a-644288e426fa">

relates to https://github.com/sveltejs/sites/issues/493

### Before submitting the PR, please make sure you do the following

~~- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs~~
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
~~- [ ] Ideally, include a test that fails without this PR but passes with it.~~

### Tests and linting

~~- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`~~
