### PR TITLE
docs: add parenthesis back to regex literal example

### DIFF
--- a/documentation/docs/02-template-syntax/02-basic-markup.md
+++ b/documentation/docs/02-template-syntax/02-basic-markup.md
@@ -113,6 +113,7 @@ Text can also contain JavaScript expressions:
 
 > If you're using a regular expression (`RegExp`) [literal notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#literal_notation_and_constructor), you'll need to wrap it in parentheses.
 
+<!-- prettier-ignore -->
 ```svelte
 <h1>Hello {name}!</h1>
 <p>{a} + {b} = {a + b}.</p>

--- a/documentation/docs/02-template-syntax/02-basic-markup.md
+++ b/documentation/docs/02-template-syntax/02-basic-markup.md
@@ -117,7 +117,7 @@ Text can also contain JavaScript expressions:
 <h1>Hello {name}!</h1>
 <p>{a} + {b} = {a + b}.</p>
 
-<div>{/^[A-Za-z ]+$/.test(value) ? x : y}</div>
+<div>{(/^[A-Za-z ]+$/).test(value) ? x : y}</div>
 ```
 
 ## Comments


### PR DESCRIPTION
Fixes #9022 

While not majorly important it could be mildly confusing for people just starting out. As pointed out by [this issue](https://github.com/sveltejs/prettier-plugin-svelte/issues/393) and obviously the text above when using literal notation you need parenthesis or svelte will fail to parse the expression.