### PR TITLE
fix: Changed fade to fly to match the tutorial

### DIFF
--- a/documentation/tutorial/10-transitions/09-key-blocks/text.md
+++ b/documentation/tutorial/10-transitions/09-key-blocks/text.md
@@ -6,7 +6,7 @@ Key blocks destroy and recreate their contents when the value of an expression c
 
 ```svelte
 {#key number}
-  <span style="display: inline-block" in:fade>
+  <span style="display: inline-block" in:fly={{ y: -20 }}>
     {number}
   </span>
 {/key}


### PR DESCRIPTION
In `Transitions / Key blocks` the documentation showed a fade transition and this was not in sync with the tutorial which used a fly transition.