### PR TITLE
fix: detect multiple animations 

### DIFF
--- a/.changeset/tricky-dryers-clap.md
+++ b/.changeset/tricky-dryers-clap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: detect multiple animations

--- a/packages/svelte/src/compiler/phases/2-analyze/css/Stylesheet.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/Stylesheet.js
@@ -214,12 +214,10 @@ class Declaration {
 		const property = this.node.property && remove_css_prefix(this.node.property.toLowerCase());
 		if (property === 'animation' || property === 'animation-name') {
 			//check if there is multiple animations
-			const multiple = /** @type {string} */ (this.node.value).split(',');
+			const names = /** @type {string} */ (this.node.value).split(/[\s,]/);
 
-			for (const curr of multiple) {
-				const name = /** @type {string} */ curr.split(' ').find((name) => keyframes.has(name));
-
-				if (name) {
+			for (const name of names) {
+				if (keyframes.has(name)) {
 					const start = code.original.indexOf(
 						name,
 						code.original.indexOf(this.node.property, this.node.start)

--- a/packages/svelte/src/compiler/phases/2-analyze/css/Stylesheet.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/Stylesheet.js
@@ -213,20 +213,23 @@ class Declaration {
 	transform(code, keyframes) {
 		const property = this.node.property && remove_css_prefix(this.node.property.toLowerCase());
 		if (property === 'animation' || property === 'animation-name') {
-			const name = /** @type {string} */ (this.node.value)
-				.split(' ')
-				.find((name) => keyframes.has(name));
+			//check if there is multiple animations
+			const multiple = /** @type {string} */ (this.node.value).split(',');
 
-			if (name) {
-				const start = code.original.indexOf(
-					name,
-					code.original.indexOf(this.node.property, this.node.start)
-				);
+			for (const curr of multiple) {
+				const name = /** @type {string} */ curr.split(' ').find((name) => keyframes.has(name));
 
-				const end = start + name.length;
+				if (name) {
+					const start = code.original.indexOf(
+						name,
+						code.original.indexOf(this.node.property, this.node.start)
+					);
 
-				const keyframe = /** @type {string} */ (keyframes.get(name));
-				code.update(start, end, keyframe);
+					const end = start + name.length;
+
+					const keyframe = /** @type {string} */ (keyframes.get(name));
+					code.update(start, end, keyframe);
+				}
 			}
 		}
 	}

--- a/packages/svelte/tests/css/samples/keyframes-from-to/expected.css
+++ b/packages/svelte/tests/css/samples/keyframes-from-to/expected.css
@@ -1,8 +1,14 @@
+
 	@keyframes svelte-xyz-why {
 		from { color: red; }
 		to { color: blue; }
 	}
 
+	@keyframes svelte-xyz-what {
+		from { color: scale(1); }
+		to { color: scale(1.5); }
+	}
+
 	.animated.svelte-xyz {
-		animation: svelte-xyz-why 2s;
+		animation: svelte-xyz-why 2s, svelte-xyz-what 2s;
 	}

--- a/packages/svelte/tests/css/samples/keyframes-from-to/expected.css
+++ b/packages/svelte/tests/css/samples/keyframes-from-to/expected.css
@@ -10,5 +10,7 @@
 	}
 
 	.animated.svelte-xyz {
-		animation: svelte-xyz-why 2s, svelte-xyz-what 2s;
+		animation:
+			svelte-xyz-why 2s,
+			svelte-xyz-what 2s;
 	}

--- a/packages/svelte/tests/css/samples/keyframes-from-to/input.svelte
+++ b/packages/svelte/tests/css/samples/keyframes-from-to/input.svelte
@@ -6,7 +6,14 @@
 		to { color: blue; }
 	}
 
+	@keyframes what {
+		from { color: scale(1); }
+		to { color: scale(1.5); }
+	}
+
 	.animated {
-		animation: why 2s;
+		animation:
+			why 2s,
+			what 2s;
 	}
 </style>

--- a/packages/svelte/tests/parser-modern/samples/whitespace-handling/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/whitespace-handling/input.svelte
@@ -1,0 +1,8 @@
+<style>
+	p {
+		animation:/*test*/
+			why 2s,
+			/*test*/
+			what 2s;
+	}
+</style>

--- a/packages/svelte/tests/parser-modern/samples/whitespace-handling/output.json
+++ b/packages/svelte/tests/parser-modern/samples/whitespace-handling/output.json
@@ -1,0 +1,64 @@
+{
+	"css": {
+		"type": "Style",
+		"start": 0,
+		"end": 80,
+		"attributes": [],
+		"children": [
+			{
+				"type": "Rule",
+				"prelude": {
+					"type": "SelectorList",
+					"start": 9,
+					"end": 10,
+					"children": [
+						{
+							"type": "Selector",
+							"start": 9,
+							"end": 10,
+							"children": [
+								{
+									"type": "TypeSelector",
+									"name": "p",
+									"start": 9,
+									"end": 10
+								}
+							]
+						}
+					]
+				},
+				"block": {
+					"type": "Block",
+					"start": 11,
+					"end": 71,
+					"children": [
+						{
+							"type": "Declaration",
+							"start": 15,
+							"end": 67,
+							"property": "animation",
+							"value": "why 2s, what 2s"
+						}
+					]
+				},
+				"start": 9,
+				"end": 71
+			}
+		],
+		"content": {
+			"start": 7,
+			"end": 72,
+			"styles": "\n\tp {\n\t\tanimation:/*test*/\n\t\t\twhy 2s,\n\t\t\t/*test*/\n\t\t\twhat 2s;\n\t}\n"
+		}
+	},
+	"js": [],
+	"start": null,
+	"end": null,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [],
+		"transparent": false
+	},
+	"options": null
+}


### PR DESCRIPTION
trims whitespace while at it, closes #10189

[the first](https://github.com/sveltejs/svelte/pull/10192/commits/0b7646caa107aff451b0397903c358e0a9108dcf) change fixes it, but I thought improving the parser whitespace handling for this case would be better and more consistent since we use it in the analyzing step, added a test case for both changes.  

we can also prevent appending the magic string to the animation name if it is inside a comment

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
