### PR TITLE
chore: optimaze get_amount_class_specificity_increased

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/css/Selector.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/Selector.js
@@ -193,13 +193,9 @@ export default class Selector {
 	}
 
 	get_amount_class_specificity_increased() {
-		let count = 0;
-		for (const block of this.blocks) {
-			if (block.should_encapsulate) {
-				count++;
-			}
-		}
-		return count;
+		return this.blocks
+			.filter((block) => block.should_encapsulate)
+			.length;
 	}
 }
 


### PR DESCRIPTION
Hello. Before byte code this function:

Bytecode age: 0
  111 S> 0x1e62fd2980ee @    0 : 0c                LdaZero
         0x1e62fd2980ef @    1 : c4                Star0
  136 S> 0x1e62fd2980f0 @    2 : 17 02             LdaImmutableCurrentContextSlot [2]
         0x1e62fd2980f2 @    4 : aa 00             ThrowReferenceErrorIfHole [0]
         0x1e62fd2980f4 @    6 : be                Star6
         0x1e62fd2980f5 @    7 : b1 f4 00 02       GetIterator r6, [0], [2]
         0x1e62fd2980f9 @   11 : bf                Star5
         0x1e62fd2980fa @   12 : 2d f5 01 04       GetNamedProperty r5, [1], [4]
         0x1e62fd2980fe @   16 : c0                Star4
         0x1e62fd2980ff @   17 : 12                LdaFalse
         0x1e62fd298100 @   18 : be                Star6
         0x1e62fd298101 @   19 : 19 ff f1          Mov <context>, r9
         0x1e62fd298104 @   22 : 11                LdaTrue
         0x1e62fd298105 @   23 : be                Star6
  127 S> 0x1e62fd298106 @   24 : 5d f6 f5 06       CallProperty0 r4, r5, [6]
         0x1e62fd29810a @   28 : ba                Star10
         0x1e62fd29810b @   29 : 9f 07             JumpIfJSReceiver [7] (0x1e62fd298112 @ 36)
         0x1e62fd29810d @   31 : 65 c6 00 f0 01    CallRuntime [ThrowIteratorResultNotAnObject], r10-r10
         0x1e62fd298112 @   36 : 2d f0 02 08       GetNamedProperty r10, [2], [8]
         0x1e62fd298116 @   40 : 96 1e             JumpIfToBooleanTrue [30] (0x1e62fd298134 @ 70)
         0x1e62fd298118 @   42 : 2d f0 03 0a       GetNamedProperty r10, [3], [10]
         0x1e62fd29811c @   46 : ba                Star10
         0x1e62fd29811d @   47 : 12                LdaFalse
         0x1e62fd29811e @   48 : be                Star6
         0x1e62fd29811f @   49 : 19 f0 f9          Mov r10, r1
  127 S> 0x1e62fd298122 @   52 : 19 f9 f7          Mov r1, r3
  160 S> 0x1e62fd298125 @   55 : 2d f0 04 0c       GetNamedProperty r10, [4], [12]
         0x1e62fd298129 @   59 : 97 07             JumpIfToBooleanFalse [7] (0x1e62fd298130 @ 66)
  188 S> 0x1e62fd29812b @   61 : 0b fa             Ldar r0
         0x1e62fd29812d @   63 : 50 0e             Inc [14]
         0x1e62fd29812f @   65 : c4                Star0
  116 E> 0x1e62fd298130 @   66 : 89 2c 00 0f       JumpLoop [44], [0], [15] (0x1e62fd298104 @ 22)
         0x1e62fd298134 @   70 : 0d ff             LdaSmi [-1]
         0x1e62fd298136 @   72 : bc                Star8
         0x1e62fd298137 @   73 : bd                Star7
         0x1e62fd298138 @   74 : 8a 05             Jump [5] (0x1e62fd29813d @ 79)
         0x1e62fd29813a @   76 : bc                Star8
         0x1e62fd29813b @   77 : 0c                LdaZero
         0x1e62fd29813c @   78 : bd                Star7
         0x1e62fd29813d @   79 : 10                LdaTheHole
         0x1e62fd29813e @   80 : a6                SetPendingMessage
         0x1e62fd29813f @   81 : bb                Star9
         0x1e62fd298140 @   82 : 0b f4             Ldar r6
         0x1e62fd298142 @   84 : 96 23             JumpIfToBooleanTrue [35] (0x1e62fd298165 @ 119)
         0x1e62fd298144 @   86 : 19 ff f0          Mov <context>, r10
         0x1e62fd298147 @   89 : 2d f5 05 10       GetNamedProperty r5, [5], [16]
         0x1e62fd29814b @   93 : 9e 1a             JumpIfUndefinedOrNull [26] (0x1e62fd298165 @ 119)
         0x1e62fd29814d @   95 : b9                Star11
         0x1e62fd29814e @   96 : 5d ef f5 12       CallProperty0 r11, r5, [18]
         0x1e62fd298152 @  100 : 9f 13             JumpIfJSReceiver [19] (0x1e62fd298165 @ 119)
         0x1e62fd298154 @  102 : b8                Star12
         0x1e62fd298155 @  103 : 65 c6 00 ee 01    CallRuntime [ThrowIteratorResultNotAnObject], r12-r12
         0x1e62fd29815a @  108 : 8a 0b             Jump [11] (0x1e62fd298165 @ 119)
         0x1e62fd29815c @  110 : ba                Star10
         0x1e62fd29815d @  111 : 0c                LdaZero
         0x1e62fd29815e @  112 : 1c f3             TestReferenceEqual r7
         0x1e62fd298160 @  114 : 98 05             JumpIfTrue [5] (0x1e62fd298165 @ 119)
         0x1e62fd298162 @  116 : 0b f0             Ldar r10
         0x1e62fd298164 @  118 : a8                ReThrow
         0x1e62fd298165 @  119 : 0b f1             Ldar r9
         0x1e62fd298167 @  121 : a6                SetPendingMessage
         0x1e62fd298168 @  122 : 0c                LdaZero
         0x1e62fd298169 @  123 : 1c f3             TestReferenceEqual r7
         0x1e62fd29816b @  125 : 99 05             JumpIfFalse [5] (0x1e62fd298170 @ 130)
         0x1e62fd29816d @  127 : 0b f2             Ldar r8
         0x1e62fd29816f @  129 : a8                ReThrow
  209 S> 0x1e62fd298170 @  130 : 0b fa             Ldar r0
  222 S> 0x1e62fd298172 @  132 : a9                Return
  
  
New realization byte code:

 308 S> 0xe4131418106 @    0 : 17 02             LdaImmutableCurrentContextSlot [2]
         0xe4131418108 @    2 : aa 00             ThrowReferenceErrorIfHole [0]
         0xe413141810a @    4 : c3                Star1
  327 E> 0xe413141810b @    5 : 2d f9 01 00       GetNamedProperty r1, [1], [0]
         0xe413141810f @    9 : c4                Star0
         0xe4131418110 @   10 : 80 02 00 02       CreateClosure [2], [0], #2
         0xe4131418114 @   14 : c2                Star2
  327 E> 0xe4131418115 @   15 : 5e fa f9 f8 02    CallProperty1 r0, r1, r2, [2]
         0xe413141811a @   20 : c4                Star0
  375 E> 0xe413141811b @   21 : 2d fa 03 04       GetNamedProperty r0, [3], [4]
  383 S> 0xe413141811f @   25 : a9                Return
  
  
  Very optimization + clear code  


## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
