### PR TITLE
fix: improve consistency issues around binding invalidation

### DIFF
--- a/.changeset/soft-clocks-remember.md
+++ b/.changeset/soft-clocks-remember.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improve consistency issues around binding invalidation

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -245,7 +245,7 @@ function setup_select_synchronization(value_binding, context) {
 	context.state.init.push(
 		b.stmt(
 			b.call(
-				'$.pre_effect',
+				'$.invalidate_effect',
 				b.thunk(
 					b.block([
 						b.stmt(

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1302,6 +1302,20 @@ export function pre_effect(init) {
  * @param {() => void | (() => void)} init
  * @returns {import('./types.js').EffectSignal}
  */
+export function invalidate_effect(init) {
+	return internal_create_effect(
+		PRE_EFFECT,
+		init,
+		true,
+		current_block,
+		true
+	);
+}
+
+/**
+ * @param {() => void | (() => void)} init
+ * @returns {import('./types.js').EffectSignal}
+ */
 function sync_effect(init) {
 	return internal_create_effect(SYNC_EFFECT, init, true, current_block, true);
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1299,17 +1299,14 @@ export function pre_effect(init) {
 }
 
 /**
+ * This effect is used to ensure binding are kept in sync. We use a pre effect to ensure we run before the
+ * bindings which are in later effects. However, we don't use a pre_effect directly as we don't want to flush anything.
+ *
  * @param {() => void | (() => void)} init
  * @returns {import('./types.js').EffectSignal}
  */
 export function invalidate_effect(init) {
-	return internal_create_effect(
-		PRE_EFFECT,
-		init,
-		true,
-		current_block,
-		true
-	);
+	return internal_create_effect(PRE_EFFECT, init, true, current_block, true);
 }
 
 /**

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -12,6 +12,7 @@ export {
 	user_effect,
 	render_effect,
 	pre_effect,
+	invalidate_effect,
 	flushSync,
 	bubble_event,
 	safe_equal,

--- a/packages/svelte/tests/runtime-runes/samples/invalidate-effect/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/invalidate-effect/_config.js
@@ -8,6 +8,9 @@ export default test({
 		b1.click();
 		await Promise.resolve();
 
-		assert.htmlEqual(target.innerHTML, 'a\n<select></select>b\n<select></select><button>change</button');
+		assert.htmlEqual(
+			target.innerHTML,
+			'a\n<select></select>b\n<select></select><button>change</button'
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/invalidate-effect/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/invalidate-effect/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		assert.htmlEqual(target.innerHTML, 'a\n<select></select><button>change</button');
+
+		const [b1] = target.querySelectorAll('button');
+		b1.click();
+		await Promise.resolve();
+
+		assert.htmlEqual(target.innerHTML, 'a\n<select></select>b\n<select></select><button>change</button');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/invalidate-effect/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/invalidate-effect/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let entries = $state([{selected: 'a'}])
+</script>
+
+{#each entries as entry}
+	{entry.selected} <select bind:value={entry.selected}></select>
+{/each}
+
+<button
+	on:click={
+		() => entries = [{selected: 'a'}, {selected: 'b'}]
+	}
+	>change</button>


### PR DESCRIPTION
Our logic for using `$.pre_effect` for binding invalidation was good, but not correct as we flush after running `pre_effect` – so this puts binding invalidations in as a pre_effect but without the flushing logic.