### PR TITLE
chore: better error message for not using snippet type

### DIFF
--- a/packages/svelte/src/main/public.d.ts
+++ b/packages/svelte/src/main/public.d.ts
@@ -195,7 +195,11 @@ declare const SnippetReturn: unique symbol;
  * You can only call a snippet through the `{@render ...}` tag.
  */
 export interface Snippet<T = void> {
-	(arg: T): typeof SnippetReturn;
+	(
+		arg: T
+	): typeof SnippetReturn & {
+		_: 'functions passed to {@render ...} tags must use the `Snippet` type imported from "svelte"';
+	};
 }
 
 interface DispatchOptions {

--- a/packages/svelte/src/main/public.d.ts
+++ b/packages/svelte/src/main/public.d.ts
@@ -195,9 +195,7 @@ declare const SnippetReturn: unique symbol;
  * You can only call a snippet through the `{@render ...}` tag.
  */
 export interface Snippet<T = void> {
-	(
-		arg: T
-	): typeof SnippetReturn & {
+	(arg: T): typeof SnippetReturn & {
 		_: 'functions passed to {@render ...} tags must use the `Snippet` type imported from "svelte"';
 	};
 }


### PR DESCRIPTION
language tools checks that a function passed to `{@render ..}` is returning a type that adheres to the `Snippet` return type. When it does not, the error message is pretty useless without this additional info text.

Before:
![image](https://github.com/sveltejs/svelte/assets/5968653/6c0db18e-551d-4405-a45d-1d935807b07f)

After:
![image](https://github.com/sveltejs/svelte/assets/5968653/c7484e13-c2a6-4372-9b86-aeb2ccb585cc)

No changelog because the Snippet type wasn't released yet.