### PR TITLE
chore: more transition code-golfing

### DIFF
--- a/.changeset/kind-deers-lay.md
+++ b/.changeset/kind-deers-lay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: more transition code-golfing

--- a/packages/svelte/src/internal/client/block.js
+++ b/packages/svelte/src/internal/client/block.js
@@ -35,8 +35,14 @@ export function create_root_block(intro) {
 /** @returns {import('./types.js').IfBlock} */
 export function create_if_block() {
 	return {
-		// current
-		c: false,
+		// alternate transitions
+		a: null,
+		// alternate effect
+		ae: null,
+		// consequent transitions
+		c: null,
+		// consequent effect
+		ce: null,
 		// dom
 		d: null,
 		// effect
@@ -46,7 +52,9 @@ export function create_if_block() {
 		// transition
 		r: null,
 		// type
-		t: IF_BLOCK
+		t: IF_BLOCK,
+		// value
+		v: false
 	};
 }
 

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -165,16 +165,24 @@ export type RootBlock = {
 };
 
 export type IfBlock = {
-	/** current */
-	c: boolean;
+	/** value */
+	v: boolean;
 	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
 	/** effect */
-	e: null | ComputationSignal;
+	e: null | EffectSignal;
 	/** parent */
 	p: Block;
 	/** transition */
 	r: null | ((transition: Transition) => void);
+	/** consequent transitions */
+	c: null | Set<Transition>;
+	/** alternate transitions */
+	a: null | Set<Transition>;
+	/** effect */
+	ce: null | EffectSignal;
+	/** effect */
+	ae: null | EffectSignal;
 	/** type */
 	t: typeof IF_BLOCK;
 };
@@ -183,7 +191,7 @@ export type KeyBlock = {
 	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
 	/** effect */
-	e: null | ComputationSignal;
+	e: null | EffectSignal;
 	/** parent */
 	p: Block;
 	/** transition */


### PR DESCRIPTION
Let's get them bytes down! This PR makes If block transitions lazy and also does a bunch in other areas to reduce code size around transitions.