### PR TITLE
fix: only escape attribute values for elements, not components

### DIFF
--- a/.changeset/sour-rules-march.md
+++ b/.changeset/sour-rules-march.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only escape attribute values for elements, not components

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -611,9 +611,15 @@ const javascript_visitors_runes = {
  * @param {true | Array<import('#compiler').Text | import('#compiler').ExpressionTag>} attribute_value
  * @param {import('./types').ComponentContext} context
  * @param {boolean} trim_whitespace
+ * @param {boolean} is_component
  * @returns {import('estree').Expression}
  */
-function serialize_attribute_value(attribute_value, context, trim_whitespace = false) {
+function serialize_attribute_value(
+	attribute_value,
+	context,
+	trim_whitespace = false,
+	is_component = false
+) {
 	if (attribute_value === true) {
 		return b.true;
 	}
@@ -629,7 +635,8 @@ function serialize_attribute_value(attribute_value, context, trim_whitespace = f
 			if (trim_whitespace) {
 				data = data.replace(regex_whitespaces_strict, ' ').trim();
 			}
-			return b.literal(escape_html(data, true));
+
+			return b.literal(is_component ? data : escape_html(data, true));
 		} else {
 			return /** @type {import('estree').Expression} */ (context.visit(value.expression));
 		}
@@ -777,12 +784,12 @@ function serialize_inline_component(node, component_name, context) {
 		} else if (attribute.type === 'Attribute') {
 			if (attribute.name === 'slot') continue;
 			if (attribute.name.startsWith('--')) {
-				const value = serialize_attribute_value(attribute.value, context);
+				const value = serialize_attribute_value(attribute.value, context, false, true);
 				custom_css_props.push(b.init(attribute.name, value));
 				continue;
 			}
 
-			const value = serialize_attribute_value(attribute.value, context);
+			const value = serialize_attribute_value(attribute.value, context, false, true);
 			push_prop(b.prop('init', b.key(attribute.name), value));
 		} else if (attribute.type === 'BindDirective') {
 			// TODO this needs to turn the whole thing into a while loop because the binding could be mutated eagerly in the child

--- a/packages/svelte/tests/runtime-runes/samples/component-prop-unescaped/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/component-prop-unescaped/Child.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { prop } = $props();
+</script>
+
+{prop}

--- a/packages/svelte/tests/runtime-runes/samples/component-prop-unescaped/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/component-prop-unescaped/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `&quot;`
+});

--- a/packages/svelte/tests/runtime-runes/samples/component-prop-unescaped/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/component-prop-unescaped/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Child from './Child.svelte';
+</script>
+
+<Child prop='"'/>


### PR DESCRIPTION
closes #9454

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
