### PR TITLE
fix: stricter validation for component exports

### DIFF
--- a/.changeset/odd-taxis-retire.md
+++ b/.changeset/odd-taxis-retire.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: disallow exporting props, derived and reassigned state from within components

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -169,8 +169,12 @@ const runes = {
 	'invalid-legacy-export': () => `Cannot use \`export let\` in runes mode — use $props instead`,
 	/** @param {string} rune */
 	'invalid-rune-usage': (rune) => `Cannot use ${rune} rune in non-runes mode`,
-	'invalid-state-export': () => `Cannot export state if it is reassigned`,
-	'invalid-derived-export': () => `Cannot export derived state`,
+	'invalid-state-export': () =>
+		`Cannot export state if it is reassigned. Either export a function returning the state value or only mutate the state value's properties`,
+	'invalid-derived-export': () =>
+		`Cannot export derived state. To expose the current derived value, export a function returning its value`,
+	'invalid-prop-export': () =>
+		`Cannot export properties. To expose the current value of a property, export a function returning its value`,
 	'invalid-props-id': () => `$props() can only be used with an object destructuring pattern`,
 	'invalid-props-pattern': () =>
 		`$props() assignment must not contain nested properties or computed keys`,

--- a/packages/svelte/tests/compiler-errors/samples/export-derived-state/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/export-derived-state/_config.js
@@ -3,7 +3,7 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'invalid-derived-export',
-		message: 'Cannot export derived state',
-		position: [24, 66]
+		message:
+			'Cannot export derived state. To expose the current derived value, export a function returning its value'
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/export-derived-state/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/export-derived-state/main.svelte
@@ -1,0 +1,4 @@
+<script>
+	let count = $state(0);
+	export const double = $derived(count * 2);
+</script>

--- a/packages/svelte/tests/compiler-errors/samples/export-state-2/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/export-state-2/_config.js
@@ -5,6 +5,6 @@ export default test({
 		code: 'invalid-state-export',
 		message:
 			"Cannot export state if it is reassigned. Either export a function returning the state value or only mutate the state value's properties",
-		position: [28, 53]
+		position: [59, 99]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/export-state-2/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/export-state-2/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	export const object = $state({
+		ok: true
+	});
+
+	export const primitive = $state('nope');
+
+	export function update_object() {
+		object.ok = !object.ok;
+	}
+
+	export function update_primitive() {
+		primitive = 'yep';
+	}
+</script>

--- a/packages/svelte/tests/compiler-errors/samples/export-state/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/export-state/_config.js
@@ -3,7 +3,8 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'invalid-state-export',
-		message: 'Cannot export state if it is reassigned',
+		message:
+			"Cannot export state if it is reassigned. Either export a function returning the state value or only mutate the state value's properties",
 		position: [46, 86]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/runes-export-prop/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-export-prop/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-prop-export',
+		message:
+			'Cannot export properties. To expose the current value of a property, export a function returning its value'
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/runes-export-prop/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/runes-export-prop/main.svelte
@@ -1,0 +1,4 @@
+<script>
+	let { foo } = $props();
+	export { foo };
+</script>


### PR DESCRIPTION
disallow exporting props, derived and reassigned state from within components
closes #10310, closes #10311, closes #10293

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
