### PR TITLE
fix: emit useful error on invalid binding to derived state

### DIFF
--- a/.changeset/clean-eels-beg.md
+++ b/.changeset/clean-eels-beg.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: emit useful error on invalid binding to derived state

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -187,6 +187,7 @@ const runes = {
 				: ''
 		}`,
 	'invalid-derived-assignment': () => `Invalid assignment to derived state`,
+	'invalid-derived-binding': () => `Invalid binding to derived state`,
 	/**
 	 * @param {string} rune
 	 * @param {number[]} args

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -274,6 +274,10 @@ export const validation = {
 				error(node.expression, 'invalid-binding-value');
 			}
 
+			if (binding.kind === 'derived') {
+				error(node.expression, 'invalid-derived-binding');
+			}
+
 			// TODO handle mutations of non-state/props in runes mode
 		}
 

--- a/packages/svelte/tests/compiler-errors/samples/runes-no-derived-binding/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-no-derived-binding/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-derived-binding',
+		message: 'Invalid binding to derived state'
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/runes-no-derived-binding/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/runes-no-derived-binding/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let a = $state(0);
+	let b = $derived({ a });
+</script>
+
+<input type="number" bind:value={b} />


### PR DESCRIPTION
closes #9495 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
