### PR TITLE
fix: catch delegated events from elements moved outside the container

### DIFF
--- a/.changeset/dirty-bats-punch.md
+++ b/.changeset/dirty-bats-punch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: handle delegated events of elements moved outside the container

--- a/packages/svelte/tests/runtime-runes/samples/event-listener-moved-outside-container/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-listener-moved-outside-container/_config.js
@@ -1,0 +1,23 @@
+import { test } from '../../test';
+
+// Tests that event delegation still works when the element with the event listener is moved outside the container
+export default test({
+	async test({ assert, target }) {
+		const btn1 = target.parentElement?.querySelector('button');
+		const btn2 = target.querySelector('button');
+
+		btn1?.click();
+		await Promise.resolve();
+		assert.htmlEqual(
+			target.parentElement?.innerHTML ?? '',
+			'<main><div><button>clicks: 1</button></div></main><button>clicks: 1</button>'
+		);
+
+		btn2?.click();
+		await Promise.resolve();
+		assert.htmlEqual(
+			target.parentElement?.innerHTML ?? '',
+			'<main><div><button>clicks: 2</button></div></main><button>clicks: 2</button>'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-listener-moved-outside-container/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-listener-moved-outside-container/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let count = $state(0);
+	let el;
+	$effect(() => {
+		document.getElementsByTagName('body')[0].appendChild(el);
+	})
+</script>
+
+<div>
+	<button bind:this={el} onclick={() => count++}>clicks: {count}</button>
+	<button onclick={() => count++}>clicks: {count}</button>
+</div>


### PR DESCRIPTION
fixes #9777

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
