### PR TITLE
site: Display full post contents in RSS

### DIFF
--- a/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
+++ b/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
@@ -43,7 +43,7 @@ const get_rss = (posts) =>
 		<item>
 			<title>${escapeHTML(post.title)}</title>
 			<link>https://svelte.dev/blog/${post.slug}</link>
-			<description>${escapeHTML(post.description)}</description>
+			<description><![CDATA[${post.content}]]></description>
 			<pubDate>${formatPubdate(post.date)}</pubDate>
 		</item>
 	`


### PR DESCRIPTION
This PR updates the RSS feed to include full blog posts, so feed subscribers can read the contents in their readers.

Unfortunately I can't get the site up & running locally following the instructions (`Cannot find base config file "./.svelte-kit/tsconfig.json"`), but if Vervel is authorized for this PR I can test in in my reader app.