### PR TITLE
chore: rename internal object properties

### DIFF
--- a/.changeset/early-ads-tie.md
+++ b/.changeset/early-ads-tie.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: rename internal object properties

--- a/packages/svelte/src/internal/client/block.js
+++ b/packages/svelte/src/internal/client/block.js
@@ -12,87 +12,123 @@ export const DYNAMIC_ELEMENT_BLOCK = 8;
 export const SNIPPET_BLOCK = 9;
 
 /**
- * @param {Node} container
  * @param {boolean} intro
  * @returns {import('./types.js').RootBlock}
  */
-export function create_root_block(container, intro) {
+export function create_root_block(intro) {
 	return {
-		dom: null,
-		effect: null,
-		container,
-		intro,
-		parent: null,
-		transition: null,
-		type: ROOT_BLOCK
+		// dom
+		d: null,
+		// effect
+		e: null,
+		// intro
+		i: intro,
+		// parent
+		p: null,
+		// transition
+		r: null,
+		// type
+		t: ROOT_BLOCK
 	};
 }
 
 /** @returns {import('./types.js').IfBlock} */
 export function create_if_block() {
 	return {
-		current: false,
-		dom: null,
-		effect: null,
-		parent: /** @type {import('./types.js').Block} */ (current_block),
-		transition: null,
-		type: IF_BLOCK
+		// current
+		c: false,
+		// dom
+		d: null,
+		// effect
+		e: null,
+		// parent
+		p: /** @type {import('./types.js').Block} */ (current_block),
+		// transition
+		r: null,
+		// type
+		t: IF_BLOCK
 	};
 }
 
 /** @returns {import('./types.js').KeyBlock} */
 export function create_key_block() {
 	return {
-		dom: null,
-		effect: null,
-		parent: /** @type {import('./types.js').Block} */ (current_block),
-		transition: null,
-		type: KEY_BLOCK
+		// dom
+		d: null,
+		// effect
+		e: null,
+		// parent
+		p: /** @type {import('./types.js').Block} */ (current_block),
+		// transition
+		r: null,
+		// type
+		t: KEY_BLOCK
 	};
 }
 
 /** @returns {import('./types.js').HeadBlock} */
 export function create_head_block() {
 	return {
-		dom: null,
-		effect: null,
-		parent: /** @type {import('./types.js').Block} */ (current_block),
-		transition: null,
-		type: HEAD_BLOCK
+		// dom
+		d: null,
+		// effect
+		e: null,
+		// parent
+		p: /** @type {import('./types.js').Block} */ (current_block),
+		// transition
+		r: null,
+		// type
+		t: HEAD_BLOCK
 	};
 }
 
 /** @returns {import('./types.js').DynamicElementBlock} */
 export function create_dynamic_element_block() {
 	return {
-		dom: null,
-		effect: null,
-		parent: /** @type {import('./types.js').Block} */ (current_block),
-		transition: null,
-		type: DYNAMIC_ELEMENT_BLOCK
+		// dom
+		d: null,
+		// effect
+		e: null,
+		// parent
+		p: /** @type {import('./types.js').Block} */ (current_block),
+		// transition
+		r: null,
+		// type
+		t: DYNAMIC_ELEMENT_BLOCK
 	};
 }
 
 /** @returns {import('./types.js').DynamicComponentBlock} */
 export function create_dynamic_component_block() {
 	return {
-		dom: null,
-		effect: null,
-		parent: /** @type {import('./types.js').Block} */ (current_block),
-		transition: null,
-		type: DYNAMIC_COMPONENT_BLOCK
+		// dom
+		d: null,
+		// effect
+		e: null,
+		// parent
+		p: /** @type {import('./types.js').Block} */ (current_block),
+		// transition
+		r: null,
+		// type
+		t: DYNAMIC_COMPONENT_BLOCK
 	};
 }
 
 /** @returns {import('./types.js').AwaitBlock} */
 export function create_await_block() {
 	return {
-		dom: null,
-		effect: null,
-		parent: /** @type {import('./types.js').Block} */ (current_block),
-		pending: true,
-		transition: null,
-		type: AWAIT_BLOCK
+		// dom
+		d: null,
+		// effect
+		e: null,
+		// parent
+		p: /** @type {import('./types.js').Block} */ (current_block),
+		// pending
+		n: true,
+		// transition
+		r: null,
+		// type
+		t: AWAIT_BLOCK
 	};
 }
 
@@ -103,15 +139,23 @@ export function create_await_block() {
  */
 export function create_each_block(flags, anchor) {
 	return {
-		anchor,
-		dom: null,
-		flags,
-		items: [],
-		effect: null,
-		parent: /** @type {import('./types.js').Block} */ (current_block),
-		transition: null,
-		transitions: [],
-		type: EACH_BLOCK
+		// anchor
+		a: anchor,
+		// dom
+		d: null,
+		// flags
+		f: flags,
+		// items
+		v: [],
+		// effect
+		e: null,
+		p: /** @type {import('./types.js').Block} */ (current_block),
+		// transition
+		r: null,
+		// transitions
+		s: [],
+		// type
+		t: EACH_BLOCK
 	};
 }
 
@@ -123,25 +167,38 @@ export function create_each_block(flags, anchor) {
  */
 export function create_each_item_block(item, index, key) {
 	return {
-		dom: null,
-		effect: null,
-		index,
-		key,
-		item,
-		parent: /** @type {import('./types.js').EachBlock} */ (current_block),
-		transition: null,
-		transitions: null,
-		type: EACH_ITEM_BLOCK
+		// dom
+		d: null,
+		// effect
+		e: null,
+		i: index,
+		// key
+		k: key,
+		// item
+		v: item,
+		// parent
+		p: /** @type {import('./types.js').EachBlock} */ (current_block),
+		// transition
+		r: null,
+		// transitions
+		s: null,
+		// type
+		t: EACH_ITEM_BLOCK
 	};
 }
 
 /** @returns {import('./types.js').SnippetBlock} */
 export function create_snippet_block() {
 	return {
-		dom: null,
-		parent: /** @type {import('./types.js').Block} */ (current_block),
-		effect: null,
-		transition: null,
-		type: SNIPPET_BLOCK
+		// dom
+		d: null,
+		// parent
+		p: /** @type {import('./types.js').Block} */ (current_block),
+		// effect
+		e: null,
+		// transition
+		r: null,
+		// type
+		t: SNIPPET_BLOCK
 	};
 }

--- a/packages/svelte/src/internal/client/reconciler.js
+++ b/packages/svelte/src/internal/client/reconciler.js
@@ -112,7 +112,7 @@ export function reconcile_html(dom, value, svg) {
  * @returns {Text | Element | Comment}
  */
 function insert_each_item_block(block, dom, is_controlled, sibling) {
-	var current = /** @type {import('./types.js').TemplateNode} */ (block.dom);
+	var current = /** @type {import('./types.js').TemplateNode} */ (block.d);
 	if (sibling === null) {
 		if (is_controlled) {
 			return insert(current, /** @type {Element} */ (dom), null);
@@ -128,7 +128,7 @@ function insert_each_item_block(block, dom, is_controlled, sibling) {
  * @returns {Text | Element | Comment}
  */
 function get_first_child(block) {
-	var current = block.dom;
+	var current = block.d;
 	if (is_array(current)) {
 		return /** @type {Text | Element | Comment} */ (current[0]);
 	}
@@ -147,9 +147,9 @@ function destroy_active_transition_blocks(active_transitions) {
 		var transition;
 		for (; i < length; i++) {
 			block = active_transitions[i];
-			transition = block.transition;
+			transition = block.r;
 			if (transition !== null) {
-				block.transition = null;
+				block.r = null;
 				destroy_each_item_block(block, null, false);
 			}
 		}
@@ -177,8 +177,8 @@ export function reconcile_indexed_array(
 	flags,
 	apply_transitions
 ) {
-	var a_blocks = each_block.items;
-	var active_transitions = each_block.transitions;
+	var a_blocks = each_block.v;
+	var active_transitions = each_block.s;
 
 	/** @type {number | void} */
 	var a = a_blocks.length;
@@ -245,7 +245,7 @@ export function reconcile_indexed_array(
 			}
 		}
 	}
-	each_block.items = b_blocks;
+	each_block.v = b_blocks;
 }
 // Reconcile arrays by the equality of the elements in the array. This algorithm
 // is based on Ivi's reconcilation logic:
@@ -275,9 +275,9 @@ export function reconcile_tracked_array(
 	apply_transitions,
 	keys
 ) {
-	var a_blocks = each_block.items;
+	var a_blocks = each_block.v;
 	const is_computed_key = keys !== null;
-	var active_transitions = each_block.transitions;
+	var active_transitions = each_block.s;
 
 	/** @type {number | void} */
 	var a = a_blocks.length;
@@ -352,7 +352,7 @@ export function reconcile_tracked_array(
 			// Step 1
 			outer: while (true) {
 				// From the end
-				while (a_blocks[a_end].key === key) {
+				while (a_blocks[a_end].k === key) {
 					block = a_blocks[a_end--];
 					item = array[b_end];
 					if (should_update_block) {
@@ -368,7 +368,7 @@ export function reconcile_tracked_array(
 				item = array[start];
 				key = is_computed_key ? keys[start] : item;
 				// At the start
-				while (start <= a_end && start <= b_end && a_blocks[start].key === key) {
+				while (start <= a_end && start <= b_end && a_blocks[start].k === key) {
 					item = array[start];
 					block = a_blocks[start];
 					if (should_update_block) {
@@ -410,7 +410,7 @@ export function reconcile_tracked_array(
 					map_set(item_index, key, a);
 				}
 				for (b = start; b <= a_end; ++b) {
-					a = map_get(item_index, /** @type {V} */ (a_blocks[b].key));
+					a = map_get(item_index, /** @type {V} */ (a_blocks[b].k));
 					block = a_blocks[b];
 					if (a !== undefined) {
 						pos = pos < a ? a : MOVED_BLOCK;
@@ -464,7 +464,7 @@ export function reconcile_tracked_array(
 			}
 		}
 	}
-	each_block.items = b_blocks;
+	each_block.v = b_blocks;
 }
 // Longest Increased Subsequence algorithm.
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -193,7 +193,7 @@ function close_template(dom, is_fragment, anchor) {
 	if (anchor !== null && current_hydration_fragment === null) {
 		insert(current, null, anchor);
 	}
-	block.dom = current;
+	block.d = current;
 }
 
 /**
@@ -1366,15 +1366,16 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 	let has_mounted = false;
 	let has_mounted_branch = false;
 
-	block.transition =
+	block.r =
 		/**
 		 * @param {import('./types.js').Transition} transition
 		 * @returns {void}
 		 */
 		(transition) => {
-			if (block.current) {
+			// block.current
+			if (block.c) {
 				consequent_transitions.add(transition);
-				transition.finished(() => {
+				transition.f(() => {
 					consequent_transitions.delete(transition);
 					remove_in_transitions(consequent_transitions);
 					if (consequent_transitions.size === 0) {
@@ -1383,7 +1384,7 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 				});
 			} else {
 				alternate_transitions.add(transition);
-				transition.finished(() => {
+				transition.f(() => {
 					alternate_transitions.delete(transition);
 					remove_in_transitions(alternate_transitions);
 					if (alternate_transitions.size === 0) {
@@ -1395,8 +1396,8 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 	const if_effect = render_effect(
 		() => {
 			const result = !!condition_fn();
-			if (block.current !== result || !has_mounted) {
-				block.current = result;
+			if (block.c !== result || !has_mounted) {
+				block.c = result;
 				if (has_mounted) {
 					if (result) {
 						remove_in_transitions(alternate_transitions);
@@ -1454,7 +1455,7 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 				remove(consequent_dom);
 				consequent_dom = null;
 			}
-			if (block.current) {
+			if (block.c) {
 				consequent_fn(anchor_node);
 				if (!has_mounted_branch) {
 					// Restore previous fragment so that Svelte continues to operate in hydration mode
@@ -1462,8 +1463,8 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 					has_mounted_branch = true;
 				}
 			}
-			consequent_dom = block.dom;
-			block.dom = null;
+			consequent_dom = block.d;
+			block.d = null;
 		},
 		block,
 		true
@@ -1475,7 +1476,7 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 				remove(alternate_dom);
 				alternate_dom = null;
 			}
-			if (!block.current) {
+			if (!block.c) {
 				if (alternate_fn !== null) {
 					alternate_fn(anchor_node);
 				}
@@ -1485,8 +1486,8 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 					has_mounted_branch = true;
 				}
 			}
-			alternate_dom = block.dom;
-			block.dom = null;
+			alternate_dom = block.d;
+			block.d = null;
 		},
 		block,
 		true
@@ -1501,7 +1502,7 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 		destroy_signal(consequent_effect);
 		destroy_signal(alternate_effect);
 	});
-	block.effect = if_effect;
+	block.e = if_effect;
 }
 export { if_block as if };
 
@@ -1520,10 +1521,10 @@ export function head(render_fn) {
 	try {
 		const head_effect = render_effect(
 			() => {
-				const current = block.dom;
+				const current = block.d;
 				if (current !== null) {
 					remove(current);
-					block.dom = null;
+					block.d = null;
 				}
 				let anchor = null;
 				if (current_hydration_fragment === null) {
@@ -1536,12 +1537,12 @@ export function head(render_fn) {
 			false
 		);
 		push_destroy_fn(head_effect, () => {
-			const current = block.dom;
+			const current = block.d;
 			if (current !== null) {
 				remove(current);
 			}
 		});
-		block.effect = head_effect;
+		block.e = head_effect;
 	} finally {
 		set_current_hydration_fragment(previous_hydration_fragment);
 	}
@@ -1554,7 +1555,7 @@ export function head(render_fn) {
  * @returns {void}
  */
 function swap_block_dom(block, from, to) {
-	const dom = block.dom;
+	const dom = block.d;
 	if (is_array(dom)) {
 		for (let i = 0; i < dom.length; i++) {
 			if (dom[i] === from) {
@@ -1563,7 +1564,7 @@ function swap_block_dom(block, from, to) {
 			}
 		}
 	} else if (dom === from) {
-		block.dom = to;
+		block.d = to;
 	}
 }
 
@@ -1607,7 +1608,7 @@ export function element(anchor_node, tag_fn, render_fn, is_svg = false) {
 				: null;
 			const prev_element = element;
 			if (prev_element !== null) {
-				block.dom = null;
+				block.d = null;
 			}
 			element = next_element;
 			if (element !== null && render_fn !== null) {
@@ -1629,7 +1630,7 @@ export function element(anchor_node, tag_fn, render_fn, is_svg = false) {
 			if (element !== null) {
 				insert(element, null, anchor_node);
 				if (has_prev_element) {
-					const parent_block = block.parent;
+					const parent_block = block.p;
 					swap_block_dom(parent_block, prev_element, element);
 				}
 			}
@@ -1640,12 +1641,12 @@ export function element(anchor_node, tag_fn, render_fn, is_svg = false) {
 	push_destroy_fn(element_effect, () => {
 		if (element !== null) {
 			remove(element);
-			block.dom = null;
+			block.d = null;
 			element = null;
 		}
 		destroy_signal(render_effect_signal);
 	});
-	block.effect = element_effect;
+	block.e = element_effect;
 }
 
 /**
@@ -1664,26 +1665,26 @@ export function component(anchor_node, component_fn, render_fn) {
 
 	/** @type {null | ((props: P) => void)} */
 	let component = null;
-	block.transition =
+	block.r =
 		/**
 		 * @param {import('./types.js').Transition} transition
 		 * @returns {void}
 		 */
 		(transition) => {
 			const render = /** @type {import('./types.js').Render} */ (current_render);
-			const transitions = render.transitions;
+			const transitions = render.s;
 			transitions.add(transition);
-			transition.finished(() => {
+			transition.f(() => {
 				transitions.delete(transition);
 				remove_in_transitions(transitions);
 				if (transitions.size === 0) {
-					if (render.effect !== null) {
-						if (render.dom !== null) {
-							remove(render.dom);
-							render.dom = null;
+					if (render.e !== null) {
+						if (render.d !== null) {
+							remove(render.d);
+							render.d = null;
 						}
-						destroy_signal(render.effect);
-						render.effect = null;
+						destroy_signal(render.e);
+						render.e = null;
 					}
 				}
 			});
@@ -1691,29 +1692,29 @@ export function component(anchor_node, component_fn, render_fn) {
 	const create_render_effect = () => {
 		/** @type {import('./types.js').Render} */
 		const render = {
-			dom: null,
-			effect: null,
-			transitions: new Set(),
-			prev: current_render
+			d: null,
+			e: null,
+			s: new Set(),
+			p: current_render
 		};
 		// Managed effect
 		const effect = render_effect(
 			() => {
-				const current = block.dom;
+				const current = block.d;
 				if (current !== null) {
 					remove(current);
-					block.dom = null;
+					block.d = null;
 				}
 				if (component) {
 					render_fn(component);
 				}
-				render.dom = block.dom;
-				block.dom = null;
+				render.d = block.d;
+				block.d = null;
 			},
 			block,
 			true
 		);
-		render.effect = effect;
+		render.e = effect;
 		current_render = render;
 	};
 	const render = () => {
@@ -1722,14 +1723,15 @@ export function component(anchor_node, component_fn, render_fn) {
 			create_render_effect();
 			return;
 		}
-		const transitions = render.transitions;
+		const transitions = render.s;
+		remove_in_transitions(transitions);
 		if (transitions.size === 0) {
-			if (render.dom !== null) {
-				remove(render.dom);
-				render.dom = null;
+			if (render.d !== null) {
+				remove(render.d);
+				render.d = null;
 			}
-			if (render.effect) {
-				execute_effect(render.effect);
+			if (render.e) {
+				execute_effect(render.e);
 			} else {
 				create_render_effect();
 			}
@@ -1752,18 +1754,18 @@ export function component(anchor_node, component_fn, render_fn) {
 	push_destroy_fn(component_effect, () => {
 		let render = current_render;
 		while (render !== null) {
-			const dom = render.dom;
+			const dom = render.d;
 			if (dom !== null) {
 				remove(dom);
 			}
-			const effect = render.effect;
+			const effect = render.e;
 			if (effect !== null) {
 				destroy_signal(effect);
 			}
-			render = render.prev;
+			render = render.p;
 		}
 	});
-	block.effect = component_effect;
+	block.e = component_effect;
 }
 
 /**
@@ -1791,26 +1793,26 @@ function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 	/** @type {unknown} */
 	let error = UNINITIALIZED;
 	let pending = false;
-	block.transition =
+	block.r =
 		/**
 		 * @param {import('./types.js').Transition} transition
 		 * @returns {void}
 		 */
 		(transition) => {
 			const render = /** @type {import('./types.js').Render} */ (current_render);
-			const transitions = render.transitions;
+			const transitions = render.s;
 			transitions.add(transition);
-			transition.finished(() => {
+			transition.f(() => {
 				transitions.delete(transition);
 				remove_in_transitions(transitions);
 				if (transitions.size === 0) {
-					if (render.effect !== null) {
-						if (render.dom !== null) {
-							remove(render.dom);
-							render.dom = null;
+					if (render.e !== null) {
+						if (render.d !== null) {
+							remove(render.d);
+							render.d = null;
 						}
-						destroy_signal(render.effect);
-						render.effect = null;
+						destroy_signal(render.e);
+						render.e = null;
 					}
 				}
 			});
@@ -1818,35 +1820,38 @@ function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 	const create_render_effect = () => {
 		/** @type {import('./types.js').Render} */
 		const render = {
-			dom: null,
-			effect: null,
-			transitions: new Set(),
-			prev: current_render
+			d: null,
+			e: null,
+			s: new Set(),
+			p: current_render
 		};
 		const effect = render_effect(
 			() => {
 				if (error === UNINITIALIZED) {
 					if (resolved_value === UNINITIALIZED) {
-						block.pending = true;
+						// pending = true
+						block.n = true;
 						if (pending_fn !== null) {
 							pending_fn(anchor_node);
 						}
 					} else if (then_fn !== null) {
-						block.pending = false;
+						// pending = false
+						block.n = false;
 						then_fn(anchor_node, resolved_value);
 					}
 				} else if (catch_fn !== null) {
-					block.pending = false;
+					// pending = false
+					block.n = false;
 					catch_fn(anchor_node, error);
 				}
-				render.dom = block.dom;
-				block.dom = null;
+				render.d = block.d;
+				block.d = null;
 			},
 			block,
 			true,
 			true
 		);
-		render.effect = effect;
+		render.e = effect;
 		current_render = render;
 	};
 	const render = () => {
@@ -1855,15 +1860,15 @@ function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 			create_render_effect();
 			return;
 		}
-		const transitions = render.transitions;
+		const transitions = render.s;
 		remove_in_transitions(transitions);
 		if (transitions.size === 0) {
-			if (render.dom !== null) {
-				remove(render.dom);
-				render.dom = null;
+			if (render.d !== null) {
+				remove(render.d);
+				render.d = null;
 			}
-			if (render.effect) {
-				execute_effect(render.effect);
+			if (render.e) {
+				execute_effect(render.e);
 			} else {
 				create_render_effect();
 			}
@@ -1918,18 +1923,18 @@ function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 		let render = current_render;
 		latest_token = {};
 		while (render !== null) {
-			const dom = render.dom;
+			const dom = render.d;
 			if (dom !== null) {
 				remove(dom);
 			}
-			const effect = render.effect;
+			const effect = render.e;
 			if (effect !== null) {
 				destroy_signal(effect);
 			}
-			render = render.prev;
+			render = render.p;
 		}
 	});
-	block.effect = await_effect;
+	block.e = await_effect;
 }
 export { await_block as await };
 
@@ -1950,26 +1955,26 @@ export function key(anchor_node, key, render_fn) {
 	/** @type {V | typeof UNINITIALIZED} */
 	let key_value = UNINITIALIZED;
 	let mounted = false;
-	block.transition =
+	block.r =
 		/**
 		 * @param {import('./types.js').Transition} transition
 		 * @returns {void}
 		 */
 		(transition) => {
 			const render = /** @type {import('./types.js').Render} */ (current_render);
-			const transitions = render.transitions;
+			const transitions = render.s;
 			transitions.add(transition);
-			transition.finished(() => {
+			transition.f(() => {
 				transitions.delete(transition);
 				remove_in_transitions(transitions);
 				if (transitions.size === 0) {
-					if (render.effect !== null) {
-						if (render.dom !== null) {
-							remove(render.dom);
-							render.dom = null;
+					if (render.e !== null) {
+						if (render.d !== null) {
+							remove(render.d);
+							render.d = null;
 						}
-						destroy_signal(render.effect);
-						render.effect = null;
+						destroy_signal(render.e);
+						render.e = null;
 					}
 				}
 			});
@@ -1977,22 +1982,22 @@ export function key(anchor_node, key, render_fn) {
 	const create_render_effect = () => {
 		/** @type {import('./types.js').Render} */
 		const render = {
-			dom: null,
-			effect: null,
-			transitions: new Set(),
-			prev: current_render
+			d: null,
+			e: null,
+			s: new Set(),
+			p: current_render
 		};
 		const effect = render_effect(
 			() => {
 				render_fn(anchor_node);
-				render.dom = block.dom;
-				block.dom = null;
+				render.d = block.d;
+				block.d = null;
 			},
 			block,
 			true,
 			true
 		);
-		render.effect = effect;
+		render.e = effect;
 		current_render = render;
 	};
 	const render = () => {
@@ -2001,15 +2006,15 @@ export function key(anchor_node, key, render_fn) {
 			create_render_effect();
 			return;
 		}
-		const transitions = render.transitions;
+		const transitions = render.s;
 		remove_in_transitions(transitions);
 		if (transitions.size === 0) {
-			if (render.dom !== null) {
-				remove(render.dom);
-				render.dom = null;
+			if (render.d !== null) {
+				remove(render.d);
+				render.d = null;
 			}
-			if (render.effect) {
-				execute_effect(render.effect);
+			if (render.e) {
+				execute_effect(render.e);
 			} else {
 				create_render_effect();
 			}
@@ -2036,18 +2041,18 @@ export function key(anchor_node, key, render_fn) {
 	push_destroy_fn(key_effect, () => {
 		let render = current_render;
 		while (render !== null) {
-			const dom = render.dom;
+			const dom = render.d;
 			if (dom !== null) {
 				remove(dom);
 			}
-			const effect = render.effect;
+			const effect = render.e;
 			if (effect !== null) {
 				destroy_signal(effect);
 			}
-			render = render.prev;
+			render = render.p;
 		}
 	});
-	block.effect = key_effect;
+	block.e = key_effect;
 }
 
 /**
@@ -2055,7 +2060,7 @@ export function key(anchor_node, key, render_fn) {
  * @returns {Text | Element | Comment}
  */
 function get_first_element(block) {
-	const current = block.dom;
+	const current = block.d;
 	if (is_array(current)) {
 		for (let i = 0; i < current.length; i++) {
 			const node = current[i];
@@ -2076,17 +2081,17 @@ function get_first_element(block) {
  */
 export function update_each_item_block(block, item, index, type) {
 	if ((type & EACH_ITEM_REACTIVE) !== 0) {
-		set_signal_value(block.item, item);
+		set_signal_value(block.v, item);
 	}
-	const transitions = block.transitions;
+	const transitions = block.s;
 	const index_is_reactive = (type & EACH_INDEX_REACTIVE) !== 0;
 	// Handle each item animations
 	if (transitions !== null && (type & EACH_KEYED) !== 0) {
-		let prev_index = block.index;
+		let prev_index = block.i;
 		if (index_is_reactive) {
 			prev_index = /** @type {import('./types.js').Signal<number>} */ (prev_index).v;
 		}
-		const items = block.parent.items;
+		const items = block.p.v;
 		if (prev_index !== index && /** @type {number} */ (index) < items.length) {
 			const from_dom = /** @type {Element} */ (get_first_element(block));
 			const from = from_dom.getBoundingClientRect();
@@ -2096,9 +2101,9 @@ export function update_each_item_block(block, item, index, type) {
 		}
 	}
 	if (index_is_reactive) {
-		set_signal_value(/** @type {import('./types.js').Signal<number>} */ (block.index), index);
+		set_signal_value(/** @type {import('./types.js').Signal<number>} */ (block.i), index);
 	} else {
-		block.index = index;
+		block.i = index;
 	}
 }
 
@@ -2115,18 +2120,18 @@ export function destroy_each_item_block(
 	apply_transitions,
 	controlled = false
 ) {
-	const transitions = block.transitions;
+	const transitions = block.s;
 	if (apply_transitions && transitions !== null) {
 		trigger_transitions(transitions, 'out');
 		if (transition_block !== null) {
 			transition_block.push(block);
 		}
 	} else {
-		const dom = block.dom;
+		const dom = block.d;
 		if (!controlled && dom !== null) {
 			remove(dom);
 		}
-		destroy_signal(/** @type {import('./types.js').EffectSignal} */ (block.effect));
+		destroy_signal(/** @type {import('./types.js').EffectSignal} */ (block.e));
 	}
 }
 
@@ -2146,12 +2151,12 @@ export function each_item_block(item, key, index, render_fn, flags) {
 	const effect = render_effect(
 		/** @param {import('./types.js').EachItemBlock} block */
 		(block) => {
-			render_fn(null, block.item, block.index);
+			render_fn(null, block.v, block.i);
 		},
 		block,
 		true
 	);
-	block.effect = effect;
+	block.e = effect;
 	return block;
 }
 
@@ -2182,23 +2187,23 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 
 	/** @type {null | import('./types.js').EffectSignal} */
 	let render = null;
-	block.transition =
+	block.r =
 		/** @param {import('./types.js').Transition} transition */
 		(transition) => {
 			const fallback = /** @type {import('./types.js').Render} */ (current_fallback);
-			const transitions = fallback.transitions;
+			const transitions = fallback.s;
 			transitions.add(transition);
-			transition.finished(() => {
+			transition.f(() => {
 				transitions.delete(transition);
 				remove_in_transitions(transitions);
 				if (transitions.size === 0) {
-					if (fallback.effect !== null) {
-						if (fallback.dom !== null) {
-							remove(fallback.dom);
-							fallback.dom = null;
+					if (fallback.e !== null) {
+						if (fallback.d !== null) {
+							remove(fallback.d);
+							fallback.d = null;
 						}
-						destroy_signal(fallback.effect);
-						fallback.effect = null;
+						destroy_signal(fallback.e);
+						fallback.e = null;
 					}
 				}
 			});
@@ -2206,33 +2211,33 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 	const create_fallback_effect = () => {
 		/** @type {import('./types.js').Render} */
 		const fallback = {
-			dom: null,
-			effect: null,
-			transitions: new Set(),
-			prev: current_fallback
+			d: null,
+			e: null,
+			s: new Set(),
+			p: current_fallback
 		};
 		// Managed effect
 		const effect = render_effect(
 			() => {
-				const dom = block.dom;
+				const dom = block.d;
 				if (dom !== null) {
 					remove(dom);
-					block.dom = null;
+					block.d = null;
 				}
-				let anchor = block.anchor;
-				const is_controlled = (block.flags & EACH_IS_CONTROLLED) !== 0;
+				let anchor = block.a;
+				const is_controlled = (block.f & EACH_IS_CONTROLLED) !== 0;
 				if (is_controlled) {
 					anchor = empty();
-					block.anchor.appendChild(anchor);
+					block.a.appendChild(anchor);
 				}
 				/** @type {(anchor: Node) => void} */ (fallback_fn)(anchor);
-				fallback.dom = block.dom;
-				block.dom = null;
+				fallback.d = block.d;
+				block.d = null;
 			},
 			block,
 			true
 		);
-		fallback.effect = effect;
+		fallback.e = effect;
 		current_fallback = fallback;
 	};
 	const each = render_effect(
@@ -2249,16 +2254,16 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 			}
 			if (fallback_fn !== null) {
 				if (array.length === 0) {
-					if (block.items.length !== 0 || render === null) {
+					if (block.v.length !== 0 || render === null) {
 						create_fallback_effect();
 					}
-				} else if (block.items.length === 0 && current_fallback !== null) {
+				} else if (block.v.length === 0 && current_fallback !== null) {
 					const fallback = current_fallback;
-					const transitions = fallback.transitions;
+					const transitions = fallback.s;
 					if (transitions.size === 0) {
-						if (fallback.dom !== null) {
-							remove(fallback.dom);
-							fallback.dom = null;
+						if (fallback.d !== null) {
+							remove(fallback.d);
+							fallback.d = null;
 						}
 					} else {
 						trigger_transitions(transitions, 'out');
@@ -2275,35 +2280,35 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 	render = render_effect(
 		/** @param {import('./types.js').EachBlock} block */
 		(block) => {
-			const flags = block.flags;
+			const flags = block.f;
 			const is_controlled = (flags & EACH_IS_CONTROLLED) !== 0;
-			const anchor_node = block.anchor;
+			const anchor_node = block.a;
 			reconcile_fn(array, block, anchor_node, is_controlled, render_fn, flags, true, keys);
 		},
 		block,
 		true
 	);
 	push_destroy_fn(each, () => {
-		const flags = block.flags;
+		const flags = block.f;
 		const is_controlled = (flags & EACH_IS_CONTROLLED) !== 0;
-		const anchor_node = block.anchor;
+		const anchor_node = block.a;
 		let fallback = current_fallback;
 		while (fallback !== null) {
-			const dom = fallback.dom;
+			const dom = fallback.d;
 			if (dom !== null) {
 				remove(dom);
 			}
-			const effect = fallback.effect;
+			const effect = fallback.e;
 			if (effect !== null) {
 				destroy_signal(effect);
 			}
-			fallback = fallback.prev;
+			fallback = fallback.p;
 		}
 		// Clear the array
 		reconcile_fn([], block, anchor_node, is_controlled, render_fn, flags, false, keys);
 		destroy_signal(/** @type {import('./types.js').EffectSignal} */ (render));
 	});
-	block.effect = each;
+	block.e = each;
 }
 
 /**
@@ -3071,7 +3076,7 @@ export function mount(component, options) {
 	init_operations();
 	const registered_events = new Set();
 	const container = options.target;
-	const block = create_root_block(container, options.intro || false);
+	const block = create_root_block(options.intro || false);
 	const first_child = /** @type {ChildNode} */ (container.firstChild);
 	const hydration_fragment = get_hydration_fragment(first_child);
 	const previous_hydration_fragment = current_hydration_fragment;
@@ -3094,7 +3099,7 @@ export function mount(component, options) {
 					push({});
 					/** @type {import('../client/types.js').ComponentContext} */ (
 						current_component_context
-					).context = options.context;
+					).c = options.context;
 				}
 				// @ts-expect-error the public typings are not what the actual function looks like
 				accessors = component(anchor, options.props || {}, options.events || {});
@@ -3105,7 +3110,7 @@ export function mount(component, options) {
 			block,
 			true
 		);
-		block.effect = effect;
+		block.e = effect;
 	} catch (error) {
 		if (options.recover !== false && hydration_fragment !== null) {
 			// eslint-disable-next-line no-console
@@ -3153,14 +3158,14 @@ export function mount(component, options) {
 				container.removeEventListener(event_name, bound_event_listener);
 			}
 			root_event_handles.delete(event_handle);
-			const dom = block.dom;
+			const dom = block.d;
 			if (dom !== null) {
 				remove(dom);
 			}
 			if (hydration_fragment !== null) {
 				remove(hydration_fragment);
 			}
-			destroy_signal(/** @type {import('./types.js').EffectSignal} */ (block.effect));
+			destroy_signal(/** @type {import('./types.js').EffectSignal} */ (block.e));
 		}
 	];
 }
@@ -3196,8 +3201,8 @@ export function snippet_effect(create_snippet) {
 	render_effect(() => {
 		create_snippet();
 		return () => {
-			if (block.dom !== null) {
-				remove(block.dom);
+			if (block.d !== null) {
+				remove(block.d);
 			}
 		};
 	}, block);
@@ -3232,58 +3237,4 @@ function get_root_for_style(node) {
 		return /** @type {ShadowRoot} */ (root);
 	}
 	return /** @type {Document} */ (node.ownerDocument);
-}
-
-/**
- * @param {string} message
- * @param {string} filename
- * @param {Array<{ line: number; highlight: boolean; source: string }>} [code_highlights]
- * @returns {void}
- */
-export function compile_error(message, filename, code_highlights) {
-	// Construct error page
-	const page = document.createElement('div');
-	const container = document.createElement('div');
-	const pre = document.createElement('pre');
-	const h1 = document.createElement('h1');
-	const h2 = document.createElement('h2');
-	const p = document.createElement('p');
-	h1.textContent = 'Compilation Error';
-	h2.textContent = message;
-	p.textContent = filename;
-	pre.appendChild(h1);
-	pre.appendChild(h2);
-	if (code_highlights) {
-		const code_container = document.createElement('div');
-		for (const line of code_highlights) {
-			const code_line = document.createElement('div');
-			const code_line_number = document.createElement('span');
-			code_line_number.textContent = String(line.line);
-			const code_source = document.createElement('span');
-			code_source.textContent = line.source;
-			if (line.highlight) {
-				code_line.style.cssText = 'padding:8px;background:#333;color:#fff';
-			} else {
-				code_line.style.cssText = 'padding:8px;background:#000;color:#999';
-			}
-			code_line_number.style.cssText = 'color:#888;padding:0 15px 0 5px;text-align:right;';
-			code_line.appendChild(code_line_number);
-			code_line.appendChild(code_source);
-			code_container.appendChild(code_line);
-		}
-		pre.appendChild(code_container);
-	}
-	h1.style.cssText = 'color:#ff5555;font-weight:normal;margin-top:0;padding:0;font-size:20px;';
-	h2.style.cssText =
-		'color:#ccc;font-weight:normal;margin-top:0;padding:0;font-size:16px;white-space:normal;';
-	p.style.cssText = 'color: #999;';
-	page.style.cssText =
-		'z-index:9999;margin:0;position:fixed;top: 0;left: 0;height:100%;width:100%;background:rgba(0,0,0,0.66)';
-	container.style.cssText = `background:#181818;margin:30px auto;padding:25px 40px;position:relative;color:#d8d8d8;border-radius:6px 6px 8px 8px;width:800px;font-family:'SF Mono', SFMono-Regular, ui-monospace,'DejaVu Sans Mono', Menlo, Consolas, monospace;;border-top:8px solid #ff5555;`;
-	pre.appendChild(p);
-	container.appendChild(pre);
-	page.appendChild(container);
-	document.body.appendChild(page);
-	// eslint-disable-next-line no-console
-	console.error('[Compilation Error] ' + message);
 }

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -30,28 +30,39 @@ export type Store<V> = {
 	set(value: V): void;
 };
 
+// For all the core internal objects, we use signal character property strings.
+// This not only reduces code-size and parsing, but it also improves the performance
+// when the JS VM JITs the code.
+
 export type ComponentContext = {
-	props: MaybeSignal<Record<string, unknown>>;
-	accessors: Record<string, any> | null;
-	effects: null | Array<EffectSignal>;
-	mounted: boolean;
-	parent: null | ComponentContext;
-	context: null | Map<unknown, unknown>;
-	immutable: boolean;
-	runes: boolean;
-	update_callbacks: null | {
-		before: Array<() => void>;
-		after: Array<() => void>;
-		execute: () => void;
+	// props
+	s: MaybeSignal<Record<string, unknown>>;
+	// accessors
+	a: Record<string, any> | null;
+	// effects
+	e: null | Array<EffectSignal>;
+	// mounted
+	m: boolean;
+	// parent
+	p: null | ComponentContext;
+	// context
+	c: null | Map<unknown, unknown>;
+	// immutable
+	i: boolean;
+	// runes
+	r: boolean;
+	// update_callbacks
+	u: null | {
+		b: Array<() => void>;
+		a: Array<() => void>;
+		e: () => void;
 	};
 };
 
-// For both SourceSignal and ComputationSignal, we use signal character property string.
-// This now only reduces code-size and parsing, but it also improves the performance of the JIT compiler.
-// It's likely not to have any real wins wwhen the JIT is disabled. Lastly, we keep two shapes rather than
-// a single monomorphic shape to improve the memory usage. Source signals don't need the same shape as they
-// simply don't do as much as computations (effects and derived signals). Thus we can improve the memory
-// profile at the slight cost of some runtime performance.
+// We keep two shapes rather than a single monomorphic shape to improve the memory usage.
+// Source signals don't need the same shape as they simply don't do as much as computations
+// (effects and derived signals). Thus we can improve the memory profile at the slight cost
+// of some runtime performance.
 
 export type SourceSignal<V = unknown> = {
 	/** consumers: Signals that read from the current signal */
@@ -114,108 +125,177 @@ export type BlockType =
 export type TemplateNode = Text | Element | Comment;
 
 export type Transition = {
-	effect: EffectSignal;
-	payload: null | TransitionPayload;
-	init: (from?: DOMRect) => TransitionPayload;
-	finished: (fn: () => void) => void;
+	// effect
+	e: EffectSignal;
+	// payload
+	p: null | TransitionPayload;
+	// init
+	i: (from?: DOMRect) => TransitionPayload;
+	// finished
+	f: (fn: () => void) => void;
 	in: () => void;
-	out: () => void;
-	cancel: () => void;
-	cleanup: () => void;
-	direction: 'in' | 'out' | 'both' | 'key';
-	dom: HTMLElement;
+	// out
+	o: () => void;
+	// cancel
+	c: () => void;
+	// cleanup
+	x: () => void;
+	// direction
+	r: 'in' | 'out' | 'both' | 'key';
+	// dom
+	d: HTMLElement;
 };
 
 export type RootBlock = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | ComputationSignal;
-	container: Node;
-	intro: boolean;
-	parent: null;
-	transition: null | ((transition: Transition) => void);
-	type: typeof ROOT_BLOCK;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | ComputationSignal;
+	// intro
+	i: boolean;
+	// parent
+	p: null;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// type
+	t: typeof ROOT_BLOCK;
 };
 
 export type IfBlock = {
-	current: boolean;
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | ComputationSignal;
-	parent: Block;
-	transition: null | ((transition: Transition) => void);
-	type: typeof IF_BLOCK;
+	// current
+	c: boolean;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | ComputationSignal;
+	// parent
+	p: Block;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// type
+	t: typeof IF_BLOCK;
 };
 
 export type KeyBlock = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | ComputationSignal;
-	parent: Block;
-	transition: null | ((transition: Transition) => void);
-	type: typeof KEY_BLOCK;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | ComputationSignal;
+	// parent
+	p: Block;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// type
+	t: typeof KEY_BLOCK;
 };
 
 export type HeadBlock = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | ComputationSignal;
-	parent: Block;
-	transition: null | ((transition: Transition) => void);
-	type: typeof HEAD_BLOCK;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | ComputationSignal;
+	// parent
+	p: Block;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// type
+	t: typeof HEAD_BLOCK;
 };
 
 export type DynamicElementBlock = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | ComputationSignal;
-	parent: Block;
-	transition: null | ((transition: Transition) => void);
-	type: typeof DYNAMIC_ELEMENT_BLOCK;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | ComputationSignal;
+	// parent
+	p: Block;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// type
+	t: typeof DYNAMIC_ELEMENT_BLOCK;
 };
 
 export type DynamicComponentBlock = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | ComputationSignal;
-	parent: Block;
-	transition: null | ((transition: Transition) => void);
-	type: typeof DYNAMIC_COMPONENT_BLOCK;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | ComputationSignal;
+	// parent
+	p: Block;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// type
+	t: typeof DYNAMIC_COMPONENT_BLOCK;
 };
 
 export type AwaitBlock = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | ComputationSignal;
-	parent: Block;
-	pending: boolean;
-	transition: null | ((transition: Transition) => void);
-	type: typeof AWAIT_BLOCK;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | ComputationSignal;
+	// parent
+	p: Block;
+	// pending
+	n: boolean;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// type
+	t: typeof AWAIT_BLOCK;
 };
 
 export type EachBlock = {
-	anchor: Element | Comment;
-	flags: number;
-	dom: null | TemplateNode | Array<TemplateNode>;
-	items: EachItemBlock[];
-	effect: null | ComputationSignal;
-	parent: Block;
-	transition: null | ((transition: Transition) => void);
-	transitions: Array<EachItemBlock>;
-	type: typeof EACH_BLOCK;
+	// anchor
+	a: Element | Comment;
+	// flags
+	f: number;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// items
+	v: EachItemBlock[];
+	// effect
+	e: null | ComputationSignal;
+	// parent
+	p: Block;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// transitions
+	s: Array<EachItemBlock>;
+	// type
+	t: typeof EACH_BLOCK;
 };
 
 export type EachItemBlock = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | ComputationSignal;
-	item: any | Signal<any>;
-	index: number | Signal<number>;
-	key: unknown;
-	parent: EachBlock;
-	transition: null | ((transition: Transition) => void);
-	transitions: null | Set<Transition>;
-	type: typeof EACH_ITEM_BLOCK;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | ComputationSignal;
+	// item
+	v: any | Signal<any>;
+	// index
+	i: number | Signal<number>;
+	// key
+	k: unknown;
+	// parent
+	p: EachBlock;
+	// transition
+	r: null | ((transition: Transition) => void);
+	// transitions
+	s: null | Set<Transition>;
+	// type
+	t: typeof EACH_ITEM_BLOCK;
 };
 
 export type SnippetBlock = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	parent: Block;
-	effect: null | ComputationSignal;
-	transition: null;
-	type: typeof SNIPPET_BLOCK;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// parent
+	p: Block;
+	// effect
+	e: null | ComputationSignal;
+	// transition
+	r: null;
+	// type
+	t: typeof SNIPPET_BLOCK;
 };
 
 export type Block =
@@ -264,10 +344,14 @@ export type StoreReferencesContainer = Record<
 export type ActionPayload<P> = { destroy?: () => void; update?: (value: P) => void };
 
 export type Render = {
-	dom: null | TemplateNode | Array<TemplateNode>;
-	effect: null | EffectSignal;
-	transitions: Set<Transition>;
-	prev: Render | null;
+	// dom
+	d: null | TemplateNode | Array<TemplateNode>;
+	// effect
+	e: null | EffectSignal;
+	// transitions
+	s: Set<Transition>;
+	// prev
+	p: Render | null;
 };
 
 export type Raf = {

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -35,26 +35,29 @@ export type Store<V> = {
 // when the JS VM JITs the code.
 
 export type ComponentContext = {
-	// props
+	/** props */
 	s: MaybeSignal<Record<string, unknown>>;
-	// accessors
+	/** accessors */
 	a: Record<string, any> | null;
-	// effects
+	/** effectgs */
 	e: null | Array<EffectSignal>;
-	// mounted
+	/** mounted */
 	m: boolean;
-	// parent
+	/** parent */
 	p: null | ComponentContext;
-	// context
+	/** context */
 	c: null | Map<unknown, unknown>;
-	// immutable
+	/** immutable */
 	i: boolean;
-	// runes
+	/** runes */
 	r: boolean;
-	// update_callbacks
+	/** update_callbacks */
 	u: null | {
+		/** before */
 		b: Array<() => void>;
+		/** after */
 		a: Array<() => void>;
+		/** execute */
 		e: () => void;
 	};
 };
@@ -125,176 +128,176 @@ export type BlockType =
 export type TemplateNode = Text | Element | Comment;
 
 export type Transition = {
-	// effect
+	/** effect */
 	e: EffectSignal;
-	// payload
+	/** payload */
 	p: null | TransitionPayload;
-	// init
+	/** init */
 	i: (from?: DOMRect) => TransitionPayload;
-	// finished
+	/** finished */
 	f: (fn: () => void) => void;
 	in: () => void;
-	// out
+	/** out */
 	o: () => void;
-	// cancel
+	/** cancel */
 	c: () => void;
-	// cleanup
+	/** cleanup */
 	x: () => void;
-	// direction
+	/** direction */
 	r: 'in' | 'out' | 'both' | 'key';
-	// dom
+	/** dom */
 	d: HTMLElement;
 };
 
 export type RootBlock = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// intro
+	/** intro */
 	i: boolean;
-	// parent
+	/** parent */
 	p: null;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// type
+	/** type */
 	t: typeof ROOT_BLOCK;
 };
 
 export type IfBlock = {
-	// current
+	/** current */
 	c: boolean;
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// parent
+	/** parent */
 	p: Block;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// type
+	/** type */
 	t: typeof IF_BLOCK;
 };
 
 export type KeyBlock = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// parent
+	/** parent */
 	p: Block;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// type
+	/** type */
 	t: typeof KEY_BLOCK;
 };
 
 export type HeadBlock = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// parent
+	/** parent */
 	p: Block;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// type
+	/** type */
 	t: typeof HEAD_BLOCK;
 };
 
 export type DynamicElementBlock = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// parent
+	/** parent */
 	p: Block;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// type
+	/** type */
 	t: typeof DYNAMIC_ELEMENT_BLOCK;
 };
 
 export type DynamicComponentBlock = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// parent
+	/** parent */
 	p: Block;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// type
+	/** type */
 	t: typeof DYNAMIC_COMPONENT_BLOCK;
 };
 
 export type AwaitBlock = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// parent
+	/** parent */
 	p: Block;
-	// pending
+	/** pending */
 	n: boolean;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// type
+	/** type */
 	t: typeof AWAIT_BLOCK;
 };
 
 export type EachBlock = {
-	// anchor
+	/** anchor */
 	a: Element | Comment;
-	// flags
+	/** flags */
 	f: number;
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// items
+	/** items */
 	v: EachItemBlock[];
-	// effect
+	/** effewct */
 	e: null | ComputationSignal;
-	// parent
+	/** parent */
 	p: Block;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// transitions
+	/** transitions */
 	s: Array<EachItemBlock>;
-	// type
+	/** type */
 	t: typeof EACH_BLOCK;
 };
 
 export type EachItemBlock = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// item
+	/** item */
 	v: any | Signal<any>;
-	// index
+	/** index */
 	i: number | Signal<number>;
-	// key
+	/** key */
 	k: unknown;
-	// parent
+	/** parent */
 	p: EachBlock;
-	// transition
+	/** transition */
 	r: null | ((transition: Transition) => void);
-	// transitions
+	/** transitions */
 	s: null | Set<Transition>;
-	// type
+	/** type */
 	t: typeof EACH_ITEM_BLOCK;
 };
 
 export type SnippetBlock = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// parent
+	/** parent */
 	p: Block;
-	// effect
+	/** effect */
 	e: null | ComputationSignal;
-	// transition
+	/** transition */
 	r: null;
-	// type
+	/** type */
 	t: typeof SNIPPET_BLOCK;
 };
 
@@ -344,13 +347,13 @@ export type StoreReferencesContainer = Record<
 export type ActionPayload<P> = { destroy?: () => void; update?: (value: P) => void };
 
 export type Render = {
-	// dom
+	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	// effect
+	/** effect */
 	e: null | EffectSignal;
-	// transitions
+	/** transitions */
 	s: Set<Transition>;
-	// prev
+	/** prev */
 	p: Render | null;
 };
 

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -121,9 +121,8 @@ export function render(component, options) {
 
 	if (options.context) {
 		$.push({});
-		/** @type {import('../client/types.js').ComponentContext} */ (
-			$.current_component_context
-		).context = options.context;
+		/** @type {import('../client/types.js').ComponentContext} */ ($.current_component_context).c =
+			options.context;
 	}
 	component(payload, options.props, {}, {});
 	if (options.context) {


### PR DESCRIPTION
This changes all our internal object properties to single characters. This improves code-size, parse time and also improves runtime performance across the board. It just makes the coder harder to read, so I've added comments throughout that labels what they are in most cases. I've likely missed some obvious ones though as there's so many properties going on here.

This saves 0.7kb min+gzip and improves parse time on the default SvelteKit app startup by 4ms!