### PR TITLE
fix: Update `$derived.call` type declaration

### DIFF
--- a/.changeset/honest-dragons-turn.md
+++ b/.changeset/honest-dragons-turn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Use generic `T` as the return type for `$derived.call()`

--- a/packages/svelte/src/main/ambient.d.ts
+++ b/packages/svelte/src/main/ambient.d.ts
@@ -77,7 +77,7 @@ declare namespace $derived {
 	 *
 	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-call
 	 */
-	export function call<T>(fn: () => T): void;
+	export function call<T>(fn: () => T): T;
 }
 
 /**

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2509,7 +2509,7 @@ declare namespace $derived {
 	 *
 	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-call
 	 */
-	export function call<T>(fn: () => T): void;
+	export function call<T>(fn: () => T): T;
 }
 
 /**


### PR DESCRIPTION
The current type declaration incorrectly suggests `$derived.call()` will always return void, instead of the return type of the function it receives.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
