### PR TITLE
fix: add `fetchpriority` to `script` and `link` tags

### DIFF
--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -882,6 +882,7 @@ export interface HTMLLinkAttributes extends HTMLAttributes<HTMLLinkElement> {
 	sizes?: string | undefined | null;
 	type?: string | undefined | null;
 	charset?: string | undefined | null;
+	fetchpriority?: 'auto' | 'high' | 'low' | undefined | null;
 }
 
 export interface HTMLMapAttributes extends HTMLAttributes<HTMLMapElement> {
@@ -1016,6 +1017,7 @@ export interface HTMLScriptAttributes extends HTMLAttributes<HTMLScriptElement> 
 	charset?: string | undefined | null;
 	crossorigin?: string | undefined | null;
 	defer?: boolean | undefined | null;
+	fetchpriority?: 'auto' | 'high' | 'low' | undefined | null;
 	integrity?: string | undefined | null;
 	nomodule?: boolean | undefined | null;
 	nonce?: string | undefined | null;


### PR DESCRIPTION
Works on more elements besides img
fixes #10394
no changeset because it's not released yet and there was a similar PR already