### PR TITLE
site: todos in `animate` tutorial render weird on chrome

### DIFF
--- a/documentation/tutorial/11-animations/01-animate/app-a/App.svelte
+++ b/documentation/tutorial/11-animations/01-animate/app-a/App.svelte
@@ -104,6 +104,7 @@
 	}
 
 	label {
+		dislay: block;
 		position: relative;
 		line-height: 1.2;
 		padding: 0.5em 2.5em 0.5em 2em;

--- a/documentation/tutorial/11-animations/01-animate/app-b/App.svelte
+++ b/documentation/tutorial/11-animations/01-animate/app-b/App.svelte
@@ -105,6 +105,7 @@
 	}
 
 	label {
+		display: block;
 		position: relative;
 		line-height: 1.2;
 		padding: 0.5em 2.5em 0.5em 2em;


### PR DESCRIPTION
Tutorial page for animate directive (https://svelte.dev/tutorial/animate) renders the todos weird on Chrome:

- Without `display: block;`
![image](https://github.com/sveltejs/svelte/assets/11947485/8263fe83-6840-4da1-adca-5f9971bf2d0f)

- With `display: block;`
![image](https://github.com/sveltejs/svelte/assets/11947485/47924073-b82b-4699-8629-5750383dfe3d)

