### PR TITLE
fix: support camelCase properties on custom elements

### DIFF
--- a/.changeset/seven-cars-drum.md
+++ b/.changeset/seven-cars-drum.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: support camelCase properties on custom elements

--- a/packages/svelte/src/compiler/compile/render_dom/wrappers/Element/Attribute.js
+++ b/packages/svelte/src/compiler/compile/render_dom/wrappers/Element/Attribute.js
@@ -103,8 +103,8 @@ export default class AttributeWrapper extends BaseAttributeWrapper {
 				this.parent.has_dynamic_value = true;
 			}
 		}
-		if (this.parent.node.namespace == namespaces.foreign) {
-			// leave attribute case alone for elements in the "foreign" namespace
+		if (this.parent.node.namespace == namespaces.foreign || this.parent.node.name.includes('-')) {
+			// leave attribute case alone for elements in the "foreign" namespace and for custom elements
 			this.name = this.node.name;
 			this.metadata = this.get_metadata();
 			this.is_indirectly_bound_value = false;

--- a/packages/svelte/src/runtime/internal/dom.js
+++ b/packages/svelte/src/runtime/internal/dom.js
@@ -480,7 +480,10 @@ export function set_custom_element_data_map(node, data_map) {
 /**
  * @returns {void} */
 export function set_custom_element_data(node, prop, value) {
-	if (prop in node) {
+	const lower = prop.toLowerCase(); // for backwards compatibility with existing behavior we do lowercase first
+	if (lower in node) {
+		node[lower] = typeof node[lower] === 'boolean' && value === '' ? true : value;
+	} else if (prop in node) {
 		node[prop] = typeof node[prop] === 'boolean' && value === '' ? true : value;
 	} else {
 		attr(node, prop, value);

--- a/packages/svelte/test/runtime/samples/attribute-casing-custom-element/_config.js
+++ b/packages/svelte/test/runtime/samples/attribute-casing-custom-element/_config.js
@@ -1,0 +1,7 @@
+export default {
+	skip_if_ssr: true,
+	skip_if_hydrate: true,
+	html: `
+		<my-custom-element>Hello World!</my-custom-element>
+	`
+};

--- a/packages/svelte/test/runtime/samples/attribute-casing-custom-element/main.svelte
+++ b/packages/svelte/test/runtime/samples/attribute-casing-custom-element/main.svelte
@@ -1,0 +1,25 @@
+<script>
+	class MyCustomElement extends HTMLElement {
+		constructor() {
+			super();
+			this._obj = null;
+		}
+
+		set camelCase(obj) {
+			this._obj = obj;
+			this.render();
+		}
+
+		connectedCallback() {
+			this.render();
+		}
+
+		render() {
+			this.innerHTML = 'Hello ' + this._obj.text + '!';
+		}
+	}
+
+	window.customElements.define('my-custom-element', MyCustomElement);
+</script>
+
+<my-custom-element camelCase={{ text: 'World' }} />

--- a/packages/svelte/test/runtime/samples/attribute-custom-element-inheritance/_config.js
+++ b/packages/svelte/test/runtime/samples/attribute-custom-element-inheritance/_config.js
@@ -1,0 +1,7 @@
+export default {
+	skip_if_ssr: true,
+	skip_if_hydrate: true,
+	html: `
+		<my-custom-element>Hello World!</my-custom-element>
+	`
+};

--- a/packages/svelte/test/runtime/samples/attribute-custom-element-inheritance/_config.js
+++ b/packages/svelte/test/runtime/samples/attribute-custom-element-inheritance/_config.js
@@ -2,6 +2,6 @@ export default {
 	skip_if_ssr: true,
 	skip_if_hydrate: true,
 	html: `
-		<my-custom-element>Hello World!</my-custom-element>
+		<my-custom-inheritance-element>Hello World!</my-custom-inheritance-element>
 	`
 };

--- a/packages/svelte/test/runtime/samples/attribute-custom-element-inheritance/main.svelte
+++ b/packages/svelte/test/runtime/samples/attribute-custom-element-inheritance/main.svelte
@@ -27,7 +27,7 @@
 
 	class Extended extends MyCustomElement {}
 
-	window.customElements.define('my-custom-element', Extended);
+	window.customElements.define('my-custom-inheritance-element', Extended);
 </script>
 
-<my-custom-element camelCase={{ text: 'World' }} text="!" />
+<my-custom-inheritance-element camelCase={{ text: 'World' }} text="!" />

--- a/packages/svelte/test/runtime/samples/attribute-custom-element-inheritance/main.svelte
+++ b/packages/svelte/test/runtime/samples/attribute-custom-element-inheritance/main.svelte
@@ -1,0 +1,33 @@
+<script>
+	class MyCustomElement extends HTMLElement {
+		constructor() {
+			super();
+			this._obj = null;
+			this._text = null;
+		}
+
+		set text(text) {
+			this._text = text;
+			this.render();
+		}
+
+		set camelCase(obj) {
+			this._obj = obj;
+			this.render();
+		}
+
+		connectedCallback() {
+			this.render();
+		}
+
+		render() {
+			this.innerHTML = 'Hello ' + this._obj.text + this._text;
+		}
+	}
+
+	class Extended extends MyCustomElement {}
+
+	window.customElements.define('my-custom-element', Extended);
+</script>
+
+<my-custom-element camelCase={{ text: 'World' }} text="!" />

--- a/packages/svelte/vitest.config.js
+++ b/packages/svelte/vitest.config.js
@@ -20,7 +20,7 @@ export default defineConfig({
 		}
 	],
 	test: {
-		dir: 'test',
+		dir: 'test/runtime',
 		reporters: ['dot'],
 		exclude: [...configDefaults.exclude, '**/samples/**'],
 		globalSetup: './test/vitest-global-setup.js'

--- a/packages/svelte/vitest.config.js
+++ b/packages/svelte/vitest.config.js
@@ -20,7 +20,7 @@ export default defineConfig({
 		}
 	],
 	test: {
-		dir: 'test/runtime',
+		dir: 'test',
 		reporters: ['dot'],
 		exclude: [...configDefaults.exclude, '**/samples/**'],
 		globalSetup: './test/vitest-global-setup.js'


### PR DESCRIPTION
while attributes are case insensitive, properties are not. to not introduce a breaking change, the lowercased variant is checked first. fixes #9325

## Svelte compiler rewrite

Please note that [the Svelte codebase is currently being rewritten](https://svelte.dev/blog/runes). Thus, it's best to hold off on new features or refactorings for the time being.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
