### PR TITLE
feat: add GamepadEventHandler type

### DIFF
--- a/.changeset/fair-eagles-wink.md
+++ b/.changeset/fair-eagles-wink.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add `gamepadconnected` and `gamepaddisconnected` events

--- a/.changeset/fair-eagles-wink.md
+++ b/.changeset/fair-eagles-wink.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-feat: add `gamepadconnected` and `gamepaddisconnected` events
+fix: add `gamepadconnected` and `gamepaddisconnected` events

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -53,6 +53,7 @@ export type KeyboardEventHandler<T extends EventTarget> = EventHandler<KeyboardE
 export type MouseEventHandler<T extends EventTarget> = EventHandler<MouseEvent, T>;
 export type TouchEventHandler<T extends EventTarget> = EventHandler<TouchEvent, T>;
 export type PointerEventHandler<T extends EventTarget> = EventHandler<PointerEvent, T>;
+export type GamepadEventHandler<T extends EventTarget> = EventHandler<GamepadEvent, T>;
 export type UIEventHandler<T extends EventTarget> = EventHandler<UIEvent, T>;
 export type WheelEventHandler<T extends EventTarget> = EventHandler<WheelEvent, T>;
 export type AnimationEventHandler<T extends EventTarget> = EventHandler<AnimationEvent, T>;
@@ -169,6 +170,10 @@ export interface DOMAttributes<T extends EventTarget> {
 	'on:pointerover'?: PointerEventHandler<T> | undefined | null;
 	'on:pointerup'?: PointerEventHandler<T> | undefined | null;
 	'on:lostpointercapture'?: PointerEventHandler<T> | undefined | null;
+
+	// Gamepad Events
+	'on:gamepadconnected'?: GamepadEventHandler<T> | undefined | null;
+	'on:gamepaddisconnected'?: GamepadEventHandler<T> | undefined | null;
 
 	// UI Events
 	'on:scroll'?: UIEventHandler<T> | undefined | null;
@@ -1454,7 +1459,7 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	z?: number | string | undefined | null;
 	zoomAndPan?: string | undefined | null;
 
- 	// allow any data- attribute
+	// allow any data- attribute
 	[key: `data-${string}`]: any;
 }
 


### PR DESCRIPTION
Add GamepadEventHandler type for window.addEventListener `gamepadconnected` and `gamepaddisconnected`

Ref: https://developer.mozilla.org/en-US/docs/Web/API/GamepadEvent

Same with https://github.com/sveltejs/svelte/pull/9861 but merge to Svelte 4

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
