### PR TITLE
fix: handle event delegation correctly when having sibling event listeners

### DIFF
--- a/.changeset/big-eyes-carry.md
+++ b/.changeset/big-eyes-carry.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: handle event delegation correctly when having sibling event listeners

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/_config.js
@@ -1,0 +1,35 @@
+import { test } from '../../test';
+import { log } from './log.js';
+
+export default test({
+	before_test() {
+		log.length = 0;
+	},
+
+	async test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+
+		btn1?.click();
+		await Promise.resolve();
+		assert.deepEqual(log, [
+			'button main',
+			'div main 1',
+			'div main 2',
+			'document main',
+			'document sub',
+			'window main',
+			'window sub'
+		]);
+
+		log.length = 0;
+		btn2?.click();
+		await Promise.resolve();
+		assert.deepEqual(log, [
+			'button sub',
+			'document main',
+			'document sub',
+			'window main',
+			'window sub'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/log.js
@@ -1,0 +1,2 @@
+/** @type {any[]} */
+export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { log } from "./log";
+	import Sub from "./sub.svelte";
+</script>
+
+<svelte:window onclick="{() => log.push('window main')}" />
+<svelte:document onclick="{() => log.push('document main')}" />
+
+<div on:click={() => log.push('div main 1')} on:click={() => log.push('div main 2')}>
+	<button onclick={() => log.push('button main')}>main</button>
+</div>
+
+<Sub />

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/sub.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/sub.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { log } from "./log";
+</script>
+
+<svelte:window onclick={() => log.push('window sub')} />
+<svelte:document onclick={() => log.push('document sub')} />
+
+<button onclick={() => log.push('button sub')}>sub</button>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../test';
+import { log } from './log.js';
+
+export default test({
+	before_test() {
+		log.length = 0;
+	},
+
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+
+		btn?.click();
+		await Promise.resolve();
+		assert.deepEqual(log, [
+			'button onclick',
+			'button on:click',
+			'inner div on:click',
+			'outer div onclick'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/log.js
@@ -1,0 +1,2 @@
+/** @type {any[]} */
+export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { log } from "./log";
+</script>
+
+<div onclick={() => log.push('outer div onclick')}>
+	<div on:click={() => log.push('inner div on:click')}>
+		<button onclick={() => log.push('button onclick')} on:click={() => log.push('button on:click')}>main</button>
+	</div>
+</div>


### PR DESCRIPTION
If you had `on:` directives listening to the same name (through multiple on:click on the same element or indirectly through multiple `<svelte:window>` elements with event listeners of the same name) there was a bug of delegation firing too often. This PR fixes that by tweaking the "should I continue with the given path index" logic. fixes #10271

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
