### PR TITLE
fix: ensure we visit assignments during compilation

### DIFF
--- a/.changeset/wicked-doors-train.md
+++ b/.changeset/wicked-doors-train.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add missing visitor for assignments during compilation

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -775,7 +775,7 @@ function serialize_inline_component(node, component_name, context) {
 					const assignment = b.assignment('=', attribute.expression, b.id('$$value'));
 					push_prop(
 						b.set(attribute.name, [
-							b.stmt(serialize_set_binding(assignment, context, () => assignment))
+							b.stmt(serialize_set_binding(assignment, context, () => context.visit(assignment)))
 						])
 					);
 				}

--- a/packages/svelte/tests/runtime-runes/samples/bind-state-property/CheckBox.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-state-property/CheckBox.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { checked, ...rest } = $props();
+</script>
+
+<input type="checkbox" bind:checked {...rest} />

--- a/packages/svelte/tests/runtime-runes/samples/bind-state-property/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-state-property/_config.js
@@ -1,0 +1,12 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<input type="checkbox"><br>\nChecked:\nfalse`,
+
+	async test({ assert, target }) {
+		const input = target.querySelector('input');
+
+		await input?.click();
+		assert.htmlEqual(target.innerHTML, `<input type="checkbox"><br>\nChecked:\ntrue`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bind-state-property/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-state-property/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	import CheckBox from './CheckBox.svelte';
+
+	let checked = $state(false);
+	function wrap() {
+		return {
+			get checked() { return checked },
+			set checked(v) { checked = v },
+		}
+	}
+</script>
+
+{#if true}
+	{@const obj = wrap()}
+	<CheckBox type="checkbox" bind:checked={obj.checked} />
+{/if}
+<br/>
+Checked: {checked}


### PR DESCRIPTION
Not sure how we missed this one, but we were never visiting binding assignments? Just noticed it by chance when looking into improving  `serialize_set_binding` usage. Fixes https://github.com/sveltejs/svelte/issues/9478