### PR TITLE
[Svelte 4] fix: Add `miter-clip` and `arcs` to `stroke-linejoin` attribute

### DIFF
--- a/.changeset/nine-bags-thank.md
+++ b/.changeset/nine-bags-thank.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: Add `miter-clip` and `arcs` to `stroke-linejoin` attribute

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1403,7 +1403,15 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	'stroke-dasharray'?: string | number | undefined | null;
 	'stroke-dashoffset'?: string | number | undefined | null;
 	'stroke-linecap'?: 'butt' | 'round' | 'square' | 'inherit' | undefined | null;
-	'stroke-linejoin'?: 'miter' | 'round' | 'bevel' | 'inherit' | undefined | null;
+	'stroke-linejoin'?:
+		| 'arcs'
+		| 'miter-clip'
+		| 'miter'
+		| 'round'
+		| 'bevel'
+		| 'inherit'
+		| undefined
+		| null;
 	'stroke-miterlimit'?: string | undefined | null;
 	'stroke-opacity'?: number | string | undefined | null;
 	'stroke-width'?: number | string | undefined | null;


### PR DESCRIPTION
#10141 for svelte 4

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
