### PR TITLE
fix: better readonly checks for proxies

### DIFF
--- a/.changeset/five-tigers-search.md
+++ b/.changeset/five-tigers-search.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better readonly checks for proxies

--- a/packages/svelte/src/internal/client/proxy/proxy.js
+++ b/packages/svelte/src/internal/client/proxy/proxy.js
@@ -15,12 +15,12 @@ import {
 	is_array,
 	object_keys
 } from '../utils.js';
-import { READONLY_SYMBOL } from './readonly.js';
 
 /** @typedef {{ s: Map<string | symbol, import('../types.js').SourceSignal<any>>; v: import('../types.js').SourceSignal<number>; a: boolean }} Metadata */
 /** @typedef {Record<string | symbol, any> & { [STATE_SYMBOL]: Metadata }} StateObject */
 
 export const STATE_SYMBOL = Symbol('$state');
+export const READONLY_SYMBOL = Symbol('readonly');
 
 const object_prototype = Object.prototype;
 const array_prototype = Array.prototype;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -4,6 +4,7 @@ import { EMPTY_FUNC, run_all } from '../common.js';
 import { get_descriptor, get_descriptors, is_array } from './utils.js';
 import { PROPS_CALL_DEFAULT_VALUE, PROPS_IS_IMMUTABLE, PROPS_IS_RUNES } from '../../constants.js';
 import { readonly } from './proxy/readonly.js';
+import { proxy } from './proxy/proxy.js';
 
 export const SOURCE = 1;
 export const DERIVED = 1 << 1;
@@ -1441,7 +1442,7 @@ export function prop_source(props_obj, key, flags, default_value) {
 			call_default_value ? default_value() : default_value;
 
 		if (DEV && runes) {
-			value = readonly(/** @type {any} */ (value));
+			value = readonly(proxy(/** @type {any} */ (value)));
 		}
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly-bail/Counter.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly-bail/Counter.svelte
@@ -1,0 +1,8 @@
+<script>
+	/** @type {{ object: { count: number }}} */
+	let { object } = $props();
+</script>
+
+<button onclick={() => object = { count: object.count + 1 } }>
+	clicks: {object.count}
+</button>

--- a/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly-bail/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly-bail/_config.js
@@ -1,0 +1,22 @@
+import { test } from '../../test';
+
+// Tests that readonly bails on setters/classes
+export default test({
+	html: `<button>clicks: 0</button><button>clicks: 0</button>`,
+
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+
+		await btn1.click();
+		await btn2.click();
+		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button><button>clicks: 1</button>`);
+
+		await btn1.click();
+		await btn2.click();
+		assert.htmlEqual(target.innerHTML, `<button>clicks: 2</button><button>clicks: 2</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly-bail/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly-bail/main.svelte
@@ -1,0 +1,25 @@
+<script>
+	import Counter from './Counter.svelte';
+
+	function createCounter() {
+		let count = $state(0)
+		return {
+			get count() {
+				return count;
+			},
+			set count(upd) {
+				count = upd
+			}
+		}
+	}
+
+	class CounterClass {
+		count = $state(0);
+	}
+
+	const counterSetter = createCounter();
+	const counterClass = new CounterClass();
+</script>
+
+<Counter object={counterSetter} />
+<Counter object={counterClass} />

--- a/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly/_config.js
@@ -14,5 +14,6 @@ export default test({
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 0</button>`);
 	},
 
-	runtime_error: 'Props cannot be mutated, unless used with `bind:`'
+	runtime_error:
+		'Props cannot be mutated, unless used with `bind:`. Use `bind:prop-in-question={..}` to make `count` settable. Fallback values can never be mutated.'
 });

--- a/packages/svelte/tests/runtime-runes/samples/proxy-prop-readonly/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-prop-readonly/_config.js
@@ -14,5 +14,6 @@ export default test({
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 0</button>`);
 	},
 
-	runtime_error: 'Props cannot be mutated, unless used with `bind:`'
+	runtime_error:
+		'Props cannot be mutated, unless used with `bind:`. Use `bind:prop-in-question={..}` to make `count` settable. Fallback values can never be mutated.'
 });


### PR DESCRIPTION
- Expect the thing that's checked to be wrapped with the proxy already, so that we can just check for the state symbol
- Make error message more descriptive

See discussion in #9789 for more info

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
