### PR TITLE
chore: treeshakeable store subs

### DIFF
--- a/.changeset/brown-months-fry.md
+++ b/.changeset/brown-months-fry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: treeshake unused store subscriptions in SSR mode

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -321,7 +321,7 @@ function serialize_get_binding(node, state) {
 	if (binding.kind === 'store_sub') {
 		const store_id = b.id(node.name.slice(1));
 		return b.call(
-			state.options.dev ? '$.store_get_dev' : '$.store_get',
+			'$.store_get',
 			b.assignment('??=', b.id('$$store_subs'), b.object([])),
 			b.literal(node.name),
 			serialize_get_binding(store_id, state)

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -322,7 +322,7 @@ function serialize_get_binding(node, state) {
 		const store_id = b.id(node.name.slice(1));
 		return b.call(
 			state.options.dev ? '$.store_get_dev' : '$.store_get',
-			b.id('$$store_subs'),
+			b.assignment('??=', b.id('$$store_subs'), b.object([])),
 			b.literal(node.name),
 			serialize_get_binding(store_id, state)
 		);
@@ -460,7 +460,7 @@ function serialize_set_binding(node, context, fallback) {
 	} else if (is_store) {
 		return b.call(
 			'$.mutate_store',
-			b.id('$$store_subs'),
+			b.assignment('??=', b.id('$$store_subs'), b.object([])),
 			b.literal(left.name),
 			b.id(left_name),
 			b.assignment(node.operator, /** @type {import('estree').Pattern} */ (visit(node.left)), value)
@@ -506,7 +506,11 @@ const global_visitors = {
 			if (node.prefix) fn += '_pre';
 
 			/** @type {import('estree').Expression[]} */
-			const args = [b.id('$$store_subs'), b.literal(argument.name), b.id(argument.name.slice(1))];
+			const args = [
+				b.assignment('??=', b.id('$$store_subs'), b.object([])),
+				b.literal(argument.name),
+				b.id(argument.name.slice(1))
+			];
 			if (node.operator === '--') {
 				args.push(b.literal(-1));
 			}
@@ -2094,8 +2098,10 @@ export function server_component(analysis, options) {
 			(binding) => binding.kind === 'store_sub'
 		)
 	) {
-		instance.body.unshift(b.const('$$store_subs', b.object([])));
-		template.body.push(b.stmt(b.call('$.unsubscribe_stores', b.id('$$store_subs'))));
+		instance.body.unshift(b.var('$$store_subs'));
+		template.body.push(
+			b.if(b.id('$$store_subs'), b.stmt(b.call('$.unsubscribe_stores', b.id('$$store_subs'))))
+		);
 	}
 	// Propagate values of bound props upwards if they're undefined in the parent and have a value.
 	// Don't do this as part of the props retrieval because people could eagerly mutate the prop in the instance script.

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -2,6 +2,7 @@ import * as $ from '../client/runtime.js';
 import { is_promise, noop } from '../common.js';
 import { subscribe_to_store } from '../../store/utils.js';
 import { DOMBooleanAttributes } from '../../constants.js';
+import { DEV } from 'esm-env';
 
 export * from '../client/validate.js';
 
@@ -340,6 +341,10 @@ export function merge_styles(style_attribute, style_directive) {
  * @returns {V}
  */
 export function store_get(store_values, store_name, store) {
+	if (DEV) {
+		validate_store(store, store_name.slice(1));
+	}
+
 	// it could be that someone eagerly updates the store in the instance script, so
 	// we should only reuse the store value in the template
 	if (store_name in store_values && store_values[store_name][0] === store) {
@@ -354,18 +359,6 @@ export function store_get(store_values, store_name, store) {
 	);
 	store_values[store_name][1] = unsub;
 	return store_values[store_name][2];
-}
-
-/**
- * @template V
- * @param {Record<string, [any, any, any]>} store_values
- * @param {string} store_name
- * @param {import('../client/types.js').Store<V> | null | undefined} store
- * @returns {V}
- */
-export function store_get_dev(store_values, store_name, store) {
-	validate_store(store, store_name.slice(1));
-	return store_get(store_values, store_name, store);
 }
 
 /**


### PR DESCRIPTION
In #10503 I removed the `store_sub_exist` mechanism for omitting store subscriptions for directive names, because it's not a great use of our complexity budget to optimise such a niche case while leaving more common uses (event handlers, effects, etc) unoptimised.

This PR proposes a more universal approach — instead of trying to do the static analysis ourselves, we leave it to tools like Rollup. With this PR, a component like this...

```svelte
<script>
  import { writable } from 'svelte/store';

  const thing = writable();

  function foo() {
    bar();
  }

  function bar() {
    console.log($thing);
  }

  $effect(() => {
    console.log($thing);
  });
</script>

<button onclick={foo}>click me</button>
```

...gets turned into this...

```diff
export default function App($$payload, $$props) {
  $.push(true);

-  const $$store_subs = {};
+  var $$store_subs;
  const thing = writable();

  function foo() {
    bar();
  }

  function bar() {
-    console.log($.store_get($$store_subs, "$thing", thing));
+    console.log($.store_get($$store_subs ??= {}, "$thing", thing));
  }

  $$payload.out += `<button>click me</button>`;
-  $.unsubscribe_stores($$store_subs);
+  if ($$store_subs) $.unsubscribe_stores($$store_subs);
  $.pop();
}
```

...which Rollup [turns into this](https://rollupjs.org/repl/?version=4.12.0&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQSUyMiUyMiUyQyUyMm1vZHVsZXMlMjIlM0ElNUIlN0IlMjJjb2RlJTIyJTNBJTIyJTJGJTJGJTIwQXBwLnN2ZWx0ZSUyMChTdmVsdGUlMjB2NS4wLjAtbmV4dC41NiklNUNuJTJGJTJGJTIwTm90ZSUzQSUyMGNvbXBpbGVyJTIwb3V0cHV0JTIwd2lsbCUyMGNoYW5nZSUyMGJlZm9yZSUyMDUuMCUyMGlzJTIwcmVsZWFzZWQhJTVDbmltcG9ydCUyMColMjBhcyUyMCUyNCUyMGZyb20lMjAlNUMlMjJzdmVsdGUlMkZpbnRlcm5hbCUyRnNlcnZlciU1QyUyMiUzQiU1Q25pbXBvcnQlMjAlN0IlMjB3cml0YWJsZSUyMCU3RCUyMGZyb20lMjAnc3ZlbHRlJTJGc3RvcmUnJTNCJTVDbiU1Q25leHBvcnQlMjBkZWZhdWx0JTIwZnVuY3Rpb24lMjBBcHAoJTI0JTI0cGF5bG9hZCUyQyUyMCUyNCUyNHByb3BzKSUyMCU3QiU1Q24lNUN0JTI0LnB1c2godHJ1ZSklM0IlNUNuJTVDbiU1Q3R2YXIlMjAlMjQlMjRzdG9yZV9zdWJzJTNCJTVDbiU1Q3Rjb25zdCUyMHRoaW5nJTIwJTNEJTIwd3JpdGFibGUoKSUzQiU1Q24lNUNuJTVDdGZ1bmN0aW9uJTIwZm9vKCklMjAlN0IlNUNuJTVDdCU1Q3RiYXIoKSUzQiU1Q24lNUN0JTdEJTVDbiU1Q24lNUN0ZnVuY3Rpb24lMjBiYXIoKSUyMCU3QiU1Q24lNUN0JTVDdGNvbnNvbGUubG9nKCUyNC5zdG9yZV9nZXQoJTI0JTI0c3RvcmVfc3VicyUyMCUzRiUzRiUzRCUyMCU3QiU3RCUyQyUyMCU1QyUyMiUyNHRoaW5nJTVDJTIyJTJDJTIwdGhpbmcpKSUzQiU1Q24lNUN0JTdEJTVDbiU1Q24lNUN0JTI0JTI0cGF5bG9hZC5vdXQlMjAlMkIlM0QlMjAlNjAlM0NidXR0b24lM0VjbGljayUyMG1lJTNDJTJGYnV0dG9uJTNFJTYwJTNCJTVDbiU1Q3RpZiUyMCglMjQlMjRzdG9yZV9zdWJzKSUyMCUyNC51bnN1YnNjcmliZV9zdG9yZXMoJTI0JTI0c3RvcmVfc3VicyklM0IlNUNuJTVDdCUyNC5wb3AoKSUzQiU1Q24lN0QlMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSUyQyUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiU3RCU3RA==) (not sure why it can't treeshake `writable()` away, but that's a separate issue):

```js
function App($$payload, $$props) {
  $.push(true);
  writable();

  $$payload.out += `<button>click me</button>`;
  $.pop();
}
```

The trade-off is that in the (perhaps more common?) case that a store value contributes to SSR, each `store_get` reference gets a `??= {}` added, and the `unsubscribe_stores(...)` call now sits inside a `if ($$store_subs)` block.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
