### PR TITLE
docs: Make "unquoted" example actually unquoted

### DIFF
--- a/documentation/docs/02-template-syntax/02-basic-markup.md
+++ b/documentation/docs/02-template-syntax/02-basic-markup.md
@@ -29,7 +29,7 @@ By default, attributes work exactly like their HTML counterparts.
 As in HTML, values may be unquoted.
 
 ```svelte
-<input type="checkbox" />
+<input type=checkbox />
 ```
 
 Attribute values can contain JavaScript expressions.

--- a/documentation/docs/02-template-syntax/02-basic-markup.md
+++ b/documentation/docs/02-template-syntax/02-basic-markup.md
@@ -28,6 +28,7 @@ By default, attributes work exactly like their HTML counterparts.
 
 As in HTML, values may be unquoted.
 
+<!-- prettier-ignore -->
 ```svelte
 <input type=checkbox />
 ```


### PR DESCRIPTION
Example should show that unquoted values work, but shows example with a quote 😄


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
