### PR TITLE
docs: add details to discloseVersion

### DIFF
--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -142,7 +142,7 @@ export interface CompileOptions extends ModuleCompileOptions {
 	 */
 	runes?: boolean | undefined;
 	/**
-	 *  If `true`, exposes the Svelte major version on the global `window` object in the browser.
+	 *  If `true`, exposes the Svelte major version in the browser by adding it to a `Set` stored in the global `window.__svelte.v`.
 	 *
 	 * @default true
 	 */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -639,7 +639,7 @@ declare module 'svelte/compiler' {
 		 */
 		runes?: boolean | undefined;
 		/**
-		 *  If `true`, exposes the Svelte major version on the global `window` object in the browser.
+		 *  If `true`, exposes the Svelte major version in the browser by adding it to a `Set` stored in the global `window.__svelte.v`.
 		 *
 		 * @default true
 		 */
@@ -2329,7 +2329,7 @@ declare module 'svelte/types/compiler/interfaces' {
 		 */
 		runes?: boolean | undefined;
 		/**
-		 *  If `true`, exposes the Svelte major version on the global `window` object in the browser.
+		 *  If `true`, exposes the Svelte major version in the browser by adding it to a `Set` stored in the global `window.__svelte.v`.
 		 *
 		 * @default true
 		 */


### PR DESCRIPTION
Not sure why this is generating a `CompileOptions` and `CompileOptions_1`...

I wasn't sure whether to send this against `main` or `svelte-4`. I sent it against `main`, which won't update the current site, but since it's the JSDoc and not the site itself, I wasn't sure if I should sent it against `svelte-4` or not.