### PR TITLE
fix: omit this bind this arg if we know it's not a signal

### DIFF
--- a/.changeset/lovely-rules-eat.md
+++ b/.changeset/lovely-rules-eat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: omit this bind this arg if we know it's not a signal

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -899,7 +899,10 @@ function serialize_inline_component(node, component_name, context) {
 	if (bind_this !== null) {
 		const prev = fn;
 		const assignment = b.assignment('=', bind_this, b.id('$$value'));
-		const bind_this_id = bind_this;
+		const bind_this_id = /** @type {import('estree').Expression} */ (
+			// if expression is not an identifier, we know it can't be a signal
+			bind_this.type === 'Identifier' ? bind_this : undefined
+		);
 		fn = (node_id) =>
 			b.call(
 				'$.bind_this',
@@ -2622,7 +2625,15 @@ export const template_visitors = {
 				}
 
 				case 'this':
-					call_expr = b.call(`$.bind_this`, state.node, setter, node.expression);
+					call_expr = b.call(
+						`$.bind_this`,
+						state.node,
+						setter,
+						/** @type {import('estree').Expression} */ (
+							// if expression is not an identifier, we know it can't be a signal
+							node.expression.type === 'Identifier' ? node.expression : undefined
+						)
+					);
 					break;
 
 				case 'textContent':

--- a/packages/svelte/tests/runtime-runes/samples/each-bind-this-member/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-bind-this-member/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, component }) {
+		assert.equal(target.querySelector('img'), component.items[0].img);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-bind-this-member/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-bind-this-member/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	let { items = [{ src: 'https://ds' }] } = $props();
+</script>
+
+{#each items as item, i}
+	<img
+		src={item.src}
+		bind:this={items[i].img}
+		alt="slider{i}"
+	/>
+{/each}


### PR DESCRIPTION
fixes #9629

Not sure if this catches all cases that matter. Maybe we need `() => exposable(..))` and then do `expose(binding())` in `bind_this` instead.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
