### PR TITLE
fix: improve nested effect heuristics

### DIFF
--- a/.changeset/angry-books-jam.md
+++ b/.changeset/angry-books-jam.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: improve nested effect heuristics

--- a/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/_config.js
@@ -1,0 +1,28 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+import { log } from './log.js';
+
+export default test({
+	before_test() {
+		log.length = 0;
+	},
+
+	async test({ assert, target }) {
+		const [b1] = target.querySelectorAll('button');
+
+		flushSync(() => {
+			b1?.click();
+		});
+
+		await Promise.resolve();
+		assert.deepEqual(log, [
+			'top level',
+			'inner',
+			0,
+			'destroy inner',
+			undefined,
+			'destroy outer',
+			undefined
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/log.js
@@ -1,0 +1,2 @@
+/** @type {any[]} */
+export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	import { log } from './log.js';
+	let c = $state({ a: 0 });
+
+	$effect(() => {
+		log.push('top level')
+			$effect(() => {
+					if (c) {
+							$effect(() => {
+								log.push('inner',c.a);
+									return () => log.push('destroy inner', c?.a);
+							});
+					}
+					return () => log.push('destroy outer', c?.a);
+			})
+	});
+</script>
+
+<button onclick={() => {
+	c.a = 1; c = null
+}}>toggle</button>


### PR DESCRIPTION
Fixes and issue with nested `$effect` calls where a mutation might incorrectly cause the inner effects to trigger before the out effect.