### PR TITLE
Fix diagnostics

### DIFF
--- a/sites/svelte-5-preview/src/lib/CodeMirror.svelte
+++ b/sites/svelte-5-preview/src/lib/CodeMirror.svelte
@@ -12,9 +12,6 @@
 	import Message from './Message.svelte';
 	import { svelteTheme } from './theme.js';
 
-	/** @type {import('./types').StartOrEnd | null} */
-	export let errorLoc = null;
-
 	/** @type {import('@codemirror/lint').LintSource | undefined} */
 	export let diagnostics = undefined;
 
@@ -171,9 +168,6 @@
 
 	let marked = false;
 
-	/** @type {number | null}*/
-	let error_line = null;
-
 	let updating_externally = false;
 
 	/** @type {import('@codemirror/state').Extension[]} */
@@ -181,27 +175,15 @@
 
 	let cursor_pos = 0;
 
-	$: {
-		if ($cmInstance.view) {
-			fulfil_module_editor_ready();
-		}
+	$: if ($cmInstance.view) {
+		fulfil_module_editor_ready();
 	}
 
 	$: if ($cmInstance.view && w && h) resize();
 
-	$: {
-		if (marked) {
-			unmarkText();
-			marked = false;
-		}
-
-		if (errorLoc) {
-			markText({ from: errorLoc.character, to: errorLoc.character + 1, className: 'error-loc' });
-
-			error_line = errorLoc.line;
-		} else {
-			error_line = null;
-		}
+	$: if (marked) {
+		unmarkText();
+		marked = false;
 	}
 
 	const watcher = EditorView.updateListener.of((viewUpdate) => {

--- a/sites/svelte-5-preview/src/lib/Input/ModuleEditor.svelte
+++ b/sites/svelte-5-preview/src/lib/Input/ModuleEditor.svelte
@@ -3,9 +3,6 @@
 	import { get_full_filename } from '$lib/utils.js';
 	import CodeMirror from '../CodeMirror.svelte';
 
-	/** @type {import('$lib/types').StartOrEnd | null} */
-	export let errorLoc = null;
-
 	/** @type {boolean} */
 	export let autocomplete;
 
@@ -58,7 +55,6 @@
 	<div class="editor notranslate" translate="no">
 		<CodeMirror
 			bind:this={$module_editor}
-			{errorLoc}
 			{autocomplete}
 			diagnostics={$selected && $bundle ? diagnostics : () => []}
 			on:change={handle_change}

--- a/sites/svelte-5-preview/src/lib/Input/ModuleEditor.svelte
+++ b/sites/svelte-5-preview/src/lib/Input/ModuleEditor.svelte
@@ -25,12 +25,14 @@
 			{autocomplete}
 			diagnostics={() => {
 				if (error) {
-					return [{
-						severity: 'error',
-						from: error.position[0],
-						to: error.position[1],
-						message: error.message
-					}];
+					return [
+						{
+							severity: 'error',
+							from: error.position[0],
+							to: error.position[1],
+							message: error.message
+						}
+					];
 				}
 
 				if (warnings) {
@@ -38,7 +40,7 @@
 						severity: 'warning',
 						from: warning.start.character,
 						to: warning.end.character,
-						message: warning.message,
+						message: warning.message
 					}));
 				}
 

--- a/sites/svelte-5-preview/src/lib/Input/ModuleEditor.svelte
+++ b/sites/svelte-5-preview/src/lib/Input/ModuleEditor.svelte
@@ -1,54 +1,21 @@
 <script>
 	import { get_repl_context } from '$lib/context.js';
-	import { get_full_filename } from '$lib/utils.js';
 	import CodeMirror from '../CodeMirror.svelte';
 
 	/** @type {boolean} */
 	export let autocomplete;
 
+	/** @type {any} */ // TODO
+	export let error;
+
+	/** @type {any[]} */ // TODO
+	export let warnings;
+
 	export function focus() {
 		$module_editor?.focus();
 	}
 
-	const { bundle, handle_change, module_editor, selected, bundling } = get_repl_context();
-
-	async function diagnostics() {
-		/** @type {import('@codemirror/lint').Diagnostic[]} */
-		const diagnostics = [];
-
-		if (!$selected || !$bundle) return diagnostics;
-
-		await $bundling;
-
-		const filename = get_full_filename($selected);
-
-		if (
-			$bundle.error &&
-			$bundle.error.filename === filename &&
-			$bundle.error.start &&
-			$bundle.error.end
-		) {
-			diagnostics.push({
-				from: $bundle.error.start.character,
-				to: $bundle.error.end.character,
-				severity: 'error',
-				message: $bundle.error.message
-			});
-		}
-
-		for (const warning of $bundle.warnings) {
-			if (warning.filename === filename) {
-				diagnostics.push({
-					from: warning.start.character,
-					to: warning.end.character,
-					severity: 'warning',
-					message: warning.message
-				});
-			}
-		}
-
-		return diagnostics;
-	}
+	const { handle_change, module_editor } = get_repl_context();
 </script>
 
 <div class="editor-wrapper">
@@ -56,7 +23,27 @@
 		<CodeMirror
 			bind:this={$module_editor}
 			{autocomplete}
-			diagnostics={$selected && $bundle ? diagnostics : () => []}
+			diagnostics={() => {
+				if (error) {
+					return [{
+						severity: 'error',
+						from: error.position[0],
+						to: error.position[1],
+						message: error.message
+					}];
+				}
+
+				if (warnings) {
+					return warnings.map((warning) => ({
+						severity: 'warning',
+						from: warning.start.character,
+						to: warning.end.character,
+						message: warning.message,
+					}));
+				}
+
+				return [];
+			}}
 			on:change={handle_change}
 		/>
 	</div>

--- a/sites/svelte-5-preview/src/lib/Output/Compiler.js
+++ b/sites/svelte-5-preview/src/lib/Output/Compiler.js
@@ -40,9 +40,9 @@ export default class Compiler {
 
 	/**
 	 * @param {import('$lib/types').File} file
-	 * @param {import('svelte/types/compiler').CompileOptions} options
+	 * @param {import('svelte/compiler').CompileOptions} options
 	 * @param {boolean} return_ast
-	 * @returns
+	 * @returns {Promise<import('$lib/workers/workers').CompileMessageData>}
 	 */
 	compile(file, options, return_ast) {
 		return new Promise((fulfil) => {

--- a/sites/svelte-5-preview/src/lib/Output/Output.svelte
+++ b/sites/svelte-5-preview/src/lib/Output/Output.svelte
@@ -38,13 +38,9 @@
 		if (selected.type === 'json') {
 			js_editor.set({ code: `/* Select a component to see its compiled code */`, lang: 'js' });
 			css_editor.set({ code: `/* Select a component to see its compiled code */`, lang: 'css' });
-		}
-
-		else if (selected.type=== 'md') {
+		} else if (selected.type === 'md') {
 			markdown = marked(selected.source);
-		}
-
-		else if (compiled) {
+		} else if (compiled) {
 			js_editor.set({ code: compiled.result.js, lang: 'js' });
 			css_editor.set({ code: compiled.result.css, lang: 'css' });
 		}

--- a/sites/svelte-5-preview/src/lib/Output/Output.svelte
+++ b/sites/svelte-5-preview/src/lib/Output/Output.svelte
@@ -10,9 +10,6 @@
 	/** @type {string | null} */
 	export let status;
 
-	/** @type {import('$lib/types').StartOrEnd | null} */
-	export let sourceErrorLoc = null;
-
 	/** @type {import('$lib/types').MessageDetails | null} */
 	export let runtimeError = null;
 
@@ -97,11 +94,11 @@
 <!-- js output -->
 <div class="tab-content" class:visible={selected?.type !== 'md' && view === 'js'}>
 	{#if embedded}
-		<CodeMirror bind:this={js_editor} errorLoc={sourceErrorLoc} readonly />
+		<CodeMirror bind:this={js_editor} readonly />
 	{:else}
 		<PaneWithPanel pos="50%" panel="Compiler options">
 			<div slot="main">
-				<CodeMirror bind:this={js_editor} errorLoc={sourceErrorLoc} readonly />
+				<CodeMirror bind:this={js_editor} readonly />
 			</div>
 
 			<div slot="panel-body">
@@ -113,7 +110,7 @@
 
 <!-- css output -->
 <div class="tab-content" class:visible={selected?.type !== 'md' && view === 'css'}>
-	<CodeMirror bind:this={css_editor} errorLoc={sourceErrorLoc} readonly />
+	<CodeMirror bind:this={css_editor} readonly />
 </div>
 
 <!-- ast output -->

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -325,7 +325,11 @@
 		>
 			<section slot="a">
 				<ComponentSelector show_modified={showModified} on:add on:remove />
-				<ModuleEditor {autocomplete} error={compiled?.result.error} warnings={compiled?.result.warnings ?? []} />
+				<ModuleEditor
+					{autocomplete}
+					error={compiled?.result.error}
+					warnings={compiled?.result.warnings ?? []}
+				/>
 			</section>
 
 			<section slot="b" style="height: 100%;">

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -11,6 +11,7 @@
 	import Output from './Output/Output.svelte';
 	import { set_repl_context } from './context.js';
 	import { get_full_filename } from './utils.js';
+	import Compiler from './Output/Compiler.js';
 
 	export let packagesUrl = 'https://unpkg.com';
 	export let svelteUrl = `${BROWSER ? location.origin : ''}/svelte`;
@@ -64,32 +65,6 @@
 		$files = $files.map((val) => ({ ...val, modified: false }));
 	}
 
-	/** @param {{ files: import('./types').File[], css?: string }} data */
-	export function update(data) {
-		$files = data.files;
-
-		const matched_file = data.files.find((file) => get_full_filename(file) === $selected_name);
-
-		$selected_name = matched_file ? get_full_filename(matched_file) : 'App.svelte';
-
-		injectedCSS = data.css ?? '';
-
-		if (matched_file) {
-			$module_editor?.update({
-				code: matched_file.source,
-				lang: matched_file.type
-			});
-
-			$output?.update?.(matched_file, $compile_options);
-
-			$module_editor?.clearEditorState();
-		}
-
-		populate_editor_state();
-
-		dispatch('change', { files: $files });
-	}
-
 	/** @type {ReturnType<typeof createEventDispatcher<{ change: { files: import('./types').File[] } }>>} */
 	const dispatch = createEventDispatcher();
 
@@ -135,9 +110,6 @@
 	/** @type {ReplContext['module_editor']} */
 	const module_editor = writable(null);
 
-	/** @type {ReplContext['output']} */
-	const output = writable(null);
-
 	/** @type {ReplContext['toggleable']} */
 	const toggleable = writable(false);
 
@@ -160,7 +132,6 @@
 		compile_options,
 		cursor_pos,
 		module_editor,
-		output,
 		toggleable,
 		runes_mode,
 
@@ -205,8 +176,6 @@
 		} else {
 			$module_editor?.clearEditorState();
 		}
-
-		$output?.set($selected, $compile_options);
 
 		is_select_changing = false;
 	}
@@ -273,8 +242,18 @@
 		}
 	}
 
-	$: if ($output && $selected) {
-		$output?.update?.($selected, $compile_options);
+	const compiler = BROWSER ? new Compiler(svelteUrl) : null;
+
+	/** @type {import('./workers/workers').CompileMessageData | null} */
+	let compiled = null;
+
+	$: if (compiler && $selected) {
+		if ($selected.type === 'svelte' || $selected.type === 'js') {
+			compiler.compile($selected, $compile_options, false).then((data) => {
+				compiled = data;
+				$runes_mode = data.metadata?.runes ?? false;
+			});
+		}
 	}
 
 	$: mobile = width < 540;
@@ -347,8 +326,6 @@
 
 			<section slot="b" style="height: 100%;">
 				<Output
-					bind:this={$output}
-					{svelteUrl}
 					status={status_visible ? status : null}
 					{embedded}
 					{relaxed}
@@ -356,6 +333,8 @@
 					{injectedCSS}
 					{showAst}
 					{previewTheme}
+					selected={$selected}
+					{compiled}
 				/>
 			</section>
 		</SplitPane>

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -247,14 +247,20 @@
 	/** @type {import('./workers/workers').CompileMessageData | null} */
 	let compiled = null;
 
-	$: if (compiler && $selected) {
+	/**
+	 * @param {import('./types').File | null} $selected
+	 * @param {import('svelte/compiler').CompileOptions} $compile_options
+	 */
+	async function recompile($selected, $compile_options) {
+		if (!compiler || !$selected) return;
+
 		if ($selected.type === 'svelte' || $selected.type === 'js') {
-			compiler.compile($selected, $compile_options, false).then((data) => {
-				compiled = data;
-				$runes_mode = data.metadata?.runes ?? false;
-			});
+			compiled = await compiler.compile($selected, $compile_options, false);
+			$runes_mode = compiled.metadata?.runes ?? false;
 		}
 	}
+
+	$: recompile($selected, $compile_options);
 
 	$: mobile = width < 540;
 
@@ -319,7 +325,7 @@
 		>
 			<section slot="a">
 				<ComponentSelector show_modified={showModified} on:add on:remove />
-				<ModuleEditor {autocomplete} />
+				<ModuleEditor {autocomplete} error={compiled?.result.error} warnings={compiled?.result.warnings ?? []} />
 			</section>
 
 			<section slot="b" style="height: 100%;">

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -260,8 +260,6 @@
 
 	$: $toggleable = mobile && orientation === 'columns';
 
-	/** @type {import('./types').StartOrEnd} */
-	let sourceErrorLoc;
 	let width = 0;
 	let show_output = false;
 
@@ -321,7 +319,7 @@
 		>
 			<section slot="a">
 				<ComponentSelector show_modified={showModified} on:add on:remove />
-				<ModuleEditor errorLoc={sourceErrorLoc} {autocomplete} />
+				<ModuleEditor {autocomplete} />
 			</section>
 
 			<section slot="b" style="height: 100%;">

--- a/sites/svelte-5-preview/src/lib/types.d.ts
+++ b/sites/svelte-5-preview/src/lib/types.d.ts
@@ -47,7 +47,6 @@ export type ReplState = {
 	cursor_pos: number;
 	toggleable: boolean;
 	module_editor: import('./CodeMirror.svelte').default | null;
-	output: import('./Output/Output.svelte').default | null;
 	runes_mode: boolean;
 };
 
@@ -62,7 +61,6 @@ export type ReplContext = {
 	cursor_pos: Writable<ReplState['cursor_pos']>;
 	toggleable: Writable<ReplState['toggleable']>;
 	module_editor: Writable<ReplState['module_editor']>;
-	output: Writable<ReplState['output']>;
 	runes_mode: Writable<ReplState['runes_mode']>;
 
 	EDITOR_STATE_MAP: Map<string, EditorState>;

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -69,9 +69,10 @@ function compile({ id, source, options, return_ast }) {
 				result: {
 					js: js.code,
 					css: css?.code || `/* Add a <sty` + `le> tag to see compiled CSS */`,
-					warnings
-				},
-				metadata
+					error: null,
+					warnings,
+					metadata
+				}
 			};
 		} else if (options.filename.endsWith('.svelte.js')) {
 			const compiled = svelte.compileModule(source, {
@@ -85,9 +86,10 @@ function compile({ id, source, options, return_ast }) {
 					result: {
 						js: compiled.js.code,
 						css,
-						warnings: compiled.warnings
-					},
-					metadata: compiled.metadata
+						error: null,
+						warnings: compiled.warnings,
+						metadata: compiled.metadata
+					}
 				};
 			}
 		}
@@ -96,7 +98,10 @@ function compile({ id, source, options, return_ast }) {
 			id,
 			result: {
 				js: `// Select a component, or a '.svelte.js' module that uses runes, to see compiled output`,
-				css
+				css,
+				error: null,
+				warnings: [],
+				metadata: null
 			}
 		};
 	} catch (err) {
@@ -107,7 +112,13 @@ function compile({ id, source, options, return_ast }) {
 			id,
 			result: {
 				js: message,
-				css: message
+				css: message,
+				error: {
+					message: err.message,
+					position: err.position
+				},
+				warnings: [],
+				metadata: null
 			}
 		};
 	}

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -62,13 +62,14 @@ function compile({ id, source, options, return_ast }) {
 				generate: options.generate
 			});
 
-			const { js, css, metadata } = compiled;
+			const { js, css, warnings, metadata } = compiled;
 
 			return {
 				id,
 				result: {
 					js: js.code,
-					css: css?.code || `/* Add a <sty` + `le> tag to see compiled CSS */`
+					css: css?.code || `/* Add a <sty` + `le> tag to see compiled CSS */`,
+					warnings
 				},
 				metadata
 			};
@@ -83,7 +84,8 @@ function compile({ id, source, options, return_ast }) {
 					id,
 					result: {
 						js: compiled.js.code,
-						css
+						css,
+						warnings: compiled.warnings
 					},
 					metadata: compiled.metadata
 				};


### PR DESCRIPTION
This updates how the diagnostics work in the playground — rather than being driven by the bundler, they're driven by the compiler directly, meaning we get diagnostics even for things that aren't yet in the module graph. (It's also just much simpler this way)

I was slightly lazy with the types because I'm under the cosh. And there's definitely more tidying up that can be done here, but it's a job for future us

## Svelte compiler rewrite

Please note that [the Svelte codebase is currently being rewritten](https://svelte.dev/blog/runes). Thus, it's best to hold off on new features or refactorings for the time being.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
