### PR TITLE
fix: only treat instance context exports as accessors

### DIFF
--- a/.changeset/sharp-gorillas-impress.md
+++ b/.changeset/sharp-gorillas-impress.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only treat instance context exports as accessors

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -680,7 +680,7 @@ const runes_scope_tweaker = {
 		});
 	},
 	ExportNamedDeclaration(node, { next, state }) {
-		if (!node.declaration) {
+		if (!node.declaration || state.ast_type !== 'instance') {
 			return next();
 		}
 

--- a/packages/svelte/tests/runtime-runes/samples/module-context-export/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/module-context-export/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<p>42</p>`,
+
+	async test({ assert, target, window, component }) {
+		assert.equal(component.answer, undefined);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/module-context-export/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/module-context-export/main.svelte
@@ -1,0 +1,7 @@
+<svelte:options runes />
+
+<script context="module">
+	export const answer = 42;
+</script>
+
+<p>{answer}</p>


### PR DESCRIPTION
closes #9499. will merge once green as this is a blocker for #9482 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
