### PR TITLE
fix: allow boolean shorthand for the HTML `popover` property

### DIFF
--- a/.changeset/tough-fishes-peel.md
+++ b/.changeset/tough-fishes-peel.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: allow boolean shorthand for HTML `popover` property
+fix: allow boolean shorthand for the HTML `popover` property

--- a/.changeset/tough-fishes-peel.md
+++ b/.changeset/tough-fishes-peel.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow boolean shorthand for HTML `popover` property

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -731,7 +731,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	title?: string | undefined | null;
 	translate?: 'yes' | 'no' | '' | undefined | null;
 	inert?: boolean | undefined | null;
-	popover?: 'auto' | 'manual' | '' | undefined | null;
+	popover?: boolean | 'auto' | 'manual' | '' | undefined | null;
 
 	// Unknown
 	radiogroup?: string | undefined | null; // <command>, <menuitem>


### PR DESCRIPTION
I believe this fixes issue: https://github.com/sveltejs/svelte/issues/10094.

According to the MDN docs for the `popover` property (see [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)), doing `<div popover>Greetings, one and all!</div>` and `<div popover="auto">Greetings, one and all!</div>` should be equivalent. 

However, Svelte's type definitions only allow for the latter and throw a type error if the former syntax is used. This change just adds the `boolean` type onto the `popover` property allowing it to be used in both ways.

(this is my first time submitting a PR to the svelte project, so any feedback is appreciated.) 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
