### PR TITLE
docs: mention `{#await}` on non-Promise values short-circuiting to the fullfilled branch

### DIFF
--- a/documentation/docs/02-template-syntax/03-logic-blocks.md
+++ b/documentation/docs/02-template-syntax/03-logic-blocks.md
@@ -152,14 +152,16 @@ Since Svelte 4 it is possible to iterate over iterables like `Map` or `Set`. Ite
 {#await expression catch name}...{/await}
 ```
 
-Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected. In SSR mode, only the pending state will be rendered on the server.
+Await blocks allow you to branch on the three possible states of a Promise — pending, fulfilled or rejected.
+In SSR mode, only the pending branch will be rendered on the server.
+If the provided expression is not a Promise only the fulfilled branch will be rendered, including in SSR mode.
 
 ```svelte
 {#await promise}
 	<!-- promise is pending -->
 	<p>waiting for the promise to resolve...</p>
 {:then value}
-	<!-- promise was fulfilled -->
+	<!-- promise was fulfilled or not a Promise -->
 	<p>The value is {value}</p>
 {:catch error}
 	<!-- promise was rejected -->


### PR DESCRIPTION
Fixes sveltejs/svelte#9323.
Wording could probably be better, feel free to fix my mediocre English.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
