### PR TITLE
Update +layout.svelte to commenting out bottom banner 

### DIFF
--- a/sites/svelte.dev/src/routes/+layout.svelte
+++ b/sites/svelte.dev/src/routes/+layout.svelte
@@ -72,10 +72,10 @@
 		</Nav>
 
 		<slot />
-
-		<div slot="banner-bottom" class="banner-bottom">
-			<a href="/blog/runes" class="banner-bottom">Introducing the upcoming Svelte 5 API: Runes</a>
-		</div>
+	
+		<!-- <div slot="banner-bottom" class="banner-bottom">
+			 <a href="/blog/runes" class="banner-bottom">Introducing the upcoming Svelte 5 API: Runes</a> 
+		</div> -->
 	</Shell>
 </div>
 


### PR DESCRIPTION
The bottom banner for blog posts takes up space on every page and it doesn't go away even when reading the docs or the very post it mentions. For future changes that affect the docs so much, maybe the sidebar can have a star/special marker on the specific doc link indicating as such.

I commented it out instead of removing it for future reference.
