### PR TITLE
feat: runes globals error

### DIFF
--- a/.changeset/swift-seahorses-deliver.md
+++ b/.changeset/swift-seahorses-deliver.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: throw descriptive error for using runes globals outside of Svelte-compiled files

--- a/packages/svelte/scripts/check-treeshakeability.js
+++ b/packages/svelte/scripts/check-treeshakeability.js
@@ -44,16 +44,17 @@ for (const key in pkg.exports) {
 			throw new Error('errr what');
 		}
 
-		const code = output[0].code;
-		if (code.trim()) {
+		const code = output[0].code.trim();
+
+		if (code === '') {
+			// eslint-disable-next-line no-console
+			console.error(`✅ ${subpackage} (${type})`);
+		} else {
 			// eslint-disable-next-line no-console
 			console.error(code);
 			// eslint-disable-next-line no-console
 			console.error(`❌ ${subpackage} (${type})`);
 			failed = true;
-		} else {
-			// eslint-disable-next-line no-console
-			console.error(`✅ ${subpackage} (${type})`);
 		}
 	}
 }

--- a/packages/svelte/scripts/check-treeshakeability.js
+++ b/packages/svelte/scripts/check-treeshakeability.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { rollup } from 'rollup';
 import virtual from '@rollup/plugin-virtual';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
@@ -27,6 +28,9 @@ for (const key in pkg.exports) {
 			plugins: [
 				virtual({
 					__entry__: `import ${JSON.stringify(resolved)}`
+				}),
+				nodeResolve({
+					exportConditions: ['production', 'import', 'browser', 'default']
 				})
 			],
 			onwarn: (warning, handle) => {
@@ -40,15 +44,8 @@ for (const key in pkg.exports) {
 			throw new Error('errr what');
 		}
 
-		const code = output[0].code
-			.replace(/import\s+([^'"]+from\s+)?(['"])[^'"]+\2\s*;?/, '')
-			.replace(/\r\n/g, '\n')
-			.trim();
-		if (
-			code !== '' &&
-			// See runtime.js code
-			!(code.startsWith('if (DEV) {') && code.endsWith("throw_rune_error('$props');\n}"))
-		) {
+		const code = output[0].code;
+		if (code.trim()) {
 			// eslint-disable-next-line no-console
 			console.error(code);
 			// eslint-disable-next-line no-console

--- a/packages/svelte/scripts/check-treeshakeability.js
+++ b/packages/svelte/scripts/check-treeshakeability.js
@@ -40,8 +40,15 @@ for (const key in pkg.exports) {
 			throw new Error('errr what');
 		}
 
-		const code = output[0].code.replace(/import\s+([^'"]+from\s+)?(['"])[^'"]+\2\s*;?/, '');
-		if (code.trim()) {
+		const code = output[0].code
+			.replace(/import\s+([^'"]+from\s+)?(['"])[^'"]+\2\s*;?/, '')
+			.replace(/\r\n/g, '\n')
+			.trim();
+		if (
+			code !== '' &&
+			// See runtime.js code
+			!(code.startsWith('if (DEV) {') && code.endsWith("throw_rune_error('$props');\n}"))
+		) {
 			// eslint-disable-next-line no-console
 			console.error(code);
 			// eslint-disable-next-line no-console

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1936,3 +1936,22 @@ export function unwrap(value) {
 	// @ts-ignore
 	return value;
 }
+
+if (DEV) {
+	/** @param {string} rune */
+	function throw_rune_error(rune) {
+		if (!(rune in globalThis)) {
+			// @ts-ignore
+			globalThis[rune] = () => {
+				// TODO if people start adjusting the "this can contain runes" config through v-p-s more, adjust this message
+				throw new Error(`${rune} is only available inside .svelte and .svelte.js/ts files`);
+			};
+		}
+	}
+
+	throw_rune_error('$state');
+	throw_rune_error('$effect');
+	throw_rune_error('$derived');
+	throw_rune_error('$inspect');
+	throw_rune_error('$props');
+}


### PR DESCRIPTION
throw descriptive error for using runes globals outside of Svelte-compiled files.

Had to adjust the treeshakeability check to ignore that part. An alternative way to ignore it would be to pass in `DEV` `false` somehow.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
