### PR TITLE
fix: remove memory leak, make `beforeUpdate` etc work correctly

### DIFF
--- a/.changeset/kind-dots-sort.md
+++ b/.changeset/kind-dots-sort.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove memory leak

--- a/.changeset/real-pandas-brush.md
+++ b/.changeset/real-pandas-brush.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: call beforeUpdate/afterUpdate callbacks when props are mutated

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1308,7 +1308,6 @@ export function derived(init) {
 		create_computation_signal(flags | CLEAN, UNINITIALIZED, current_block)
 	);
 	signal.i = init;
-	bind_signal_to_component_context(signal);
 	signal.e = default_equals;
 	if (current_consumer !== null) {
 		push_reference(current_consumer, signal);
@@ -1335,26 +1334,7 @@ export function derived_safe_equal(init) {
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function source(initial_value) {
-	const source = create_source_signal(SOURCE | CLEAN, initial_value);
-	bind_signal_to_component_context(source);
-	return source;
-}
-
-/**
- * This function binds a signal to the component context, so that we can fire
- * beforeUpdate/afterUpdate callbacks at the correct time etc
- * @param {import('./types.js').Signal} signal
- */
-function bind_signal_to_component_context(signal) {
-	if (current_component_context === null || !current_component_context.r) return;
-
-	const signals = current_component_context.d;
-
-	if (signals) {
-		signals.push(signal);
-	} else {
-		current_component_context.d = [signal];
-	}
+	return create_source_signal(SOURCE | CLEAN, initial_value);
 }
 
 /**
@@ -1366,6 +1346,19 @@ function bind_signal_to_component_context(signal) {
 export function mutable_source(initial_value) {
 	const s = source(initial_value);
 	s.e = safe_equal;
+
+	// bind the signal to the component context, in case we need to
+	// track updates to trigger beforeUpdate/afterUpdate callbacks
+	if (current_component_context && !current_component_context.r) {
+		const signals = current_component_context.d;
+
+		if (signals) {
+			signals.push(s);
+		} else {
+			current_component_context.d = [s];
+		}
+	}
+
 	return s;
 }
 
@@ -1971,10 +1964,7 @@ function observe_all(context) {
 		for (const signal of context.d) get(signal);
 	}
 
-	const props = get_descriptors(context.s);
-	for (const descriptor of Object.values(props)) {
-		if (descriptor.get) descriptor.get();
-	}
+	deep_read(context.s);
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1350,7 +1350,7 @@ export function mutable_source(initial_value) {
 	// bind the signal to the component context, in case we need to
 	// track updates to trigger beforeUpdate/afterUpdate callbacks
 	if (current_component_context) {
-		(current_component_context.d ?? []).push(s);
+		(current_component_context.d ??= []).push(s);
 	}
 
 	return s;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1349,7 +1349,7 @@ export function mutable_source(initial_value) {
 
 	// bind the signal to the component context, in case we need to
 	// track updates to trigger beforeUpdate/afterUpdate callbacks
-	if (current_component_context && !current_component_context.r) {
+	if (current_component_context) {
 		const signals = current_component_context.d;
 
 		if (signals) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1350,13 +1350,7 @@ export function mutable_source(initial_value) {
 	// bind the signal to the component context, in case we need to
 	// track updates to trigger beforeUpdate/afterUpdate callbacks
 	if (current_component_context) {
-		const signals = current_component_context.d;
-
-		if (signals) {
-			signals.push(s);
-		} else {
-			current_component_context.d = [s];
-		}
+		(current_component_context.d ?? []).push(s);
 	}
 
 	return s;

--- a/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/Child.svelte
@@ -1,0 +1,12 @@
+<svelte:options runes={false} />
+
+<script>
+	import { beforeUpdate } from 'svelte';
+	import { logs } from './logs.js'
+
+	export let object;
+
+	beforeUpdate(() => {
+		logs.push('changed');
+	});
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+import { logs } from './logs.js';
+
+export default test({
+	html: `<button>clicks: 0</button>`,
+
+	test({ assert, target }) {
+		const btn = target.querySelector('button');
+
+		flushSync(() => btn?.click());
+
+		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
+		assert.deepEqual(logs, ['changed', 'changed']);
+	},
+
+	after_test() {
+		logs.length = 0;
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/logs.js
+++ b/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/logs.js
@@ -1,0 +1,2 @@
+/** @type {any[]} */
+export const logs = [];

--- a/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Child from './Child.svelte';
+	let object = $state({ count: 0 })
+</script>
+
+<button onclick={() => object.count += 1}>
+	clicks: {object.count}
+</button>
+
+<Child {object} />


### PR DESCRIPTION
Fixes #10548. We were pushing signals to an array on the component context so that `beforeUpdate`/`afterUpdate` callbacks could observe them, but we were never cleaning this array up.

It turns out we only need to create this array for non-runes components, since `beforeUpdate`/`afterUpdate` are forbidden in runes mode. We can therefore do the binding inside `mutable_source`. We don't need to do any additional cleanup work because the context should be garbage collected when the component is destroyed.

I also realised that in the (vanishingly rare!) case that a runes-mode component is passing proxied state into a non-runes-mode component, which has a `beforeUpdate`/`afterUpdate` callback, the callbacks do not run when a property of the proxied state is updated. This is fixed in this PR by using `deep_read` instead of shallowly reading props.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
