### PR TITLE
fix: else-if-blocks on tutorial

### DIFF
--- a/documentation/tutorial/04-logic/03-else-if-blocks/app-a/App.svelte
+++ b/documentation/tutorial/04-logic/03-else-if-blocks/app-a/App.svelte
@@ -4,8 +4,6 @@
 
 {#if x > 10}
 	<p>{x} is greater than 10</p>
-{:else if 5 > x}
-	<p>{x} is less than 5</p>
 {:else}
-	<p>{x} is between 5 and 10</p>
+	<p>{x} is between 0 and 10</p>
 {/if}


### PR DESCRIPTION
## Done
- Fix https://github.com/sveltejs/svelte/issues/9335
- Fixed `Show me` button is not showing on `/tutorial/else-if-blocks`
- https://learn.svelte.dev/tutorial/else-if-blocks was referred for fix.

## QA
- Go to `/tutorial/else-blocks` 
- Check `Show me`/`Reset` buttons are working properly
(I had a problem QAing on Chrome. It should work on Firefox)   

## Svelte compiler rewrite

Please note that [the Svelte codebase is currently being rewritten](https://svelte.dev/blog/runes). Thus, it's best to hold off on new features or refactorings for the time being.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
