### PR TITLE
fix: make `@types/estree` a dependency (v5)

### DIFF
--- a/.changeset/bright-snakes-sing.md
+++ b/.changeset/bright-snakes-sing.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make `@types/estree` a dependency

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -106,7 +106,6 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-virtual": "^3.0.2",
     "@types/aria-query": "^5.0.3",
-    "@types/estree": "^1.0.5",
     "dts-buddy": "^0.4.3",
     "esbuild": "^0.19.2",
     "rollup": "^4.1.5",
@@ -116,6 +115,7 @@
   "dependencies": {
     "@ampproject/remapping": "^2.2.1",
     "@jridgewell/sourcemap-codec": "^1.4.15",
+    "@types/estree": "^1.0.5",
     "acorn": "^8.10.0",
     "acorn-typescript": "^1.4.13",
     "aria-query": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.4.15
         version: 1.4.15
+      '@types/estree':
+        specifier: ^1.0.5
+        version: 1.0.5
       acorn:
         specifier: ^8.10.0
         version: 8.11.2
@@ -117,9 +120,6 @@ importers:
       '@types/aria-query':
         specifier: ^5.0.3
         version: 5.0.4
-      '@types/estree':
-        specifier: ^1.0.5
-        version: 1.0.5
       dts-buddy:
         specifier: ^0.4.3
         version: 0.4.3(typescript@5.2.2)


### PR DESCRIPTION
types are exposed through our types, so we need to add it as a dependency fixes #10010

v5 version of #10149

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
