### PR TITLE
fix: allow stores in `transition`,`animation`,`use` directives

### DIFF
--- a/.changeset/stale-jeans-refuse.md
+++ b/.changeset/stale-jeans-refuse.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow stores in `transition`,`animation`,`use` directives

--- a/.changeset/stale-jeans-refuse.md
+++ b/.changeset/stale-jeans-refuse.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: allow stores in `transition`,`animation`,`use` directives
+fix: subscribe to stores in `transition`,`animation`,`use` directives

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -375,7 +375,6 @@ function store_sub_exist(bindings) {
 				// make sure it is not a sub in a directive e.g. use:$store as it is unneeded
 				if (node?.type !== 'RegularElement') {
 					return true;
-					s;
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -375,6 +375,7 @@ function store_sub_exist(bindings) {
 				// make sure it is not a sub in a directive e.g. use:$store as it is unneeded
 				if (node?.type !== 'RegularElement') {
 					return true;
+					s;
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -345,11 +345,11 @@ function get_assignment_value(node, { state, visit }) {
 		return operator === '='
 			? /** @type {import('estree').Expression} */ (visit(node.right))
 			: // turn something like x += 1 into x = x + 1
-			  b.binary(
+				b.binary(
 					/** @type {import('estree').BinaryOperator} */ (operator.slice(0, -1)),
 					serialize_get_binding(node.left, state),
 					/** @type {import('estree').Expression} */ (visit(node.right))
-			  );
+				);
 	} else {
 		return /** @type {import('estree').Expression} */ (visit(node.right));
 	}
@@ -801,7 +801,7 @@ function serialize_element_spread_attributes(
 						b.id('join')
 					),
 					b.literal(' ')
-			  )
+				)
 			: b.literal('');
 		args.push(
 			b.object([
@@ -965,7 +965,7 @@ function serialize_inline_component(node, component_name, context) {
 			: b.call(
 					'$.spread_props',
 					b.array(props_and_spreads.map((p) => (Array.isArray(p) ? b.object(p) : p)))
-			  );
+				);
 
 	/** @type {import('estree').Statement} */
 	let statement = b.stmt(
@@ -974,7 +974,7 @@ function serialize_inline_component(node, component_name, context) {
 				? b.call(
 						'$.validate_component',
 						typeof component_name === 'string' ? b.id(component_name) : component_name
-				  )
+					)
 				: component_name,
 			b.id('$$payload'),
 			props_expression
@@ -1066,7 +1066,7 @@ const javascript_visitors_legacy = {
 							'$.value_or_fallback',
 							prop,
 							/** @type {import('estree').Expression} */ (visit(declarator.init))
-					  )
+						)
 					: prop;
 
 				declarations.push(b.declarator(declarator.id, init));
@@ -1204,7 +1204,7 @@ const template_visitors = {
 							template: [],
 							init: []
 						}
-				  }
+					}
 				: { ...context, state };
 
 		const { hoisted, trimmed } = clean_nodes(
@@ -1532,9 +1532,9 @@ const template_visitors = {
 							b.let(
 								node.expression.type === 'ObjectExpression'
 									? // @ts-expect-error types don't match, but it can't contain spread elements and the structure is otherwise fine
-									  b.object_pattern(node.expression.properties)
+										b.object_pattern(node.expression.properties)
 									: // @ts-expect-error types don't match, but it can't contain spread elements and the structure is otherwise fine
-									  b.array_pattern(node.expression.elements),
+										b.array_pattern(node.expression.elements),
 								b.member(b.id('$$slotProps'), b.id(node.name))
 							),
 							b.return(b.object(bindings.map((binding) => b.init(binding.node.name, binding.node))))
@@ -1768,12 +1768,12 @@ function serialize_element_attributes(node, context) {
 								? b.call(
 										b.member(attribute.expression, b.id('includes')),
 										serialize_attribute_value(value_attribute.value, context)
-								  )
+									)
 								: b.binary(
 										'===',
 										attribute.expression,
 										serialize_attribute_value(value_attribute.value, context)
-								  ),
+									),
 							metadata: {
 								contains_call_expression: false,
 								dynamic: false

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -372,7 +372,7 @@ function store_sub_exist(bindings) {
 			for (const reference of binding.references) {
 				const node = reference.path.at(-1);
 
-				// make sure it is not a sub in a directive e.g. use:$store as it is unneeded
+				// hacky way to ensure the sub is not in a directive e.g. use:$store as it is unneeded
 				if (node?.type !== 'RegularElement') {
 					return true;
 				}

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -366,7 +366,7 @@ function is_store_name(name) {
  *
  * @param {Iterable<import('#compiler').Binding>} bindings
  */
-function is_store_exists(bindings) {
+function store_sub_exist(bindings) {
 	for (const binding of bindings) {
 		if (binding.kind === 'store_sub') {
 			for (const reference of binding.references) {
@@ -2108,7 +2108,7 @@ export function server_component(analysis, options) {
 		];
 	}
 
-	if (is_store_exists(analysis.instance.scope.declarations.values())) {
+	if (store_sub_exist(analysis.instance.scope.declarations.values())) {
 		instance.body.unshift(b.const('$$store_subs', b.object([])));
 		template.body.push(b.stmt(b.call('$.unsubscribe_stores', b.id('$$store_subs'))));
 	}

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -289,17 +289,6 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 	};
 
 	/**
-	 * @type {import('zimmerframe').Visitor<import('#compiler').Directive, State, import('#compiler').SvelteNode>}
-	 */
-	const SvelteDirective = (node, context) => {
-		const name = node.name;
-
-		if (name[0] === '$') {
-			context.state.scope.reference(b.id(name), context.path);
-		}
-	};
-
-	/**
 	 * @param {import('#compiler').ElementLike} node
 	 * @param {Scope} parent
 	 */
@@ -340,6 +329,18 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 
 		return /** @type {const} */ ([scope, is_default_slot]);
 	}
+
+	/**
+	 * Reference store in transion:, use:, animate: directives
+	 * @type {import('zimmerframe').Visitor<import('#compiler').Directive, State, import('#compiler').SvelteNode>}
+	 */
+	const SvelteDirective = (node, context) => {
+		const name = node.name;
+
+		if (name[0] === '$') {
+			context.state.scope.reference(b.id(name), context.path);
+		}
+	};
 
 	walk(ast, state, {
 		// references

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -185,6 +185,7 @@ export class Scope {
 	reference(node, path) {
 		path = [...path]; // ensure that mutations to path afterwards don't affect this reference
 		let references = this.references.get(node.name);
+
 		if (!references) this.references.set(node.name, (references = []));
 
 		references.push({ node, path });
@@ -285,6 +286,15 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 		const [scope] = analyze_let_directives(node, state.scope);
 		scopes.set(node, scope);
 		next({ scope });
+	};
+
+	/**
+	 * @type {import('zimmerframe').Visitor<import('#compiler').Directive, State, import('#compiler').SvelteNode>}
+	 */
+	const SvelteDirective = (node, context) => {
+		const name = node.name;
+
+		if (name[0] === '$') context.state.scope.reference(b.id(name), context.path);
 	};
 
 	/**
@@ -625,7 +635,11 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 				)
 			]);
 			context.next();
-		}
+		},
+
+		TransitionDirective: SvelteDirective,
+		AnimateDirective: SvelteDirective,
+		UseDirective: SvelteDirective
 
 		// TODO others
 	});

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -294,7 +294,9 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 	const SvelteDirective = (node, context) => {
 		const name = node.name;
 
-		if (name[0] === '$') context.state.scope.reference(b.id(name), context.path);
+		if (name[0] === '$') {
+			context.state.scope.reference(b.id(name), context.path);
+		}
 	};
 
 	/**

--- a/packages/svelte/tests/snapshot/samples/store-transition/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/store-transition/_expected/client/main.svelte.js
@@ -1,0 +1,32 @@
+// main.svelte (Svelte VERSION)
+// Note: compiler output will change before 5.0 is released!
+import "svelte/internal/disclose-version";
+import * as $ from "svelte/internal";
+import { writable } from 'svelte/store';
+
+var frag = $.template(`<div>Hello!</div> <div>Hello!</div>`, true);
+
+export default function Main($$anchor, $$props) {
+	$.push($$props, false);
+
+	const $$subscriptions = {};
+
+	$.unsubscribe_on_destroy($$subscriptions);
+
+	const $animate = () => $.store_get(animate, "$animate", $$subscriptions);
+	const animate = writable();
+
+	$.init();
+
+	/* Init */
+	var fragment = $.open_frag($$anchor, true, frag);
+	var div = $.child_frag(fragment);
+
+	$.in(div, $animate, () => ({ duration: 750, x: 0, y: -200 }), false);
+
+	var div_1 = $.sibling($.sibling(div, true));
+
+	$.action(div_1, ($$node) => $animate()($$node));
+	$.close_frag($$anchor, fragment);
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/store-transition/_expected/server/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/store-transition/_expected/server/main.svelte.js
@@ -1,0 +1,15 @@
+// main.svelte (Svelte VERSION)
+// Note: compiler output will change before 5.0 is released!
+import * as $ from "svelte/internal/server";
+import { writable } from 'svelte/store';
+
+export default function Main($$payload, $$props) {
+	$.push(false);
+
+	const $$store_subs = {};
+	const animate = writable();
+
+	$$payload.out += `<div>Hello!</div> <div>Hello!</div>`;
+	$.unsubscribe_stores($$store_subs);
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/store-transition/_expected/server/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/store-transition/_expected/server/main.svelte.js
@@ -6,10 +6,8 @@ import { writable } from 'svelte/store';
 export default function Main($$payload, $$props) {
 	$.push(false);
 
-	const $$store_subs = {};
 	const animate = writable();
 
 	$$payload.out += `<div>Hello!</div> <div>Hello!</div>`;
-	$.unsubscribe_stores($$store_subs);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/store-transition/main.svelte
+++ b/packages/svelte/tests/snapshot/samples/store-transition/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { writable, } from 'svelte/store';
+
+	const animate = writable();
+</script>
+
+<div in:$animate={{ duration: 750, x:0, y: -200}}>Hello!</div>
+<div use:$animate>Hello!</div>


### PR DESCRIPTION
I'm not sure if this should be the output for SSR, but it's harmless either way.

closes #9518 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
