### PR TITLE
fix: svelte.dev site scripts filepath generation

### DIFF
--- a/sites/svelte.dev/scripts/get_contributors.js
+++ b/sites/svelte.dev/scripts/get_contributors.js
@@ -65,7 +65,9 @@ try {
 	await sprite
 		.quality(80)
 		.writeAsync(
-			new URL(`../src/routes/_components/Supporters/contributors.jpg`, import.meta.url).pathname
+			fileURLToPath(
+				new URL(`../src/routes/_components/Supporters/contributors.jpg`, import.meta.url)
+			)
 		);
 
 	const str = `[\n\t${authors.map((a) => `'${a.login}'`).join(',\n\t')}\n]`;

--- a/sites/svelte.dev/scripts/get_donors.js
+++ b/sites/svelte.dev/scripts/get_donors.js
@@ -59,7 +59,7 @@ try {
 	await sprite
 		.quality(80)
 		.writeAsync(
-			new URL(`../src/routes/_components/Supporters/donors.jpg`, import.meta.url).pathname
+			fileURLToPath(new URL(`../src/routes/_components/Supporters/donors.jpg`, import.meta.url))
 		);
 
 	const str = `[\n\t${included.map((a) => `${JSON.stringify(a.backer.name)}`).join(',\n\t')}\n]`;


### PR DESCRIPTION
This small change fixes an issue when attempting to run the svelte.dev site locally on a windows machine:

```
Error: ENOENT: no such file or directory, mkdir '/C:/somepath/svelte/sites/svelte.dev/src/routes/_components/Supporters'
```

Notice the leading `/` in the path above, which comes from using `.pathname` directly instead of `fileURLToPath`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
