### PR TITLE
fix: handle spreads within static strings

### DIFF
--- a/.changeset/gentle-spies-cover.md
+++ b/.changeset/gentle-spies-cover.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: handle spreads within static strings

--- a/packages/svelte/src/compiler/compile/render_dom/wrappers/Element/index.js
+++ b/packages/svelte/src/compiler/compile/render_dom/wrappers/Element/index.js
@@ -1312,9 +1312,19 @@ function to_html(wrappers, block, literal, state, can_use_raw_text) {
 					// The value attribute of <textarea> renders as content.
 					return;
 				}
-				state.quasi.value.raw += ` ${fix_attribute_casing(attr.node.name)}="`;
-				to_html_for_attr_value(attr, block, literal, state);
-				state.quasi.value.raw += '"';
+
+				if (attr instanceof SpreadAttributeWrapper) {
+					literal.quasis.push(state.quasi);
+					literal.expressions.push(x`@stringify_spread(${attr.node.expression.manipulate(block)})`);
+					state.quasi = {
+						type: 'TemplateElement',
+						value: { raw: '' }
+					};
+				} else {
+					state.quasi.value.raw += ` ${fix_attribute_casing(attr.node.name)}="`;
+					to_html_for_attr_value(attr, block, literal, state);
+					state.quasi.value.raw += '"';
+				}
 			});
 			if (!wrapper.void) {
 				state.quasi.value.raw += '>';

--- a/packages/svelte/src/runtime/internal/dom.js
+++ b/packages/svelte/src/runtime/internal/dom.js
@@ -1180,6 +1180,36 @@ export function attribute_to_object(attributes) {
 	return result;
 }
 
+const escaped = {
+	'"': '&quot;',
+	'&': '&amp;',
+	'<': '&lt;'
+};
+
+const regex_attribute_characters_to_escape = /["&<]/g;
+
+/**
+ * Note that the attribute itself should be surrounded in double quotes
+ * @param {any} attribute
+ */
+function escape_attribute(attribute) {
+	return String(attribute).replace(regex_attribute_characters_to_escape, (match) => escaped[match]);
+}
+
+/**
+ * @param {Record<string, string>} attributes
+ */
+export function stringify_spread(attributes) {
+	let str = ' ';
+	for (const key in attributes) {
+		if (attributes[key] != null) {
+			str += `${key}="${escape_attribute(attributes[key])}" `;
+		}
+	}
+
+	return str;
+}
+
 /**
  * @param {HTMLElement} element
  * @returns {{}}

--- a/packages/svelte/test/runtime/samples/spread-from-import/_config.js
+++ b/packages/svelte/test/runtime/samples/spread-from-import/_config.js
@@ -1,0 +1,11 @@
+export default {
+	html: `
+	<div>
+		<p class="tooltip">static stuff</p>
+	</div>
+	<div>
+		<p class="tooltip">dynamic stuff</p>
+	</div>
+	<button>unused</button>
+	`
+};

--- a/packages/svelte/test/runtime/samples/spread-from-import/main.svelte
+++ b/packages/svelte/test/runtime/samples/spread-from-import/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { spread } from './spread.js';
+	let dynamic = 'dynamic';
+</script>
+
+<div>
+	<p {...spread()}>static stuff</p>
+</div>
+
+<div>
+	<p {...spread()}>{dynamic} stuff</p>
+</div>
+
+<button on:click={() => dynamic = ''}>unused</button>

--- a/packages/svelte/test/runtime/samples/spread-from-import/spread.js
+++ b/packages/svelte/test/runtime/samples/spread-from-import/spread.js
@@ -1,0 +1,6 @@
+export function spread() {
+	return {
+		class: 'tooltip',
+		id: null
+	};
+}


### PR DESCRIPTION
Previously, if a part of the template was determined be be optimizable using innerHTML, it would error if there's a spread on an attribute.
I escaped the attribute values just to be extra sure although these can only be coming from purely static content anyway.

Discovered this while working on image optimization in SvelteKit.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
