### PR TITLE
feat: add vim mode to repl

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^2.31.0
         version: 2.31.0
       '@sveltejs/repl':
-        specifier: 0.5.0
-        version: 0.5.0(@codemirror/lang-html@6.4.5)(@codemirror/search@6.5.0)(@lezer/common@1.0.3)(@lezer/javascript@1.4.5)(@lezer/lr@1.3.9)(@sveltejs/kit@1.22.4)(svelte@packages+svelte)
+        specifier: 0.6.0
+        version: 0.6.0(@codemirror/lang-html@6.4.5)(@codemirror/search@6.5.0)(@lezer/common@1.0.3)(@lezer/javascript@1.4.5)(@lezer/lr@1.3.9)(@sveltejs/kit@1.22.4)(svelte@packages+svelte)
       cookie:
         specifier: ^0.5.0
         version: 0.5.0
@@ -557,7 +557,7 @@ packages:
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.14.1
       '@lezer/common': 1.0.3
-      '@lezer/javascript': 1.4.4
+      '@lezer/javascript': 1.4.5
     dev: false
 
   /@codemirror/lang-json@6.0.1:
@@ -1499,13 +1499,6 @@ packages:
       '@lezer/lr': 1.3.9
     dev: false
 
-  /@lezer/javascript@1.4.4:
-    resolution: {integrity: sha512-0BiBjpEcrt2IXrIzEAsdTLylrVhGHRqVQL3baTBx1sf4qewjIvhG1/pTUumu7W/7YR0AASjLQOQxFmo5EvNmzQ==}
-    dependencies:
-      '@lezer/highlight': 1.1.6
-      '@lezer/lr': 1.3.9
-    dev: false
-
   /@lezer/javascript@1.4.5:
     resolution: {integrity: sha512-FmBUHz8K1V22DgjTd6SrIG9owbzOYZ1t3rY6vGEmw+e2RVBd7sqjM8uXEVRFmfxKFn1Mx2ABJehHjrN3G2ZpmA==}
     dependencies:
@@ -1654,6 +1647,22 @@ packages:
       '@lezer/highlight': 1.1.6
       '@lezer/javascript': 1.4.5
       '@lezer/lr': 1.3.9
+    dev: false
+
+  /@replit/codemirror-vim@6.0.14(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1):
+    resolution: {integrity: sha512-wwhqhvL76FdRTdwfUWpKCbv0hkp2fvivfMosDVlL/popqOiNLtUhL02ThgHZH8mus/NkVr5Mj582lyFZqQrjOA==}
+    peerDependencies:
+      '@codemirror/commands': ^6.0.0
+      '@codemirror/language': ^6.1.0
+      '@codemirror/search': ^6.2.0
+      '@codemirror/state': ^6.0.1
+      '@codemirror/view': ^6.0.3
+    dependencies:
+      '@codemirror/commands': 6.2.4
+      '@codemirror/language': 6.8.0
+      '@codemirror/search': 6.5.0
+      '@codemirror/state': 6.2.1
+      '@codemirror/view': 6.14.1
     dev: false
 
   /@resvg/resvg-js-android-arm-eabi@2.4.1:
@@ -2006,8 +2015,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@sveltejs/repl@0.5.0(@codemirror/lang-html@6.4.5)(@codemirror/search@6.5.0)(@lezer/common@1.0.3)(@lezer/javascript@1.4.5)(@lezer/lr@1.3.9)(@sveltejs/kit@1.22.4)(svelte@packages+svelte):
-    resolution: {integrity: sha512-SyrMn3moP74PY7OtQONom9X53SYREQ7p8CEgspeNK0VG9AYUWc2UPvDDRAHTK94TC7GoNWgOafDw04HJGrOl2g==}
+  /@sveltejs/repl@0.6.0(@codemirror/lang-html@6.4.5)(@codemirror/search@6.5.0)(@lezer/common@1.0.3)(@lezer/javascript@1.4.5)(@lezer/lr@1.3.9)(@sveltejs/kit@1.22.4)(svelte@packages+svelte):
+    resolution: {integrity: sha512-NADKN0NZhLlSatTSh5CCsdzgf2KHJFRef/8krA/TVWAWos5kSwmZ5fF0UImuqs61Pu/SiMXksaWNTGTiOtr4fQ==}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0-next.0 || ^4.0.0
     dependencies:
