### PR TITLE
fix: ignore comments while comparing nodes in node_match

### DIFF
--- a/.changeset/thirty-steaks-dream.md
+++ b/.changeset/thirty-steaks-dream.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-ignore trailing comments when comparing nodes while invalidating
+fix: ignore trailing comments when comparing nodes

--- a/.changeset/thirty-steaks-dream.md
+++ b/.changeset/thirty-steaks-dream.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+ignore trailing comments when comparing nodes while invalidating

--- a/packages/svelte/src/compiler/compile/render_dom/invalidate.js
+++ b/packages/svelte/src/compiler/compile/render_dom/invalidate.js
@@ -50,7 +50,7 @@ export function invalidate(renderer, scope, node, names, main_execution_context 
 	if (
 		node.type === 'AssignmentExpression' &&
 		node.operator === '=' &&
-		nodes_match(node.left, node.right) &&
+		nodes_match(node.left, node.right, ["trailingComments","leadingComments"]) &&
 		tail.length === 0
 	) {
 		return get_invalidated(head, node);

--- a/packages/svelte/src/compiler/compile/render_dom/invalidate.js
+++ b/packages/svelte/src/compiler/compile/render_dom/invalidate.js
@@ -50,7 +50,7 @@ export function invalidate(renderer, scope, node, names, main_execution_context 
 	if (
 		node.type === 'AssignmentExpression' &&
 		node.operator === '=' &&
-		nodes_match(node.left, node.right, ["trailingComments","leadingComments"]) &&
+		nodes_match(node.left, node.right, ['trailingComments','leadingComments']) &&
 		tail.length === 0
 	) {
 		return get_invalidated(head, node);

--- a/packages/svelte/src/compiler/utils/nodes_match.js
+++ b/packages/svelte/src/compiler/utils/nodes_match.js
@@ -1,4 +1,4 @@
-export function nodes_match(a, b) {
+export function nodes_match(a, b, ignoreKeys=[]) {
 	if (!!a !== !!b) return false;
 	if (Array.isArray(a) !== Array.isArray(b)) return false;
 
@@ -8,8 +8,8 @@ export function nodes_match(a, b) {
 			return a.every((child, i) => nodes_match(child, b[i]));
 		}
 
-		const a_keys = Object.keys(a).sort();
-		const b_keys = Object.keys(b).sort();
+		const a_keys = Object.keys(a).sort().filter(key => !ignoreKeys.includes(key));
+		const b_keys = Object.keys(b).sort().filter(key => !ignoreKeys.includes(key));
 
 		if (a_keys.length !== b_keys.length) return false;
 

--- a/packages/svelte/test/runtime/samples/comment-effect-on-reactivity/SomeComponent.svelte
+++ b/packages/svelte/test/runtime/samples/comment-effect-on-reactivity/SomeComponent.svelte
@@ -1,0 +1,20 @@
+<script>
+	export let objectProp;
+	let count = 0;
+	$: objectPropCopy = [...objectProp];
+
+	$: incrementCount(), console.log('propDependencyChanged', objectProp);
+	const incrementCount = () => {
+		count++;
+	};
+	const clickAction = () => {
+		//note that this file shouldn't be formatted and the trailing comment must be rightnext to the variable name
+		// prettier-ignore
+		objectPropCopy = objectPropCopy// trailing comment
+	};
+</script>
+
+<button on:click={clickAction}>click me!</button>
+
+{objectPropCopy}
+<div id="render-count">{count}</div>

--- a/packages/svelte/test/runtime/samples/comment-effect-on-reactivity/_config.js
+++ b/packages/svelte/test/runtime/samples/comment-effect-on-reactivity/_config.js
@@ -1,0 +1,9 @@
+export default {
+	async test({ assert, target, window }) {
+		const incrementButton = target.querySelector('button');
+
+		assert.equal(target.querySelector('#render-count').innerHTML, '1');
+		await incrementButton.dispatchEvent(new window.MouseEvent('click'));
+		assert.equal(target.querySelector('#render-count').innerHTML, '2');
+	}
+};

--- a/packages/svelte/test/runtime/samples/comment-effect-on-reactivity/main.svelte
+++ b/packages/svelte/test/runtime/samples/comment-effect-on-reactivity/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import SomeComponent from './SomeComponent.svelte';
+	let objectProp = ['name', 'age'];
+
+	// look in SomeComponent.svelte for explaination
+</script>
+
+<SomeComponent {objectProp} />


### PR DESCRIPTION
## Ignore trailing comments when comparing nodes with `node_match` in `invalidate` function.

related to issue https://github.com/sveltejs/svelte/issues/9088
it doesn't solve the main problem of dependencies getting invalidated whenever value of a variable gets changed.  
but it fixes the behavior difference between the code with and without comments

the problem is demonstrated in this repl: https://svelte.dev/repl/81bdbbbb88694b4a80d2619bd2dbfc2e?version=4.2.0
