### PR TITLE
fix: wait a longer tick before checking slots

### DIFF
--- a/.changeset/tiny-walls-brake.md
+++ b/.changeset/tiny-walls-brake.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: wait a longer tick before checking slots

--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -215,7 +215,7 @@ if (typeof HTMLElement === 'function') {
 			this.$$cn = true;
 			if (!this.$$c) {
 				// We wait one tick to let possible child slot elements be created/mounted
-				await Promise.resolve();
+				await new Promise((f) => setTimeout(f)); // don't do Promise.resolve() as that fires too soon
 				if (!this.$$cn) {
 					return;
 				}
@@ -316,7 +316,8 @@ if (typeof HTMLElement === 'function') {
 		disconnectedCallback() {
 			this.$$cn = false;
 			// In a microtask, because this could be a move within the DOM
-			Promise.resolve().then(() => {
+			// don't do Promise.resolve() as that fires too soon
+			new Promise((f) => setTimeout(f)).then(() => {
 				if (!this.$$cn) {
 					this.$$c.$destroy();
 					this.$$c = undefined;


### PR DESCRIPTION
It seems that browser resolve "await Promise.resolve()" extra fast (close to synchronous) so the DOM isn't actually updated further. This fixes an issue where web component slots don't appear when the script registering the web components is invoked before them being added to the DOM fixes #8997


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
