### PR TITLE
chore: remove unneeded store_get_dev function

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -321,7 +321,7 @@ function serialize_get_binding(node, state) {
 	if (binding.kind === 'store_sub') {
 		const store_id = b.id(node.name.slice(1));
 		return b.call(
-			state.options.dev ? '$.store_get_dev' : '$.store_get',
+			'$.store_get',
 			b.id('$$store_subs'),
 			b.literal(node.name),
 			serialize_get_binding(store_id, state)

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -2,6 +2,7 @@ import * as $ from '../client/runtime.js';
 import { is_promise, noop } from '../common.js';
 import { subscribe_to_store } from '../../store/utils.js';
 import { DOMBooleanAttributes } from '../../constants.js';
+import { DEV } from 'esm-env';
 
 export * from '../client/validate.js';
 
@@ -340,6 +341,10 @@ export function merge_styles(style_attribute, style_directive) {
  * @returns {V}
  */
 export function store_get(store_values, store_name, store) {
+	if (DEV) {
+		validate_store(store, store_name.slice(1));
+	}
+
 	// it could be that someone eagerly updates the store in the instance script, so
 	// we should only reuse the store value in the template
 	if (store_name in store_values && store_values[store_name][0] === store) {
@@ -354,18 +359,6 @@ export function store_get(store_values, store_name, store) {
 	);
 	store_values[store_name][1] = unsub;
 	return store_values[store_name][2];
-}
-
-/**
- * @template V
- * @param {Record<string, [any, any, any]>} store_values
- * @param {string} store_name
- * @param {import('../client/types.js').Store<V> | null | undefined} store
- * @returns {V}
- */
-export function store_get_dev(store_values, store_name, store) {
-	validate_store(store, store_name.slice(1));
-	return store_get(store_values, store_name, store);
 }
 
 /**


### PR DESCRIPTION
decided to extract the drive-by fix in #10506 into its own PR, in case we decide against merging that one. we're relying on `DEV` in other places, no reason we shouldn't use the same mechanism everywhere