### PR TITLE
Fix weird formatting in recent changelog entry

### DIFF
--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - fix: skip certain slot validations for custom elements ([#10207](https://github.com/sveltejs/svelte/pull/10207))
 
-- fix: add compiler error for invalid <p> contents ([#10201](https://github.com/sveltejs/svelte/pull/10201))
+- fix: add compiler error for invalid &lt;p&gt; contents ([#10201](https://github.com/sveltejs/svelte/pull/10201))
 
 - fix: correctly apply event.currentTarget ([#10216](https://github.com/sveltejs/svelte/pull/10216))
 

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - fix: skip certain slot validations for custom elements ([#10207](https://github.com/sveltejs/svelte/pull/10207))
 
-- fix: add compiler error for invalid &lt;p&gt; contents ([#10201](https://github.com/sveltejs/svelte/pull/10201))
+- fix: add compiler error for invalid `<p>` contents ([#10201](https://github.com/sveltejs/svelte/pull/10201))
 
 - fix: correctly apply event.currentTarget ([#10216](https://github.com/sveltejs/svelte/pull/10216))
 


### PR DESCRIPTION
A recent auto-generated changelog entry had a `<p>` in it, which caused the Markdown rendering to look strange. Replacing `<p>` with `&lt;p&gt;` fixes the rendering.
