### PR TITLE
fix: This makes the indeterminate HTML attribute available for use. Fixes #9176.

### DIFF
--- a/.changeset/ten-poems-remember.md
+++ b/.changeset/ten-poems-remember.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-This allows a User to set the indeterminate HTML Attribute by adding it to the list of HTMLAttributes.
+fix: add `indeterminate` to the list of HTMLAttributes

--- a/.changeset/ten-poems-remember.md
+++ b/.changeset/ten-poems-remember.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+This allows a User to set the indeterminate HTML Attribute by adding it to the list of HTMLAttributes.

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -808,6 +808,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	formnovalidate?: boolean | undefined | null;
 	formtarget?: string | undefined | null;
 	height?: number | string | undefined | null;
+	indeterminate?: boolean | undefined | null;
 	list?: string | undefined | null;
 	max?: number | string | undefined | null;
 	maxlength?: number | undefined | null;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [X ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ X] This message body should clearly illustrate what problems it solves.
- [ X] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Fixes #9176. This adds `indeterminate` to the list of `HTMLAttributes` so that one can use it without receiving an error.
