### PR TITLE
fix: improve each key animations

### DIFF
--- a/.changeset/fifty-rice-wait.md
+++ b/.changeset/fifty-rice-wait.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improve each key animations

--- a/packages/svelte/src/internal/client/each.js
+++ b/packages/svelte/src/internal/client/each.js
@@ -512,7 +512,7 @@ function reconcile_tracked_array(
 					while (i-- > 0) {
 						b_end = i + start;
 						a = sources[i];
-						if (pos === MOVED_BLOCK && a !== LIS_BLOCK) {
+						if (pos === MOVED_BLOCK) {
 							block = b_blocks[b_end];
 							item = array[b_end];
 							update_each_item_block(block, item, b_end, flags);
@@ -726,6 +726,12 @@ function update_each_item_block(block, item, index, type) {
 		if (prev_index !== index && /** @type {number} */ (index) < items.length) {
 			const from_dom = /** @type {Element} */ (get_first_element(block));
 			const from = from_dom.getBoundingClientRect();
+			// Cancel any existing key transitions
+			for (const transition of transitions) {
+				if (transition.r === 'key') {
+					transition.c();
+				}
+			}
 			schedule_task(() => {
 				trigger_transitions(transitions, 'key', from);
 			});

--- a/packages/svelte/src/internal/client/transitions.js
+++ b/packages/svelte/src/internal/client/transitions.js
@@ -376,7 +376,9 @@ function create_transition(dom, init, direction, effect) {
 		},
 		// cancel
 		c() {
-			/** @type {Animation | TickAnimation} */ (animation).cancel();
+			if (animation !== null) {
+				/** @type {Animation | TickAnimation} */ (animation).cancel();
+			}
 			cancelled = true;
 		},
 		// cleanup


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/9805. This addresses the fact that animation transitions aren't cancelled before being re-executed, causing them to incorrectly stack upon older key animation transitions. I spent forever trying to get a test that captures this, but I wasn't able to because none of this stuff is visible to JSDOM.