### PR TITLE
rename dev script, update contributor guide and readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ The maintainers meet on the final Saturday of each month. While these meetings a
 
 ### Prioritization
 
-We do our best to review PRs and RFCs as they are sent, but it is difficult to keep up. We welcome help in reviewing PRs, RFC, and issues. If an item aligns with the current priority on our [roadmap](https://svelte.dev/roadmap), it is more likely to be reviewed quickly. PRs to the most important and active ones repositories get reviewed more quickly while PRs to smaller inactive repos may sit for a bit before we periodically come by and review the pending PRs in a batch.
+We do our best to review PRs and RFCs as they are sent, but it is difficult to keep up. We welcome help in reviewing PRs, RFCs, and issues. If an item aligns with the current priority on our [roadmap](https://svelte.dev/roadmap), it is more likely to be reviewed quickly. PRs to the most important and active ones repositories get reviewed more quickly while PRs to smaller inactive repos may sit for a bit before we periodically come by and review the pending PRs in a batch.
 
 ## Bugs
 
@@ -74,10 +74,11 @@ Small pull requests are much easier to review and more likely to get merged.
 
 ### Installation
 
-1. Ensure you have [pnpm](https://pnpm.io/installation) installed
-1. After cloning the repository, run `pnpm install`. You can do this in the root directory or in the `svelte` project
-1. Move into the `svelte` directory with `cd packages/svelte`
-1. To compile in watch mode, run `pnpm dev`
+Ensure you have [pnpm](https://pnpm.io/installation) installed. After cloning the repository, run `pnpm install`.
+
+### Developing
+
+To build the UMD version of `svelte/compiler` (this is only necessary for CommonJS consumers, or in-browser use), run `pnpm build` inside `packages/svelte`. To rebuild whenever source files change, run `pnpm dev`.
 
 ### Creating a branch
 
@@ -100,18 +101,26 @@ Test samples are kept in `/test/xxx/samples` folder.
 > PREREQUISITE: Install chromium via playwright by running `pnpm playwright install chromium`
 
 1. To run test, run `pnpm test`.
-1. To run test for a specific feature, you can use the `-g` (aka `--grep`) option. For example, to only run test involving transitions, run `pnpm test -- -g transition`.
+1. To run a particular test suite, use `pnpm test <suite-name>`, for example:
 
-##### Running solo test
+   ```bash
+   pnpm test validator
+   ```
 
-1. To run only one test, rename the test sample folder to end with `.solo`. For example, to run the `test/js/samples/action` only, rename it to `test/js/samples/action.solo`.
-1. To run only one test suite, rename the test suite folder to end with `.solo`. For example, to run the `test/js` test suite only, rename it to `test/js.solo`.
-1. Remember to rename the test folder back. The CI will fail if there's a solo test.
+1. To run an individual test _within_ a test suite, use `FILTER=<test-name> pnpm test <suite-name>`, for example:
+
+   ```bash
+   FILTER=a11y-alt-text pnpm test validator
+   ```
 
 ##### Updating `.expected` files
 
-1. Tests suites like `css`, `js`, `server-side-rendering` asserts that the generated output has to match the content in the `.expected` file. For example, in the `js` test suites, the generated js code is compared against the content in `expected.js`.
-1. To update the content of the `.expected` file, run the test with `--update` flag. (`pnpm test --update`)
+1. Tests suites like `snapshot` and `parser` assert that the generated output matches the existing snapshot.
+1. To update these snapshots, run `UPDATE_SNAPSHOTS=true pnpm test`.
+
+### Typechecking
+
+To typecheck the codebase, run `pnpm check` inside `packages/svelte`. To typecheck in watch mode, run `pnpm check:watch`.
 
 ### Style guide
 

--- a/README.md
+++ b/README.md
@@ -22,47 +22,7 @@ You may view [our roadmap](https://svelte.dev/roadmap) if you'd like to see what
 
 ## Contributing
 
-Please see the [Contributing Guide](CONTRIBUTING.md) and [svelte package](packages/svelte) for contributing to Svelte.
-
-### Development
-
-Pull requests are encouraged and always welcome. [Pick an issue](https://github.com/sveltejs/svelte/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) and help us out!
-
-To install and work on Svelte locally:
-
-```bash
-git clone https://github.com/sveltejs/svelte.git
-cd svelte
-pnpm install
-```
-
-> Do not use Yarn to install the dependencies, as the specific package versions in `pnpm-lock.json` are used to build and test Svelte.
-
-To build the compiler and all the other modules included in the package:
-
-```bash
-pnpm build
-```
-
-To watch for changes and continually rebuild the package (this is useful if you're using [`pnpm link`](https://pnpm.io/cli/link) to test out changes in a project locally):
-
-```bash
-pnpm dev
-```
-
-The compiler is written in JavaScript and uses [JSDoc](https://jsdoc.app/index.html) comments for type-checking.
-
-### Running Tests
-
-```bash
-pnpm test
-```
-
-To filter tests, use `-g` (aka `--grep`). For example, to only run tests involving transitions:
-
-```bash
-pnpm test -- -g transition
-```
+Please see the [Contributing Guide](CONTRIBUTING.md) and the [`svelte`](packages/svelte) package for information on contributing to Svelte.
 
 ### svelte.dev
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -91,7 +91,7 @@
   ],
   "scripts": {
     "build": "rollup -c && node scripts/build.js && node scripts/check-treeshakeability.js",
-    "watch": "rollup -cw",
+    "dev": "rollup -cw",
     "check": "tsc && cd ./tests/types && tsc",
     "check:watch": "tsc --watch",
     "generate:version": "node ./scripts/generate-version.js",


### PR DESCRIPTION
follow-up to #9671. a lot of this stuff is horribly out of date. it also doesn't make sense to have incomplete developing/testing instructions in the readme, that stuff belongs in the contributor guide

this also changes `pnpm watch` to `pnpm dev`