### PR TITLE
feat: parameter for running outro transitions on `$destroy`

### DIFF
--- a/documentation/docs/04-compiler-and-api/02-client-side-component-api.md
+++ b/documentation/docs/04-compiler-and-api/02-client-side-component-api.md
@@ -178,19 +178,19 @@ import { SvelteComponent, ComponentConstructorOptions } from 'svelte';
 declare global {
 	class Component extends SvelteComponent {}
 	var component: Component;
-	var run_outro: boolean;
+	var options: { runOutro: boolean };
 }
 
 export {}
 
 // @filename: index.ts
 // ---cut---
-component.$destroy(run_outro);
+component.$destroy(options);
 ```
 
 Removes a component from the DOM and triggers any `onDestroy` handlers.
 
-If `run_outro` is `true`, any outro transitions will play before the component is destroyed.
+`options` may contain the property `runOutro` which indicates whether to play any outro transitions before the component is destroyed.
 
 ## Component props
 

--- a/documentation/docs/04-compiler-and-api/02-client-side-component-api.md
+++ b/documentation/docs/04-compiler-and-api/02-client-side-component-api.md
@@ -178,7 +178,7 @@ import { SvelteComponent, ComponentConstructorOptions } from 'svelte';
 declare global {
 	class Component extends SvelteComponent {}
 	var component: Component;
-	var options: { runOutro: boolean };
+	var options: { runOutro: boolean } | undefined;
 }
 
 export {}

--- a/documentation/docs/04-compiler-and-api/02-client-side-component-api.md
+++ b/documentation/docs/04-compiler-and-api/02-client-side-component-api.md
@@ -178,16 +178,19 @@ import { SvelteComponent, ComponentConstructorOptions } from 'svelte';
 declare global {
 	class Component extends SvelteComponent {}
 	var component: Component;
+	var run_outro: boolean;
 }
 
 export {}
 
 // @filename: index.ts
 // ---cut---
-component.$destroy();
+component.$destroy(run_outro);
 ```
 
 Removes a component from the DOM and triggers any `onDestroy` handlers.
+
+If `run_outro` is `true`, any outro transitions will play before the component is destroyed.
 
 ## Component props
 

--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -1,23 +1,23 @@
 import {
-	attr,
+	add_render_callback,
+	flush,
+	flush_render_callbacks,
+	schedule_update,
+	dirty_components
+} from './scheduler.js';
+import { current_component, set_current_component } from './lifecycle.js';
+import { blank_object, is_empty, is_function, run, run_all, noop } from './utils.js';
+import {
 	children,
 	detach,
-	element,
+	start_hydrating,
 	end_hydrating,
 	get_custom_elements_slots,
 	insert,
-	start_hydrating
+	element,
+	attr
 } from './dom.js';
-import { current_component, set_current_component } from './lifecycle.js';
-import {
-	add_render_callback,
-	dirty_components,
-	flush,
-	flush_render_callbacks,
-	schedule_update
-} from './scheduler.js';
 import { check_outros, group_outros, transition_in, transition_out } from './transitions.js';
