### PR TITLE
site: allow multiple blog authors

### DIFF
--- a/documentation/blog/2023-02-21-streaming-snapshots-sveltekit.md
+++ b/documentation/blog/2023-02-21-streaming-snapshots-sveltekit.md
@@ -1,8 +1,8 @@
 ---
 title: Streaming, snapshots, and other new features since SvelteKit 1.0
 description: Exciting improvements in the latest version of SvelteKit
-author: Geoff Rich
-authorURL: https://geoffrich.net
+author: Geoff Rich, Rich Harris
+authorURL: https://geoffrich.net, https://twitter.com/Rich_Harris
 ---
 
 The Svelte team has been hard at work since the release of SvelteKit 1.0. Let’s talk about some of the major new features that have shipped since launch: [streaming non-essential data](https://kit.svelte.dev/docs/load#streaming-with-promises), [snapshots](https://kit.svelte.dev/docs/snapshots), and [route-level config](https://kit.svelte.dev/docs/page-options#config).

--- a/sites/svelte.dev/src/lib/server/blog/index.js
+++ b/sites/svelte.dev/src/lib/server/blog/index.js
@@ -35,6 +35,8 @@ export async function get_blog_data(base = CONTENT_BASE_PATHS.BLOG) {
 
 		const { date, date_formatted, slug } = get_date_and_slug(file);
 		const { metadata, body } = extractFrontmatter(await readFile(`${base}/${file}`, 'utf-8'));
+		const authors = metadata.author.split(',').map((author) => author.trim());
+		const authorUrls = metadata.authorURL.split(',').map((author) => author.trim());
 
 		blog_posts.push({
 			date,
@@ -45,10 +47,10 @@ export async function get_blog_data(base = CONTENT_BASE_PATHS.BLOG) {
 			slug,
 			title: metadata.title,
 			file,
-			author: {
-				name: metadata.author,
-				url: metadata.authorURL
-			},
+			authors: authors.map((author, i) => ({
+				name: author,
+				url: authorUrls[i]
+			})),
 			sections: await get_sections(body)
 		});
 	}

--- a/sites/svelte.dev/src/lib/server/blog/types.d.ts
+++ b/sites/svelte.dev/src/lib/server/blog/types.d.ts
@@ -7,10 +7,10 @@ export interface BlogPost {
 	date_formatted: string;
 	slug: string;
 	file: string;
-	author: {
+	authors: {
 		name: string;
 		url?: string;
-	};
+	}[];
 	draft: boolean;
 	content: string;
 	sections: Section[];

--- a/sites/svelte.dev/src/routes/blog/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/blog/[slug]/+page.svelte
@@ -26,7 +26,14 @@
 		<p class="standfirst">{data.post.description}</p>
 
 		<p class="byline">
-			<a href={data.post.author.url}>{data.post.author.name}</a>
+			{#each data.post.authors as author, i}
+				{@const show_comma = data.post.authors.length > 2 && i < data.post.authors.length - 1}
+				{@const show_and = i === data.post.authors.length - 2}
+				<svelte:element this={author.url ? 'a' : 'span'} href={author.url}
+					>{author.name}</svelte:element
+				>{#if show_comma},&nbsp;{/if}
+				{#if show_and}and&nbsp;{/if}
+			{/each}
 			<time datetime={data.post.date}>{data.post.date_formatted}</time>
 		</p>
 


### PR DESCRIPTION
Opened against the `svelte-4` branch since I think that's the only one where site deploys work, but lmk if it should be `main` instead.

This PR allows specifying multiple authors on a blog post by adding comma separation in the frontmatter, e.g.

```
---
title: Streaming, snapshots, and other new features since SvelteKit 1.0
description: Exciting improvements in the latest version of SvelteKit
author: Geoff Rich, Rich Harris
authorURL: https://geoffrich.net, https://twitter.com/Rich_Harris
---
```

Updated the streaming blog post from earlier this year to give credit to Rich, since he wrote the "how does this work" section.

<img width="734" alt="image" src="https://github.com/sveltejs/svelte/assets/4992896/9d99f093-e6dc-4722-b2aa-e7b6cb1cff66">



