### PR TITLE
fix: `:global()` compound selector validation tweak

### DIFF
--- a/.changeset/thirty-pears-hug.md
+++ b/.changeset/thirty-pears-hug.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow type selector in `:global()` when it's at a start of a compound selector

--- a/packages/svelte/src/compiler/phases/2-analyze/css/Selector.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/Selector.js
@@ -181,9 +181,19 @@ export default class Selector {
 
 			for (let i = 0; i < block.selectors.length; i++) {
 				const selector = block.selectors[i];
+
 				if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
 					const child = selector.args?.children[0].children[0];
-					if (child?.type === 'TypeSelector' && !/[.:#]/.test(child.name[0])) {
+					if (
+						child?.type === 'TypeSelector' &&
+						!/[.:#]/.test(child.name[0]) &&
+						(i !== 0 ||
+							block.selectors
+								.slice(1)
+								.some(
+									(s) => s.type !== 'PseudoElementSelector' && s.type !== 'PseudoClassSelector'
+								))
+					) {
 						error(selector, 'invalid-css-global-selector-list');
 					}
 				}

--- a/packages/svelte/tests/validator/samples/css-invalid-global-placement-2/errors.json
+++ b/packages/svelte/tests/validator/samples/css-invalid-global-placement-2/errors.json
@@ -3,11 +3,11 @@
 		"code": "invalid-css-global-placement",
 		"message": ":global(...) can be at the start or end of a selector sequence, but not in the middle",
 		"start": {
-			"line": 5,
+			"line": 8,
 			"column": 6
 		},
 		"end": {
-			"line": 5,
+			"line": 8,
 			"column": 19
 		}
 	}

--- a/packages/svelte/tests/validator/samples/css-invalid-global-placement-2/input.svelte
+++ b/packages/svelte/tests/validator/samples/css-invalid-global-placement-2/input.svelte
@@ -2,6 +2,9 @@
 	.foo :global(.bar):first-child {
 		color: red;
 	}
+	.foo :global(p):first-child {
+		color: red;
+	}
 	.foo :global(.bar):first-child .baz {
 		color: red;
 	}

--- a/packages/svelte/tests/validator/samples/css-invalid-global-placement-6/errors.json
+++ b/packages/svelte/tests/validator/samples/css-invalid-global-placement-6/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "invalid-css-global-selector-list",
+		"message": ":global(...) must not contain type or universal selectors when used in a compound selector",
+		"start": {
+			"line": 5,
+			"column": 5
+		},
+		"end": {
+			"line": 5,
+			"column": 17
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/css-invalid-global-placement-6/input.svelte
+++ b/packages/svelte/tests/validator/samples/css-invalid-global-placement-6/input.svelte
@@ -1,0 +1,8 @@
+<style>
+	:global(div):first-child {
+		color: red;
+	}
+	.foo:global(div):first-child {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
Allow type selector in `:global()` when it's at a start of a compound selector
fixes #10286


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
