### PR TITLE
work around acorn types

### DIFF
--- a/packages/svelte/src/compiler/parse/acorn-types.d.ts
+++ b/packages/svelte/src/compiler/parse/acorn-types.d.ts
@@ -1,0 +1,4 @@
+declare module 'acorn' {
+	export function isIdentifierStart(code: number, astral: boolean): boolean;
+	export function isIdentifierChar(code: number, astral: boolean): boolean;
+}

--- a/sites/svelte.dev/src/routes/(authed)/repl/[id]/embed/+page.server.js
+++ b/sites/svelte.dev/src/routes/(authed)/repl/[id]/embed/+page.server.js
@@ -4,7 +4,7 @@ export async function load({ fetch, params, url }) {
 	const res = await fetch(`/repl/api/${params.id}.json`);
 
 	if (!res.ok) {
-		throw error(res.status);
+		throw error(/** @type {any} */ (res.status));
 	}
 
 	const gist = await res.json();


### PR DESCRIPTION
this isn't the cleanest fix (which would be to not depend on these imports at all — see https://github.com/acornjs/acorn/issues/1260) but it'll tidy up our CI