### PR TITLE
fix: return ast from `compile`

### DIFF
--- a/.changeset/silly-balloons-deny.md
+++ b/.changeset/silly-balloons-deny.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: return ast from `compile`

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -28,7 +28,7 @@ export function compile(source, options) {
 		});
 
 		const analysis = analyze_component(parsed, combined_options);
-		const result = transform_component(analysis, source, combined_options);
+		const result = transform_component(parsed, analysis, source, combined_options);
 		return result;
 	} catch (e) {
 		if (e instanceof CompileError) {
@@ -45,7 +45,7 @@ export function compile(source, options) {
  * https://svelte.dev/docs/svelte-compiler#svelte-compile
  * @param {string} source The component source code
  * @param {import('#compiler').ModuleCompileOptions} options
- * @returns {import('#compiler').CompileResult}
+ * @returns {import('#compiler').ModuleCompileResult}
  */
 export function compileModule(source, options) {
 	try {

--- a/packages/svelte/src/compiler/phases/3-transform/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/index.js
@@ -5,12 +5,13 @@ import { client_component, client_module } from './client/transform-client.js';
 import { getLocator } from 'locate-character';
 
 /**
+ * @param {import('#compiler').Root} ast
  * @param {import('../types').ComponentAnalysis} analysis
  * @param {string} source
  * @param {import('#compiler').ValidatedCompileOptions} options
  * @returns {import('#compiler').CompileResult}
  */
-export function transform_component(analysis, source, options) {
+export function transform_component(ast, analysis, source, options) {
 	if (options.generate === false) {
 		return {
 			js: /** @type {any} */ (null),
@@ -18,7 +19,8 @@ export function transform_component(analysis, source, options) {
 			warnings: transform_warnings(source, options.filename, analysis.warnings),
 			metadata: {
 				runes: analysis.runes
-			}
+			},
+			ast
 		};
 	}
 
@@ -50,7 +52,8 @@ export function transform_component(analysis, source, options) {
 		warnings: transform_warnings(source, options.filename, analysis.warnings),
 		metadata: {
 			runes: analysis.runes
-		}
+		},
+		ast
 	};
 }
 
@@ -58,13 +61,12 @@ export function transform_component(analysis, source, options) {
  * @param {import('../types').Analysis} analysis
  * @param {string} source
  * @param {import('#compiler').ValidatedModuleCompileOptions} options
- * @returns {import('#compiler').CompileResult}
+ * @returns {import('#compiler').ModuleCompileResult}
  */
 export function transform_module(analysis, source, options) {
 	if (options.generate === false) {
 		return {
 			js: /** @type {any} */ (null),
-			css: null,
 			warnings: transform_warnings(source, analysis.name, analysis.warnings),
 			metadata: {
 				runes: true
@@ -89,7 +91,6 @@ export function transform_module(analysis, source, options) {
 
 	return {
 		js: print(program, {}),
-		css: null,
 		warnings: transform_warnings(source, analysis.name, analysis.warnings),
 		metadata: {
 			runes: true

--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -11,19 +11,12 @@ import type { SourceMap } from 'magic-string';
 import type { Context } from 'zimmerframe';
 import type { Scope } from '../phases/scope.js';
 import * as Css from './css.js';
-import type { EachBlock, Namespace, SvelteNode } from './template.js';
+import type { EachBlock, Namespace, Root, SvelteNode } from './template.js';
 
-/** The return value of `compile` from `svelte/compiler` */
-export interface CompileResult {
+/** The return value of `compileModule` from `svelte/compiler` */
+export interface ModuleCompileResult {
 	/** The compiled JavaScript */
 	js: {
-		/** The generated code */
-		code: string;
-		/** A source map */
-		map: SourceMap;
-	};
-	/** The compiled CSS */
-	css: null | {
 		/** The generated code */
 		code: string;
 		/** A source map */
@@ -46,6 +39,19 @@ export interface CompileResult {
 		 */
 		runes: boolean;
 	};
+}
+
+/** The return value of `compile` from `svelte/compiler` */
+export interface CompileResult extends ModuleCompileResult {
+	/** The compiled CSS */
+	css: null | {
+		/** The generated code */
+		code: string;
+		/** A source map */
+		map: SourceMap;
+	};
+	/** The AST */
+	ast: Root;
 }
 
 export interface Warning {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -502,7 +502,7 @@ declare module 'svelte/compiler' {
 	 * https://svelte.dev/docs/svelte-compiler#svelte-compile
 	 * @param source The component source code
 	 * */
-	export function compileModule(source: string, options: ModuleCompileOptions): CompileResult;
+	export function compileModule(source: string, options: ModuleCompileOptions): ModuleCompileResult;
 	/**
 	 * The parse function parses a component, returning only its abstract syntax tree.
 	 *
@@ -519,17 +519,10 @@ declare module 'svelte/compiler' {
 	 * @deprecated Replace this with `import { walk } from 'estree-walker'`
 	 * */
 	function walk(): never;
-	/** The return value of `compile` from `svelte/compiler` */
-	interface CompileResult {
+	/** The return value of `compileModule` from `svelte/compiler` */
+	interface ModuleCompileResult {
 		/** The compiled JavaScript */
 		js: {
-			/** The generated code */
-			code: string;
-			/** A source map */
-			map: SourceMap;
-		};
-		/** The compiled CSS */
-		css: null | {
 			/** The generated code */
 			code: string;
 			/** A source map */
@@ -552,6 +545,19 @@ declare module 'svelte/compiler' {
 			 */
 			runes: boolean;
 		};
+	}
+
+	/** The return value of `compile` from `svelte/compiler` */
+	interface CompileResult extends ModuleCompileResult {
+		/** The compiled CSS */
+		css: null | {
+			/** The generated code */
+			code: string;
+			/** A source map */
+			map: SourceMap;
+		};
+		/** The AST */
+		ast: Root;
 	}
 
 	interface Warning {


### PR DESCRIPTION
Was returned from Svelte 4's compile method, and language tools uses it in various places for perf reasons (not doing double parses unnecessarily if you need both)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
