### PR TITLE
fix: custom element reflected attribute remove fails when attribute and props property have different values

### DIFF
--- a/.changeset/tame-tomatoes-warn.md
+++ b/.changeset/tame-tomatoes-warn.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: custom element reflected attribute remove fails when attribute and props property have different values
+fix: take custom attribute name into account when reflecting property

--- a/.changeset/tame-tomatoes-warn.md
+++ b/.changeset/tame-tomatoes-warn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: custom element reflected attribute remove fails when attribute and props property have different values

--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -283,7 +283,7 @@ if (typeof HTMLElement === 'function') {
 								'toAttribute'
 							);
 							if (attribute_value == null) {
-								this.removeAttribute(key);
+								this.removeAttribute(this.$$p_d[key].attribute || key);
 							} else {
 								this.setAttribute(this.$$p_d[key].attribute || key, attribute_value);
 							}

--- a/packages/svelte/test/runtime-browser/custom-elements-samples/reflect-attributes-add-remove/main.svelte
+++ b/packages/svelte/test/runtime-browser/custom-elements-samples/reflect-attributes-add-remove/main.svelte
@@ -1,0 +1,23 @@
+<svelte:options
+	customElement={{
+		tag: 'custom-element',
+		props: {
+			expanded: { reflect: true, type: 'Boolean', attribute: 'aria-expanded' }
+		}
+	}}
+/>
+
+<script>
+	export let expanded = false;
+</script>
+
+<div>
+	<button on:click={() => (expanded = !expanded)}>Toggle</button>
+	<div class:hidden={!expanded}>Hidden Text</div>
+</div>
+
+<style>
+	.hidden {
+		display: none;
+	}
+</style>

--- a/packages/svelte/test/runtime-browser/custom-elements-samples/reflect-attributes-add-remove/test.js
+++ b/packages/svelte/test/runtime-browser/custom-elements-samples/reflect-attributes-add-remove/test.js
@@ -1,0 +1,19 @@
+import * as assert from 'assert.js';
+import { tick } from 'svelte';
+import './main.svelte';
+
+export default async function (target) {
+	const element = document.createElement('custom-element');
+	target.appendChild(element);
+	await tick();
+
+	const el = target.querySelector('custom-element');
+	el.shadowRoot.querySelector('button').click();
+	await tick();
+
+	assert.equal(el.getAttribute('aria-expanded'), '');
+	el.shadowRoot.querySelector('button').click();
+	await tick();
+
+	assert.equal(el.getAttribute('aria-expanded'), null);
+}


### PR DESCRIPTION
fixes #9134

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
