### PR TITLE
fix: add `onscrollend` event type

### DIFF
--- a/.changeset/tame-cycles-kneel.md
+++ b/.changeset/tame-cycles-kneel.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: add `scrollend` event type

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -351,6 +351,9 @@ export interface DOMAttributes<T extends EventTarget> {
 	'on:scroll'?: UIEventHandler<T> | undefined | null;
 	onscroll?: UIEventHandler<T> | undefined | null;
 	onscrollcapture?: UIEventHandler<T> | undefined | null;
+	'on:scrollend'?: UIEventHandler<T> | undefined | null;
+	onscrollend?: UIEventHandler<T> | undefined | null;
+	onscrollendcapture?: UIEventHandler<T> | undefined | null;
 	'on:resize'?: UIEventHandler<T> | undefined | null;
 	onresize?: UIEventHandler<T> | undefined | null;
 	onresizecapture?: UIEventHandler<T> | undefined | null;


### PR DESCRIPTION
Same as #10336 but with svelte 5 variants

Added `scrollend` event type which is useful when you want to fire an event handler after scrolling has finished vs firing continuously while scrolling as `scroll` does. closes #10258

Ref: 
https://developer.mozilla.org/en-US/docs/Web/API/Document/scrollend_event
https://developer.chrome.com/blog/scrollend-a-new-javascript-event
https://caniuse.com/?search=scrollend

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
