### PR TITLE
feat: add fetchpriority to image attrs

### DIFF
--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -762,6 +762,7 @@ export interface HTMLImgAttributes extends HTMLAttributes<HTMLImageElement> {
 	alt?: string | undefined | null;
 	crossorigin?: 'anonymous' | 'use-credentials' | '' | undefined | null;
 	decoding?: 'async' | 'auto' | 'sync' | undefined | null;
+	fetchpriority?: 'auto' | 'high' | 'low' | undefined | null;
 	height?: number | string | undefined | null;
 	ismap?: boolean | undefined | null;
 	loading?: 'eager' | 'lazy' | undefined | null;


### PR DESCRIPTION
This is a version of #10388 for Svelte 4

This PR adds the [fetchpriority attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#fetchpriority) to HTML attributes. This has been requested in #8099, which was rejected as an experimental feature. It is now implemented in Chromium and Safari, and is in [the WhatWG spec](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-fetchpriority).

I am the maintainer of `@unpic/svelte` (recommended [in the docs](https://kit.svelte.dev/docs/images#loading-images-dynamically-from-a-cdn) ), and currently need to add it as an augmented property. It would be good if we could add it instead.

Fixes #8099

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
