### PR TITLE
chore: improve code generation for `bind:this` in SSR mode

### DIFF
--- a/.changeset/brave-points-sleep.md
+++ b/.changeset/brave-points-sleep.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: improve code generation for `bind:this` in SSR mode

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1060,7 +1060,9 @@ const common_visitors = {
 				parent.type === 'SvelteComponent' ||
 				parent.type === 'SvelteSelf'
 			) {
-				context.state.analysis.uses_component_bindings = true;
+				if (node.name !== 'this') {
+					context.state.analysis.uses_component_bindings = true;
+				}
 				break;
 			} else if (is_element_node(parent)) {
 				break;

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -853,7 +853,7 @@ function serialize_inline_component(node, component_name, context) {
 
 			const value = serialize_attribute_value(attribute.value, context, false, true);
 			push_prop(b.prop('init', b.key(attribute.name), value));
-		} else if (attribute.type === 'BindDirective') {
+		} else if (attribute.type === 'BindDirective' && attribute.name !== 'this') {
 			// TODO this needs to turn the whole thing into a while loop because the binding could be mutated eagerly in the child
 			push_prop(
 				b.get(attribute.name, [

--- a/packages/svelte/tests/snapshot/samples/bind-this/_config.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
@@ -1,0 +1,17 @@
+// index.svelte (Svelte VERSION)
+// Note: compiler output will change before 5.0 is released!
+import "svelte/internal/disclose-version";
+import * as $ from "svelte/internal";
+
+export default function Bind_this($$anchor, $$props) {
+	$.push($$props, false);
+	$.init();
+
+	/* Init */
+	var fragment = $.comment($$anchor);
+	var node = $.child_frag(fragment);
+
+	$.bind_this(Foo(node, {}), ($$value) => foo = $$value, foo);
+	$.close_frag($$anchor, fragment);
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/server/index.svelte.js
@@ -1,0 +1,14 @@
+// index.svelte (Svelte VERSION)
+// Note: compiler output will change before 5.0 is released!
+import * as $ from "svelte/internal/server";
+
+export default function Bind_this($$payload, $$props) {
+	$.push(false);
+
+	const anchor = $.create_anchor($$payload);
+
+	$$payload.out += `${anchor}`;
+	Foo($$payload, {});
+	$$payload.out += `${anchor}`;
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/bind-this/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/bind-this/index.svelte
@@ -1,0 +1,1 @@
+<Foo bind:this={foo} />


### PR DESCRIPTION
We do the whole `$$settled` dance in SSR for components with `bind:this`, quite unnecessarily. Given this input...

```svelte
<Child bind:this={child} />
```

...this PR produces much better output:

```js
// old
export default function App($$payload, $$props) {
  $.push(false);

  let $$settled = true;
  let $$inner_payload;

  function $$render_inner($$payload) {
    const anchor = $.create_anchor($$payload);

    $$payload.out += `${anchor}`;

    Foo($$payload, {
      get this() {
        return foo;
      },
      set this($$value) {
        foo = $$value;
        $$settled = false;
      }
    });

    $$payload.out += `${anchor}`;
  };

  do {
    $$settled = true;
    $$inner_payload = $.copy_payload($$payload);
    $$render_inner($$inner_payload);
  } while (!$$settled);

  $.assign_payload($$payload, $$inner_payload);
  $.pop();
}
```

```js
// new
export default function App($$payload, $$props) {
  $.push(false);

  const anchor = $.create_anchor($$payload);

  $$payload.out += `${anchor}`;
  Foo($$payload, {});
  $$payload.out += `${anchor}`;
  $.pop();
}
```

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
