### PR TITLE
fix: stringify attribute values before comparison

### DIFF
--- a/.changeset/curly-lizards-dream.md
+++ b/.changeset/curly-lizards-dream.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: coerce attribute value to string before comparison

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2658,7 +2658,7 @@ export function attr_effect(dom, attribute, value) {
  * @param {string | null} value
  */
 export function attr(dom, attribute, value) {
-	value = value == null ? null : stringify(value);
+	value = value == null ? null : value + '';
 
 	if (DEV) {
 		check_src_in_dev_hydration(dom, attribute, value);

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2658,9 +2658,12 @@ export function attr_effect(dom, attribute, value) {
  * @param {string | null} value
  */
 export function attr(dom, attribute, value) {
+	value = value == null ? null : stringify(value);
+
 	if (DEV) {
 		check_src_in_dev_hydration(dom, attribute, value);
 	}
+
 	if (
 		current_hydration_fragment === null ||
 		(dom.getAttribute(attribute) !== value &&
@@ -2671,7 +2674,7 @@ export function attr(dom, attribute, value) {
 			attribute !== 'src' &&
 			attribute !== 'srcset')
 	) {
-		if (value == null) {
+		if (value === null) {
 			dom.removeAttribute(attribute);
 		} else {
 			dom.setAttribute(attribute, value);


### PR DESCRIPTION
This is one of two possible solutions to the following problem: when hydrating, we check to see if `value` is identical to the value of `getAttribute(name)`, but `value` might not be a string. As a result, in cases like this...

```svelte
<div aria-current={some_boolean}>
```

...we unnecessarily call `setAttribute`. Worse (and unrelated to hydration), calling `setAttribute` with a non-string value causes an inexplicable slowdown.

The alternative fix is to coerce values before the `attr` function is called. Doing so would result in fewer `typeof` checks (since in some cases we already know the attribute is a string), but would result in larger output.