### PR TITLE
fix: Derived stores are re-evaluated on invalid upstream state

### DIFF
--- a/packages/svelte/src/store/private.d.ts
+++ b/packages/svelte/src/store/private.d.ts
@@ -3,8 +3,11 @@ import { Readable, Subscriber } from './public.js';
 /** Cleanup logic callback. */
 export type Invalidator<T> = (value?: T) => void;
 
+/** Cleanup logic callback. */
+export type Revalidator<T> = (value?: T) => void;
+
 /** Pair of subscriber and invalidator. */
-export type SubscribeInvalidateTuple<T> = [Subscriber<T>, Invalidator<T>];
+export type SubscribeInvalidateTuple<T> = [Subscriber<T>, Invalidator<T>, Revalidator<T>];
 
 /** One or more `Readable`s. */
 export type Stores =

--- a/packages/svelte/src/store/public.d.ts
+++ b/packages/svelte/src/store/public.d.ts
@@ -13,7 +13,7 @@ export type Updater<T> = (value: T) => T;
  * Start and stop notification callbacks.
  * This function is called when the first subscriber subscribes.
  *
- * @param {(value: T) => void} set Function that sets the value of the store.
+ * @param {((value: T) => void) & { set: (value: T) => void, update: (fn: Updater<T>) => void, invalidate: () => void })} set Function that sets the value of the store.
  * @param {(value: Updater<T>) => void} update Function that sets the value of the store after passing the current value to the update function.
  * @returns {void | (() => void)} Optionally, a cleanup function that is called when the last remaining
  * subscriber unsubscribes.

--- a/packages/svelte/src/store/public.d.ts
+++ b/packages/svelte/src/store/public.d.ts
@@ -1,4 +1,4 @@
-import type { Invalidator } from './private.js';
+import type { Invalidator, Revalidator } from './private.js';
 
 /** Callback to inform of a value updates. */
 export type Subscriber<T> = (value: T) => void;
@@ -22,7 +22,8 @@ export type StartStopNotifier<T> = (
 	set: ((value: T) => void) & {
 		set: (value: T) => void,
 		update: (fn: Updater<T>) => void,
-		invalidate: () => void
+		invalidate: () => void,
+		revalidate: () => void
 	},
 	update: (fn: Updater<T>) => void
 ) => void | (() => void);
@@ -32,9 +33,10 @@ export interface Readable<T> {
 	/**
 	 * Subscribe on value changes.
 	 * @param run subscription callback
-	 * @param invalidate cleanup callback
+	 * @param invalidate cleanup callback - run when inputs are in an indeterminate state
+	 * @param revalidate cleanup callback - run when inputs have been resolved to their previous values
 	 */
-	subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
+	subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator<T>, revalidate?: Revalidator<T>): Unsubscriber;
 }
 
 /** Writable interface for both updating and subscribing. */

--- a/packages/svelte/src/store/public.d.ts
+++ b/packages/svelte/src/store/public.d.ts
@@ -19,7 +19,11 @@ export type Updater<T> = (value: T) => T;
  * subscriber unsubscribes.
  */
 export type StartStopNotifier<T> = (
-	set: (value: T) => void,
+	set: ((value: T) => void) & {
+		set: (value: T) => void,
+		update: (fn: Updater<T>) => void,
+		invalidate: () => void
+	},
 	update: (fn: Updater<T>) => void
 ) => void | (() => void);
 

--- a/packages/svelte/src/store/utils.js
+++ b/packages/svelte/src/store/utils.js
@@ -5,9 +5,10 @@ import { noop } from '../internal/common.js';
  * @param {import('./public').Readable<T> | null | undefined} store
  * @param {(value: T) => void} run
  * @param {(value: T) => void} [invalidate]
+ * @param {(value: T) => void} [revalidate]
  * @returns {() => void}
  */
-export function subscribe_to_store(store, run, invalidate) {
+export function subscribe_to_store(store, run, invalidate, revalidate) {
 	if (store == null) {
 		// @ts-expect-error
 		run(undefined);
@@ -22,7 +23,8 @@ export function subscribe_to_store(store, run, invalidate) {
 	const unsub = store.subscribe(
 		run,
 		// @ts-expect-error
-		invalidate
+		invalidate,
+		revalidate
 	);
 
 	// Also support RxJS

--- a/packages/svelte/tests/store/test.ts
+++ b/packages/svelte/tests/store/test.ts
@@ -551,6 +551,22 @@ describe('derived', () => {
 			});
 		});
 	});
+
+	it('only updates once dependents are resolved', () => {
+		const a = writable(1);
+		const b = derived(a, a => a*2);
+		const c = derived([a,b], ([a,b]) => a+b);
+
+		const values: number[] = [];
+
+		const unsubscribe = c.subscribe(c => {
+			values.push(c);
+		});
+
+		a.set(2);
+		a.set(3);
+		assert.deepEqual(values, [3, 6, 9]);
+	});
 });
 
 describe('get', () => {


### PR DESCRIPTION
## Svelte 5 rewrite

This PR specifically targets svelte 5 though the issue this PR addresses is relevant to svelte 5 and svelte 4.
I would be happy to make a svelte 4 PR once this one is resolved.

### Before submitting the PR, please make sure you do the following

This PR addresses #10376.

Currently, a change to a store's value only causes stores which are immediately dependent on it to be invalidated. Svelte does not propagate invalidation downstream to subsequent derived stores, and this can cause issues when two criteria are met:

- the store dependency graph forks and merges again at least once; and
- the two or more paths between the fork and merge points are of unequal length.

Svelte's current implementation [correctly handles dependency diamonds](https://github.com/sveltejs/svelte/issues/2660), but such cases do not meet the second criterion; unequal path length.

## Example

Consider the following example:
```js
const a = writable(1);
const b = derived(a, a => a*2);
const c = derived([a,b], ([a,b]) => a+b);
c.subscribe(c => console.log(c));
...
<input type=number bind:value={$a} />
```

This creates a dependency graph something like:
```mermaid
stateDiagram-v2
	direction RL
  
	input
	a
	b
	c
	log

	log --> c
	c --> b
	b --> a
	c --> a
	a --> input
```

### Svelte's Current Implementation
With sveltes current implementation, the derived store c will prematurely evaluate every time store a changes.
In the example above, if we change the input to `2`, the current implementation will go through the following sequence:

```mermaid
sequenceDiagram
	autonumber
	
	participant input
	participant a
	participant b
	participant c
	participant log

	note right of a: a == 1
	note right of b: b == a * 2 == 1 * 2 == 2
	note right of c: c == a + b == 1 + 2 == 3

	input ->> a: 2
	note right of a: a == 2
	a -->> c: invalidate
	activate c
	a -->> b: invalidate
	activate b
	a ->> c: 2
	deactivate c
	rect rgb(255, 128, 128)
	note right of c: c == a + b == 2 + 2 == 4
	c ->> log: 4
	end
	a ->> b: 2
	deactivate b
	note right of b: b == a * 2 == 2 * 2 == 4
	b -->> c: invalidate
	activate c
	b ->> c: 4
	deactivate c
	note right of c: c == a + b == 2 + 4 == 6
	c ->> log: 6
```

Following the diagram, it's clear at point (5) that store `c` is evaluating prematurely. At point (5) store `c` believes both its dependencies to be valid, but in fact only `a` has been resolved at this point.

The correct behaviour would be for invalidations to be "deep" and for resolution to only occur once all dependencies are fully resolved. Thus in the given example, `c` should only emit once for each change to `a`.
