### PR TITLE
docs: clarify "obsolete" in runes blog post

### DIFF
--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -208,10 +208,9 @@ Runes are an additive feature, but they make a whole bunch of existing concepts 
 - `export let`
 - `$:`, with all its attendant quirks
 - different behaviour between `<script>` and `<script context="module">`
-- the store API, parts of which are genuinely quite complicated
-- the `$` store prefix
 - `$$props` and `$$restProps`
-- lifecycle functions (things like `onMount` can just be `$effect` functions)
+- lifecycle functions (things like `afterUpdate` can just be `$effect` functions)
+- the store API and `$` store prefix (while stores are no longer necessary, they are not being deprecated)
 
 For those of you who already use Svelte, it's new stuff to learn, albeit hopefully stuff that makes your Svelte apps easier to build and maintain. But newcomers won't need to learn all those things — it'll just be in a section of the docs titled 'old stuff'.
 


### PR DESCRIPTION
People continue to be confused by this section

![Screenshot from 2023-10-30 18-31-06](https://github.com/sveltejs/svelte/assets/322311/1cc5b353-500f-4e57-baa8-90e7904caa3b)

We've had an FAQ about this forever, but not everyone who reads the blog post will see the FAQ
https://svelte-5-preview.vercel.app/docs/faq#breaking-changes-and-migration-which-things-will-be-deprecated-in-svelte-5