### PR TITLE
fix: correct each block update index type

### DIFF
--- a/.changeset/eight-steaks-shout.md
+++ b/.changeset/eight-steaks-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correct update_block index type

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2078,7 +2078,7 @@ function get_first_element(block) {
 /**
  * @param {import('./types.js').EachItemBlock} block
  * @param {any} item
- * @param {import('./types.js').MaybeSignal<number>} index
+ * @param {number} index
  * @param {number} type
  * @returns {void}
  */
@@ -2093,7 +2093,6 @@ export function update_each_item_block(block, item, index, type) {
 		let prev_index = block.index;
 		if (index_is_reactive) {
 			prev_index = /** @type {import('./types.js').Signal<number>} */ (prev_index).value;
-			index = /** @type {import('./types.js').Signal<number>} */ (index).value;
 		}
 		const items = block.parent.items;
 		if (prev_index !== index && /** @type {number} */ (index) < items.length) {


### PR DESCRIPTION
When looking through the each block code, it occurred to me the index is always a number and never a signal. Not sure why this was constructed this way, but this likely will cause overhead in keyed updates.

### Before submitting the PR, please make sure you do the following

- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
