### PR TITLE
chore: remove unused check

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -409,10 +409,10 @@ export function analyze_component(root, options) {
 		analysis.reactive_statements = order_reactive_statements(analysis.reactive_statements);
 	}
 
-	// warn on any nonstate declarations that are a) reassigned and mutated and b) referenced in the template
+	// warn on any nonstate declarations that are a) reassigned and b) referenced in the template
 	for (const scope of [module.scope, instance.scope]) {
 		outer: for (const [name, binding] of scope.declarations) {
-			if (binding.kind === 'normal' && binding.reassigned && binding.mutated) {
+			if (binding.kind === 'normal' && binding.reassigned) {
 				for (const { path } of binding.references) {
 					if (path[0].type !== 'Fragment') continue;
 					for (let i = 1; i < path.length; i += 1) {


### PR DESCRIPTION
follow-up to #9809 — we don't need to care about `binding.mutated`, but in any case it will always be true if `binding.reassigned` is true