### PR TITLE
feat: typed context draft

### DIFF
--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -39,17 +39,11 @@ export function onMount(fn) {
 }
 
 /**
- * Retrieves the context that belongs to the closest parent component with the specified `key`.
- * Must be called during component initialisation.
- *
- * https://svelte.dev/docs/svelte#getcontext
- * @template T
  * @param {any} key
- * @returns {T}
  */
 export function getContext(key) {
 	const context_map = get_or_init_context_map();
-	return /** @type {T} */ (context_map.get(key));
+	return context_map.get(key);
 }
 
 /**
@@ -61,7 +55,7 @@ export function getContext(key) {
  *
  * https://svelte.dev/docs/svelte#setcontext
  * @template T
- * @param {any} key
+ * @param {{} | import('./public.js').ContextKey<T>} key
  * @param {T} context
  * @returns {T}
  */
@@ -76,8 +70,9 @@ export function setContext(key, context) {
  * Must be called during component initialisation.
  *
  * https://svelte.dev/docs/svelte#hascontext
- * @param {any} key
- * @returns {boolean}
+ * @template T
+ * @param {{} | import('./public.js').ContextKey<T>} key
+ * @returns {key is import('./public.js').CheckedContextKey<T>}
  */
 export function hasContext(key) {
 	const context_map = get_or_init_context_map();

--- a/packages/svelte/src/main/public.d.ts
+++ b/packages/svelte/src/main/public.d.ts
@@ -202,5 +202,25 @@ export interface EventDispatcher<EventMap extends Record<string, any>> {
 	): boolean;
 }
 
+/**
+ * Provided as key to `setContext`, `hasContext` and `getContext` in order to enable strict typing
+ */
+export interface ContextKey<T> extends Symbol {}
+
+declare const isChecked: unique symbol;
+export interface CheckedContextKey<T> extends ContextKey<T> {
+	[isChecked]: undefined;
+}
+
+/**
+ * Retrieves the context that belongs to the closest parent component with the specified `key`.
+ * Must be called during component initialisation.
+ *
+ * https://svelte.dev/docs/svelte#getcontext
+ */
+export function getContext<T>(key: CheckedContextKey<T>): T;
+export function getContext<T>(key: ContextKey<T>): T | undefined;
+export function getContext<T>(key: {}): T;
+
 export * from './main-client.js';
 import './ambient.js';

--- a/packages/svelte/tests/types/context.ts
+++ b/packages/svelte/tests/types/context.ts
@@ -1,0 +1,49 @@
+import { getContext, hasContext, setContext, type ContextKey } from 'svelte';
+
+// non ContextKey still works
+setContext('string', 0);
+setContext(5, 0);
+setContext(true, 0);
+setContext({}, 0);
+setContext([], 0);
+setContext(Symbol(), 0);
+let resGet: number;
+resGet = getContext<number>('string');
+resGet = getContext<number>(5);
+resGet = getContext<number>(true);
+resGet = getContext<number>({});
+resGet = getContext<number>([]);
+
+// because `Symbol` is structurally the same as `ContextKey`, it returns optional type
+const resSymbol: number | undefined = getContext<number>(Symbol());
+
+let resHas: boolean;
+resHas = hasContext('string');
+resHas = hasContext(5);
+resHas = hasContext(true);
+resHas = hasContext({});
+resHas = hasContext([]);
+resHas = hasContext(Symbol());
+
+// ContextKey works
+const stringKey: ContextKey<string> = Symbol();
+setContext(stringKey, 'hello');
+// @ts-expect-error: wrong type of context
+setContext(stringKey, 1);
+const res1: string | undefined = getContext(stringKey);
+// @ts-expect-error: should be optional
+const res2: string = getContext(stringKey);
+if (hasContext(stringKey)) {
+	const resChecked: string = getContext(stringKey);
+}
+// @ts-expect-error: wrong type of variable
+const res3: number = getContext(stringKey);
+
+// TODO: generic takes over the ContextKey and function signature is: `getContext<number>(key: {})`
+// instead of`getContext<number>(key: ContextKey<string>)`
+// // @ts-expect-error: wrong type of generic
+// getContext<number>(stringKey);
+
+// TODO: fix this
+// // @ts-expect-error: wrong type of context generic
+// const numberKey: ContextKey<number> = stringKey;


### PR DESCRIPTION
Svelte lacks strong types in it's context functions. This PR is a draft of what this could look like. More details in this issue: #8941.

1. I tried to preserve backwards compatibility by replacing `key: any` with `key: {}`. It should be the same as before except `undefined` and `null`. But I don't think someone used `undefined` or `null` as keys anyway.

2. There are 2 commented out tests because I didn't want to think how to fix those edge cases because IDK if this PR will even be merged.
3. There is a nasty edge case with `getContext(Symbol())`, which returns `T | undefined` instead of `T`. But I believe if # 2 is resolved, this will be resolved too.
4. Also, I moved `getContext` types to `public.d.ts` because JSDoc doesn't support function overloads(as far as I am aware).

Is it possible for this to be merged in Svelte 5?

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
