### PR TITLE
fix: issue with assiging prop values as defaults of other props

### DIFF
--- a/.changeset/itchy-kings-deliver.md
+++ b/.changeset/itchy-kings-deliver.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Fix issue with assigning prop values as defaults of other props

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -179,7 +179,9 @@ export const javascript_visitors_runes = {
 							id = property.value.left;
 							initial = property.value.right;
 						}
-						initial = initial ? /** @type {import('estree').Expression} */ (visit(initial)) : undefined;
+						initial = initial
+							? /** @type {import('estree').Expression} */ (visit(initial))
+							: undefined;
 
 						assert.equal(id.type, 'Identifier');
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -179,6 +179,7 @@ export const javascript_visitors_runes = {
 							id = property.value.left;
 							initial = property.value.right;
 						}
+						initial = initial ? /** @type {import('estree').Expression} */ (visit(initial)) : undefined;
 
 						assert.equal(id.type, 'Identifier');
 

--- a/packages/svelte/tests/runtime-runes/samples/assign-prop-to-prop/Test.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/assign-prop-to-prop/Test.svelte
@@ -1,0 +1,9 @@
+<script>
+	let z = 8;
+	let { a, b = a, c = b * b, d = z * b + c } = $props();
+</script>
+
+<p>{a}</p>
+<p>{b}</p>
+<p>{c}</p>
+<p>{d}</p>

--- a/packages/svelte/tests/runtime-runes/samples/assign-prop-to-prop/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/assign-prop-to-prop/_config.js
@@ -1,0 +1,6 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<p>5</p><p>5</p><p>25</p><p>65</p>`,
+});
+

--- a/packages/svelte/tests/runtime-runes/samples/assign-prop-to-prop/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/assign-prop-to-prop/_config.js
@@ -1,6 +1,5 @@
 import { test } from '../../test';
 
 export default test({
-	html: `<p>5</p><p>5</p><p>25</p><p>65</p>`,
+	html: `<p>5</p><p>5</p><p>25</p><p>65</p>`
 });
-

--- a/packages/svelte/tests/runtime-runes/samples/assign-prop-to-prop/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/assign-prop-to-prop/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Test from './Test.svelte'
+</script>
+
+<Test a={5} />


### PR DESCRIPTION
Fixes #9302

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
