### PR TITLE
feat: add support for {@const} inside snippet block

### DIFF
--- a/.changeset/chatty-cups-drop.md
+++ b/.changeset/chatty-cups-drop.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add support for `{@const}` inside snippet block

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -333,7 +333,7 @@ const compiler_options = {
 /** @satisfies {Errors} */
 const const_tag = {
 	'invalid-const-placement': () =>
-		`{@const} must be the immediate child of {#if}, {:else if}, {:else}, {#each}, {:then}, {:catch}, <svelte:fragment> or <Component>`
+		`{@const} must be the immediate child of {#snippet}, {#if}, {:else if}, {:else}, {#each}, {:then}, {:catch}, <svelte:fragment> or <Component>`
 };
 
 /** @satisfies {Errors} */

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -476,6 +476,7 @@ export const validation = {
 				grand_parent?.type !== 'SvelteComponent' &&
 				grand_parent?.type !== 'EachBlock' &&
 				grand_parent?.type !== 'AwaitBlock' &&
+				grand_parent?.type !== 'SnippetBlock' &&
 				((grand_parent?.type !== 'RegularElement' && grand_parent?.type !== 'SvelteElement') ||
 					!grand_parent.attributes.some((a) => a.type === 'Attribute' && a.name === 'slot')))
 		) {

--- a/packages/svelte/tests/runtime-runes/samples/snippet-const/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-const/_config.js
@@ -1,0 +1,16 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<button>0</button>`,
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+
+		assert.htmlEqual(target.innerHTML, '<button>0</button>');
+
+		await btn?.click();
+		assert.htmlEqual(target.innerHTML, '<button>2</button>');
+
+		await btn?.click();
+		assert.htmlEqual(target.innerHTML, '<button>4</button>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-const/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-const/main.svelte
@@ -1,0 +1,10 @@
+<script>
+  let count = $state(0);
+</script>
+
+{#snippet counter()}
+  {@const doubled = count * 2}
+  <button on:click={() => (count += 1)}>{doubled}</button>
+{/snippet}
+
+{@render counter()}

--- a/packages/svelte/tests/validator/samples/const-tag-placement-1/errors.json
+++ b/packages/svelte/tests/validator/samples/const-tag-placement-1/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "invalid-const-placement",
-		"message": "{@const} must be the immediate child of {#if}, {:else if}, {:else}, {#each}, {:then}, {:catch}, <svelte:fragment> or <Component>",
+		"message": "{@const} must be the immediate child of {#snippet}, {#if}, {:else if}, {:else}, {#each}, {:then}, {:catch}, <svelte:fragment> or <Component>",
 		"start": { "line": 5, "column": 0 },
 		"end": { "line": 5, "column": 18 }
 	}

--- a/packages/svelte/tests/validator/samples/const-tag-placement-2/errors.json
+++ b/packages/svelte/tests/validator/samples/const-tag-placement-2/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "invalid-const-placement",
-		"message": "{@const} must be the immediate child of {#if}, {:else if}, {:else}, {#each}, {:then}, {:catch}, <svelte:fragment> or <Component>",
+		"message": "{@const} must be the immediate child of {#snippet}, {#if}, {:else if}, {:else}, {#each}, {:then}, {:catch}, <svelte:fragment> or <Component>",
 		"start": { "line": 7, "column": 4 },
 		"end": { "line": 7, "column": 18 }
 	}


### PR DESCRIPTION
## Svelte 5 rewrite
Fixes #9897 

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
