### PR TITLE
chore: skip generating $.proxy() calls for more expressions

### DIFF
--- a/.changeset/pretty-ties-help.md
+++ b/.changeset/pretty-ties-help.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Skip generating $.proxy() calls for unary and binary expressions

--- a/.changeset/pretty-ties-help.md
+++ b/.changeset/pretty-ties-help.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Skip generating $.proxy() calls for unary and binary expressions
+fix: skip generating $.proxy() calls for unary and binary expressions

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -498,6 +498,8 @@ export function should_proxy(node) {
 		node.type === 'Literal' ||
 		node.type === 'ArrowFunctionExpression' ||
 		node.type === 'FunctionExpression' ||
+		node.type === 'UnaryExpression' ||
+		node.type === 'BinaryExpression' ||
 		(node.type === 'Identifier' && node.name === 'undefined')
 	) {
 		return false;

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -9,16 +9,18 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 	let count = $.source(0);
 
 	function onmouseup() {
-		$.set(count, $.proxy($.get(count) + 2));
+		$.set(count, $.get(count) + 2);
 	}
 
+	const plusOne = (num) => num + 1;
 	/* Init */
 	var fragment = $.comment($$anchor);
 	var node = $.child_frag(fragment);
 
 	Button(node, {
-		onmousedown: () => $.set(count, $.proxy($.get(count) + 1)),
+		onmousedown: () => $.set(count, $.get(count) + 1),
 		onmouseup,
+		onmouseenter: () => $.set(count, $.proxy(plusOne($.get(count)))),
 		children: ($$anchor, $$slotProps) => {
 			/* Init */
 			var node_1 = $.space($$anchor);

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/server/index.svelte.js
@@ -11,6 +11,7 @@ export default function Function_prop_no_getter($$payload, $$props) {
 		count += 2;
 	}
 
+	const plusOne = (num) => num + 1;
 	const anchor = $.create_anchor($$payload);
 
 	$$payload.out += `${anchor}`;
@@ -18,6 +19,7 @@ export default function Function_prop_no_getter($$payload, $$props) {
 	Button($$payload, {
 		onmousedown: () => count += 1,
 		onmouseup,
+		onmouseenter: () => count = plusOne(count),
 		children: ($$payload, $$slotProps) => {
 			$$payload.out += `clicks: ${$.escape(count)}`;
 		}

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/index.svelte
@@ -4,8 +4,10 @@
 	function onmouseup() {
 		count += 2;
 	}
+
+	const plusOne = (num) => num + 1;
 </script>
 
-<Button onmousedown={() => count += 1} {onmouseup}>
+<Button onmousedown={() => count += 1} {onmouseup} onmouseenter={() => count = plusOne(count)}>
 	clicks: {count}
 </Button>


### PR DESCRIPTION
Resolves https://github.com/sveltejs/svelte/issues/9966.

This PR adds unary and binary expressions to the list of cases where expressions being assigned to state don't get wrapped in `$.proxy()` in the generated output.

Unary and binary expressions (e.g. `+x`, `!x`, `x + y`, `x in y`) can never produce object values, so it doesn't make sense to wrap them in `$.proxy()`.