### PR TITLE
feat: add type of `$effect.active`

### DIFF
--- a/.changeset/dirty-garlics-design.md
+++ b/.changeset/dirty-garlics-design.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add type of `$effect.active`

--- a/packages/svelte/src/main/ambient.d.ts
+++ b/packages/svelte/src/main/ambient.d.ts
@@ -68,6 +68,28 @@ declare namespace $effect {
 	 * @param fn The function to execute
 	 */
 	export function pre(fn: () => void | (() => void)): void;
+
+	/**
+	 * The `$effect.active` rune is an advanced feature that tells you whether or not the code is running inside an effect or inside your template.
+	 *
+	 * Example:
+	 * ```svelte
+	 * <script>
+	 *   console.log('in component setup:', $effect.active()); // false
+	 *
+	 *   $effect(() => {
+	 *     console.log('in effect:', $effect.active()); // true
+	 *   });
+	 * </script>
+	 *
+	 * <p>in template: {$effect.active()}</p> <!-- true -->
+	 * ```
+	 *
+	 * This allows you to (for example) add things like subscriptions without causing memory leaks, by putting them in child effects.
+	 *
+	 * https://svelte-5-preview.vercel.app/docs/runes#$effect-active
+	 */
+	export function active(): boolean;
 }
 
 /**


### PR DESCRIPTION
I noticed that `$effect.active` was increasing when I was working on something else. I wanted to add a type to `svelte-eslint-parser`, but noticed that there was no type definition.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
