### PR TITLE
fix: spreading attributes on option value attribute get's replaced by option's inner text

### DIFF
--- a/.changeset/tricky-planets-rush.md
+++ b/.changeset/tricky-planets-rush.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: spreading attributes on option value attribute get's replaced by option's inner text
+fix: recognize option value on spread attribute

--- a/.changeset/tricky-planets-rush.md
+++ b/.changeset/tricky-planets-rush.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: spreading attributes on option value attribute get's replaced by option's inner text

--- a/packages/svelte/test/runtime/samples/select-options-spread-attributes/_config.js
+++ b/packages/svelte/test/runtime/samples/select-options-spread-attributes/_config.js
@@ -1,0 +1,7 @@
+export default {
+	html: `
+		<select>
+			<option value="value" class="option">Label</option>
+		</select>
+	`
+};

--- a/packages/svelte/test/runtime/samples/select-options-spread-attributes/main.svelte
+++ b/packages/svelte/test/runtime/samples/select-options-spread-attributes/main.svelte
@@ -1,0 +1,3 @@
+<select>
+	<option {...{ value: 'value', class: 'option' }}>Label</option>
+</select>


### PR DESCRIPTION
fixes #9107
Apart from the problem with the option the same happens with the textarea.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
