### PR TITLE
fix: address unowned propagation signal issue

### DIFF
--- a/.changeset/fifty-steaks-float.md
+++ b/.changeset/fifty-steaks-float.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: address unowned propagation signal issue

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -895,15 +895,17 @@ function mark_signal_consumers(signal, to_status, force_schedule) {
 		for (i = 0; i < length; i++) {
 			const consumer = consumers[i];
 			const flags = consumer.flags;
+			const unowned = (flags & UNOWNED) !== 0;
+			const dirty = (flags & DIRTY) !== 0;
 			if (
-				(flags & DIRTY) !== 0 ||
+				(dirty && !unowned) ||
 				(!runes && consumer === current_effect) ||
 				(!force_schedule && consumer === current_effect)
 			) {
 				continue;
 			}
 			set_signal_status(consumer, to_status);
-			if ((flags & CLEAN) !== 0) {
+			if ((flags & CLEAN) !== 0 || (dirty && unowned)) {
 				if ((consumer.flags & IS_EFFECT) !== 0) {
 					schedule_effect(/** @type {import('./types.js').EffectSignal} */ (consumer), false);
 				} else {

--- a/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/_config.js
@@ -1,0 +1,45 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	// The component context class instance gets shared between tests, strangely, causing hydration to fail?
+	skip_if_hydrate: 'permanent',
+
+	async test({ assert, target, component }) {
+		const btn = target.querySelector('button');
+
+		flushSync(() => {
+			btn?.click();
+		});
+
+		assert.deepEqual(component.log, [0, 'class trigger false', 'local trigger false', 1]);
+
+		flushSync(() => {
+			btn?.click();
+		});
+
+		assert.deepEqual(component.log, [0, 'class trigger false', 'local trigger false', 1, 2]);
+
+		flushSync(() => {
+			btn?.click();
+		});
+
+		assert.deepEqual(component.log, [0, 'class trigger false', 'local trigger false', 1, 2, 3]);
+
+		flushSync(() => {
+			btn?.click();
+		});
+
+		assert.deepEqual(component.log, [
+			0,
+			'class trigger false',
+			'local trigger false',
+			1,
+			2,
+			3,
+			4,
+			'class trigger true',
+			'local trigger true'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/main.svelte
@@ -1,0 +1,38 @@
+<script context="module">
+		class SomeLogic {
+		someValue = $state(0);
+		isAboveThree = $derived(this.someValue > 3)
+		trigger(){
+			this.someValue++;
+		}
+	}
+
+	const someLogic = new SomeLogic();
+</script>
+
+<script>
+	const {log = []} = $props();
+
+	function increment() {
+		someLogic.trigger();
+	}
+
+	let localDerived = $derived(someLogic.someValue > 3);
+
+	$effect(() => {
+		log.push(someLogic.someValue);
+	});
+	$effect(() => {
+		// Does not trigger
+		log.push('class trigger ' + someLogic.isAboveThree)
+	});
+	$effect(() => {
+		// Does Triggers
+		log.push('local trigger ' + localDerived)
+	});
+
+</script>
+
+<button on:click={increment}>
+	clicks: {someLogic.someValue}
+</button>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/9489. We have an issue with unowned signals where propagation would stop because we weren't handle their special case during propagation of scheduling effects.