@@ -2025,6 +2034,7 @@ packages:
       '@lezer/highlight': 1.1.6
       '@neocodemirror/svelte': 0.0.15(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.4.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)
       '@replit/codemirror-lang-svelte': 6.0.0(@codemirror/autocomplete@6.8.1)(@codemirror/lang-css@6.2.0)(@codemirror/lang-html@6.4.5)(@codemirror/lang-javascript@6.1.9)(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)(@lezer/common@1.0.3)(@lezer/highlight@1.1.6)(@lezer/javascript@1.4.5)(@lezer/lr@1.3.9)
+      '@replit/codemirror-vim': 6.0.14(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)
       '@rich_harris/svelte-split-pane': 1.1.1(svelte@packages+svelte)
       '@rollup/browser': 3.26.2
       '@sveltejs/site-kit': 5.2.2(@sveltejs/kit@1.22.4)(svelte@packages+svelte)
@@ -7103,9 +7113,9 @@ packages:
         optional: true
     dependencies:
       '@types/node': 14.18.51
-      esbuild: 0.18.11
+      esbuild: 0.18.17
       postcss: 8.4.27
-      rollup: 3.26.2
+      rollup: 3.27.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/sites/svelte.dev/package.json
+++ b/sites/svelte.dev/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@jridgewell/sourcemap-codec": "^1.4.15",
     "@supabase/supabase-js": "^2.31.0",
-    "@sveltejs/repl": "0.5.0",
+    "@sveltejs/repl": "0.6.0",
     "cookie": "^0.5.0",
     "devalue": "^4.3.2",
     "do-not-zip": "^1.0.0",

--- a/sites/svelte.dev/src/routes/(authed)/repl/+page.js
+++ b/sites/svelte.dev/src/routes/(authed)/repl/+page.js
@@ -1,10 +1,26 @@
 import { redirect } from '@sveltejs/kit';
 
+/**
+ * create a query params string from an object of query parameters
+ * @param {Record<string, string>} queries
+ * @returns {string}
+ */
+function add_query_params(queries) {
+	const query_array = [];
+	for (let query in queries) {
+		if (queries[query] !== null) {
+			query_array.push(`${query}=${queries[query]}`);
+		}
+	}
+	return query_array.length > 0 ? `?${query_array.join('&')}` : ``;
+}
+
 export function load({ url }) {
 	const query = url.searchParams;
 	const gist = query.get('gist');
 	const example = query.get('example');
 	const version = query.get('version');
+	const vim = query.get('vim');
 
 	// redirect to v2 REPL if appropriate
 	if (/^[^>]?[12]/.test(version)) {
@@ -12,7 +28,9 @@ export function load({ url }) {
 	}
 
 	const id = gist || example || 'hello-world';
-	const q = version ? `?version=${version}` : ``;
-
+	const q = add_query_params({
+		version,
+		vim
+	});
 	throw redirect(301, `/repl/${id}${q}`);
 }

--- a/sites/svelte.dev/src/routes/(authed)/repl/[id]/+page.js
+++ b/sites/svelte.dev/src/routes/(authed)/repl/[id]/+page.js
@@ -1,0 +1,18 @@
+import { browser } from '$app/environment';
+
+export function load({ data, url }) {
+	// initialize vim with the search param
+	const vim_search_params = url.searchParams.get('vim');
+	let vim = vim_search_params !== null && vim_search_params !== 'false';
+	// when in the browser check if there's a local storage entry and eventually override
+	// vim if there's not a search params otherwise update the local storage
+	if (browser) {
+		const vim_local_storage = window.localStorage.getItem('svelte:vim-enabled');
+		if (vim_search_params !== null) {
+			window.localStorage.setItem('svelte:vim-enabled', vim.toString());
+		} else if (vim_local_storage) {
+			vim = vim_local_storage !== 'false';
+		}
+	}
+	return { ...data, vim };
+}

--- a/sites/svelte.dev/src/routes/(authed)/repl/[id]/+page.svelte
+++ b/sites/svelte.dev/src/routes/(authed)/repl/[id]/+page.svelte
@@ -61,6 +61,8 @@
 			: `https://unpkg.com/svelte@${version}`;
 
 	$: relaxed = data.gist.relaxed || (data.user && data.user.id === data.gist.owner);
+
+	$: vim = data.vim;
 </script>
 
 <svelte:head>
@@ -87,6 +89,7 @@
 			bind:this={repl}
 			{svelteUrl}
 			{relaxed}
+			{vim}
 			injectedJS={mapbox_setup}
 			showModified
 			showAst


### PR DESCRIPTION
Add vim mode to the repl. As discussed with @PuruVJ you can enable vim mode by adding the query param `?vim` to the end of a REPL. Vim mode will stay enabled (stored in the local storage) until you add the query param `?vim=false` (or delete the local storage)

let me know if i should create tests for this

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
