### PR TITLE
fix: avoid duplicate arg names

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -430,7 +430,13 @@ export function serialize_hoistable_params(node, context) {
 	}
 
 	params.push(...hoistable_params);
-	return params;
+
+  const seen = new Set();
+  for (const param of params) {
+    seen.add(param.name);
+  }
+  const uniqueParams = params.filter(param => !seen.has(param.name));
+	return uniqueParams;
 }
 
 /**


### PR DESCRIPTION
Making sure that hoistable params have unique names, to avoid the duplicate argument name error. Fixes #9611.

I'm not sure if this fix is sufficient (worked fine for me), but it unblocked me and it's a start.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
