### PR TITLE
fix: allow let directive on `<svelte:self>`

### DIFF
--- a/.changeset/green-birds-tan.md
+++ b/.changeset/green-birds-tan.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow let directive on <svelte:self>

--- a/.changeset/green-birds-tan.md
+++ b/.changeset/green-birds-tan.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: allow let directive on <svelte:self>
+fix: allow let directive on `<svelte:self>`

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -373,6 +373,19 @@ export const validation = {
 			}
 		}
 	},
+	LetDirective(node, context) {
+		const parent = context.path.at(-1);
+		if (
+			parent === undefined ||
+			(parent.type !== 'Component' &&
+				parent.type !== 'RegularElement' &&
+				parent.type !== 'SvelteSelf' &&
+				parent.type !== 'SvelteFragment')
+		) {
+			// TODO this should probably be a proper error, not an `INTERNAL` one
+			error(node, 'INTERNAL', 'let directive at invalid position');
+		}
+	},
 	RegularElement(node, context) {
 		if (node.name === 'textarea' && node.fragment.nodes.length > 0) {
 			for (const attribute of node.attributes) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2757,19 +2757,9 @@ export const template_visitors = {
 			serialize_event_attribute(node, context);
 		}
 	},
-	LetDirective(node, { state, path }) {
+	LetDirective(node, { state }) {
 		// let:x        -->  const x = $.derived(() => $.unwrap($$slotProps).x);
 		// let:x={{y, z}}  -->  const derived_x = $.derived(() => { const { y, z } = $.unwrap($$slotProps).x; return { y, z }));
-		const parent = path.at(-1);
-		if (
-			parent === undefined ||
-			(parent.type !== 'Component' &&
-				parent.type !== 'RegularElement' &&
-				parent.type !== 'SvelteFragment')
-		) {
-			error(node, 'INTERNAL', 'let directive at invalid position');
-		}
-
 		if (node.expression && node.expression.type !== 'Identifier') {
 			const name = state.scope.generate(node.name);
 			const bindings = state.scope.get_bindings(node);

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -1495,17 +1495,7 @@ const template_visitors = {
 		state.template.push(t_statement(call));
 		state.template.push(t_expression(id));
 	},
-	LetDirective(node, { state, path }) {
-		const parent = path.at(-1);
-		if (
-			parent === undefined ||
-			(parent.type !== 'Component' &&
-				parent.type !== 'RegularElement' &&
-				parent.type !== 'SvelteFragment')
-		) {
-			error(node, 'INTERNAL', 'let directive at invalid position');
-		}
-
+	LetDirective(node, { state }) {
 		if (node.expression && node.expression.type !== 'Identifier') {
 			const name = state.scope.generate(node.name);
 			const bindings = state.scope.get_bindings(node);


### PR DESCRIPTION
closes #9710. In most cases we probably shouldn't be erroring during the transform phase, that's what validation is for — especially if the error is repeated between client and server transformers.

Didn't add a test or a 'real' (not `INTERNAL`) error because I expect this to come up in the process of getting all the other validation tests ported — just wanted to remove the duplication and fix the immediate bug so that we can close the issue quickly

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
