### PR TITLE
chore: Show AST on Svelte5 Playground

### DIFF
--- a/sites/svelte-5-preview/src/lib/Output/Output.svelte
+++ b/sites/svelte-5-preview/src/lib/Output/Output.svelte
@@ -58,8 +58,7 @@
 	let view = 'result';
 	let markdown = '';
 
-	/** @type {import('svelte/types/compiler/interfaces').Ast} */
-	let ast;
+	$: ast = compiled?.result?.ast;
 </script>
 
 <div class="view-toggle">
@@ -110,7 +109,7 @@
 </div>
 
 <!-- ast output -->
-{#if showAst}
+{#if showAst && ast}
 	<div class="tab-content" class:visible={selected?.type !== 'md' && view === 'ast'}>
 		<!-- ast view interacts with the module editor, wait for it first -->
 		{#if $module_editor}

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -254,7 +254,7 @@
 		if (!compiler || !$selected) return;
 
 		if ($selected.type === 'svelte' || $selected.type === 'js') {
-			compiled = await compiler.compile($selected, $compile_options, false);
+			compiled = await compiler.compile($selected, $compile_options, true);
 			runes = compiled.result.metadata?.runes ?? false;
 		} else {
 			runes = false;

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -3,6 +3,7 @@ self.window = self; //TODO: still need?: egregious hack to get magic-string to w
 
 /**
  * @type {{
+ * 	 parse: typeof import('svelte/compiler').parse;
  *   compile: typeof import('svelte/compiler').compile;
  *   compileModule: typeof import('svelte/compiler').compileModule;
  *   VERSION: string;
@@ -65,6 +66,8 @@ function compile({ id, source, options, return_ast }) {
 
 			const { js, css, warnings, metadata } = compiled;
 
+			const ast = return_ast ? svelte.parse(source, { modern: true }) : undefined;
+
 			return {
 				id,
 				result: {
@@ -72,7 +75,8 @@ function compile({ id, source, options, return_ast }) {
 					css: css?.code || `/* Add a <sty` + `le> tag to see compiled CSS */`,
 					error: null,
 					warnings,
-					metadata
+					metadata,
+					ast
 				}
 			};
 		} else if (options.filename.endsWith('.svelte.js')) {

--- a/sites/svelte-5-preview/src/routes/+page.svelte
+++ b/sites/svelte-5-preview/src/routes/+page.svelte
@@ -92,4 +92,5 @@
 	on:change={change_from_editor}
 	on:remove={change_from_editor}
 	previewTheme={$theme.current}
+	showAst={true}
 />


### PR DESCRIPTION
I wanted to see the AST when I do something for ESLint plugin.

<img width="1435" alt="image" src="https://github.com/sveltejs/svelte/assets/19153718/00d45eb0-0711-4bb6-890f-114663382142">


## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
