### PR TITLE
fix: make inline doc links valid

### DIFF
--- a/.changeset/silver-guests-search.md
+++ b/.changeset/silver-guests-search.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make inline doc links valid

--- a/packages/svelte/scripts/generate-dts.js
+++ b/packages/svelte/scripts/generate-dts.js
@@ -35,6 +35,20 @@ await createBundle({
 
 // There's no way to tell in JS that a class can have arbitrary properties, so we need to add that manually
 const types = fs.readFileSync('types/index.d.ts', 'utf-8');
+
+const bad_links = [...types.matchAll(/\]\((\/[^)]+)\)/g)];
+if (bad_links.length > 0) {
+	console.error(
+		`The following links in JSDoc annotations should be prefixed with https://svelte.dev:`
+	);
+
+	for (const [, link] of bad_links) {
+		console.error(`- ${link}`);
+	}
+
+	process.exit(1);
+}
+
 fs.writeFileSync(
 	'types/index.d.ts',
 	// same line to not affect source map

--- a/packages/svelte/scripts/generate-dts.js
+++ b/packages/svelte/scripts/generate-dts.js
@@ -39,7 +39,7 @@ const types = fs.readFileSync('types/index.d.ts', 'utf-8');
 const bad_links = [...types.matchAll(/\]\((\/[^)]+)\)/g)];
 if (bad_links.length > 0) {
 	console.error(
-		`The following links in JSDoc annotations should be prefixed with https://svelte.dev:`
+		'The following links in JSDoc annotations should be prefixed with https://svelte.dev:'
 	);
 
 	for (const [, link] of bad_links) {

--- a/packages/svelte/src/runtime/internal/lifecycle.js
+++ b/packages/svelte/src/runtime/internal/lifecycle.js
@@ -32,7 +32,7 @@ export function beforeUpdate(fn) {
  *
  * If a function is returned _synchronously_ from `onMount`, it will be called when the component is unmounted.
  *
- * `onMount` does not run inside a [server-side component](/docs#run-time-server-side-component-api).
+ * `onMount` does not run inside a [server-side component](https://svelte.dev/docs#run-time-server-side-component-api).
  *
  * https://svelte.dev/docs/svelte#onmount
  * @template T
@@ -71,7 +71,7 @@ export function onDestroy(fn) {
 }
 
 /**
- * Creates an event dispatcher that can be used to dispatch [component events](/docs#template-syntax-component-directives-on-eventname).
+ * Creates an event dispatcher that can be used to dispatch [component events](https://svelte.dev/docs#template-syntax-component-directives-on-eventname).
  * Event dispatchers are functions that can take two arguments: `name` and `detail`.
  *
  * Component events created with `createEventDispatcher` create a

--- a/packages/svelte/src/runtime/transition/index.js
+++ b/packages/svelte/src/runtime/transition/index.js
@@ -179,7 +179,7 @@ export function draw(node, { delay = 0, speed, duration, easing = cubicInOut } =
 }
 
 /**
- * The `crossfade` function creates a pair of [transitions](/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.
+ * The `crossfade` function creates a pair of [transitions](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.
  *
  * https://svelte.dev/docs/svelte-transition#crossfade
  * @param {import('./public').CrossfadeParams & {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -189,7 +189,7 @@ declare module 'svelte' {
 	 *
 	 * If a function is returned _synchronously_ from `onMount`, it will be called when the component is unmounted.
 	 *
-	 * `onMount` does not run inside a [server-side component](/docs#run-time-server-side-component-api).
+	 * `onMount` does not run inside a [server-side component](https://svelte.dev/docs#run-time-server-side-component-api).
 	 *
 	 * https://svelte.dev/docs/svelte#onmount
 	 * */
@@ -212,7 +212,7 @@ declare module 'svelte' {
 	 * */
 	export function onDestroy(fn: () => any): void;
 	/**
-	 * Creates an event dispatcher that can be used to dispatch [component events](/docs#template-syntax-component-directives-on-eventname).
+	 * Creates an event dispatcher that can be used to dispatch [component events](https://svelte.dev/docs#template-syntax-component-directives-on-eventname).
 	 * Event dispatchers are functions that can take two arguments: `name` and `detail`.
 	 *
 	 * Component events created with `createEventDispatcher` create a
@@ -1789,7 +1789,7 @@ declare module 'svelte/transition' {
 		getTotalLength(): number;
 	}, { delay, speed, duration, easing }?: DrawParams | undefined): TransitionConfig;
 	/**
-	 * The `crossfade` function creates a pair of [transitions](/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.
+	 * The `crossfade` function creates a pair of [transitions](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.
 	 *
 	 * https://svelte.dev/docs/svelte-transition#crossfade
 	 * */


### PR DESCRIPTION
#10365, but for `svelte-4`