### PR TITLE
feat: conditional transition

### DIFF
--- a/documentation/docs/03-runtime/04-svelte-transition.md
+++ b/documentation/docs/03-runtime/04-svelte-transition.md
@@ -27,6 +27,7 @@ Animates the opacity of an element from 0 to the current opacity for `in` transi
 - `delay` (`number`, default 0) — milliseconds before starting
 - `duration` (`number`, default 400) — milliseconds the transition lasts
 - `easing` (`function`, default `linear`) — an [easing function](/docs/svelte-easing)
+- `condition` (`function`, default `undefined`) - condition to run the transition
 
 You can see the `fade` transition in action in the [transition tutorial](https://learn.svelte.dev/tutorial/transition).
 
@@ -63,6 +64,7 @@ Animates a `blur` filter alongside an element's opacity.
 - `delay` (`number`, default 0) — milliseconds before starting
 - `duration` (`number`, default 400) — milliseconds the transition lasts
 - `easing` (`function`, default `cubicInOut`) — an [easing function](/docs/svelte-easing)
+- `condition` (`function`, default `undefined`) - condition to run the transition
 - `opacity` (`number`, default 0) - the opacity value to animate out to and in from
 - `amount` (`number | string`, default 5) - the size of the blur. Supports css units (for example: `"4rem"`). The default unit is `px`
 
@@ -99,6 +101,7 @@ Animates the x and y positions and the opacity of an element. `in` transitions a
 - `delay` (`number`, default 0) — milliseconds before starting
 - `duration` (`number`, default 400) — milliseconds the transition lasts
 - `easing` (`function`, default `cubicOut`) — an [easing function](/docs/svelte-easing)
+- `condition` (`function`, default `undefined`) - condition to run the transition
 - `x` (`number | string`, default 0) - the x offset to animate out to and in from
 - `y` (`number | string`, default 0) - the y offset to animate out to and in from
 - `opacity` (`number`, default 0) - the opacity value to animate out to and in from
@@ -144,6 +147,7 @@ Slides an element in and out.
 - `delay` (`number`, default 0) — milliseconds before starting
 - `duration` (`number`, default 400) — milliseconds the transition lasts
 - `easing` (`function`, default `cubicOut`) — an [easing function](/docs/svelte-easing)
+- `condition` (`function`, default `undefined`) - condition to run the transition
 
 * `axis` (`x` | `y`, default `y`) — the axis of motion along which the transition occurs
 
@@ -183,6 +187,7 @@ Animates the opacity and scale of an element. `in` transitions animate from an e
 - `delay` (`number`, default 0) — milliseconds before starting
 - `duration` (`number`, default 400) — milliseconds the transition lasts
 - `easing` (`function`, default `cubicOut`) — an [easing function](/docs/svelte-easing)
+- `condition` (`function`, default `undefined`) - condition to run the transition
 - `start` (`number`, default 0) - the scale value to animate out to and in from
 - `opacity` (`number`, default 0) - the opacity value to animate out to and in from
 
@@ -220,9 +225,10 @@ Animates the stroke of an SVG element, like a snake in a tube. `in` transitions 
 `draw` accepts the following parameters:
 
 - `delay` (`number`, default 0) — milliseconds before starting
-- `speed` (`number`, default undefined) - the speed of the animation, see below.
+- `speed` (`number`, default `undefined`) - the speed of the animation, see below.
 - `duration` (`number` | `function`, default 800) — milliseconds the transition lasts
 - `easing` (`function`, default `cubicInOut`) — an [easing function](/docs/svelte-easing)
+- `condition` (`function`, default `undefined`) - condition to run the transition
 
 The `speed` parameter is a means of setting the duration of the transition relative to the path's length. It is a modifier that is applied to the length of the path: `duration = length / speed`. A path that is 1000 pixels with a speed of 1 will have a duration of `1000ms`, setting the speed to `0.5` will double that duration and setting it to `2` will halve it.
 
@@ -257,6 +263,7 @@ The `crossfade` function creates a pair of [transitions](/docs/element-directive
 - `delay` (`number`, default 0) — milliseconds before starting
 - `duration` (`number` | `function`, default 800) — milliseconds the transition lasts
 - `easing` (`function`, default `cubicOut`) — an [easing function](/docs/svelte-easing)
+- `condition` (`function`, default `undefined`) - condition to run the transition
 - `fallback` (`function`) — A fallback [transition](/docs/element-directives#transition-fn) to use for send when there is no matching element being received, and for receive when there is no element being sent.
 
 ```svelte

--- a/packages/svelte/src/runtime/internal/transitions.js
+++ b/packages/svelte/src/runtime/internal/transitions.js
@@ -163,9 +163,11 @@ export function create_in_transition(node, fn, params) {
 			delete_rule(node);
 			if (is_function(config)) {
 				config = config(options);
-				wait().then(go);
+				wait().then(() => {
+					if (!config.condition || config.condition()) go();
+				});
 			} else {
-				go();
+				if (!config.condition || config.condition()) go();
 			}
 		},
 		invalidate() {
@@ -244,10 +246,19 @@ export function create_out_transition(node, fn, params) {
 		wait().then(() => {
 			// @ts-ignore
 			config = config(options);
-			go();
+
+			if (!config.condition || config.condition()) {
+				go();
+			} else {
+				if (!--group.r) run_all(group.c);
+			}
 		});
 	} else {
-		go();
+		if (!config.condition || config.condition()) {
+			go();
+		} else {
+			if (!--group.r) run_all(group.c);
+		}
 	}
 
 	return {
@@ -417,10 +428,21 @@ export function create_bidirectional_transition(node, fn, params, intro) {
 					const opts = { direction: b ? 'in' : 'out' };
 					// @ts-ignore
 					config = config(opts);
-					go(b);
+
+					if (!config.condition || config.condition()) {
+						go(b);
+					} else {
+						t = b;
+						if (!b && !outros.r) run_all(outros.c);
+					}
 				});
 			} else {
-				go(b);
+				if (!config.condition || config.condition()) {
+					go(b);
+				} else {
+					t = b;
+					if (!b && !outros.r) run_all(outros.c);
+				}
 			}
 		},
 		end() {

--- a/packages/svelte/src/runtime/transition/index.js
+++ b/packages/svelte/src/runtime/transition/index.js
@@ -11,7 +11,14 @@ import { assign, split_css_unit, is_function } from '../internal/index.js';
  */
 export function blur(
 	node,
-	{ delay = 0, duration = 400, easing = cubicInOut, amount = 5, opacity = 0 } = {}
+	{
+		delay = 0,
+		duration = 400,
+		easing = cubicInOut,
+		condition = undefined,
+		amount = 5,
+		opacity = 0
+	} = {}
 ) {
 	const style = getComputedStyle(node);
 	const target_opacity = +style.opacity;
@@ -22,7 +29,8 @@ export function blur(
 		delay,
 		duration,
 		easing,
-		css: (_t, u) => `opacity: ${target_opacity - od * u}; filter: ${f} blur(${u * value}${unit});`
+		css: (_t, u) => `opacity: ${target_opacity - od * u}; filter: ${f} blur(${u * value}${unit});`,
+		condition
 	};
 }
 
@@ -34,13 +42,17 @@ export function blur(
  * @param {import('./public').FadeParams} [params]
  * @returns {import('./public').TransitionConfig}
  */
-export function fade(node, { delay = 0, duration = 400, easing = linear } = {}) {
+export function fade(
+	node,
+	{ delay = 0, duration = 400, easing = linear, condition = undefined } = {}
+) {
 	const o = +getComputedStyle(node).opacity;
 	return {
 		delay,
 		duration,
 		easing,
-		css: (t) => `opacity: ${t * o}`
+		css: (t) => `opacity: ${t * o}`,
+		condition
 	};
 }
 
@@ -54,7 +66,15 @@ export function fade(node, { delay = 0, duration = 400, easing = linear } = {}) 
  */
 export function fly(
 	node,
-	{ delay = 0, duration = 400, easing = cubicOut, x = 0, y = 0, opacity = 0 } = {}
+	{
+		delay = 0,
+		duration = 400,
+		easing = cubicOut,
+		condition = undefined,
+		x = 0,
+		y = 0,
+		opacity = 0
+	} = {}
 ) {
 	const style = getComputedStyle(node);
 	const target_opacity = +style.opacity;
@@ -68,7 +88,8 @@ export function fly(
 		easing,
 		css: (t, u) => `
 			transform: ${transform} translate(${(1 - t) * xValue}${xUnit}, ${(1 - t) * yValue}${yUnit});
-			opacity: ${target_opacity - od * u}`
+			opacity: ${target_opacity - od * u}`,
+		condition
 	};
 }
 
@@ -80,7 +101,10 @@ export function fly(
  * @param {import('./public').SlideParams} [params]
  * @returns {import('./public').TransitionConfig}
  */
-export function slide(node, { delay = 0, duration = 400, easing = cubicOut, axis = 'y' } = {}) {
+export function slide(
+	node,
+	{ delay = 0, duration = 400, easing = cubicOut, condition = undefined, axis = 'y' } = {}
+) {
 	const style = getComputedStyle(node);
 	const opacity = +style.opacity;
 	const primary_property = axis === 'y' ? 'height' : 'width';
@@ -112,7 +136,8 @@ export function slide(node, { delay = 0, duration = 400, easing = cubicOut, axis
 			`margin-${secondary_properties[0]}: ${t * margin_start_value}px;` +
 			`margin-${secondary_properties[1]}: ${t * margin_end_value}px;` +
 			`border-${secondary_properties[0]}-width: ${t * border_width_start_value}px;` +
-			`border-${secondary_properties[1]}-width: ${t * border_width_end_value}px;`
+			`border-${secondary_properties[1]}-width: ${t * border_width_end_value}px;`,
+		condition
 	};
 }
 
@@ -126,7 +151,14 @@ export function slide(node, { delay = 0, duration = 400, easing = cubicOut, axis
  */
 export function scale(
 	node,
-	{ delay = 0, duration = 400, easing = cubicOut, start = 0, opacity = 0 } = {}
+	{
+		delay = 0,
+		duration = 400,
+		easing = cubicOut,
+		condition = undefined,
+		start = 0,
+		opacity = 0
+	} = {}
 ) {
 	const style = getComputedStyle(node);
 	const target_opacity = +style.opacity;
@@ -140,7 +172,8 @@ export function scale(
 		css: (_t, u) => `
 			transform: ${transform} scale(${1 - sd * u});
 			opacity: ${target_opacity - od * u}
-		`
+		`,
+		condition
 	};
 }
 
@@ -152,7 +185,10 @@ export function scale(
  * @param {import('./public').DrawParams} [params]
  * @returns {import('./public').TransitionConfig}
  */
-export function draw(node, { delay = 0, speed, duration, easing = cubicInOut } = {}) {
+export function draw(
+	node,
+	{ delay = 0, speed, duration, easing = cubicInOut, condition = undefined } = {}
+) {
 	let len = node.getTotalLength();
 	const style = getComputedStyle(node);
 	if (style.strokeLinecap !== 'butt') {
@@ -174,7 +210,8 @@ export function draw(node, { delay = 0, speed, duration, easing = cubicInOut } =
 		css: (_, u) => `
 			stroke-dasharray: ${len};
 			stroke-dashoffset: ${u * len};
-		`
+		`,
+		condition
 	};
 }
 
@@ -202,7 +239,8 @@ export function crossfade({ fallback, ...defaults }) {
 		const {
 			delay = 0,
 			duration = (d) => Math.sqrt(d) * 30,
-			easing = cubicOut
+			easing = cubicOut,
+			condition = undefined
 		} = assign(assign({}, defaults), params);
 		const from = from_node.getBoundingClientRect();
 		const to = node.getBoundingClientRect();
@@ -224,7 +262,8 @@ export function crossfade({ fallback, ...defaults }) {
 				transform: ${transform} translate(${u * dx}px,${u * dy}px) scale(${t + (1 - t) * dw}, ${
 				t + (1 - t) * dh
 			});
-			`
+			`,
+			condition
 		};
 	}
 

--- a/packages/svelte/src/runtime/transition/public.d.ts
+++ b/packages/svelte/src/runtime/transition/public.d.ts
@@ -6,6 +6,7 @@ export interface TransitionConfig {
 	easing?: EasingFunction;
 	css?: (t: number, u: number) => string;
 	tick?: (t: number, u: number) => void;
+	condition?: () => boolean;
 }
 
 export interface BlurParams {

--- a/packages/svelte/src/runtime/transition/public.d.ts
+++ b/packages/svelte/src/runtime/transition/public.d.ts
@@ -1,4 +1,5 @@
 export type EasingFunction = (t: number) => number;
+export type ConditionFunction = () => boolean;
 
 export interface TransitionConfig {
 	delay?: number;
@@ -6,13 +7,14 @@ export interface TransitionConfig {
 	easing?: EasingFunction;
 	css?: (t: number, u: number) => string;
 	tick?: (t: number, u: number) => void;
-	condition?: () => boolean;
+	condition?: ConditionFunction;
 }
 
 export interface BlurParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
+	condition?: ConditionFunction;
 	amount?: number | string;
 	opacity?: number;
 }
@@ -21,12 +23,14 @@ export interface FadeParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
+	condition?: ConditionFunction;
 }
 
 export interface FlyParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
+	condition?: ConditionFunction;
 	x?: number | string;
 	y?: number | string;
 	opacity?: number;
@@ -36,6 +40,7 @@ export interface SlideParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
+	condition?: ConditionFunction;
 	axis?: 'x' | 'y';
 }
 
@@ -43,6 +48,7 @@ export interface ScaleParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
+	condition?: ConditionFunction;
 	start?: number;
 	opacity?: number;
 }
@@ -52,12 +58,14 @@ export interface DrawParams {
 	speed?: number;
 	duration?: number | ((len: number) => number);
 	easing?: EasingFunction;
+	condition?: ConditionFunction;
 }
 
 export interface CrossfadeParams {
 	delay?: number;
 	duration?: number | ((len: number) => number);
 	easing?: EasingFunction;
+	condition?: ConditionFunction;
 }
 
 export * from './index.js';

--- a/packages/svelte/test/runtime/samples/transition-js-condition-dynamic-in-out/_config.js
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-dynamic-in-out/_config.js
@@ -1,0 +1,105 @@
+export default {
+	test({ assert, component, target, raf }) {
+		// Undefined -> true
+		component.visible = true;
+		let div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+		assert.isUndefined(div.bar);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+		assert.isUndefined(div.bar);
+
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 1);
+		assert.equal(div.bar, 0);
+
+		component.visible = true;
+		div = target.querySelector('div');
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+		assert.isUndefined(div.bar);
+
+		raf.tick(300);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+		assert.isUndefined(div.bar);
+
+		// Create a condition objects that can be toggled
+		let shouldRunIn = true;
+		let shouldRunOut = true;
+		let conditionObject = {
+			get conditionIn() {
+				return shouldRunIn;
+			},
+			get conditionOut() {
+				return shouldRunOut;
+			}
+		};
+		component.conditionIn = () => conditionObject.conditionIn;
+		component.conditionOut = () => conditionObject.conditionOut;
+
+		component.visible = false;
+		raf.tick(400);
+		assert.htmlEqual(target.innerHTML, '');
+
+		// in: true, out: false
+		shouldRunIn = true;
+		shouldRunOut = false;
+
+		component.visible = true;
+		div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+		assert.isUndefined(div.bar);
+
+		raf.tick(500);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+		assert.isUndefined(div.bar);
+
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 1);
+		assert.isUndefined(div.bar);
+
+		raf.tick(600);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 1);
+		assert.isUndefined(div.bar);
+
+		// in: false, out: true
+		shouldRunIn = false;
+		shouldRunOut = true;
+
+		component.visible = true;
+		div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+		assert.isUndefined(div.bar);
+
+		raf.tick(700);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+		assert.isUndefined(div.bar);
+
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+
+		raf.tick(800);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.isUndefined(div.foo, 1);
+		assert.equal(div.bar, 0);
+	}
+};

--- a/packages/svelte/test/runtime/samples/transition-js-condition-dynamic-in-out/main.svelte
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-dynamic-in-out/main.svelte
@@ -1,0 +1,29 @@
+<script>
+	export let visible;
+	export let conditionIn;
+	export let conditionOut;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.foo = t;
+			},
+			condition: conditionIn
+		};
+	}
+
+	function bar(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.bar = t;
+			},
+			condition: conditionOut
+		};
+	}
+</script>
+
+{#if visible}
+	<div in:foo out:bar />
+{/if}

--- a/packages/svelte/test/runtime/samples/transition-js-condition-dynamic/_config.js
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-dynamic/_config.js
@@ -1,0 +1,85 @@
+export default {
+	test({ assert, component, target, raf }) {
+		// Undefined -> true
+		component.visible = true;
+		let div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 0);
+
+		component.visible = true;
+		div = target.querySelector('div');
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+
+		raf.tick(300);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+
+		// Create a condition object that can be toggled
+		let shouldRun = true;
+		let conditionObject = {
+			get condition() {
+				return shouldRun;
+			}
+		};
+		component.condition = () => conditionObject.condition;
+
+		component.visible = false;
+		raf.tick(400);
+		assert.htmlEqual(target.innerHTML, '');
+		
+		// in: true, out: false
+		shouldRun = true;
+		component.visible = true;
+		div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+
+		raf.tick(500);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+
+		shouldRun = false;
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 1);
+
+		raf.tick(600);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 1);
+
+		// in: false, out: true
+		shouldRun = false;
+		component.visible = true;
+		div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+
+		raf.tick(700);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+
+		shouldRun = true;
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+
+		raf.tick(800);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 0);
+	}
+};

