### PR TITLE
docs: fix typo inside example in 03-typescript.md

### DIFF
--- a/documentation/docs/05-misc/03-typescript.md
+++ b/documentation/docs/05-misc/03-typescript.md
@@ -97,8 +97,8 @@ Events can be typed with `createEventDispatcher`:
 
 	const dispatch = createEventDispatcher<{
 		event: null; // does not accept a payload
-		type: string; // has a required string payload
-		click: string | null; // has an optional string payload
+		click: string; // has a required string payload
+		type: string | null; // has an optional string payload
 	}>();
 
 	function handleClick() {


### PR DESCRIPTION
This just fixes a small mistake in the example for typing Events.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
