### PR TITLE
fix: ensure proxy owner set always has 1 or more members

### DIFF
--- a/.changeset/sour-bags-fail.md
+++ b/.changeset/sour-bags-fail.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: inherit ownerlessness when creating child proxies

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -84,7 +84,7 @@ export function proxy(value, immutable = true, owners) {
 							? // @ts-expect-error
 								new Set([current_component_context.function])
 							: null
-						: new Set(owners);
+						: owners && new Set(owners);
 			}
 
 			return proxy;

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-2/_config.js
@@ -1,0 +1,37 @@
+import { test } from '../../test';
+
+/** @type {typeof console.warn} */
+let warn;
+
+/** @type {any[]} */
+let warnings = [];
+
+export default test({
+	html: `<button>clicks: 0</button>`,
+
+	compileOptions: {
+		dev: true
+	},
+
+	before_test: () => {
+		warn = console.warn;
+
+		console.warn = (...args) => {
+			warnings.push(...args);
+		};
+	},
+
+	after_test: () => {
+		console.warn = warn;
+		warnings = [];
+	},
+
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+		await btn?.click();
+
+		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
+
+		assert.deepEqual(warnings, []);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-2/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { global } from './state.svelte.js';
+
+	global.a = { b: 0 };
+</script>
+
+<button onclick={() => global.a.b += 1}>
+	clicks: {global.a.b}
+</button>

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-2/state.svelte.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-2/state.svelte.js
@@ -1,0 +1,1 @@
+export let global = $state({});


### PR DESCRIPTION
I forgot about the `null` case, and didn't realise that `new Set(null)` creates an empty set.

Fixes #10573 and https://github.com/sveltejs/kit/issues/11878

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
