### PR TITLE
fix: add types for popover attributes and events

### DIFF
--- a/.changeset/orange-dingos-poke.md
+++ b/.changeset/orange-dingos-poke.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: add `popover`, `popovertarget` and `popovertargetaction` attribute types
+fix: add types for popover attributes and events 

--- a/.changeset/orange-dingos-poke.md
+++ b/.changeset/orange-dingos-poke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add `popover`, `popovertarget` and `popovertargetaction` attribute types

--- a/.changeset/orange-dingos-poke.md
+++ b/.changeset/orange-dingos-poke.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-feat: add `popover`, `popovertarget` and `popovertargetaction` attribute types
+fix: add `popover`, `popovertarget` and `popovertargetaction` attribute types

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -727,6 +727,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	title?: string | undefined | null;
 	translate?: 'yes' | 'no' | '' | undefined | null;
 	inert?: boolean | undefined | null;
+	popover?: 'auto' | 'manual' | '' | undefined | null;
 
 	// Unknown
 	radiogroup?: string | undefined | null; // <command>, <menuitem>
@@ -873,6 +874,8 @@ export interface HTMLButtonAttributes extends HTMLAttributes<HTMLButtonElement> 
 	name?: string | undefined | null;
 	type?: 'submit' | 'reset' | 'button' | undefined | null;
 	value?: string | string[] | number | undefined | null;
+	popovertarget?: string | undefined | null;
+	popovertargetaction?: 'toggle' | 'show' | 'hide' | undefined | null;
 }
 
 export interface HTMLCanvasAttributes extends HTMLAttributes<HTMLCanvasElement> {

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -139,8 +139,8 @@ export interface DOMAttributes<T extends EventTarget> {
 
 	// Popover Events
 	'on:beforetoggle'?: ToggleEventHandler<T> | undefined | null;
-	beforetoggle?: ToggleEventHandler<T> | undefined | null;
-	beforetogglecapture?: ToggleEventHandler<T> | undefined | null;
+	onbeforetoggle?: ToggleEventHandler<T> | undefined | null;
+	onbeforetogglecapture?: ToggleEventHandler<T> | undefined | null;
 	'on:toggle'?: ToggleEventHandler<T> | undefined | null;
 	ontoggle?: ToggleEventHandler<T> | undefined | null;
 	ontogglecapture?: ToggleEventHandler<T> | undefined | null;
@@ -905,9 +905,9 @@ export interface HTMLDetailsAttributes extends HTMLAttributes<HTMLDetailsElement
 
 	'bind:open'?: boolean | undefined | null;
 
-	'on:toggle'?: EventHandler<Event, T> | undefined | null;
-	ontoggle?: EventHandler<Event, T> | undefined | null;
-	ontogglecapture?: EventHandler<Event, T> | undefined | null;
+	'on:toggle'?: EventHandler<Event, HTMLDetailsElement> | undefined | null;
+	ontoggle?: EventHandler<Event, HTMLDetailsElement> | undefined | null;
+	ontogglecapture?: EventHandler<Event, HTMLDetailsElement> | undefined | null;
 }
 
 export interface HTMLDelAttributes extends HTMLAttributes<HTMLModElement> {

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -145,11 +145,6 @@ export interface DOMAttributes<T extends EventTarget> {
 	ontoggle?: ToggleEventHandler<T> | undefined | null;
 	ontogglecapture?: ToggleEventHandler<T> | undefined | null;
 
-	// Detail Events
-	'on:toggle'?: EventHandler<Event, T> | undefined | null;
-	ontoggle?: EventHandler<Event, T> | undefined | null;
-	ontogglecapture?: EventHandler<Event, T> | undefined | null;
-
 	// Keyboard Events
 	'on:keydown'?: KeyboardEventHandler<T> | undefined | null;
 	onkeydown?: KeyboardEventHandler<T> | undefined | null;
@@ -909,6 +904,10 @@ export interface HTMLDetailsAttributes extends HTMLAttributes<HTMLDetailsElement
 	open?: boolean | undefined | null;
 
 	'bind:open'?: boolean | undefined | null;
+
+	'on:toggle'?: EventHandler<Event, T> | undefined | null;
+	ontoggle?: EventHandler<Event, T> | undefined | null;
+	ontogglecapture?: EventHandler<Event, T> | undefined | null;
 }
 
 export interface HTMLDelAttributes extends HTMLAttributes<HTMLModElement> {

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -59,6 +59,7 @@ export type WheelEventHandler<T extends EventTarget> = EventHandler<WheelEvent, 
 export type AnimationEventHandler<T extends EventTarget> = EventHandler<AnimationEvent, T>;
 export type TransitionEventHandler<T extends EventTarget> = EventHandler<TransitionEvent, T>;
 export type MessageEventHandler<T extends EventTarget> = EventHandler<MessageEvent, T>;
+export type ToggleEventHandler<T extends EventTarget> = EventHandler<ToggleEvent, T>;
 
 //
 // DOM Attributes
@@ -135,6 +136,14 @@ export interface DOMAttributes<T extends EventTarget> {
 	'on:error'?: EventHandler | undefined | null; // also a Media Event
 	onerror?: EventHandler | undefined | null; // also a Media Event
 	onerrorcapture?: EventHandler | undefined | null; // also a Media Event
+
+	// Popover Events
+	'on:beforetoggle'?: ToggleEventHandler<T> | undefined | null;
+	beforetoggle?: ToggleEventHandler<T> | undefined | null;
+	beforetogglecapture?: ToggleEventHandler<T> | undefined | null;
+	'on:toggle'?: ToggleEventHandler<T> | undefined | null;
+	ontoggle?: ToggleEventHandler<T> | undefined | null;
+	ontogglecapture?: ToggleEventHandler<T> | undefined | null;
 
 	// Detail Events
 	'on:toggle'?: EventHandler<Event, T> | undefined | null;


### PR DESCRIPTION
closes #10036, this also moves the HTMLDetailsElement `toggle` event to its interface as it was conflicting with HTMLElement popover `toggle` event.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
