### PR TITLE
site: generate blog RSS feed with full content rather than a description

### DIFF
--- a/sites/svelte.dev/src/lib/server/blog/index.js
+++ b/sites/svelte.dev/src/lib/server/blog/index.js
@@ -65,6 +65,21 @@ export function get_blog_list(blog_data) {
 	}));
 }
 
+/** @param {import('./types').BlogData} blog_data */
+export async function get_rss_contents(blog_data) {
+	return await Promise.all(
+		blog_data.map(async ({ slug, title, content, file, author, date, draft }) => ({
+			slug,
+			title,
+			content: await render_content(file, content),
+			author,
+			date,
+			draft,
+		}))
+	)
+}
+
+
 /** @param {string} filename */
 function get_date_and_slug(filename) {
 	const match = BLOG_NAME_REGEX.exec(filename);

--- a/sites/svelte.dev/src/lib/server/blog/types.d.ts
+++ b/sites/svelte.dev/src/lib/server/blog/types.d.ts
@@ -15,10 +15,13 @@ export interface BlogPost {
 
 export type BlogData = BlogPost[];
 
-export interface BlogPostSummary {
+export interface BlogPostRSS {
 	slug: string;
 	title: string;
-	description: string;
+	content: string;
+	author: {
+		name: string;
+	};
 	date: string;
 	draft: boolean;
 }

--- a/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
+++ b/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
@@ -1,4 +1,4 @@
-import { get_blog_data, get_blog_list } from '$lib/server/blog/index.js';
+import { get_blog_data, get_rss_contents } from '$lib/server/blog/index.js';
 
 export const prerender = true;
 
@@ -18,11 +18,13 @@ function escapeHTML(html) {
 		'>': 'gt'
 	};
 
-	return html.replace(/["'&<>]/g, (c) => `&${chars[c]};`);
+	return html
+		.replace(/<a[^>]*class="permalink"[^>]*>.*?<\/a>/gi, '') // remove anchor permalinks
+		.replace(/["'&<>]/g, (c) => `&${chars[c]};`);
 }
 
-/** @param {import('$lib/server/blog/types').BlogPostSummary[]} posts */
-const get_rss = (posts) =>
+/** @param {import('$lib/server/blog/types').BlogPostRSS[]} posts */
+const get_rss = (posts) => 
 	`
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
@@ -43,6 +45,7 @@ const get_rss = (posts) =>
 		<item>
 			<title>${escapeHTML(post.title)}</title>
 			<link>https://svelte.dev/blog/${post.slug}</link>
+			<author>${escapeHTML(post.author.name)}</author>
 			<description>${escapeHTML(post.content)}</description>
 			<pubDate>${formatPubdate(post.date)}</pubDate>
 		</item>
@@ -58,7 +61,8 @@ const get_rss = (posts) =>
 		.trim();
 
 export async function GET() {
-	const posts = get_blog_list(await get_blog_data());
+	const blogData = await get_blog_data();
+	const posts = await get_rss_contents(blogData);
 
 	return new Response(get_rss(posts), {
 		headers: {

--- a/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
+++ b/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
@@ -43,7 +43,7 @@ const get_rss = (posts) =>
 		<item>
 			<title>${escapeHTML(post.title)}</title>
 			<link>https://svelte.dev/blog/${post.slug}</link>
-			<description>${escapeHTML(post.description)}</description>
+			<description>${escapeHTML(post.content)}</description>
 			<pubDate>${formatPubdate(post.date)}</pubDate>
 		</item>
 	`


### PR DESCRIPTION
In the Svelte blog, only a short description is being generated for each post. This PR changes that to use the full content instead. This has a few benefits including letting people read the blog post offline (imagine you have a spotty connection or are traveling) and it also avoids a browser click. This PR also adds author information to the feed.

I've tested locally on [NetNewsWire](https://netnewswire.com/) and it works well with a localhost feed.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
