### PR TITLE
fix: Still failing bind:group for nested data

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1036,7 +1036,7 @@ const common_visitors = {
 		// If the same identifiers in the same order are used in another bind:group, they will be in the same group.
 		// (there's an edge case where `bind:group={a[i]}` will be in a different group than `bind:group={a[j]}` even when i == j,
 		//  but this is a limitation of the current static analysis we do; it also never worked in Svelte 4)
-		const bindings = expression_ids.map((id) => context.state.scope.get(id.name));
+		const bindings = expression_ids.map((id) => context.state.scope.get(id.name) ?? id);
 		let group_name;
 		outer: for (const [b, group] of context.state.analysis.binding_groups) {
 			if (b.length !== bindings.length) continue;

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -68,7 +68,7 @@ export interface ComponentAnalysis extends Analysis {
 	inject_styles: boolean;
 	reactive_statements: Map<LabeledStatement, ReactiveStatement>;
 	/** Identifiers that make up the `bind:group` expression -> internal group binding name */
-	binding_groups: Map<Array<Binding | null>, Identifier>;
+	binding_groups: Map<Array<Binding | Identifier | null>, Identifier>;
 	slot_names: Set<string>;
 }
 

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -108,11 +108,8 @@ export function extract_all_identifiers_from_expression(expr) {
 		expr,
 		{},
 		{
-			Identifier(node, { path }) {
-				const parent = path.at(-1);
-				if (parent?.type !== 'MemberExpression' || parent.property !== node || parent.computed) {
-					nodes.push(node);
-				}
+			Identifier(node) {
+				nodes.push(node);
 			}
 		}
 	);

--- a/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-16/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-16/_config.js
@@ -1,0 +1,23 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const checkboxes = /** @type {NodeListOf<HTMLInputElement>} */ (
+			target.querySelectorAll('input[type="checkbox"]')
+		);
+
+		assert.isFalse(checkboxes[0].checked);
+		assert.isTrue(checkboxes[1].checked);
+		assert.isFalse(checkboxes[2].checked);
+
+		await checkboxes[1].click();
+
+		const noChecked = target.querySelector('#output')?.innerHTML;
+		assert.equal(noChecked, '');
+
+		await checkboxes[1].click();
+
+		const oneChecked = target.querySelector('#output')?.innerHTML;
+		assert.equal(oneChecked, 'Mint choc chip');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-16/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-16/main.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { writable } from 'svelte/store';
+	let menu = ['Cookies and cream', 'Mint choc chip', 'Raspberry ripple'];
+	let order = writable({flavours: ['Mint choc chip'], scoops: 1 });
+</script>
+
+<form method="POST">
+	<input type="radio" bind:group={$order.scoops} name="scoops" value={1} /> One scoop
+	<input type="radio" bind:group={$order.scoops} name="scoops" value={2} /> Two scoops
+	<input type="radio" bind:group={$order.scoops} name="scoops" value={3} /> Three scoops
+
+	{#each menu as flavour}
+		<input type="checkbox" bind:group={$order.flavours} name="flavours" value={flavour} /> {flavour}
+	{/each}
+</form>
+
+<div id="output">{$order.flavours.join('+')}</div>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Description

After the #10368 fix in next.45, I tried my code to see if #9947 was fixed, but unfortunately it doesn't work for a simpler case. Apologies for providing an edge case test in `runtime-legacy/samples/binding-input-group-each-15`, but not a more common one.

Currently, `extract_all_identifiers_from_expression` in `ast.js` won't extract both identifiers from `$order.scoops` and `$order.flavours`. 

### Attempted fix

My attempt of fixing this (by no means a perfect fix) is to make `extract_all_identifiers_from_expression` return all identifiers, and in `2-analyze/index.js` use the binding *or* the identifier when detecting what group to bind to.

This fixes the test added in this PR, `runtime-legacy/samples/binding-input-group-each-16` but makes another test fail, `runtime-legacy/samples/binding-input-group-each-12`. This makes me wonder if the combination of identifiers and each block to detect the group maybe isn't working properly.

In the case of `each-16`, the `$order.flavours` binding has no reference to its each block, which should make it "standalone", but still be fully referenced to distinguish it from `$order.scoops`. 

On the other hand, `each-12` references its each block, which references its parent, and so on, so maybe it should be referenced all the way up to `pipelineOperations`, but that's the limit of my knowledge on how to reference it properly.
