### PR TITLE
chore: simplify accessor return

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -287,12 +287,8 @@ export function client_component(source, analysis, options) {
 			: () => {};
 
 	if (properties.length > 0) {
-		component_block.body.push(
-			b.var('$$accessors', b.object(properties)),
-			b.stmt(b.call('$.pop', b.id('$$accessors')))
-		);
 		append_styles();
-		component_block.body.push(b.return(b.id('$$accessors')));
+		component_block.body.push(b.return(b.call('$.pop', b.object(properties))));
 	} else {
 		component_block.body.push(b.stmt(b.call('$.pop')));
 		append_styles();

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -286,13 +286,12 @@ export function client_component(source, analysis, options) {
 					)
 			: () => {};
 
-	if (properties.length > 0) {
-		append_styles();
-		component_block.body.push(b.return(b.call('$.pop', b.object(properties))));
-	} else {
-		component_block.body.push(b.stmt(b.call('$.pop')));
-		append_styles();
-	}
+	append_styles();
+	component_block.body.push(
+		properties.length > 0
+			? b.return(b.call('$.pop', b.object(properties)))
+			: b.stmt(b.call('$.pop'))
+	);
 
 	if (analysis.uses_rest_props) {
 		/** @type {string[]} */

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1907,7 +1907,7 @@ export function push(props, runes = false) {
 
 /**
  * @template {Record<string, any>} T
- * @param {T} component
+ * @param {T} [component]
  * @returns {T | void}
  */
 export function pop(component) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1907,10 +1907,10 @@ export function push(props, runes = false) {
 
 /**
  * @template {Record<string, any>} T
- * @param {T} component
+ * @param {T} [component]
  * @returns {T}
  */
-export function pop(component = /** @type {T} */ ({})) {
+export function pop(component) {
 	const context_stack_item = current_component_context;
 	if (context_stack_item !== null) {
 		if (component !== undefined) {
@@ -1926,7 +1926,9 @@ export function pop(component = /** @type {T} */ ({})) {
 		current_component_context = context_stack_item.p;
 		context_stack_item.m = true;
 	}
-	return component;
+	// Micro-optimization: Don't set .a above to the empty object
+	// so it can be garbage-collected when the return here is unused
+	return component || /** @type {T} */ ({});
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1906,14 +1906,15 @@ export function push(props, runes = false) {
 }
 
 /**
- * @param {Record<string, any>} [accessors]
- * @returns {void}
+ * @template {Record<string, any>} T
+ * @param {T} component
+ * @returns {T | void}
  */
-export function pop(accessors) {
+export function pop(component) {
 	const context_stack_item = current_component_context;
 	if (context_stack_item !== null) {
-		if (accessors !== undefined) {
-			context_stack_item.a = accessors;
+		if (component !== undefined) {
+			context_stack_item.a = component;
 		}
 		const effects = context_stack_item.e;
 		if (effects !== null) {
@@ -1925,6 +1926,7 @@ export function pop(accessors) {
 		current_component_context = context_stack_item.p;
 		context_stack_item.m = true;
 	}
+	return component;
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1907,10 +1907,10 @@ export function push(props, runes = false) {
 
 /**
  * @template {Record<string, any>} T
- * @param {T} [component]
- * @returns {T | void}
+ * @param {T} component
+ * @returns {T}
  */
-export function pop(component) {
+export function pop(component = /** @type {T} */ ({})) {
 	const context_stack_item = current_component_context;
 	if (context_stack_item !== null) {
 		if (component !== undefined) {


### PR DESCRIPTION
There's a few small changes I'd like to make around accessors, starting with this:

```diff
-var $$accessors = {
+return $.pop({
  get message() {
    return message;
  }
-};
+});

-$.pop($$accessors);
-return $$accessors;
```

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
