### PR TITLE
fix: improve proxy effect dependency tracking

### DIFF
--- a/.changeset/cold-masks-learn.md
+++ b/.changeset/cold-masks-learn.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: improve proxy effect dependency tracking

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -5,7 +5,8 @@ import {
 	update,
 	updating_derived,
 	batch_inspect,
-	current_component_context
+	current_component_context,
+	set_ignore_mutation_validation
 } from './runtime.js';
 import { effect_active } from './reactivity/computations.js';
 import {
@@ -182,7 +183,11 @@ const state_proxy_handler = {
 		}
 		if (s !== undefined) set(s, UNINITIALIZED);
 
-		if (boolean) update(metadata.v);
+		if (boolean) {
+			set_ignore_mutation_validation(true);
+			update(metadata.v);
+			set_ignore_mutation_validation(false);
+		}
 
 		return boolean;
 	},
@@ -291,8 +296,9 @@ const state_proxy_handler = {
 					set(ls, length);
 				}
 			}
-
+			set_ignore_mutation_validation(true);
 			update(metadata.v);
+			set_ignore_mutation_validation(false);
 		}
 
 		return true;

--- a/packages/svelte/tests/runtime-runes/samples/state-proxy-version/Item.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-proxy-version/Item.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { getContext } from 'svelte';
+
+	let context = getContext('container');
+
+	$effect(() => {
+		context.register('test');
+		return () => context.unregister('test');
+	});
+</script>
+
+<div>Item</div>

--- a/packages/svelte/tests/runtime-runes/samples/state-proxy-version/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-proxy-version/_config.js
@@ -1,0 +1,9 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		flushSync();
+		assert.htmlEqual(target.innerHTML, `<div>Item</div>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-proxy-version/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-proxy-version/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { setContext } from 'svelte';
+
+	import Item from './Item.svelte'
+
+	let items = $state({});
+
+	setContext('container', {
+		register: (id) => items[id] = true,
+		unregister: (id) => delete items[id]
+	});
+</script>
+
+<Item />


### PR DESCRIPTION
When we mutate the version around the proxy version, we also need to disable mutation validation otherwise this can cause the version to trigger a schedule on the effect its in when initializing the version – which causes the test to get stuck in an infinite loop.