### PR TITLE
fix: handle member expressions in directives

### DIFF
--- a/.changeset/good-rivers-yawn.md
+++ b/.changeset/good-rivers-yawn.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: handle member expressions in directives

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -334,7 +334,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 	 * @type {import('zimmerframe').Visitor<import('#compiler').AnimateDirective | import('#compiler').TransitionDirective | import('#compiler').UseDirective, State, import('#compiler').SvelteNode>}
 	 */
 	const SvelteDirective = (node, { state, path, visit }) => {
-		state.scope.reference(b.id(node.name), path);
+		state.scope.reference(b.id(node.name.split('.')[0]), path);
 
 		if (node.expression) {
 			visit(node.expression);

--- a/packages/svelte/tests/runtime-runes/samples/store-directive/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-directive/main.svelte
@@ -1,11 +1,14 @@
 <script>
 	import { writable } from 'svelte/store';
 
-	let action = writable((node, text) => {
+	let store = writable({action: (node, text) => {
 		node.textContent = text;
-	});
+		return {
+			destroy() {}
+		}
+	}});
 
-	let text = writable('mounted')
+	let text = writable('mounted');
 </script>
 
-<div use:$action={$text}>hello</div>
+<div use:$store.action={$text}>hello</div>


### PR DESCRIPTION
tried some more edge cases as well, this should match svelte 4's behaviour. 

honestly, this would have been better if this was done this at the AST level but this isn't needed if stores are gonna be removed/deprecated in svelte 6 ( i believe? ) anyways.

closes #10566 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
