### PR TITLE
fix: simplify event delegation logic

### DIFF
--- a/.changeset/rich-cobras-exist.md
+++ b/.changeset/rich-cobras-exist.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: simplify event delegation logic, only delegate event attributes

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -128,8 +128,7 @@ export default function tag(parser) {
 					fragment: create_fragment(true),
 					metadata: {
 						svg: false,
-						has_spread: false,
-						can_delegate_events: null
+						has_spread: false
 					},
 					parent: null
 				}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1309,7 +1309,7 @@ function serialize_event_handler(node, { state, visit }) {
 
 /**
  * Serializes an event handler function of the `on:` directive or an attribute starting with `on`
- * @param {Pick<import('#compiler').OnDirective, 'name' | 'modifiers' | 'expression' | 'metadata'>} node
+ * @param {{name: string; modifiers: string[]; expression: import('estree').Expression | null; delegated?: import('#compiler').DelegatedEvent | null; }} node
  * @param {import('../types.js').ComponentContext} context
  */
 function serialize_event(node, context) {
@@ -1318,9 +1318,9 @@ function serialize_event(node, context) {
 	if (node.expression) {
 		let handler = serialize_event_handler(node, context);
 		const event_name = node.name;
-		const delegated = node.metadata.delegated;
+		const delegated = node.delegated;
 
-		if (delegated !== null) {
+		if (delegated != null) {
 			let delegated_assignment;
 
 			if (!state.events.has(event_name)) {
@@ -1415,7 +1415,7 @@ function serialize_event_attribute(node, context) {
 			name: event_name,
 			expression: node.value[0].expression,
 			modifiers,
-			metadata: node.metadata
+			delegated: node.metadata.delegated
 		},
 		context
 	);

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -202,9 +202,6 @@ export interface OnDirective extends BaseNode {
 	/** The 'y' in `on:x={y}` */
 	expression: null | Expression;
 	modifiers: string[]; // TODO specify
-	metadata: {
-		delegated: null | DelegatedEvent;
-	};
 }
 
 export type DelegatedEvent =
@@ -288,12 +285,6 @@ export interface RegularElement extends BaseElement {
 		svg: boolean;
 		/** `true` if contains a SpreadAttribute */
 		has_spread: boolean;
-		/**
-		 * `true` if events on this element can theoretically be delegated. This doesn't necessarily mean that
-		 * a specific event will be delegated, as there are other factors which affect the final outcome.
-		 * `null` only until it was determined whether this element can be delegated or not.
-		 */
-		can_delegate_events: boolean | null;
 	};
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/inspect-trace/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-trace/_config.js
@@ -31,9 +31,7 @@ export default test({
 		b2.click();
 		await Promise.resolve();
 
-		assert.ok(
-			log[0].stack.startsWith('Error:') && log[0].stack.includes('HTMLButtonElement.on_click')
-		);
+		assert.ok(log[0].stack.startsWith('Error:') && log[0].stack.includes('HTMLButtonElement.'));
 		assert.deepEqual(log[1], 1);
 	}
 });

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1241,9 +1241,6 @@ declare module 'svelte/compiler' {
 		/** The 'y' in `on:x={y}` */
 		expression: null | Expression;
 		modifiers: string[]; // TODO specify
-		metadata: {
-			delegated: null | DelegatedEvent;
-		};
 	}
 
 	type DelegatedEvent =
@@ -1327,12 +1324,6 @@ declare module 'svelte/compiler' {
 			svg: boolean;
 			/** `true` if contains a SpreadAttribute */
 			has_spread: boolean;
-			/**
-			 * `true` if events on this element can theoretically be delegated. This doesn't necessarily mean that
-			 * a specific event will be delegated, as there are other factors which affect the final outcome.
-			 * `null` only until it was determined whether this element can be delegated or not.
-			 */
-			can_delegate_events: boolean | null;
 		};
 	}
 


### PR DESCRIPTION
Only delegate event attributes, and don't take into account bindings/actions while determining that. Never delegate `on:` directives. This simplifies the logic and makes it easier to explain, while avoiding any accidental breaking changes when upgrading from Svelte 4 to 5 without changing code.
Fixes #10165
Related to #9714

No test because it feels weird to test the absence of something that will never come back.

Side note: With this change we can measure the impact of event delegation using the JS framework benchmark and switching between `onclick` and `on:click`

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
