### PR TITLE
fix: bail-out of event delegation for each block reference

### DIFF
--- a/.changeset/modern-ghosts-melt.md
+++ b/.changeset/modern-ghosts-melt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: bail-out of event delegation for each block reference

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -157,7 +157,7 @@ function get_delegated_event(node, context) {
 		if (
 			binding !== null &&
 			// Bail-out if we reference anything from the EachBlock (for now) that mutates in non-runes mode,
-			((!context.state.analysis.runes && binding.kind === 'each') ||
+			(binding.kind === 'each' ||
 				// or any normal not reactive bindings that are mutated.
 				(binding.kind === 'normal' && context.state.analysis.runes) ||
 				// or any reactive imports (those are rewritten) (can only happen in legacy mode)

--- a/packages/svelte/tests/runtime-runes/samples/each-mutation-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-mutation-2/_config.js
@@ -1,0 +1,24 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<button>Click me and get error</button><button>Click me and get error</button><button>Click me and get error</button>`,
+
+	async test({ assert, target }) {
+		const [btn1, btn2, btn3] = target.querySelectorAll('button');
+
+		// ensure each click doesn't trigger an error
+		await btn1.click();
+		await Promise.resolve();
+
+		await btn2.click();
+		await Promise.resolve();
+
+		await btn3.click();
+		await Promise.resolve();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>Click me and get error</button><button>Click me and get error</button><button>Click me and get error</button>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-mutation-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-mutation-2/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let arr = $state([1,2,3]);
+</script>
+
+{#each arr as value}
+			<button onclick={() => value += 1}>Click me and get error</button>
+{/each}


### PR DESCRIPTION
Tune event delegation so we bail-out when referencing each block bindings.

Fixes https://github.com/sveltejs/svelte/issues/9400.