### PR TITLE
docs: Update Breaking changes section

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -71,3 +71,7 @@ Previously Svelte would always insert the CSS hash last. This is no longer guara
 ### `contenteditable` behavior change
 
 If you have a `contenteditable` node with a corresponding binding _and_ a reactive value inside it (example: `<div contenteditable=true bind:textContent>count is {count}</div>`), then the value inside the contenteditable will not be updated by updates to `count` because the binding takes full control over the content immediately and it should only be updated through it.
+
+### `oneventname` attributes no longer accept string values
+
+In Svelte4, it was possible to specify HTML event attributes like `<button onclick="foo">`. However, this is no longer allowed in Svelte5.

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -80,4 +80,4 @@ In Svelte 4, it was possible to specify event attributes on HTML elements as a s
 <button onclick="alert('hello')">...</button>
 ```
 
-This is considered an anti-pattern and is no longer possible in Svelte 5, where properties like `onclick` replace `on:click` as the mechanism for adding [event handlers](/docs/event-handlers).
+This is not recommended, and is no longer possible in Svelte 5, where properties like `onclick` replace `on:click` as the mechanism for adding [event handlers](/docs/event-handlers).

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -74,4 +74,10 @@ If you have a `contenteditable` node with a corresponding binding _and_ a reacti
 
 ### `oneventname` attributes no longer accept string values
 
-In Svelte 4, it was possible to specify HTML event attributes like `<button onclick="foo">`. However, this is no longer allowed in Svelte 5.
+In Svelte 4, it was possible to specify event attributes on HTML elements as a string:
+
+```svelte
+<button onclick="alert('hello')">...</button>
+```
+
+This is considered an anti-pattern and is no longer possible in Svelte 5, where properties like `onclick` replace `on:click` as the mechanism for adding [event handlers](/docs/event-handlers).

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -74,4 +74,4 @@ If you have a `contenteditable` node with a corresponding binding _and_ a reacti
 
 ### `oneventname` attributes no longer accept string values
 
-In Svelte4, it was possible to specify HTML event attributes like `<button onclick="foo">`. However, this is no longer allowed in Svelte5.
+In Svelte 4, it was possible to specify HTML event attributes like `<button onclick="foo">`. However, this is no longer allowed in Svelte 5.


### PR DESCRIPTION
Related to https://github.com/sveltejs/svelte/issues/9437

I considered allowing event attributes by strings, but I think it was better to mark it as a breaking change because it’s easy to avoid by the following code.

```svelte
<script>
  window.foo = () => console.log("hi!")
  const foo = window.foo;
</script>

<button onclick="{foo}">Hi!</button>
```


## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
