### PR TITLE
docs: update routing FAQ with some more recent options

### DIFF
--- a/documentation/docs/05-misc/01-faq.md
+++ b/documentation/docs/05-misc/01-faq.md
@@ -100,7 +100,7 @@ If you need hash-based routing on the client side, check out [svelte-spa-router]
 
 [Routify](https://routify.dev) is another filesystem-based router, similar to SvelteKit's router. Version 3 supports Svelte's native SSR.
 
-[Vite](https://vike.dev/svelte) is another Vite-based router, like SvelteKit's router, but is still experimental.
+[Vike](https://vike.dev/svelte) is another Vite-based router, like SvelteKit's router, but is still experimental.
 
 You can see a [community-maintained list of routers on sveltesociety.dev](https://sveltesociety.dev/components#routers).
 

--- a/documentation/docs/05-misc/01-faq.md
+++ b/documentation/docs/05-misc/01-faq.md
@@ -94,7 +94,7 @@ The official routing library is [SvelteKit](https://kit.svelte.dev/). SvelteKit 
 
 However, you can use any router library. Some framework-agnostic libraries include [navaid](https://github.com/lukeed/navaid); [universal-router](https://github.com/kriasoft/universal-router), which is isomorphic; [Hono](https://hono.dev/), which supports multiple JS runtimes; and [TanStack Router](https://github.com/TanStack/router/tree/beta-agnostic), which is typesafe and supports caching.
 
-If you prefer a declarative HTML approach, there's the isomorphic [svelte-routing](https://github.com/EmilTholin/svelte-routing) library and a fork of it called [svelte-navigator](https://github.com/mefechoel/svelte-navigator) containing some additional functionality.
+If you prefer a declarative HTML approach, the isomorphic [svelte-routing](https://github.com/EmilTholin/svelte-routing) and [svelte-pilot](https://svelte-pilot.github.io/en/link#toc) libraries are available.
 
 If you need hash-based routing on the client side, check out [svelte-spa-router](https://github.com/ItalyPaleAle/svelte-spa-router) or [abstract-state-router](https://github.com/TehShrike/abstract-state-router/).
 

--- a/documentation/docs/05-misc/01-faq.md
+++ b/documentation/docs/05-misc/01-faq.md
@@ -92,13 +92,15 @@ Some resources for getting started with testing:
 
 The official routing library is [SvelteKit](https://kit.svelte.dev/). SvelteKit provides a filesystem router, server-side rendering (SSR), and hot module reloading (HMR) in one easy-to-use package. It shares similarities with Next.js for React.
 
-However, you can use any router library. A lot of people use [page.js](https://github.com/visionmedia/page.js). There's also [navaid](https://github.com/lukeed/navaid), which is very similar. And [universal-router](https://github.com/kriasoft/universal-router), which is isomorphic with child routes, but without built-in history support.
+However, you can use any router library. Some framework-agnostic libraries include [navaid](https://github.com/lukeed/navaid); [universal-router](https://github.com/kriasoft/universal-router), which is isomorphic; [Hono](https://hono.dev/), which supports multiple JS runtimes; and [TanStack Router](https://github.com/TanStack/router/tree/beta-agnostic), which is typesafe and supports caching.
 
 If you prefer a declarative HTML approach, there's the isomorphic [svelte-routing](https://github.com/EmilTholin/svelte-routing) library and a fork of it called [svelte-navigator](https://github.com/mefechoel/svelte-navigator) containing some additional functionality.
 
 If you need hash-based routing on the client side, check out [svelte-spa-router](https://github.com/ItalyPaleAle/svelte-spa-router) or [abstract-state-router](https://github.com/TehShrike/abstract-state-router/).
 
 [Routify](https://routify.dev) is another filesystem-based router, similar to SvelteKit's router. Version 3 supports Svelte's native SSR.
+
+[Vite](https://vike.dev/svelte) is another Vite-based router, like SvelteKit's router, but is still experimental.
 
 You can see a [community-maintained list of routers on sveltesociety.dev](https://sveltesociety.dev/components#routers).
 


### PR DESCRIPTION
removed `page.js`, which hasn't been updated in 4 years, and `svelte-navigator`, which hasn't been updated in two years and added some newer options that @GrygrFlzr shared