### PR TITLE
docs: update readme and contributing from pnpm dev to pnpm watch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Small pull requests are much easier to review and more likely to get merged.
 1. Ensure you have [pnpm](https://pnpm.io/installation) installed
 1. After cloning the repository, run `pnpm install`. You can do this in the root directory or in the `svelte` project
 1. Move into the `svelte` directory with `cd packages/svelte`
-1. To compile in watch mode, run `pnpm dev`
+1. To compile in watch mode, run `pnpm watch`
 
 ### Creating a branch
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pnpm build
 To watch for changes and continually rebuild the package (this is useful if you're using [`pnpm link`](https://pnpm.io/cli/link) to test out changes in a project locally):
 
 ```bash
-pnpm dev
+pnpm watch
 ```
 
 The compiler is written in JavaScript and uses [JSDoc](https://jsdoc.app/index.html) comments for type-checking.
@@ -58,10 +58,10 @@ The compiler is written in JavaScript and uses [JSDoc](https://jsdoc.app/index.h
 pnpm test
 ```
 
-To filter tests, use `-g` (aka `--grep`). For example, to only run tests involving transitions:
+### Running Type-Check
 
 ```bash
-pnpm test -- -g transition
+pnpm check
 ```
 
 ### svelte.dev


### PR DESCRIPTION
while I doing the codebase setup locally, I have found that `pnpm dev` is not defined in any `package.json` file, but was renamed to `watch`

and added to the README Type-Checking command.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
