### PR TITLE
fix: improve infinite loop capturing

### DIFF
--- a/.changeset/tall-tigers-wait.md
+++ b/.changeset/tall-tigers-wait.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improve infinite loop capturing

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -63,6 +63,7 @@ export interface RuntimeTest<Props extends Record<string, any> = Record<string, 
 	intro?: boolean;
 	load_compiled?: boolean;
 	error?: string;
+	runtime_error?: string;
 	warnings?: string[];
 	expect_unhandled_rejections?: boolean;
 	withoutNormalizeHtml?: boolean;
@@ -315,7 +316,9 @@ async function run_test_variant(
 			}
 		}
 	} catch (err) {
-		if (config.error && !unintended_error) {
+		if (config.runtime_error) {
+			assert.equal((err as Error).message, config.runtime_error);
+		} else if (config.error && !unintended_error) {
 			assert.equal((err as Error).message, config.error);
 		} else {
 			throw err;

--- a/packages/svelte/tests/runtime-runes/samples/effect-infinite/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-infinite/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	runtime_error:
+		'ERR_SVELTE_TOO_MANY_UPDATES: Maximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops.',
+	async test({ assert, target }) {}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-infinite/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-infinite/main.svelte
@@ -1,0 +1,11 @@
+<script>
+  const v = { value: 1 };
+  let s = $state(v)
+
+  $effect(() => {
+		s = v;
+		s;
+	});
+</script>
+
+{JSON.stringify(s)}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/9694.

This PR improves infinite loop guarding by ensuring we have a test that captures it and also ensures this works in `flushSync`. Plus, it fixes the case where we weren't correctly marking an effect to run again with a cyclical dependency.