### PR TITLE
fix: make `bind_this` implementation more robust

### DIFF
--- a/.changeset/moody-sheep-type.md
+++ b/.changeset/moody-sheep-type.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: make `bind_this` implementation more robust

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -434,6 +434,7 @@ export function execute_effect(signal) {
 
 function infinite_loop_guard() {
 	if (flush_count > 100) {
+		flush_count = 0;
 		throw new Error(
 			'ERR_SVELTE_TOO_MANY_UPDATES' +
 				(DEV

--- a/packages/svelte/tests/runtime-legacy/samples/await-then-catch-event/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/await-then-catch-event/_config.js
@@ -1,3 +1,4 @@
+import { tick } from 'svelte';
 import { test } from '../../test';
 import { create_deferred } from '../../../helpers.js';
 
@@ -22,7 +23,8 @@ export default test({
 		deferred.resolve(42);
 
 		return deferred.promise
-			.then(() => {
+			.then(async () => {
+				await tick();
 				assert.htmlEqual(target.innerHTML, '<button>click me</button>');
 
 				const { button } = component;

--- a/packages/svelte/tests/runtime-legacy/samples/binding-this-with-context/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-this-with-context/_config.js
@@ -46,10 +46,8 @@ export default test({
 		component.items = ['foo', 'baz'];
 		assert.equal(component.divs.length, 3, 'the divs array is still 3 long');
 		assert.equal(component.divs[2], null, 'the last div is unregistered');
-		// Different from Svelte 3
-		assert.equal(component.ps[1], null, 'the second p is unregistered');
-		// Different from Svelte 3
-		assert.equal(component.spans['-baz2'], null, 'the baz span is unregistered');
+		assert.equal(component.ps[2], null, 'the last p is unregistered');
+		assert.equal(component.spans['-bar1'], null, 'the bar span is unregistered');
 		assert.equal(component.hrs.bar, null, 'the bar hr is unregistered');
 
 		divs = target.querySelectorAll('div');
@@ -58,22 +56,17 @@ export default test({
 			assert.equal(e, divs[i], `div ${i} is still correct`);
 		});
 
-		// TODO: unsure if need these two tests to pass, as the logic between Svelte 3
-		// and Svelte 5 is different for these cases.
+		spans = target.querySelectorAll('span');
+		// @ts-ignore
+		component.items.forEach((e, i) => {
+			assert.equal(component.spans[`-${e}${i}`], spans[i], `span -${e}${i} is still correct`);
+		});
 
-		// elems = target.querySelectorAll('span');
-		// component.items.forEach((e, i) => {
-		//   assert.equal(
-		//     component.spans[`-${e}${i}`],
-		//     elems[i],
-		//     `span -${e}${i} is still correct`,
-		//   );
-		// });
-
-		// elems = target.querySelectorAll('p');
-		// component.ps.forEach((e, i) => {
-		//   assert.equal(e, elems[i], `p ${i} is still correct`);
-		// });
+		ps = target.querySelectorAll('p');
+		// @ts-ignore
+		component.ps.forEach((e, i) => {
+			assert.equal(e, ps[i], `p ${i} is still correct`);
+		});
 
 		hrs = target.querySelectorAll('hr');
 		// @ts-ignore

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-if-block-outro-timeout/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-if-block-outro-timeout/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -15,7 +16,8 @@ export default test({
 		assert.equal(window.getComputedStyle(div).opacity, '0');
 
 		raf.tick(600);
-		assert.equal(component.div, undefined);
 		assert.equal(target.querySelector('div'), undefined);
+		flushSync();
+		assert.equal(component.div, undefined);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/bind-this-no-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-this-no-state/_config.js
@@ -1,0 +1,43 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+/** @param {number | null} selected */
+function get_html(selected) {
+	return `
+		<button>1</button>
+		<button>2</button>
+		<button>3</button>
+
+		<hr></hr>
+
+		${selected !== null ? `<div>${selected}</div>` : ''}
+
+		<hr></hr>
+
+		<p>${selected ?? '...'}</p>
+	`;
+}
+
+export default test({
+	html: get_html(null),
+
+	async test({ assert, target }) {
+		const [btn1, btn2, btn3] = target.querySelectorAll('button');
+
+		await btn1?.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, get_html(1));
+
+		await btn2?.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, get_html(2));
+
+		await btn1?.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, get_html(1));
+
+		await btn3?.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, get_html(3));
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bind-this-no-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-this-no-state/main.svelte
@@ -1,0 +1,30 @@
+<script>
+	import { tick } from 'svelte';
+	
+	let selected = $state(-1);
+	let current = $state();
+
+	let div; // explicitly no $state
+</script>
+
+{#each [1, 2, 3] as n, i}
+	<button
+		onclick={async () => {
+			selected = i;
+			await tick();
+			current = div?.textContent;
+		}}
+	>{n}</button>
+{/each}
+
+<hr />
+
+{#each [1, 2, 3] as n, i}
+	{#if selected === i}
+		<div bind:this={div}>{n}</div>
+	{/if}
+{/each}
+
+<hr />
+
+<p>{current ?? '...'}</p>

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
@@ -11,7 +11,7 @@ export default function Bind_this($$anchor, $$props) {
 	var fragment = $.comment($$anchor);
 	var node = $.child_frag(fragment);
 
-	$.bind_this(Foo(node, {}), ($$value) => foo = $$value, foo);
+	$.bind_this(Foo(node, {}), ($$value) => foo = $$value, () => foo);
 	$.close_frag($$anchor, fragment);
 	$.pop();
 }


### PR DESCRIPTION
The previous `bind_this` implementation had flaws around timing and didn't work correctly when the binding wasn't `$state` in runes mode. This PR reimplements `bind_this` by aligning it more with how Svelte 4 bindings work, namely reacting to each block context variables updates properly and introducing a mechanism to get the previous binding destination using said variables.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
