### PR TITLE
chore: add proxy date usage warning

### DIFF
--- a/.changeset/fifty-donkeys-call.md
+++ b/.changeset/fifty-donkeys-call.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+chore: add proxy date usage warning

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -87,6 +87,13 @@ export function proxy(value, immutable = true, owners) {
 
 			return proxy;
 		}
+		if (DEV && prototype === Date.prototype) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`Date objects used within the $state() rune will not be reactive. Consider using Svelte's reactive version of the Date object from 'svelte/reactivity':` +
+					`\n\nimport { Date } from 'svelte/reactivity';\n\nconst date = new Date();`
+			);
+		}
 	}
 
 	return value;

--- a/packages/svelte/tests/runtime-runes/samples/state-date-discouraged/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-date-discouraged/_config.js
@@ -1,0 +1,44 @@
+import { test } from '../../test';
+
+/** @type {typeof console.warn} */
+let warn;
+
+/** @type {typeof console.trace} */
+let trace;
+
+/** @type {any[]} */
+let warnings = [];
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	before_test: () => {
+		warn = console.warn;
+		trace = console.trace;
+
+		console.warn = (...args) => {
+			warnings.push(...args);
+		};
+
+		console.trace = () => {};
+	},
+
+	after_test: () => {
+		console.warn = warn;
+		console.trace = trace;
+
+		warnings = [];
+	},
+
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+		await btn?.click();
+
+		assert.deepEqual(warnings, [
+			`Date objects used within the $state() rune will not be reactive. Consider using Svelte's reactive version of the Date object from 'svelte/reactivity':` +
+				`\n\nimport { Date } from 'svelte/reactivity';\n\nconst date = new Date();`
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-date-discouraged/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-date-discouraged/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let state = $state({
+		date: null,
+	});
+</script>
+<button onclick={() => {
+	state.date = new Date();
+}}>click</button>
+
+{state.date}


### PR DESCRIPTION
This adds a warning when a raw Date object is used as part of `$state`, instead recommending usage of the reactive Date object instead.