### PR TITLE
chore: remove internal functions from `svelte/transition` exports

### DIFF
--- a/.changeset/lucky-toes-begin.md
+++ b/.changeset/lucky-toes-begin.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: remove internal functions from `svelte/transition` exports

--- a/packages/svelte/src/transition/index.js
+++ b/packages/svelte/src/transition/index.js
@@ -12,14 +12,14 @@ function cubic_out(t) {
  * @param {number} t
  * @returns {number}
  */
-export function cubic_in_out(t) {
+function cubic_in_out(t) {
 	return t < 0.5 ? 4.0 * t * t * t : 0.5 * Math.pow(2.0 * t - 2.0, 3.0) + 1.0;
 }
 
 /** @param {number | string} value
  * @returns {[number, string]}
  */
-export function split_css_unit(value) {
+function split_css_unit(value) {
 	const split = typeof value === 'string' && value.match(/^\s*(-?[\d.]+)([^\s]*)\s*$/);
 	return split ? [parseFloat(split[1]), split[2] || 'px'] : [/** @type {number} */ (value), 'px'];
 }

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2080,12 +2080,6 @@ declare module 'svelte/transition' {
 		easing?: EasingFunction;
 	}
 	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
-	export function cubic_in_out(t: number): number;
-
-	export function split_css_unit(value: number | string): [number, string];
-	/**
 	 * Animates a `blur` filter alongside an element's opacity.
 	 *
 	 * https://svelte.dev/docs/svelte-transition#blur


### PR DESCRIPTION
I suppose `cubic_in_out` could also be imported from the easing module rather than being duplicated, don't know why it was copied (is it important that the file has no imports?).

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
