### PR TITLE
fix: Add transform-origin to SVGAttributes

### DIFF
--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1405,6 +1405,7 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	'text-rendering'?: number | string | undefined | null;
 	to?: number | string | undefined | null;
 	transform?: string | undefined | null;
+	'transform-origin'?: string | undefined | null;
 	u1?: number | string | undefined | null;
 	u2?: number | string | undefined | null;
 	'underline-position'?: number | string | undefined | null;


### PR DESCRIPTION
```
<rect
  x="10"
  y="10"
  width="10"
  height="10"
  transform="scale(2)"
  transform-origin="10 10"
/>
```

gives the following error in VS Code 

```
Argument of type '{ x: string; y: string; width: string; height: string; transform: string; "transform-origin": string; }' is not assignable to parameter of type 'HTMLProps<"rect", SVGAttributes<any>>'.
  Object literal may only specify known properties, and '"transform-origin"' does not exist in type 'HTMLProps<"rect", SVGAttributes<any>>'. js(2345)
```

`transform-origin` can be set as a presentational attribute but it's missing in the `SVGAttributes`.

See:
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform-origin
https://www.w3.org/TR/SVG2/styling.html#PresentationAttributes (missing in the original spec, I guess it was forgotten)
https://svgwg.org/svg2-draft/styling.html#PresentationAttributes (added in the latest draft)

Do we also need to add transform-origin to packages/svelte/src/compiler/compile/render_dom/wrappers/Element/fix_attribute_casing.js then?

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
