### PR TITLE
fix: don't execute scripts inside `@html` when instantiated on the client

### DIFF
--- a/.changeset/moody-carrots-lay.md
+++ b/.changeset/moody-carrots-lay.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: don't execute scripts inside `@html` when instantiated on the client

--- a/packages/svelte/src/internal/client/reconciler.js
+++ b/packages/svelte/src/internal/client/reconciler.js
@@ -103,7 +103,9 @@ export function reconcile_html(target, value, svg) {
 	if (svg) {
 		html = `<svg>${html}</svg>`;
 	}
-	var content = create_fragment_with_script_from_html(html);
+	// Don't use create_fragment_with_script_from_html here because that would mean script tags are executed.
+	// @html is basically `.innerHTML = ...` and that doesn't execute scripts either due to security reasons.
+	var content = create_fragment_from_html(html);
 	if (svg) {
 		content = /** @type {DocumentFragment} */ (/** @type {unknown} */ (content.firstChild));
 	}

--- a/packages/svelte/tests/runtime-browser/samples/html-tag-script/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/html-tag-script/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../assert';
+
+export default test({
+	// Test that @html does not execute scripts when instantiated in the client.
+	// Needs to be in this test suite because JSDOM does not quite get this right.
+	html: `<div></div><script>document.body.innerHTML = 'this should not be executed'</script>`,
+	skip_if_ssr: 'permanent',
+	skip_if_hydrate: 'permanent'
+});

--- a/packages/svelte/tests/runtime-browser/samples/html-tag-script/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/html-tag-script/main.svelte
@@ -1,0 +1,2 @@
+<div></div>
+{@html `<script>document.body.innerHTML = 'this should not be executed'</script>`}


### PR DESCRIPTION
In Svelte 4, scripts inside `@html` were not executed when it was created client-side. This is because `innerHTML = ..` which was used under the hood does not execute scripts due to security reasons. This adjusts the code so the same is true for Svelte 5.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
