### PR TITLE
fix: correctly determine `bind:group` members

### DIFF
--- a/.changeset/cyan-flowers-destroy.md
+++ b/.changeset/cyan-flowers-destroy.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: correctly determine `bind:group` members

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2720,8 +2720,7 @@ export const template_visitors = {
 				case 'group': {
 					/** @type {import('estree').CallExpression[]} */
 					const indexes = [];
-					// we only care about the indexes above the first each block
-					for (const parent_each_block of node.metadata.parent_each_blocks.slice(0, -1)) {
+					for (const parent_each_block of node.metadata.parent_each_blocks) {
 						indexes.push(b.call('$.unwrap', parent_each_block.metadata.index));
 					}
 

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -3,7 +3,7 @@ import { walk } from 'zimmerframe';
 import { is_element_node } from './nodes.js';
 import * as b from '../utils/builders.js';
 import { error } from '../errors.js';
-import { extract_identifiers, extract_identifiers_from_expression } from '../utils/ast.js';
+import { extract_identifiers, extract_identifiers_from_destructuring } from '../utils/ast.js';
 import { JsKeywords, Runes } from './constants.js';
 
 export class Scope {
@@ -306,7 +306,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			scopes.set(attribute, scope);
 
 			if (attribute.expression) {
-				for (const id of extract_identifiers_from_expression(attribute.expression)) {
+				for (const id of extract_identifiers_from_destructuring(attribute.expression)) {
 					const binding = scope.declare(id, 'derived', 'const');
 					bindings.push(binding);
 				}
@@ -548,6 +548,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 				array_name: needs_array_deduplication ? state.scope.root.unique('$$array') : null,
 				index: scope.root.unique('$$index'),
 				item_name: node.context.type === 'Identifier' ? node.context.name : '$$item',
+				declarations: scope.declarations,
 				references: [...references_within]
 					.map((id) => /** @type {import('#compiler').Binding} */ (state.scope.get(id.name)))
 					.filter(Boolean),

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -28,11 +28,6 @@ export interface ReactiveStatement {
 	dependencies: Set<Binding>;
 }
 
-export interface BindingGroup {
-	name: Identifier;
-	directives: BindDirective[];
-}
-
 export interface RawWarning {
 	code: string;
 	message: string;
@@ -72,7 +67,8 @@ export interface ComponentAnalysis extends Analysis {
 	/** If `true`, should append styles through JavaScript */
 	inject_styles: boolean;
 	reactive_statements: Map<LabeledStatement, ReactiveStatement>;
-	binding_groups: Map<Binding, BindingGroup>;
+	/** Identifiers that make up the `bind:group` expression -> internal group binding name */
+	binding_groups: Map<Array<Binding | null>, Identifier>;
 	slot_names: Set<string>;
 }
 

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -379,6 +379,7 @@ export interface EachBlock extends BaseNode {
 		array_name: Identifier | null;
 		index: Identifier;
 		item_name: string;
+		declarations: Map<string, Binding>;
 		/** List of bindings that are referenced within the expression */
 		references: Binding[];
 		/**

--- a/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-14/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-14/_config.js
@@ -1,0 +1,39 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, window }) {
+		const [input1, input2, input3, input4] = target.querySelectorAll('input');
+		const [p] = target.querySelectorAll('p');
+		const event = new window.Event('change');
+
+		input1.checked = true;
+		await input1.dispatchEvent(event);
+		await Promise.resolve();
+		assert.htmlEqual(p.innerHTML, '["1a"]');
+
+		input2.checked = true;
+		await input1.dispatchEvent(event);
+		await Promise.resolve();
+		assert.htmlEqual(p.innerHTML, '["1a","1b"]');
+
+		input3.checked = true;
+		await input1.dispatchEvent(event);
+		await Promise.resolve();
+		assert.htmlEqual(p.innerHTML, '["1a","1b","2a"]');
+
+		input4.checked = true;
+		await input1.dispatchEvent(event);
+		await Promise.resolve();
+		assert.htmlEqual(p.innerHTML, '["1a","1b","2a","2b"]');
+
+		input1.checked = false;
+		await input1.dispatchEvent(event);
+		await Promise.resolve();
+		assert.htmlEqual(p.innerHTML, '["1b","2a","2b"]');
+
+		input3.checked = false;
+		await input1.dispatchEvent(event);
+		await Promise.resolve();
+		assert.htmlEqual(p.innerHTML, '["1b","2b"]');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-14/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-14/main.svelte
@@ -1,0 +1,26 @@
+<script>
+	let group = [];
+	
+	const options = [
+		["1", ["1a", "1b"]],
+		["2", ["2a", "2b"]],
+	];
+</script>
+
+{#each options as [prefix, arr]}
+	{prefix}
+	<div>
+		{#each arr as item}
+			<label>
+				<input
+					type="checkbox"
+					bind:group
+					value={item}
+				/>
+				{item}
+			</label>
+		{/each}
+	</div>
+{/each}
+
+<p>{JSON.stringify(group)}</p>

--- a/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-15/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-15/_config.js
@@ -1,0 +1,23 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const checkboxes = /** @type {NodeListOf<HTMLInputElement>} */ (
+			target.querySelectorAll('input[type="checkbox"]')
+		);
+
+		assert.isFalse(checkboxes[0].checked);
+		assert.isTrue(checkboxes[1].checked);
+		assert.isFalse(checkboxes[2].checked);
+
+		await checkboxes[1].click();
+
+		const noChecked = target.querySelector('#output')?.innerHTML;
+		assert.equal(noChecked, '');
+
+		await checkboxes[1].click();
+
+		const oneChecked = target.querySelector('#output')?.innerHTML;
+		assert.equal(oneChecked, 'Mint choc chip');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-15/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-15/main.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { writable } from 'svelte/store';
+	let menu = ['Cookies and cream', 'Mint choc chip', 'Raspberry ripple'];
+	let order = writable({ iceCream: [{flavours: ['Mint choc chip']}], scoops: 1 });
+	let index = 0
+</script>
+
+<form method="POST">
+	<input type="radio" bind:group={$order.scoops} name="scoops" value={1} /> One scoop
+	<input type="radio" bind:group={$order.scoops} name="scoops" value={2} /> Two scoops
+	<input type="radio" bind:group={$order.scoops} name="scoops" value={3} /> Three scoops
+
+	{#each menu as flavour}
+		<input type="checkbox" bind:group={$order.iceCream[index].flavours} name="flavours" value={flavour} /> {flavour}
+	{/each}
+</form>
+
+<div id="output">{$order.iceCream[index].flavours.join('+')}</div>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1408,6 +1408,7 @@ declare module 'svelte/compiler' {
 			array_name: Identifier | null;
 			index: Identifier;
 			item_name: string;
+			declarations: Map<string, Binding>;
 			/** List of bindings that are referenced within the expression */
 			references: Binding[];
 			/**


### PR DESCRIPTION
- Previously, any each block parents were used as keys for the sub group. That's wrong, it should only be using each blocks whos declarations contribute to the `bind:group` expression. Fixes #10345
- Only the left-most identifier of the expression was used to determine the binding group. This is wrong, all identifiers within the expression need to be taken into account. Fixes #9947

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
