### PR TITLE
chore: fix tests on Node 18.17.0

### DIFF
--- a/packages/svelte/test/helpers.js
+++ b/packages/svelte/test/helpers.js
@@ -100,7 +100,7 @@ export function show_output(cwd, options = {}) {
 	});
 }
 
-const svelte_path = fileURLToPath(new URL('..', import.meta.url)).replace(/\\/g, '/');
+const svelte_path = fileURLToPath(new URL('..', import.meta.url).href).replace(/\\/g, '/');
 
 const AsyncFunction = /** @type {typeof Function} */ (async function () {}.constructor);
 


### PR DESCRIPTION
For some bizarre reason, Node 16.17.0 is complaining that `fileURLToPath` is getting passed an instance of `URL` when it expects an instance of `URL`. I don't know what this could be caused by other than https://github.com/nodejs/node/pull/47179, but that's still entirely mysterious. To get the tests working again, I'm instead just getting an uncontroversial string to pass to `fileURLToPath` to do with as it pleases.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
