### PR TITLE
fix: delegate events on elements with bind-this

### DIFF
--- a/.changeset/chatty-taxis-juggle.md
+++ b/.changeset/chatty-taxis-juggle.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: delegate events on elements with bind-this

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1094,7 +1094,8 @@ function determine_element_spread_and_delegatable(node) {
 			has_spread = true;
 		} else if (
 			!has_action_or_bind &&
-			(attribute.type === 'BindDirective' || attribute.type === 'UseDirective')
+			((attribute.type === 'BindDirective' && attribute.name !== 'this') ||
+				attribute.type === 'UseDirective')
 		) {
 			has_action_or_bind = true;
 		}


### PR DESCRIPTION
fixes #9688

Although this fixes that specific issue, it uncovered a major flaw in our event delegation logic: If an event is stopped from being propagated, and that event is delegated, then the propagation isn't really stopped. If there's now another event handler for the same event type above that delegated listener but below the root that listens to the delegated events, and that event handler is _not_ delegated, then it will still get notified of the event.

I'm honestly not sure if we can fix this in a sensible way that covers all cases, at least not as long as we have `on:x` still around.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