--- a/packages/svelte/test/runtime/samples/transition-js-condition-dynamic/main.svelte
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-dynamic/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	export let visible;
+	export let condition;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.foo = t;
+			},
+			condition
+		};
+	}
+</script>
+
+{#if visible}
+	<div transition:foo />
+{/if}

--- a/packages/svelte/test/runtime/samples/transition-js-condition-false-in-out/_config.js
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-false-in-out/_config.js
@@ -1,0 +1,35 @@
+export default {
+	test({ assert, component, target, raf }) {
+		component.visible = true;
+		let div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+		assert.isUndefined(div.bar);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+		assert.isUndefined(div.bar);
+
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '');
+		assert.isUndefined(div.foo);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.isUndefined(div.foo);
+		assert.isUndefined(div.bar);
+
+		component.visible = true;
+		div = target.querySelector('div');
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+		assert.isUndefined(div.bar);
+
+		raf.tick(300);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+		assert.isUndefined(div.bar);
+	}
+};

--- a/packages/svelte/test/runtime/samples/transition-js-condition-false-in-out/main.svelte
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-false-in-out/main.svelte
@@ -1,0 +1,27 @@
+<script>
+	export let visible;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.foo = t;
+			},
+			condition: () => false
+		};
+	}
+
+	function bar(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.bar = t;
+			},
+			condition: () => false
+		};
+	}
+</script>
+
+{#if visible}
+	<div in:foo out:bar />
+{/if}

--- a/packages/svelte/test/runtime/samples/transition-js-condition-false/_config.js
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-false/_config.js
@@ -1,0 +1,30 @@
+export default {
+	test({ assert, component, target, raf }) {
+		component.visible = true;
+		let div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '');
+		assert.isUndefined(div.foo);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.isUndefined(div.foo);
+
+		component.visible = true;
+		div = target.querySelector('div');
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+
+		raf.tick(300);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.isUndefined(div.foo);
+	}
+};

