### PR TITLE
docs: add missing parens for getter

### DIFF
--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -119,13 +119,13 @@ With runes, things get much simpler:
 
 export function createCounter() {
 -	const { subscribe, update } = writable(0);
-+	let count = $state(0);
++	let value = $state(0);
 
 	return {
 -		subscribe,
 -		increment: () => update((n) => n + 1)
-+		get count { return count },
-+		increment: () => count += 1
++		get value() { return value },
++		increment: () => value += 1
    };
 }
 ```
@@ -139,11 +139,11 @@ export function createCounter() {
 
 <button on:click={counter.increment}>
 -	clicks: {$counter}
-+	clicks: {counter.count}
++	clicks: {counter.value}
 </button>
 ```
 
-Note that we're using a [get property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) in the returned object, so that `counter.count` always refers to the current value rather than the value at the time the function was called.
+Note that we're using a [get property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) in the returned object, so that `counter.value` always refers to the current value rather than the value at the time the function was called.
 
 ## Runtime reactivity
 


### PR DESCRIPTION
`get count` should be `get count()`. Also, I personally think `counter.count` looks a bit weird and might call it `counter.value`, but that's a bit subjective