### PR TITLE
fix: deeply unstate objects passed to inspect

### DIFF
--- a/.changeset/curvy-ties-shout.md
+++ b/.changeset/curvy-ties-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: deeply unstate objects passed to inspect

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -108,6 +108,8 @@ export type ComputationSignal<V = unknown> = {
 
 export type Signal<V = unknown> = SourceSignal<V> | ComputationSignal<V>;
 
+export type SignalDebug<V = unknown> = SourceSignalDebug & Signal<V>;
+
 export type EffectSignal = ComputationSignal<null | (() => void)>;
 
 export type MaybeSignal<T = unknown> = T | Signal<T>;

--- a/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/_config.js
@@ -1,0 +1,40 @@
+import { test } from '../../test';
+
+/**
+ * @type {any[]}
+ */
+let log;
+/**
+ * @type {typeof console.log}}
+ */
+let original_log;
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+	before_test() {
+		log = [];
+		original_log = console.log;
+		console.log = (...v) => {
+			log.push(...v);
+		};
+	},
+	after_test() {
+		console.log = original_log;
+	},
+	async test({ assert, target }) {
+		const [b1] = target.querySelectorAll('button');
+		b1.click();
+		await Promise.resolve();
+
+		assert.deepEqual(log, [
+			'init',
+			{ x: { count: 0 } },
+			[{ count: 0 }],
+			'update',
+			{ x: { count: 1 } },
+			[{ count: 1 }]
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let x = $state({count: 0});
+
+	$inspect({x}, [x]);
+</script>
+
+<button on:click={() => x.count++}>{x.count}</button>


### PR DESCRIPTION
When doing `$inspect({ x, y })`, both `x` and `y` are now unstated if they are signals, compared to before where `unstate` was only called on the top level object, leaving the proxies in place which results in a worse debugging experience. Also improved typings which makes it easier to find related code paths.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