-import { blank_object, is_empty, is_function, noop, run, run_all } from './utils.js';
 
 /** @returns {void} */
 export function bind(component, name, callback) {

--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -1,23 +1,23 @@
 import {
-	add_render_callback,
-	flush,
-	flush_render_callbacks,
-	schedule_update,
-	dirty_components
-} from './scheduler.js';
-import { current_component, set_current_component } from './lifecycle.js';
-import { blank_object, is_empty, is_function, run, run_all, noop } from './utils.js';
-import {
+	attr,
 	children,
 	detach,
-	start_hydrating,
+	element,
 	end_hydrating,
 	get_custom_elements_slots,
 	insert,
-	element,
-	attr
+	start_hydrating
 } from './dom.js';
+import { current_component, set_current_component } from './lifecycle.js';
+import {
+	add_render_callback,
+	dirty_components,
+	flush,
+	flush_render_callbacks,
+	schedule_update
+} from './scheduler.js';
 import { check_outros, group_outros, transition_in, transition_out } from './transitions.js';
+import { blank_object, is_empty, is_function, noop, run, run_all } from './utils.js';
 
 /** @returns {void} */
 export function bind(component, name, callback) {
@@ -456,11 +456,11 @@ export class SvelteComponent {
 	$$set = undefined;
 
 	/**
-	 * @param {boolean} [run_outro]
+	 * @param {import('./private.js').ComponentDestroyOptions} [options]
 	 * @returns {void}
 	 */
-	$destroy(run_outro) {
-		if (run_outro && this.$$.fragment && this.$$.fragment.o) {
+	$destroy(options) {
+		if (options?.runOutro && this.$$.fragment && this.$$.fragment.o) {
 			group_outros();
 			transition_out(this.$$.fragment, 0, 0, () => {
 				destroy_component(this, 1);

--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -17,7 +17,7 @@ import {
 	element,
 	attr
 } from './dom.js';
-import { transition_in } from './transitions.js';
+import { check_outros, group_outros, transition_in, transition_out } from './transitions.js';
 
 /** @returns {void} */
 export function bind(component, name, callback) {
@@ -455,10 +455,22 @@ export class SvelteComponent {
 	 */
 	$$set = undefined;
 
-	/** @returns {void} */
-	$destroy() {
-		destroy_component(this, 1);
-		this.$destroy = noop;
+	/**
+	 * @param {boolean} [run_outro]
+	 * @returns {void}
+	 */
+	$destroy(run_outro) {
+		if (run_outro && this.$$.fragment && this.$$.fragment.o) {
+			group_outros();
+			transition_out(this.$$.fragment, 0, 0, () => {
+				destroy_component(this, 1);
+				this.$destroy = noop;
+			});
+			check_outros();
+		} else {
+			destroy_component(this, 1);
+			this.$destroy = noop;
+		}
 	}
 
 	/**

--- a/packages/svelte/src/runtime/internal/dev.js
+++ b/packages/svelte/src/runtime/internal/dev.js
@@ -331,9 +331,12 @@ export class SvelteComponentDev extends SvelteComponent {
 		super();
 	}
 
-	/** @returns {void} */
-	$destroy() {
-		super.$destroy();
+	/**
+	 * @param {import('./private.js').ComponentDestroyOptions} [options]
+	 * @returns {void}
+	 */
+	$destroy(options) {
+		super.$destroy(options);
 		this.$destroy = () => {
 			console.warn('Component was already destroyed'); // eslint-disable-line no-console
 		};

--- a/packages/svelte/src/runtime/internal/private.d.ts
+++ b/packages/svelte/src/runtime/internal/private.d.ts
@@ -75,6 +75,10 @@ export interface StyleInformation {
 	rules: Record<string, true>;
 }
 
+export interface ComponentDestroyOptions {
+	runOutro?: boolean;
+}
+
 export type TaskCallback = (now: number) => boolean | void;
 
 export type TaskEntry = { c: TaskCallback; f: () => void };

--- a/packages/svelte/test/runtime/samples/transition-js-destroy/_config.js
+++ b/packages/svelte/test/runtime/samples/transition-js-destroy/_config.js
@@ -3,7 +3,7 @@ export default {
 	skip_if_hydrate: true,
 	skip_if_hydrate_from_ssr: true,
 	test({ assert, component, target, raf }) {
-		component.$destroy(true);
+		component.$destroy({ runOutro: true });
 
 		return Promise.resolve().then(() => {
 			const div = target.querySelector('div');

--- a/packages/svelte/test/runtime/samples/transition-js-destroy/_config.js
+++ b/packages/svelte/test/runtime/samples/transition-js-destroy/_config.js
@@ -1,0 +1,15 @@
+export default {
+	skip_if_ssr: true,
+	skip_if_hydrate: true,
+	skip_if_hydrate_from_ssr: true,
+	test({ assert, component, target, raf }) {
+		component.$destroy(true);
+
+		return Promise.resolve().then(() => {
+			const div = target.querySelector('div');
+
+			raf.tick(50);
+			assert.equal(div.transitioned, 0.5);
+		});
+	}
+};

--- a/packages/svelte/test/runtime/samples/transition-js-destroy/main.svelte
+++ b/packages/svelte/test/runtime/samples/transition-js-destroy/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	function transitionOut(node) {
+		return () => {
+			return {
+				duration: 100,
+				tick: t => {
+					node.transitioned = t;
+				}
+			};
+		};
+	}
+</script>
+
+<div out:transitionOut|global></div>


### PR DESCRIPTION
Make it possible to run outro transitions when manually calling $destroy on a component.

In Svelte 4, [the workaround](https://github.com/sveltejs/svelte/issues/4056#issuecomment-791317426) mentioned in #4056 no longer works because those APIs are not public / exported.

Fixes #4056 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
