### PR TITLE
docs: update link to build plugins in introduction

### DIFF
--- a/documentation/docs/01-getting-started/01-introduction.md
+++ b/documentation/docs/01-getting-started/01-introduction.md
@@ -23,7 +23,7 @@ SvelteKit will handle calling [the Svelte compiler](https://www.npmjs.com/packag
 
 If you don't want to use SvelteKit for some reason, you can also use Svelte with Vite (but without SvelteKit) by running `npm create vite@latest` and selecting the `svelte` option. With this, `npm run build` will generate HTML, JS and CSS files inside the `dist` directory. In most cases, you will probably need to [choose a routing library](/faq#is-there-a-router) as well.
 
-Alternatively, there are [plugins for all the major web bundlers](https://sveltesociety.dev/packages?category=bundler-plugins) to handle Svelte compilation — which will output `.js` and `.css` that you can insert into your HTML — but most others won't handle SSR.
+Alternatively, there are [plugins for all the major web bundlers](https://sveltesociety.dev/packages?category=build-plugins) to handle Svelte compilation — which will output `.js` and `.css` that you can insert into your HTML — but most others won't handle SSR.
 
 ## Editor tooling
 


### PR DESCRIPTION
The link to https://www.sveltesociety.dev/packages?category=bundler-plugins yields no results since the tag has been renamed to "build-plugins", so I updated it to https://www.sveltesociety.dev/packages?category=build-plugins