--- a/packages/svelte/test/runtime/samples/transition-js-condition-false/main.svelte
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-false/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	export let visible;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.foo = t;
+			},
+			condition: () => false
+		};
+	}
+</script>
+
+{#if visible}
+	<div transition:foo />
+{/if}

--- a/packages/svelte/test/runtime/samples/transition-js-condition-true-in-out/_config.js
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-true-in-out/_config.js
@@ -1,0 +1,35 @@
+export default {
+	test({ assert, component, target, raf }) {
+		component.visible = true;
+		let div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+		assert.isUndefined(div.bar);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+		assert.isUndefined(div.bar);
+
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 1);
+		assert.equal(div.bar, 0);
+
+		component.visible = true;
+		div = target.querySelector('div');
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+		assert.isUndefined(div.bar);
+
+		raf.tick(300);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+		assert.isUndefined(div.bar);
+	}
+};

--- a/packages/svelte/test/runtime/samples/transition-js-condition-true-in-out/main.svelte
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-true-in-out/main.svelte
@@ -1,0 +1,27 @@
+<script>
+	export let visible;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.foo = t;
+			},
+			condition: () => true
+		};
+	}
+
+	function bar(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.bar = t;
+			},
+			condition: () => true
+		};
+	}
+</script>
+
+{#if visible}
+	<div in:foo out:bar />
+{/if}

--- a/packages/svelte/test/runtime/samples/transition-js-condition-true/_config.js
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-true/_config.js
@@ -1,0 +1,30 @@
+export default {
+	test({ assert, component, target, raf }) {
+		component.visible = true;
+		let div = target.querySelector('div');
+
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+
+		raf.tick(100);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+
+		component.visible = false;
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+
+		raf.tick(200);
+		assert.htmlEqual(target.innerHTML, '');
+		assert.equal(div.foo, 0);
+
+		component.visible = true;
+		div = target.querySelector('div');
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 0);
+
+		raf.tick(300);
+		assert.htmlEqual(target.innerHTML, '<div></div>');
+		assert.equal(div.foo, 1);
+	}
+};

