### PR TITLE
fix: support dynamic attributes containing call expressions

### DIFF
--- a/.changeset/lucky-schools-hang.md
+++ b/.changeset/lucky-schools-hang.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure dynamic attributes containing call expressions update

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -762,7 +762,7 @@ const common_visitors = {
 				return false;
 			}
 
-			return chunk.metadata.dynamic;
+			return chunk.metadata.dynamic || chunk.metadata.contains_call_expression;
 		});
 
 		if (is_event_attribute(node)) {

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-style-attr/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-style-attr/_config.js
@@ -1,0 +1,17 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	html: `<div style="background-color: red">Hello world</div><button>Make blue</button`,
+
+	async test({ assert, target, component }) {
+		const [b1] = target.querySelectorAll('button');
+		flushSync(() => {
+			b1.click();
+		});
+		assert.htmlEqual(
+			target.innerHTML,
+			`<div style="background-color: blue">Hello world</div><button>Make blue</button`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-style-attr/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-style-attr/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let color = $state('red');
+
+	const getColor = () => color;
+</script>
+
+<div style="background-color: {getColor()}">Hello world</div>
+
+<button onclick={() => color = 'blue'}>Make blue</button>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/9403. We weren't taking into account the containment of call expressions logic before.