### PR TITLE
fix: allow duplicate snippet declaration names

### DIFF
--- a/.changeset/khaki-moose-arrive.md
+++ b/.changeset/khaki-moose-arrive.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow duplicate snippet declaration names

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2453,7 +2453,7 @@ export const template_visitors = {
 			body = /** @type {import('estree').BlockStatement} */ (context.visit(node.body));
 		}
 
-		context.state.init.push(b.var(node.expression, b.arrow(args, body)));
+		context.state.init.push(b.const(node.expression, b.arrow(args, body)));
 		if (context.state.options.dev) {
 			context.state.init.push(b.stmt(b.call('$.add_snippet_symbol', node.expression)));
 		}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2453,7 +2453,7 @@ export const template_visitors = {
 			body = /** @type {import('estree').BlockStatement} */ (context.visit(node.body));
 		}
 
-		context.state.init.push(b.function_declaration(node.expression, args, body));
+		context.state.init.push(b.var(node.expression, b.arrow(args, body)));
 		if (context.state.options.dev) {
 			context.state.init.push(b.stmt(b.call('$.add_snippet_symbol', node.expression)));
 		}

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -375,7 +375,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 					scopes.set(child, state.scope);
 					visit(child);
 				} else if (child.type === 'SnippetBlock') {
-					visit(child);
+					visit(child, { scope });
 				} else {
 					visit(child, { scope });
 				}

--- a/packages/svelte/tests/runtime-runes/samples/snippet-duplicate-children/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-duplicate-children/Child.svelte
@@ -1,0 +1,4 @@
+<script>
+	const {children} = $props();
+</script>
+<div>{@render children()}</div>

--- a/packages/svelte/tests/runtime-runes/samples/snippet-duplicate-children/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-duplicate-children/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<div>Hello</div><div>World</div>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-duplicate-children/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-duplicate-children/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	import Child from './Child.svelte';
+</script>
+
+<Child>
+	{#snippet children()}
+		Hello
+	{/snippet}
+</Child>
+
+<Child>
+	{#snippet children()}
+		World
+	{/snippet}
+</Child>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/9756.