### PR TITLE
fix: hack fix for svelte.dev homepage in dev server

### DIFF
--- a/sites/svelte.dev/src/routes/_components/Hero.svelte
+++ b/sites/svelte.dev/src/routes/_components/Hero.svelte
@@ -3,10 +3,12 @@
 	import SvelteLogotype from './svelte-logotype.svg';
 	// @ts-ignore
 	import MachineDesktop from './svelte-machine-desktop.png?w=1200;2000;2800;4400&format=avif;webp;png;&as=picture';
+	// console.log(MachineDesktop)
 	// @ts-ignore
 	import MachineMobile from './svelte-machine-mobile.png?w=960&format=avif;webp;png;&as=picture';
 
-	const srcset = (sources) => sources.map(({ src, w }) => `${src} ${w}w`).join(', ');
+	// const srcset = (sources) => sources.map(({ src, w }) => `${src} ${w}w`).join(', ');
+	const srcset = (sources) => sources;
 </script>
 
 <div class="hero">


### PR DESCRIPTION
## Svelte 5 rewrite
For whatever reason, the dev output doesn't match up with the specs [here](https://github.com/JonasKruckenberg/imagetools/blob/main/docs/directives.md#picture), which states each `source` should correspond to an array, when in reality, without any preprocessing, it already results in the following (output from `console.log(MachineDesktop)`):
```
{
  sources: {
    avif: '/@imagetools/7421d927e8cfd8dfe5534bb30ca29461899a1018 1200w, /@imagetools/ad517dc07d6b6e18d7b61052a49cbab2c21e937c 2000w, /@imagetools/123ecfe5373a1206fbe458dde56b18940c74042e 2800w, /@imagetools/ef32fe3c8ee942458ff09449321030e629f0ba23 3795w',
    webp: '/@imagetools/12bccde62eaf7644d17e45b5a8916711e2cecc06 1200w, /@imagetools/70d02fcd11f77792d94e0dc6d2e8abadcfe33517 2000w, /@imagetools/309014eea1b3fc4b99a9f5d7b33210a2ef0907c2 2800w, /@imagetools/267ca349e21fb7341c1453a243ae30f147eaf4c9 3795w',
    png: '/@imagetools/7ef1611e7d2c38f4b18a2678f91d31462b238043 1200w, /@imagetools/9369df36a6723d1ba42b8210ac1fe0ac5ac4b793 1200w, /@imagetools/3ba2d11ad9bbaee9c9b63658106c7dca49c7d9cd 2000w, /@imagetools/2d3e9b4aa44a7f2e9024658b7d341e99ee985c09 2000w, /@imagetools/109345621b7681aec5bb393d4829ca76dfc0540f 2800w, /@imagetools/65c3b0bd3ade62fe2dd09864fd38c2880cda7358 2800w, /@imagetools/a3f6d13ad10aba8df0d80719b3884987fcccf4b2 3795w, /@imagetools/1dd327ca59237478efe960b9d593a4ec1ab9bc6c 3795w'
  },
  img: {
    src: '/@imagetools/a3f6d13ad10aba8df0d80719b3884987fcccf4b2',
    w: 3795,
    h: 993
  }
}
```
Is this just some janky dev server issue I'm unaware of?

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
