### PR TITLE
docs: clarify `on:event` usage

### DIFF
--- a/documentation/docs/02-template-syntax/06-component-directives.md
+++ b/documentation/docs/02-template-syntax/06-component-directives.md
@@ -28,14 +28,16 @@ Components can emit events using [`createEventDispatcher`](/docs/svelte#createev
 Listening for component events looks the same as listening for DOM events:
 
 ```svelte
-<SomeComponent on:whatever={handler} />
+<SomeComponent on:hello={helloHandler} on:click={clickHandler} />
 ```
 
 As with DOM events, if the `on:` directive is used without a value, the event will be forwarded, meaning that a consumer can listen for it.
 
 ```svelte
-<SomeComponent on:whatever />
+<SomeComponent on:hello on:click />
 ```
+
+> Components can only listen to events forwarded by their direct child components or elements.
 
 ## --style-props
 

--- a/documentation/docs/02-template-syntax/06-component-directives.md
+++ b/documentation/docs/02-template-syntax/06-component-directives.md
@@ -37,7 +37,7 @@ As with DOM events, if the `on:` directive is used without a value, the event wi
 <SomeComponent on:hello on:click />
 ```
 
-> Components can only listen to events forwarded by their direct child components or elements.
+> Components can only listen to events forwarded or emitted by their direct child components or elements.
 
 ## --style-props
 


### PR DESCRIPTION
Problem 1: The events emitted/forwarded were not listened for.
Fix 1: Changed event names to show consistency amongst examples

Problem 2: Why events need to be forwarded is unclear (on this page). `createEventDispatcher` docs does mention custom events dont bubble. But components also cannot listen to DOM events that do bubble. 
Fix 2: Clarified that components only listen to event from their direct children

Please close https://github.com/sveltejs/svelte/pull/10087 as I tried to merge svelte-4 into main (my bad)

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
