### PR TITLE
fix: ensure keyed fallback to indexed

### DIFF
--- a/.changeset/honest-icons-change.md
+++ b/.changeset/honest-icons-change.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+patch: ensure keyed each block fallback to indexed each block

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2066,7 +2066,10 @@ export const template_visitors = {
 		/** @type {number} */
 		let each_type;
 
-		if (node.key) {
+		if (
+			node.key &&
+			(node.key.type !== 'Identifier' || !node.index || node.key.name !== node.index)
+		) {
 			each_type = EACH_KEYED;
 			if (
 				node.key.type === 'Identifier' &&

--- a/packages/svelte/tests/runtime-legacy/samples/keyed-each-index-same/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/keyed-each-index-same/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: '1'
+});

--- a/packages/svelte/tests/runtime-legacy/samples/keyed-each-index-same/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/keyed-each-index-same/main.svelte
@@ -1,0 +1,3 @@
+{#each [1] as item, i (i)}
+	{item}
+{/each}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/9408. Ensures that if we have a key that matches the index, that we fallback to using an indexed each block.