### PR TITLE
feat: allow modifiying derived props

### DIFF
--- a/.changeset/hungry-trees-travel.md
+++ b/.changeset/hungry-trees-travel.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: allow modifiying derived props

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -854,19 +854,19 @@ function validate_assignment(node, argument, state) {
 
 	let left = /** @type {import('estree').Expression | import('estree').Super} */ (argument);
 
+	if (left.type === 'Identifier') {
+		const binding = state.scope.get(left.name);
+		if (binding?.kind === 'derived') {
+			error(node, 'invalid-derived-assignment');
+		}
+	}
+
 	/** @type {import('estree').Expression | import('estree').PrivateIdentifier | null} */
 	let property = null;
 
 	while (left.type === 'MemberExpression') {
 		property = left.property;
 		left = left.object;
-	}
-
-	if (left.type === 'Identifier') {
-		const binding = state.scope.get(left.name);
-		if (binding?.kind === 'derived') {
-			error(node, 'invalid-derived-assignment');
-		}
 	}
 
 	if (left.type === 'ThisExpression' && property?.type === 'PrivateIdentifier') {

--- a/packages/svelte/tests/compiler-errors/samples/runes-no-derived-assignment/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/runes-no-derived-assignment/main.svelte
@@ -1,5 +1,5 @@
 <script>
 	const a = $state(0);
-	const b = $derived({ a });
-	b.a += 1;
+	let b = $derived(a);
+	b = 1;
 </script>

--- a/packages/svelte/tests/compiler-errors/samples/runes-no-derived-update/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/runes-no-derived-update/main.svelte
@@ -1,5 +1,5 @@
 <script>
 	const a = $state(0);
-	const b = $derived({ a });
-	b.a++;
+	let b = $derived(a);
+	b++;
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/derived-proxy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-proxy/_config.js
@@ -1,0 +1,15 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<button>0 / 0</button><button>0 / 0</button>`,
+
+	async test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+
+		await btn1?.click();
+		assert.htmlEqual(target.innerHTML, `<button>1 / 2</button><button>1 / 2</button>`);
+
+		await btn2?.click();
+		assert.htmlEqual(target.innerHTML, `<button>2 / 4</button><button>2 / 4</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-proxy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-proxy/main.svelte
@@ -1,0 +1,7 @@
+<script>
+  let count = $state(0);
+  let double = $derived({ get value() { return count * 2}, set value(c) { count = c / 2 } });
+</script>
+
+<button on:click={() => count++}>{count} / {double.value}</button>
+<button on:click={() => double.value += 2}>{count} / {double.value}</button>


### PR DESCRIPTION
Started this when looking into #9998 and thinking `$derived` is necessary - turns out it's not, but I thought I'd create this PR anyway and put it up for discussion whether or not this should be allowed.

Pros:
- You can write code that's valid using it, so it may be overzealous to disallow it
- You can hide the `$derived` behind a getter and then the validation wouldn't catch it anyway
- We do allow it for the `bind:x` case

Cons:
- May allow spaghetti code

Personally I lean towards relaxing this rule.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
