### PR TITLE
chore: use `$$props` directly where possible

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -74,18 +74,10 @@ export function serialize_get_binding(node, state) {
 
 		if (
 			!state.analysis.accessors &&
-			!(state.analysis.runes ? binding.reassigned : binding.mutated) &&
+			!(state.analysis.immutable ? binding.reassigned : binding.mutated) &&
 			!binding.initial
 		) {
 			return b.member(b.id('$$props'), node);
-		}
-
-		if (
-			!(state.analysis.immutable ? binding.reassigned : binding.mutated) &&
-			!binding.initial &&
-			!state.analysis.accessors
-		) {
-			return b.call(node);
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -353,67 +353,53 @@ export function serialize_hoistable_params(node, context) {
 }
 
 /**
- *
- * @param {import('#compiler').Binding} binding
  * @param {import('./types').ComponentClientTransformState} state
  * @param {string} name
- * @param {import('estree').Expression | null} [default_value]
+ * @param {import('estree').Expression | null} [initial]
  * @returns
  */
-export function get_props_method(binding, state, name, default_value) {
+export function get_prop_source(state, name, initial) {
 	/** @type {import('estree').Expression[]} */
 	const args = [b.id('$$props'), b.literal(name)];
 
-	// Use $.prop_source in the following cases:
-	// - accessors/mutated: needs to be able to set the prop value from within
-	// - default value: we set the fallback value only initially, and it's not possible to know this timing in $.prop
-	const needs_source =
-		default_value ||
-		state.analysis.accessors ||
-		(state.analysis.immutable ? binding.reassigned : binding.mutated);
+	let flags = 0;
 
-	if (needs_source) {
-		let flags = 0;
-
-		/** @type {import('estree').Expression | undefined} */
-		let arg;
-
-		if (state.analysis.immutable) {
-			flags |= PROPS_IS_IMMUTABLE;
-		}
-
-		if (state.analysis.runes) {
-			flags |= PROPS_IS_RUNES;
-		}
-
-		if (default_value) {
-			// To avoid eagerly evaluating the right-hand-side, we wrap it in a thunk if necessary
-			if (is_simple_expression(default_value)) {
-				arg = default_value;
-			} else {
-				if (
-					default_value.type === 'CallExpression' &&
-					default_value.callee.type === 'Identifier' &&
-					default_value.arguments.length === 0
-				) {
-					arg = default_value.callee;
-				} else {
-					arg = b.thunk(default_value);
-				}
-
-				flags |= PROPS_CALL_DEFAULT_VALUE;
-			}
-		}
-
-		if (flags || arg) {
-			args.push(b.literal(flags));
-			if (arg) args.push(arg);
-		}
-
-		return b.call('$.prop_source', ...args);
+	if (state.analysis.immutable) {
+		flags |= PROPS_IS_IMMUTABLE;
 	}
 
-	return b.call('$.prop', ...args);
+	if (state.analysis.runes) {
+		flags |= PROPS_IS_RUNES;
+	}
+
+	/** @type {import('estree').Expression | undefined} */
+	let arg;
+
+	if (initial) {
+		// To avoid eagerly evaluating the right-hand-side, we wrap it in a thunk if necessary
+		if (is_simple_expression(initial)) {
+			arg = initial;
+		} else {
+			if (
+				initial.type === 'CallExpression' &&
+				initial.callee.type === 'Identifier' &&
+				initial.arguments.length === 0
+			) {
+				arg = initial.callee;
+			} else {
+				arg = b.thunk(initial);
+			}
+
+			flags |= PROPS_CALL_DEFAULT_VALUE;
+		}
+	}
+
+	if (flags || arg) {
+		args.push(b.literal(flags));
+		if (arg) args.push(arg);
+	}
+
+	return b.call('$.prop_source', ...args);
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -65,18 +65,29 @@ export function serialize_get_binding(node, state) {
 		return binding.expression;
 	}
 
-	if (binding.kind === 'prop' && binding.node.name === '$$props') {
-		// Special case for $$props which only exists in the old world
-		return node;
-	}
+	if (binding.kind === 'prop') {
+		if (binding.node.name === '$$props') {
+			// Special case for $$props which only exists in the old world
+			// TODO this probably should have a 'prop' binding kind
+			return node;
+		}
 
-	if (
-		binding.kind === 'prop' &&
-		!(state.analysis.immutable ? binding.reassigned : binding.mutated) &&
-		!binding.initial &&
-		!state.analysis.accessors
-	) {
-		return b.call(node);
+		if (
+			state.analysis.runes &&
+			!state.analysis.accessors &&
+			!binding.reassigned &&
+			!binding.initial
+		) {
+			return b.member(b.id('$$props'), node);
+		}
+
+		if (
+			!(state.analysis.immutable ? binding.reassigned : binding.mutated) &&
+			!binding.initial &&
+			!state.analysis.accessors
+		) {
+			return b.call(node);
+		}
 	}
 
 	if (binding.kind === 'legacy_reactive_import') {

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -68,7 +68,7 @@ export function serialize_get_binding(node, state) {
 	if (binding.kind === 'prop') {
 		if (binding.node.name === '$$props') {
 			// Special case for $$props which only exists in the old world
-			// TODO this probably should have a 'prop' binding kind
+			// TODO this probably shouldn't have a 'prop' binding kind
 			return node;
 		}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -73,9 +73,8 @@ export function serialize_get_binding(node, state) {
 		}
 
 		if (
-			state.analysis.runes &&
 			!state.analysis.accessors &&
-			!binding.reassigned &&
+			!(state.analysis.runes ? binding.reassigned : binding.mutated) &&
 			!binding.initial
 		) {
 			return b.member(b.id('$$props'), node);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
@@ -1,7 +1,7 @@
 import { is_hoistable_function } from '../../utils.js';
 import * as b from '../../../../utils/builders.js';
 import { extract_paths } from '../../../../utils/ast.js';
-import { create_state_declarators, get_props_method, serialize_get_binding } from '../utils.js';
+import { create_state_declarators, get_prop_source, serialize_get_binding } from '../utils.js';
 
 /** @type {import('../types.js').ComponentVisitors} */
 export const javascript_visitors_legacy = {
@@ -55,7 +55,7 @@ export const javascript_visitors_legacy = {
 							b.declarator(
 								path.node,
 								binding.kind === 'prop'
-									? get_props_method(binding, state, binding.prop_alias ?? name, value)
+									? get_prop_source(state, binding.prop_alias ?? name, value)
 									: value
 							)
 						);
@@ -75,8 +75,7 @@ export const javascript_visitors_legacy = {
 					declarations.push(
 						b.declarator(
 							declarator.id,
-							get_props_method(
-								binding,
+							get_prop_source(
 								state,
 								binding.prop_alias ?? declarator.id.name,
 								declarator.init &&

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
@@ -67,17 +67,24 @@ export const javascript_visitors_legacy = {
 					state.scope.get(declarator.id.name)
 				);
 
-				declarations.push(
-					b.declarator(
-						declarator.id,
-						get_props_method(
-							binding,
-							state,
-							binding.prop_alias ?? declarator.id.name,
-							declarator.init && /** @type {import('estree').Expression} */ (visit(declarator.init))
+				if (
+					state.analysis.accessors ||
+					(state.analysis.immutable ? binding.reassigned : binding.mutated) ||
+					declarator.init
+				) {
+					declarations.push(
+						b.declarator(
+							declarator.id,
+							get_props_method(
+								binding,
+								state,
+								binding.prop_alias ?? declarator.id.name,
+								declarator.init &&
+									/** @type {import('estree').Expression} */ (visit(declarator.init))
+							)
 						)
-					)
-				);
+					);
+				}
 
 				continue;
 			}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
@@ -54,7 +54,7 @@ export const javascript_visitors_legacy = {
 						declarations.push(
 							b.declarator(
 								path.node,
-								binding.kind === 'prop' || binding.kind === 'rest_prop'
+								binding.kind === 'prop'
 									? get_props_method(binding, state, binding.prop_alias ?? name, value)
 									: value
 							)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -2,7 +2,7 @@ import { get_rune } from '../../../scope.js';
 import { is_hoistable_function } from '../../utils.js';
 import * as b from '../../../../utils/builders.js';
 import * as assert from '../../../../utils/assert.js';
-import { create_state_declarators, get_props_method, should_proxy } from '../utils.js';
+import { create_state_declarators, get_prop_source, should_proxy } from '../utils.js';
 import { unwrap_ts_expression } from '../../../../utils/ast.js';
 
 /** @type {import('../types.js').ComponentVisitors} */
@@ -185,7 +185,7 @@ export const javascript_visitors_runes = {
 						const binding = /** @type {import('#compiler').Binding} */ (state.scope.get(id.name));
 
 						if (binding.reassigned || state.analysis.accessors || initial) {
-							declarations.push(b.declarator(id, get_props_method(binding, state, name, initial)));
+							declarations.push(b.declarator(id, get_prop_source(state, name, initial)));
 						}
 					} else {
 						// RestElement

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1480,17 +1480,6 @@ export function prop_source(props, key, flags, default_value) {
 }
 
 /**
- * If the prop is readonly and has no fallback value, we can use this function, else we need to use `prop_source`.
- * @param {Record<string, unknown>} props
- * @param {string} key
- * @returns {any}
- */
-export function prop(props, key) {
-	// TODO skip this, and rewrite as `$$props.foo`
-	return () => props[key];
-}
-
-/**
  * @param {boolean} immutable
  * @param {unknown} a
  * @param {unknown} b

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -7,7 +7,6 @@ export {
 	source,
 	mutable_source,
 	derived,
-	prop,
 	prop_source,
 	user_effect,
 	render_effect,


### PR DESCRIPTION
Now that `$$props` is always an object, it makes no sense to hide props behind a function call:

```diff
-const foo = $.prop($$props, 'foo');
-console.log(foo());
+console.log($$props.foo);
```

We still need `prop_source` for reassigned (or mutated, in mutable mode) props or those with initial values, though I expect there's room for tweaks there as well

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
