### PR TITLE
chore: tweak readonly error message

### DIFF
--- a/packages/svelte/src/internal/client/proxy/readonly.js
+++ b/packages/svelte/src/internal/client/proxy/readonly.js
@@ -42,7 +42,7 @@ export function readonly(value) {
  */
 const readonly_error = (_, prop) => {
 	throw new Error(
-		`Props cannot be mutated, unless used with \`bind:\`. Use \`bind:prop-in-question={..}\` to make \`${prop}\` settable. Fallback values can never be mutated.`
+		`Non-bound props cannot be mutated — use \`bind:<prop>={...}\` to make \`${prop}\` settable. Fallback values can never be mutated.`
 	);
 };
 

--- a/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-prop-default-readonly/_config.js
@@ -15,5 +15,5 @@ export default test({
 	},
 
 	runtime_error:
-		'Props cannot be mutated, unless used with `bind:`. Use `bind:prop-in-question={..}` to make `count` settable. Fallback values can never be mutated.'
+		'Non-bound props cannot be mutated — use `bind:<prop>={...}` to make `count` settable. Fallback values can never be mutated.'
 });

--- a/packages/svelte/tests/runtime-runes/samples/proxy-prop-readonly/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-prop-readonly/_config.js
@@ -15,5 +15,5 @@ export default test({
 	},
 
 	runtime_error:
-		'Props cannot be mutated, unless used with `bind:`. Use `bind:prop-in-question={..}` to make `count` settable. Fallback values can never be mutated.'
+		'Non-bound props cannot be mutated — use `bind:<prop>={...}` to make `count` settable. Fallback values can never be mutated.'
 });


### PR DESCRIPTION
The current message is a bit duplicative — we can shorten it. We should also signal 'your code here' with special characters rather than doing things like `bind:prop-in-question` (which is perfectly valid, if weird, code), and it should always be three dots, never two.