### PR TITLE
chore: split $.each into $.each_keyed/$.each_indexed

### DIFF
--- a/.changeset/quiet-camels-mate.md
+++ b/.changeset/quiet-camels-mate.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+improve keyblock treeshaking

--- a/.changeset/quiet-camels-mate.md
+++ b/.changeset/quiet-camels-mate.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-improve keyblock treeshaking
+chore: improve keyblock treeshaking

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@ Please note that [the Svelte codebase is currently being rewritten for Svelte 5]
 
 If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.
 
-
 ### Before submitting the PR, please make sure you do the following
 
 - [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2227,19 +2227,34 @@ export const template_visitors = {
 			declarations.push(b.let(node.index, index));
 		}
 
-		context.state.after_update.push(
-			b.stmt(
-				b.call(
-					'$.each',
-					context.state.node,
-					each_node_meta.array_name ? each_node_meta.array_name : b.thunk(collection),
-					b.literal(each_type),
-					key_function,
-					b.arrow([b.id('$$anchor'), item, index], b.block(declarations.concat(children))),
-					else_block
+		if ((each_type & EACH_KEYED) !== 0) {
+			context.state.after_update.push(
+				b.stmt(
+					b.call(
+						'$.each_keyed',
+						context.state.node,
+						each_node_meta.array_name ? each_node_meta.array_name : b.thunk(collection),
+						b.literal(each_type),
+						key_function,
+						b.arrow([b.id('$$anchor'), item, index], b.block(declarations.concat(children))),
+						else_block
+					)
 				)
-			)
-		);
+			);
+		} else {
+			context.state.after_update.push(
+				b.stmt(
+					b.call(
+						'$.each_indexed',
+						context.state.node,
+						each_node_meta.array_name ? each_node_meta.array_name : b.thunk(collection),
+						b.literal(each_type),
+						b.arrow([b.id('$$anchor'), item, index], b.block(declarations.concat(children))),
+						else_block
+					)
+				)
+			);
+		}
 	},
 	IfBlock(node, context) {
 		context.state.template.push('<!>');

--- a/packages/svelte/src/internal/client/reconciler.js
+++ b/packages/svelte/src/internal/client/reconciler.js
@@ -260,9 +260,9 @@ export function reconcile_indexed_array(
  * @param {Element | Comment | Text} dom
  * @param {boolean} is_controlled
  * @param {(anchor: null, item: V, index: number | import('./types.js').Signal<number>) => void} render_fn
- * @param {Array<string> | null} keys
  * @param {number} flags
  * @param {boolean} apply_transitions
+ * @param {Array<string> | null} keys
  * @returns {void}
  */
 export function reconcile_tracked_array(
@@ -271,9 +271,9 @@ export function reconcile_tracked_array(
 	dom,
 	is_controlled,
 	render_fn,
-	keys,
 	flags,
-	apply_transitions
+	apply_transitions,
+	keys
 ) {
 	var a_blocks = each_block.items;
 	const is_computed_key = keys !== null;

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2263,9 +2263,10 @@ export function each_item_block(item, key, index, render_fn, flags) {
  * @param {null | ((item: V) => string)} key_fn
  * @param {(anchor: null, item: V, index: import('./types.js').MaybeSignal<number>) => void} render_fn
  * @param {null | ((anchor: Node) => void)} fallback_fn
+ * @param {typeof reconcile_indexed_array | reconcile_tracked_array} reconcile_fn
  * @returns {void}
  */
-export function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn) {
+function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, reconcile_fn) {
 	const is_controlled = (flags & EACH_IS_CONTROLLED) !== 0;
 	const block = create_each_block(flags, anchor_node);
 
@@ -2385,20 +2386,7 @@ export function each(anchor_node, collection, flags, key_fn, render_fn, fallback
 			const flags = block.flags;
 			const is_controlled = (flags & EACH_IS_CONTROLLED) !== 0;
 			const anchor_node = block.anchor;
-			if ((flags & EACH_KEYED) !== 0) {
-				reconcile_tracked_array(
-					array,
-					block,
-					anchor_node,
-					is_controlled,
-					render_fn,
-					keys,
-					flags,
-					true
-				);
-			} else {
-				reconcile_indexed_array(array, block, anchor_node, is_controlled, render_fn, flags, true);
-			}
+			reconcile_fn(array, block, anchor_node, is_controlled, render_fn, flags, true, keys);
 		},
 		block,
 		true
@@ -2424,6 +2412,33 @@ export function each(anchor_node, collection, flags, key_fn, render_fn, fallback
 		destroy_signal(/** @type {import('./types.js').EffectSignal} */ (render));
 	});
 	block.effect = each;
+}
+
+/**
+ * @template V
+ * @param {Element | Comment} anchor_node
+ * @param {() => V[]} collection
+ * @param {number} flags
+ * @param {null | ((item: V) => string)} key_fn
+ * @param {(anchor: null, item: V, index: import('./types.js').MaybeSignal<number>) => void} render_fn
+ * @param {null | ((anchor: Node) => void)} fallback_fn
+ * @returns {void}
+ */
+export function each_keyed(anchor_node, collection, flags, key_fn, render_fn, fallback_fn) {
+	each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, reconcile_tracked_array);
+}
+
+/**
+ * @template V
+ * @param {Element | Comment} anchor_node
+ * @param {() => V[]} collection
+ * @param {number} flags
+ * @param {(anchor: null, item: V, index: import('./types.js').MaybeSignal<number>) => void} render_fn
+ * @param {null | ((anchor: Node) => void)} fallback_fn
+ * @returns {void}
+ */
+export function each_indexed(anchor_node, collection, flags, render_fn, fallback_fn) {
+	each(anchor_node, collection, flags, null, render_fn, fallback_fn, reconcile_indexed_array);
 }
 
 /**

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -68,7 +68,7 @@ import {
 	hydrate_block_anchor,
 	set_current_hydration_fragment
 } from './hydration.js';
-import { array_from, define_property, get_descriptor, get_descriptors, is_array } from './utils.js';
+import { array_from, define_property, get_descriptor, is_array } from './utils.js';
 import { is_promise } from '../common.js';
 import { bind_transition } from './transitions.js';
 
@@ -2408,7 +2408,7 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 			fallback = fallback.prev;
 		}
 		// Clear the array
-		reconcile_indexed_array([], block, anchor_node, is_controlled, render_fn, flags, false);
+		reconcile_fn([], block, anchor_node, is_controlled, render_fn, flags, false, keys);
 		destroy_signal(/** @type {import('./types.js').EffectSignal} */ (render));
 	});
 	block.effect = each;


### PR DESCRIPTION
With Svelte 5, we load both each block reconciliation functions, making it impossible to tree shake one or the other if you don't use them. This PR changes that, ensuring we can treeshake them respectfully by breaking the compiled function into either `$.each_keyed` or `$.each_indexed`.

### Before submitting the PR, please make sure you do the following
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
