### PR TITLE
fix: add `scrollend` event type

### DIFF
--- a/.changeset/fair-phones-dance.md
+++ b/.changeset/fair-phones-dance.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add `scrollend` event type

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -179,6 +179,7 @@ export interface DOMAttributes<T extends EventTarget> {
 
 	// UI Events
 	'on:scroll'?: UIEventHandler<T> | undefined | null;
+	'on:scrollend'?: UIEventHandler<T> | undefined | null;
 	'on:resize'?: UIEventHandler<T> | undefined | null;
 
 	// Wheel Events


### PR DESCRIPTION
Added `scrollend` event type which is useful when you want to fire an event handler after scrolling has finished vs firing continuously while scrolling as `scroll` does. closes #10258

Ref: 
https://developer.mozilla.org/en-US/docs/Web/API/Document/scrollend_event
https://developer.chrome.com/blog/scrollend-a-new-javascript-event
https://caniuse.com/?search=scrollend

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
