### PR TITLE
fix: improve non state referenced warning

### DIFF
--- a/.changeset/polite-dolphins-care.md
+++ b/.changeset/polite-dolphins-care.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improve non state referenced warning

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -409,10 +409,10 @@ export function analyze_component(root, options) {
 		analysis.reactive_statements = order_reactive_statements(analysis.reactive_statements);
 	}
 
-	// warn on any nonstate declarations that are a) mutated and b) referenced in the template
+	// warn on any nonstate declarations that are a) reassigned and mutated and b) referenced in the template
 	for (const scope of [module.scope, instance.scope]) {
 		outer: for (const [name, binding] of scope.declarations) {
-			if (binding.kind === 'normal' && binding.mutated) {
+			if (binding.kind === 'normal' && binding.reassigned && binding.mutated) {
 				for (const { path } of binding.references) {
 					if (path[0].type !== 'Fragment') continue;
 					for (let i = 1; i < path.length; i += 1) {


### PR DESCRIPTION
Now we have deep reactive state, this warning could do with a bit of improvement. Currently it warns on this:

```js
some_state.foo.bar = something_else;
```

It should really only warn when re-assigning `some_state`. So this PR fixes that.