### PR TITLE
fix: address intro transition bugs

### DIFF
--- a/.changeset/odd-needles-joke.md
+++ b/.changeset/odd-needles-joke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: address intro transition bugs

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -26,7 +26,6 @@ import {
 	EACH_IS_CONTROLLED,
 	EACH_INDEX_REACTIVE,
 	EACH_ITEM_REACTIVE,
-	EACH_IS_ANIMATED,
 	PassiveDelegatedEvents,
 	DelegatedEvents
 } from '../../constants.js';
@@ -1400,6 +1399,7 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 				block.current = result;
 				if (has_mounted) {
 					if (result) {
+						remove_in_transitions(alternate_transitions);
 						if (alternate_transitions.size === 0) {
 							execute_effect(alternate_effect);
 						} else {
@@ -1411,6 +1411,7 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 							trigger_transitions(consequent_transitions, 'in');
 						}
 					} else {
+						remove_in_transitions(consequent_transitions);
 						if (consequent_transitions.size === 0) {
 							execute_effect(consequent_effect);
 						} else {

--- a/packages/svelte/src/internal/client/transitions.js
+++ b/packages/svelte/src/internal/client/transitions.js
@@ -485,7 +485,6 @@ export function bind_transition(dom, transition_fn, props_fn, direction, global)
 					}
 					if (
 						parent === null ||
-						is_intro ||
 						(!global &&
 							(transition_block.type !== IF_BLOCK || parent.type !== IF_BLOCK || parent.current))
 					) {
@@ -530,9 +529,6 @@ export function trigger_transitions(transitions, target_direction, from) {
 		const direction = transition.direction;
 		if (target_direction === 'in') {
 			if (direction === 'in' || direction === 'both') {
-				if (direction === 'in') {
-					transition.cancel();
-				}
 				transition.in();
 			} else {
 				transition.cancel();

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-each-block-intro-outro/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-each-block-intro-outro/_config.js
@@ -34,7 +34,7 @@ export default test({
 
 		component.visible = true;
 
-		raf.tick(80);
+		raf.tick(100);
 		assert.equal(divs[0].foo, 1);
 		assert.equal(divs[1].foo, 1);
 		assert.equal(divs[2].foo, 1);

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-each-block-intro-outro/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-each-block-intro-outro/_config.js
@@ -34,10 +34,10 @@ export default test({
 
 		component.visible = true;
 
-		raf.tick(100);
-		assert.equal(divs[0].foo, 0.3);
-		assert.equal(divs[1].foo, 0.3);
-		assert.equal(divs[2].foo, 0.3);
+		raf.tick(80);
+		assert.equal(divs[0].foo, 1);
+		assert.equal(divs[1].foo, 1);
+		assert.equal(divs[2].foo, 1);
 
 		assert.equal(divs[0].bar, 1);
 		assert.equal(divs[1].bar, 1);

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-if-else-block-intro/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-if-else-block-intro/_config.js
@@ -14,7 +14,7 @@ export default test({
 
 		raf.tick(500);
 		component.x = true;
-		assert.equal(component.no, target.querySelector('div'));
+		assert.equal(component.no, null);
 		assert.equal(component.yes.foo, undefined);
 
 		raf.tick(700);


### PR DESCRIPTION
Follow up to https://github.com/sveltejs/svelte/pull/9515. After getting feedback, we need to keep `intro` transition propagating but instead we need to clear them down accordingly in if blocks, like we do in other blocks. This was trickier to deal with as it turned out we had some tests that needed updating to reflect this behavior.