### PR TITLE
chore: fix xml2js security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
     "prettier-plugin-svelte": "^3.0.3",
     "typescript": "^5.2.2",
     "vitest": "^0.34.6"
+  },
+  "pnpm": {
+    "overrides": {
+      "jimp>xml2js": "^0.6.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  jimp>xml2js: ^0.6.0
+
 importers:
 
   .:


### PR DESCRIPTION
workaround for https://github.com/jimp-dev/jimp/issues/1223