### PR TITLE
fix: allow setting `files` binding for `<input type="file" />` (Svelte 5)

### DIFF
--- a/.changeset/soft-geese-learn.md
+++ b/.changeset/soft-geese-learn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow setting files binding for `<input type="file" />`

--- a/packages/svelte/src/compiler/phases/bindings.js
+++ b/packages/svelte/src/compiler/phases/bindings.js
@@ -182,6 +182,7 @@ export const binding_properties = {
 	},
 	files: {
 		event: 'change',
+		type: 'set',
 		valid_elements: ['input'],
 		omit_in_ssr: true
 	}

--- a/packages/svelte/tests/runtime-browser/samples/binding-files/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/binding-files/_config.js
@@ -1,0 +1,12 @@
+import { test } from '../../assert';
+
+export default test({
+	async test({ assert, window }) {
+		const input = window.document.querySelector('input');
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(input?.files?.length, 1);
+		window.document.querySelector('button')?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(input?.files?.length, 0);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/binding-files/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/binding-files/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { onMount } from "svelte";
+
+  let files;
+
+  onMount(() => {
+		let list = new DataTransfer();
+		let file = new File(["content"], "filename.jpg");
+		list.items.add(file);
+		files = list.files;
+	})
+</script>
+
+<input type="file" bind:files />
+
+<button onclick={() => files = new DataTransfer().files}>Reset</button>


### PR DESCRIPTION
fixes https://github.com/sveltejs/svelte/issues/9419

Equivalent of https://github.com/sveltejs/svelte/pull/9080 which is for Svelte 4

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
