### PR TITLE
feat: add GamepadEventHandler type 

### DIFF
--- a/.changeset/late-crabs-lay.md
+++ b/.changeset/late-crabs-lay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add GamepadEventHandler type for window.addEventListener `gamepadconnected` and `gamepaddisconnected`

--- a/.changeset/late-crabs-lay.md
+++ b/.changeset/late-crabs-lay.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-feat: add GamepadEventHandler type for window.addEventListener `gamepadconnected` and `gamepaddisconnected`
+feat: add `gamepadconnected` and `gamepaddisconnected` events

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -53,6 +53,7 @@ export type KeyboardEventHandler<T extends EventTarget> = EventHandler<KeyboardE
 export type MouseEventHandler<T extends EventTarget> = EventHandler<MouseEvent, T>;
 export type TouchEventHandler<T extends EventTarget> = EventHandler<TouchEvent, T>;
 export type PointerEventHandler<T extends EventTarget> = EventHandler<PointerEvent, T>;
+export type GamepadEventHandler<T extends EventTarget> = EventHandler<GamepadEvent, T>;
 export type UIEventHandler<T extends EventTarget> = EventHandler<UIEvent, T>;
 export type WheelEventHandler<T extends EventTarget> = EventHandler<WheelEvent, T>;
 export type AnimationEventHandler<T extends EventTarget> = EventHandler<AnimationEvent, T>;
@@ -335,6 +336,12 @@ export interface DOMAttributes<T extends EventTarget> {
 	'on:lostpointercapture'?: PointerEventHandler<T> | undefined | null;
 	onlostpointercapture?: PointerEventHandler<T> | undefined | null;
 	onlostpointercapturecapture?: PointerEventHandler<T> | undefined | null;
+
+	// Gamepad Events
+	'on:gamepadconnected'?: GamepadEventHandler<T> | undefined | null;
+	ongamepadconnected?: GamepadEventHandler<T> | undefined | null;
+	'on:gamepaddisconnected'?: GamepadEventHandler<T> | undefined | null;
+	ongamepaddisconnected?: GamepadEventHandler<T> | undefined | null;
 
 	// UI Events
 	'on:scroll'?: UIEventHandler<T> | undefined | null;


### PR DESCRIPTION
Add GamepadEventHandler type for window.addEventListener `gamepadconnected` and `gamepaddisconnected`

Ref: https://developer.mozilla.org/en-US/docs/Web/API/GamepadEvent

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
