### PR TITLE
chore: configure search.exclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ node_modules/
 
 # IDE related
 .idea
-.vscode/*
-!.vscode/launch.json
 
 # Test coverage
 coverage

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"search.exclude": {
+		"sites/svelte-5-preview/static/*": true
+	}
+}


### PR DESCRIPTION
QOL change that means search results aren't duplicated when you use `Cmd-P` to quickly open files.

This means that VSCode settings are checked in, which prevents people having their own personal per-workspace settings. Which is probably fine, since personal settings probably belong outside the workspace, but maybe others feel differently?