### PR TITLE
fix: improve namespace inference when having `{@render}` and `{@html}` tags

### DIFF
--- a/.changeset/giant-planets-shake.md
+++ b/.changeset/giant-planets-shake.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: treat snippets like normal components when inferring namespace
+fix: treat snippets like components when inferring namespace

--- a/.changeset/giant-planets-shake.md
+++ b/.changeset/giant-planets-shake.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: treat snippets like normal components when inferring namespace

--- a/.changeset/giant-planets-shake.md
+++ b/.changeset/giant-planets-shake.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: treat snippets like child components when inferring namespace
+fix: improve namespace inference when having `{@render}` and `{@html}` tags

--- a/.changeset/giant-planets-shake.md
+++ b/.changeset/giant-planets-shake.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: treat snippets like components when inferring namespace
+fix: treat snippets like child components when inferring namespace

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -239,12 +239,6 @@ export function infer_namespace(namespace, parent, nodes, path) {
  */
 function check_nodes_for_namespace(nodes, namespace) {
 	/**
-	 * @param {import('#compiler').SvelteNode} node}
-	 * @param {{next: () => void}} context
-	 */
-	const SvelteBlock = (node, { next }) => next();
-
-	/**
 	 * @param {import('#compiler').SvelteElement | import('#compiler').RegularElement} node}
 	 * @param {{stop: () => void}} context
 	 */

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -245,11 +245,7 @@ function check_nodes_for_namespace(nodes, namespace) {
 			} else if (namespace === 'keep') {
 				namespace = 'svg';
 			}
-		} else if (
-			(node.type === 'Text' && node.data.trim() !== '') ||
-			node.type === 'HtmlTag' ||
-			node.type === 'RenderTag'
-		) {
+		} else if ((node.type === 'Text' && node.data.trim() !== '') || node.type === 'HtmlTag') {
 			namespace = 'maybe_html';
 		} else if (node.type === 'EachBlock') {
 			namespace = check_nodes_for_namespace(node.body.nodes, namespace);

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -278,9 +278,6 @@ function check_nodes_for_namespace(nodes, namespace) {
 					if (node.data.trim() !== '') {
 						namespace = 'maybe_html';
 					}
-				},
-				HtmlTag() {
-					namespace = 'maybe_html';
 				}
 			}
 		);

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -256,10 +256,22 @@ function check_nodes_for_namespace(nodes, namespace) {
 			node,
 			{},
 			{
-				EachBlock: SvelteBlock,
-				IfBlock: SvelteBlock,
-				AwaitBlock: SvelteBlock,
-				KeyBlock: SvelteBlock,
+				_(node, { next }) {
+					if (
+						node.type === 'EachBlock' ||
+						node.type === 'IfBlock' ||
+						node.type === 'AwaitBlock' ||
+						node.type === 'Fragment' ||
+						node.type === 'KeyBlock' ||
+						node.type === 'RegularElement' ||
+						node.type === 'SvelteElement' ||
+						node.type === 'Text' ||
+						node.type === 'HtmlTag' ||
+						node.type === 'RenderTag'
+					) {
+						next();
+					}
+				},
 				SvelteElement: RegularElement,
 				RegularElement,
 				Text(node) {

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -265,9 +265,7 @@ function check_nodes_for_namespace(nodes, namespace) {
 						node.type === 'KeyBlock' ||
 						node.type === 'RegularElement' ||
 						node.type === 'SvelteElement' ||
-						node.type === 'Text' ||
-						node.type === 'HtmlTag' ||
-						node.type === 'RenderTag'
+						node.type === 'Text'
 					) {
 						next();
 					}

--- a/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/Wrapper.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/Wrapper.svelte
@@ -2,12 +2,16 @@
 
 {#if true}
   <text x="0" y="26">true</text>
-{:else}
-  <text x="0" y="26">false</text>
 {/if}
 
-{#each  Array(3).fill(0) as item, idx}
+{#each Array(2).fill(0) as item, idx}
   <text x={idx * 10} y={42}>{idx}</text>
 {/each}
 
-<!-- comment should not set infer html namespace -->
+{@render test("test")}
+
+{#snippet test(text)}
+<text x={20} y={42}>{text}</text>
+{/snippet}
+
+<!-- comment should not infer html namespace -->

--- a/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/Wrapper.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/Wrapper.svelte
@@ -8,6 +8,8 @@
   <text x={idx * 10} y={42}>{idx}</text>
 {/each}
 
+{@html '<text x="0" y="40">html</text>'}
+
 {@render test("test")}
 
 {#snippet test(text)}

--- a/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/Wrapper.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/Wrapper.svelte
@@ -10,7 +10,7 @@
 
 {@html '<text x="0" y="40">html</text>'}
 
-{@render test("test")}
+{@render test("snippet")}
 
 {#snippet test(text)}
 <text x={20} y={42}>{text}</text>

--- a/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/_config.js
@@ -7,7 +7,8 @@ export default test({
 		<text x="0" y="26">true</text>
 		<text x="0" y="42">0</text>
 		<text x="10" y="42">1</text>
-		<text x="20" y="42">test</text>
+		<text x="0" y="40">html</text>
+		<text x="20" y="42">snippet</text>
 	</svg>
 `,
 	test({ assert, target }) {
@@ -18,7 +19,7 @@ export default test({
 
 		const text_elements = target.querySelectorAll('text');
 
-		assert.equal(text_elements.length, 5);
+		assert.equal(text_elements.length, 6);
 
 		for (const { namespaceURI } of text_elements)
 			assert.equal(namespaceURI, 'http://www.w3.org/2000/svg');

--- a/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svg-namespace-infer/_config.js
@@ -7,7 +7,7 @@ export default test({
 		<text x="0" y="26">true</text>
 		<text x="0" y="42">0</text>
 		<text x="10" y="42">1</text>
-		<text x="20" y="42">2</text>
+		<text x="20" y="42">test</text>
 	</svg>
 `,
 	test({ assert, target }) {


### PR DESCRIPTION
When using `{@render ...}` in a component that has only svg nodes, the namespace gets the `maybe_html` value which returns the default namespace (html). Instead `{@render ...}` should be treated like child components, they should not affect the component's namespace.

I also simplified the code a bit.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
