### PR TITLE
fix: #4265 prevent double update when bind to object

### DIFF
--- a/packages/svelte/src/compiler/compile/render_dom/wrappers/InlineComponent/index.js
+++ b/packages/svelte/src/compiler/compile/render_dom/wrappers/InlineComponent/index.js
@@ -345,8 +345,8 @@ export default class InlineComponentWrapper extends Wrapper {
 				block.maintain_context = true; // TODO put this somewhere more logical
 			}
 			block.chunks.init.push(b`
-				function ${id}(#value) {
-					${callee}(${args});
+				function ${id}(#value, #skip_binding) {
+					${callee}(#skip_binding, ${args});
 				}
 			`);
 			let invalidate_binding = b`
@@ -360,9 +360,14 @@ export default class InlineComponentWrapper extends Wrapper {
 					}
 				`;
 			}
+			// `skip_binding` is set by runtime/internal `bind()` function only at first call
+			// this prevents child -> parent reflow that triggers unnecessary $$.update (#4265)
+			// ignore this flag when parent value is undefined
 			const body = b`
-				function ${id}(${params}) {
-					${invalidate_binding}
+				function ${id}(#skip_binding, ${params}) {
+					if (!#skip_binding || ${lhs} === void 0) {
+						${invalidate_binding}
+					}
 				}
 			`;
 			component.partly_hoisted.push(body);

