### PR TITLE
chore: simplify await blocks

### DIFF
--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1726,7 +1726,7 @@ export function component(anchor_node, component_fn, render_fn) {
 /**
  * @template V
  * @param {Comment} anchor_node
- * @param {import('./types.js').Signal<Promise<V>> | Promise<V> | (() => Promise<V>)} input
+ * @param {(() => Promise<V>)} input
  * @param {null | ((anchor: Node) => void)} pending_fn
  * @param {null | ((anchor: Node, value: V) => void)} then_fn
  * @param {null | ((anchor: Node, error: unknown) => void)} catch_fn
@@ -1834,7 +1834,7 @@ function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 		() => {
 			const token = {};
 			latest_token = token;
-			const promise = is_signal(input) ? get(input) : typeof input === 'function' ? input() : input;
+			const promise = input();
 			if (is_promise(promise)) {
 				promise.then(
 					/** @param {V} v */


### PR DESCRIPTION
we always pass a function to `await`. maybe we could change that in future, but unless and until we do we should remove the `is_signal` stuff

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
