### PR TITLE
chore: add dummy svelte.dev site

### DIFF
--- a/sites/svelte-5-preview/placeholder/index.html
+++ b/sites/svelte-5-preview/placeholder/index.html
@@ -1,0 +1,1 @@
+<p>placeholder</p>

--- a/sites/svelte-5-preview/vercel.json
+++ b/sites/svelte-5-preview/vercel.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "http://openapi.vercel.sh/vercel.json",
+	"github": {
+		"silent": true
+	},
+	"buildCommand": "echo \"ignore this\"",
+	"outputDirectory": "placeholder"
+}


### PR DESCRIPTION
maybe there's a smarter way to do this, but: currently, any PRs targeting `svelte-4` fail CI because Vercel can't deploy svelte-5-preview.vercel.app previews from the `svelte-4` branch.

This gives it something to deploy. It won't overwrite the production deployment because they can only come from the `main` branch