### PR TITLE
fix: ensure computed props are cached with derived

### DIFF
--- a/.changeset/selfish-tools-hide.md
+++ b/.changeset/selfish-tools-hide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure computed props are cached with derived

--- a/packages/svelte/tests/runtime-runes/samples/props-derived/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived/Child.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { random } = $props();
+</script>
+
+<p>{random}</p>
+<p>{random}</p>
+<p>{random}</p>

--- a/packages/svelte/tests/runtime-runes/samples/props-derived/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../test';
+
+let math_random = Math.random;
+let calls = 0;
+
+export default test({
+	skip_if_hydrate: 'permanent',
+	before_test() {
+		Math.random = function () {
+			calls++;
+			return math_random.call(this);
+		};
+	},
+	after_test() {
+		Math.random = math_random;
+		calls = 0;
+	},
+	test({ assert }) {
+		assert.equal(calls, 1);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/props-derived/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Child from './Child.svelte';
+</script>
+
+<Child random={Math.random().toFixed(2)} />


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/9751. Ensures computed props that contain call expressions are cached in derived signals.