### PR TITLE
fix: fix hint to match animation used in solution

### DIFF
--- a/documentation/tutorial/10-transitions/09-key-blocks/text.md
+++ b/documentation/tutorial/10-transitions/09-key-blocks/text.md
@@ -6,7 +6,7 @@ Key blocks destroy and recreate their contents when the value of an expression c
 
 ```svelte
 {#key number}
-  <span style="display: inline-block" in:fade>
+  <span style="display: inline-block" in:fly={{ y: -20 }}>
     {number}
   </span>
 {/key}


### PR DESCRIPTION
The code (both app-a and app-b) references the fly transition, but the hint mentions a different transition (fade). Probably less confusing for a newbie if the hint does not have this  extraneous discrepancy. Fixed hint in description to match problem code.


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
