### PR TITLE
chore: fix broken script for generating parser tests

### DIFF
--- a/packages/svelte/test/parser/update.js
+++ b/packages/svelte/test/parser/update.js
@@ -3,7 +3,7 @@
 // broken anything!
 import * as fs from 'node:fs';
 import { dirname } from 'node:path';
-import { fileURLtoPath } from "node:url";
+import { fileURLToPath } from 'node:url';
 import glob from 'tiny-glob/sync.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/svelte/test/parser/update.js
+++ b/packages/svelte/test/parser/update.js
@@ -4,6 +4,8 @@
 import * as fs from 'node:fs';
 import glob from 'tiny-glob/sync.js';
 
+const __dirname = new URL('.', import.meta.url).pathname;
+
 glob('samples/*/_actual.json', { cwd: __dirname }).forEach((file) => {
 	const actual = fs.readFileSync(`${__dirname}/${file}`, 'utf-8');
 	fs.writeFileSync(`${__dirname}/${file.replace('_actual.json', 'output.json')}`, actual);

--- a/packages/svelte/test/parser/update.js
+++ b/packages/svelte/test/parser/update.js
@@ -2,9 +2,11 @@
 // equivalents. Only use it when you're sure that you haven't
 // broken anything!
 import * as fs from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLtoPath } from "node:url";
 import glob from 'tiny-glob/sync.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 glob('samples/*/_actual.json', { cwd: __dirname }).forEach((file) => {
 	const actual = fs.readFileSync(`${__dirname}/${file}`, 'utf-8');


### PR DESCRIPTION
It looks like we missed doing this when we converted everything to ESM