### PR TITLE
chore: remove more .at() usage from runtime

### DIFF
--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -75,8 +75,8 @@ export function mark_module_end() {
 	const end = get_stack()?.[2];
 
 	if (end) {
-		// @ts-expect-error
-		boundaries[end.file].at(-1).end = end;
+		const boundaries_file = boundaries[end.file];
+		boundaries_file[boundaries_file.length - 1].end = end;
 	}
 }
 

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -393,7 +393,8 @@ function reconcile_indexed_array(
 				b_blocks[index] = block;
 
 				hydrating_node = /** @type {import('../../types.js').TemplateNode} */ (
-					/** @type {Node} */ (/** @type {Node} */ (fragment.at(-1)).nextSibling).nextSibling
+					/** @type {Node} */ (/** @type {Node} */ (fragment[fragment.length - 1]).nextSibling)
+						.nextSibling
 				);
 			}
 
@@ -517,7 +518,8 @@ function reconcile_tracked_array(
 				// Get the <!--ssr:..--> tag of the next item in the list
 				// The fragment array can be empty if each block has no content
 				hydrating_node = /** @type {import('../../types.js').TemplateNode} */ (
-					/** @type {Node} */ ((fragment.at(-1) || hydrating_node).nextSibling).nextSibling
+					/** @type {Node} */ ((fragment[fragment.length - 1] || hydrating_node).nextSibling)
+						.nextSibling
 				);
 			}
 

--- a/packages/svelte/src/internal/client/operations.js
+++ b/packages/svelte/src/internal/client/operations.js
@@ -274,10 +274,10 @@ function capture_fragment_from_node(node) {
 	if (
 		node.nodeType === 8 &&
 		/** @type {Comment} */ (node).data.startsWith('ssr:') &&
-		current_hydration_fragment.at(-1) !== node
+		current_hydration_fragment[current_hydration_fragment.length - 1] !== node
 	) {
 		const fragment = /** @type {Array<Element | Text | Comment>} */ (get_hydration_fragment(node));
-		const last_child = fragment.at(-1) || node;
+		const last_child = fragment[fragment.length - 1] || node;
 		const target = /** @type {Node} */ (last_child.nextSibling);
 		// @ts-ignore
 		target.$$fragment = fragment;


### PR DESCRIPTION
Let's make Svelte 5's runtime more browser compatible.