### PR TITLE
fix(repl): runes bottom banner overlapping fixed

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
         specifier: ^1.24.1
         version: 1.25.0(svelte@packages+svelte)(vite@4.4.9)
       '@sveltejs/site-kit':
-        specifier: 6.0.0-next.47
-        version: 6.0.0-next.47(@sveltejs/kit@1.25.0)(svelte@packages+svelte)
+        specifier: 6.0.0-next.50
+        version: 6.0.0-next.50(@sveltejs/kit@1.25.0)(svelte@packages+svelte)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.4.6
         version: 2.4.6(svelte@packages+svelte)(vite@4.4.9)
@@ -2424,8 +2424,8 @@ packages:
       svelte-local-storage-store: 0.4.0(svelte@packages+svelte)
     dev: false
 
-  /@sveltejs/site-kit@6.0.0-next.47(@sveltejs/kit@1.25.0)(svelte@packages+svelte):
-    resolution: {integrity: sha512-vHKtz71e4bKH0gja//rSd/1rR8qHNCtdtXzjJ2nSdeACaZ5Daql7Q4JJ+0D9OM3Q9t/uj3XAFUPAmEaFENn5kA==}
+  /@sveltejs/site-kit@6.0.0-next.50(@sveltejs/kit@1.25.0)(svelte@packages+svelte):
+    resolution: {integrity: sha512-kgJVREVGuhhNO1YfQwJelFsBqfJiPhP7J4ytGUg05FaYlNQn3jb+BMUo027fSRpLgAjCqoo0IzIwX6CSSqqyJg==}
     peerDependencies:
       '@sveltejs/kit': ^1.20.0
       svelte: ^4.0.0

--- a/sites/svelte.dev/package.json
+++ b/sites/svelte.dev/package.json
@@ -30,7 +30,7 @@
     "@resvg/resvg-js": "^2.4.1",
     "@sveltejs/adapter-vercel": "^3.0.3",
     "@sveltejs/kit": "^1.24.1",
-    "@sveltejs/site-kit": "6.0.0-next.47",
+    "@sveltejs/site-kit": "6.0.0-next.50",
     "@sveltejs/vite-plugin-svelte": "^2.4.6",
     "@types/cookie": "^0.5.2",
     "@types/node": "^20.5.9",

--- a/sites/svelte.dev/src/routes/(authed)/repl/[id]/+page.svelte
+++ b/sites/svelte.dev/src/routes/(authed)/repl/[id]/+page.svelte
@@ -104,8 +104,8 @@
 <style>
 	.repl-outer {
 		position: relative;
-		height: calc(100% - var(--sk-nav-height));
-		height: calc(100dvh - var(--sk-nav-height));
+		height: calc(100% - var(--sk-nav-height) - var(--sk-banner-bottom-height));
+		height: calc(100dvh - var(--sk-nav-height) - var(--sk-banner-bottom-height));
 		--app-controls-h: 5.6rem;
 		--pane-controls-h: 4.2rem;
 		overflow: hidden;

--- a/sites/svelte.dev/src/routes/+layout.svelte
+++ b/sites/svelte.dev/src/routes/+layout.svelte
@@ -99,5 +99,6 @@
 		color: white;
 		text-decoration: underline;
 		padding: 8px;
+    z-index: 10;
 	}
 </style>

--- a/sites/svelte.dev/src/routes/+layout.svelte
+++ b/sites/svelte.dev/src/routes/+layout.svelte
@@ -99,6 +99,5 @@
 		color: white;
 		text-decoration: underline;
 		padding: 8px;
-    z-index: 10;
 	}
 </style>

--- a/sites/svelte.dev/src/routes/blog/+page.svelte
+++ b/sites/svelte.dev/src/routes/blog/+page.svelte
@@ -34,7 +34,7 @@
 	.posts {
 		grid-template-columns: 1fr 1fr;
 		grid-gap: 1em;
-		min-height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom));
+		min-height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom-height));
 		padding: var(--sk-page-padding-top) var(--sk-page-padding-side) 6rem var(--sk-page-padding-side);
 		max-width: var(--sk-page-main-width);
 		margin: 0 auto;

--- a/sites/svelte.dev/src/routes/blog/+page.svelte
+++ b/sites/svelte.dev/src/routes/blog/+page.svelte
@@ -34,7 +34,7 @@
 	.posts {
 		grid-template-columns: 1fr 1fr;
 		grid-gap: 1em;
-		min-height: calc(100vh - var(--sk-nav-height));
+		min-height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom));
 		padding: var(--sk-page-padding-top) var(--sk-page-padding-side) 6rem var(--sk-page-padding-side);
 		max-width: var(--sk-page-main-width);
 		margin: 0 auto;

--- a/sites/svelte.dev/src/routes/docs/+layout.svelte
+++ b/sites/svelte.dev/src/routes/docs/+layout.svelte
@@ -70,7 +70,7 @@
 		.toc-container {
 			display: block;
 			width: var(--sidebar-width);
-			height: calc(100vh - var(--sk-nav-height));
+			height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom));
 			position: fixed;
 			left: 0;
 			top: var(--sk-nav-height);

--- a/sites/svelte.dev/src/routes/docs/+layout.svelte
+++ b/sites/svelte.dev/src/routes/docs/+layout.svelte
@@ -70,7 +70,7 @@
 		.toc-container {
 			display: block;
 			width: var(--sidebar-width);
-			height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom));
+			height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom-height));
 			position: fixed;
 			left: 0;
 			top: var(--sk-nav-height);

--- a/sites/svelte.dev/src/routes/examples/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/examples/[slug]/+page.svelte
@@ -65,7 +65,7 @@
 <style>
 	.examples-container {
 		position: relative;
-		height: calc(100vh - var(--sk-nav-height));
+		height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom));
 		overflow: hidden;
 		padding: 0 0 42px 0;
 		box-sizing: border-box;

--- a/sites/svelte.dev/src/routes/examples/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/examples/[slug]/+page.svelte
@@ -65,7 +65,7 @@
 <style>
 	.examples-container {
 		position: relative;
-		height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom));
+		height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom-height));
 		overflow: hidden;
 		padding: 0 0 42px 0;
 		box-sizing: border-box;

--- a/sites/svelte.dev/src/routes/tutorial/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/+page.svelte
@@ -161,7 +161,7 @@
 <style>
 	.tutorial-outer {
 		position: relative;
-		height: calc(100vh - var(--sk-nav-height));
+		height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom));
 		overflow: hidden;
 		padding: 0 0 42px 0;
 		box-sizing: border-box;

--- a/sites/svelte.dev/src/routes/tutorial/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/+page.svelte
@@ -161,7 +161,7 @@
 <style>
 	.tutorial-outer {
 		position: relative;
-		height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom));
+		height: calc(100vh - var(--sk-nav-height) - var(--sk-banner-bottom-height));
 		overflow: hidden;
 		padding: 0 0 42px 0;
 		box-sizing: border-box;


### PR DESCRIPTION
The issue of overlapping runes bottom banner on the REPL has been resolved.

## Svelte compiler rewrite

Please note that [the Svelte codebase is currently being rewritten](https://svelte.dev/blog/runes). Thus, it's best to hold off on new features or refactorings for the time being.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
