### PR TITLE
fix: ensure if block is executed in correct order

### DIFF
--- a/.changeset/unlucky-trees-lick.md
+++ b/.changeset/unlucky-trees-lick.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure if block is executed in correct order

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -350,9 +350,16 @@ function execute_signal_fn(signal) {
 		if (current_dependencies !== null) {
 			let i;
 			if (dependencies !== null) {
-				for (i = current_dependencies_index; i < dependencies.length; i++) {
+				const dep_length = dependencies.length;
+				// If we have more than 16 elements in the array then use a Set for faster performance
+				// TODO: evaluate if we should always just use a Set or not here?
+				const current_dependencies_set = dep_length > 16 ? new Set(current_dependencies) : null;
+				for (i = current_dependencies_index; i < dep_length; i++) {
 					const dependency = dependencies[i];
-					if (!current_dependencies.includes(dependency)) {
+					if (
+						(current_dependencies_set !== null && !current_dependencies_set.has(dependency)) ||
+						!current_dependencies.includes(dependency)
+					) {
 						remove_consumer(signal, dependency, false);
 					}
 				}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -843,7 +843,7 @@ export function get(signal) {
 			current_dependencies_index++;
 		} else if (current_dependencies === null) {
 			current_dependencies = [signal];
-		} else if (signal !== current_dependencies[current_dependencies.length - 1]) {
+		} else {
 			current_dependencies.push(signal);
 		}
 		if (

--- a/packages/svelte/tests/runtime-runes/samples/block-dependency-sequence/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/block-dependency-sequence/Component.svelte
@@ -1,0 +1,9 @@
+<script>
+	const { item } = $props();
+</script>
+
+<div>
+	{#if item}
+		{item.length}
+	{/if}
+</div>

--- a/packages/svelte/tests/runtime-runes/samples/block-dependency-sequence/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/block-dependency-sequence/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, component }) {
+		const [b1, b2] = target.querySelectorAll('button');
+		assert.htmlEqual(target.innerHTML, '<div>5</div><div>5</div><div>3</div><button>set null</button><button>set object</button');
+		flushSync(() => {
+			b2.click();
+		});
+		assert.htmlEqual(target.innerHTML, '<div>5</div><div>5</div><div>3</div><button>set null</button><button>set object</button');
+		flushSync(() => {
+			b1.click();
+		});
+		assert.htmlEqual(target.innerHTML, '<div>5</div><div></div><div>3</div><button>set null</button><button>set object</button');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/block-dependency-sequence/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/block-dependency-sequence/_config.js
@@ -4,14 +4,23 @@ import { test } from '../../test';
 export default test({
 	async test({ assert, target, component }) {
 		const [b1, b2] = target.querySelectorAll('button');
-		assert.htmlEqual(target.innerHTML, '<div>5</div><div>5</div><div>3</div><button>set null</button><button>set object</button');
+		assert.htmlEqual(
+			target.innerHTML,
+			'<div>5</div><div>5</div><div>3</div><button>set null</button><button>set object</button'
+		);
 		flushSync(() => {
 			b2.click();
 		});
-		assert.htmlEqual(target.innerHTML, '<div>5</div><div>5</div><div>3</div><button>set null</button><button>set object</button');
+		assert.htmlEqual(
+			target.innerHTML,
+			'<div>5</div><div>5</div><div>3</div><button>set null</button><button>set object</button'
+		);
 		flushSync(() => {
 			b1.click();
 		});
-		assert.htmlEqual(target.innerHTML, '<div>5</div><div></div><div>3</div><button>set null</button><button>set object</button');
+		assert.htmlEqual(
+			target.innerHTML,
+			'<div>5</div><div></div><div>3</div><button>set null</button><button>set object</button'
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/block-dependency-sequence/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/block-dependency-sequence/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	import Component from './Component.svelte';
+
+	let items = $state(['hello', 'world', 'bye']);
+</script>
+
+{#each items as item}
+	<Component {item} />
+{/each}
+
+<button onclick={() => (items[1] = null)}> set null </button>
+<button onclick={() => (items[1] = 'hello')}> set object </button>


### PR DESCRIPTION
Turns out that we had an index signal dependency index mishap that resulted in consumers being removed when they didn't need to. Fixes https://github.com/sveltejs/svelte/issues/10020.