### PR TITLE
fix: make beforeUpdate/afterUpdate behave more like Svelte 4

### DIFF
--- a/.changeset/afraid-dogs-matter.md
+++ b/.changeset/afraid-dogs-matter.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: align `beforeUpdate`/`afterUpdate` behavior better with that in Svelte 4

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -200,6 +200,8 @@ const runes = {
 		`${rune} can only be called with ${list(args, 'or')} ${
 			args.length === 1 && args[0] === 1 ? 'argument' : 'arguments'
 		}`,
+	/** @param {string} name */
+	'invalid-runes-mode-import': (name) => `${name} cannot be used in runes mode`,
 	'duplicate-props-rune': () => `Cannot use $props() more than once`
 };
 

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -493,7 +493,7 @@ const validation = {
 		}
 	},
 	ImportDeclaration(node, context) {
-		if (context.state.analysis.runes) {
+		if (node.source.value === 'svelte' && context.state.analysis.runes) {
 			for (const specifier of node.specifiers) {
 				if (specifier.type === 'ImportSpecifier') {
 					if (

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -492,6 +492,20 @@ const validation = {
 			error(node, 'invalid-const-placement');
 		}
 	},
+	ImportDeclaration(node, context) {
+		if (context.state.analysis.runes) {
+			for (const specifier of node.specifiers) {
+				if (specifier.type === 'ImportSpecifier') {
+					if (
+						specifier.imported.name === 'beforeUpdate' ||
+						specifier.imported.name === 'afterUpdate'
+					) {
+						error(specifier, 'invalid-runes-mode-import', specifier.imported.name);
+					}
+				}
+			}
+		}
+	},
 	LetDirective(node, context) {
 		const parent = context.path.at(-1);
 		if (

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -262,6 +262,7 @@ export function client_component(source, analysis, options) {
 		...legacy_reactive_declarations,
 		...group_binding_declarations,
 		.../** @type {import('estree').Statement[]} */ (instance.body),
+		analysis.runes ? b.empty : b.stmt(b.call('$.init')),
 		.../** @type {import('estree').Statement[]} */ (template.body),
 		...static_bindings
 	]);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -153,7 +153,7 @@ export function default_equals(a, b) {
  * @param {V} value
  * @returns {import('./types.js').SourceSignal<V> | import('./types.js').SourceSignal<V> & import('./types.js').SourceSignalDebug}
  */
-export function create_source_signal(flags, value) {
+function create_source_signal(flags, value) {
 	if (DEV) {
 		return {
 			// consumers

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1327,7 +1327,10 @@ function bind_signal_to_component_context(signal) {
 			signals.push(signal);
 
 			// update dummy signal
+			const previous_ignore_mutation_validation = ignore_mutation_validation;
+			ignore_mutation_validation = true;
 			set_signal_value(signals[0], signals[0].v + 1);
+			ignore_mutation_validation = previous_ignore_mutation_validation;
 		} else {
 			// if we're creating the array, insert a dummy signal whose value we can
 			// increment whenever we add new sources. This ensures that late-declared

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1304,12 +1304,15 @@ function bind_signal_to_component_context(signal) {
 	if (current_component_context === null) return;
 
 	signal.x = current_component_context;
-	const signals = current_component_context.d;
 
-	if (signals) {
-		signals.push(signal);
-	} else {
-		current_component_context.d = [signal];
+	if (current_component_context.r) {
+		const signals = current_component_context.d;
+
+		if (signals) {
+			signals.push(signal);
+		} else {
+			current_component_context.d = [signal];
+		}
 	}
 }
 
@@ -1929,8 +1932,9 @@ export function pop(accessors) {
 
 /** @param {import('./types.js').ComponentContext} context */
 function observe_all(context) {
-	const signals = (context.d ??= []);
-	for (const signal of signals) get(signal);
+	if (context.d) {
+		for (const signal of context.d) get(signal);
+	}
 
 	const props = get_descriptors(context.s);
 	for (const descriptor of Object.values(props)) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -897,7 +897,7 @@ export function store_set(store, value) {
  * @param {import('./types.js').StoreReferencesContainer} stores
  */
 export function unsubscribe_on_destroy(stores) {
-	onDestroy(() => {
+	on_destroy(() => {
 		let store_name;
 		for (store_name in stores) {
 			const ref = stores[store_name];
@@ -1859,15 +1859,10 @@ export function value_or_fallback(value, fallback) {
 
 /**
  * Schedules a callback to run immediately before the component is unmounted.
- *
- * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the
- * only one that runs inside a server-side component.
- *
- * https://svelte.dev/docs/svelte#ondestroy
  * @param {() => any} fn
  * @returns {void}
  */
-export function onDestroy(fn) {
+function on_estroy(fn) {
 	user_effect(() => () => untrack(fn));
 }
 
@@ -1921,7 +1916,11 @@ export function pop(accessors) {
 	}
 }
 
-/** @param {import('./types.js').ComponentContext} context */
+/**
+ * Invoke the getter of all signals associated with a component
+ * so they can be registered to the effect this function is called in.
+ * @param {import('./types.js').ComponentContext} context
+ */
 function observe_all(context) {
 	if (context.d) {
 		for (const signal of context.d) get(signal);
@@ -1933,6 +1932,9 @@ function observe_all(context) {
 	}
 }
 
+/**
+ * Legacy-mode only: Call `onMount` callbacks and set up `beforeUpdate`/`afterUpdate` effects
+ */
 export function init() {
 	const context = /** @type {import('./types.js').ComponentContext} */ (current_component_context);
 	const callbacks = context.u;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1318,25 +1318,24 @@ export function source(initial_value) {
  * @param {import('./types.js').Signal} signal
  */
 function bind_signal_to_component_context(signal) {
-	if (current_component_context) {
-		signal.x = current_component_context;
+	if (current_component_context === null) return;
 
-		const signals = current_component_context.d;
+	signal.x = current_component_context;
+	const signals = current_component_context.d;
 
-		if (signals) {
-			signals.push(signal);
+	if (signals) {
+		signals.push(signal);
 
-			// update dummy signal
-			const previous_ignore_mutation_validation = ignore_mutation_validation;
-			ignore_mutation_validation = true;
-			set_signal_value(signals[0], signals[0].v + 1);
-			ignore_mutation_validation = previous_ignore_mutation_validation;
-		} else {
-			// if we're creating the array, insert a dummy signal whose value we can
-			// increment whenever we add new sources. This ensures that late-declared
-			// signals will still cause `beforeUpdate` and `afterUpdate` etc to fire
-			current_component_context.d = [create_source_signal(SOURCE | CLEAN, 0), signal];
-		}
+		// update dummy signal
+		const previous_ignore_mutation_validation = ignore_mutation_validation;
+		ignore_mutation_validation = true;
+		set_signal_value(signals[0], signals[0].v + 1);
+		ignore_mutation_validation = previous_ignore_mutation_validation;
+	} else {
+		// if we're creating the array, insert a dummy signal whose value we can
+		// increment whenever we add new sources. This ensures that late-declared
+		// signals will still cause `beforeUpdate` and `afterUpdate` etc to fire
+		current_component_context.d = [create_source_signal(SOURCE | CLEAN, 0), signal];
 	}
 }
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1862,7 +1862,7 @@ export function value_or_fallback(value, fallback) {
  * @param {() => any} fn
  * @returns {void}
  */
-function on_estroy(fn) {
+function on_destroy(fn) {
 	user_effect(() => () => untrack(fn));
 }
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1280,7 +1280,12 @@ export function derived(init) {
 		create_computation_signal(flags | CLEAN, UNINITIALIZED, current_block)
 	);
 	signal.i = init;
-	signal.x = current_component_context;
+
+	if (current_component_context) {
+		signal.x = current_component_context;
+		current_component_context.d.push(signal);
+	}
+
 	signal.e = default_equals;
 	if (current_consumer !== null) {
 		push_reference(current_consumer, signal);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -148,14 +148,6 @@ export function batch_inspect(target, prop, receiver) {
 }
 
 /**
- * @param {null | import('./types.js').ComponentContext} context_stack_item
- * @returns {void}
- */
-export function set_current_component_context(context_stack_item) {
-	current_component_context = context_stack_item;
-}
-
-/**
  * @param {unknown} a
  * @param {unknown} b
  * @returns {boolean}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1927,25 +1927,26 @@ export function pop(accessors) {
 	}
 }
 
+/** @param {import('./types.js').ComponentContext} context */
+function observe_all(context) {
+	const signals = (context.d ??= []);
+	for (const signal of signals) get(signal);
+
+	const props = get_descriptors(context.s);
+	for (const descriptor of Object.values(props)) {
+		if (descriptor.get) descriptor.get();
+	}
+}
+
 export function init() {
 	const context = /** @type {import('./types.js').ComponentContext} */ (current_component_context);
 	const callbacks = context.u;
 
 	if (!callbacks) return;
 
-	function observe_all() {
-		const signals = (context.d ??= []);
-		for (const signal of signals) get(signal);
-
-		const props = get_descriptors(context.s);
-		for (const descriptor of Object.values(props)) {
-			if (descriptor.get) descriptor.get();
-		}
-	}
-
 	// beforeUpdate
 	pre_effect(() => {
-		observe_all();
+		observe_all(context);
 		callbacks.b.forEach(run);
 	});
 
@@ -1963,7 +1964,7 @@ export function init() {
 
 	// afterUpdate
 	user_effect(() => {
-		observe_all();
+		observe_all(context);
 		callbacks.a.forEach(run);
 	});
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -104,17 +104,8 @@ export let current_block = null;
 
 /** @type {import('./types.js').ComponentContext | null} */
 export let current_component_context = null;
-export let is_ssr = false;
 
 export let updating_derived = false;
-
-/**
- * @param {boolean} ssr
- * @returns {void}
- */
-export function set_is_ssr(ssr) {
-	is_ssr = ssr;
-}
 
 /**
  * @param {null | import('./types.js').ComponentContext} context
@@ -1892,9 +1883,7 @@ export function value_or_fallback(value, fallback) {
  * @returns {void}
  */
 export function onDestroy(fn) {
-	if (!is_ssr) {
-		user_effect(() => () => untrack(fn));
-	}
+	user_effect(() => () => untrack(fn));
 }
 
 /**

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -37,7 +37,7 @@ export type Store<V> = {
 
 export type ComponentContext = {
 	/** local signals */
-	d: Signal<any>[];
+	d: null | Signal<any>[];
 	/** props */
 	s: Record<string, unknown>;
 	/** accessors */

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -54,10 +54,12 @@ export type ComponentContext = {
 	r: boolean;
 	/** update_callbacks */
 	u: null | {
-		/** before */
-		b: null | Array<() => void>;
-		/** after */
-		a: null | Array<() => void>;
+		/** afterUpdate callbacks */
+		a: Array<() => void>;
+		/** beforeUpdate callbacks */
+		b: Array<() => void>;
+		/** onMount callbacks */
+		m: Array<() => any>;
 	};
 };
 

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -36,6 +36,8 @@ export type Store<V> = {
 // when the JS VM JITs the code.
 
 export type ComponentContext = {
+	/** local signals */
+	d: Signal<any>[];
 	/** props */
 	s: Record<string, unknown>;
 	/** accessors */
@@ -53,11 +55,9 @@ export type ComponentContext = {
 	/** update_callbacks */
 	u: null | {
 		/** before */
-		b: Array<() => void>;
+		b: null | Array<() => void>;
 		/** after */
-		a: Array<() => void>;
-		/** execute */
-		e: () => void;
+		a: null | Array<() => void>;
 	};
 };
 

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -36,7 +36,7 @@ export type Store<V> = {
 // when the JS VM JITs the code.
 
 export type ComponentContext = {
-	/** local signals */
+	/** local signals (needed for beforeUpdate/afterUpdate) */
 	d: null | Signal<any>[];
 	/** props */
 	s: Record<string, unknown>;
@@ -71,8 +71,6 @@ export type ComponentContext = {
 export type SourceSignal<V = unknown> = {
 	/** consumers: Signals that read from the current signal */
 	c: null | ComputationSignal[];
-	/** context: The associated component if this signal is an effect/computed */
-	x: null | ComponentContext;
 	/** equals: For value equality */
 	e: null | EqualsFunctions;
 	/** flags: The types that the signal represent, as a bitwise value */

--- a/packages/svelte/src/internal/common.js
+++ b/packages/svelte/src/internal/common.js
@@ -19,3 +19,8 @@ export function run_all(arr) {
 		arr[i]();
 	}
 }
+
+/** @param {Function} fn */
+export function run(fn) {
+	fn();
+}

--- a/packages/svelte/src/internal/common.js
+++ b/packages/svelte/src/internal/common.js
@@ -22,5 +22,5 @@ export function run_all(arr) {
 
 /** @param {Function} fn */
 export function run(fn) {
-	fn();
+	return fn();
 }

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -38,7 +38,8 @@ export {
 	user_root_effect,
 	inspect,
 	unwrap,
-	freeze
+	freeze,
+	init
 } from './client/runtime.js';
 export * from './client/each.js';
 export * from './client/render.js';

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -30,7 +30,6 @@ export {
 	exclude_from_object,
 	store_set,
 	unsubscribe_on_destroy,
-	onDestroy,
 	pop,
 	push,
 	reactive_import,

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -1,5 +1,4 @@
 import * as $ from '../client/runtime.js';
-import { set_is_ssr } from '../client/runtime.js';
 import { is_promise, noop } from '../common.js';
 import { subscribe_to_store } from '../../store/utils.js';
 import { DOMBooleanAttributes } from '../../constants.js';
@@ -95,7 +94,6 @@ export function render(component, options) {
 	const root_anchor = create_anchor(payload);
 	const root_head_anchor = create_anchor(payload.head);
 
-	set_is_ssr(true);
 	const prev_on_destroy = on_destroy;
 	on_destroy = [];
 	payload.out += root_anchor;
@@ -112,7 +110,6 @@ export function render(component, options) {
 	payload.out += root_anchor;
 	for (const cleanup of on_destroy) cleanup();
 	on_destroy = prev_on_destroy;
-	set_is_ssr(false);
 
 	return {
 		head:

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -224,7 +224,7 @@ export function afterUpdate(fn) {
 }
 
 /**
- *
+ * Legacy-mode: Init callbacks object for onMount/beforeUpdate/afterUpdate
  * @param {import('../internal/client/types.js').ComponentContext} context
  */
 function init_update_callbacks(context) {

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -171,7 +171,11 @@ export function createEventDispatcher() {
  */
 export function beforeUpdate(fn) {
 	if (current_component_context === null) {
-		throw new Error('beforeUpdate can only be used during component initialisation.');
+		throw new Error('beforeUpdate can only be used during component initialisation');
+	}
+
+	if (current_component_context.r) {
+		throw new Error('beforeUpdate cannot be used in runes mode');
 	}
 
 	(current_component_context.u ??= init_update_callbacks(current_component_context)).b.push(fn);
@@ -193,6 +197,10 @@ export function beforeUpdate(fn) {
 export function afterUpdate(fn) {
 	if (current_component_context === null) {
 		throw new Error('afterUpdate can only be used during component initialisation.');
+	}
+
+	if (current_component_context.r) {
+		throw new Error('afterUpdate cannot be used in runes mode');
 	}
 
 	(current_component_context.u ??= init_update_callbacks(current_component_context)).a.push(fn);

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -1,12 +1,9 @@
 import {
 	current_component_context,
-	destroy_signal,
 	get_or_init_context_map,
 	is_ssr,
-	managed_effect,
 	untrack,
 	user_effect,
-	flush_local_render_effects,
 	pre_effect,
 	get
 } from '../internal/client/runtime.js';
@@ -156,36 +153,6 @@ export function createEventDispatcher() {
 
 		return true;
 	};
-}
-
-/** @param {import('../internal/client/types.js').ComponentContext} context */
-function init_update_callbacks(context) {
-	/** @type {NonNullable<import('../internal/client/types.js').ComponentContext['u']>} */
-	const update_callbacks = {
-		b: [],
-		a: []
-	};
-
-	function observe_all() {
-		for (const signal of context.d) get(signal);
-
-		const props = get_descriptors(context.s);
-		for (const descriptor of Object.values(props)) {
-			if (descriptor.get) descriptor.get();
-		}
-	}
-
-	pre_effect(() => {
-		observe_all();
-		update_callbacks.b.forEach(run);
-	});
-
-	user_effect(() => {
-		observe_all();
-		update_callbacks.a.forEach(run);
-	});
-
-	return update_callbacks;
 }
 
 // TODO mark beforeUpdate and afterUpdate as deprecated in Svelte 6

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -1,7 +1,6 @@
 import {
 	current_component_context,
 	get_or_init_context_map,
-	is_ssr,
 	untrack,
 	user_effect,
 	pre_effect,
@@ -31,6 +30,8 @@ export function onMount(fn) {
 	if (current_component_context === null) {
 		throw new Error('onMount can only be used during component initialisation.');
 	}
+
+	console.error('onMount');
 
 	init_update_callbacks(current_component_context).m.push(fn);
 }
@@ -179,7 +180,7 @@ export function beforeUpdate(fn) {
 	}
 
 	init_update_callbacks(current_component_context).b.push(fn);
-	if (!is_ssr) fn();
+	fn();
 }
 
 /**
@@ -214,8 +215,6 @@ function init_update_callbacks(context) {
 	if (context.u) return context.u;
 
 	const callbacks = (context.u = { a: [], b: [], m: [] });
-
-	if (is_ssr) return callbacks; // TODO this shouldn't be necessary but is, because of the tests
 
 	function observe_all() {
 		const signals = (context.d ??= [create_source_signal(SOURCE | CLEAN, 0)]);

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -200,11 +200,7 @@ export function afterUpdate(fn) {
  * @param {import('../internal/client/types.js').ComponentContext} context
  */
 function init_update_callbacks(context) {
-	const callbacks = (context.u = {
-		a: [],
-		b: [],
-		m: []
-	});
+	const callbacks = (context.u = { a: [], b: [], m: [] });
 
 	if (is_ssr) return callbacks; // TODO this shouldn't be necessary but is, because of the tests
 

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -5,7 +5,10 @@ import {
 	untrack,
 	user_effect,
 	pre_effect,
-	get
+	get,
+	create_source_signal,
+	SOURCE,
+	CLEAN
 } from '../internal/client/runtime.js';
 import { get_descriptors, is_array } from '../internal/client/utils.js';
 import { run } from '../internal/common.js';
@@ -205,7 +208,8 @@ function init_update_callbacks(context) {
 	if (is_ssr) return callbacks; // TODO this shouldn't be necessary but is, because of the tests
 
 	function observe_all() {
-		for (const signal of context.d) get(signal);
+		const signals = (context.d ??= [create_source_signal(SOURCE | CLEAN, 0)]);
+		for (const signal of signals) get(signal);
 
 		const props = get_descriptors(context.s);
 		for (const descriptor of Object.values(props)) {

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -32,7 +32,7 @@ export function onMount(fn) {
 		throw new Error('onMount can only be used during component initialisation.');
 	}
 
-	(current_component_context.u ??= init_update_callbacks(current_component_context)).m.push(fn);
+	init_update_callbacks(current_component_context).m.push(fn);
 }
 
 /**
@@ -178,7 +178,7 @@ export function beforeUpdate(fn) {
 		throw new Error('beforeUpdate cannot be used in runes mode');
 	}
 
-	(current_component_context.u ??= init_update_callbacks(current_component_context)).b.push(fn);
+	init_update_callbacks(current_component_context).b.push(fn);
 	if (!is_ssr) fn();
 }
 
@@ -203,7 +203,7 @@ export function afterUpdate(fn) {
 		throw new Error('afterUpdate cannot be used in runes mode');
 	}
 
-	(current_component_context.u ??= init_update_callbacks(current_component_context)).a.push(fn);
+	init_update_callbacks(current_component_context).a.push(fn);
 }
 
 /**
@@ -211,6 +211,8 @@ export function afterUpdate(fn) {
  * @param {import('../internal/client/types.js').ComponentContext} context
  */
 function init_update_callbacks(context) {
+	if (context.u) return context.u;
+
 	const callbacks = (context.u = { a: [], b: [], m: [] });
 
 	if (is_ssr) return callbacks; // TODO this shouldn't be necessary but is, because of the tests

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -217,10 +217,17 @@ function init_update_callbacks(context) {
 		}
 	}
 
+	let skip = false;
+
 	// beforeUpdate
 	pre_effect(() => {
 		observe_all();
+		if (skip) return;
 		callbacks.b.forEach(run);
+	});
+
+	pre_effect(() => {
+		skip = true;
 	});
 
 	// onMount (must run before afterUpdate)
@@ -239,6 +246,10 @@ function init_update_callbacks(context) {
 	user_effect(() => {
 		observe_all();
 		callbacks.a.forEach(run);
+	});
+
+	user_effect(() => {
+		skip = false;
 	});
 
 	return callbacks;

--- a/packages/svelte/src/main/main-client.js
+++ b/packages/svelte/src/main/main-client.js
@@ -170,6 +170,9 @@ export function createEventDispatcher() {
  * @returns {void}
  */
 export function beforeUpdate(fn) {
+	// TODO this shouldn't be necessary but is, because of the tests
+	if (is_ssr) return;
+
 	const context = current_component_context;
 
 	if (context === null) {
@@ -210,6 +213,9 @@ export function beforeUpdate(fn) {
  * @returns {void}
  */
 export function afterUpdate(fn) {
+	// TODO this shouldn't be necessary but is, because of the tests
+	if (is_ssr) return;
+
 	const context = current_component_context;
 
 	if (context === null) {

--- a/packages/svelte/src/store/index.js
+++ b/packages/svelte/src/store/index.js
@@ -1,4 +1,4 @@
-import { noop } from '../internal/common.js';
+import { noop, run } from '../internal/common.js';
 import { subscribe_to_store } from './utils.js';
 
 /**
@@ -104,11 +104,6 @@ export function writable(value, start = noop) {
 		};
 	}
 	return { set, update, subscribe };
-}
-
-/** @param {Function} fn */
-function run(fn) {
-	return fn();
 }
 
 /**

--- a/packages/svelte/tests/compiler-errors/samples/runes-before-after-update/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-before-after-update/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-runes-mode-import',
+		message: 'beforeUpdate cannot be used in runes mode'
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/runes-before-after-update/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/runes-before-after-update/main.svelte
@@ -1,0 +1,5 @@
+<svelte:options runes />
+
+<script>
+	import { beforeUpdate, afterUpdate } from 'svelte';
+</script>

--- a/packages/svelte/tests/runtime-browser/test.ts
+++ b/packages/svelte/tests/runtime-browser/test.ts
@@ -125,6 +125,8 @@ async function run_test(
 				{
 					name: 'testing-runtime-browser-ssr',
 					setup(build) {
+						// When running the server version of the Svelte files,
+						// we also want to use the server export of the Svelte package
 						build.onResolve({ filter: /./ }, (args) => {
 							if (args.path === 'svelte') {
 								return { path: ssr_entry };

--- a/packages/svelte/tests/runtime-browser/test.ts
+++ b/packages/svelte/tests/runtime-browser/test.ts
@@ -112,6 +112,8 @@ async function run_test(
 
 	let build_result_ssr;
 	if (hydrate) {
+		const ssr_entry = path.resolve(__dirname, '../../src/main/main-server.js');
+
 		build_result_ssr = await build({
 			entryPoints: [`${__dirname}/driver-ssr.js`],
 			write: false,
@@ -123,6 +125,12 @@ async function run_test(
 				{
 					name: 'testing-runtime-browser-ssr',
 					setup(build) {
+						build.onResolve({ filter: /./ }, (args) => {
+							if (args.path === 'svelte') {
+								return { path: ssr_entry };
+							}
+						});
+
 						build.onLoad({ filter: /\.svelte$/ }, (args) => {
 							const compiled = compile(fs.readFileSync(args.path, 'utf-8').replace(/\r/g, ''), {
 								generate: 'server',

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/Child.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/Child.svelte
@@ -1,0 +1,25 @@
+<script>
+	import { beforeUpdate, afterUpdate } from "svelte";
+	import { log } from './log.js';
+
+	export let a;
+	export let b;
+
+	beforeUpdate(() => {
+		log.push('before');
+	});
+
+	beforeUpdate(()=>{
+		log.push(`before ${a}, ${b}`);
+	});
+
+	afterUpdate(() => {
+		log.push('after');
+	});
+
+	afterUpdate(()=>{
+		log.push(`after ${a}, ${b}`);
+	});
+</script>
+
+<p>a: {a}</p>

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
@@ -37,7 +37,7 @@ export default test({
 			target.innerHTML,
 			`
 				<button>a: 1</button>
-				<button>b: 2</button>
+				<button>b: 1</button>
 				<p>a: 1</p>
 			`
 		);

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
@@ -3,6 +3,11 @@ import { log } from './log.js';
 import { test, ok } from '../../test';
 
 export default test({
+	// somewhat troublingly, there's no way to make beforeUpdate/afterUpdate
+	// behave as no-ops while testing SSR
+	skip_if_ssr: true,
+	skip_if_hydrate: true,
+
 	before_test: () => {
 		log.length = 0;
 	},

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
@@ -3,11 +3,6 @@ import { log } from './log.js';
 import { test, ok } from '../../test';
 
 export default test({
-	// somewhat troublingly, there's no way to make beforeUpdate/afterUpdate
-	// behave as no-ops while testing SSR
-	skip_if_ssr: true,
-	skip_if_hydrate: true,
-
 	before_test: () => {
 		log.length = 0;
 	},

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
@@ -1,0 +1,45 @@
+import { flushSync } from 'svelte';
+import { log } from './log.js';
+import { test, ok } from '../../test';
+
+export default test({
+	before_test: () => {
+		log.length = 0;
+	},
+
+	test({ assert, target }) {
+		const [button1, button2] = target.querySelectorAll('button');
+		ok(button1);
+		ok(button2);
+
+		button1.click();
+		flushSync();
+
+		button2.click();
+		flushSync();
+
+		assert.deepEqual(log, [
+			'before',
+			'before 0, 0',
+			'after',
+			'after 0, 0',
+			'before',
+			'before 1, 0',
+			'after',
+			'after 1, 0',
+			'before',
+			'before 1, 1',
+			'after',
+			'after 1, 1'
+		]);
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>a: 1</button>
+				<button>b: 2</button>
+				<p>a: 1</p>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/log.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/log.js
@@ -1,0 +1,2 @@
+/** @type {string[]} */
+export const log = [];

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Child from "./Child.svelte";
+
+	let a = 0;
+	let b = 0;
+</script>
+
+<button on:click={() => a += 1}>a: {a}</button>
+<button on:click={() => b += 1}>b: {b}</button>
+<Child {a} {b}/>

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-order-for-children/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-order-for-children/_config.js
@@ -46,10 +46,10 @@ export default test({
 			'2: render 1',
 			'3: beforeUpdate 1',
 			'3: render 1',
-			'parent: afterUpdate 1',
 			'1: afterUpdate 1',
 			'2: afterUpdate 1',
-			'3: afterUpdate 1'
+			'3: afterUpdate 1',
+			'parent: afterUpdate 1'
 		]);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/spread-reuse-levels/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/spread-reuse-levels/_config.js
@@ -3,7 +3,7 @@ import { test } from '../../test';
 export default test({
 	html: `
 		<pre>{"a":1,"b":[1],"c":42}</pre>
-		<pre>{"a":false,"b":false,"c":false}</pre>
+		<pre>{"a":true,"b":true,"c":true}</pre>
 	`,
 
 	ssrHtml: `

--- a/packages/svelte/tests/runtime-legacy/samples/spread-reuse-levels/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/spread-reuse-levels/_config.js
@@ -3,7 +3,7 @@ import { test } from '../../test';
 export default test({
 	html: `
 		<pre>{"a":1,"b":[1],"c":42}</pre>
-		<pre>{"a":true,"b":true,"c":true}</pre>
+		<pre>{"a":false,"b":false,"c":false}</pre>
 	`,
 
 	ssrHtml: `

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -5,6 +5,7 @@ import * as $ from "svelte/internal";
 
 export default function Each_string_template($$anchor, $$props) {
 	$.push($$props, false);
+	$.init();
 
 	/* Init */
 	var fragment = $.comment($$anchor);

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -7,6 +7,7 @@ var frag = $.template(`<h1>hello world</h1>`);
 
 export default function Hello_world($$anchor, $$props) {
 	$.push($$props, false);
+	$.init();
 
 	/* Init */
 	var h1 = $.open($$anchor, true, frag);

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -235,6 +235,15 @@ declare module 'svelte' {
 	 * */
 	export function onMount<T>(fn: () => NotFunction<T> | Promise<NotFunction<T>> | (() => any)): void;
 	/**
+	 * Schedules a callback to run immediately before the component is unmounted.
+	 *
+	 * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the
+	 * only one that runs inside a server-side component.
+	 *
+	 * https://svelte.dev/docs/svelte#ondestroy
+	 * */
+	export function onDestroy(fn: () => any): void;
+	/**
 	 * Retrieves the context that belongs to the closest parent component with the specified `key`.
 	 * Must be called during component initialisation.
 	 *
@@ -360,15 +369,6 @@ declare module 'svelte' {
 	 * https://svelte-5-preview.vercel.app/docs/functions#untrack
 	 * */
 	export function untrack<T>(fn: () => T): T;
-	/**
-	 * Schedules a callback to run immediately before the component is unmounted.
-	 *
-	 * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the
-	 * only one that runs inside a server-side component.
-	 *
-	 * https://svelte.dev/docs/svelte#ondestroy
-	 * */
-	export function onDestroy(fn: () => any): void;
 	export function unstate<T>(value: T): T;
 }
 

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -90,6 +90,10 @@ Various error and warning codes have been renamed slightly.
 
 The number of valid namespaces you can pass to the compiler option `namespace` has been reduced to `html` (the default), `svg` and `foreign`.
 
+### afterUpdate changes
+
+`afterUpdate` callbacks in a parent component will now run after `afterUpdate` callbacks in any child components.
+
 ### `contenteditable` behavior change
 
 If you have a `contenteditable` node with a corresponding binding _and_ a reactive value inside it (example: `<div contenteditable=true bind:textContent>count is {count}</div>`), then the value inside the contenteditable will not be updated by updates to `count` because the binding takes full control over the content immediately and it should only be updated through it.

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -90,7 +90,9 @@ Various error and warning codes have been renamed slightly.
 
 The number of valid namespaces you can pass to the compiler option `namespace` has been reduced to `html` (the default), `svg` and `foreign`.
 
-### afterUpdate changes
+### beforeUpdate/afterUpdate changes
+
+`beforeUpdate` no longer runs twice on initial render if it modifies a variable referenced in the template.
 
 `afterUpdate` callbacks in a parent component will now run after `afterUpdate` callbacks in any child components.
 

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -96,6 +96,8 @@ The number of valid namespaces you can pass to the compiler option `namespace` h
 
 `afterUpdate` callbacks in a parent component will now run after `afterUpdate` callbacks in any child components.
 
+Both functions are disallowed in runes mode — use `$effect.pre(...)` and `$effect(...)` instead.
+
 ### `contenteditable` behavior change
 
 If you have a `contenteditable` node with a corresponding binding _and_ a reactive value inside it (example: `<div contenteditable=true bind:textContent>count is {count}</div>`), then the value inside the contenteditable will not be updated by updates to `count` because the binding takes full control over the content immediately and it should only be updated through it.

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -90,10 +90,6 @@ Various error and warning codes have been renamed slightly.
 
 The number of valid namespaces you can pass to the compiler option `namespace` has been reduced to `html` (the default), `svg` and `foreign`.
 
-### beforeUpdate change
-
-`beforeUpdate` no longer runs twice on initial render if it modifies a variable referenced in the template.
-
 ### `contenteditable` behavior change
 
 If you have a `contenteditable` node with a corresponding binding _and_ a reactive value inside it (example: `<div contenteditable=true bind:textContent>count is {count}</div>`), then the value inside the contenteditable will not be updated by updates to `count` because the binding takes full control over the content immediately and it should only be updated through it.


### PR DESCRIPTION
Closes #9420.

As shown in #9442, `beforeUpdate` and `afterUpdate` aren't quite right at the moment — they will only fire when locally declared signals, or signals that are used in the template, change.

Unfortunately #9442 doesn't fix it, because it's quite possible for an `afterUpdate` callback to not reference any state. Turning it into an effect therefore doesn't solve the problem.

This PR proposes a solution that seems a bit simpler than the alternatives — we simply create an `$effect.pre` (before `beforeUpdate` and an `$effect` (for `afterUpdate`) and, inside those, listen for all locally declared signals plus reactive props. 

This does mean that we need to link the locally declared signals to the component context (the reverse of the current behaviour, wherein we link the component context to locally declared signals). If we're averse to that, then one option would be to simply forbid the use of `beforeUpdate`/`afterUpdate`/`onMount` in a runes-mode component. This is probably a good thing to do anyway, since these functions are fundamentally unreliable in a runes-mode context (for example callbacks won't fire if a component imports some reactive state which isn't referenced inside the callback) and not recommended.

Notes:

- ~~this undoes a breaking change around re-running `beforeUpdate` callbacks twice on component initialisation~~
- this adds a breaking change — parent `afterUpdate` callbacks now run after child `afterUpdate` callbacks. (Happily, this makes way more sense, and probably won't cause any problems in real usage)

Todo:

- [x] bind deriveds (and anything else?) to the component context
- [x] handle late-created signals (i.e. a signal that is created after the `beforeUpdate` callback runs)

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
