### PR TITLE
fix: don't add accessor twice

### DIFF
--- a/.changeset/ten-gifts-design.md
+++ b/.changeset/ten-gifts-design.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't add accessor twice

--- a/packages/svelte/src/compiler/compile/render_dom/index.js
+++ b/packages/svelte/src/compiler/compile/render_dom/index.js
@@ -583,7 +583,11 @@ export default function dom(component, options) {
 		}, {});
 		const slots_str = [...component.slots.keys()].map((key) => `"${key}"`).join(',');
 		const accessors_str = accessors
-			.filter((accessor) => !writable_props.some((prop) => prop.export_name === accessor.key.name))
+			.filter(
+				(accessor) =>
+					accessor.kind === 'get' &&
+					!writable_props.some((prop) => prop.export_name === accessor.key.name)
+			)
 			.map((accessor) => `"${accessor.key.name}"`)
 			.join(',');
 		const use_shadow_dom =


### PR DESCRIPTION
In dev mode, Svelte creates a setter to throw an error noting that you can't set that readonly prop, which resulted in the accessor getting applied twice to the custom element wrapper, causing an error
fixes #8971

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
