### PR TITLE
[WIP: FEAT]: Going 100% JavaScript for Modern Groove Dealers Approvals

### DIFF
--- a/packages/svelte/jsconfig.json
+++ b/packages/svelte/jsconfig.json
@@ -12,7 +12,6 @@
 		"verbatimModuleSyntax": true,
 		"types": ["node"],
 		"strict": true,
-		"allowJs": true,
 		"checkJs": true,
 		"paths": {
 			"acorn-typescript": ["./src/compiler/phases/1-parse/ambient.d.ts"],

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -92,8 +92,8 @@
   "scripts": {
     "build": "rollup -c && node scripts/build.js && node scripts/check-treeshakeability.js",
     "dev": "rollup -cw",
-    "check": "tsc && cd ./tests/types && tsc",
-    "check:watch": "tsc --watch",
+    "check": "eslint --ext .ts --resolve-plugins-relative-to .",
+    "check:watch": "nodemon --watch src --ext ts --exec 'npm run check'",
     "generate:version": "node ./scripts/generate-version.js",
     "prepublishOnly": "pnpm build"
   },
@@ -106,8 +106,12 @@
     "@rollup/plugin-virtual": "^3.0.2",
     "@types/aria-query": "^5.0.3",
     "@types/estree": "^1.0.5",
+    "@typescript-eslint/eslint-plugin": "^6.15.0",
+    "@typescript-eslint/parser": "^6.15.0",
     "dts-buddy": "^0.4.0",
     "esbuild": "^0.19.2",
+    "eslint": "^8.56.0",
+    "nodemon": "^3.0.2",
     "rollup": "^4.1.5",
     "source-map": "^0.7.4",
     "tiny-glob": "^0.2.9"


### PR DESCRIPTION
## Svelte 5 rewrite

Hey there maintainers! I've got a little something to chat about regarding the whole TypeScript vs. JavaScript debate. Even though [Lord Rich mentioned he's not actively using TypeScript](https://www.youtube.com/watch?v=zPOHY-cZ1wE), it turns out the TypeScript compiler (`tsc`) is still hanging around in this project.

So, I had this idea: what if we ditched `tsc` altogether and did a little file renaming? I propose changing `tsconfig.json` to `jsconfig.json` to create a pure JavaScript setup.

Note that this pull request is a work in progress. The ultimate plan is to eventually transform all those TypeScript files into JavaScript ones with some JSDoc annotations for that extra flair. Let me know what you think!

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
