### PR TITLE
chore: hoist IfBlock else-if closures

### DIFF
--- a/.changeset/nervous-ties-sin.md
+++ b/.changeset/nervous-ties-sin.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: hoist else-if block closures

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -93,7 +93,8 @@ export function client_component(source, analysis, options) {
 		preserve_whitespace: options.preserveWhitespace,
 		public_state: new Map(),
 		private_state: new Map(),
-		in_constructor: false
+		in_constructor: false,
+		else_if_init: null
 	};
 
 	const module = /** @type {import('estree').Program} */ (
@@ -466,7 +467,8 @@ export function client_module(analysis, options) {
 		legacy_reactive_statements: new Map(),
 		public_state: new Map(),
 		private_state: new Map(),
-		in_constructor: false
+		in_constructor: false,
+		else_if_init: null
 	};
 
 	const module = /** @type {import('estree').Program} */ (

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -20,8 +20,8 @@ export interface ClientTransformState extends TransformState {
 	readonly in_constructor: boolean;
 
 	/**
-	 * `true` if the current lexical scope belongs to the alternate of an IfBlock. This
-	 * allows us to hoist alternate if-blocks to the same scope as the original IfBlock.
+	 * Contains the current lexical init statement block of the starting IfBlock in the case
+	 * where we have many else-if blocks that can be hoisted.
 	 */
 	readonly else_if_init: null | Statement[];
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -19,6 +19,12 @@ export interface ClientTransformState extends TransformState {
 	 */
 	readonly in_constructor: boolean;
 
+	/**
+	 * `true` if the current lexical scope belongs to the alternate of an IfBlock. This
+	 * allows us to hoist alternate if-blocks to the same scope as the original IfBlock.
+	 */
+	readonly else_if_init: null | Statement[];
+
 	/** The $: calls, which will be ordered in the end */
 	readonly legacy_reactive_statements: Map<LabeledStatement, Statement>;
 }


### PR DESCRIPTION
This PR hoists the else if blocks on IfBlocks, which improves runtime performance (no creating lots of nested closures) and also significantly improves compile time as seen in https://github.com/sveltejs/svelte/issues/9579.