### PR TITLE
docs: changed path color for better visibility with dark theme

### DIFF
--- a/documentation/examples/11-easing/00-easing/App.svelte
+++ b/documentation/examples/11-easing/00-easing/App.svelte
@@ -42,7 +42,7 @@
 		<g class="canvas">
 			<Grid x={$time} y={$value} />
 			<g class="graph">
-				<path d={$ease_path} stroke="#333" stroke-width="2" fill="none" />
+				<path d={$ease_path} stroke="#ff3e00" stroke-width="2" fill="none" />
 
 				<path
 					d="M0,23.647C0,22.41 27.014,0.407 28.496,0.025C29.978,-0.357 69.188,3.744 70.104,4.744C71.02,5.745 71.02,41.499 70.104,42.5C69.188,43.501 29.978,47.601 28.496,47.219C27.014,46.837 0,24.884 0,23.647Z"


### PR DESCRIPTION
In the easing example the dark theme makes almost impossible to see the path of the selected function. Changed the color to the same as the line and the dot to respect Svelte branding and solving the issue.

### Before submitting the PR, please make sure you do the following

- [ X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
