### PR TITLE
fix: prevent calling remove fn with null value in snippet_effect

### DIFF
--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -3182,8 +3182,9 @@ export function snippet_effect(get_snippet, node, args) {
 		const snippet = get_snippet();
 		untrack(() => snippet(node, args));
 		return () => {
-			if (block.d !== null) {
-				remove(block.d);
+			const d = (is_array(block.d) ? block.d[0] : block.d) ?? null;
+			if (d !== null) {
+				remove(d);
 			}
 		};
 	}, block);


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/9678

There might be a bug related to **snippet_effect** or **create_snippet_block** fns...At some point block.d becomes [null] for some reason. Very likely not the right fix, just a hint.

- svelte 5.0.0-next.15
- @sveltejs/kit 1.27.6

<img width="728" alt="Screenshot 2023-11-27 at 21 32 36" src="https://github.com/sveltejs/svelte/assets/2613273/28edcbcf-3178-48c5-a98f-3fcd7148a5f0">
<img width="728" alt="Screenshot 2023-11-27 at 19 37 28" src="https://github.com/sveltejs/svelte/assets/2613273/b77ca926-d609-46f7-90c2-58394c55f716">

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
