### PR TITLE
fix: css sourcemap generation with unicode filenames

### DIFF
--- a/.changeset/eighty-poems-deliver.md
+++ b/.changeset/eighty-poems-deliver.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: css sourcemap generation with unicode filenames

--- a/packages/svelte/src/compiler/utils/mapped_code.js
+++ b/packages/svelte/src/compiler/utils/mapped_code.js
@@ -299,7 +299,9 @@ export function apply_preprocessor_sourcemap(filename, svelte_map, preprocessor_
 				} else if (typeof Buffer !== 'undefined') {
 					b64 = Buffer.from(this.toString(), 'utf8').toString('base64');
 				} else {
-					throw new Error('Unsupported environment: `window.btoa` or `Buffer` should be present to use toUrl.');
+					throw new Error(
+						'Unsupported environment: `window.btoa` or `Buffer` should be present to use toUrl.'
+					);
 				}
 				return 'data:application/json;charset=utf-8;base64,' + b64;
 			}

--- a/packages/svelte/src/compiler/utils/mapped_code.js
+++ b/packages/svelte/src/compiler/utils/mapped_code.js
@@ -292,7 +292,16 @@ export function apply_preprocessor_sourcemap(filename, svelte_map, preprocessor_
 		toUrl: {
 			enumerable: false,
 			value: function toUrl() {
-				return 'data:application/json;charset=utf-8;base64,' + btoa(this.toString());
+				let b64 = '';
+				if (typeof window !== 'undefined' && window.btoa) {
+					// btoa doesn't support multi-byte characters
+					b64 = window.btoa(unescape(encodeURIComponent(this.toString())));
+				} else if (typeof Buffer !== 'undefined') {
+					b64 = Buffer.from(this.toString(), 'utf8').toString('base64');
+				} else {
+					throw new Error('Unsupported environment: `window.btoa` or `Buffer` should be present to use toUrl.');
+				}
+				return 'data:application/json;charset=utf-8;base64,' + b64;
 			}
 		}
 	});


### PR DESCRIPTION
fixes #6714

code-red will fail on such cases too, but that codepath doesn't seem to be hit by Svelte currently, if the error pops up again that'd be the place to look

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
