### PR TITLE
chore: remove array.at usage from runtime

### DIFF
--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -2540,7 +2540,7 @@ export function hydrate(component, options) {
 			);
 			remove(hydration_fragment);
 			first_child.remove();
-			hydration_fragment.at(-1)?.nextSibling?.remove();
+			hydration_fragment[hydration_fragment.length - 1]?.nextSibling?.remove();
 			set_current_hydration_fragment(null);
 			return mount(component, options);
 		} else {


### PR DESCRIPTION
We have a single usage of `array.at` in the runtime that we can swap for array index access instead. Fixes https://github.com/sveltejs/svelte/issues/10438