### PR TITLE
chore: ensure $state always uses === equality

### DIFF
--- a/.changeset/lucky-geckos-boil.md
+++ b/.changeset/lucky-geckos-boil.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: ensure $state always uses === equality

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -366,7 +366,10 @@ export function create_state_declarators(declarator, scope, value, runes) {
 	// in the simple `let count = $state(0)` case, we rewrite `$state` as `$.source`
 	if (declarator.id.type === 'Identifier') {
 		return [
-			b.declarator(declarator.id, runes ? b.call('$.source', value) : b.call('$.source', value))
+			b.declarator(
+				declarator.id,
+				runes ? b.call('$.source', value, b.id('$.equals')) : b.call('$.source', value)
+			)
 		];
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
@@ -86,7 +86,8 @@ export const javascript_visitors_legacy = {
 				...create_state_declarators(
 					declarator,
 					state.scope,
-					/** @type {import('estree').Expression} */ (declarator.init && visit(declarator.init))
+					/** @type {import('estree').Expression} */ (declarator.init && visit(declarator.init)),
+					false
 				)
 			);
 		}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -215,11 +215,16 @@ export const javascript_visitors_runes = {
 				args.length === 0
 					? b.id('undefined')
 					: /** @type {import('estree').Expression} */ (visit(args[0]));
-			const opts = args[1] && /** @type {import('estree').Expression} */ (visit(args[1]));
+			let opts = args[1] && /** @type {import('estree').Expression} */ (visit(args[1]));
 
 			if (declarator.id.type === 'Identifier') {
 				const callee = rune === '$state' ? '$.source' : '$.derived';
-				const arg = rune === '$state' ? value : b.thunk(value);
+				/** @type {import('estree').Expression} */
+				let arg = b.thunk(value);
+				if (rune === '$state') {
+					arg = value;
+					opts = b.id('$.equals')
+				}
 				declarations.push(b.declarator(declarator.id, b.call(callee, arg, opts)));
 				continue;
 			}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -247,7 +247,7 @@ export const javascript_visitors_runes = {
 				continue;
 			}
 
-			declarations.push(...create_state_declarators(declarator, state.scope, value));
+			declarations.push(...create_state_declarators(declarator, state.scope, value, true));
 		}
 
 		if (declarations.length === 0) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1130,7 +1130,7 @@ export function derived(init, equals) {
 	);
 	signal.i = init;
 	signal.x = current_component_context;
-	signal.e = get_equals_method(equals);
+	signal.e = equals || default_equals;
 	if (!is_unowned) {
 		push_reference(/** @type {import('./types.js').EffectSignal} */ (current_effect), signal);
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -149,6 +149,8 @@ function default_equals(a, b) {
 	return a === b;
 }
 
+export { default_equals as equals };
+
 /**
  * @template V
  * @param {import('./types.js').SignalFlags} flags

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -38,7 +38,8 @@ export {
 	reactive_import,
 	effect_active,
 	user_root_effect,
-	inspect
+	inspect,
+	equals
 } from './client/runtime.js';
 
 export * from './client/validate.js';

--- a/packages/svelte/tests/runtime-runes/samples/effect-order/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order/main.svelte
@@ -3,7 +3,7 @@
 
 	let myList = $state([{ name: 'one' ,age: 4 }, {name: 'two', age: 5}]);
 
-	let myDerived = $derived([...myList])
+	let myDerived = $derived(myList)
 
 	$effect(() => {
 		myList

--- a/packages/svelte/tests/runtime-runes/samples/effect-order/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order/main.svelte
@@ -3,7 +3,7 @@
 
 	let myList = $state([{ name: 'one' ,age: 4 }, {name: 'two', age: 5}]);
 
-	let myDerived = $derived(myList)
+	let myDerived = $derived([...myList])
 
 	$effect(() => {
 		myList
@@ -11,7 +11,7 @@
 	})
 
 	$effect(() => {
-		myDerived		
+		myDerived
 		log.push('B')
 	})
 </script>


### PR DESCRIPTION
This PR changes `$state` and `$derived` runes to always use strict `===` equality (or maybe `Object.is`).

> Note, PR is pending other changes before tests can pass.