### PR TITLE
docs: fix typos

### DIFF
--- a/documentation/blog/2022-12-01-whats-new-in-svelte-december-2022.md
+++ b/documentation/blog/2022-12-01-whats-new-in-svelte-december-2022.md
@@ -47,7 +47,7 @@ For all the changes to the Svelte compiler, including unreleased changes, check 
 
 **Apps & Sites built with Svelte**
 
-- [Appwrite's new console](https://github.com/appwrite/console) makes its secure backend server for web, mobile & Flutter developers avaiable in the browser
+- [Appwrite's new console](https://github.com/appwrite/console) makes its secure backend server for web, mobile & Flutter developers available in the browser
 - [RepoMagic](https://www.repomagic.com/) is a search and analytics tool for GitHub
 - [Podman Desktop](https://github.com/containers/podman-desktop) is a graphical tool for developing on containers and Kubernetes
 - [Ballerine](https://github.com/ballerine-io/ballerine) is a Know Your Customer (KYC) UX for any vertical or geography using modular building blocks, components, and 3rd party integrations

--- a/documentation/docs/05-misc/03-typescript.md
+++ b/documentation/docs/05-misc/03-typescript.md
@@ -10,7 +10,7 @@ To use TypeScript within Svelte components, you need to add a preprocessor that 
 
 ### Using SvelteKit or Vite
 
-The easiest way to get started is scaffolding a new SvelteKit project by typing `npm create svelte@latest`, following the prompts and chosing the TypeScript option.
+The easiest way to get started is scaffolding a new SvelteKit project by typing `npm create svelte@latest`, following the prompts and choosing the TypeScript option.
 
 ```ts
 /// file: svelte.config.js


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `documentation/blog/2022-12-01-whats-new-in-svelte-december-2022.md`
1 typo in `documentation/docs/05-misc/03-typescript.md`


Best!