### PR TITLE
feat: warn on referenced mutated nonstate

### DIFF
--- a/.changeset/friendly-lies-camp.md
+++ b/.changeset/friendly-lies-camp.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: warn on references to mutated non-state in template

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -218,7 +218,7 @@ export function analyze_module(ast, options) {
 	for (const [, scope] of scopes) {
 		for (const [name, binding] of scope.declarations) {
 			if (binding.kind === 'state' && !binding.mutated) {
-				warn(warnings, binding.node, [], 'state-rune-not-mutated', name);
+				warn(warnings, binding.node, [], 'state-not-mutated', name);
 			}
 		}
 	}
@@ -377,7 +377,7 @@ export function analyze_component(root, options) {
 		for (const [, scope] of instance.scopes) {
 			for (const [name, binding] of scope.declarations) {
 				if (binding.kind === 'state' && !binding.mutated) {
-					warn(warnings, binding.node, [], 'state-rune-not-mutated', name);
+					warn(warnings, binding.node, [], 'state-not-mutated', name);
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -268,6 +268,7 @@ export interface Binding {
 	initial: null | Expression | FunctionDeclaration | ClassDeclaration | ImportDeclaration;
 	is_called: boolean;
 	references: { node: Identifier; path: SvelteNode[] }[];
+	referenced_in_template: boolean;
 	mutated: boolean;
 	scope: Scope;
 	/** For `legacy_reactive`: its reactive dependencies */

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -22,7 +22,7 @@ const runes = {
 		`It looks like you're using the $${name} rune, but there is a local binding called ${name}. ` +
 		`Referencing a local variable with a $ prefix will create a store subscription. Please rename ${name} to avoid the ambiguity.`,
 	/** @param {string} name */
-	'state-rune-not-mutated': (name) =>
+	'state-not-mutated': (name) =>
 		`${name} is declared with $state(...) but is never updated. Did you mean to create a function that changes its value?`,
 	/** @param {string} name */
 	'non-state-reference': (name) =>

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -23,7 +23,10 @@ const runes = {
 		`Referencing a local variable with a $ prefix will create a store subscription. Please rename ${name} to avoid the ambiguity.`,
 	/** @param {string} name */
 	'state-rune-not-mutated': (name) =>
-		`${name} is declared with $state(...) but is never updated. Did you mean to create a function that changes its value?`
+		`${name} is declared with $state(...) but is never updated. Did you mean to create a function that changes its value?`,
+	/** @param {string} name */
+	'non-state-reference': (name) =>
+		`${name} is updated, but is not declared with $state(...). Changing its value will not correctly trigger updates.`
 };
 
 /** @satisfies {Warnings} */

--- a/packages/svelte/tests/validator/samples/runes-referenced-nonstate/_config.js
+++ b/packages/svelte/tests/validator/samples/runes-referenced-nonstate/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/validator/samples/runes-referenced-nonstate/input.svelte
+++ b/packages/svelte/tests/validator/samples/runes-referenced-nonstate/input.svelte
@@ -1,0 +1,8 @@
+<script>
+	let a = $state(1);
+	let b = 2;
+</script>
+
+<button onclick={() => a += 1}>a += 1</button>
+<button onclick={() => b += 1}>b += 1</button>
+<p>{a} + {b} = {a + b}</p>

--- a/packages/svelte/tests/validator/samples/runes-referenced-nonstate/warnings.json
+++ b/packages/svelte/tests/validator/samples/runes-referenced-nonstate/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "non-state-reference",
+		"message": "b is updated, but is not declared with $state(...). Changing its value will not correctly trigger updates.",
+		"start": {
+			"column": 5,
+			"line": 3
+		},
+		"end": {
+			"column": 6,
+			"line": 3
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/runes-state-rune-not-mutated/warnings.json
+++ b/packages/svelte/tests/validator/samples/runes-state-rune-not-mutated/warnings.json
@@ -1,6 +1,6 @@
 [
 	{
-		"code": "state-rune-not-mutated",
+		"code": "state-not-mutated",
 		"end": {
 			"column": 11,
 			"line": 3


### PR DESCRIPTION
This implements the warning described in https://github.com/sveltejs/svelte/pull/9571#issuecomment-1821219536, and would allow us to merge that PR (without the test added in the most recent commit).

I don't love how invasive this change is. I might try another approach that just checks the references directly — in theory it's less efficient (since you need to walk up the `path`) but in practice I don't think it would matter even a little bit

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
