### PR TITLE
chore: use proxy instead of signal in createRoot

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -456,6 +456,7 @@ function read_attribute(parser) {
 				expression,
 				parent: null,
 				metadata: {
+					contains_call_expression: false,
 					dynamic: false
 				}
 			};

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -906,7 +906,10 @@ const common_visitors = {
 		}
 	},
 	CallExpression(node, context) {
-		if (context.state.expression?.type === 'ExpressionTag' && !is_known_safe_call(node, context)) {
+		if (
+			context.state.expression?.type === 'ExpressionTag' ||
+			(context.state.expression?.type === 'SpreadAttribute' && !is_known_safe_call(node, context))
+		) {
 			context.state.expression.metadata.contains_call_expression = true;
 		}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -67,7 +67,7 @@ export function serialize_get_binding(node, state) {
 
 	if (binding.kind === 'prop' && binding.node.name === '$$props') {
 		// Special case for $$props which only exists in the old world
-		return b.call('$.unwrap', node);
+		return node;
 	}
 
 	if (
@@ -88,7 +88,6 @@ export function serialize_get_binding(node, state) {
 			(!state.analysis.immutable || state.analysis.accessors || binding.reassigned)) ||
 		binding.kind === 'derived' ||
 		binding.kind === 'prop' ||
-		binding.kind === 'rest_prop' ||
 		binding.kind === 'legacy_reactive'
 	) {
 		return b.call('$.get', node);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/global.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/global.js
@@ -7,7 +7,7 @@ export const global_visitors = {
 	Identifier(node, { path, state }) {
 		if (is_reference(node, /** @type {import('estree').Node} */ (path.at(-1)))) {
 			if (node.name === '$$props') {
-				return b.call('$.get', b.id('$$sanitized_props'));
+				return b.id('$$sanitized_props');
 			}
 			return serialize_get_binding(node, state);
 		}

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -434,6 +434,7 @@ export interface SpreadAttribute extends BaseNode {
 	type: 'SpreadAttribute';
 	expression: Expression;
 	metadata: {
+		contains_call_expression: boolean;
 		dynamic: boolean;
 	};
 }

--- a/packages/svelte/src/internal/client/each.js
+++ b/packages/svelte/src/internal/client/each.js
@@ -243,7 +243,7 @@ function reconcile_indexed_array(
 	flags,
 	apply_transitions
 ) {
-	var is_proxied_array = STATE_SYMBOL in array && array[STATE_SYMBOL].i;
+	var is_proxied_array = STATE_SYMBOL in array && /** @type {any} */ (array[STATE_SYMBOL]).i;
 	var a_blocks = each_block.v;
 	var active_transitions = each_block.s;
 
@@ -351,7 +351,7 @@ function reconcile_tracked_array(
 ) {
 	var a_blocks = each_block.v;
 	const is_computed_key = keys !== null;
-	var is_proxied_array = STATE_SYMBOL in array && array[STATE_SYMBOL].i;
+	var is_proxied_array = STATE_SYMBOL in array && /** @type {any} */ (array[STATE_SYMBOL]).i;
 	var active_transitions = each_block.s;
 
 	if (is_proxied_array) {

--- a/packages/svelte/src/internal/client/each.js
+++ b/packages/svelte/src/internal/client/each.js
@@ -243,7 +243,7 @@ function reconcile_indexed_array(
 	flags,
 	apply_transitions
 ) {
-	var is_proxied_array = STATE_SYMBOL in array;
+	var is_proxied_array = STATE_SYMBOL in array && array[STATE_SYMBOL].i;
 	var a_blocks = each_block.v;
 	var active_transitions = each_block.s;
 
@@ -351,7 +351,7 @@ function reconcile_tracked_array(
 ) {
 	var a_blocks = each_block.v;
 	const is_computed_key = keys !== null;
-	var is_proxied_array = STATE_SYMBOL in array;
+	var is_proxied_array = STATE_SYMBOL in array && array[STATE_SYMBOL].i;
 	var active_transitions = each_block.s;
 
 	if (is_proxied_array) {

--- a/packages/svelte/src/internal/client/proxy/proxy.js
+++ b/packages/svelte/src/internal/client/proxy/proxy.js
@@ -31,6 +31,7 @@ const is_frozen = Object.isFrozen;
 /**
  * @template {StateObject} T
  * @param {T} value
+ * @param {boolean} [immutable]
  * @returns {T}
  */
 export function proxy(value, immutable = true) {

--- a/packages/svelte/src/internal/client/proxy/proxy.js
+++ b/packages/svelte/src/internal/client/proxy/proxy.js
@@ -239,6 +239,12 @@ const handler = {
 	}
 };
 
+/** @param {any} object */
+export function observe(object) {
+	const metadata = object[STATE_SYMBOL];
+	if (metadata) get(metadata.v);
+}
+
 if (DEV) {
 	handler.setPrototypeOf = () => {
 		throw new Error('Cannot set prototype of $state object');

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -27,7 +27,6 @@ import {
 	get,
 	is_signal,
 	push_destroy_fn,
-	set,
 	execute_effect,
 	UNINITIALIZED,
 	derived,
@@ -36,13 +35,11 @@ import {
 	flushSync,
 	safe_not_equal,
 	current_block,
-	source,
 	managed_effect,
 	push,
 	current_component_context,
 	pop,
-	unwrap,
-	mutable_source
+	unwrap
 } from './runtime.js';
 import {
 	current_hydration_fragment,
@@ -57,12 +54,11 @@ import {
 	get_descriptors,
 	is_array,
 	object_assign,
-	object_entries,
 	object_keys
 } from './utils.js';
 import { is_promise } from '../common.js';
 import { bind_transition, trigger_transitions } from './transitions.js';
-import { STATE_SYMBOL, proxy } from './proxy/proxy.js';
+import { observe, proxy } from './proxy/proxy.js';
 
 /** @type {Set<string>} */
 const all_registerd_events = new Set();
@@ -2540,8 +2536,7 @@ export function rest_props(props_signal, rest) {
 	return derived(() => {
 		var props = unwrap(props_signal);
 
-		const metadata = props[STATE_SYMBOL];
-		if (metadata) get(metadata.v);
+		observe(props);
 
 		/** @type {Record<string, unknown>} */
 		var rest_props = {};

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -98,32 +98,6 @@ export function set_is_ssr(ssr) {
 }
 
 /**
- * @param {import('./types.js').MaybeSignal<Record<string, unknown>>} props
- * @returns {import('./types.js').ComponentContext}
- */
-export function create_component_context(props) {
-	const parent = current_component_context;
-	return {
-		// accessors
-		a: null,
-		// context
-		c: null,
-		// effects
-		e: null,
-		// mounted
-		m: false,
-		// parent
-		p: parent,
-		// props
-		s: props,
-		// runes
-		r: false,
-		// update_callbacks
-		u: null
-	};
-}
-
-/**
  * @param {null | import('./types.js').ComponentContext} context
  * @returns {boolean}
  */
@@ -1415,18 +1389,17 @@ export function is_store(val) {
  *   - otherwise create a signal that updates whenever the value is updated from the parent, and when it's updated
  *	 from within the component itself, call the setter of the parent which will propagate the value change back
  * @template V
- * @param {import('./types.js').MaybeSignal<Record<string, unknown>>} props_obj
+ * @param {Record<string, unknown>} props
  * @param {string} key
  * @param {number} flags
  * @param {V | (() => V)} [default_value]
  * @returns {import('./types.js').Signal<V> | (() => V)}
  */
-export function prop_source(props_obj, key, flags, default_value) {
+export function prop_source(props, key, flags, default_value) {
 	const call_default_value = (flags & PROPS_CALL_DEFAULT_VALUE) !== 0;
 	const immutable = (flags & PROPS_IS_IMMUTABLE) !== 0;
 	const runes = (flags & PROPS_IS_RUNES) !== 0;
 
-	const props = is_signal(props_obj) ? get(props_obj) : props_obj;
 	const update_bound_prop = get_descriptor(props, key)?.set;
 	let value = props[key];
 	const should_set_default_value = value === undefined && default_value !== undefined;
@@ -1457,9 +1430,7 @@ export function prop_source(props_obj, key, flags, default_value) {
 
 	let mount = true;
 	sync_effect(() => {
-		const props = is_signal(props_obj) ? get(props_obj) : props_obj;
-
-		observe(props_obj);
+		observe(props);
 
 		// Before if to ensure signal dependency is registered
 		const propagating_value = props[key];
@@ -1510,12 +1481,13 @@ export function prop_source(props_obj, key, flags, default_value) {
 
 /**
  * If the prop is readonly and has no fallback value, we can use this function, else we need to use `prop_source`.
- * @param {import('./types.js').MaybeSignal<Record<string, unknown>>} props_obj
+ * @param {Record<string, unknown>} props
  * @param {string} key
  * @returns {any}
  */
-export function prop(props_obj, key) {
-	return is_signal(props_obj) ? () => get(props_obj)[key] : () => props_obj[key];
+export function prop(props, key) {
+	// TODO skip this, and rewrite as `$$props.foo`
+	return () => props[key];
 }
 
 /**
@@ -1595,23 +1567,18 @@ function get_parent_context(component_context) {
 
 /**
  * @this {any}
- * @param {import('./types.js').MaybeSignal<Record<string, unknown>>} $$props
+ * @param {Record<string, unknown>} $$props
  * @param {Event} event
  * @returns {void}
  */
 export function bubble_event($$props, event) {
-	const events = /** @type {Record<string, Function[] | Function>} */ (unwrap($$props).$$events)?.[
+	var events = /** @type {Record<string, Function[] | Function>} */ ($$props.$$events)?.[
 		event.type
 	];
-	const callbacks = is_array(events) ? events.slice() : events == null ? [] : [events];
-	let fn;
-	for (fn of callbacks) {
+	var callbacks = is_array(events) ? events.slice() : events == null ? [] : [events];
+	for (var fn of callbacks) {
 		// Preserve "this" context
-		if (is_signal(fn)) {
-			get(fn).call(this, event);
-		} else {
-			fn.call(this, event);
-		}
+		fn.call(this, event);
 	}
 }
 
@@ -1756,14 +1723,29 @@ export function onDestroy(fn) {
 }
 
 /**
- * @param {import('./types.js').MaybeSignal<Record<string, unknown>>} props
+ * @param {Record<string, unknown>} props
  * @param {any} runes
  * @returns {void}
  */
 export function push(props, runes = false) {
-	const context_stack_item = create_component_context(props);
-	context_stack_item.r = runes;
-	current_component_context = context_stack_item;
+	current_component_context = {
+		// accessors
+		a: null,
+		// context
+		c: null,
+		// effects
+		e: null,
+		// mounted
+		m: false,
+		// parent
+		p: current_component_context,
+		// props
+		s: props,
+		// runes
+		r: runes,
+		// update_callbacks
+		u: null
+	};
 }
 
 /**
@@ -1819,7 +1801,7 @@ function deep_read(value, visited = new Set()) {
 }
 
 /**
- * @param {() => import('./types.js').MaybeSignal<>} get_value
+ * @param {() => any} get_value
  * @param {Function} inspect
  * @returns {void}
  */

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -4,7 +4,7 @@ import { EMPTY_FUNC, run_all } from '../common.js';
 import { get_descriptor, get_descriptors, is_array } from './utils.js';
 import { PROPS_CALL_DEFAULT_VALUE, PROPS_IS_IMMUTABLE, PROPS_IS_RUNES } from '../../constants.js';
 import { readonly } from './proxy/readonly.js';
-import { STATE_SYMBOL } from './proxy/proxy.js';
+import { observe } from './proxy/proxy.js';
 
 export const SOURCE = 1;
 export const DERIVED = 1 << 1;
@@ -1463,8 +1463,7 @@ export function prop_source(props_obj, key, flags, default_value) {
 	sync_effect(() => {
 		const props = is_signal(props_obj) ? get(props_obj) : props_obj;
 
-		const metadata = props[STATE_SYMBOL];
-		if (metadata) get(metadata.v);
+		observe(props_obj);
 
 		// Before if to ensure signal dependency is registered
 		const propagating_value = props[key];

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1426,10 +1426,6 @@ export function prop_source(props_obj, key, flags, default_value) {
 	const immutable = (flags & PROPS_IS_IMMUTABLE) !== 0;
 	const runes = (flags & PROPS_IS_RUNES) !== 0;
 
-	if (is_signal(props_obj)) {
-		// throw new Error('nope');
-	}
-
 	const props = is_signal(props_obj) ? get(props_obj) : props_obj;
 	const update_bound_prop = get_descriptor(props, key)?.set;
 	let value = props[key];

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -4,6 +4,7 @@ import { EMPTY_FUNC, run_all } from '../common.js';
 import { get_descriptor, get_descriptors, is_array } from './utils.js';
 import { PROPS_CALL_DEFAULT_VALUE, PROPS_IS_IMMUTABLE, PROPS_IS_RUNES } from '../../constants.js';
 import { readonly } from './proxy/readonly.js';
+import { STATE_SYMBOL } from './proxy/proxy.js';
 
 export const SOURCE = 1;
 export const DERIVED = 1 << 1;
@@ -1425,6 +1426,10 @@ export function prop_source(props_obj, key, flags, default_value) {
 	const immutable = (flags & PROPS_IS_IMMUTABLE) !== 0;
 	const runes = (flags & PROPS_IS_RUNES) !== 0;
 
+	if (is_signal(props_obj)) {
+		// throw new Error('nope');
+	}
+
 	const props = is_signal(props_obj) ? get(props_obj) : props_obj;
 	const update_bound_prop = get_descriptor(props, key)?.set;
 	let value = props[key];
@@ -1457,6 +1462,10 @@ export function prop_source(props_obj, key, flags, default_value) {
 	let mount = true;
 	sync_effect(() => {
 		const props = is_signal(props_obj) ? get(props_obj) : props_obj;
+
+		const metadata = props[STATE_SYMBOL];
+		if (metadata) get(metadata.v);
+
 		// Before if to ensure signal dependency is registered
 		const propagating_value = props[key];
 		if (mount) {

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -36,7 +36,7 @@ export type Store<V> = {
 
 export type ComponentContext = {
 	/** props */
-	s: MaybeSignal<Record<string, unknown>>;
+	s: Record<string, unknown>;
 	/** accessors */
 	a: Record<string, any> | null;
 	/** effectgs */

--- a/packages/svelte/src/internal/client/utils.js
+++ b/packages/svelte/src/internal/client/utils.js
@@ -8,3 +8,11 @@ export var object_assign = Object.assign;
 export var define_property = Object.defineProperty;
 export var get_descriptor = Object.getOwnPropertyDescriptor;
 export var get_descriptors = Object.getOwnPropertyDescriptors;
+
+/**
+ * @param {any} thing
+ * @returns {thing is Function}
+ */
+export function is_function(thing) {
+	return typeof thing === 'function';
+}

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -5,13 +5,10 @@ import {
 	is_ssr,
 	managed_effect,
 	untrack,
-	is_signal,
-	get,
 	user_effect,
 	flush_local_render_effects
 } from '../internal/client/runtime.js';
 import { is_array } from '../internal/client/utils.js';
-import { unwrap } from '../internal/index.js';
 
 /**
  * The `onMount` function schedules a callback to run as soon as the component has been mounted to the DOM.
@@ -139,10 +136,9 @@ export function createEventDispatcher() {
 	}
 
 	return (type, detail, options) => {
-		const $$events = /** @type {Record<string, Function | Function[]>} */ (
-			unwrap(component_context.s).$$events
-		);
-		const events = $$events?.[/** @type {any} */ (type)];
+		const events = /** @type {Record<string, Function | Function[]>} */ (
+			component_context.s.$$events
+		)?.[/** @type {any} */ (type)];
 
 		if (events) {
 			const callbacks = is_array(events) ? events.slice() : [events];
@@ -150,11 +146,7 @@ export function createEventDispatcher() {
 			// in a server (non-DOM) environment?
 			const event = create_custom_event(/** @type {string} */ (type), detail, options);
 			for (const fn of callbacks) {
-				if (is_signal(fn)) {
-					get(fn).call(component_context.a, event);
-				} else {
-					fn.call(component_context.a, event);
-				}
+				fn.call(component_context.a, event);
 			}
 			return !event.defaultPrevented;
 		}

--- a/packages/svelte/tests/runtime-legacy/samples/component-props/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/component-props/_config.js
@@ -10,6 +10,6 @@ export default test({
 		});
 		await Promise.resolve();
 
-		assert.htmlEqual(target.innerHTML, '{"visible":true,"foo":"bar"} {"foo":"bar"}');
+		assert.htmlEqual(target.innerHTML, '{"foo":"bar","visible":true} {"foo":"bar"}');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/props/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props/main.svelte
@@ -1,5 +1,5 @@
 <script>
-    const { foo, default1 = 1, default2 = 2, default3 = 3, ...others } = $props();
+	const { foo, default1 = 1, default2 = 2, default3 = 3, ...others } = $props();
 </script>
 
 {foo} {default1} {default2} {default3} {others.bar}


### PR DESCRIPTION
This is part of a larger effort to simplify props handling internally, by using proxies rather than signals to represent the props object. In time, this will hopefully enable us to get rid of things like `sync_effect`.

Just one small change in behaviour — the enumeration order of keys in rest props is different. (I cannot imagine this ever mattering)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
