### PR TITLE
docs: update text color in animate example

### DIFF
--- a/documentation/examples/10-animations/00-animate/App.svelte
+++ b/documentation/examples/10-animations/00-animate/App.svelte
@@ -113,6 +113,7 @@
 		border-radius: 2px;
 		background-color: #eee;
 		user-select: none;
+		color: black;
 	}
 
 	input {


### PR DESCRIPTION
This PR makes the text in labels visible when seeing the documentation in dark mode:

New version:
![image](https://github.com/sveltejs/svelte/assets/480413/26f02074-fe73-4611-936a-f68ed9f89b3a)

Original:
![image](https://github.com/sveltejs/svelte/assets/480413/55809444-5310-4a4b-a08e-d5a31e1aae26)






## Svelte compiler rewrite

Please note that [the Svelte codebase is currently being rewritten](https://svelte.dev/blog/runes). Thus, it's best to hold off on new features or refactorings for the time being.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
