### PR TITLE
fix: warn when `$props` rune not called

### DIFF
--- a/.changeset/slow-kids-sparkle.md
+++ b/.changeset/slow-kids-sparkle.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: warn when `$props` rune not called

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -1002,7 +1002,12 @@ export const validation_runes = merge(validation, a11y_validators, {
 		const init = node.init;
 		const rune = get_rune(init, state.scope);
 
-		if (rune === null) return;
+		if (rune === null) {
+			if (init?.type === 'Identifier' && init.name === '$props' && !state.scope.get('props')) {
+				warn(state.analysis.warnings, node, path, 'invalid-props-declaration');
+			}
+			return;
+		}
 
 		const args = /** @type {import('estree').CallExpression} */ (init).arguments;
 

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -27,7 +27,10 @@ const runes = {
 	/** @param {string} name */
 	'non-state-reference': (name) =>
 		`${name} is updated, but is not declared with $state(...). Changing its value will not correctly trigger updates.`,
-	'derived-iife': () => `Use \`$derived.by(() => {...})\` instead of \`$derived((() => {...})());\``
+	'derived-iife': () =>
+		`Use \`$derived.by(() => {...})\` instead of \`$derived((() => {...})());\``,
+	'invalid-props-declaration': () =>
+		`Component properties are declared using $props() in runes mode. Did you forget to call the function?`
 };
 
 /** @satisfies {Warnings} */

--- a/packages/svelte/tests/validator/samples/runes-props-not-called/_config.js
+++ b/packages/svelte/tests/validator/samples/runes-props-not-called/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/validator/samples/runes-props-not-called/input.svelte
+++ b/packages/svelte/tests/validator/samples/runes-props-not-called/input.svelte
@@ -1,0 +1,3 @@
+<script>
+	let { a } = $props;
+</script>

--- a/packages/svelte/tests/validator/samples/runes-props-not-called/warnings.json
+++ b/packages/svelte/tests/validator/samples/runes-props-not-called/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "invalid-props-declaration",
+		"message": "Component properties are declared using $props() in runes mode. Did you forget to call the function?",
+		"start": {
+			"column": 5,
+			"line": 2
+		},
+		"end": {
+			"column": 19,
+			"line": 2
+		}
+	}
+]


### PR DESCRIPTION
It's a warning because even when typing it out and knowing what to do you'll always be in a state where the validation kicks in, and it would be too distracting to always see a compiler error during that short time frame.
closes #10374

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
