### PR TITLE
chore: document and test signals edge case

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -76,7 +76,11 @@ export let current_effect = null;
 /** @type {null | import('./types.js').Signal[]} */
 let current_dependencies = null;
 let current_dependencies_index = 0;
-/** @type {null | import('./types.js').Signal[]} */
+/**
+ * Tracks writes that the effect it's executed in doesn't listen to yet,
+ * so that the dependency can be added to the effect later on if it then reads it
+ * @type {null | import('./types.js').Signal[]}
+ */
 let current_untracked_writes = null;
 /** @type {null | import('./types.js').SignalDebug} */
 let last_inspected_signal = null;


### PR DESCRIPTION
I came across this code and was wondering what it was doing. I saw it was introduced in #9721 but deleted in a #9791 because it seemed it no longer fails, but slightly changing the test still makes it fail as expected. This PR documents the code a bit and adds back the test (in a different form).

That said, I'm not really sure if #9721 should have happened in the first place. It's a bit of code to accomodate for something that reads like a user error - why would anyone first write to something and then read it later on, without it causing an infinite loop? @ogheorghies you opened the related issue - what was the underlying use case for making this work?

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
