### PR TITLE
fix: add `string` to the union type for `HTMLTableAttributes['border']`

### DIFF
--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1045,7 +1045,7 @@ export interface HTMLStyleAttributes extends HTMLAttributes<HTMLStyleElement> {
 export interface HTMLTableAttributes extends HTMLAttributes<HTMLTableElement> {
 	align?: 'left' | 'center' | 'right' | undefined | null;
 	bgcolor?: string | undefined | null;
-	border?: number | undefined | null;
+	border?: number | string | undefined | null;
 	cellpadding?: number | string | undefined | null;
 	cellspacing?: number | string | undefined | null;
 	frame?: boolean | undefined | null;


### PR DESCRIPTION
Fixes this issue with the `HTMLTableAttributes` type:

<img width="922" alt="CleanShot 2023-10-10 at 10 21 19@2x" src="https://github.com/sveltejs/svelte/assets/1141869/f97e2fe5-f7ab-4e14-8499-ebe2ff38f61b">

Since cellpadding and cellspacing both include `string`, I'm guessing that leaving it off of border was just an oversight.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
