### PR TITLE
fix: trigger again when window listener already handled

### DIFF
--- a/.changeset/fresh-impalas-bow.md
+++ b/.changeset/fresh-impalas-bow.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: trigger again when window listener already handled

--- a/.changeset/fresh-impalas-bow.md
+++ b/.changeset/fresh-impalas-bow.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: trigger again when window listener already handled
+fix: prevent window listeners from triggering events twice

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1383,6 +1383,7 @@ export function delegate(events) {
  * @returns {void}
  */
 function handle_event_propagation(handler_element, event) {
+	const owner_document = handler_element.ownerDocument;
 	const event_name = event.type;
 	const path = event.composedPath?.() || [];
 	let current_target = /** @type {null | Element} */ (path[0] || event.target);
@@ -1402,9 +1403,11 @@ function handle_event_propagation(handler_element, event) {
 	const handled_at = event.__root;
 	if (handled_at) {
 		const at_idx = path.indexOf(handled_at);
-		// @ts-ignore
-		if (at_idx !== -1 && (handler_element === document || handler_element === window)) {
-			// This is the fallback document/window listener but the event was already handled
+		if (
+			at_idx !== -1 &&
+			(handler_element === owner_document || handler_element === /** @type {any} */ (window))
+		) {
+			// This is the fallback document listener or a window listener, but the event was already handled
 			// -> ignore, but set handle_at to document/window so that we're resetting the event
 			// chain in case someone manually dispatches the same event object again.
 			// @ts-expect-error
@@ -1434,8 +1437,7 @@ function handle_event_propagation(handler_element, event) {
 	define_property(event, 'currentTarget', {
 		configurable: true,
 		get() {
-			// TODO: ensure correct document?
-			return current_target || document;
+			return current_target || owner_document;
 		}
 	});
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1402,12 +1402,13 @@ function handle_event_propagation(handler_element, event) {
 	const handled_at = event.__root;
 	if (handled_at) {
 		const at_idx = path.indexOf(handled_at);
-		if (at_idx !== -1 && handler_element === document) {
-			// This is the fallback document listener but the event was already handled
-			// -> ignore, but set handle_at to document so that we're resetting the event
+		// @ts-ignore
+		if (at_idx !== -1 && (handler_element === document || handler_element === window)) {
+			// This is the fallback document/window listener but the event was already handled
+			// -> ignore, but set handle_at to document/window so that we're resetting the event
 			// chain in case someone manually dispatches the same event object again.
 			// @ts-expect-error
-			event.__root = document;
+			event.__root = handler_element;
 			return;
 		}
 		// We're deliberately not skipping if the index is higher, because

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1405,7 +1405,7 @@ function handle_event_propagation(handler_element, event) {
 		const at_idx = path.indexOf(handled_at);
 		if (
 			at_idx !== -1 &&
-			(handler_element === owner_document || handler_element === /** @type {any} */ (window))
+			(handler_element === document || handler_element === /** @type {any} */ (window))
 		) {
 			// This is the fallback document listener or a window listener, but the event was already handled
 			// -> ignore, but set handle_at to document/window so that we're resetting the event


### PR DESCRIPTION
fixes #10271

the window case was not handle when query listener had handled.

why test ok in before pr https://github.com/sveltejs/svelte/pull/10307?

because window in event.composedPath() at jsdom is
```js
// run in jsdom
const l = event.composedPath()
// log window in l is
Object [Window] {
  ...
}
```
but other case is

```js
// run in jsdom
console.log(window)
// ->
Object [global] {
 ...
}
```
so ``event.composedPath().indexOf(window)`` is away equal -1.
the following code will skips the event handle and makes the test pass.
https://github.com/sveltejs/svelte/blob/506196b72b459b3219b8c3e8db6fcc67fc101974/packages/svelte/src/internal/client/render.js#L1430-L1435

it seems to be jsdom's bug,  there is no way to test this case in jsdom.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
