### PR TITLE
feat: add option to preserve unused css selectors

### DIFF
--- a/packages/svelte/src/compiler/compile/css/Stylesheet.js
+++ b/packages/svelte/src/compiler/compile/css/Stylesheet.js
@@ -86,12 +86,13 @@ class Rule {
 	/**
 	 * @param {import('magic-string').default} code
 	 * @param {boolean} _dev
+	 * @param {boolean} preserveUnusedSelectors
 	 */
-	minify(code, _dev) {
+	minify(code, _dev, preserveUnusedSelectors) {
 		let c = this.node.start;
 		let started = false;
 		this.selectors.forEach((selector) => {
-			if (selector.used) {
+			if (preserveUnusedSelectors === true || selector.used) {
 				const separator = started ? ',' : '';
 				if (selector.node.start - c > separator.length) {
 					code.update(c, selector.node.start, separator);
@@ -229,8 +230,9 @@ class Atrule {
 	/**
 	 * @param {import('magic-string').default} code
 	 * @param {boolean} dev
+	 * @param {boolean} _preserveUnusedSelectors
 	 */
-	minify(code, dev) {
+	minify(code, dev, _preserveUnusedSelectors) {
 		if (this.node.name === 'media') {
 			const expression_char = code.original[this.node.prelude.start];
 			let c = this.node.start + (expression_char === '(' ? 6 : 7);
@@ -449,8 +451,11 @@ export default class Stylesheet {
 		});
 	}
 
-	/** @param {string} file */
-	render(file) {
+	/**
+	 * @param {string} file
+	 * @param {boolean} preserveUnusedSelectors
+	 */
+	render(file, preserveUnusedSelectors) {
 		if (!this.has_styles) {
 			return { code: null, map: null };
 		}
@@ -469,9 +474,9 @@ export default class Stylesheet {
 		});
 		let c = 0;
 		this.children.forEach((child) => {
-			if (child.is_used(this.dev)) {
+			if (preserveUnusedSelectors === true || child.is_used(this.dev)) {
 				code.remove(c, child.node.start);
-				child.minify(code, this.dev);
+				child.minify(code, this.dev, preserveUnusedSelectors);
 				c = child.node.end;
 			}
 		});

--- a/packages/svelte/src/compiler/compile/index.js
+++ b/packages/svelte/src/compiler/compile/index.js
@@ -31,7 +31,8 @@ const valid_options = [
 	'preserveComments',
 	'preserveWhitespace',
 	'cssHash',
-	'discloseVersion'
+	'discloseVersion',
+	'preserveUnusedSelectors'
 ];
 const valid_css_values = [true, false, 'injected', 'external', 'none'];
 const regex_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
@@ -126,7 +127,13 @@ function validate_options(options, warnings) {
  */
 export default function compile(source, options = {}) {
 	options = Object.assign(
-		{ generate: 'dom', dev: false, enableSourcemap: true, css: 'injected' },
+		{
+			generate: 'dom',
+			dev: false,
+			enableSourcemap: true,
+			css: 'injected',
+			preserveUnusedSelectors: false
+		},
 		options
 	);
 	const stats = new Stats();

--- a/packages/svelte/src/compiler/compile/render_dom/index.js
+++ b/packages/svelte/src/compiler/compile/render_dom/index.js
@@ -24,7 +24,7 @@ export default function dom(component, options) {
 		const file = component.file ? x`"${component.file}"` : x`undefined`;
 		body.push(b`const ${renderer.file_var} = ${file};`);
 	}
-	const css = component.stylesheet.render(options.filename);
+	const css = component.stylesheet.render(options.filename, options.preserveUnusedSelectors);
 	const css_sourcemap_enabled = check_enable_sourcemap(options.enableSourcemap, 'css');
 	if (css_sourcemap_enabled) {
 		css.map = apply_preprocessor_sourcemap(

--- a/packages/svelte/src/compiler/compile/render_ssr/index.js
+++ b/packages/svelte/src/compiler/compile/render_ssr/index.js
@@ -31,7 +31,7 @@ export default function ssr(component, options) {
 	// TODO concatenate CSS maps
 	const css = options.customElement
 		? { code: null, map: null }
-		: component.stylesheet.render(options.filename);
+		: component.stylesheet.render(options.filename, options.preserveUnusedSelectors);
 	const uses_rest = component.var_lookup.has('$$restProps');
 	const props = component.vars.filter((variable) => !variable.module && variable.export_name);
 	const rest = uses_rest

--- a/packages/svelte/src/compiler/interfaces.d.ts
+++ b/packages/svelte/src/compiler/interfaces.d.ts
@@ -350,6 +350,13 @@ export interface CompileOptions {
 	 * @default true
 	 */
 	discloseVersion?: boolean;
+
+	/**
+	 * If `true`, unused stylesheet selectors will be kept instead of removed.
+	 *
+	 * @default false
+	 */
+	preserveUnusedSelectors?: boolean;
 }
 
 export interface ParserOptions {

--- a/packages/svelte/test/css/samples/preserve-unused-selector/_config.js
+++ b/packages/svelte/test/css/samples/preserve-unused-selector/_config.js
@@ -1,0 +1,30 @@
+export default {
+	compileOptions: {
+		preserveUnusedSelectors: true
+	},
+	warnings: [
+		{
+			filename: 'SvelteComponent.svelte',
+			code: 'css-unused-selector',
+			message: 'Unused CSS selector ".bar"',
+			start: {
+				line: 8,
+				column: 1,
+				character: 60
+			},
+			end: {
+				line: 8,
+				column: 5,
+				character: 64
+			},
+			pos: 60,
+			frame: `
+			 6:   }
+			 7:
+			 8:   .bar {
+			      ^
+			 9:     color: blue;
+			10:   }`
+		}
+	]
+};

--- a/packages/svelte/test/css/samples/preserve-unused-selector/expected.css
+++ b/packages/svelte/test/css/samples/preserve-unused-selector/expected.css
@@ -1,0 +1,1 @@
+.foo.svelte-xyz{color:red}.bar{color:blue}

--- a/packages/svelte/test/css/samples/preserve-unused-selector/expected.html
+++ b/packages/svelte/test/css/samples/preserve-unused-selector/expected.html
@@ -1,0 +1,1 @@
+<div class="foo svelte-xyz"></div>

--- a/packages/svelte/test/css/samples/preserve-unused-selector/input.svelte
+++ b/packages/svelte/test/css/samples/preserve-unused-selector/input.svelte
@@ -1,0 +1,11 @@
+<div class='foo'></div>
+
+<style>
+	.foo {
+		color: red;
+	}
+
+	.bar {
+		color: blue;
+	}
+</style>


### PR DESCRIPTION
Hello Svelte contributors,

This PR proposes to add a compile option, `preserveUnusedSelectors`, that keeps unused stylesheet selectors when set to `true`. It is set to `false` by default, which means it does not affect previous behaviour and is not a breaking change. I've also written the preserve-unused-selectors test to accompany this new option.

### Related
- Addresses #1594, #5804, and #7751.
- Removal of unused selectors originally added in #729 in response to #697.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
