### PR TITLE
fix: prevent false positive store error in module script

### DIFF
--- a/.changeset/tall-mugs-buy.md
+++ b/.changeset/tall-mugs-buy.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: prevent false positive store error in module script

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -435,10 +435,6 @@ const errors = {
 	// 	code: 'illegal-declaration',
 	// 	message: 'The $ prefix is reserved, and cannot be used for variable and import names'
 	// },
-	// illegal_subscription: {
-	// 	code: 'illegal-subscription',
-	// 	message: 'Cannot reference store value inside <script context="module">'
-	// },
 	// illegal_global: /** @param {string} name */ (name) => ({
 	// 	code: 'illegal-global',
 	// 	message: `${name} is an illegal variable name`

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -306,11 +306,13 @@ export function analyze_component(root, options) {
 			}
 
 			if (module.ast) {
-				// if the reference is inside context="module", error. this is a bit hacky but it works
-				for (const { node } of references) {
+				for (const { node, path } of references) {
+					// if the reference is inside context="module", error. this is a bit hacky but it works
 					if (
 						/** @type {number} */ (node.start) > /** @type {number} */ (module.ast.start) &&
-						/** @type {number} */ (node.end) < /** @type {number} */ (module.ast.end)
+						/** @type {number} */ (node.end) < /** @type {number} */ (module.ast.end) &&
+						// const state = $state(0) is valid
+						get_rune(/** @type {import('estree').Node} */ (path.at(-1)), module.scope) === null
 					) {
 						error(node, 'illegal-subscription');
 					}

--- a/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/_config.js
@@ -3,6 +3,7 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'illegal-subscription',
-		message: 'Cannot reference store value inside <script context="module">'
+		message: 'Cannot reference store value inside <script context="module">',
+		position: [164, 168]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/store-autosub-context-module/main.svelte
@@ -1,6 +1,13 @@
 <script context="module">
+	// this should be fine (state rune is not treated as a store)
+	const state = $state(0);
+	// this is not
 	const foo = {};
 	const answer = $foo;
+</script>
+
+<script>
+	let state;
 </script>
 
 <p>{answer}</p>


### PR DESCRIPTION
When a variable with the same name was declared in the instance script, the module-no-auto-store-subscription-validation would fail fixes #10285

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
