### PR TITLE
perf: bail early when traversing non-state

### DIFF
--- a/.changeset/chatty-sloths-allow.md
+++ b/.changeset/chatty-sloths-allow.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+perf: bail early when traversing non-state

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
@@ -170,7 +170,7 @@ export const javascript_visitors_legacy = {
 			// If the binding is a prop, we need to deep read it because it could be fine-grained $state
 			// from a runes-component, where mutations don't trigger an update on the prop as a whole.
 			if (name === '$$props' || name === '$$restProps' || binding.kind === 'prop') {
-				serialized = b.call('$.deep_read', serialized);
+				serialized = b.call('$.deep_read_state', serialized);
 			}
 
 			sequence.push(serialized);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1245,6 +1245,29 @@ export function pop(component) {
 }
 
 /**
+ * Possibly traverse an object and read all its properties so that they're all reactive in case this is `$state`.
+ * Does only check first level of an object for performance reasons (heuristic should be good for 99% of all cases).
+ * @param {any} value
+ * @returns {void}
+ */
+export function deep_read_state(value) {
+	if (typeof value !== 'object' || !value || value instanceof EventTarget) {
+		return;
+	}
+
+	if (STATE_SYMBOL in value) {
+		deep_read(value);
+	} else if (!Array.isArray(value)) {
+		for (let key in value) {
+			const prop = value[key];
+			if (typeof prop === 'object' && prop && STATE_SYMBOL in prop) {
+				deep_read(prop);
+			}
+		}
+	}
+}
+
+/**
  * Deeply traverse an object and read all its properties
  * so that they're all reactive in case this is `$state`
  * @param {any} value

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -18,7 +18,8 @@ export {
 	inspect,
 	unwrap,
 	freeze,
-	deep_read
+	deep_read,
+	deep_read_state
 } from './client/runtime.js';
 export * from './client/dev/ownership.js';
 export { await_block as await } from './client/dom/blocks/await.js';


### PR DESCRIPTION
We need to use `deep_read` to traverse all properties of an object inside legacy mode and inside actions, because the input we get could be a state proxy. This proxy will have fine-grained reactivity and therefore only update the signal at the location that got an update. In order to have interop with the coarse-grained "notify me when _anything_ in that object changes" behavior, we need to setup up signals for all of the object's properties before they're potentially mutated.
This has a lot of overhead for large lists, and we can at least diminish in the "no state proxy" case by applying a sensible heuristic:
- If the value passed is a state proxy, read it
- If not, and if the value is an array, then bail because an array of state proxies is highly unlikely
- Traverse the first level of properties of the object and look if these are state, if not bail. State proxies nested further down are highly unlikely, too

part of #10637


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
