### PR TITLE
perf: save some bytes with more concise comparisons

### DIFF
--- a/packages/svelte/src/internal/client/each.js
+++ b/packages/svelte/src/internal/client/each.js
@@ -74,8 +74,8 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 			transition.f(() => {
 				transitions.delete(transition);
 				if (transitions.size === 0) {
-					if (fallback.e !== null) {
-						if (fallback.d !== null) {
+					if (fallback.e) {
+						if (fallback.d) {
 							remove(fallback.d);
 							fallback.d = null;
 						}
@@ -98,7 +98,7 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 		const effect = render_effect(
 			() => {
 				const dom = block.d;
-				if (dom !== null) {
+				if (dom) {
 					remove(dom);
 					block.d = null;
 				}
@@ -136,24 +136,24 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 				: maybe_array == null
 				? []
 				: Array.from(maybe_array);
-			if (key_fn !== null) {
+			if (key_fn) {
 				keys = array.map(key_fn);
 			} else if ((flags & EACH_KEYED) === 0) {
 				array.map(no_op);
 			}
 			const length = array.length;
-			if (fallback_fn !== null) {
+			if (fallback_fn) {
 				if (length === 0) {
-					if (block.v.length !== 0 || render === null) {
+					if (block.v.length !== 0 || !render) {
 						clear_each(block);
 						create_fallback_effect();
 						return;
 					}
-				} else if (block.v.length === 0 && current_fallback !== null) {
+				} else if (block.v.length === 0 && current_fallback) {
 					const fallback = current_fallback;
 					const transitions = fallback.s;
 					if (transitions.size === 0) {
-						if (fallback.d !== null) {
+						if (fallback.d) {
 							remove(fallback.d);
 							fallback.d = null;
 						}
@@ -162,7 +162,7 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 					}
 				}
 			}
-			if (render !== null) {
+			if (render) {
 				execute_effect(render);
 			}
 		},
@@ -177,13 +177,13 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 		const anchor_node = block.a;
 		const is_controlled = (flags & EACH_IS_CONTROLLED) !== 0;
 		let fallback = current_fallback;
-		while (fallback !== null) {
+		while (fallback) {
 			const dom = fallback.d;
-			if (dom !== null) {
+			if (dom) {
 				remove(dom);
 			}
 			const effect = fallback.e;
-			if (effect !== null) {
+			if (effect) {
 				destroy_signal(effect);
 			}
 			fallback = fallback.p;
@@ -280,7 +280,7 @@ function reconcile_indexed_array(
 	} else {
 		var item;
 		b_blocks = Array(b);
-		if (current_hydration_fragment !== null) {
+		if (current_hydration_fragment) {
 			/** @type {Node} */
 			var hydrating_node = current_hydration_fragment[0];
 			for (; index < length; index++) {
@@ -350,7 +350,7 @@ function reconcile_tracked_array(
 	keys
 ) {
 	var a_blocks = each_block.v;
-	const is_computed_key = keys !== null;
+	const is_computed_key = !!keys;
 	var active_transitions = each_block.s;
 
 	/** @type {number | void} */
@@ -384,7 +384,7 @@ function reconcile_tracked_array(
 		var item;
 		var idx;
 		b_blocks = Array(b);
-		if (current_hydration_fragment !== null) {
+		if (current_hydration_fragment) {
 			var fragment;
 
 			/** @type {Node} */
@@ -469,7 +469,7 @@ function reconcile_tracked_array(
 			} else if (start > b_end) {
 				b = start;
 				do {
-					if ((block = a_blocks[b++]) !== null) {
+					if ((block = a_blocks[b++])) {
 						destroy_each_item_block(block, active_transitions, apply_transitions);
 					}
 				} while (b <= a_end);
@@ -493,7 +493,7 @@ function reconcile_tracked_array(
 						pos = pos < a ? a : MOVED_BLOCK;
 						sources[a - start] = b;
 						b_blocks[a] = block;
-					} else if (block !== null) {
+					} else if (block) {
 						destroy_each_item_block(block, active_transitions, apply_transitions);
 					}
 				}
@@ -628,7 +628,7 @@ function mark_lis(a) {
 function insert_each_item_block(block, dom, is_controlled, sibling) {
 	var current = /** @type {import('./types.js').TemplateNode} */ (block.d);
 
-	if (sibling === null) {
+	if (!sibling) {
 		if (is_controlled) {
 			return insert(current, /** @type {Element} */ (dom), null);
 		} else {
@@ -668,7 +668,7 @@ function destroy_active_transition_blocks(active_transitions) {
 		for (; i < length; i++) {
 			block = active_transitions[i];
 			transition = block.r;
-			if (transition !== null) {
+			if (!transition) {
 				block.r = null;
 				destroy_each_item_block(block, null, false);
 			}
@@ -714,7 +714,7 @@ function update_each_item_block(block, item, index, type) {
 	const index_is_reactive = (type & EACH_INDEX_REACTIVE) !== 0;
 	// Handle each item animations
 	const each_animation = block.a;
-	if (transitions !== null && (type & EACH_KEYED) !== 0 && each_animation !== null) {
+	if (transitions && (type & EACH_KEYED) !== 0 && each_animation) {
 		each_animation(block, transitions, index, index_is_reactive);
 	}
 	if (index_is_reactive) {
@@ -739,7 +739,7 @@ export function destroy_each_item_block(
 ) {
 	const transitions = block.s;
 
-	if (apply_transitions && transitions !== null) {
+	if (apply_transitions && transitions) {
 		// We might have pending key transitions, if so remove them first
 		for (let other of transitions) {
 			if (other.r === 'key') {
@@ -750,14 +750,14 @@ export function destroy_each_item_block(
 			block.s = null;
 		} else {
 			trigger_transitions(transitions, 'out');
-			if (transition_block !== null) {
+			if (transition_block) {
 				transition_block.push(block);
 			}
 			return;
 		}
 	}
 	const dom = block.d;
-	if (!controlled && dom !== null) {
+	if (!controlled && dom) {
 		remove(dom);
 	}
 	destroy_signal(/** @type {import('./types.js').EffectSignal} */ (block.e));

--- a/packages/svelte/src/internal/client/each.js
+++ b/packages/svelte/src/internal/client/each.js
@@ -371,7 +371,7 @@ function reconcile_tracked_array(
 		if (is_controlled && a) {
 			clear_text_content(dom);
 		}
-		while (a > 0) {
+		while (a) {
 			block = a_blocks[--a];
 			destroy_each_item_block(block, active_transitions, apply_transitions, is_controlled);
 		}
@@ -387,7 +387,7 @@ function reconcile_tracked_array(
 
 			/** @type {Node} */
 			var hydrating_node = current_hydration_fragment[0];
-			while (b > 0) {
+			while (b) {
 				// Hydrate block
 				idx = b_end - --b;
 				item = array[idx];
@@ -406,7 +406,7 @@ function reconcile_tracked_array(
 			}
 		} else if (!a) {
 			// Create new blocks
-			while (b > 0) {
+			while (b) {
 				idx = b_end - --b;
 				item = array[idx];
 				key = is_computed_key ? keys[idx] : item;
@@ -502,7 +502,7 @@ function reconcile_tracked_array(
 				var should_create;
 				if (is_animated) {
 					var i = b_length;
-					while (i-- > 0) {
+					while (i--) {
 						b_end = i + start;
 						a = sources[i];
 						if (pos === MOVED_BLOCK) {
@@ -514,7 +514,7 @@ function reconcile_tracked_array(
 				}
 				var last_block;
 				var last_sibling;
-				while (b_length-- > 0) {
+				while (b_length--) {
 					b_end = b_length + start;
 					a = sources[b_length];
 					should_create = a === -1;
@@ -597,7 +597,7 @@ function mark_lis(a) {
 				}
 
 				if (k < a[index[lo]]) {
-					if (lo > 0) {
+					if (lo) {
 						parent[i] = index[lo - 1];
 					}
 					index[lo] = i;
@@ -657,7 +657,7 @@ function get_first_child(block) {
 function destroy_active_transition_blocks(active_transitions) {
 	var length = active_transitions.length;
 
-	if (length > 0) {
+	if (length) {
 		var i = 0;
 		var block;
 		var transition;

--- a/packages/svelte/src/internal/client/hydration.js
+++ b/packages/svelte/src/internal/client/hydration.js
@@ -27,7 +27,7 @@ export function get_hydration_fragment(node) {
 
 	/** @type {null | string} */
 	let target_depth = null;
-	while (current_node !== null) {
+	while (current_node) {
 		const node_type = current_node.nodeType;
 		const next_sibling = current_node.nextSibling;
 		if (node_type === 8) {
@@ -61,7 +61,7 @@ export function get_hydration_fragment(node) {
 export function hydrate_block_anchor(anchor_node, is_controlled) {
 	/** @type {Node} */
 	let target_node = anchor_node;
-	if (current_hydration_fragment !== null) {
+	if (current_hydration_fragment) {
 		if (is_controlled) {
 			target_node = /** @type {Node} */ (target_node.firstChild);
 		}
@@ -79,7 +79,7 @@ export function hydrate_block_anchor(anchor_node, is_controlled) {
 			set_current_hydration_fragment(fragment);
 		} else {
 			const first_child = /** @type {Element | null} */ (target_node.firstChild);
-			set_current_hydration_fragment(first_child === null ? [] : [first_child]);
+			set_current_hydration_fragment(!first_child ? [] : [first_child]);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/loop.js
+++ b/packages/svelte/src/internal/client/loop.js
@@ -13,7 +13,7 @@ function run_tasks(now) {
 			task.f();
 		}
 	});
-	if (tasks.size !== 0) raf.tick(run_tasks);
+	if (tasks.size) raf.tick(run_tasks);
 }
 
 /**
@@ -33,7 +33,7 @@ export function clear_loops() {
 export function loop(callback) {
 	/** @type {import('./private.js').TaskEntry} */
 	let task;
-	if (tasks.size === 0) raf.tick(run_tasks);
+	if (!tasks.size) raf.tick(run_tasks);
 	return {
 		promise: new Promise((fulfill) => {
 			tasks.add((task = { c: callback, f: fulfill }));

--- a/packages/svelte/src/internal/client/operations.js
+++ b/packages/svelte/src/internal/client/operations.js
@@ -166,9 +166,9 @@ export function clone_node(node, deep) {
 /*#__NO_SIDE_EFFECTS__*/
 export function child(node) {
 	const child = first_child_get.call(node);
-	if (current_hydration_fragment !== null) {
+	if (current_hydration_fragment) {
 		// Child can be null if we have an element with a single child, like `<p>{text}</p>`, where `text` is empty
-		if (child === null) {
+		if (!child) {
 			const text = document.createTextNode('');
 			node.appendChild(text);
 			return text;
@@ -186,9 +186,9 @@ export function child(node) {
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function child_frag(node) {
-	if (current_hydration_fragment !== null) {
+	if (current_hydration_fragment) {
 		const first_node = /** @type {Node[]} */ (node)[0];
-		if (current_hydration_fragment !== null && first_node !== null) {
+		if (current_hydration_fragment && first_node) {
 			return capture_fragment_from_node(first_node);
 		}
 		return first_node;
@@ -204,7 +204,7 @@ export function child_frag(node) {
 /*#__NO_SIDE_EFFECTS__*/
 export function sibling(node) {
 	const next_sibling = next_sibling_get.call(node);
-	if (current_hydration_fragment !== null && next_sibling !== null) {
+	if (current_hydration_fragment && next_sibling) {
 		return capture_fragment_from_node(next_sibling);
 	}
 	return next_sibling;

--- a/packages/svelte/src/internal/client/reconciler.js
+++ b/packages/svelte/src/internal/client/reconciler.js
@@ -21,18 +21,18 @@ export function insert(current, parent_element, sibling) {
 		var node;
 		for (; i < current.length; i++) {
 			node = current[i];
-			if (sibling === null) {
-				append_child(/** @type {Element} */ (parent_element), /** @type {Node} */ (node));
-			} else {
+			if (sibling) {
 				sibling.before(/** @type {Node} */ (node));
+			} else {
+				append_child(/** @type {Element} */ (parent_element), /** @type {Node} */ (node));
 			}
 		}
 		return current[0];
-	} else if (current !== null) {
-		if (sibling === null) {
-			append_child(/** @type {Element} */ (parent_element), /** @type {Node} */ (current));
-		} else {
+	} else if (current) {
+		if (sibling) {
 			sibling.before(/** @type {Node} */ (current));
+		} else {
+			append_child(/** @type {Element} */ (parent_element), /** @type {Node} */ (current));
 		}
 	}
 	return /** @type {Text | Element | Comment} */ (current);
@@ -71,7 +71,7 @@ export function remove(current) {
  */
 export function reconcile_html(dom, value, svg) {
 	hydrate_block_anchor(dom);
-	if (current_hydration_fragment !== null) {
+	if (current_hydration_fragment) {
 		return current_hydration_fragment;
 	}
 	var html = value + '';

--- a/packages/svelte/src/internal/client/reconciler.js
+++ b/packages/svelte/src/internal/client/reconciler.js
@@ -49,7 +49,7 @@ export function remove(current) {
 		var node;
 		for (; i < current.length; i++) {
 			node = current[i];
-			if (i === 0) {
+			if (!i) {
 				first_node = node;
 			}
 			if (node.isConnected) {

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -831,7 +831,7 @@ class ResizeObserverSingleton {
 		return () => {
 			const listeners = this.#listeners.get(element);
 			listeners.delete(listener);
-			if (listeners.size === 0) {
+			if (!listeners.size) {
 				this.#listeners.delete(element);
 				/** @type {ResizeObserver} */ (this.#observer).unobserve(element);
 			}
@@ -1368,23 +1368,23 @@ function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 					const consequent_transitions = block.c;
 					const alternate_transitions = block.a;
 					if (result) {
-						if (alternate_transitions === null || alternate_transitions.size === 0) {
+						if (alternate_transitions === null || !alternate_transitions.size) {
 							execute_effect(alternate_effect);
 						} else {
 							trigger_transitions(alternate_transitions, 'out');
 						}
-						if (consequent_transitions === null || consequent_transitions.size === 0) {
+						if (consequent_transitions === null || !consequent_transitions.size) {
 							execute_effect(consequent_effect);
 						} else {
 							trigger_transitions(consequent_transitions, 'in');
 						}
 					} else {
-						if (consequent_transitions === null || consequent_transitions.size === 0) {
+						if (consequent_transitions === null || !consequent_transitions.size) {
 							execute_effect(consequent_effect);
 						} else {
 							trigger_transitions(consequent_transitions, 'out');
 						}
-						if (alternate_transitions === null || alternate_transitions.size === 0) {
+						if (alternate_transitions === null || !alternate_transitions.size) {
 							execute_effect(alternate_effect);
 						} else {
 							trigger_transitions(alternate_transitions, 'in');
@@ -1643,15 +1643,13 @@ export function component(anchor_node, component_fn, render_fn) {
 			transitions.add(transition);
 			transition.f(() => {
 				transitions.delete(transition);
-				if (transitions.size === 0) {
-					if (render.e) {
-						if (render.d) {
-							remove(render.d);
-							render.d = null;
-						}
-						destroy_signal(render.e);
-						render.e = null;
+				if (!transitions.size && render.e) {
+					if (render.d) {
+						remove(render.d);
+						render.d = null;
 					}
+					destroy_signal(render.e);
+					render.e = null;
 				}
 			});
 		};
@@ -1690,7 +1688,7 @@ export function component(anchor_node, component_fn, render_fn) {
 			return;
 		}
 		const transitions = render.s;
-		if (transitions.size === 0) {
+		if (!transitions.size) {
 			if (render.d) {
 				remove(render.d);
 				render.d = null;
@@ -1769,15 +1767,13 @@ function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 			transitions.add(transition);
 			transition.f(() => {
 				transitions.delete(transition);
-				if (transitions.size === 0) {
-					if (render.e) {
-						if (render.d) {
-							remove(render.d);
-							render.d = null;
-						}
-						destroy_signal(render.e);
-						render.e = null;
+				if (!transitions.size && render.e) {
+					if (render.d) {
+						remove(render.d);
+						render.d = null;
 					}
+					destroy_signal(render.e);
+					render.e = null;
 				}
 			});
 		};
@@ -1825,7 +1821,7 @@ function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 			return;
 		}
 		const transitions = render.s;
-		if (transitions.size === 0) {
+		if (!transitions.size) {
 			if (render.d) {
 				remove(render.d);
 				render.d = null;
@@ -1929,7 +1925,7 @@ export function key(anchor_node, key, render_fn) {
 			transitions.add(transition);
 			transition.f(() => {
 				transitions.delete(transition);
-				if (transitions.size === 0) {
+				if (!transitions.size) {
 					if (render.e) {
 						if (render.d) {
 							remove(render.d);
@@ -1969,7 +1965,7 @@ export function key(anchor_node, key, render_fn) {
 			return;
 		}
 		const transitions = render.s;
-		if (transitions.size === 0) {
+		if (!transitions.size) {
 			if (render.d) {
 				remove(render.d);
 				render.d = null;
@@ -2456,7 +2452,7 @@ export function spread_attributes_effect(dom, attrs, lowercase_attributes, css_h
  */
 export function spread_attributes(dom, prev, attrs, lowercase_attributes, css_hash) {
 	const next = object_assign({}, ...attrs);
-	const has_hash = css_hash.length !== 0;
+	const has_hash = css_hash.length;
 	for (const key in prev) {
 		if (!(key in next)) {
 			next[key] = null;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -371,7 +371,7 @@ function execute_signal_fn(signal) {
 				}
 			}
 
-			if (dependencies && current_dependencies_index > 0) {
+			if (dependencies && current_dependencies_index) {
 				dependencies.length = current_dependencies_index + current_dependencies.length;
 				for (i = 0; i < current_dependencies.length; i++) {
 					dependencies[current_dependencies_index + i] = current_dependencies[i];
@@ -520,7 +520,7 @@ export function execute_effect(signal) {
 	if (
 		is_runes(component_context) && // Don't rerun pre effects more than once to accomodate for "$: only runs once" behavior
 		signal.f & PRE_EFFECT &&
-		current_queued_pre_and_render_effects.length > 0
+		current_queued_pre_and_render_effects.length
 	) {
 		flush_local_pre_effects(component_context);
 	}
@@ -545,7 +545,7 @@ function infinite_loop_guard() {
  */
 function flush_queued_effects(effects) {
 	const length = effects.length;
-	if (length > 0) {
+	if (length) {
 		infinite_loop_guard();
 		let i;
 		for (i = 0; i < length; i++) {
@@ -566,7 +566,7 @@ function flush_queued_effects(effects) {
 
 function process_microtask() {
 	is_micro_task_queued = false;
-	if (current_queued_microtasks.length > 0) {
+	if (current_queued_microtasks.length) {
 		const tasks = current_queued_microtasks.slice();
 		current_queued_microtasks = [];
 		run_all(tasks);
@@ -698,7 +698,7 @@ export function flushSync(fn) {
 		if (fn) {
 			fn();
 		}
-		if (current_queued_pre_and_render_effects.length > 0 || effects.length > 0) {
+		if (current_queued_pre_and_render_effects.length || effects.length) {
 			flushSync();
 		}
 		if (is_micro_task_queued) {
@@ -1551,7 +1551,7 @@ export function prop(props, key, flags, initial) {
 			get(inner_current_value);
 		}
 
-		if (arguments.length > 0) {
+		if (arguments.length) {
 			if (mutation || (immutable ? value !== current : safe_not_equal(value, current))) {
 				from_child = true;
 				set(inner_current_value, mutation ? current : value);

--- a/packages/svelte/src/internal/client/transitions.js
+++ b/packages/svelte/src/internal/client/transitions.js
@@ -569,7 +569,7 @@ export function trigger_transitions(transitions, target_direction, from) {
 			mark_subtree_inert(transition.e, true);
 		}
 	}
-	if (outros.length > 0) {
+	if (outros.length) {
 		// Defer the outros to a microtask
 		const e = managed_pre_effect(() => {
 			destroy_signal(e);

--- a/packages/svelte/src/store/utils.js
+++ b/packages/svelte/src/store/utils.js
@@ -8,7 +8,7 @@ import { EMPTY_FUNC } from '../internal/common.js';
  * @returns {() => void}
  */
 export function subscribe_to_store(store, run, invalidate) {
-	if (store == null) {
+	if (!store) {
 		// @ts-expect-error
 		run(undefined);
 


### PR DESCRIPTION
I don't know if this is someone's coding style, but figured it was probably leftover from the TypeScript conversion. I only updated the code that gets shipped to the client and didn't bother touching the compiler code at all