### PR TITLE
fix: bind:group incorrectly considers other groups for nested data

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/bind-group-nested-data/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-group-nested-data/_config.js
@@ -1,0 +1,23 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, window, component }) {
+		const checkboxes = /** @type {NodeListOf<HTMLInputElement>} */ (
+			target.querySelectorAll('input[type="checkbox"]')
+		);
+
+		assert.isFalse(checkboxes[0].checked);
+		assert.isTrue(checkboxes[1].checked);
+		assert.isFalse(checkboxes[2].checked);
+
+		await checkboxes[1].click();
+
+		const noChecked = target.querySelector('#output')?.innerHTML;
+		assert.equal(noChecked, '');
+
+		await checkboxes[1].click();
+
+		const oneChecked = target.querySelector('#output')?.innerHTML;
+		assert.equal(oneChecked, 'Mint choc chip');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bind-group-nested-data/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-group-nested-data/main.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { writable } from 'svelte/store';
+
+  let menu = ['Cookies and cream', 'Mint choc chip', 'Raspberry ripple'];
+  let order = writable({ flavours: ['Mint choc chip'], scoops: 1 });
+</script>
+
+<form method="POST">
+  <h2>Size</h2>
+
+  <label>
+    <input type="radio" bind:group={$order.scoops} name="scoops" value={1} />
+    One scoop
+  </label>
+
+  <label>
+    <input type="radio" bind:group={$order.scoops} name="scoops" value={2} />
+    Two scoops
+  </label>
+
+  <label>
+    <input type="radio" bind:group={$order.scoops} name="scoops" value={3} />
+    Three scoops
+  </label>
+
+  <h2>Flavours</h2>
+
+  {#each menu as flavour}
+    <label>
+      <input
+        type="checkbox"
+        bind:group={$order.flavours}
+        name="flavours"
+        value={flavour}
+      />
+      {flavour}
+    </label>
+  {/each}
+</form>
+
+<div>
+	<h2>Current flavours</h2>
+	<span id="output">{$order.flavours.join('+')}</span>
+</div>

--- a/packages/svelte/tests/runtime-runes/samples/bind-group-nested-data/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-group-nested-data/main.svelte
@@ -2,43 +2,18 @@
   import { writable } from 'svelte/store';
 
   let menu = ['Cookies and cream', 'Mint choc chip', 'Raspberry ripple'];
-  let order = writable({ flavours: ['Mint choc chip'], scoops: 1 });
+  let order = writable({ iceCream: [{flavours: ['Mint choc chip']}], scoops: 1 });
+  let index = 0
 </script>
 
 <form method="POST">
-  <h2>Size</h2>
-
-  <label>
-    <input type="radio" bind:group={$order.scoops} name="scoops" value={1} />
-    One scoop
-  </label>
-
-  <label>
-    <input type="radio" bind:group={$order.scoops} name="scoops" value={2} />
-    Two scoops
-  </label>
-
-  <label>
-    <input type="radio" bind:group={$order.scoops} name="scoops" value={3} />
-    Three scoops
-  </label>
-
-  <h2>Flavours</h2>
+  <input type="radio" bind:group={$order.scoops} name="scoops" value={1} /> One scoop
+  <input type="radio" bind:group={$order.scoops} name="scoops" value={2} /> Two scoops
+  <input type="radio" bind:group={$order.scoops} name="scoops" value={3} /> Three scoops
 
   {#each menu as flavour}
-    <label>
-      <input
-        type="checkbox"
-        bind:group={$order.flavours}
-        name="flavours"
-        value={flavour}
-      />
-      {flavour}
-    </label>
+    <input type="checkbox" bind:group={$order.iceCream[index].flavours} name="flavours" value={flavour} /> {flavour}
   {/each}
 </form>
 
-<div>
-	<h2>Current flavours</h2>
-	<span id="output">{$order.flavours.join('+')}</span>
-</div>
+<div id="output">{$order.iceCream[index].flavours.join('+')}</div>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Description

This PR is a start of fixing #9947. The failing test shows that binding groups aren't properly being separated when binding to nested data, like `$order.scoops` in the example. It will be intermingled with the `$order.flavours` group.

### Details

In `src\compiler\phases\2-analyze\index.js` around line 1024, a binding is referenced based on the left-most identifier of a member expression or identifier (by way of the `object` function). 

This makes the `$order.scoops` and the `$order.flavours` reference to the same group binding, `$order`.

Changing the id of the binding to the whole expression doesn't work, as that binding id doesn't exist in `context.state.scope`.

Also, the `binding_groups` of the `ComponentAnalysis` interface is a Map that only accepts one group per binding, so it seems like you cannot add different groups like that, based on the same binding.

If it's a relatively simple fix, with some pointers in the right direction, I can keep working on it.
