### PR TITLE
fix: Add missing miter-clip and arcs value to stroke-linejoin attribute

### DIFF
--- a/.changeset/wise-jobs-admire.md
+++ b/.changeset/wise-jobs-admire.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: Add missing `miter-clip` and `arcs` values to `stroke-linejoin` attribute

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1639,7 +1639,15 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	'stroke-dasharray'?: string | number | undefined | null;
 	'stroke-dashoffset'?: string | number | undefined | null;
 	'stroke-linecap'?: 'butt' | 'round' | 'square' | 'inherit' | undefined | null;
-	'stroke-linejoin'?: 'arcs' | 'miter-clip' | 'miter' | 'round' | 'bevel' | 'inherit' | undefined | null;
+	'stroke-linejoin'?:
+		| 'arcs'
+		| 'miter-clip'
+		| 'miter'
+		| 'round'
+		| 'bevel'
+		| 'inherit'
+		| undefined
+		| null;
 	'stroke-miterlimit'?: string | undefined | null;
 	'stroke-opacity'?: number | string | undefined | null;
 	'stroke-width'?: number | string | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1639,7 +1639,7 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	'stroke-dasharray'?: string | number | undefined | null;
 	'stroke-dashoffset'?: string | number | undefined | null;
 	'stroke-linecap'?: 'butt' | 'round' | 'square' | 'inherit' | undefined | null;
-	'stroke-linejoin'?: 'miter' | 'round' | 'bevel' | 'inherit' | undefined | null;
+	'stroke-linejoin'?: 'arcs' | 'miter-clip' | 'miter' | 'round' | 'bevel' | 'inherit' | undefined | null;
 	'stroke-miterlimit'?: string | undefined | null;
 	'stroke-opacity'?: number | string | undefined | null;
 	'stroke-width'?: number | string | undefined | null;


### PR DESCRIPTION
'miter-clip' and 'arcs' value for stroke-linejoin attribute is missing in types for SVGAttributes. Adding them here.
Reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linejoin