### PR TITLE
fix: take snippets into account when scoping css selectors

### DIFF
--- a/.changeset/four-actors-grow.md
+++ b/.changeset/four-actors-grow.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: take snippets into account when scoping css selectors

--- a/packages/svelte/tests/css/samples/descendant-selectors-render-tag/expected.css
+++ b/packages/svelte/tests/css/samples/descendant-selectors-render-tag/expected.css
@@ -1,0 +1,16 @@
+
+	div.svelte-xyz > span.svelte-xyz {
+		background-color: red;
+	}
+
+	div.svelte-xyz span.svelte-xyz {
+		letter-spacing: 10px;
+	}
+
+	div.svelte-xyz span {
+		text-decoration: underline;
+	}
+
+	p.svelte-xyz span.svelte-xyz.svelte-xyz {
+		background: black;
+	}

--- a/packages/svelte/tests/css/samples/descendant-selectors-render-tag/expected.html
+++ b/packages/svelte/tests/css/samples/descendant-selectors-render-tag/expected.html
@@ -1,0 +1,2 @@
+<div class="svelte-xyz"><span class="svelte-xyz">Hello world</span></div>
+<p class="svelte-xyz"><strong><span class="svelte-xyz">Hello world</span></strong></p>

--- a/packages/svelte/tests/css/samples/descendant-selectors-render-tag/input.svelte
+++ b/packages/svelte/tests/css/samples/descendant-selectors-render-tag/input.svelte
@@ -1,0 +1,31 @@
+{#snippet my_snippet()}
+  <span>Hello world</span>
+{/snippet}
+
+<div>{@render my_snippet()}</div>
+
+<p>
+	{#snippet my_snippet()}
+		<span>Hello world</span>
+	{/snippet}
+
+	<strong>{@render my_snippet()}</strong>
+</p>
+
+<style>
+	div > span {
+		background-color: red;
+	}
+
+	div span {
+		letter-spacing: 10px;
+	}
+
+	div :global(span) {
+		text-decoration: underline;
+	}
+
+	p span {
+		background: black;
+	}
+</style>


### PR DESCRIPTION
This is an attempt to fix #10143
The CSS scoping logic is enhanced to take render tags into account - if one is found as the child of an element, we assume that the selector might match at runtime when combining the element(s) above the render tag and the element(s) inside the snippet. This doesn't do any advanced static analysis checks, so there can be false positives. I also notices that it's not enough to just check the current element for render tags, we need to do that recursively. I'm not sure I'm going down the right path doing this though, so I'm going to leave this as a draft for now for others that have worked in this code area before to take a look first.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
