### PR TITLE
chore: improve readability of proxy fnc

### DIFF
--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -35,10 +35,11 @@ export function proxy(value, immutable = true) {
 	if (typeof value !== 'object' || value == null || is_frozen(value)) return value;
 
 	// proxy available already?
+	// If we have an existing proxy, return it...
 	if (STATE_SYMBOL in value) {
 		const metadata = /** @type {import('./types.js').ProxyMetadata<T>} */ (value[STATE_SYMBOL]);
-		// Return the existing proxy if it belongs to the current object,
-		// otherwise, handle as a new proxy (e.g., due to copied state symbol).
+		// ...unless the proxy belonged to a different object, because
+		// someone copied the state symbol using `Reflect.ownKeys(...)`
 		if (metadata.t === value || metadata.p === value) {
 			return metadata.p;
 		}
@@ -54,14 +55,14 @@ export function proxy(value, immutable = true) {
 	// make new proxy
 	const proxy = new Proxy(value, state_proxy_handler);
 	define_property(value, STATE_SYMBOL, {
-		value: {
+		value: /** @type {import('./types.js').ProxyMetadata} */ ({
 			s: new Map(),
 			v: source(0),
 			a: is_array(value),
 			i: immutable,
 			p: proxy,
 			t: value
-		},
+		}),
 		writable: true,
 		enumerable: false
 	});


### PR DESCRIPTION
I decided to give this another shot, based on Rich's feedback in #10384.

This should make the proxy control flow easier to reason about (without touching performance).
- decreases if nesting
- adds early exit section comments

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
