### PR TITLE
Improve ssr template generation

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -1355,15 +1355,13 @@ const template_visitors = {
 		// and continue hydration without having to re-render everything from scratch.
 
 		const consequent = create_block(node, node.consequent.nodes, context);
-		consequent.unshift(
-			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!--ssr:if:true-->')))
-		);
+		consequent.unshift(b.stmt(b.assignment('+=', b.id('$$payload.out'), b.id('$.SSR_IF_TRUE'))));
 
 		const alternate = node.alternate
 			? /** @type {import('estree').BlockStatement} */ (context.visit(node.alternate))
 			: b.block([]);
 		alternate.body.unshift(
-			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!--ssr:if:false-->')))
+			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.id('$.SSR_IF_FALSE')))
 		);
 
 		state.template.push(

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -32,6 +32,9 @@ const CONTENT_REGEX = /[&<]/g;
 const INVALID_ATTR_NAME_CHAR_REGEX =
 	/[\s'">/=\u{FDD0}-\u{FDEF}\u{FFFE}\u{FFFF}\u{1FFFE}\u{1FFFF}\u{2FFFE}\u{2FFFF}\u{3FFFE}\u{3FFFF}\u{4FFFE}\u{4FFFF}\u{5FFFE}\u{5FFFF}\u{6FFFE}\u{6FFFF}\u{7FFFE}\u{7FFFF}\u{8FFFE}\u{8FFFF}\u{9FFFE}\u{9FFFF}\u{AFFFE}\u{AFFFF}\u{BFFFE}\u{BFFFF}\u{CFFFE}\u{CFFFF}\u{DFFFE}\u{DFFFF}\u{EFFFE}\u{EFFFF}\u{FFFFE}\u{FFFFF}\u{10FFFE}\u{10FFFF}]/u;
 
+export const SSR_IF_FALSE = '<!--ssr:if:false-->';
+export const SSR_IF_TRUE = '<!--ssr:if:true-->';
+
 export const VoidElements = new Set([
 	'area',
 	'base',


### PR DESCRIPTION
While reviewing generated server-side code, I found that the literals `<!--ssr:if:true-->` and `<!--ssr:if:false-->` are used at every branch. Replace them by constants `$.SSR_IF_TRUE` and `$.SSR_IF_FALSE` resulting in smaller generated code that can be minified more and perform less memory allocations.

I don't know if it it is a good idea nor it has drawbacks.
