### PR TITLE
fix: improve handling of unowned derived signals

### DIFF
--- a/.changeset/green-tigers-judge.md
+++ b/.changeset/green-tigers-judge.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: improve handling of unowned derived signals

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -77,6 +77,8 @@ export type SourceSignal<V = unknown> = {
 	f: SignalFlags;
 	/** value: The latest value for this signal */
 	v: V;
+	// write version
+	w: number,
 };
 
 export type SourceSignalDebug = {
@@ -111,6 +113,8 @@ export type ComputationSignal<V = unknown> = {
 	v: V;
 	/** level: the depth from the root signal, used for ordering render/pre-effects topologically **/
 	l: number;
+	/** write version: used for unowned signals to track if their depdendencies are dirty or not **/
+	w: number;
 };
 
 export type Signal<V = unknown> = SourceSignal<V> | ComputationSignal<V>;

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -78,7 +78,7 @@ export type SourceSignal<V = unknown> = {
 	/** value: The latest value for this signal */
 	v: V;
 	// write version
-	w: number,
+	w: number;
 };
 
 export type SourceSignalDebug = {

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -227,7 +227,7 @@ describe('signals', () => {
 			// Ensure we're not leaking dependencies
 			assert.deepEqual(
 				nested.slice(0, -2).map((s) => s.d),
-				[null, null, null, null]
+				[null, null]
 			);
 		};
 	});
@@ -281,6 +281,28 @@ describe('signals', () => {
 		return () => {
 			$.flushSync();
 			assert.deepEqual(log, [[], []]);
+		};
+	});
+
+	let some_state = $.source({});
+	let some_deps = $.derived(() => {
+		return [$.get(some_state)];
+	});
+
+	test('two effects with an unowned derived that has some depedencies', () => {
+		const log: Array<Array<any>> = [];
+
+		$.render_effect(() => {
+			log.push($.get(some_deps));
+		});
+
+		$.render_effect(() => {
+			log.push($.get(some_deps));
+		});
+
+		return () => {
+			$.flushSync();
+			assert.deepEqual(log, [[{}], [{}]]);
 		};
 	});
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/10549. 

This PR introduces write versions to the both types of signal. For source signals we increment this version number every time a new value is written to the signal. For computation signals we only use the write version for unowned signals (signals that aren't owned by an effect). We check the dependencies of an unowned derived to see if a version is higher than that of the unowned derived signal to determine if the derived is dirty or not.