### PR TITLE
fix: use init properties when exporting non-state values

### DIFF
--- a/.changeset/empty-bags-heal.md
+++ b/.changeset/empty-bags-heal.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: use init properties when exporting non-state values in prod

--- a/.changeset/empty-bags-heal.md
+++ b/.changeset/empty-bags-heal.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-chore: use init properties when exporting non-state values in prod
+fix: use init properties when exporting non-state values in prod

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -242,9 +242,11 @@ export function client_component(source, analysis, options) {
 		const binding = analysis.instance.scope.get(name);
 		const is_source = binding !== null && is_state_source(binding, state);
 
-		// TODO This is always a getter because the `renamed-instance-exports` test wants it that way.
-		// Should we for code size reasons make it an init in runes mode and/or non-dev mode?
-		return b.get(alias ?? name, [b.return(is_source ? b.call('$.get', b.id(name)) : b.id(name))]);
+		if (is_source || options.dev) {
+			return b.get(alias ?? name, [b.return(is_source ? b.call('$.get', b.id(name)) : b.id(name))]);
+		}
+
+		return b.init(alias ?? name, b.id(name));
 	});
 
 	if (analysis.accessors) {

--- a/packages/svelte/tests/runtime-legacy/samples/prop-accessors/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/prop-accessors/_config.js
@@ -1,7 +1,12 @@
 import { test } from '../../test';
 
 export default test({
+	compileOptions: {
+		dev: true
+	},
+
 	accessors: false,
+
 	test({ assert, component }) {
 		assert.equal(component.foo1, 42);
 		assert.equal(component.foo2(), 42);

--- a/packages/svelte/tests/runtime-legacy/samples/renamed-instance-exports/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/renamed-instance-exports/_config.js
@@ -1,6 +1,10 @@
 import { test } from '../../test';
 
 export default test({
+	compileOptions: {
+		dev: true
+	},
+
 	test({ assert, component }) {
 		assert.equal(component.bar1, 42);
 		assert.equal(component.bar2, 42);


### PR DESCRIPTION
Follow-up to #10520. Changes this...

```js
var $$accessors = {
  get message() {
    return message;
  }
};
```

...to this, for non-state values (except in dev, where we want to guard against people incorrectly setting stuff from outside):

```js
var $$accessors = { message };
```

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
