### PR TITLE
chore: more signal fine-tuning

### DIFF
--- a/.changeset/hungry-dots-fry.md
+++ b/.changeset/hungry-dots-fry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: more signal perf tuning

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/global.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/global.js
@@ -14,21 +14,21 @@ export const global_visitors = {
 	},
 	MemberExpression(node, { state, next }) {
 		if (node.object.type === 'ThisExpression') {
-			// rewrite `this.#foo` as `this.#foo.value` inside a constructor
+			// rewrite `this.#foo` as `this.#foo.v` inside a constructor
 			if (node.property.type === 'PrivateIdentifier') {
 				const field = state.private_state.get(node.property.name);
 
 				if (field) {
-					return state.in_constructor ? b.member(node, b.id('value')) : b.call('$.get', node);
+					return state.in_constructor ? b.member(node, b.id('v')) : b.call('$.get', node);
 				}
 			}
 
-			// rewrite `this.foo` as `this.#foo.value` inside a constructor
+			// rewrite `this.foo` as `this.#foo.v` inside a constructor
 			if (node.property.type === 'Identifier' && !node.computed) {
 				const field = state.public_state.get(node.property.name);
 
 				if (field && state.in_constructor) {
-					return b.member(b.member(b.this, field.id), b.id('value'));
+					return b.member(b.member(b.this, field.id), b.id('v'));
 				}
 			}
 		}

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -624,7 +624,7 @@ export function bind_playback_rate(media, get_value, update) {
 	// Needs to happen after the element is inserted into the dom, else playback will be set back to 1 by the browser.
 	// For hydration we could do it immediately but the additional code is not worth the lost microtask.
 
-	/** @type {import('./types.js').Signal | undefined} */
+	/** @type {import('./types.js').ComputationSignal | undefined} */
 	let render;
 	let destroyed = false;
 	const effect = managed_effect(() => {
@@ -2125,7 +2125,7 @@ export function destroy_each_item_block(
 		if (!controlled && dom !== null) {
 			remove(dom);
 		}
-		destroy_signal(/** @type {import('./types.js').Signal} */ (block.effect));
+		destroy_signal(/** @type {import('./types.js').EffectSignal} */ (block.effect));
 	}
 }
 
@@ -3163,7 +3163,7 @@ export function mount(component, options) {
 			if (hydration_fragment !== null) {
 				remove(hydration_fragment);
 			}
-			destroy_signal(/** @type {import('./types.js').Signal} */ (block.effect));
+			destroy_signal(/** @type {import('./types.js').EffectSignal} */ (block.effect));
 		}
 	];
 }

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2082,7 +2082,7 @@ export function update_each_item_block(block, item, index, type) {
 	if (transitions !== null && (type & EACH_KEYED) !== 0) {
 		let prev_index = block.index;
 		if (index_is_reactive) {
-			prev_index = /** @type {import('./types.js').Signal<number>} */ (prev_index).value;
+			prev_index = /** @type {import('./types.js').Signal<number>} */ (prev_index).v;
 		}
 		const items = block.parent.items;
 		if (prev_index !== index && /** @type {number} */ (index) < items.length) {

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -26,7 +26,6 @@ import {
 	EACH_IS_CONTROLLED,
 	EACH_INDEX_REACTIVE,
 	EACH_ITEM_REACTIVE,
-	EACH_IS_ANIMATED,
 	PassiveDelegatedEvents,
 	DelegatedEvents
 } from '../../constants.js';
@@ -2244,11 +2243,7 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 				? []
 				: Array.from(maybe_array);
 			if (key_fn !== null) {
-				const length = array.length;
-				keys = Array(length);
-				for (let i = 0; i < length; i++) {
-					keys[i] = key_fn(array[i]);
-				}
+				keys = array.map(key_fn);
 			}
 			if (fallback_fn !== null) {
 				if (array.length === 0) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -873,7 +873,8 @@ export function mutate_store(store, expression, new_value) {
  */
 export function mark_subtree_inert(signal, inert) {
 	const flags = signal.f;
-	if (((flags & INERT) === 0 && inert) || ((flags & INERT) !== 0 && !inert)) {
+	const is_already_inert = (flags & INERT) !== 0;
+	if (is_already_inert !== inert) {
 		signal.f ^= INERT;
 		if (!inert && (flags & IS_EFFECT) !== 0 && (flags & CLEAN) === 0) {
 			schedule_effect(/** @type {import('./types.js').EffectSignal} */ (signal), false);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1,7 +1,6 @@
 import { subscribe_to_store } from '../../store/utils.js';
 import { EMPTY_FUNC } from '../common.js';
 import { unwrap } from './render.js';
-import { map_delete, map_get, map_set } from './operations.js';
 import { is_array } from './utils.js';
 
 export const SOURCE = 1;
@@ -197,22 +196,25 @@ function is_signal_dirty(signal) {
 		return true;
 	}
 	if ((flags & MAYBE_DIRTY) !== 0) {
-		const dependencies = /** @type {import('./types.js').ComputationSignal<V>} **/ (signal).dependencies;
+		const dependencies = /** @type {import('./types.js').ComputationSignal<V>} **/ (signal)
+			.dependencies;
 		if (dependencies !== null) {
 			const length = dependencies.length;
 			let i;
 			for (i = 0; i < length; i++) {
 				const dependency = dependencies[i];
-				const dep_flags = dependency.flags;
 
-				if ((dep_flags & MAYBE_DIRTY) !== 0 && !is_signal_dirty(dependency)) {
+				if ((dependency.flags & MAYBE_DIRTY) !== 0 && !is_signal_dirty(dependency)) {
 					set_signal_status(dependency, CLEAN);
 					continue;
 				}
 				// The flags can be marked as dirty from the above is_signal_dirty call.
 				if ((dependency.flags & DIRTY) !== 0) {
-					if ((dep_flags & DERIVED) !== 0) {
-						update_derived(/** @type {import('./types.js').ComputationSignal<V>} **/ (dependency), true);
+					if ((dependency.flags & DERIVED) !== 0) {
+						update_derived(
+							/** @type {import('./types.js').ComputationSignal<V>} **/ (dependency),
+							true
+						);
 						// Might have been mutated from above get.
 						if ((signal.flags & DIRTY) !== 0) {
 							return true;
@@ -276,7 +278,9 @@ function execute_signal_fn(signal) {
 					dependencies[current_dependencies_index + i] = current_dependencies[i];
 				}
 			} else {
-				signal.dependencies = /** @type {import('./types.js').Signal<V>[]} **/ (dependencies = current_dependencies);
+				signal.dependencies = /** @type {import('./types.js').Signal<V>[]} **/ (
+					dependencies = current_dependencies
+				);
 			}
 
 			if (!current_skip_consumer) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -756,7 +756,7 @@ export function get(signal) {
 			current_dependencies_index++;
 		} else if (current_dependencies === null) {
 			current_dependencies = [signal];
-		} else if (signal !== current_dependencies.at(-1)) {
+		} else if (signal !== current_dependencies[current_dependencies.length - 1]) {
 			current_dependencies.push(signal);
 		}
 	}

--- a/packages/svelte/src/internal/client/transitions.js
+++ b/packages/svelte/src/internal/client/transitions.js
@@ -253,7 +253,7 @@ function handle_raf(time) {
  * @param {HTMLElement} dom
  * @param {() => import('./types.js').TransitionPayload} init
  * @param {'in' | 'out' | 'both' | 'key'} direction
- * @param {import('./types.js').Signal<unknown>} effect
+ * @param {import('./types.js').EffectSignal} effect
  * @returns {import('./types.js').Transition}
  */
 function create_transition(dom, init, direction, effect) {

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -46,40 +46,45 @@ export type ComponentContext = {
 	};
 };
 
+
+// For both SourceSignal and ComputationSignal, we use signal character property string.
+// This now only reduces code-size and parsing, but it also improves the performance of the JIT compiler.
+// It's likely not to have any real wins wwhen the JIT is disabled however.
+
 export type SourceSignal<V = unknown> = {
-	/** Signals that read from the current signal */
-	consumers: null | ComputationSignal[];
-	/** The associated component if this signal is an effect/computed */
-	context: null | ComponentContext;
-	/** For value equality */
-	equals: null | EqualsFunctions;
-	/** The types that the signal represent, as a bitwise value */
-	flags: SignalFlags;
-	/** The latest value for this signal, doubles as the teardown for effects */
-	value: V;
+	/** consumers: Signals that read from the current signal */
+	c: null | ComputationSignal[];
+	/** context: The associated component if this signal is an effect/computed */
+	x: null | ComponentContext;
+	/** equals: For value equality */
+	e: null | EqualsFunctions;
+	/** flags: The types that the signal represent, as a bitwise value */
+	f: SignalFlags;
+	/** value: The latest value for this signal */
+	v: V;
 };
 
 export type ComputationSignal<V = unknown> = {
-	/** The block associated with this effect/computed */
-	block: null | Block;
-	/** Signals that read from the current signal */
-	consumers: null | ComputationSignal[];
-	/** The associated component if this signal is an effect/computed */
-	context: null | ComponentContext;
-	/** Signals that this signal reads from */
-	dependencies: null | Signal<V>[];
-	/** Thing(s) that need destroying */
-	destroy: null | (() => void) | Array<() => void>;
-	/** For value equality */
-	equals: null | EqualsFunctions;
+	/** block: The block associated with this effect/computed */
+	b: null | Block;
+	/** consumers: Signals that read from the current signal */
+	c: null | ComputationSignal[];
+	/** context: The associated component if this signal is an effect/computed */
+	x: null | ComponentContext;
+	/** dependencies: Signals that this signal reads from */
+	d: null | Signal<V>[];
+	/** destroy: Thing(s) that need destroying */
+	y: null | (() => void) | Array<() => void>;
+	/** equals: For value equality */
+	e: null | EqualsFunctions;
 	/** The types that the signal represent, as a bitwise value */
-	flags: SignalFlags;
-	/** The function that we invoke for effects and computeds */
-	init: null | (() => V) | (() => void | (() => void)) | ((b: Block) => void | (() => void));
-	/** Anything that a signal owns */
-	references: null | ComputationSignal[];
-	/** The latest value for this signal, doubles as the teardown for effects */
-	value: V;
+	f: SignalFlags;
+	/** init: The function that we invoke for effects and computeds */
+	i: null | (() => V) | (() => void | (() => void)) | ((b: Block) => void | (() => void));
+	/** references: Anything that a signal owns */
+	r: null | ComputationSignal[];
+	/** value: The latest value for this signal, doubles as the teardown for effects */
+	v: V;
 };
 
 export type Signal<V = unknown> = SourceSignal<V> | ComputationSignal<V>;

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -46,7 +46,6 @@ export type ComponentContext = {
 	};
 };
 
-
 // For both SourceSignal and ComputationSignal, we use signal character property string.
 // This now only reduces code-size and parsing, but it also improves the performance of the JIT compiler.
 // It's likely not to have any real wins wwhen the JIT is disabled. Lastly, we keep two shapes rather than

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -49,7 +49,10 @@ export type ComponentContext = {
 
 // For both SourceSignal and ComputationSignal, we use signal character property string.
 // This now only reduces code-size and parsing, but it also improves the performance of the JIT compiler.
-// It's likely not to have any real wins wwhen the JIT is disabled however.
+// It's likely not to have any real wins wwhen the JIT is disabled. Lastly, we keep two shapes rather than
+// a single monomorphic shape to improve the memory usage. Source signals don't need the same shape as they
+// simply don't do as much as computations (effects and derived signals). Thus we can improve the memory
+// profile at the slight cost of some runtime performance.
 
 export type SourceSignal<V = unknown> = {
 	/** consumers: Signals that read from the current signal */

--- a/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/client/index.svelte.js
@@ -20,8 +20,8 @@ export default function Class_state_field_constructor_assignment($$anchor, $$pro
 		#b = $.source();
 
 		constructor() {
-			this.#a.value = 1;
-			this.#b.value = 2;
+			this.#a.v = 1;
+			this.#b.v = 2;
 		}
 	}
 


### PR DESCRIPTION
Rather than having a single monomorphic signal object, it can be just as fast two have two object shapes. This also reduces memory usage as the source signal shape can be cheaper.