### PR TITLE
site: todos in `animate` tutorial render weird due to typo

### DIFF
--- a/documentation/tutorial/11-animations/01-animate/app-a/App.svelte
+++ b/documentation/tutorial/11-animations/01-animate/app-a/App.svelte
@@ -104,6 +104,7 @@
 	}
 
 	label {
+		dislay: block;
 		position: relative;
 		line-height: 1.2;
 		padding: 0.5em 2.5em 0.5em 2em;

--- a/documentation/tutorial/11-animations/01-animate/app-a/App.svelte
+++ b/documentation/tutorial/11-animations/01-animate/app-a/App.svelte
@@ -104,7 +104,7 @@
 	}
 
 	label {
-		dislay: block;
+		display: block;
 		position: relative;
 		line-height: 1.2;
 		padding: 0.5em 2.5em 0.5em 2em;

--- a/documentation/tutorial/11-animations/01-animate/app-b/App.svelte
+++ b/documentation/tutorial/11-animations/01-animate/app-b/App.svelte
@@ -105,6 +105,7 @@
 	}
 
 	label {
+		display: block;
 		position: relative;
 		line-height: 1.2;
 		padding: 0.5em 2.5em 0.5em 2em;


### PR DESCRIPTION
Fixing typo from https://github.com/sveltejs/svelte/pull/8951, sorry!