### PR TITLE
docs: remove compiler duplicate paragraph

### DIFF
--- a/documentation/docs/04-compiler-and-api/01-svelte-compiler.md
+++ b/documentation/docs/04-compiler-and-api/01-svelte-compiler.md
@@ -125,8 +125,6 @@ const { code } = await preprocess(
 );
 ```
 
-The `script` and `style` functions receive the contents of `<script>` and `<style>` elements respectively (`content`) as well as the entire component source text (`markup`). In addition to `filename`, they get an object of the element's attributes.
-
 If a `dependencies` array is returned, it will be included in the result object. This is used by packages like [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) and [rollup-plugin-svelte](https://github.com/sveltejs/rollup-plugin-svelte) to watch additional files for changes, in the case where your `<style>` tag has an `@import` (for example).
 
 ```ts


### PR DESCRIPTION
The removed paragraph appears twice in the same section, first occurence is line 87.
I thought it should be removed.
