### PR TITLE
fix: address runtime effect issues

### DIFF
--- a/.changeset/khaki-mails-draw.md
+++ b/.changeset/khaki-mails-draw.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Fix runtime signal issues

--- a/.changeset/khaki-mails-draw.md
+++ b/.changeset/khaki-mails-draw.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Fix runtime signal issues
+fix: tighten up signals implementation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@ Please note that [the Svelte codebase is currently being rewritten for Svelte 5]
 
 If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.
 
-
 ### Before submitting the PR, please make sure you do the following
 
 - [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -251,6 +251,8 @@ export const function_visitor = (node, context) => {
 		const in_constructor = parent.type === 'MethodDefinition' && parent.kind === 'constructor';
 
 		state = { ...context.state, in_constructor };
+	} else {
+		state = { ...context.state, in_constructor: false };
 	}
 
 	if (metadata?.hoistable === true) {

--- a/packages/svelte/src/internal/client/operations.js
+++ b/packages/svelte/src/internal/client/operations.js
@@ -7,7 +7,9 @@ const has_browser_globals = typeof window !== 'undefined';
 // We cache the Node and Element prototype methods, so that subsequent calls-sites are monomorphic rather
 // than megamorphic.
 const node_prototype = /** @type {Node} */ (has_browser_globals ? Node.prototype : {});
-const element_prototype = /** @type {Element} */ (has_browser_globals ? Element.prototype : {});
+const html_element_prototype = /** @type {Element} */ (
+	has_browser_globals ? HTMLElement.prototype : {}
+);
 const text_prototype = /** @type {Text} */ (has_browser_globals ? Text.prototype : {});
 const map_prototype = Map.prototype;
 const append_child_method = node_prototype.appendChild;
@@ -15,12 +17,12 @@ const clone_node_method = node_prototype.cloneNode;
 const map_set_method = map_prototype.set;
 const map_get_method = map_prototype.get;
 const map_delete_method = map_prototype.delete;
-// @ts-expect-error improve perf of expando on DOM nodes for events
-element_prototype.__click = undefined;
-// @ts-expect-error improve perf of expando on DOM textValue updates
+// @ts-expect-error improve perf of expando on DOM events
+html_element_prototype.__click = undefined;
+// @ts-expect-error improve perf of expando on DOM text updates
 text_prototype.__nodeValue = ' ';
 // @ts-expect-error improve perf of expando on DOM className updates
-element_prototype.__className = '';
+html_element_prototype.__className = '';
 
 const first_child_get = /** @type {(this: Node) => ChildNode | null} */ (
 	// @ts-ignore
@@ -35,11 +37,6 @@ const next_sibling_get = /** @type {(this: Node) => ChildNode | null} */ (
 const text_content_set = /** @type {(this: Node, text: string ) => void} */ (
 	// @ts-ignore
 	has_browser_globals ? get_descriptor(node_prototype, 'textContent').set : null
-);
-
-const class_name_set = /** @type {(this: Element, class_name: string) => void} */ (
-	// @ts-ignore
-	has_browser_globals ? get_descriptor(element_prototype, 'className').set : null
 );
 
 /**
@@ -148,23 +145,12 @@ export function sibling(node) {
 }
 
 /**
- * @template {Element} N
- * @param {N} node
- * @param {string} class_name
- * @returns {void}
- */
-export function set_class_name(node, class_name) {
-	class_name_set.call(node, class_name);
-}
-
-/**
  * @template {Node} N
  * @param {N} node
- * @param {string} text
  * @returns {void}
  */
-export function text_content(node, text) {
-	text_content_set.call(node, text);
+export function clear_text_content(node) {
+	text_content_set.call(node, '');
 }
 
 /** @param {string} name */

--- a/packages/svelte/src/internal/client/operations.js
+++ b/packages/svelte/src/internal/client/operations.js
@@ -8,9 +8,7 @@ const has_browser_globals = typeof window !== 'undefined';
 // than megamorphic.
 const node_prototype = /** @type {Node} */ (has_browser_globals ? Node.prototype : {});
 const element_prototype = /** @type {Element} */ (has_browser_globals ? Element.prototype : {});
-const event_target_prototype = /** @type {EventTarget} */ (
-	has_browser_globals ? EventTarget.prototype : {}
-);
+const text_prototype = /** @type {Text} */ (has_browser_globals ? Text.prototype : {});
 const map_prototype = Map.prototype;
 const append_child_method = node_prototype.appendChild;
 const clone_node_method = node_prototype.cloneNode;
@@ -18,11 +16,11 @@ const map_set_method = map_prototype.set;
 const map_get_method = map_prototype.get;
 const map_delete_method = map_prototype.delete;
 // @ts-expect-error improve perf of expando on DOM nodes for events
-event_target_prototype.__click = undefined;
+element_prototype.__click = undefined;
 // @ts-expect-error improve perf of expando on DOM textValue updates
-event_target_prototype.__nodeValue = ' ';
+text_prototype.__nodeValue = ' ';
 // @ts-expect-error improve perf of expando on DOM className updates
-event_target_prototype.__className = '';
+element_prototype.__className = '';
 
 const first_child_get = /** @type {(this: Node) => ChildNode | null} */ (
 	// @ts-ignore

--- a/packages/svelte/src/internal/client/operations.js
+++ b/packages/svelte/src/internal/client/operations.js
@@ -7,9 +7,7 @@ const has_browser_globals = typeof window !== 'undefined';
 // We cache the Node and Element prototype methods, so that subsequent calls-sites are monomorphic rather
 // than megamorphic.
 const node_prototype = /** @type {Node} */ (has_browser_globals ? Node.prototype : {});
-const html_element_prototype = /** @type {Element} */ (
-	has_browser_globals ? HTMLElement.prototype : {}
-);
+const element_prototype = /** @type {Element} */ (has_browser_globals ? Element.prototype : {});
 const text_prototype = /** @type {Text} */ (has_browser_globals ? Text.prototype : {});
 const map_prototype = Map.prototype;
 const append_child_method = node_prototype.appendChild;
@@ -18,11 +16,11 @@ const map_set_method = map_prototype.set;
 const map_get_method = map_prototype.get;
 const map_delete_method = map_prototype.delete;
 // @ts-expect-error improve perf of expando on DOM events
-html_element_prototype.__click = undefined;
+element_prototype.__click = undefined;
 // @ts-expect-error improve perf of expando on DOM text updates
 text_prototype.__nodeValue = ' ';
 // @ts-expect-error improve perf of expando on DOM className updates
-html_element_prototype.__className = '';
+element_prototype.__className = '';
 
 const first_child_get = /** @type {(this: Node) => ChildNode | null} */ (
 	// @ts-ignore
@@ -37,6 +35,11 @@ const next_sibling_get = /** @type {(this: Node) => ChildNode | null} */ (
 const text_content_set = /** @type {(this: Node, text: string ) => void} */ (
 	// @ts-ignore
 	has_browser_globals ? get_descriptor(node_prototype, 'textContent').set : null
+);
+
+const class_name_set = /** @type {(this: Element, class_name: string) => void} */ (
+	// @ts-ignore
+	has_browser_globals ? get_descriptor(element_prototype, 'className').set : null
 );
 
 /**
@@ -142,6 +145,16 @@ export function sibling(node) {
 		return capture_fragment_from_node(next_sibling);
 	}
 	return next_sibling;
+}
+
+/**
+ * @template {Element} N
+ * @param {N} node
+ * @param {string} class_name
+ * @returns {void}
+ */
+export function set_class_name(node, class_name) {
+	class_name_set.call(node, class_name);
 }
 
 /**

--- a/packages/svelte/src/internal/client/reconciler.js
+++ b/packages/svelte/src/internal/client/reconciler.js
@@ -1,4 +1,4 @@
-import { append_child, map_get, map_set, text_content } from './operations.js';
+import { append_child, map_get, map_set, clear_text_content } from './operations.js';
 import {
 	current_hydration_fragment,
 	get_hydration_fragment,
@@ -198,7 +198,7 @@ export function reconcile_indexed_array(
 		b_blocks = [];
 		// Remove old blocks
 		if (is_controlled && a !== 0) {
-			text_content(dom, '');
+			clear_text_content(dom);
 		}
 		while (index < length) {
 			block = a_blocks[index++];
@@ -295,7 +295,7 @@ export function reconcile_tracked_array(
 		b_blocks = [];
 		// Remove old blocks
 		if (is_controlled && a !== 0) {
-			text_content(dom, '');
+			clear_text_content(dom);
 		}
 		while (a > 0) {
 			block = a_blocks[--a];

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1270,15 +1270,15 @@ function handle_event_propagation(root_element, event) {
 	}
 
 	// composedPath contains list of nodes the event has propagated through.
-	// We check __handled_event_at to skip all nodes below it in case this is a
-	// parent of the __handled_event_at node, which indicates that there's nested
+	// We check __root to skip all nodes below it in case this is a
+	// parent of the __root node, which indicates that there's nested
 	// mounted apps. In this case we don't want to trigger events multiple times.
 	// We're deliberately not skipping if the index is the same or higher, because
 	// someone could create an event programmatically and emit it multiple times,
 	// in which case we want to handle the whole propagation chain properly each time.
 	let path_idx = 0;
 	// @ts-expect-error is added below
-	const handled_at = event.__handled_event_at;
+	const handled_at = event.__root;
 	if (handled_at) {
 		const at_idx = path.indexOf(handled_at);
 		if (at_idx < path.indexOf(root_element)) {
@@ -1317,7 +1317,7 @@ function handle_event_propagation(root_element, event) {
 	}
 
 	// @ts-expect-error is used above
-	event.__handled_event_at = root_element;
+	event.__root = root_element;
 }
 
 /**

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1,13 +1,5 @@
 import { DEV } from 'esm-env';
-import {
-	append_child,
-	child,
-	clone_node,
-	create_element,
-	map_get,
-	map_set,
-	set_class_name
-} from './operations.js';
+import { append_child, child, clone_node, create_element, map_get, map_set } from './operations.js';
 import {
 	create_root_block,
 	create_each_item_block,
@@ -357,7 +349,7 @@ export function class_name(dom, value) {
 		if (next_class_name === '') {
 			dom.removeAttribute('class');
 		} else {
-			set_class_name(dom, next_class_name);
+			dom.className = next_class_name;
 		}
 		// @ts-expect-error need to add __className to patched prototype
 		dom.__className = next_class_name;

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1,5 +1,13 @@
 import { DEV } from 'esm-env';
-import { append_child, child, clone_node, create_element, map_get, map_set } from './operations.js';
+import {
+	append_child,
+	child,
+	clone_node,
+	create_element,
+	map_get,
+	map_set,
+	set_class_name
+} from './operations.js';
 import {
 	create_root_block,
 	create_each_item_block,
@@ -349,7 +357,7 @@ export function class_name(dom, value) {
 		if (next_class_name === '') {
 			dom.removeAttribute('class');
 		} else {
-			dom.className = next_class_name;
+			set_class_name(dom, next_class_name);
 		}
 		// @ts-expect-error need to add __className to patched prototype
 		dom.__className = next_class_name;

--- a/packages/svelte/tests/runtime-runes/samples/class-state-constructor-closure-private/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-constructor-closure-private/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<button>10</button>`,
+	ssrHtml: `<button>0</button>`,
+
+	async test({ assert, target }) {
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<button>10</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/class-state-constructor-closure-private/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-constructor-closure-private/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	class Counter {
+		count = $state(0);
+
+		constructor() {
+			$effect(() => {
+				this.count = 10;
+			});
+		}
+	}
+	const counter = new Counter();
+</script>
+
+<button on:click={() => counter.count++}>{counter.count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/class-state-constructor-closure/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-constructor-closure/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<button>10</button>`,
+	ssrHtml: `<button>0</button>`,
+
+	async test({ assert, target }) {
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<button>10</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/class-state-constructor-closure/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-constructor-closure/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	class Counter {
+		#count = $state(0);
+
+		constructor() {
+			$effect(() => {
+				this.#count = 10;
+			});
+		}
+
+		getCount() {
+			return this.#count;
+		}
+
+		increment() {
+			this.#count++;
+		}
+	}
+	const counter = new Counter();
+</script>
+
+<button on:click={() => counter.increment()}>{counter.getCount()}</button>

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
@@ -1,0 +1,19 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	get props() {
+		return { log: [] };
+	},
+
+	async test({ assert, target, component }) {
+		const [b1] = target.querySelectorAll('button');
+		flushSync(() => {
+			b1.click();
+		});
+		flushSync(() => {
+			b1.click();
+		});
+		assert.deepEqual(component.log, ['init 0', 'cleanup 2', 'init 2', 'cleanup 4', 'init 4']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	const {log} = $props();
+
+	let count = $state(0);
+
+	$effect(() => {
+		let double = $derived(count * 2)
+
+		log.push('init ' + double);
+
+		return () => {
+			log.push('cleanup ' + double);
+		};
+	})
+</script>
+
+<button on:click={() => count++ }>Click</button>


### PR DESCRIPTION
This PR addresses several issues relating to the runtime:

- When updating state inside a class constructor (from within a closure) ensure the state updates correctly. Fixes https://github.com/sveltejs/svelte/issues/9407.
- When reading a derived from within an effect's cleanup, ensure that value is accessible. Fixes https://github.com/sveltejs/svelte/issues/9409.
- Ensure that `$effect.pre` triggers an error when called outside of having an active effect parent. Fixes https://github.com/sveltejs/svelte/issues/9410.
- I also fixed the `__` properties in operations, which were pointing to the wrong prototype.

### Before submitting the PR, please make sure you do the following

- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
