### PR TITLE
docs: improve autoscroll logic to handle long messages #10448

### DIFF
--- a/documentation/tutorial/07-lifecycle/03-update/app-b/App.svelte
+++ b/documentation/tutorial/07-lifecycle/03-update/app-b/App.svelte
@@ -6,7 +6,7 @@
 	let autoscroll;
 
 	beforeUpdate(() => {
-		autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 20;
+		autoscroll = div && div.scrollTop + div.clientHeight + 100 >= div.scrollHeight;
 	});
 
 	afterUpdate(() => {

--- a/documentation/tutorial/07-lifecycle/03-update/text.md
+++ b/documentation/tutorial/07-lifecycle/03-update/text.md
@@ -13,7 +13,7 @@ let div;
 let autoscroll;
 
 beforeUpdate(() => {
-	autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 20;
+	autoscroll = div && div.scrollTop + div.clientHeight + 100 >= div.scrollHeight;
 });
 
 afterUpdate(() => {


### PR DESCRIPTION
### Describe the problem

**Description:**

In the Svelte tutorial section discussing lifecycle and the update lifecycle function (specifically, the autoscroll functionality), the current implementation does not consistently trigger autoscrolling for very long messages. The existing logic, `autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 20;`, fails to account for cases where a user inputs a message that significantly increases the `scrollHeight` of the container. This can lead to a scenario where the chat does not automatically scroll to the bottom after a long message is added, detracting from the user experience. An improvement to the autoscroll logic is proposed to ensure that autoscrolling is triggered regardless of the message length.

**Reproduction:**
1. Visit the Svelte interactive tutorial at [Svelte Tutorial - Lifecycle - Update](https://learn.svelte.dev/tutorial/update).
2. Follow the tutorial steps until you reach the section that implements autoscroll functionality using `beforeUpdate` and `afterUpdate`.
3. Use the chat application to input and send a very long message, such as a large paragraph of "Lorem ipsum..." text. You may need to adjust the amount of text based on your device to replicate the bug effectively.
4. Observe that after sending a long message, the chat does not scroll to the bottom as expected, leaving the bot message partially or completely out of view.

### Describe the proposed solution

**Proposed Fix:**

To address this issue, the autoscroll logic should be updated to better capture scenarios where new content significantly increases the container's `scrollHeight`. 

The proposed change is: `autoscroll = div && div.scrollTop + div.clientHeight + 100 >= div.scrollHeight;`. 

This adjustment ensures that autoscroll is activated when the user is within 100 pixels of the bottom of the chat, providing a more reliable trigger for autoscrolling after long messages are added. 

This change aims to enhance the functionality by ensuring that the chat window always scrolls to the newest message, improving the overall usability and user experience. 

It also ensures that the Svelte tutorial provides a robust example of implementing autoscroll functionality, making it more useful for learners who are looking to implement similar features in their own projects.

Fixes #10448 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