--- a/packages/svelte/test/runtime/samples/transition-js-condition-true/main.svelte
+++ b/packages/svelte/test/runtime/samples/transition-js-condition-true/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	export let visible;
+
+	function foo(node, params) {
+		return {
+			duration: 100,
+			tick: (t) => {
+				node.foo = t;
+			},
+			condition: () => true
+		};
+	}
+</script>
+
+{#if visible}
+	<div transition:foo />
+{/if}


### PR DESCRIPTION
I was running into a problem where a race condition between the Svelte transition code and the SvelteKit navigation code caused a component to stay mounted even on the new site that was navigated to (#9028). This not only caused a little flicker, but crucially also broke scroll restoration, which is really important to me.

Issue reproduction: https://stackblitz.com/edit/sveltejs-kit-template-default-atnnds

This PR introduces a `condition` property on [`TransitionConfig`](https://svelte.dev/docs/svelte-transition#types-transitionconfig) that allows the user to dynamically decide whether the transition should run. This allows me to check whether kit is navigating and abort the transition with something like [this](https://gist.github.com/Coronon/09d3d8821273bf0072dac6b95f1ab491).

It is also fully backwards compatible and should not modify the behavior of any existing code.

Please take a look if the tests I added for the condition are enough.

I would also like to thank @gtm-nayan for his guidance :)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
