### PR TITLE
fix: treat new expression references in template as possibly dynamic

### DIFF
--- a/.changeset/gorgeous-pugs-design.md
+++ b/.changeset/gorgeous-pugs-design.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: treat new expression references in template as possibly dynamic

--- a/packages/svelte/tests/runtime-runes/samples/date/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/date/_config.js
@@ -1,8 +1,24 @@
 import { flushSync } from '../../../../src/main/main-client';
 import { test } from '../../test';
 
+const date_proto = Date.prototype;
+let date_proto_to_string = date_proto.toString;
+
 export default test({
-	html: `<div>getSeconds: 0</div><div>getMinutes: 0</div><div>getHours: 15</div><div>getTime: 1708700400000</div><div>toDateString: Fri Feb 23 2024</div><button>1 second</button><button>1 minute</button><button>1 hour</button>`,
+	html: `<div>getSeconds: 0</div><div>getMinutes: 0</div><div>getHours: 15</div><div>getTime: 1708700400000</div><div>toDateString: Fri Feb 23 2024</div><div>date: [date: 0, 0, 15]</div><button>1 second</button><button>1 minute</button><button>1 hour</button>`,
+
+	before_test() {
+		date_proto_to_string = date_proto.toString;
+
+		// This test will fail between different machines because of timezones, so we instead mock it to be a different toString().
+		date_proto.toString = function () {
+			return `[date: ${this.getSeconds()}, ${this.getMinutes()}, ${this.getHours()}]`;
+		};
+	},
+
+	after_test() {
+		date_proto.toString = date_proto_to_string;
+	},
 
 	test({ assert, target }) {
 		const [btn, btn2, btn3] = target.querySelectorAll('button');
@@ -13,7 +29,7 @@ export default test({
 
 		assert.htmlEqual(
 			target.innerHTML,
-			`<div>getSeconds: 1</div><div>getMinutes: 0</div><div>getHours: 15</div><div>getTime: 1708700401000</div><div>toDateString: Fri Feb 23 2024</div><button>1 second</button><button>1 minute</button><button>1 hour</button>`
+			`<div>getSeconds: 1</div><div>getMinutes: 0</div><div>getHours: 15</div><div>getTime: 1708700401000</div><div>toDateString: Fri Feb 23 2024</div><div>date: [date: 1, 0, 15]</div><button>1 second</button><button>1 minute</button><button>1 hour</button>`
 		);
 
 		flushSync(() => {
@@ -22,7 +38,7 @@ export default test({
 
 		assert.htmlEqual(
 			target.innerHTML,
-			`<div>getSeconds: 1</div><div>getMinutes: 1</div><div>getHours: 15</div><div>getTime: 1708700461000</div><div>toDateString: Fri Feb 23 2024</div><button>1 second</button><button>1 minute</button><button>1 hour</button>`
+			`<div>getSeconds: 1</div><div>getMinutes: 1</div><div>getHours: 15</div><div>getTime: 1708700461000</div><div>toDateString: Fri Feb 23 2024</div><div>date: [date: 1, 1, 15]</div><button>1 second</button><button>1 minute</button><button>1 hour</button>`
 		);
 
 		flushSync(() => {
@@ -31,7 +47,7 @@ export default test({
 
 		assert.htmlEqual(
 			target.innerHTML,
-			`<div>getSeconds: 1</div><div>getMinutes: 1</div><div>getHours: 16</div><div>getTime: 1708704061000</div><div>toDateString: Fri Feb 23 2024</div><button>1 second</button><button>1 minute</button><button>1 hour</button>`
+			`<div>getSeconds: 1</div><div>getMinutes: 1</div><div>getHours: 16</div><div>getTime: 1708704061000</div><div>toDateString: Fri Feb 23 2024</div><div>date: [date: 1, 1, 16]</div><button>1 second</button><button>1 minute</button><button>1 hour</button>`
 		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/date/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/date/main.svelte
@@ -9,6 +9,7 @@
 <div>getHours: {date.getUTCHours()}</div>
 <div>getTime: {date.getTime()}</div>
 <div>toDateString: {date.toDateString()}</div>
+<div>date: {date}</div>
 
 <button onclick={() => {
 	date.setSeconds(date.getSeconds() + 1);


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/10629.

This is an interesting one, but one I think worth considering. When a binding is passed into a template such as

```svelte
<div>{foo}</div>
```

When we check if `foo` is dynamic, unless it comes from state or a prop, it will generally be considered as not dynamic as its just an identifier (member expressions and call expressions are always treated as dynamic). Maybe we can tweak this so that if we see it comes from a `new` expression that is gets treated as being possibly dynamic. That's because classes are more likely to have a custom `toString` that might be reactive, thus the identifier itself might be dynamic.