### PR TITLE
fix: untrack reads of mutated object

### DIFF
--- a/.changeset/beige-donkeys-remain.md
+++ b/.changeset/beige-donkeys-remain.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: untrack reads of mutated object

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -1,5 +1,5 @@
 import { error } from '../../errors.js';
-import { extract_identifiers, is_text_attribute } from '../../utils/ast.js';
+import { extract_identifiers, is_text_attribute, object } from '../../utils/ast.js';
 import { warn } from '../../warnings.js';
 import fuzzymatch from '../1-parse/utils/fuzzymatch.js';
 import { binding_properties } from '../bindings.js';
@@ -248,12 +248,8 @@ export const validation = {
 	BindDirective(node, context) {
 		validate_no_const_assignment(node, node.expression, context.state.scope, true);
 
-		let left = node.expression;
-		while (left.type === 'MemberExpression') {
-			left = /** @type {import('estree').MemberExpression} */ (left.object);
-		}
-
-		if (left.type !== 'Identifier') {
+		const left = object(node.expression);
+		if (left === null) {
 			error(node, 'invalid-binding-expression');
 		}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -206,13 +206,7 @@ function collect_transitive_dependencies(binding, seen = new Set()) {
  * @param {import('../types.js').ComponentContext} context
  */
 function setup_select_synchronization(value_binding, context) {
-	let bound = value_binding.expression;
-	while (bound.type === 'MemberExpression') {
-		bound = /** @type {import('estree').Identifier | import('estree').MemberExpression} */ (
-			bound.object
-		);
-	}
-
+	const bound = /** @type {import('estree').Identifier} */ (object(value_binding.expression));
 	/** @type {string[]} */
 	const names = [];
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -1,6 +1,11 @@
 import { walk } from 'zimmerframe';
 import { set_scope, get_rune } from '../../scope.js';
-import { extract_identifiers, extract_paths, is_event_attribute } from '../../../utils/ast.js';
+import {
+	extract_identifiers,
+	extract_paths,
+	is_event_attribute,
+	object
+} from '../../../utils/ast.js';
 import * as b from '../../../utils/builders.js';
 import is_reference from 'is-reference';
 import {
@@ -417,14 +422,8 @@ function serialize_set_binding(node, context, fallback) {
 		error(node, 'INTERNAL', `Unexpected assignment type ${node.left.type}`);
 	}
 
-	let left = node.left;
-
-	while (left.type === 'MemberExpression') {
-		// @ts-expect-error
-		left = left.object;
-	}
-
-	if (left.type !== 'Identifier') {
+	const left = object(node.left);
+	if (left === null) {
 		return fallback();
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/mutating-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/mutating-state/_config.js
@@ -1,0 +1,54 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+// Test ensures that reading the state that's mutated is done in a manner
+// so that the read is untracked so it doesn't trigger infinite loops
+export default test({
+	html: `
+		<input>
+		<input>
+		<p>text: foo</p>
+		<p>wrapped.contents: foo</p>
+	`,
+	skip_if_ssr: true,
+
+	test({ assert, target }) {
+		const [input1, input2] = target.querySelectorAll('input');
+
+		input1.value = 'bar';
+		flushSync(() => input1.dispatchEvent(new Event('input')));
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<input>
+			<input>
+			<p>text: bar</p>
+			<p>wrapped.contents: bar</p>
+		`
+		);
+
+		input2.value = 'baz';
+		flushSync(() => input2.dispatchEvent(new Event('input')));
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<input>
+			<input>
+			<p>text: bar</p>
+			<p>wrapped.contents: baz</p>
+		`
+		);
+
+		input1.value = 'foo';
+		flushSync(() => input1.dispatchEvent(new Event('input')));
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<input>
+			<input>
+			<p>text: foo</p>
+			<p>wrapped.contents: foo</p>
+		`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/mutating-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/mutating-state/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let text = $state('foo');
+	let wrapped = $state({});
+	$effect(() => { wrapped.contents = text; })
+</script>
+
+<input bind:value={text} />
+<input bind:value={wrapped.contents} />
+<p>text: {text}</p>
+<p>wrapped.contents: {wrapped.contents}</p> 

--- a/packages/svelte/tests/runtime-runes/samples/mutating-store-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/mutating-store-state/_config.js
@@ -1,0 +1,54 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+// Test ensures that reading the state that's mutated is done in a manner
+// so that the read is untracked so it doesn't trigger infinite loops
+export default test({
+	html: `
+		<input>
+		<input>
+		<p>text: foo</p>
+		<p>wrapped.contents: foo</p>
+	`,
+	skip_if_ssr: true,
+
+	test({ assert, target }) {
+		const [input1, input2] = target.querySelectorAll('input');
+
+		input1.value = 'bar';
+		flushSync(() => input1.dispatchEvent(new Event('input')));
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<input>
+			<input>
+			<p>text: bar</p>
+			<p>wrapped.contents: bar</p>
+		`
+		);
+
+		input2.value = 'baz';
+		flushSync(() => input2.dispatchEvent(new Event('input')));
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<input>
+			<input>
+			<p>text: bar</p>
+			<p>wrapped.contents: baz</p>
+		`
+		);
+
+		input1.value = 'foo';
+		flushSync(() => input1.dispatchEvent(new Event('input')));
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<input>
+			<input>
+			<p>text: foo</p>
+			<p>wrapped.contents: foo</p>
+		`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/mutating-store-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/mutating-store-state/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { writable } from "svelte/store";
+
+	let text = writable('foo');
+	let wrapped = writable({});
+	$effect(() => { $wrapped.contents = $text; })
+</script>
+
+<input bind:value={$text} />
+<input bind:value={$wrapped.contents} />
+<p>text: {$text}</p>
+<p>wrapped.contents: {$wrapped.contents}</p> 


### PR DESCRIPTION
prevents infinite loops when mutation happens inside an effect
came up in #9639

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
