### PR TITLE
fix: allow svelte:self in snippets

### DIFF
--- a/.changeset/funny-wombats-argue.md
+++ b/.changeset/funny-wombats-argue.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow svelte:self in snippets

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -141,7 +141,7 @@ const special_elements = {
 	/** @param {string} name */
 	'duplicate-svelte-element': (name) => `A component can only have one <${name}> element`,
 	'invalid-self-placement': () =>
-		`<svelte:self> components can only exist inside {#if} blocks, {#each} blocks, or slots passed to components`,
+		`<svelte:self> components can only exist inside {#if} blocks, {#each} blocks, {#snippet} blocks or slots passed to components`,
 	'missing-svelte-element-definition': () => `<svelte:element> must have a 'this' attribute`,
 	'missing-svelte-component-definition': () => `<svelte:component> must have a 'this' attribute`,
 	'invalid-svelte-element-definition': () => `Invalid element definition — must be an {expression}`,

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -331,7 +331,8 @@ function read_tag_name(parser) {
 			if (
 				fragment.type === 'IfBlock' ||
 				fragment.type === 'EachBlock' ||
-				fragment.type === 'Component'
+				fragment.type === 'Component' ||
+				fragment.type === 'SnippetBlock'
 			) {
 				legal = true;
 				break;

--- a/packages/svelte/tests/compiler-errors/samples/self-reference/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/self-reference/_config.js
@@ -4,7 +4,7 @@ export default test({
 	error: {
 		code: 'invalid-self-placement',
 		message:
-			'<svelte:self> components can only exist inside {#if} blocks, {#each} blocks, or slots passed to components',
+			'<svelte:self> components can only exist inside {#if} blocks, {#each} blocks,, {#snippet} blocks or slots passed to components',
 		position: [1, 1]
 	}
 });


### PR DESCRIPTION
This closes #9436 however i'm not entirely sure we should do this.

On one hand is reasonable to be able to render <svelte:self /> inside a snippet that is than passed to a component even without an if block. On the other this remove a safe security pin against infinite loops if i do something like

```svelte
{#snippet infinite()}
<svelte:self />
{/snippet}

{@render infinite()}
```

at the same time this is still doable by doing this

```svelte
{#snippet infinite()}
    {#if true}
        <svelte:self />
    {/if}
{/snippet}

{@render infinite()}
```

For the moment i've opened this PR but i leave this to the wise minds of the maintainers to decide what's best to do.

P.s. i did not include a test to check for this behavior because i didn't see tests to check that svelte:self is allowed inside the other blocks....but i can add one for all the cases if needed.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
