### PR TITLE
fix: prevent false positive non-state warnings for `bind:this`

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -460,6 +460,25 @@ export function analyze_component(root, options) {
 						) {
 							continue inner;
 						}
+						// bind:this doesn't need to be a state reference if it will never change
+						if (
+							type === 'BindDirective' &&
+							/** @type {import('#compiler').BindDirective} */ (path[i]).name === 'this'
+						) {
+							for (let j = i - 1; j >= 0; j -= 1) {
+								const type = path[j].type;
+								if (
+									type === 'IfBlock' ||
+									type === 'EachBlock' ||
+									type === 'AwaitBlock' ||
+									type === 'KeyBlock'
+								) {
+									warn(warnings, binding.node, [], 'non-state-reference', name);
+									continue outer;
+								}
+							}
+							continue inner;
+						}
 					}
 
 					warn(warnings, binding.node, [], 'non-state-reference', name);

--- a/packages/svelte/tests/validator/samples/runes-referenced-nonstate-bind-this/_config.js
+++ b/packages/svelte/tests/validator/samples/runes-referenced-nonstate-bind-this/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/validator/samples/runes-referenced-nonstate-bind-this/input.svelte
+++ b/packages/svelte/tests/validator/samples/runes-referenced-nonstate-bind-this/input.svelte
@@ -1,0 +1,11 @@
+<script>
+	let no_need;
+	let does_need1;
+	let does_need2 = $state();
+</script>
+
+<div bind:this={no_need}></div>
+{#if true}
+	<div bind:this={does_need1}></div>
+	<div bind:this={does_need2}></div>
+{/if}

--- a/packages/svelte/tests/validator/samples/runes-referenced-nonstate-bind-this/warnings.json
+++ b/packages/svelte/tests/validator/samples/runes-referenced-nonstate-bind-this/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "non-state-reference",
+		"message": "does_need1 is updated, but is not declared with $state(...). Changing its value will not correctly trigger updates.",
+		"start": {
+			"column": 5,
+			"line": 3
+		},
+		"end": {
+			"column": 15,
+			"line": 3
+		}
+	}
+]


### PR DESCRIPTION
`bind:this` doesn't need to be a state reference if it will never change
fixes #10435

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
