### PR TITLE
fix: add children to element typings

### DIFF
--- a/.changeset/kind-eagles-join.md
+++ b/.changeset/kind-eagles-join.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add children to element typings

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -65,7 +65,7 @@ export type MessageEventHandler<T extends EventTarget> = EventHandler<MessageEve
 
 export interface DOMAttributes<T extends EventTarget> {
 	// Implicit children prop every element has
-	// Add this here so that libraries doing `props$<HTMLButtonAttributes>()` don't need a separate interface
+	// Add this here so that libraries doing `$props<HTMLButtonAttributes>()` don't need a separate interface
 	children?: import('svelte').Snippet<any>;
 
 	// Clipboard Events

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -64,6 +64,10 @@ export type MessageEventHandler<T extends EventTarget> = EventHandler<MessageEve
 // ----------------------------------------------------------------------
 
 export interface DOMAttributes<T extends EventTarget> {
+	// Implicit children prop every element has
+	// Add this here so that libraries doing `props$<HTMLButtonAttributes>()` don't need a separate interface
+	children?: import('svelte').Snippet<any>;
+
 	// Clipboard Events
 	'on:copy'?: ClipboardEventHandler<T> | undefined | null;
 	oncopy?: ClipboardEventHandler<T> | undefined | null;


### PR DESCRIPTION
Add this here so that libraries doing `$props<HTMLButtonAttributes>()` don't need a separate interface
fixes #https://github.com/sveltejs/language-tools/issues/2218

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
