### PR TITLE
docs: Fix a regression for a quoted-attribute example

### DIFF
--- a/documentation/docs/02-template-syntax/02-basic-markup.md
+++ b/documentation/docs/02-template-syntax/02-basic-markup.md
@@ -56,6 +56,7 @@ All other attributes are included unless their value is [nullish](https://develo
 
 An expression might include characters that would cause syntax highlighting to fail in regular HTML, so quoting the value is permitted. The quotes do not affect how the value is parsed:
 
+<!-- prettier-ignore -->
 ```svelte
 <button disabled="{number !== 42}">...</button>
 ```

--- a/documentation/docs/02-template-syntax/02-basic-markup.md
+++ b/documentation/docs/02-template-syntax/02-basic-markup.md
@@ -57,7 +57,7 @@ All other attributes are included unless their value is [nullish](https://develo
 An expression might include characters that would cause syntax highlighting to fail in regular HTML, so quoting the value is permitted. The quotes do not affect how the value is parsed:
 
 ```svelte
-<button disabled={number !== 42}>...</button>
+<button disabled="{number !== 42}">...</button>
 ```
 
 When the attribute name and value match (`name={name}`), they can be replaced with `{name}`.


### PR DESCRIPTION
The code example is inconsistent with the text:

> An expression might include characters that would cause syntax highlighting to fail in regular HTML, so quoting the value is permitted. The quotes do not affect how the value is parsed: [...]

But the attribute in the code example is not quoted at all:

```
<button disabled={number !== 42}>...</button>
```

This small PR fixes the code example by placing back missing quotation marks.

It is a regression, as the docs before site redesign explain it correctly; see https://github.com/sveltejs/svelte/blob/v3.59.2/site/content/docs/03-template-syntax.md.

---

### Before submitting the PR, please make sure you do the following

- [v] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [v] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [v] This message body should clearly illustrate what problems it solves.
- (N/A) Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [v] Run the tests with `pnpm test` and lint the project with `pnpm lint`
