### PR TITLE
fix: don't collapse whitespace within text nodes

### DIFF
--- a/.changeset/happy-beds-scream.md
+++ b/.changeset/happy-beds-scream.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: don't collapse whitespace within text nodes

--- a/packages/svelte/src/compiler/phases/patterns.js
+++ b/packages/svelte/src/compiler/phases/patterns.js
@@ -2,9 +2,9 @@ export const regex_whitespace = /\s/;
 export const regex_whitespaces = /\s+/;
 export const regex_starts_with_newline = /^\r?\n/;
 export const regex_starts_with_whitespace = /^\s/;
-export const regex_starts_with_whitespaces = /^[ \t\r\n]*/;
+export const regex_starts_with_whitespaces = /^[ \t\r\n]+/;
 export const regex_ends_with_whitespace = /\s$/;
-export const regex_ends_with_whitespaces = /[ \t\r\n]*$/;
+export const regex_ends_with_whitespaces = /[ \t\r\n]+$/;
 /** Not \S because that also removes explicit whitespace defined through things like `&nbsp;` */
 export const regex_not_whitespace = /[^ \t\r\n]/;
 /** Not \s+ because that also includes explicit whitespace defined through things like `&nbsp;` */

--- a/packages/svelte/tests/runtime-legacy/samples/pre-tag/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/pre-tag/_config.js
@@ -20,7 +20,10 @@ function get_html(ssr) {
   </span>
   E
   F
-</pre> <div id="div">A B <span>C D</span> E F</div> <div id="div-with-pre"><pre>    A
+</pre> <div id="div">A
+  B <span>C
+    D</span> E
+  F</div> <div id="div-with-pre"><pre>    A
     B
     <span>
       C

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -66,7 +66,7 @@ export interface RuntimeTest<Props extends Record<string, any> = Record<string, 
 	runtime_error?: string;
 	warnings?: string[];
 	expect_unhandled_rejections?: boolean;
-	withoutNormalizeHtml?: boolean;
+	withoutNormalizeHtml?: boolean | 'only-strip-comments';
 	recover?: boolean;
 }
 
@@ -213,13 +213,15 @@ async function run_test_variant(
 		if (variant === 'ssr') {
 			if (config.ssrHtml) {
 				assert_html_equal_with_options(target.innerHTML, config.ssrHtml, {
-					preserveComments: config.compileOptions?.preserveComments,
-					withoutNormalizeHtml: config.withoutNormalizeHtml
+					preserveComments:
+						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
+					withoutNormalizeHtml: !!config.withoutNormalizeHtml
 				});
 			} else if (config.html) {
 				assert_html_equal_with_options(target.innerHTML, config.html, {
-					preserveComments: config.compileOptions?.preserveComments,
-					withoutNormalizeHtml: config.withoutNormalizeHtml
+					preserveComments:
+						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
+					withoutNormalizeHtml: !!config.withoutNormalizeHtml
 				});
 			}
 
@@ -283,7 +285,9 @@ async function run_test_variant(
 			if (config.html) {
 				$.flushSync();
 				assert_html_equal_with_options(target.innerHTML, config.html, {
-					withoutNormalizeHtml: config.withoutNormalizeHtml
+					preserveComments:
+						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
+					withoutNormalizeHtml: !!config.withoutNormalizeHtml
 				});
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/snippet-whitespace/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-whitespace/_config.js
@@ -4,5 +4,11 @@ export default test({
 	compileOptions: {
 		dev: true // Render in dev mode to check that the validation error is not thrown
 	},
-	html: `A\nB\nC\nD`
+	withoutNormalizeHtml: 'only-strip-comments',
+	html: `A B C D <pre>Testing
+123          ;
+    456</pre>`,
+	ssrHtml: `A B C D <pre>Testing
+123          ;
+    456</pre>`
 });

--- a/packages/svelte/tests/runtime-runes/samples/snippet-whitespace/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-whitespace/main.svelte
@@ -1,5 +1,15 @@
+<script>
+	import Pre from "./pre.svelte";
+
+</script>
 A
 {#snippet snip()}C{/snippet}
 B
 {@render snip()}
 D
+
+<Pre>
+    Testing
+123          ;
+    456
+</Pre>

--- a/packages/svelte/tests/runtime-runes/samples/snippet-whitespace/pre.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-whitespace/pre.svelte
@@ -1,0 +1,5 @@
+<script>
+    let { children } = $props();
+</script>
+
+<pre>{@render children()}</pre>


### PR DESCRIPTION
fixes #9892 - whitespace at the edges of text is trimmed as before, but whitespace within text nodes is kept as-is under the assumption that someone has put the whitespace there on purpose.

We still need to decide whether or not we actually want to do this (I'm in favor) - this PR shows that it's possible to do without adjustments anywhere else in the compiler (no difference in walking nodes etc)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
