### PR TITLE
fix: prevent infinite loops stemming from invalidation method

### DIFF
--- a/.changeset/healthy-planes-vanish.md
+++ b/.changeset/healthy-planes-vanish.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent infinite loops stemming from invalidation method

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -863,28 +863,29 @@ export function set_sync(signal, value) {
  * Invokes a function and captures all signals that are read during the invocation,
  * then invalidates them.
  * @param {() => any} fn
- * @returns {Set<import('./types.js').Signal>}
  */
 export function invalidate_inner_signals(fn) {
-	const previous_is_signals_recorded = is_signals_recorded;
-	const previous_captured_signals = captured_signals;
+	var previous_is_signals_recorded = is_signals_recorded;
+	var previous_captured_signals = captured_signals;
 	is_signals_recorded = true;
 	captured_signals = new Set();
+	var captured = captured_signals;
 	try {
 		untrack(fn);
 	} finally {
 		is_signals_recorded = previous_is_signals_recorded;
-		let signal;
-		for (signal of captured_signals) {
-			previous_captured_signals.add(signal);
+		if (is_signals_recorded) {
+			var signal;
+			for (signal of captured_signals) {
+				previous_captured_signals.add(signal);
+			}
 		}
 		captured_signals = previous_captured_signals;
 	}
-	let signal;
-	for (signal of captured_signals) {
+	var signal;
+	for (signal of captured) {
 		mutate(signal, null /* doesnt matter */);
 	}
-	return captured_signals;
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -870,19 +870,18 @@ export function invalidate_inner_signals(fn) {
 	is_signals_recorded = true;
 	captured_signals = new Set();
 	var captured = captured_signals;
+	var signal;
 	try {
 		untrack(fn);
 	} finally {
 		is_signals_recorded = previous_is_signals_recorded;
 		if (is_signals_recorded) {
-			var signal;
 			for (signal of captured_signals) {
 				previous_captured_signals.add(signal);
 			}
 		}
 		captured_signals = previous_captured_signals;
 	}
-	var signal;
 	for (signal of captured) {
 		mutate(signal, null /* doesnt matter */);
 	}

--- a/packages/svelte/tests/runtime-legacy/samples/select-in-each/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/select-in-each/_config.js
@@ -1,0 +1,32 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+export default test({
+	html: `
+		<select>
+			<option value="a">A</option>
+			<option value="b">B</option>
+		</select>
+		selected: a
+	`,
+
+	test({ assert, target }) {
+		const select = target.querySelector('select');
+		ok(select);
+		const event = new window.Event('change');
+		select.value = 'b';
+		select.dispatchEvent(event);
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<select>
+				<option value="a">A</option>
+				<option value="b">B</option>
+			</select>
+			selected: b
+		`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/select-in-each/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/select-in-each/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	let entries = [{selected: 'a' }]
+</script>
+
+{#each entries as entry}
+	<select bind:value={entry.selected}>
+		<option value='a'>A</option>
+		<option value='b'>B</option>
+	</select>
+	selected: {entry.selected}
+{/each}


### PR DESCRIPTION
The logic was flawed: the captured signals where always added to the previous captured no matter what, which meant a) memory leak b) that when another one runs afterwards, it will falsely contain the signals from the previous run fixes #9788

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
