### PR TITLE
fix: Add missing plaintext-only value to contenteditable type

### DIFF
--- a/.changeset/slimy-comics-switch.md
+++ b/.changeset/slimy-comics-switch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add missing plaintext-only value to contenteditable type

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -486,7 +486,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	accesskey?: string | undefined | null;
 	autofocus?: boolean | undefined | null;
 	class?: string | undefined | null;
-	contenteditable?: Booleanish | 'inherit' | undefined | null;
+	contenteditable?: Booleanish | 'inherit' | 'plaintext-only' | undefined | null;
 	contextmenu?: string | undefined | null;
 	dir?: string | undefined | null;
 	draggable?: Booleanish | undefined | null;


### PR DESCRIPTION
## Svelte compiler rewrite

As it was mentioned in #9181 contenteditable property was incomplete and missing 'plaintext-only'. This PR actually add this value to type.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
