### PR TITLE
fix: styling - fix styling on documentation for lesson 8-h

### DIFF
--- a/documentation/tutorial/10-transitions/08-deferred-transitions/app-a/App.svelte
+++ b/documentation/tutorial/10-transitions/08-deferred-transitions/app-a/App.svelte
@@ -96,6 +96,11 @@
 		grid-column: 1/3;
 	}
 
+	.left, .right {
+		display: flex;
+		flex-direction: column;
+	}
+
 	h2 {
 		font-size: 2em;
 		font-weight: 200;

--- a/documentation/tutorial/10-transitions/08-deferred-transitions/app-b/App.svelte
+++ b/documentation/tutorial/10-transitions/08-deferred-transitions/app-b/App.svelte
@@ -96,6 +96,11 @@
 		grid-column: 1/3;
 	}
 
+	.left, .right {
+		display: flex;
+		flex-direction: column;
+	}
+
 	h2 {
 		font-size: 2em;
 		font-weight: 200;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [X] This message body should clearly illustrate what problems it solves.

In lessons 8 - H it's appear to be missing style, the disturbing list harm the comprehension of the lesson.

Current Displa
<img width="960" alt="Screenshot 2023-07-18 at 11 32 57" src="https://github.com/sveltejs/svelte/assets/88052842/a58dc25a-48d4-4f67-b190-84de2852b907">
y: 

Solution proposed:
<img width="1913" alt="Screenshot 2023-07-18 at 11 33 11" src="https://github.com/sveltejs/svelte/assets/88052842/e742f00d-03ca-48d2-b0d0-561325a8b0cd">


### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
