### PR TITLE
docs: Make transition global in Deferred transition example

### DIFF
--- a/documentation/examples/09-transitions/06-deferred-transitions/App.svelte
+++ b/documentation/examples/09-transitions/06-deferred-transitions/App.svelte
@@ -48,7 +48,7 @@
 
 		{#if selected}
 			{#await selected then d}
-				<div class="photo" in:receive={{ key: d.id }} out:send={{ key: d.id }}>
+				<div class="photo" in:receive|global={{ key: d.id }} out:send|global={{ key: d.id }}>
 					<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-noninteractive-element-interactions -->
 					<img alt={d.alt} src="{ASSETS}/{d.id}.jpg" on:click={() => (selected = null)} />
 


### PR DESCRIPTION
Svelte 4 uses `local` for transitions by default. [changelog](https://github.com/sveltejs/svelte/blob/master/packages/svelte/CHANGELOG.md#patch-changes-6). Therefore, the deferred transition example doesn't work. I fixed it

# Before

https://github.com/sveltejs/svelte/assets/76736580/4363217d-ed5c-487a-a772-a1057b389474

# After

https://github.com/sveltejs/svelte/assets/76736580/5089b5c0-8d8f-4cfe-a81a-da1e75932239



