### PR TITLE
fix: generate type definition with nullable types

### DIFF
--- a/.changeset/funny-bags-occur.md
+++ b/.changeset/funny-bags-occur.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: generate type definition with nullable types

--- a/packages/svelte/scripts/generate-dts.js
+++ b/packages/svelte/scripts/generate-dts.js
@@ -16,6 +16,9 @@ fs.writeFileSync('./types/compiler/interfaces.d.ts', `import '../index.js';`);
 
 await createBundle({
 	output: 'types/index.d.ts',
+	compilerOptions: {
+		strict: true
+	},
 	modules: {
 		svelte: 'src/runtime/public.d.ts',
 		'svelte/compiler': 'src/compiler/public.d.ts',


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.


### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Fix regression introduced in svelte 4. https://github.com/sveltejs/language-tools/issues/1767. This is because the type definition is now generated from the source, and TypeScript will ignore nullable types when `strictNullCheck` isn't enabled. 

Since the types aren't in source control. Manually create a diff between before and after for record and review. 

```diff
--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -110,7 +110,7 @@ declare module 'svelte' {
 		
 		$destroy(): void;
 		
-		$on<K extends Extract<keyof Events, string>>(type: K, callback: (e: Events[K]) => void): () => void;
+		$on<K extends Extract<keyof Events, string>>(type: K, callback: ((e: Events[K]) => void) | null | undefined): () => void;
 		
 		$set(props: Partial<Props>): void;
 	}
@@ -772,8 +772,8 @@ declare module 'svelte/compiler' {
 	 * https://svelte.dev/docs/svelte-compiler#svelte-preprocess
 	 * */
 	export function preprocess(source: string, preprocessor: PreprocessorGroup | PreprocessorGroup[], options?: {
-		filename?: string;
-	}): Promise<Processed>;
+		filename?: string | undefined;
+	} | undefined): Promise<Processed>;
 	/**
 	 * The current version, as set in package.json.
 	 *
@@ -1576,13 +1576,13 @@ declare module 'svelte/motion' {
 	 *
 	 * https://svelte.dev/docs/svelte-motion#spring
 	 * */
-	export function spring<T = any>(value?: T, opts?: SpringOpts): Spring<T>;
+	export function spring<T = any>(value?: T | undefined, opts?: SpringOpts | undefined): Spring<T>;
 	/**
 	 * A tweened store in Svelte is a special type of store that provides smooth transitions between state values over time.
 	 *
 	 * https://svelte.dev/docs/svelte-motion#tweened
 	 * */
-	export function tweened<T>(value?: T, defaults?: TweenedOptions<T>): Tweened<T>;
+	export function tweened<T>(value?: T | undefined, defaults?: TweenedOptions<T> | undefined): Tweened<T>;
 }
 
 declare module 'svelte/store' {
@@ -1652,16 +1652,16 @@ declare module 'svelte/store' {
 	 * https://svelte.dev/docs/svelte-store#readable
 	 * @param value initial value
 	 * */
-	export function readable<T>(value?: T, start?: StartStopNotifier<T>): Readable<T>;
+	export function readable<T>(value?: T | undefined, start?: StartStopNotifier<T> | undefined): Readable<T>;
 	/**
 	 * Create a `Writable` store that allows both updating and reading by subscription.
 	 *
 	 * https://svelte.dev/docs/svelte-store#writable
 	 * @param value initial value
 	 * */
-	export function writable<T>(value?: T, start?: StartStopNotifier<T>): Writable<T>;
-	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>, set: (value: T) => void, update: (fn: Updater<T>) => void) => Unsubscriber | void, initial_value?: T): Readable<T>;
-	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>) => T, initial_value?: T): Readable<T>;
+	export function writable<T>(value?: T | undefined, start?: StartStopNotifier<T> | undefined): Writable<T>;
+	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>, set: (value: T) => void, update: (fn: Updater<T>) => void) => Unsubscriber | void, initial_value?: T | undefined): Readable<T>;
+	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>) => T, initial_value?: T | undefined): Readable<T>;
 	/**
 	 * Takes a store and returns a new one derived from the old one that is readable.
 	 *
@@ -1743,31 +1743,31 @@ declare module 'svelte/transition' {
 	 *
 	 * https://svelte.dev/docs/svelte-transition#blur
 	 * */
-	export function blur(node: Element, { delay, duration, easing, amount, opacity }?: BlurParams): TransitionConfig;
+	export function blur(node: Element, { delay, duration, easing, amount, opacity }?: BlurParams | undefined): TransitionConfig;
 	/**
 	 * Animates the opacity of an element from 0 to the current opacity for `in` transitions and from the current opacity to 0 for `out` transitions.
 	 *
 	 * https://svelte.dev/docs/svelte-transition#fade
 	 * */
-	export function fade(node: Element, { delay, duration, easing }?: FadeParams): TransitionConfig;
+	export function fade(node: Element, { delay, duration, easing }?: FadeParams | undefined): TransitionConfig;
 	/**
 	 * Animates the x and y positions and the opacity of an element. `in` transitions animate from the provided values, passed as parameters to the element's default values. `out` transitions animate from the element's default values to the provided values.
 	 *
 	 * https://svelte.dev/docs/svelte-transition#fly
 	 * */
-	export function fly(node: Element, { delay, duration, easing, x, y, opacity }?: FlyParams): TransitionConfig;
+	export function fly(node: Element, { delay, duration, easing, x, y, opacity }?: FlyParams | undefined): TransitionConfig;
 	/**
 	 * Slides an element in and out.
 	 *
 	 * https://svelte.dev/docs/svelte-transition#slide
 	 * */
-	export function slide(node: Element, { delay, duration, easing, axis }?: SlideParams): TransitionConfig;
+	export function slide(node: Element, { delay, duration, easing, axis }?: SlideParams | undefined): TransitionConfig;
 	/**
 	 * Animates the opacity and scale of an element. `in` transitions animate from an element's current (default) values to the provided values, passed as parameters. `out` transitions animate from the provided values to an element's default values.
 	 *
 	 * https://svelte.dev/docs/svelte-transition#scale
 	 * */
-	export function scale(node: Element, { delay, duration, easing, start, opacity }?: ScaleParams): TransitionConfig;
+	export function scale(node: Element, { delay, duration, easing, start, opacity }?: ScaleParams | undefined): TransitionConfig;
 	/**
 	 * Animates the stroke of an SVG element, like a snake in a tube. `in` transitions begin with the path invisible and draw the path to the screen over time. `out` transitions start in a visible state and gradually erase the path. `draw` only works with elements that have a `getTotalLength` method, like `<path>` and `<polyline>`.
 	 *
@@ -1775,14 +1775,14 @@ declare module 'svelte/transition' {
 	 * */
 	export function draw(node: SVGElement & {
 		getTotalLength(): number;
-	}, { delay, speed, duration, easing }?: DrawParams): TransitionConfig;
+	}, { delay, speed, duration, easing }?: DrawParams | undefined): TransitionConfig;
 	/**
 	 * The `crossfade` function creates a pair of [transitions](/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.
 	 *
 	 * https://svelte.dev/docs/svelte-transition#crossfade
 	 * */
 	export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
-		fallback?: (node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig;
+		fallback?: ((node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig) | undefined;
 	}): [(node: any, params: CrossfadeParams & {
 		key: any;
 	}) => () => TransitionConfig, (node: any, params: CrossfadeParams & {
```
```