### PR TITLE
docs: incorrect order of directives

### DIFF
--- a/documentation/docs/03-runtime/07-svelte-action.md
+++ b/documentation/docs/03-runtime/07-svelte-action.md
@@ -72,7 +72,7 @@ Sometimes actions emit custom events and apply custom attributes to the element 
 	}
 </script>
 
-<div use:foo={{ prop: 'someValue' }} on:emit={handleEmit} />
+<div on:emit={handleEmit} use:foo={{ prop: 'someValue' }} />
 ```
 
 ## Types


### PR DESCRIPTION
The event listener must be registered before the event is dispatched in order for this code snippet to work.

Redone with correct branch as requested by @dummdidumm here:
https://github.com/sveltejs/svelte/pull/9399#issuecomment-1807714247