### PR TITLE
chore: remove redundant hydration code

### DIFF
--- a/.changeset/sour-forks-stare.md
+++ b/.changeset/sour-forks-stare.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: remove redundant hydration code

--- a/packages/svelte/src/internal/client/hydration.js
+++ b/packages/svelte/src/internal/client/hydration.js
@@ -1,5 +1,7 @@
 // Handle hydration
 
+import { schedule_task } from './runtime';
+
 /** @type {null | Array<Text | Comment | Element>} */
 export let current_hydration_fragment = null;
 
@@ -68,6 +70,11 @@ export function hydrate_block_anchor(anchor_node, is_controlled) {
 			let fragment = target_node.$$fragment;
 			if (fragment === undefined) {
 				fragment = get_hydration_fragment(target_node);
+			} else {
+				schedule_task(() => {
+					// @ts-expect-error clean up memory
+					target_node.$$fragment = undefined;
+				});
 			}
 			set_current_hydration_fragment(fragment);
 		} else {

--- a/packages/svelte/src/internal/client/hydration.js
+++ b/packages/svelte/src/internal/client/hydration.js
@@ -68,12 +68,11 @@ export function hydrate_block_anchor(anchor_node, is_controlled) {
 			let fragment = target_node.$$fragment;
 			if (fragment === undefined) {
 				fragment = get_hydration_fragment(target_node);
-				// @ts-ignore remove to prevent memory leaks
-				target_node.$$fragment = undefined;
 			}
 			set_current_hydration_fragment(fragment);
 		} else {
-			set_current_hydration_fragment([/** @type {Element} */ (target_node.firstChild)]);
+			const firstChild = /** @type {Element | null} */ (target_node.firstChild);
+			set_current_hydration_fragment(firstChild === null ? [] : [firstChild]);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/hydration.js
+++ b/packages/svelte/src/internal/client/hydration.js
@@ -71,8 +71,8 @@ export function hydrate_block_anchor(anchor_node, is_controlled) {
 			}
 			set_current_hydration_fragment(fragment);
 		} else {
-			const firstChild = /** @type {Element | null} */ (target_node.firstChild);
-			set_current_hydration_fragment(firstChild === null ? [] : [firstChild]);
+			const first_child = /** @type {Element | null} */ (target_node.firstChild);
+			set_current_hydration_fragment(first_child === null ? [] : [first_child]);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1396,9 +1396,7 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 				} else if (current_hydration_fragment !== null) {
 					const comment_text = /** @type {Comment} */ (current_hydration_fragment?.[0])?.data;
 					if (
-						(!comment_text &&
-							// Can happen when a svelte:element that is turned into a void element has an if block inside
-							current_hydration_fragment[0] !== null) ||
+						!comment_text ||
 						(comment_text === 'ssr:if:true' && !result) ||
 						(comment_text === 'ssr:if:false' && result)
 					) {

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -213,8 +213,6 @@ function close_template(dom, is_fragment, anchor) {
 	if (anchor !== null) {
 		if (current_hydration_fragment === null) {
 			insert(current, null, anchor);
-		} else {
-			cleanup_hyration_node(anchor);
 		}
 	}
 	block.d = current;
@@ -1344,20 +1342,6 @@ export function slot(anchor_node, slot_fn, slot_props, fallback_fn) {
 	} else {
 		slot_fn(anchor_node, slot_props);
 	}
-	cleanup_hyration_node(anchor_node);
-}
-
-/**
- *
- * @param {Element | Comment} node
- */
-function cleanup_hyration_node(node) {
-	// Let's ensure we don't leak the hydration fragment
-	// @ts-expect-error internal field
-	if (node.$$fragment) {
-		// @ts-expect-error internal field
-		node.$$fragment = undefined;
-	}
 }
 
 /**
@@ -1489,7 +1473,6 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 		destroy_signal(alternate_effect);
 	});
 	block.e = if_effect;
-	cleanup_hyration_node(anchor_node);
 }
 export { if_block as if };
 
@@ -1633,7 +1616,6 @@ export function element(anchor_node, tag_fn, render_fn, is_svg = false) {
 		}
 		destroy_signal(render_effect_signal);
 	});
-	cleanup_hyration_node(anchor_node);
 	block.e = element_effect;
 }
 
@@ -1751,7 +1733,6 @@ export function component(anchor_node, component_fn, render_fn) {
 			render = render.p;
 		}
 	});
-	cleanup_hyration_node(anchor_node);
 	block.e = component_effect;
 }
 
@@ -1919,7 +1900,6 @@ function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 			render = render.p;
 		}
 	});
-	cleanup_hyration_node(anchor_node);
 	block.e = await_effect;
 }
 export { await_block as await };
@@ -2036,7 +2016,6 @@ export function key(anchor_node, key, render_fn) {
 			render = render.p;
 		}
 	});
-	cleanup_hyration_node(anchor_node);
 	block.e = key_effect;
 }
 
@@ -2292,7 +2271,6 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 		reconcile_fn([], block, anchor_node, is_controlled, render_fn, flags, false, keys);
 		destroy_signal(/** @type {import('./types.js').EffectSignal} */ (render));
 	});
-	cleanup_hyration_node(anchor_node);
 	block.e = each;
 }
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -198,7 +198,7 @@ export function comment(anchor) {
 /**
  * @param {Element | Text} dom
  * @param {boolean} is_fragment
- * @param {null | ((Text | Comment | Element) & {$$fragment: undefined | Node[]})} anchor
+ * @param {null | Text | Comment | Element} anchor
  * @returns {void}
  */
 function close_template(dom, is_fragment, anchor) {
@@ -221,7 +221,7 @@ function close_template(dom, is_fragment, anchor) {
 }
 
 /**
- * @param {null | ((Text | Comment | Element) & {$$fragment: undefined | Node[]})} anchor
+ * @param {null | Text | Comment | Element} anchor
  * @param {Element | Text} dom
  * @returns {void}
  */
@@ -230,7 +230,7 @@ export function close(anchor, dom) {
 }
 
 /**
- * @param {null | ((Text | Comment | Element) & {$$fragment: undefined | Node[]})} anchor
+ * @param {null | Text | Comment | Element} anchor
  * @param {Element | Text} dom
  * @returns {void}
  */


### PR DESCRIPTION
Turns out we don't need to set `$$fragment` to `undefined` anymore. Also noticed some suspect code just below it that should probably be fixed too.