### PR TITLE
fix: styling - fix on documentation for lesson 8-h

### DIFF
--- a/documentation/tutorial/10-transitions/08-deferred-transitions/app-a/App.svelte
+++ b/documentation/tutorial/10-transitions/08-deferred-transitions/app-a/App.svelte
@@ -104,6 +104,7 @@
 	}
 
 	label {
+		display: block;
 		position: relative;
 		line-height: 1.2;
 		padding: 0.5em 2.5em 0.5em 2em;

--- a/documentation/tutorial/10-transitions/08-deferred-transitions/app-b/App.svelte
+++ b/documentation/tutorial/10-transitions/08-deferred-transitions/app-b/App.svelte
@@ -104,6 +104,7 @@
 	}
 
 	label {
+		display: block;
 		position: relative;
 		line-height: 1.2;
 		padding: 0.5em 2.5em 0.5em 2em;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [X] This message body should clearly illustrate what problems it solves.

In lessons 8 - H it's appear to be missing style, the disturbing list harm the comprehension of the lesson.

Current Display:
<img width="960" alt="Screenshot 2023-07-18 at 11 32 57" src="https://github.com/sveltejs/svelte/assets/88052842/a58dc25a-48d4-4f67-b190-84de2852b907">


Solution proposed:
<img width="1919" alt="Screenshot 2023-07-18 at 11 43 49" src="https://github.com/sveltejs/svelte/assets/88052842/d8c0ec39-b42d-40f0-8124-2e6e79570cdf">


### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
