### PR TITLE
treat `slot` the same as other props

### DIFF
--- a/.changeset/tiny-kings-whisper.md
+++ b/.changeset/tiny-kings-whisper.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: treat `slot` the same as other props

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -710,7 +710,6 @@ function serialize_inline_component(node, component_name, context) {
 		} else if (attribute.type === 'SpreadAttribute') {
 			props_and_spreads.push(/** @type {import('estree').Expression} */ (context.visit(attribute)));
 		} else if (attribute.type === 'Attribute') {
-			if (attribute.name === 'slot') continue;
 			if (attribute.name.startsWith('--')) {
 				custom_css_props.push(
 					b.init(attribute.name, serialize_attribute_value(attribute.value, context)[1])

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -782,7 +782,6 @@ function serialize_inline_component(node, component_name, context) {
 		} else if (attribute.type === 'SpreadAttribute') {
 			props_and_spreads.push(/** @type {import('estree').Expression} */ (context.visit(attribute)));
 		} else if (attribute.type === 'Attribute') {
-			if (attribute.name === 'slot') continue;
 			if (attribute.name.startsWith('--')) {
 				const value = serialize_attribute_value(attribute.value, context, false, true);
 				custom_css_props.push(b.init(attribute.name, value));


### PR DESCRIPTION
closes #9455. this code is very weird, it must have been left over from something. not worried about it regressing so i'm not bothering to clutter the test suite

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
