### PR TITLE
document class state fields

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -24,6 +24,22 @@ Reactive state is declared with the `$state` rune:
 </button>
 ```
 
+You can also use `$state` in class fields (whether public or private):
+
+```js
+// @errors: 7006 2554
+class Todo {
+	done = $state(false);
+	text = $state();
+
+	constructor(text) {
+		this.text = text;
+	}
+}
+```
+
+> In this example, the compiler transforms `done` and `text` into `get`/`set` methods on the class prototype referencing private fields
+
 ### What this replaces
 
 In non-runes mode, a `let` declaration is treated as reactive state if it is updated at some point. Unlike `$state(...)`, which works anywhere in your app, `let` only behaves this way at the top level of a component.
@@ -46,6 +62,8 @@ Derived state is declared with the `$derived` rune:
 ```
 
 The expression inside `$derived(...)` should be free of side-effects. Svelte will disallow state changes (e.g. `count++`) inside derived expressions.
+
+As with `$state`, you can mark class fields as `$derived`.
 
 ### What this replaces
 


### PR DESCRIPTION
~~don't merge yet, it looks like there's a bug (we still reference `this.#foo.value` rather than `this.#foo.v` after #9532)~~ nvm, i just hadn't rebuilt the compiler locally