### PR TITLE
fix: set `open` binding value in `<details>`

### DIFF
--- a/.changeset/strange-apricots-happen.md
+++ b/.changeset/strange-apricots-happen.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: set initial value for `open` binding in `<details>`
+fix: set `open` binding value in `<details>`

--- a/.changeset/strange-apricots-happen.md
+++ b/.changeset/strange-apricots-happen.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: set initial value for `open` binding in `<details>`

--- a/packages/svelte/src/compiler/phases/bindings.js
+++ b/packages/svelte/src/compiler/phases/bindings.js
@@ -175,6 +175,7 @@ export const binding_properties = {
 	textContent: {},
 	open: {
 		event: 'toggle',
+		type: 'set',
 		valid_elements: ['details']
 	},
 	value: {

--- a/packages/svelte/tests/runtime-runes/samples/details-binding-initial/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/details-binding-initial/_config.js
@@ -1,0 +1,11 @@
+import { ok, test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const details_el = target.querySelector('details');
+
+		ok(details_el);
+
+		assert.strictEqual(details_el.open, true);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/details-binding-initial/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/details-binding-initial/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	let open = $state(true);
+</script>
+
+<details bind:open>
+	 <summary>Details</summary>
+	 ...
+</details>


### PR DESCRIPTION
closes #9466

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
