### PR TITLE
feat: ignore href when hydrating

### DIFF
--- a/.changeset/slimy-clouds-talk.md
+++ b/.changeset/slimy-clouds-talk.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: ignore href attributes when hydrating

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2551,7 +2551,7 @@ let src_url_equal_anchor;
  * @param {string} url
  * @returns {boolean}
  */
-export function src_url_equal(element_src, url) {
+function src_url_equal(element_src, url) {
 	if (element_src === url) return true;
 	if (!src_url_equal_anchor) {
 		src_url_equal_anchor = document.createElement('a');

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2532,6 +2532,7 @@ export function attr(dom, attribute, value) {
 			// (we can't just compare the strings as they can be different between client and server but result in the
 			// same url, so we would need to create hidden anchor elements to compare them)
 			attribute !== 'src' &&
+			attribute !== 'href' &&
 			attribute !== 'srcset')
 	) {
 		if (value === null) {
@@ -2566,13 +2567,13 @@ function split_srcset(srcset) {
 }
 
 /**
- * @param {HTMLSourceElement | HTMLImageElement} element_srcset
+ * @param {HTMLSourceElement | HTMLImageElement} element
  * @param {string | undefined | null} srcset
  * @returns {boolean}
  */
-export function srcset_url_equal(element_srcset, srcset) {
-	const element_urls = split_srcset(element_srcset.srcset);
-	const urls = split_srcset(srcset || '');
+export function srcset_url_equal(element, srcset) {
+	const element_urls = split_srcset(element.srcset);
+	const urls = split_srcset(srcset ?? '');
 
 	return (
 		urls.length === element_urls.length &&
@@ -2595,22 +2596,20 @@ export function srcset_url_equal(element_srcset, srcset) {
  * @param {string | null} value
  */
 function check_src_in_dev_hydration(dom, attribute, value) {
-	if (current_hydration_fragment !== null && (attribute === 'src' || attribute === 'srcset')) {
-		if (
-			(attribute === 'src' && !src_url_equal(dom.getAttribute('src') || '', value || '')) ||
-			(attribute === 'srcset' &&
-				!srcset_url_equal(/** @type {HTMLImageElement | HTMLSourceElement} */ (dom), value || ''))
-		) {
-			// eslint-disable-next-line no-console
-			console.error(
-				'Detected a src/srcset attribute value change during hydration. This will not be repaired during hydration, ' +
-					'the src/srcset value that came from the server will be used. Related element:',
-				dom,
-				' Differing value:',
-				value
-			);
-		}
-	}
+	if (!current_hydration_fragment) return;
+	if (attribute !== 'src' && attribute !== 'href' && attribute !== 'srcset') return;
+
+	if (attribute === 'srcset' && srcset_url_equal(dom, value)) return;
+	if (src_url_equal(dom.getAttribute(attribute) ?? '', value ?? '')) return;
+
+	// eslint-disable-next-line no-console
+	console.error(
+		`Detected a ${attribute} attribute value change during hydration. This will not be repaired during hydration, ` +
+			`the ${attribute} value that came from the server will be used. Related element:`,
+		dom,
+		' Differing value:',
+		value
+	);
 }
 
 /**
@@ -2778,7 +2777,7 @@ export function spread_attributes(dom, prev, attrs, lowercase_attributes, css_ha
 				if (
 					current_hydration_fragment === null ||
 					//  @ts-ignore see attr method for an explanation of src/srcset
-					(dom[name] !== value && name !== 'src' && name !== 'srcset')
+					(dom[name] !== value && name !== 'src' && name !== 'href' && name !== 'srcset')
 				) {
 					// @ts-ignore
 					dom[name] = value;

--- a/packages/svelte/tests/hydration/samples/ignore-mismatched-href/_before.html
+++ b/packages/svelte/tests/hydration/samples/ignore-mismatched-href/_before.html
@@ -1,0 +1,1 @@
+<!--ssr:0--><a href="/bar">foo</a><!--ssr:0-->

--- a/packages/svelte/tests/hydration/samples/ignore-mismatched-href/_config.js
+++ b/packages/svelte/tests/hydration/samples/ignore-mismatched-href/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	test(assert, target) {
+		assert.equal(target.querySelector('a')?.getAttribute('href'), '/bar');
+	}
+});

--- a/packages/svelte/tests/hydration/samples/ignore-mismatched-href/main.svelte
+++ b/packages/svelte/tests/hydration/samples/ignore-mismatched-href/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	let browser = typeof window !== 'undefined';
+</script>
+
+<a href={browser ? '/foo': '/bar'}>foo</a>


### PR DESCRIPTION
Putting this up for discussion. Currently, a SvelteKit app will often render HTML with relative paths, which are replaced with absolute paths upon hydration. (This behaviour is intentional — it means that the HTML is more portable and resilient, for example if it ends up on the Internet Archive or on IPFS. It will likely be the default for all base-relative paths in SvelteKit 2.0.)

The cost is that something like `<a href="{paths.base}/whatever">` will differ between SSR and CSR:

- `<a href="../whatever">`
- `<a href="https://example.com/foo/bar/whatever">`

As a result, Svelte updates the attribute during hydration, even though it resolves to the same URL.

For `src` and `srcset` attributes, we always skip hydration, on the assumption that the resolved value will be unchanged. (In dev, we check that this is in fact the case.) We could do the same thing for `href`. The stakes are lower — whereas updating `src` can cause unnecessary network requests, or cause iframes to be reloaded, this is only about avoiding unnecessary work — but it's probably worthwhile anyway.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
