### PR TITLE
chore: add $derived.call rune

### DIFF
--- a/.changeset/nervous-spoons-relax.md
+++ b/.changeset/nervous-spoons-relax.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-chore: add $derived.fn rune
+chore: add $derived.call rune

--- a/.changeset/nervous-spoons-relax.md
+++ b/.changeset/nervous-spoons-relax.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+chore: add $derived.fn rune

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -171,10 +171,9 @@ const runes = {
 		`$props() assignment must not contain nested properties or computed keys`,
 	'invalid-props-location': () =>
 		`$props() can only be used at the top level of components as a variable declaration initializer`,
-	'invalid-derived-location': () =>
-		`$derived() can only be used as a variable declaration initializer or a class field`,
-	'invalid-state-location': () =>
-		`$state() can only be used as a variable declaration initializer or a class field`,
+	/** @param {string} rune */
+	'invalid-state-location': (rune) =>
+		`${rune}(...) can only be used as a variable declaration initializer or a class field`,
 	'invalid-effect-location': () => `$effect() can only be used as an expression statement`,
 	/**
 	 * @param {boolean} is_binding

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -674,7 +674,7 @@ const runes_scope_js_tweaker = {
 			rune !== '$state' &&
 			rune !== '$state.frozen' &&
 			rune !== '$derived' &&
-			rune !== '$derived.fn'
+			rune !== '$derived.call'
 		)
 			return;
 
@@ -710,7 +710,7 @@ const runes_scope_tweaker = {
 			rune !== '$state' &&
 			rune !== '$state.frozen' &&
 			rune !== '$derived' &&
-			rune !== '$derived.fn' &&
+			rune !== '$derived.call' &&
 			rune !== '$props'
 		)
 			return;
@@ -723,7 +723,7 @@ const runes_scope_tweaker = {
 					? 'state'
 					: rune === '$state.frozen'
 						? 'frozen_state'
-						: rune === '$derived' || rune === '$derived.fn'
+						: rune === '$derived' || rune === '$derived.call'
 							? 'derived'
 							: path.is_rest
 								? 'rest_prop'

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -670,7 +670,13 @@ const runes_scope_js_tweaker = {
 		const callee = node.init.callee;
 		if (callee.type !== 'Identifier' && callee.type !== 'MemberExpression') return;
 
-		if (rune !== '$state' && rune !== '$state.frozen' && rune !== '$derived') return;
+		if (
+			rune !== '$state' &&
+			rune !== '$state.frozen' &&
+			rune !== '$derived' &&
+			rune !== '$derived.fn'
+		)
+			return;
 
 		for (const path of extract_paths(node.id)) {
 			// @ts-ignore this fails in CI for some insane reason
@@ -700,7 +706,13 @@ const runes_scope_tweaker = {
 		const callee = init.callee;
 		if (callee.type !== 'Identifier' && callee.type !== 'MemberExpression') return;
 
-		if (rune !== '$state' && rune !== '$state.frozen' && rune !== '$derived' && rune !== '$props')
+		if (
+			rune !== '$state' &&
+			rune !== '$state.frozen' &&
+			rune !== '$derived' &&
+			rune !== '$derived.fn' &&
+			rune !== '$props'
+		)
 			return;
 
 		for (const path of extract_paths(node.id)) {
@@ -711,7 +723,7 @@ const runes_scope_tweaker = {
 					? 'state'
 					: rune === '$state.frozen'
 						? 'frozen_state'
-						: rune === '$derived'
+						: rune === '$derived' || rune === '$derived.fn'
 							? 'derived'
 							: path.is_rest
 								? 'rest_prop'

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -715,7 +715,7 @@ function validate_call_expression(node, scope, path) {
 		error(node, 'invalid-props-location');
 	}
 
-	if (rune === '$state' || rune === '$derived' || rune === '$derived.fn') {
+	if (rune === '$state' || rune === '$derived' || rune === '$derived.call') {
 		if (parent.type === 'VariableDeclarator') return;
 		if (parent.type === 'PropertyDefinition' && !parent.static && !parent.computed) return;
 		error(node, rune === '$derived' ? 'invalid-derived-location' : 'invalid-state-location');

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -950,16 +950,6 @@ export const validation_runes = merge(validation, a11y_validators, {
 
 		const args = /** @type {import('estree').CallExpression} */ (init).arguments;
 
-		if (rune === '$derived') {
-			const arg = args[0];
-			if (
-				arg.type === 'CallExpression' &&
-				(arg.callee.type === 'ArrowFunctionExpression' || arg.callee.type === 'FunctionExpression')
-			) {
-				warn(state.analysis.warnings, node, path, 'derived-iife');
-			}
-		}
-
 		// TODO some of this is duplicated with above, seems off
 		if ((rune === '$derived' || rune === '$derived.call') && args.length !== 1) {
 			error(node, 'invalid-rune-args-length', rune, [1]);
@@ -997,6 +987,16 @@ export const validation_runes = merge(validation, a11y_validators, {
 						error(property, 'invalid-props-pattern');
 					}
 				}
+			}
+		}
+
+		if (rune === '$derived') {
+			const arg = args[0];
+			if (
+				arg.type === 'CallExpression' &&
+				(arg.callee.type === 'ArrowFunctionExpression' || arg.callee.type === 'FunctionExpression')
+			) {
+				warn(state.analysis.warnings, node, path, 'derived-iife');
 			}
 		}
 	},

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -718,7 +718,7 @@ function validate_call_expression(node, scope, path) {
 	if (rune === '$state' || rune === '$derived' || rune === '$derived.call') {
 		if (parent.type === 'VariableDeclarator') return;
 		if (parent.type === 'PropertyDefinition' && !parent.static && !parent.computed) return;
-		error(node, rune === '$derived' ? 'invalid-derived-location' : 'invalid-state-location');
+		error(node, 'invalid-state-location', rune);
 	}
 
 	if (rune === '$effect' || rune === '$effect.pre') {
@@ -786,10 +786,10 @@ export const validation_runes_js = {
 
 		const args = /** @type {import('estree').CallExpression} */ (init).arguments;
 
-		if (rune === '$derived' && args.length !== 1) {
-			error(node, 'invalid-rune-args-length', '$derived', [1]);
+		if ((rune === '$derived' || rune === '$derived.call') && args.length !== 1) {
+			error(node, 'invalid-rune-args-length', rune, [1]);
 		} else if (rune === '$state' && args.length > 1) {
-			error(node, 'invalid-rune-args-length', '$state', [0, 1]);
+			error(node, 'invalid-rune-args-length', rune, [0, 1]);
 		} else if (rune === '$props') {
 			error(node, 'invalid-props-location');
 		}
@@ -811,7 +811,7 @@ export const validation_runes_js = {
 				definition.value?.type === 'CallExpression'
 			) {
 				const rune = get_rune(definition.value, context.state.scope);
-				if (rune === '$derived') {
+				if (rune === '$derived' || rune === '$derived.call') {
 					private_derived_state.push(definition.key.name);
 				}
 			}
@@ -938,14 +938,11 @@ export const validation_runes = merge(validation, a11y_validators, {
 			context.type === 'Identifier' &&
 			(context.name === '$state' || context.name === '$derived')
 		) {
-			error(
-				node,
-				context.name === '$derived' ? 'invalid-derived-location' : 'invalid-state-location'
-			);
+			error(node, 'invalid-state-location', context.name);
 		}
 		next({ ...state });
 	},
-	VariableDeclarator(node, { state }) {
+	VariableDeclarator(node, { state, path }) {
 		const init = unwrap_ts_expression(node.init);
 		const rune = get_rune(init, state.scope);
 
@@ -953,10 +950,21 @@ export const validation_runes = merge(validation, a11y_validators, {
 
 		const args = /** @type {import('estree').CallExpression} */ (init).arguments;
 
-		if (rune === '$derived' && args.length !== 1) {
-			error(node, 'invalid-rune-args-length', '$derived', [1]);
+		if (rune === '$derived') {
+			const arg = args[0];
+			if (
+				arg.type === 'CallExpression' &&
+				(arg.callee.type === 'ArrowFunctionExpression' || arg.callee.type === 'FunctionExpression')
+			) {
+				warn(state.analysis.warnings, node, path, 'derived-iife');
+			}
+		}
+
+		// TODO some of this is duplicated with above, seems off
+		if ((rune === '$derived' || rune === '$derived.call') && args.length !== 1) {
+			error(node, 'invalid-rune-args-length', rune, [1]);
 		} else if (rune === '$state' && args.length > 1) {
-			error(node, 'invalid-rune-args-length', '$state', [0, 1]);
+			error(node, 'invalid-rune-args-length', rune, [0, 1]);
 		} else if (rune === '$props') {
 			if (state.has_props_rune) {
 				error(node, 'duplicate-props-rune');

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -715,7 +715,7 @@ function validate_call_expression(node, scope, path) {
 		error(node, 'invalid-props-location');
 	}
 
-	if (rune === '$state' || rune === '$derived') {
+	if (rune === '$state' || rune === '$derived' || rune === '$derived.fn') {
 		if (parent.type === 'VariableDeclarator') return;
 		if (parent.type === 'PropertyDefinition' && !parent.static && !parent.computed) return;
 		error(node, rune === '$derived' ? 'invalid-derived-location' : 'invalid-state-location');

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -58,7 +58,7 @@ export interface ComponentClientTransformState extends ClientTransformState {
 }
 
 export interface StateField {
-	kind: 'state' | 'frozen_state' | 'derived';
+	kind: 'state' | 'frozen_state' | 'derived' | 'derived_fn';
 	id: PrivateIdentifier;
 }
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -58,7 +58,7 @@ export interface ComponentClientTransformState extends ClientTransformState {
 }
 
 export interface StateField {
-	kind: 'state' | 'frozen_state' | 'derived' | 'derived_fn';
+	kind: 'state' | 'frozen_state' | 'derived' | 'derived_call';
 	id: PrivateIdentifier;
 }
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -302,13 +302,9 @@ export const javascript_visitors_runes = {
 							b.id(id),
 							b.call(
 								'$.derived',
-								b.arrow(
-									[b.id('$$derived')],
+								b.thunk(
 									b.block([
-										b.let(
-											declarator.id,
-											rune === '$derived.call' ? b.call(value, b.id('$$derived')) : value
-										),
+										b.let(declarator.id, rune === '$derived.call' ? b.call(value) : value),
 										b.return(b.array(bindings.map((binding) => binding.node)))
 									])
 								)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -33,7 +33,7 @@ export const javascript_visitors_runes = {
 						rune === '$state' ||
 						rune === '$state.frozen' ||
 						rune === '$derived' ||
-						rune === '$derived.fn'
+						rune === '$derived.call'
 					) {
 						/** @type {import('../types.js').StateField} */
 						const field = {
@@ -42,8 +42,8 @@ export const javascript_visitors_runes = {
 									? 'state'
 									: rune === '$state.frozen'
 										? 'frozen_state'
-										: rune === '$derived.fn'
-											? 'derived_fn'
+										: rune === '$derived.call'
+											? 'derived_call'
 											: 'derived',
 							// @ts-expect-error this is set in the next pass
 							id: is_private ? definition.key : null
@@ -102,7 +102,7 @@ export const javascript_visitors_runes = {
 											'$.source',
 											should_proxy_or_freeze(init) ? b.call('$.freeze', init) : init
 										)
-									: field.kind === 'derived_fn'
+									: field.kind === 'derived_call'
 										? b.call('$.derived', init)
 										: b.call('$.derived', b.thunk(init));
 					} else {
@@ -146,7 +146,7 @@ export const javascript_visitors_runes = {
 							);
 						}
 
-						if ((field.kind === 'derived' || field.kind === 'derived_fn') && state.options.dev) {
+						if ((field.kind === 'derived' || field.kind === 'derived_call') && state.options.dev) {
 							body.push(
 								b.method(
 									'set',
@@ -286,12 +286,12 @@ export const javascript_visitors_runes = {
 				continue;
 			}
 
-			if (rune === '$derived' || rune === '$derived.fn') {
+			if (rune === '$derived' || rune === '$derived.call') {
 				if (declarator.id.type === 'Identifier') {
 					declarations.push(
 						b.declarator(
 							declarator.id,
-							b.call('$.derived', rune === '$derived.fn' ? value : b.thunk(value))
+							b.call('$.derived', rune === '$derived.call' ? value : b.thunk(value))
 						)
 					);
 				} else {
@@ -307,7 +307,7 @@ export const javascript_visitors_runes = {
 									b.block([
 										b.let(
 											declarator.id,
-											rune === '$derived.fn' ? b.call(value, b.id('$$derived')) : value
+											rune === '$derived.call' ? b.call(value, b.id('$$derived')) : value
 										),
 										b.return(b.array(bindings.map((binding) => binding.node)))
 									])

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1711,13 +1711,12 @@ export const template_visitors = {
 		const declaration = node.declaration.declarations[0];
 		// TODO we can almost certainly share some code with $derived(...)
 		if (declaration.id.type === 'Identifier') {
-			// debugger
 			state.init.push(
 				b.const(
 					declaration.id,
 					b.call(
 						'$.derived',
-						b.arrow([], /** @type {import('estree').Expression} */ (visit(declaration.init)))
+						b.thunk(/** @type {import('estree').Expression} */ (visit(declaration.init)))
 					)
 				)
 			);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1711,12 +1711,13 @@ export const template_visitors = {
 		const declaration = node.declaration.declarations[0];
 		// TODO we can almost certainly share some code with $derived(...)
 		if (declaration.id.type === 'Identifier') {
+			// debugger
 			state.init.push(
 				b.const(
 					declaration.id,
 					b.call(
 						'$.derived',
-						b.thunk(/** @type {import('estree').Expression} */ (visit(declaration.init)))
+						b.arrow([], /** @type {import('estree').Expression} */ (visit(declaration.init)))
 					)
 				)
 			);

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -558,6 +558,15 @@ const javascript_visitors_runes = {
 							: /** @type {import('estree').Expression} */ (visit(node.value.arguments[0]))
 				};
 			}
+			if (rune === '$derived.fn') {
+				return {
+					...node,
+					value:
+						node.value.arguments.length === 0
+							? null
+							: b.call(/** @type {import('estree').Expression} */ (visit(node.value.arguments[0])))
+				};
+			}
 		}
 		next();
 	},
@@ -582,6 +591,16 @@ const javascript_visitors_runes = {
 				args.length === 0
 					? b.id('undefined')
 					: /** @type {import('estree').Expression} */ (visit(args[0]));
+
+			if (rune === '$derived.fn') {
+				declarations.push(
+					b.declarator(
+						/** @type {import('estree').Pattern} */ (visit(declarator.id)),
+						b.call(value)
+					)
+				);
+				continue;
+			}
 
 			if (declarator.id.type === 'Identifier') {
 				declarations.push(b.declarator(declarator.id, value));

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -558,7 +558,7 @@ const javascript_visitors_runes = {
 							: /** @type {import('estree').Expression} */ (visit(node.value.arguments[0]))
 				};
 			}
-			if (rune === '$derived.fn') {
+			if (rune === '$derived.call') {
 				return {
 					...node,
 					value:
@@ -592,7 +592,7 @@ const javascript_visitors_runes = {
 					? b.id('undefined')
 					: /** @type {import('estree').Expression} */ (visit(args[0]));
 
-			if (rune === '$derived.fn') {
+			if (rune === '$derived.call') {
 				declarations.push(
 					b.declarator(
 						/** @type {import('estree').Pattern} */ (visit(declarator.id)),

--- a/packages/svelte/src/compiler/phases/constants.js
+++ b/packages/svelte/src/compiler/phases/constants.js
@@ -75,6 +75,7 @@ export const Runes = /** @type {const} */ ([
 	'$state.frozen',
 	'$props',
 	'$derived',
+	'$derived.fn',
 	'$effect',
 	'$effect.pre',
 	'$effect.active',

--- a/packages/svelte/src/compiler/phases/constants.js
+++ b/packages/svelte/src/compiler/phases/constants.js
@@ -75,7 +75,7 @@ export const Runes = /** @type {const} */ ([
 	'$state.frozen',
 	'$props',
 	'$derived',
-	'$derived.fn',
+	'$derived.call',
 	'$effect',
 	'$effect.pre',
 	'$effect.active',

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -395,6 +395,7 @@ export function thunk(expression) {
 		expression.type === 'CallExpression' &&
 		expression.callee.type !== 'Super' &&
 		expression.callee.type !== 'MemberExpression' &&
+		expression.callee.type !== 'CallExpression' &&
 		expression.arguments.length === 0
 	) {
 		return expression.callee;

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -23,7 +23,9 @@ const runes = {
 		`Referencing a local variable with a $ prefix will create a store subscription. Please rename ${name} to avoid the ambiguity.`,
 	/** @param {string} name */
 	'non-state-reference': (name) =>
-		`${name} is updated, but is not declared with $state(...). Changing its value will not correctly trigger updates.`
+		`${name} is updated, but is not declared with $state(...). Changing its value will not correctly trigger updates.`,
+	'derived-iife': () =>
+		`Use \`$derived.call(() => {...})\` instead of \`$derived((() => {...})());\``
 };
 
 /** @satisfies {Warnings} */

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -328,7 +328,6 @@ function is_signal_dirty(signal) {
  */
 function execute_signal_fn(signal) {
 	const init = signal.i;
-	const flags = signal.f;
 	const previous_dependencies = current_dependencies;
 	const previous_dependencies_index = current_dependencies_index;
 	const previous_untracked_writes = current_untracked_writes;
@@ -336,7 +335,7 @@ function execute_signal_fn(signal) {
 	const previous_block = current_block;
 	const previous_component_context = current_component_context;
 	const previous_skip_consumer = current_skip_consumer;
-	const is_render_effect = (flags & RENDER_EFFECT) !== 0;
+	const is_render_effect = (signal.f & RENDER_EFFECT) !== 0;
 	const previous_untracking = current_untracking;
 	current_dependencies = /** @type {null | import('./types.js').Signal[]} */ (null);
 	current_dependencies_index = 0;
@@ -344,7 +343,7 @@ function execute_signal_fn(signal) {
 	current_consumer = signal;
 	current_block = signal.b;
 	current_component_context = signal.x;
-	current_skip_consumer = !is_flushing_effect && (flags & UNOWNED) !== 0;
+	current_skip_consumer = !is_flushing_effect && (signal.f & UNOWNED) !== 0;
 	current_untracking = false;
 
 	// Render effects are invoked when the UI is about to be updated - run beforeUpdate at that point
@@ -363,11 +362,6 @@ function execute_signal_fn(signal) {
 					/** @type {import('./types.js').Block} */ (signal.b),
 					/** @type {import('./types.js').Signal} */ (signal)
 				);
-		} else if ((flags & DERIVED) !== 0) {
-			const prev_value = signal.v;
-			res = /** @type {(prev: V) => V} */ (init)(
-				/** @type {V} */ (prev_value === UNINITIALIZED ? undefined : prev_value)
-			);
 		} else {
 			res = /** @type {() => V} */ (init)();
 		}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -328,6 +328,7 @@ function is_signal_dirty(signal) {
  */
 function execute_signal_fn(signal) {
 	const init = signal.i;
+	const flags = signal.f;
 	const previous_dependencies = current_dependencies;
 	const previous_dependencies_index = current_dependencies_index;
 	const previous_untracked_writes = current_untracked_writes;
@@ -335,7 +336,7 @@ function execute_signal_fn(signal) {
 	const previous_block = current_block;
 	const previous_component_context = current_component_context;
 	const previous_skip_consumer = current_skip_consumer;
-	const is_render_effect = (signal.f & RENDER_EFFECT) !== 0;
+	const is_render_effect = (flags & RENDER_EFFECT) !== 0;
 	const previous_untracking = current_untracking;
 	current_dependencies = /** @type {null | import('./types.js').Signal[]} */ (null);
 	current_dependencies_index = 0;
@@ -343,7 +344,7 @@ function execute_signal_fn(signal) {
 	current_consumer = signal;
 	current_block = signal.b;
 	current_component_context = signal.x;
-	current_skip_consumer = !is_flushing_effect && (signal.f & UNOWNED) !== 0;
+	current_skip_consumer = !is_flushing_effect && (flags & UNOWNED) !== 0;
 	current_untracking = false;
 
 	// Render effects are invoked when the UI is about to be updated - run beforeUpdate at that point
@@ -362,6 +363,11 @@ function execute_signal_fn(signal) {
 					/** @type {import('./types.js').Block} */ (signal.b),
 					/** @type {import('./types.js').Signal} */ (signal)
 				);
+		} else if ((flags & DERIVED) !== 0) {
+			const prev_value = signal.v;
+			res = /** @type {(prev: V) => V} */ (init)(
+				/** @type {V} */ (prev_value === UNINITIALIZED ? undefined : prev_value)
+			);
 		} else {
 			res = /** @type {() => V} */ (init)();
 		}

--- a/packages/svelte/src/main/ambient.d.ts
+++ b/packages/svelte/src/main/ambient.d.ts
@@ -75,14 +75,9 @@ declare namespace $derived {
 	 * });
 	 * ```
 	 *
-	 * `$derived.fn` passes the previous derived value as a single argument to the derived function. This can be useful for when
-	 * you might want to compare the latest derived value with the previous derived value. Furthermore, you might want to pluck out
-	 * specific properties of derived state to use in the new derived state given a certain condition – which can be useful when dealing
-	 * with more complex state machines.
-	 *
 	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-fn
 	 */
-	export function fn<T>(fn: (prev: T) => T): void;
+	export function fn<T>(fn: () => T): void;
 }
 
 /**

--- a/packages/svelte/src/main/ambient.d.ts
+++ b/packages/svelte/src/main/ambient.d.ts
@@ -62,11 +62,11 @@ declare function $derived<T>(expression: T): T;
 declare namespace $derived {
 	/**
 	 * Sometimes you need to create complex derivations which don't fit inside a short expression.
-	 * In this case, you can resort to `$derived.fn` which accepts a function as its argument and returns its value.
+	 * In this case, you can resort to `$derived.call` which accepts a function as its argument and returns its value.
 	 *
 	 * Example:
 	 * ```ts
-	 * $derived.fn(() => {
+	 * $derived.call(() => {
 	 *   let tmp = count;
 	 *	 if (count > 10) {
 	 *	   tmp += 100;

--- a/packages/svelte/src/main/ambient.d.ts
+++ b/packages/svelte/src/main/ambient.d.ts
@@ -61,21 +61,21 @@ declare function $derived<T>(expression: T): T;
 
 declare namespace $derived {
 	/**
-	 * Sometimes you need to create complex derivations which don't fit inside a short expression.
-	 * In this case, you can resort to `$derived.call` which accepts a function as its argument and returns its value.
+	 * Sometimes you need to create complex derivations that don't fit inside a short expression.
+	 * In these cases, you can use `$derived.call` which accepts a function as its argument.
 	 *
 	 * Example:
 	 * ```ts
-	 * $derived.call(() => {
-	 *   let tmp = count;
-	 *	 if (count > 10) {
-	 *	   tmp += 100;
-	 *	 }
-	 *	 return tmp * 2;
+	 * let total = $derived.call(() => {
+	 *   let result = 0;
+	 *	 for (const n of numbers) {
+	 *	   result += n;
+	 *   }
+	 *   return result;
 	 * });
 	 * ```
 	 *
-	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-fn
+	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-call
 	 */
 	export function fn<T>(fn: () => T): void;
 }

--- a/packages/svelte/src/main/ambient.d.ts
+++ b/packages/svelte/src/main/ambient.d.ts
@@ -59,6 +59,32 @@ declare namespace $state {
  */
 declare function $derived<T>(expression: T): T;
 
+declare namespace $derived {
+	/**
+	 * Sometimes you need to create complex derivations which don't fit inside a short expression.
+	 * In this case, you can resort to `$derived.fn` which accepts a function as its argument and returns its value.
+	 *
+	 * Example:
+	 * ```ts
+	 * $derived.fn(() => {
+	 *   let tmp = count;
+	 *	 if (count > 10) {
+	 *	   tmp += 100;
+	 *	 }
+	 *	 return tmp * 2;
+	 * });
+	 * ```
+	 *
+	 * `$derived.fn` passes the previous derived value as a single argument to the derived function. This can be useful for when
+	 * you might want to compare the latest derived value with the previous derived value. Furthermore, you might want to pluck out
+	 * specific properties of derived state to use in the new derived state given a certain condition – which can be useful when dealing
+	 * with more complex state machines.
+	 *
+	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-fn
+	 */
+	export function fn<T>(fn: (prev: T) => T): void;
+}
+
 /**
  * Runs code when a component is mounted to the DOM, and then whenever its dependencies change, i.e. `$state` or `$derived` values.
  * The timing of the execution is after the DOM has been updated.

--- a/packages/svelte/tests/compiler-errors/samples/class-state-field-static/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/class-state-field-static/_config.js
@@ -3,7 +3,7 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'invalid-state-location',
-		message: '$state() can only be used as a variable declaration initializer or a class field',
+		message: '$state(...) can only be used as a variable declaration initializer or a class field',
 		position: [33, 41]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/_config.js
@@ -3,6 +3,6 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'invalid-state-location',
-		message: '$state() can only be used as a variable declaration initializer or a class field'
+		message: '$state(...) can only be used as a variable declaration initializer or a class field'
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/runes-wrong-derived-placement/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-wrong-derived-placement/_config.js
@@ -2,7 +2,7 @@ import { test } from '../../test';
 
 export default test({
 	error: {
-		code: 'invalid-derived-location',
-		message: '$derived() can only be used as a variable declaration initializer or a class field'
+		code: 'invalid-state-location',
+		message: '$derived(...) can only be used as a variable declaration initializer or a class field'
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-placement/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-placement/_config.js
@@ -3,6 +3,6 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'invalid-state-location',
-		message: '$state() can only be used as a variable declaration initializer or a class field'
+		message: '$state(...) can only be used as a variable declaration initializer or a class field'
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/class-state-derived-fn/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-derived-fn/_config.js
@@ -1,0 +1,30 @@
+import { test } from '../../test';
+
+export default test({
+	html: `
+		<button>0</button>
+		<p>doubled: 0</p>
+	`,
+
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+
+		await btn?.click();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>1</button>
+				<p>doubled: 2</p>
+			`
+		);
+
+		await btn?.click();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>2</button>
+				<p>doubled: 4</p>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/class-state-derived-fn/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-derived-fn/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	class Counter {
+		count = $state(0);
+		doubled = $derived.fn(() => this.count * 2);
+	}
+
+	const counter = new Counter();
+</script>
+
+<button on:click={() => counter.count++}>{counter.count}</button>
+<p>doubled: {counter.doubled}</p>

--- a/packages/svelte/tests/runtime-runes/samples/class-state-derived-fn/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-derived-fn/main.svelte
@@ -1,7 +1,7 @@
 <script>
 	class Counter {
 		count = $state(0);
-		doubled = $derived.fn(() => this.count * 2);
+		doubled = $derived.call(() => this.count * 2);
 	}
 
 	const counter = new Counter();

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<button>0</button>`,
+
+	async test({ assert, target, window }) {
+		const btn = target.querySelector('button');
+		const clickEvent = new window.Event('click', { bubbles: true });
+		await btn?.dispatchEvent(clickEvent);
+
+		assert.htmlEqual(target.innerHTML, `<button>2</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn/main.svelte
@@ -1,6 +1,6 @@
 <script>
   let count = $state(0);
-  let double = $derived.fn(() => count * 2);
+  let double = $derived.call(() => count * 2);
 </script>
 
 <button on:click={() => count++}>{double}</button>

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn/main.svelte
@@ -1,0 +1,6 @@
+<script>
+  let count = $state(0);
+  let double = $derived.fn(() => count * 2);
+</script>
+
+<button on:click={() => count++}>{double}</button>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -988,15 +988,15 @@ declare module 'svelte/compiler' {
 		filename?: string | undefined;
 	} | undefined): Promise<Processed>;
 	export class CompileError extends Error {
-		
+
 		constructor(code: string, message: string, position: [number, number] | undefined);
-		
+
 		filename: CompileError_1['filename'];
-		
+
 		position: CompileError_1['position'];
-		
+
 		start: CompileError_1['start'];
-		
+
 		end: CompileError_1['end'];
 		code: string;
 	}
@@ -1007,9 +1007,9 @@ declare module 'svelte/compiler' {
 	 * */
 	export const VERSION: string;
 	class Scope {
-		
+
 		constructor(root: ScopeRoot, parent: Scope | null, porous: boolean);
-		
+
 		root: ScopeRoot;
 		/**
 		 * A map of every identifier declared by this scope, and all the
@@ -1033,25 +1033,25 @@ declare module 'svelte/compiler' {
 		 * which is usually an error. Block statements do not increase this value
 		 */
 		function_depth: number;
-		
+
 		declare(node: import('estree').Identifier, kind: Binding['kind'], declaration_kind: DeclarationKind, initial?: null | import('estree').Expression | import('estree').FunctionDeclaration | import('estree').ClassDeclaration | import('estree').ImportDeclaration | EachBlock): Binding;
 		child(porous?: boolean): Scope;
-		
+
 		generate(preferred_name: string): string;
-		
+
 		get(name: string): Binding | null;
-		
+
 		get_bindings(node: import('estree').VariableDeclarator | LetDirective): Binding[];
-		
+
 		owner(name: string): Scope | null;
-		
+
 		reference(node: import('estree').Identifier, path: SvelteNode[]): void;
 		#private;
 	}
 	class ScopeRoot {
-		
+
 		conflicts: Set<string>;
-		
+
 		unique(preferred_name: string): import("estree").Identifier;
 	}
 	interface BaseNode {
@@ -2464,11 +2464,11 @@ declare function $derived<T>(expression: T): T;
 declare namespace $derived {
 	/**
 	 * Sometimes you need to create complex derivations which don't fit inside a short expression.
-	 * In this case, you can resort to `$derived.fn` which accepts a function as its argument and returns its value.
+	 * In this case, you can resort to `$derived.call` which accepts a function as its argument and returns its value.
 	 *
 	 * Example:
 	 * ```ts
-	 * $derived.fn(() => {
+	 * $derived.call(() => {
 	 *   let tmp = count;
 	 *	 if (count > 10) {
 	 *	   tmp += 100;

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2461,6 +2461,32 @@ declare namespace $state {
  */
 declare function $derived<T>(expression: T): T;
 
+declare namespace $derived {
+	/**
+	 * Sometimes you need to create complex derivations which don't fit inside a short expression.
+	 * In this case, you can resort to `$derived.fn` which accepts a function as its argument and returns its value.
+	 *
+	 * Example:
+	 * ```ts
+	 * $derived.fn(() => {
+	 *   let tmp = count;
+	 *	 if (count > 10) {
+	 *	   tmp += 100;
+	 *	 }
+	 *	 return tmp * 2;
+	 * });
+	 * ```
+	 *
+	 * `$derived.fn` passes the previous derived value as a single argument to the derived function. This can be useful for when
+	 * you might want to compare the latest derived value with the previous derived value. Furthermore, you might want to pluck out
+	 * specific properties of derived state to use in the new derived state given a certain condition – which can be useful when dealing
+	 * with more complex state machines.
+	 *
+	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-fn
+	 */
+	export function fn<T>(fn: (prev: T) => T): void;
+}
+
 /**
  * Runs code when a component is mounted to the DOM, and then whenever its dependencies change, i.e. `$state` or `$derived` values.
  * The timing of the execution is after the DOM has been updated.

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2477,14 +2477,9 @@ declare namespace $derived {
 	 * });
 	 * ```
 	 *
-	 * `$derived.fn` passes the previous derived value as a single argument to the derived function. This can be useful for when
-	 * you might want to compare the latest derived value with the previous derived value. Furthermore, you might want to pluck out
-	 * specific properties of derived state to use in the new derived state given a certain condition – which can be useful when dealing
-	 * with more complex state machines.
-	 *
 	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-fn
 	 */
-	export function fn<T>(fn: (prev: T) => T): void;
+	export function fn<T>(fn: () => T): void;
 }
 
 /**

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -988,15 +988,15 @@ declare module 'svelte/compiler' {
 		filename?: string | undefined;
 	} | undefined): Promise<Processed>;
 	export class CompileError extends Error {
-
+		
 		constructor(code: string, message: string, position: [number, number] | undefined);
-
+		
 		filename: CompileError_1['filename'];
-
+		
 		position: CompileError_1['position'];
-
+		
 		start: CompileError_1['start'];
-
+		
 		end: CompileError_1['end'];
 		code: string;
 	}
@@ -1007,9 +1007,9 @@ declare module 'svelte/compiler' {
 	 * */
 	export const VERSION: string;
 	class Scope {
-
+		
 		constructor(root: ScopeRoot, parent: Scope | null, porous: boolean);
-
+		
 		root: ScopeRoot;
 		/**
 		 * A map of every identifier declared by this scope, and all the
@@ -1033,25 +1033,25 @@ declare module 'svelte/compiler' {
 		 * which is usually an error. Block statements do not increase this value
 		 */
 		function_depth: number;
-
+		
 		declare(node: import('estree').Identifier, kind: Binding['kind'], declaration_kind: DeclarationKind, initial?: null | import('estree').Expression | import('estree').FunctionDeclaration | import('estree').ClassDeclaration | import('estree').ImportDeclaration | EachBlock): Binding;
 		child(porous?: boolean): Scope;
-
+		
 		generate(preferred_name: string): string;
-
+		
 		get(name: string): Binding | null;
-
+		
 		get_bindings(node: import('estree').VariableDeclarator | LetDirective): Binding[];
-
+		
 		owner(name: string): Scope | null;
-
+		
 		reference(node: import('estree').Identifier, path: SvelteNode[]): void;
 		#private;
 	}
 	class ScopeRoot {
-
+		
 		conflicts: Set<string>;
-
+		
 		unique(preferred_name: string): import("estree").Identifier;
 	}
 	interface BaseNode {
@@ -2463,21 +2463,21 @@ declare function $derived<T>(expression: T): T;
 
 declare namespace $derived {
 	/**
-	 * Sometimes you need to create complex derivations which don't fit inside a short expression.
-	 * In this case, you can resort to `$derived.call` which accepts a function as its argument and returns its value.
+	 * Sometimes you need to create complex derivations that don't fit inside a short expression.
+	 * In these cases, you can use `$derived.call` which accepts a function as its argument.
 	 *
 	 * Example:
 	 * ```ts
-	 * $derived.call(() => {
-	 *   let tmp = count;
-	 *	 if (count > 10) {
-	 *	   tmp += 100;
-	 *	 }
-	 *	 return tmp * 2;
+	 * let total = $derived.call(() => {
+	 *   let result = 0;
+	 *	 for (const n of numbers) {
+	 *	   result += n;
+	 *   }
+	 *   return result;
 	 * });
 	 * ```
 	 *
-	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-fn
+	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-call
 	 */
 	export function fn<T>(fn: () => T): void;
 }

--- a/sites/svelte-5-preview/src/lib/CodeMirror.svelte
+++ b/sites/svelte-5-preview/src/lib/CodeMirror.svelte
@@ -205,9 +205,14 @@
 		return {
 			from: word.from - 1,
 			options: [
-				{ label: '$state', type: 'keyword', boost: 9 },
-				{ label: '$props', type: 'keyword', boost: 8 },
-				{ label: '$derived', type: 'keyword', boost: 7 },
+				{ label: '$state', type: 'keyword', boost: 10 },
+				{ label: '$props', type: 'keyword', boost: 9 },
+				{ label: '$derived', type: 'keyword', boost: 8 },
+				snip('$derived.fn(() => {\n\t${}\n});', {
+					label: '$derived.fn',
+					type: 'keyword',
+					boost: 7
+				}),
 				snip('$effect(() => {\n\t${}\n});', { label: '$effect', type: 'keyword', boost: 6 }),
 				snip('$effect.pre(() => {\n\t${}\n});', {
 					label: '$effect.pre',

--- a/sites/svelte-5-preview/src/lib/CodeMirror.svelte
+++ b/sites/svelte-5-preview/src/lib/CodeMirror.svelte
@@ -208,8 +208,8 @@
 				{ label: '$state', type: 'keyword', boost: 10 },
 				{ label: '$props', type: 'keyword', boost: 9 },
 				{ label: '$derived', type: 'keyword', boost: 8 },
-				snip('$derived.fn(() => {\n\t${}\n});', {
-					label: '$derived.fn',
+				snip('$derived.call(() => {\n\t${}\n});', {
+					label: '$derived.call',
 					type: 'keyword',
 					boost: 7
 				}),

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -134,14 +134,14 @@ If the value of a reactive variable is being computed it should be replaced with
   ```
   ...`double` will be calculated first despite the source order. In runes mode, `triple` cannot reference `double` before it has been declared.
 
-### `$derived.fn`
+### `$derived.call`
 
-Sometimes you need to create complex derivations which don't fit inside a short expression. In this case, you can resort to `$derived.fn` which accepts a function as its argument and returns its value.
+Sometimes you need to create complex derivations which don't fit inside a short expression. In this case, you can resort to `$derived.call` which accepts a function as its argument and returns its value.
 
 ```svelte
 <script>
 	let count = $state(0);
-	let complex = $derived.fn(() => {
+	let complex = $derived.call(() => {
 		let tmp = count;
 		if (count > 10) {
 			tmp += 100;

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -155,30 +155,6 @@ Sometimes you need to create complex derivations which don't fit inside a short 
 </button>
 ```
 
-`$derived.fn` passes the previous derived value as a single argument to the derived function. This can be useful for when
-you might want to compare the latest derived value with the previous derived value. Furthermore, you might want to pluck out
-specific properties of derived state to use in the new derived state given a certain condition – which can be useful when dealing
-with more complex state machines.
-
-```svelte
-<script>
-	let items = $state([1, 1, 1]);
-
-	let reversed = $derived.fn((prev) => {
-		const reversed = items.toReversed();
-		// Naive deep equals comparison
-		if (JSON.stringify(reversed) === JSON.stringify(prev)) {
-			return prev;
-		}
-		return reversed;
-	});
-</script>
-
-<button on:click={() => items.push(1)}>
-	{reversed}
-</button>
-```
-
 ## `$effect`
 
 To run side-effects like logging or analytics whenever some specific values change, or when a component is mounted to the DOM, we can use the `$effect` rune:

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -134,6 +134,51 @@ If the value of a reactive variable is being computed it should be replaced with
   ```
   ...`double` will be calculated first despite the source order. In runes mode, `triple` cannot reference `double` before it has been declared.
 
+### `$derived.fn`
+
+Sometimes you need to create complex derivations which don't fit inside a short expression. In this case, you can resort to `$derived.fn` which accepts a function as its argument and returns its value.
+
+```svelte
+<script>
+	let count = $state(0);
+	let complex = $derived.fn(() => {
+		let tmp = count;
+		if (count > 10) {
+			tmp += 100;
+		}
+		return tmp * 2;
+	});
+</script>
+
+<button on:click={() => count++}>
+	{complex}
+</button>
+```
+
+`$derived.fn` passes the previous derived value as a single argument to the derived function. This can be useful for when
+you might want to compare the latest derived value with the previous derived value. Furthermore, you might want to pluck out
+specific properties of derived state to use in the new derived state given a certain condition – which can be useful when dealing
+with more complex state machines.
+
+```svelte
+<script>
+	let items = $state([1, 1, 1]);
+
+	let reversed = $derived.fn((prev) => {
+		const reversed = items.toReversed();
+		// Naive deep equals comparison
+		if (JSON.stringify(reversed) === JSON.stringify(prev)) {
+			return prev;
+		}
+		return reversed;
+	});
+</script>
+
+<button on:click={() => items.push(1)}>
+	{reversed}
+</button>
+```
+
 ## `$effect`
 
 To run side-effects like logging or analytics whenever some specific values change, or when a component is mounted to the DOM, we can use the `$effect` rune:

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -134,26 +134,28 @@ If the value of a reactive variable is being computed it should be replaced with
   ```
   ...`double` will be calculated first despite the source order. In runes mode, `triple` cannot reference `double` before it has been declared.
 
-### `$derived.call`
+## `$derived.call`
 
-Sometimes you need to create complex derivations which don't fit inside a short expression. In this case, you can resort to `$derived.call` which accepts a function as its argument and returns its value.
+Sometimes you need to create complex derivations that don't fit inside a short expression. In these cases, you can use `$derived.call` which accepts a function as its argument.
 
 ```svelte
 <script>
-	let count = $state(0);
-	let complex = $derived.call(() => {
-		let tmp = count;
-		if (count > 10) {
-			tmp += 100;
+	let numbers = $state([1, 2, 3]);
+	let total = $derived.call(() => {
+		let total = 0;
+		for (const n of numbers) {
+			total += n;
 		}
-		return tmp * 2;
+		return total;
 	});
 </script>
 
-<button on:click={() => count++}>
-	{complex}
+<button on:click={() => numbers.push(numbers.length + 1)}>
+	{numbers.join(' + ')} = {total}
 </button>
 ```
+
+In essence, `$derived(expression)` is equivalent to `$derived.call(() => expression)`.
 
 ## `$effect`
 


### PR DESCRIPTION
_Rich here — after extensive discussion we decided to leave out the previous value from the signature, and to call it `$derived.call(fn)` rather than `$derived.fn(fn)`. Original comment follows:_

---

### `$derived.fn`

Sometimes you need to create complex derivations which don't fit inside a short expression. In this case, you can resort to `$derived.fn` which accepts a function as its argument and returns its value.

```svelte
<script>
	let count = $state(0);
	let complex = $derived.fn(() => {
		let tmp = count;
		if (count > 10) {
			tmp += 100;
		}
		return tmp * 2;
	});
</script>

<button on:click={() => count++}>
	{complex}
</button>
```

`$derived.fn` passes the previous derived value as a single argument to the derived function. This can be useful for when
you might want to compare the latest derived value with the previous derived value. Furthermore, you might want to pluck out specific properties of derived state to use in the new derived state given a certain condition – which can be useful when dealing with more complex state machines.

```svelte
<script>
	let items = $state([1, 1, 1]);

	let reversed = $derived.fn((prev) => {
		const reversed = items.toReversed();
		// Naive deep equals comparison
		if (JSON.stringify(reversed) === JSON.stringify(prev)) {
			return prev;
		}
		return reversed;
	});
</script>

<button on:click={() => items.push(1)}>
	{reversed}
</button>
```