### PR TITLE
fix: use hybrid scoping strategy for consistent specificity increase

### DIFF
--- a/.changeset/long-lobsters-mate.md
+++ b/.changeset/long-lobsters-mate.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: use hybrid scoping strategy for consistent specificity increase

--- a/packages/svelte/src/compiler/phases/2-analyze/css/Selector.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/Selector.js
@@ -70,9 +70,9 @@ export default class Selector {
 
 	/**
 	 * @param {import('magic-string').default} code
-	 * @param {string} attr
+	 * @param {string} modifier
 	 */
-	transform(code, attr) {
+	transform(code, modifier) {
 		/** @param {import('#compiler').Css.SimpleSelector} selector */
 		function remove_global_pseudo_class(selector) {
 			code
@@ -90,20 +90,24 @@ export default class Selector {
 					remove_global_pseudo_class(selector);
 				}
 			}
+
 			let i = block.selectors.length;
 			while (i--) {
 				const selector = block.selectors[i];
+
 				if (selector.type === 'PseudoElementSelector' || selector.type === 'PseudoClassSelector') {
 					if (selector.name !== 'root' && selector.name !== 'host') {
 						if (i === 0) code.prependRight(selector.start, modifier);
 					}
 					continue;
 				}
+
 				if (selector.type === 'TypeSelector' && selector.name === '*') {
 					code.update(selector.start, selector.end, modifier);
 				} else {
 					code.appendLeft(selector.end, modifier);
 				}
+
 				break;
 			}
 		}
@@ -115,9 +119,10 @@ export default class Selector {
 			}
 
 			if (block.should_encapsulate) {
-				const modifier = first ? attr : `:where(${attr})`;
-				encapsulate_block(block, modifier);
-
+				// for the first occurrence, we use a classname selector, so that every
+				// encapsulated selector gets a +0-1-0 specificity bump. thereafter,
+				// we use a `:where` selector, which does not affect specificity
+				encapsulate_block(block, first ? modifier : `:where(${modifier})`);
 				first = false;
 			}
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/css/Stylesheet.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/Stylesheet.js
@@ -103,8 +103,8 @@ class Rule {
 			return;
 		}
 
-		const attr = `.${id}`;
-		this.selectors.forEach((selector) => selector.transform(code, attr));
+		const modifier = `.${id}`;
+		this.selectors.forEach((selector) => selector.transform(code, modifier));
 		this.declarations.forEach((declaration) => declaration.transform(code, keyframes));
 	}
 

--- a/packages/svelte/src/compiler/phases/2-analyze/css/Stylesheet.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/Stylesheet.js
@@ -97,17 +97,14 @@ class Rule {
 	 * @param {import('magic-string').default} code
 	 * @param {string} id
 	 * @param {Map<string, string>} keyframes
-	 * @param {number} max_amount_class_specificity_increased
 	 */
-	transform(code, id, keyframes, max_amount_class_specificity_increased) {
+	transform(code, id, keyframes) {
 		if (this.parent && this.parent.node.type === 'Atrule' && is_keyframes_node(this.parent.node)) {
 			return;
 		}
 
 		const attr = `.${id}`;
-		this.selectors.forEach((selector) =>
-			selector.transform(code, attr, max_amount_class_specificity_increased)
-		);
+		this.selectors.forEach((selector) => selector.transform(code, attr));
 		this.declarations.forEach((declaration) => declaration.transform(code, keyframes));
 	}
 
@@ -123,13 +120,6 @@ class Rule {
 		this.selectors.forEach((selector) => {
 			if (!selector.used) handler(selector);
 		});
-	}
-
-	/** @returns number */
-	get_max_amount_class_specificity_increased() {
-		return Math.max(
-			...this.selectors.map((selector) => selector.get_amount_class_specificity_increased())
-		);
 	}
 
 	/**
@@ -287,9 +277,8 @@ class Atrule {
 	 * @param {import('magic-string').default} code
 	 * @param {string} id
 	 * @param {Map<string, string>} keyframes
-	 * @param {number} max_amount_class_specificity_increased
 	 */
-	transform(code, id, keyframes, max_amount_class_specificity_increased) {
+	transform(code, id, keyframes) {
 		if (is_keyframes_node(this.node)) {
 			let start = this.node.start + this.node.name.length + 1;
 			while (code.original[start] === ' ') start += 1;
@@ -309,7 +298,7 @@ class Atrule {
 			}
 		}
 		this.children.forEach((child) => {
-			child.transform(code, id, keyframes, max_amount_class_specificity_increased);
+			child.transform(code, id, keyframes);
 		});
 	}
 
@@ -326,13 +315,6 @@ class Atrule {
 		this.children.forEach((child) => {
 			child.warn_on_unused_selector(handler);
 		});
-	}
-
-	/** @returns {number} */
-	get_max_amount_class_specificity_increased() {
-		return Math.max(
-			...this.children.map((rule) => rule.get_max_amount_class_specificity_increased())
-		);
 	}
 
 	/**
@@ -517,12 +499,8 @@ export default class Stylesheet {
 			}
 		});
 
-		const max = Math.max(
-			...this.children.map((rule) => rule.get_max_amount_class_specificity_increased())
-		);
-
 		for (const child of this.children) {
-			child.transform(code, this.id, this.keyframes, max);
+			child.transform(code, this.id, this.keyframes);
 		}
 
 		code.remove(0, this.ast.content.start);

--- a/packages/svelte/tests/css/samples/child-combinator/expected.css
+++ b/packages/svelte/tests/css/samples/child-combinator/expected.css
@@ -1,7 +1,7 @@
-  main.svelte-xyz button.svelte-xyz.svelte-xyz {
+  main.svelte-xyz button:where(.svelte-xyz) {
     background-color: red;
   }
 
-  main.svelte-xyz div.svelte-xyz > button.svelte-xyz {
+  main.svelte-xyz div:where(.svelte-xyz) > button:where(.svelte-xyz) {
     background-color: blue;
   }

--- a/packages/svelte/tests/css/samples/combinator-child/expected.css
+++ b/packages/svelte/tests/css/samples/combinator-child/expected.css
@@ -1,3 +1,3 @@
-	.test.svelte-xyz > div.svelte-xyz {
+	.test.svelte-xyz > div:where(.svelte-xyz) {
 		color: #0af;
 	}

--- a/packages/svelte/tests/css/samples/descendant-selector-non-top-level-outer/expected.css
+++ b/packages/svelte/tests/css/samples/descendant-selector-non-top-level-outer/expected.css
@@ -1,3 +1,3 @@
-	p.svelte-xyz span.svelte-xyz {
+	p.svelte-xyz span:where(.svelte-xyz) {
 		color: red;
 	}

--- a/packages/svelte/tests/css/samples/dynamic-element-tag/expected.css
+++ b/packages/svelte/tests/css/samples/dynamic-element-tag/expected.css
@@ -1,18 +1,18 @@
-	div.svelte-xyz.svelte-xyz.svelte-xyz {
+	div.svelte-xyz {
 		color: red;
 	}
-	h2.svelte-xyz > p.svelte-xyz.svelte-xyz {
+	h2.svelte-xyz > p:where(.svelte-xyz) {
 		color: red;
 	}
-	h2.svelte-xyz span.svelte-xyz.svelte-xyz {
+	h2.svelte-xyz span:where(.svelte-xyz) {
 		color: red;
 	}
-	h2.svelte-xyz > span.svelte-xyz > b.svelte-xyz {
+	h2.svelte-xyz > span:where(.svelte-xyz) > b:where(.svelte-xyz) {
 		color: red;
 	}
-	h2.svelte-xyz span b.svelte-xyz.svelte-xyz {
+	h2.svelte-xyz span b:where(.svelte-xyz) {
 		color: red;
 	}
-	h2.svelte-xyz b.svelte-xyz.svelte-xyz {
+	h2.svelte-xyz b:where(.svelte-xyz) {
 		color: red;
 	}

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-await-not-exhaustive/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-await-not-exhaustive/expected.css
@@ -1,13 +1,13 @@
-	.a.svelte-xyz ~ .b.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .e.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .f.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .g.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .h.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .h:where(.svelte-xyz) { color: green; }
 
-	.b.svelte-xyz ~ .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .e.svelte-xyz ~ .f.svelte-xyz ~ .h.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .d.svelte-xyz ~ .h.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .g.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
+	.b.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .e:where(.svelte-xyz) ~ .f:where(.svelte-xyz) ~ .h:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .d:where(.svelte-xyz) ~ .h:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-await/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-await/expected.css
@@ -1,10 +1,10 @@
-	.a.svelte-xyz ~ .b.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .d.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .e.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .e.svelte-xyz { color: green; }
-	.d.svelte-xyz ~ .e.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .e.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .b ~ .c { color: green; }*/

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-each-2/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-each-2/expected.css
@@ -1,22 +1,22 @@
 	/* boundary of each */
-	.a.svelte-xyz ~ .b.svelte-xyz {
+	.a.svelte-xyz ~ .b:where(.svelte-xyz) {
 		color: green;
 	}
-	.c.svelte-xyz ~ .d.svelte-xyz {
+	.c.svelte-xyz ~ .d:where(.svelte-xyz) {
 		color: green;
 	}
 	/* if array is empty */
-	.a.svelte-xyz ~ .d.svelte-xyz {
+	.a.svelte-xyz ~ .d:where(.svelte-xyz) {
 		color: green;
 	}
 	/* if array has multiple items */
-	.c.svelte-xyz ~ .b.svelte-xyz {
+	.c.svelte-xyz ~ .b:where(.svelte-xyz) {
 		color: green;
 	}
 	/* normal sibling */
-	.b.svelte-xyz ~ .c.svelte-xyz {
+	.b.svelte-xyz ~ .c:where(.svelte-xyz) {
 		color: green;
 	}
-	.a.svelte-xyz ~ .c.svelte-xyz {
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) {
 		color: green;
 	}

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-each-else-nested/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-each-else-nested/expected.css
@@ -1,30 +1,30 @@
-	.a.svelte-xyz ~ .e.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .f.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .c.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .e.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .f.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.d.svelte-xyz ~ .e.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.d.svelte-xyz ~ .f.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.e.svelte-xyz ~ .e.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz ~ .j.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz ~ .h.svelte-xyz ~ .j.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz ~ .i.svelte-xyz ~ .j.svelte-xyz.svelte-xyz { color: green; }
-	.m.svelte-xyz ~ .m.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.m.svelte-xyz ~ .l.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.l.svelte-xyz ~ .m.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .g.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .e.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .g.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .k.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.d.svelte-xyz ~ .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz ~ .g.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.h.svelte-xyz ~ .h.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz ~ .i.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.j.svelte-xyz ~ .j.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz ~ .j.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz ~ .h.svelte-xyz ~ .i.svelte-xyz ~ .j.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz ~ .j:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz ~ .h:where(.svelte-xyz) ~ .j:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz ~ .i:where(.svelte-xyz) ~ .j:where(.svelte-xyz) { color: green; }
+	.m.svelte-xyz ~ .m:where(.svelte-xyz) { color: green; }
+	.m.svelte-xyz ~ .l:where(.svelte-xyz) { color: green; }
+	.l.svelte-xyz ~ .m:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .k:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.h.svelte-xyz ~ .h:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz ~ .i:where(.svelte-xyz) { color: green; }
+	.j.svelte-xyz ~ .j:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz ~ .j:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz ~ .h:where(.svelte-xyz) ~ .i:where(.svelte-xyz) ~ .j:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .e ~ .f { color: green; }*/

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-each-else/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-each-else/expected.css
@@ -1,8 +1,8 @@
-	.a.svelte-xyz ~ .b.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .d.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .d.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .d.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .b ~ .c { color: green; }*/

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-each-nested/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-each-nested/expected.css
@@ -1,60 +1,60 @@
 	/* boundary of each */
-	.a.svelte-xyz ~ .d.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .e.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .f.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .g.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .d.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .e.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .f.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .g.svelte-xyz.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
 
 	/* nested boundary of each */
-	.j.svelte-xyz ~ .m.svelte-xyz.svelte-xyz { color: green; }
-	.j.svelte-xyz ~ .n.svelte-xyz.svelte-xyz { color: green; }
-	.j.svelte-xyz ~ .o.svelte-xyz.svelte-xyz { color: green; }
-	.k.svelte-xyz ~ .m.svelte-xyz.svelte-xyz { color: green; }
-	.k.svelte-xyz ~ .n.svelte-xyz.svelte-xyz { color: green; }
-	.k.svelte-xyz ~ .o.svelte-xyz.svelte-xyz { color: green; }
-	.l.svelte-xyz ~ .m.svelte-xyz.svelte-xyz { color: green; }
-	.l.svelte-xyz ~ .n.svelte-xyz.svelte-xyz { color: green; }
-	.l.svelte-xyz ~ .o.svelte-xyz.svelte-xyz { color: green; }
+	.j.svelte-xyz ~ .m:where(.svelte-xyz) { color: green; }
+	.j.svelte-xyz ~ .n:where(.svelte-xyz) { color: green; }
+	.j.svelte-xyz ~ .o:where(.svelte-xyz) { color: green; }
+	.k.svelte-xyz ~ .m:where(.svelte-xyz) { color: green; }
+	.k.svelte-xyz ~ .n:where(.svelte-xyz) { color: green; }
+	.k.svelte-xyz ~ .o:where(.svelte-xyz) { color: green; }
+	.l.svelte-xyz ~ .m:where(.svelte-xyz) { color: green; }
+	.l.svelte-xyz ~ .n:where(.svelte-xyz) { color: green; }
+	.l.svelte-xyz ~ .o:where(.svelte-xyz) { color: green; }
 
 	/* parent each */
-	.d.svelte-xyz ~ .e.svelte-xyz.svelte-xyz { color: green; }
-	.e.svelte-xyz ~ .f.svelte-xyz.svelte-xyz { color: green; }
+	.d.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
 
 	/* child each */
-	.g.svelte-xyz ~ .h.svelte-xyz.svelte-xyz { color: green; }
+	.g.svelte-xyz ~ .h:where(.svelte-xyz) { color: green; }
 
 	/* wrap around */
-	.f.svelte-xyz ~ .d.svelte-xyz.svelte-xyz { color: green; }
-	.f.svelte-xyz ~ .e.svelte-xyz.svelte-xyz { color: green; }
-	.f.svelte-xyz ~ .f.svelte-xyz.svelte-xyz { color: green; }
+	.f.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.f.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.f.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
 
-	.h.svelte-xyz ~ .g.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz ~ .h.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz ~ .g.svelte-xyz.svelte-xyz { color: green; }
+	.h.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz ~ .h:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
 
 	/* wrap around self */
-	.d.svelte-xyz ~ .d.svelte-xyz.svelte-xyz { color: green; }
-	.e.svelte-xyz ~ .e.svelte-xyz.svelte-xyz { color: green; }
-	.f.svelte-xyz ~ .f.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz ~ .g.svelte-xyz.svelte-xyz { color: green; }
-	.h.svelte-xyz ~ .h.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz ~ .i.svelte-xyz.svelte-xyz { color: green; }
+	.d.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.f.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.h.svelte-xyz ~ .h:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz ~ .i:where(.svelte-xyz) { color: green; }
 
 	/* wrap around self ~ next */
-	.e.svelte-xyz ~ .e.svelte-xyz ~ .f.svelte-xyz { color: green; }
-	.e.svelte-xyz ~ .e.svelte-xyz ~ .d.svelte-xyz { color: green; }
-	.h.svelte-xyz ~ .h.svelte-xyz ~ .i.svelte-xyz { color: green; }
-	.h.svelte-xyz ~ .h.svelte-xyz ~ .g.svelte-xyz { color: green; }
+	.e.svelte-xyz ~ .e:where(.svelte-xyz) ~ .f:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz ~ .e:where(.svelte-xyz) ~ .d:where(.svelte-xyz) { color: green; }
+	.h.svelte-xyz ~ .h:where(.svelte-xyz) ~ .i:where(.svelte-xyz) { color: green; }
+	.h.svelte-xyz ~ .h:where(.svelte-xyz) ~ .g:where(.svelte-xyz) { color: green; }
 
 	/* general siblings */
-	.a.svelte-xyz ~ .h.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .i.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .h.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .i.svelte-xyz.svelte-xyz { color: green; }
-	.d.svelte-xyz ~ .f.svelte-xyz.svelte-xyz { color: green; }
-	.d.svelte-xyz ~ .g.svelte-xyz.svelte-xyz { color: green; }
-	.e.svelte-xyz ~ .g.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz ~ .i.svelte-xyz.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .h:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .i:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .h:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .i:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz ~ .f:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz ~ .i:where(.svelte-xyz) { color: green; }

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-each/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-each/expected.css
@@ -1,3 +1,3 @@
-	div.svelte-xyz ~ span.svelte-xyz {
+	div.svelte-xyz ~ span:where(.svelte-xyz) {
 		color: green;
 	}

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-former-element-in-slot/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-former-element-in-slot/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz ~ p.svelte-xyz {
+  h1.svelte-xyz ~ p:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-if-not-exhaustive-with-each/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-if-not-exhaustive-with-each/expected.css
@@ -1,12 +1,12 @@
-	.a.svelte-xyz ~ .b.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
 
-	.a.svelte-xyz ~ .c.svelte-xyz ~ .c.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .c.svelte-xyz ~ .d.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz ~ .c.svelte-xyz ~ .d.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) ~ .c:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .c:where(.svelte-xyz) ~ .d:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) ~ .c:where(.svelte-xyz) ~ .d:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .b ~ .c { color: green; }*/

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-if-not-exhaustive/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-if-not-exhaustive/expected.css
@@ -1,8 +1,8 @@
-	.a.svelte-xyz ~ .b.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .d.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .d.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .d.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .b ~ .c { color: green; }*/

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-if/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-if/expected.css
@@ -1,10 +1,10 @@
-	.a.svelte-xyz ~ .b.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .d.svelte-xyz { color: green; }
-	.b.svelte-xyz ~ .e.svelte-xyz { color: green; }
-	.c.svelte-xyz ~ .e.svelte-xyz { color: green; }
-	.d.svelte-xyz ~ .e.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .e.svelte-xyz { color: green; }
+	.a.svelte-xyz ~ .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .b ~ .c { color: green; }*/

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-nested-slots-flattened/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-nested-slots-flattened/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz ~ p.svelte-xyz {
+  h1.svelte-xyz ~ p:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-nested-slots/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-nested-slots/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz ~ p.svelte-xyz {
+  h1.svelte-xyz ~ p:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-selects-slot-fallback/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-selects-slot-fallback/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz ~ p.svelte-xyz {
+  h1.svelte-xyz ~ p:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-slot/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-slot/expected.css
@@ -1,5 +1,5 @@
-	.d.svelte-xyz ~ .e.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .g.svelte-xyz { color: green; }
+	.d.svelte-xyz ~ .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .g:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .a ~ .b { color: green; }*/

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-slots-between/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-slots-between/expected.css
@@ -1,11 +1,11 @@
-	h1.svelte-xyz ~ span.svelte-xyz {
+	h1.svelte-xyz ~ span:where(.svelte-xyz) {
 		color: green;
 	}
 
-  h1.svelte-xyz ~ p.svelte-xyz {
+  h1.svelte-xyz ~ p:where(.svelte-xyz) {
     color: red;
   }
 
-	span.svelte-xyz ~ p.svelte-xyz {
+	span.svelte-xyz ~ p:where(.svelte-xyz) {
 		color: blue;
 	}

--- a/packages/svelte/tests/css/samples/general-siblings-combinator-star/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator-star/expected.css
@@ -1,4 +1,4 @@
-	.match.svelte-xyz > .svelte-xyz ~ .svelte-xyz {
+	.match.svelte-xyz > :where(.svelte-xyz) ~ :where(.svelte-xyz) {
 		margin-left: 4px;
 	}
 	/* (unused) .not-match > * ~ * {

--- a/packages/svelte/tests/css/samples/general-siblings-combinator/expected.css
+++ b/packages/svelte/tests/css/samples/general-siblings-combinator/expected.css
@@ -1,11 +1,11 @@
-	div.svelte-xyz ~ article.svelte-xyz.svelte-xyz { color: green; }
-	span.svelte-xyz ~ b.svelte-xyz.svelte-xyz { color: green; }
-	div.svelte-xyz span.svelte-xyz ~ b.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ article.svelte-xyz.svelte-xyz { color: green; }
-	div.svelte-xyz ~ .b.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ .c.svelte-xyz.svelte-xyz { color: green; }
-	article.svelte-xyz ~ details.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz ~ details.svelte-xyz.svelte-xyz { color: green; }
+	div.svelte-xyz ~ article:where(.svelte-xyz) { color: green; }
+	span.svelte-xyz ~ b:where(.svelte-xyz) { color: green; }
+	div.svelte-xyz span:where(.svelte-xyz) ~ b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ article:where(.svelte-xyz) { color: green; }
+	div.svelte-xyz ~ .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ .c:where(.svelte-xyz) { color: green; }
+	article.svelte-xyz ~ details:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz ~ details:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) article ~ div { color: green; }*/

--- a/packages/svelte/tests/css/samples/omit-scoping-attribute-global-descendants/expected.css
+++ b/packages/svelte/tests/css/samples/omit-scoping-attribute-global-descendants/expected.css
@@ -1,3 +1,3 @@
-	html body .root.svelte-xyz p.svelte-xyz {
+	html body .root.svelte-xyz p:where(.svelte-xyz) {
 		color: red;
 	}

--- a/packages/svelte/tests/css/samples/omit-scoping-attribute-multiple-descendants/expected.css
+++ b/packages/svelte/tests/css/samples/omit-scoping-attribute-multiple-descendants/expected.css
@@ -1,3 +1,3 @@
-	.root.svelte-xyz p.svelte-xyz {
+	.root.svelte-xyz p:where(.svelte-xyz) {
 		color: red;
 	}

--- a/packages/svelte/tests/css/samples/omit-scoping-attribute-whitespace-multiple/expected.css
+++ b/packages/svelte/tests/css/samples/omit-scoping-attribute-whitespace-multiple/expected.css
@@ -1,3 +1,3 @@
-	div.svelte-xyz section p.svelte-xyz {
+	div.svelte-xyz section p:where(.svelte-xyz) {
 		color: red;
 	}

--- a/packages/svelte/tests/css/samples/omit-scoping-attribute-whitespace/expected.css
+++ b/packages/svelte/tests/css/samples/omit-scoping-attribute-whitespace/expected.css
@@ -1,3 +1,3 @@
-	div.svelte-xyz p.svelte-xyz {
+	div.svelte-xyz p:where(.svelte-xyz) {
 		color: red;
 	}

--- a/packages/svelte/tests/css/samples/preserve-specificity/expected.css
+++ b/packages/svelte/tests/css/samples/preserve-specificity/expected.css
@@ -1,8 +1,8 @@
-  a.svelte-xyz b c span.svelte-xyz {
+  a.svelte-xyz b c span:where(.svelte-xyz) {
     color: red;
     font-size: 2em;
     font-family: 'Comic Sans MS';
   }
-  .foo.svelte-xyz.svelte-xyz {
+  .foo.svelte-xyz {
     color: green;
   }

--- a/packages/svelte/tests/css/samples/siblings-combinator-await-not-exhaustive/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-await-not-exhaustive/expected.css
@@ -1,13 +1,13 @@
-	.a.svelte-xyz + .b.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .c.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .e.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .f.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .g.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .h.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
+	.a.svelte-xyz + .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .g:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .h:where(.svelte-xyz) { color: green; }
 
-	.b.svelte-xyz + .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz + .e.svelte-xyz + .f.svelte-xyz + .h.svelte-xyz { color: green; }
-	.b.svelte-xyz + .d.svelte-xyz + .h.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .g.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
+	.b.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .e:where(.svelte-xyz) + .f:where(.svelte-xyz) + .h:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .d:where(.svelte-xyz) + .h:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .g:where(.svelte-xyz) { color: green; }

--- a/packages/svelte/tests/css/samples/siblings-combinator-await/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-await/expected.css
@@ -1,9 +1,9 @@
-	.a.svelte-xyz + .b.svelte-xyz { color: green; }
-	.a.svelte-xyz + .c.svelte-xyz { color: green; }
-	.a.svelte-xyz + .d.svelte-xyz { color: green; }
-	.b.svelte-xyz + .e.svelte-xyz { color: green; }
-	.c.svelte-xyz + .e.svelte-xyz { color: green; }
-	.d.svelte-xyz + .e.svelte-xyz { color: green; }
+	.a.svelte-xyz + .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .a + .e { color: green; }*/

--- a/packages/svelte/tests/css/samples/siblings-combinator-each-2/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-each-2/expected.css
@@ -1,20 +1,20 @@
 	/* boundary of each */
-	.a.svelte-xyz + .b.svelte-xyz {
+	.a.svelte-xyz + .b:where(.svelte-xyz) {
 		color: green;
 	}
-	.c.svelte-xyz + .d.svelte-xyz {
+	.c.svelte-xyz + .d:where(.svelte-xyz) {
 		color: green;
 	}
 	/* if array is empty */
-	.a.svelte-xyz + .d.svelte-xyz {
+	.a.svelte-xyz + .d:where(.svelte-xyz) {
 		color: green;
 	}
 	/* if array has multiple items */
-	.c.svelte-xyz + .b.svelte-xyz {
+	.c.svelte-xyz + .b:where(.svelte-xyz) {
 		color: green;
 	}
 	/* normal sibling */
-	.b.svelte-xyz + .c.svelte-xyz {
+	.b.svelte-xyz + .c:where(.svelte-xyz) {
 		color: green;
 	}
 	/* not match */

--- a/packages/svelte/tests/css/samples/siblings-combinator-each-else-nested/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-each-else-nested/expected.css
@@ -1,18 +1,18 @@
-	.a.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .f.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz + .c.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz + .d.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .f.svelte-xyz.svelte-xyz { color: green; }
-	.d.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.d.svelte-xyz + .f.svelte-xyz.svelte-xyz { color: green; }
-	.e.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz + .j.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz + .h.svelte-xyz + .j.svelte-xyz { color: green; }
-	.g.svelte-xyz + .i.svelte-xyz + .j.svelte-xyz { color: green; }
-	.m.svelte-xyz + .m.svelte-xyz.svelte-xyz { color: green; }
-	.m.svelte-xyz + .l.svelte-xyz.svelte-xyz { color: green; }
-	.l.svelte-xyz + .m.svelte-xyz.svelte-xyz { color: green; }
+	.a.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .c:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz + .j:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz + .h:where(.svelte-xyz) + .j:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz + .i:where(.svelte-xyz) + .j:where(.svelte-xyz) { color: green; }
+	.m.svelte-xyz + .m:where(.svelte-xyz) { color: green; }
+	.m.svelte-xyz + .l:where(.svelte-xyz) { color: green; }
+	.l.svelte-xyz + .m:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .a + .c { color: green; }*/

--- a/packages/svelte/tests/css/samples/siblings-combinator-each-else/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-each-else/expected.css
@@ -1,7 +1,7 @@
-	.a.svelte-xyz + .b.svelte-xyz { color: green; }
-	.a.svelte-xyz + .c.svelte-xyz { color: green; }
-	.b.svelte-xyz + .d.svelte-xyz { color: green; }
-	.c.svelte-xyz + .d.svelte-xyz { color: green; }
+	.a.svelte-xyz + .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .c:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .a + .d { color: green; }*/

--- a/packages/svelte/tests/css/samples/siblings-combinator-each-nested/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-each-nested/expected.css
@@ -1,53 +1,53 @@
 	/* boundary of each */
-	.a.svelte-xyz + .d.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .f.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .g.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .d.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .f.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .g.svelte-xyz.svelte-xyz { color: green; }
+	.a.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .g:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .g:where(.svelte-xyz) { color: green; }
 
 	/* nested boundary of each */
-	.j.svelte-xyz + .m.svelte-xyz.svelte-xyz { color: green; }
-	.j.svelte-xyz + .n.svelte-xyz.svelte-xyz { color: green; }
-	.j.svelte-xyz + .o.svelte-xyz.svelte-xyz { color: green; }
-	.k.svelte-xyz + .m.svelte-xyz.svelte-xyz { color: green; }
-	.k.svelte-xyz + .n.svelte-xyz.svelte-xyz { color: green; }
-	.k.svelte-xyz + .o.svelte-xyz.svelte-xyz { color: green; }
-	.l.svelte-xyz + .m.svelte-xyz.svelte-xyz { color: green; }
-	.l.svelte-xyz + .n.svelte-xyz.svelte-xyz { color: green; }
-	.l.svelte-xyz + .o.svelte-xyz.svelte-xyz { color: green; }
+	.j.svelte-xyz + .m:where(.svelte-xyz) { color: green; }
+	.j.svelte-xyz + .n:where(.svelte-xyz) { color: green; }
+	.j.svelte-xyz + .o:where(.svelte-xyz) { color: green; }
+	.k.svelte-xyz + .m:where(.svelte-xyz) { color: green; }
+	.k.svelte-xyz + .n:where(.svelte-xyz) { color: green; }
+	.k.svelte-xyz + .o:where(.svelte-xyz) { color: green; }
+	.l.svelte-xyz + .m:where(.svelte-xyz) { color: green; }
+	.l.svelte-xyz + .n:where(.svelte-xyz) { color: green; }
+	.l.svelte-xyz + .o:where(.svelte-xyz) { color: green; }
 
 	/* parent each */
-	.d.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.e.svelte-xyz + .f.svelte-xyz.svelte-xyz { color: green; }
+	.d.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
 
 	/* child each */
-	.g.svelte-xyz + .h.svelte-xyz.svelte-xyz { color: green; }
+	.g.svelte-xyz + .h:where(.svelte-xyz) { color: green; }
 
 	/* wrap around */
-	.f.svelte-xyz + .d.svelte-xyz.svelte-xyz { color: green; }
-	.f.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.f.svelte-xyz + .f.svelte-xyz.svelte-xyz { color: green; }
+	.f.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.f.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.f.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
 
-	.h.svelte-xyz + .g.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz + .h.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz + .g.svelte-xyz.svelte-xyz { color: green; }
+	.h.svelte-xyz + .g:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz + .h:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz + .g:where(.svelte-xyz) { color: green; }
 
 	/* wrap around self */
-	.d.svelte-xyz + .d.svelte-xyz.svelte-xyz { color: green; }
-	.e.svelte-xyz + .e.svelte-xyz.svelte-xyz { color: green; }
-	.f.svelte-xyz + .f.svelte-xyz.svelte-xyz { color: green; }
-	.g.svelte-xyz + .g.svelte-xyz.svelte-xyz { color: green; }
-	.h.svelte-xyz + .h.svelte-xyz.svelte-xyz { color: green; }
-	.i.svelte-xyz + .i.svelte-xyz.svelte-xyz { color: green; }
+	.d.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.f.svelte-xyz + .f:where(.svelte-xyz) { color: green; }
+	.g.svelte-xyz + .g:where(.svelte-xyz) { color: green; }
+	.h.svelte-xyz + .h:where(.svelte-xyz) { color: green; }
+	.i.svelte-xyz + .i:where(.svelte-xyz) { color: green; }
 
 	/* wrap around self + next */
-	.e.svelte-xyz + .e.svelte-xyz + .f.svelte-xyz { color: green; }
-	.e.svelte-xyz + .e.svelte-xyz + .d.svelte-xyz { color: green; }
-	.h.svelte-xyz + .h.svelte-xyz + .i.svelte-xyz { color: green; }
-	.h.svelte-xyz + .h.svelte-xyz + .g.svelte-xyz { color: green; }
+	.e.svelte-xyz + .e:where(.svelte-xyz) + .f:where(.svelte-xyz) { color: green; }
+	.e.svelte-xyz + .e:where(.svelte-xyz) + .d:where(.svelte-xyz) { color: green; }
+	.h.svelte-xyz + .h:where(.svelte-xyz) + .i:where(.svelte-xyz) { color: green; }
+	.h.svelte-xyz + .h:where(.svelte-xyz) + .g:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .a + .h { color: green; }*/

--- a/packages/svelte/tests/css/samples/siblings-combinator-each/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-each/expected.css
@@ -1,3 +1,3 @@
-	div.svelte-xyz + span.svelte-xyz {
+	div.svelte-xyz + span:where(.svelte-xyz) {
 		color: green;
 	}

--- a/packages/svelte/tests/css/samples/siblings-combinator-former-element-in-slot/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-former-element-in-slot/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz + span.svelte-xyz {
+  h1.svelte-xyz + span:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/siblings-combinator-if-not-exhaustive-with-each/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-if-not-exhaustive-with-each/expected.css
@@ -1,12 +1,12 @@
-	.a.svelte-xyz + .b.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .c.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.b.svelte-xyz + .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .d.svelte-xyz.svelte-xyz.svelte-xyz { color: green; }
+	.a.svelte-xyz + .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
 
-	.a.svelte-xyz + .c.svelte-xyz + .c.svelte-xyz.svelte-xyz { color: green; }
-	.c.svelte-xyz + .c.svelte-xyz + .d.svelte-xyz.svelte-xyz { color: green; }
-	.a.svelte-xyz + .c.svelte-xyz + .c.svelte-xyz + .d.svelte-xyz { color: green; }
+	.a.svelte-xyz + .c:where(.svelte-xyz) + .c:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .c:where(.svelte-xyz) + .d:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .c:where(.svelte-xyz) + .c:where(.svelte-xyz) + .d:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .b + .c { color: green; }*/

--- a/packages/svelte/tests/css/samples/siblings-combinator-if-not-exhaustive/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-if-not-exhaustive/expected.css
@@ -1,8 +1,8 @@
-	.a.svelte-xyz + .b.svelte-xyz { color: green; }
-	.a.svelte-xyz + .c.svelte-xyz { color: green; }
-	.a.svelte-xyz + .d.svelte-xyz { color: green; }
-	.b.svelte-xyz + .d.svelte-xyz { color: green; }
-	.c.svelte-xyz + .d.svelte-xyz { color: green; }
+	.a.svelte-xyz + .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .b + .c { color: green; }*/

--- a/packages/svelte/tests/css/samples/siblings-combinator-if/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-if/expected.css
@@ -1,9 +1,9 @@
-	.a.svelte-xyz + .b.svelte-xyz { color: green; }
-	.a.svelte-xyz + .c.svelte-xyz { color: green; }
-	.a.svelte-xyz + .d.svelte-xyz { color: green; }
-	.b.svelte-xyz + .e.svelte-xyz { color: green; }
-	.c.svelte-xyz + .e.svelte-xyz { color: green; }
-	.d.svelte-xyz + .e.svelte-xyz { color: green; }
+	.a.svelte-xyz + .b:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .c:where(.svelte-xyz) { color: green; }
+	.a.svelte-xyz + .d:where(.svelte-xyz) { color: green; }
+	.b.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.c.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
+	.d.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .a + .e { color: green; }*/

--- a/packages/svelte/tests/css/samples/siblings-combinator-nested-slots-flattened/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-nested-slots-flattened/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz + span.svelte-xyz {
+  h1.svelte-xyz + span:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/siblings-combinator-nested-slots/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-nested-slots/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz + span.svelte-xyz {
+  h1.svelte-xyz + span:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/siblings-combinator-selects-slot-fallback/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-selects-slot-fallback/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz + span.svelte-xyz {
+  h1.svelte-xyz + span:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/siblings-combinator-slot/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-slot/expected.css
@@ -1,4 +1,4 @@
-	.d.svelte-xyz + .e.svelte-xyz { color: green; }
+	.d.svelte-xyz + .e:where(.svelte-xyz) { color: green; }
 
 	/* no match */
 	/* (unused) .a + .b { color: green; }*/

--- a/packages/svelte/tests/css/samples/siblings-combinator-slots-between/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-slots-between/expected.css
@@ -1,3 +1,3 @@
-  h1.svelte-xyz + span.svelte-xyz {
+  h1.svelte-xyz + span:where(.svelte-xyz) {
     color: red;
   }

--- a/packages/svelte/tests/css/samples/siblings-combinator-star/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-star/expected.css
@@ -1,4 +1,4 @@
-	.match.svelte-xyz > .svelte-xyz + .svelte-xyz {
+	.match.svelte-xyz > :where(.svelte-xyz) + :where(.svelte-xyz) {
 		margin-left: 4px;
 	}
 	/* (unused) .not-match > * + * {

--- a/packages/svelte/tests/css/samples/siblings-combinator-with-spread/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator-with-spread/expected.css
@@ -1,2 +1,2 @@
-	input.svelte-xyz:focus + div.svelte-xyz { color: red; }
-	input.svelte-xyz:focus ~ div.svelte-xyz { color: red; }
+	input.svelte-xyz:focus + div:where(.svelte-xyz) { color: red; }
+	input.svelte-xyz:focus ~ div:where(.svelte-xyz) { color: red; }

--- a/packages/svelte/tests/css/samples/siblings-combinator/expected.css
+++ b/packages/svelte/tests/css/samples/siblings-combinator/expected.css
@@ -1,4 +1,4 @@
-	div.svelte-xyz + article.svelte-xyz.svelte-xyz {
+	div.svelte-xyz + article:where(.svelte-xyz) {
 		color: green;
 	}
 	/* (unused) article + div {
@@ -13,15 +13,15 @@
 	/* (unused) span + div {
 		color: green;
 	}*/
-	span.svelte-xyz + b.svelte-xyz.svelte-xyz {
+	span.svelte-xyz + b:where(.svelte-xyz) {
 		color: green;
 	}
-	div.svelte-xyz span.svelte-xyz + b.svelte-xyz {
+	div.svelte-xyz span:where(.svelte-xyz) + b:where(.svelte-xyz) {
 		color: green;
 	}
-	.a.svelte-xyz + article.svelte-xyz.svelte-xyz {
+	.a.svelte-xyz + article:where(.svelte-xyz) {
 		color: green;
 	}
-	div.svelte-xyz + .b.svelte-xyz.svelte-xyz {
+	div.svelte-xyz + .b:where(.svelte-xyz) {
 		color: green;
 	}

--- a/packages/svelte/tests/css/samples/unused-selector-child-combinator/expected.css
+++ b/packages/svelte/tests/css/samples/unused-selector-child-combinator/expected.css
@@ -10,6 +10,6 @@
 		font-size: 48px;
 	}*/
 
-	div.svelte-xyz > .svelte-xyz {
+	div.svelte-xyz > :where(.svelte-xyz) {
 		color: orange;
 	}

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -82,6 +82,16 @@ Previously, a compound selector starting with a global modifier which has univer
 
 Previously Svelte would always insert the CSS hash last. This is no longer guaranteed in Svelte 5. This is only breaking if you [have very weird css selectors](https://stackoverflow.com/questions/15670631/does-the-order-of-classes-listed-on-an-item-affect-the-css).
 
+### Scoped CSS uses :where(...)
+
+To avoid issues caused by unpredictable specificity changes, scoped CSS selectors now use `:where(.svelte-xyz123)` selector modifiers alongside `.svelte-xyz123` (where `xyz123` is, as previously, a hash of the `<style>` contents). You can read more detail [here](https://github.com/sveltejs/svelte/pull/10443).
+
+In the event that you need to support ancient browsers that don't implement `:where`, you can manually alter the emitted CSS, at the cost of unpredictable specificity changes:
+
+```js
+css = css.replace(/:where\((.+?)\)/, '$1');
+```
+
 ### Renames of various error/warning codes
 
 Various error and warning codes have been renamed slightly.

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -89,6 +89,7 @@ To avoid issues caused by unpredictable specificity changes, scoped CSS selector
 In the event that you need to support ancient browsers that don't implement `:where`, you can manually alter the emitted CSS, at the cost of unpredictable specificity changes:
 
 ```js
+// @errors: 2552
 css = css.replace(/:where\((.+?)\)/, '$1');
 ```
 


### PR DESCRIPTION
The context for this is #9549, though I think it may also address #7991.

Today, Svelte uses class selectors to scope local styles to the component. In other words, this...

```svelte
<p>red</p>

<style>
  p {
    color: red;
  }
</style>
```

...is effectively turned into this, so that `<p>` elements outside the component are not affected by this component's styles:

```svelte
<p class="svelte-xyz123">red</p>

<style>
  p.svelte-xyz123 {
    color: red;
  }
</style>
```

The wrinkle is that this affects the selector's specificity, in a way that could cause bugs — #1277 — unless we add redundant-looking duplicate class selectors so that the specificity increase is uniform within a component.

Unfortunately, this approach also has its flaws:

- the specificity increase isn't uniform _between_ components, leading to issues like #7991
- it makes it impossible to correctly implement support for CSS nesting, as described [here](https://github.com/sveltejs/svelte/pull/9549#issuecomment-1934828649)

Happily, it's 2024, and we now have a way of scoping selectors _without_ increasing specificity — [`:where`](https://developer.mozilla.org/en-US/docs/Web/CSS/:where).

One approach would be to use `:where(.svelte-xyz)` everywhere instead of just `.svelte-xyz`. We briefly tried that, but found that it violated people's expectations that component styles would be more specific than global styles that were appended to the document later. In practice, people _want_ a specificity bump, they just want it to be predictable.

Another approach would be to make it an option. This is what Astro does with [`scopedStyleStrategy`](https://docs.astro.build/en/reference/configuration-reference/#scopedstylestrategy), for example, but I'm not personally a fan of this sort of approach — it forces the developer to think about the problem, and yields subtle differences between different apps (which might affect e.g. component libraries that they use in common). (In Astro's case there's an option to use data attributes instead of classnames — this arguably yields cleaner markup, though when we've investigated this in the past we've found that class selectors have better performance, which eventually starts to matter. For now I think we should stick with classnames, though that could be decided independently of the `:where` question.)

So this PR proposes a third option — a hybrid approach, that uses a class selector exactly once per compound selector, for a uniform specificity bump of `+0-1-0`, and uses `:where` for any subsequent selectors. As a bonus, it allows us to simplify the code a bit.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
