### PR TITLE
feat: access store `value` dirctly throuh a getter

### DIFF
--- a/packages/svelte/src/store/public.d.ts
+++ b/packages/svelte/src/store/public.d.ts
@@ -31,6 +31,7 @@ export interface Readable<T> {
 	 * @param invalidate cleanup callback
 	 */
 	subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
+	readonly value: T;
 }
 
 /** Writable interface for both updating and subscribing. */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1927,6 +1927,7 @@ declare module 'svelte/motion' {
 		 * @param invalidate cleanup callback
 		 */
 		subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
+		readonly value: T
 	}
 	interface SpringOpts {
 		stiffness?: number;
@@ -2006,6 +2007,7 @@ declare module 'svelte/store' {
 		 * @param invalidate cleanup callback
 		 */
 		subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
+		readonly value: T
 	}
 
 	/** Writable interface for both updating and subscribing. */


### PR DESCRIPTION
I have added a value getter that will return the most updated internal value of the store without extra complexity. This will avoid subscribing and unsubscribing to get the value, which is how the `get()` function works.

```
const num = writable(5)

console.log(num.value) // will print the value of 5
```

### Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