--- a/packages/svelte/src/compiler/compile/render_dom/wrappers/InlineComponent/index.js
+++ b/packages/svelte/src/compiler/compile/render_dom/wrappers/InlineComponent/index.js
@@ -361,11 +361,12 @@ export default class InlineComponentWrapper extends Wrapper {
 				`;
 			}
 			// `skip_binding` is set by runtime/internal `bind()` function only at first call
-			// this prevents child -> parent reflow that triggers unnecessary $$.update (#4265)
-			// ignore this flag when parent value is undefined
+			// this prevents child -> parent backflow that triggers unnecessary $$.update (#4265)
+			// the flag is used to detech reactive mutation to object in `child.$$.update`
+			// ignore this flag when parent_value !== child_value
 			const body = b`
 				function ${id}(#skip_binding, ${params}) {
-					if (!#skip_binding || ${lhs} === void 0) {
+					if (!#skip_binding || ${lhs} !== #value) {
 						${invalidate_binding}
 					}
 				}

--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -21,10 +21,15 @@ import { transition_in } from './transitions.js';
 
 /** @returns {void} */
 export function bind(component, name, callback) {
-	const index = component.$$.props[name];
-	if (index !== undefined) {
-		component.$$.bound[index] = callback;
-		callback(component.$$.ctx[index]);
+	const i = component.$$.props[name];
+	if (i !== undefined) {
+		let dirty = false;
+		if (component.$$.dirty[0] !== -1) {
+			dirty = !!(component.$$.dirty[(i / 31) | 0] & (1 << i % 31));
+		}
+		component.$$.bound[i] = callback;
+		// first binding call, if child value is not yet dirty, skip to prevent unnecessary backflow
+		callback(component.$$.ctx[i], /** skip_binding */ !dirty);
 	}
 }
 

--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -24,9 +24,7 @@ export function bind(component, name, callback) {
 	const i = component.$$.props[name];
 	if (i !== undefined) {
 		let dirty = false;
-		if (component.$$.dirty[0] !== -1) {
-			dirty = !!(component.$$.dirty[(i / 31) | 0] & (1 << i % 31));
-		}
+		if (component.$$.bound[i]) dirty = true;
 		component.$$.bound[i] = callback;
 		// first binding call, if child value is not yet dirty, skip to prevent unnecessary backflow
 		callback(component.$$.ctx[i], /** skip_binding */ !dirty);
@@ -130,8 +128,9 @@ export function init(
 		? instance(component, options.props || {}, (i, ret, ...rest) => {
 				const value = rest.length ? rest[0] : ret;
 				if ($$.ctx && not_equal($$.ctx[i], ($$.ctx[i] = value))) {
-					if (!$$.skip_bound && $$.bound[i]) $$.bound[i](value);
+					if (!$$.skip_bound && is_function($$.bound[i])) $$.bound[i](value);
 					if (ready) make_dirty(component, i);
+					else $$.bound[i] = true; // dirty flag consumed in bind()
 				}
 				return ret;
 		  })

--- a/packages/svelte/test/runtime/samples/binding-backflow/Child.svelte
+++ b/packages/svelte/test/runtime/samples/binding-backflow/Child.svelte
@@ -6,6 +6,10 @@
     value = { foo: 'kid' }
   }
 
+  if (testcase === 'init_mutate') {
+    value.foo = 'kid'
+  }
+
   $: if (testcase === 'reactive_update') {
     value = { foo: 'kid' }
   }

--- a/packages/svelte/test/runtime/samples/binding-backflow/Child.svelte
+++ b/packages/svelte/test/runtime/samples/binding-backflow/Child.svelte
@@ -1,0 +1,21 @@
+<script>
+  export let testcase;
+	export let value = { foo: 'kid' };
+
+  if (testcase === 'init_update') {
+    value = { foo: 'kid' }
+  }
+
+  $: if (testcase === 'reactive_update') {
+    value = { foo: 'kid' }
+  }
+
+  $: if (testcase === 'reactive_mutate') {
+    value.foo = 'kid'
+  }
+
+	export let updates = [];
+	$: updates = [...updates, value];
+</script>
+
+<div>child: {value?.foo} | updates: {updates.length}</div>

--- a/packages/svelte/test/runtime/samples/binding-backflow/Parent.svelte
+++ b/packages/svelte/test/runtime/samples/binding-backflow/Parent.svelte
@@ -1,0 +1,12 @@
+<script>
+	import Child from './Child.svelte';
+	export let child;
+
+	export let testcase;
+	export let value;
+	export let updates = [];
+	$: updates = [...updates, value];
+</script>
+
+<div>parent: {value?.foo} | updates: {updates.length}</div>
+<Child bind:value bind:this={child} {testcase} />

--- a/packages/svelte/test/runtime/samples/binding-backflow/_config.js
+++ b/packages/svelte/test/runtime/samples/binding-backflow/_config.js
@@ -6,7 +6,8 @@ export default {
 				{ testcase: 'child_default_populate_parent', value: undefined },
 				{ testcase: 'reactive_update', value: { foo: 'mon' } },
 				{ testcase: 'reactive_mutate', value: { foo: 'mon' } },
-				{ testcase: 'init_update', value: { foo: 'mon' } }
+				{ testcase: 'init_update', value: { foo: 'mon' } },
+				{ testcase: 'init_mutate', value: { foo: 'mon' } }
 			]
 		};
 	},
@@ -34,6 +35,10 @@ export default {
 		assert.equal(p.updates.length, 2);
 
 		p = parents['init_update'];
+		assert.deepEqual(p.value, { foo: 'kid' });
+		assert.equal(p.updates.length, 2);
+
+		p = parents['init_mutate'];
 		assert.deepEqual(p.value, { foo: 'kid' });
 		assert.equal(p.updates.length, 2);
 	}

--- a/packages/svelte/test/runtime/samples/binding-backflow/_config.js
+++ b/packages/svelte/test/runtime/samples/binding-backflow/_config.js
@@ -1,0 +1,40 @@
+export default {
+	get props() {
+		return {
+			configs: [
+				{ testcase: 'parent_override_child_default', value: { foo: 'mon' } },
+				{ testcase: 'child_default_populate_parent', value: undefined },
+				{ testcase: 'reactive_update', value: { foo: 'mon' } },
+				{ testcase: 'reactive_mutate', value: { foo: 'mon' } },
+				{ testcase: 'init_update', value: { foo: 'mon' } }
+			]
+		};
+	},
+
+	async test({ assert, component }) {
+		const parents = component.parents;
+
+		// first testcase should update once
+		// the rest should update twice
+		let p;
+		p = parents['parent_override_child_default'];
+		assert.deepEqual(p.value, { foo: 'mon' });
+		assert.equal(p.updates.length, 1);
+
+		p = parents['child_default_populate_parent'];
+		assert.deepEqual(p.value, { foo: 'kid' });
+		assert.equal(p.updates.length, 2);
+
+		p = parents['reactive_update'];
+		assert.deepEqual(p.value, { foo: 'kid' });
+		assert.equal(p.updates.length, 2);
+
+		p = parents['reactive_mutate'];
+		assert.deepEqual(p.value, { foo: 'kid' });
+		assert.equal(p.updates.length, 2);
+
+		p = parents['init_update'];
+		assert.deepEqual(p.value, { foo: 'kid' });
+		assert.equal(p.updates.length, 2);
+	}
+};

--- a/packages/svelte/test/runtime/samples/binding-backflow/main.svelte
+++ b/packages/svelte/test/runtime/samples/binding-backflow/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Parent from './Parent.svelte';
+	export let configs = [];
+	export let parents = {};
+</script>
+
+{#each configs as config}
+	<Parent bind:this={parents[config.testcase]} value={config.value} testcase={config.testcase} />
+{/each}

--- a/packages/svelte/test/runtime/samples/binding-no-unnecessary-invalidation.skip/_config.js
+++ b/packages/svelte/test/runtime/samples/binding-no-unnecessary-invalidation.skip/_config.js
@@ -1,7 +1,5 @@
-// this test currently fails because the fix that made it pass broke other tests,
 // see https://github.com/sveltejs/svelte/pull/8114 for more context.
 export default {
-	skip: true,
 	async test({ assert, target }) {
 		assert.htmlEqual(
 			target.innerHTML,


### PR DESCRIPTION
fix #4265 

This is a long standing issue that's been reported multiple times, see #4430 #4447 #5555 #6590, the list goes on...It was once partially fixed in #7981 but then reverted in #8114.

## Main idea of the fix

The thing that bugs ppl the most is *double firing update* when bind to non-primitive value at component init phase. This fix targets this scenario specifically.

```html
<script> // Parent.svelte
import Child from './Child.svelte';
let value = ['foo']
$: console.log('parent value', value);
</script>

<Child bind:value />
```

```html
<script> // Child.svelte
export let value = ['zoo'] 
$: console.log('child value', value);
</script>

<div>{JSON.stringify(value)}</div>
```

I'm gonna use the term "backflow" to refer to the process of `child_value_binding() -> invalidate(parent_value)`. Backflow is necessary to sync child value back to parent. But it could be unnecessary in some cases. Because `safe_not_equal` conservatively invalidates non-primitive value, it's a failed guard. So this fix propose an extra flag `skip_binding` to guard against unnecessary backflow.

Noted that first backflow happen at `flush -> binding_callbacks.pop()() -> bind -> child_value_binding`. By this time we've completed init phase, and every component is `ready`. 

Now focus on init phase and consider the following cases (✅ = necessary backflow,  ❌ = unnecessary backflow)

1. ✅ first to tick off the obvious, when Parent value is `undefined`, Child shall backflow to populate Parent value.
Below we discuss cases where Parent pass non-undefined down to Child.
2. ❌ Child does not touch the value at all, then value is already at-sync after init, no backflow needed. 
This is also THE MOST COMMON USE CASE which current PR seek to fix.
3. ✅ Child reactively (within `$:` statements) modifies the value, during `child.$$.update()` call, need backflow.
4. ✅ Child imperatively modifies the value at init phase, during `init -> instance` call, need backflow. 
This case should be further broken down to 2 sub-cases:
  4.1. Immutable modification, value's reference changed, e.g. `export let value; value = ["default"];`
  4.2. Mutable modification, e.g. `export let value; value.foo = "bar";`

<del>Proposed fix correctly handles backflow in all above cases EXCEPT sub-case 4.2.</del>

Proposed fix correctly handles backflow in all above cases.

## Implementation

Changes made to three places:
1. The `$$invalidate` runtime function, when `ready == false` sets `$$.bound[i] = true` in order to cater for case 3. This mark is essentially the same as `$$.dirty` which is not available before `ready`.
2. The `bind` runtime function triggers the first backflow during `flush`, here I pass a `skip_binding` flag to `child_value_binding`. The flag is determined by `$$.bound[i]` dirty mark. This takes care of case 2 and 3.
3. The generated `child_value_binding` function, I add `if (!#skip_binding || ${lhs} !== #value)` guard. It prevents the unnecessary backflow of case 2, also `${lhs} !== #value` check allows backflow for case 1 and 4.1. 

Case 4.2. needs backflow <del>but is unfortunately left out, because a) `$$invalidate` is not called, b) `${lhs} !== #value` fails to detect, we don't have the tool to distinguish this case.</del> and is now detected by inserting `$$invalidate` call on prop assignment at `instance` top level context.

---

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
