### PR TITLE
fix: better interop of `$state` with actions/`$:` statements

### DIFF
--- a/.changeset/light-days-clean.md
+++ b/.changeset/light-days-clean.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure update methods of actions and reactive statements work with fine-grained `$state`

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
@@ -167,8 +167,10 @@ export const javascript_visitors_legacy = {
 			const name = binding.node.name;
 			let serialized = serialize_get_binding(b.id(name), state);
 
-			if (name === '$$props' || name === '$$restProps') {
-				serialized = b.call('$.access_props', serialized);
+			// If the binding is a prop, we need to deep read it because it could be fine-grained $state
+			// from a runes-component, where mutations don't trigger an update on the prop as a whole.
+			if (name === '$$props' || name === '$$restProps' || binding.kind === 'prop') {
+				serialized = b.call('$.deep_read', serialized);
 			}
 
 			sequence.push(serialized);

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -3052,25 +3052,6 @@ export function unmount(component) {
 }
 
 /**
- * @param {Record<string, unknown>} props
- * @returns {void}
- */
-export function access_props(props) {
-	for (const prop in props) {
-		deep_read(props[prop]);
-	}
-}
-
-/**
- * @param {any[]} values
- */
-export function deep_read_all(...values) {
-	for (const value of values) {
-		deep_read(value);
-	}
-}
-
-/**
  * @param {Record<string, any>} props
  * @returns {Record<string, any>}
  */

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2317,10 +2317,10 @@ export function action(dom, action, value_fn) {
 			untrack(() => {
 				if (payload === undefined) {
 					payload = action(dom, value) || {};
+					needs_deep_read = !!payload?.update;
 				} else {
 					const update = payload.update;
 					if (typeof update === 'function') {
-						needs_deep_read = true;
 						update(value);
 					}
 				}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1985,11 +1985,13 @@ export function init() {
 }
 
 /**
+ * Deeply traverse an object and read all its properties
+ * so that they're all reactive in case this is `$state`
  * @param {any} value
  * @param {Set<any>} visited
  * @returns {void}
  */
-function deep_read(value, visited = new Set()) {
+export function deep_read(value, visited = new Set()) {
 	if (typeof value === 'object' && value !== null && !visited.has(value)) {
 		visited.add(value);
 		for (let key in value) {

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -38,7 +38,8 @@ export {
 	inspect,
 	unwrap,
 	freeze,
-	init
+	init,
+	deep_read
 } from './client/runtime.js';
 export * from './client/each.js';
 export * from './client/render.js';

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -66,6 +66,9 @@ class Svelte4Component {
 	 * }} options
 	 */
 	constructor(options) {
+		// Using proxy state here isn't completely mirroring the Svelte 4 behavior, because mutations to a property
+		// cause fine-grained updates to only the places where that property is used, and not the entire property.
+		// Reactive statements and actions (the things where this matters) are handling this properly regardless, so it should be fine in practise.
 		const props = $.proxy({ ...(options.props || {}), $$events: this.#events }, false);
 		this.#instance = (options.hydrate ? $.hydrate : $.mount)(options.component, {
 			target: options.target,

--- a/packages/svelte/tests/runtime-legacy/samples/binding-backflow/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-backflow/_config.js
@@ -34,7 +34,7 @@ export default test({
 
 		p = parents['reactive_mutate'];
 		assert.deepEqual(p.value, { foo: 'kid' });
-		assert.equal(p.updates.length, 1);
+		assert.equal(p.updates.length, 2);
 
 		p = parents['init_update'];
 		assert.deepEqual(p.value, { foo: 'kid' });
@@ -42,6 +42,6 @@ export default test({
 
 		p = parents['init_mutate'];
 		assert.deepEqual(p.value, { foo: 'kid' });
-		assert.equal(p.updates.length, 1);
+		assert.equal(p.updates.length, 2);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/action-state-arg/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/action-state-arg/_config.js
@@ -2,7 +2,7 @@ import { test } from '../../test';
 import { tick } from 'svelte';
 
 export default test({
-	html: `<button>reassign</button><button>mutate</button><div>0</div>`,
+	html: `<button>mutate</button><button>reassign</button><div>0</div>`,
 
 	async test({ assert, target }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
@@ -11,14 +11,14 @@ export default test({
 		await tick();
 		assert.htmlEqual(
 			target.innerHTML,
-			`<button>reassign</button><button>mutate</button><div>1</div>`
+			`<button>mutate</button><button>reassign</button><div>1</div>`
 		);
 
 		btn2.click();
 		await tick();
 		assert.htmlEqual(
 			target.innerHTML,
-			`<button>reassign</button><button>mutate</button><div>2</div>`
+			`<button>mutate</button><button>reassign</button><div>2</div>`
 		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/action-state-arg/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/action-state-arg/_config.js
@@ -1,0 +1,24 @@
+import { test } from '../../test';
+import { tick } from 'svelte';
+
+export default test({
+	html: `<button>reassign</button><button>mutate</button><div>0</div>`,
+
+	async test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+
+		btn1.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>reassign</button><button>mutate</button><div>1</div>`
+		);
+
+		btn2.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>reassign</button><button>mutate</button><div>2</div>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/action-state-arg/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/action-state-arg/main.svelte
@@ -1,0 +1,16 @@
+<script>
+    let foo = $state({ count: 0 });
+    let count = $state(0);
+
+    function action() {
+        return {
+            update(foo) {
+                count = foo.count;
+            }
+        }
+    }
+</script>
+
+<button onclick={() => foo = {...foo, count: foo.count + 1 }}>reassign</button>
+<button onclick={() => foo.count++}>mutate</button>
+<div use:action={foo}>{count}</div>

--- a/packages/svelte/tests/runtime-runes/samples/action-state-arg/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/action-state-arg/main.svelte
@@ -11,6 +11,6 @@
     }
 </script>
 
-<button onclick={() => foo = {...foo, count: foo.count + 1 }}>reassign</button>
 <button onclick={() => foo.count++}>mutate</button>
+<button onclick={() => foo = {...foo, count: foo.count + 1 }}>reassign</button>
 <div use:action={foo}>{count}</div>

--- a/packages/svelte/tests/runtime-runes/samples/fine-grained-prop-reactive-statement/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/fine-grained-prop-reactive-statement/_config.js
@@ -1,0 +1,24 @@
+import { test } from '../../test';
+import { tick } from 'svelte';
+
+export default test({
+	html: `<button>reassign</button><button>mutate</button><p>0 / 0</p>`,
+
+	async test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+
+		btn1.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>reassign</button><button>mutate</button><p>1 / 1</p>`
+		);
+
+		btn2.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>reassign</button><button>mutate</button><p>2 / 2</p>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/fine-grained-prop-reactive-statement/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/fine-grained-prop-reactive-statement/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Old from './old.svelte';
+
+	let prop = $state({ count: 0 });
+</script>
+
+<button onclick={() => prop = {...prop, count: prop.count + 1 }}>reassign</button>
+<button onclick={() => prop.count++}>mutate</button>
+<Old {prop}></Old>

--- a/packages/svelte/tests/runtime-runes/samples/fine-grained-prop-reactive-statement/old.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/fine-grained-prop-reactive-statement/old.svelte
@@ -1,0 +1,11 @@
+<svelte:options runes={false} />
+<script>
+	export let prop;
+    let count_1 = prop.count;
+	$: {
+        count_1 = prop.count;
+    }
+    $: count_2 = prop.count;
+</script>
+
+<p>{count_1} / {count_2}</p>


### PR DESCRIPTION
Ensure update methods of actions and reactive statements work with fine-grained `$state` by deep-reading them. This is necessary because mutations to `$state` objects don't notify listeners to only the object as a whole, it only notifies the listeners of the property that changed.
fixes #10460
fixes https://github.com/simeydotme/svelte-range-slider-pips/issues/130

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
