### PR TITLE
fix: make `$props()` rune non-generic

### DIFF
--- a/.changeset/fair-spies-repeat.md
+++ b/.changeset/fair-spies-repeat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: make `$props()` rune non-generic

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -67,7 +67,7 @@ export type ToggleEventHandler<T extends EventTarget> = EventHandler<ToggleEvent
 
 export interface DOMAttributes<T extends EventTarget> {
 	// Implicit children prop every element has
-	// Add this here so that libraries doing `$props<HTMLButtonAttributes>()` don't need a separate interface
+	// Add this here so that libraries doing `let { ...props }: HTMLButtonAttributes = $props()` don't need a separate interface
 	children?: import('svelte').Snippet;
 
 	// Clipboard Events

--- a/packages/svelte/src/main/ambient.d.ts
+++ b/packages/svelte/src/main/ambient.d.ts
@@ -172,12 +172,12 @@ declare namespace $effect {
  * Declares the props that a component accepts. Example:
  *
  * ```ts
- * let { optionalProp = 42, requiredProp } = $props<{ optionalProp?: number; requiredProps: string}>();
+ * let { optionalProp = 42, requiredProp }: { optionalProp?: number; requiredProps: string } = $props();
  * ```
  *
  * https://svelte-5-preview.vercel.app/docs/runes#$props
  */
-declare function $props<T>(): T;
+declare function $props(): any;
 
 /**
  * Inspects one or more values whenever they, or the properties they contain, change. Example:

--- a/packages/svelte/src/main/public.d.ts
+++ b/packages/svelte/src/main/public.d.ts
@@ -186,7 +186,7 @@ declare const SnippetReturn: unique symbol;
 /**
  * The type of a `#snippet` block. You can use it to (for example) express that your component expects a snippet of a certain type:
  * ```ts
- * let { banner } = $props<{ banner: Snippet<{ text: string }> }>();
+ * let { banner }: { banner: Snippet<{ text: string }> } = $props();
  * ```
  * You can only call a snippet through the `{@render ...}` tag.
  */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -187,7 +187,7 @@ declare module 'svelte' {
 	/**
 	 * The type of a `#snippet` block. You can use it to (for example) express that your component expects a snippet of a certain type:
 	 * ```ts
-	 * let { banner } = $props<{ banner: Snippet<{ text: string }> }>();
+	 * let { banner }: { banner: Snippet<{ text: string }> } = $props();
 	 * ```
 	 * You can only call a snippet through the `{@render ...}` tag.
 	 */
@@ -1879,7 +1879,7 @@ declare module 'svelte/legacy' {
 	/**
 	 * The type of a `#snippet` block. You can use it to (for example) express that your component expects a snippet of a certain type:
 	 * ```ts
-	 * let { banner } = $props<{ banner: Snippet<{ text: string }> }>();
+	 * let { banner }: { banner: Snippet<{ text: string }> } = $props();
 	 * ```
 	 * You can only call a snippet through the `{@render ...}` tag.
 	 */
@@ -2615,12 +2615,12 @@ declare namespace $effect {
  * Declares the props that a component accepts. Example:
  *
  * ```ts
- * let { optionalProp = 42, requiredProp } = $props<{ optionalProp?: number; requiredProps: string}>();
+ * let { optionalProp = 42, requiredProp }: { optionalProp?: number; requiredProps: string } = $props();
  * ```
  *
  * https://svelte-5-preview.vercel.app/docs/runes#$props
  */
-declare function $props<T>(): T;
+declare function $props(): any;
 
 /**
  * Inspects one or more values whenever they, or the properties they contain, change. Example:

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -465,12 +465,12 @@ To get all properties, use rest syntax:
 let { a, b, c, ...everythingElse } = $props();
 ```
 
-If you're using TypeScript, you can use type arguments:
+If you're using TypeScript, you can declare the prop types:
 
 ```ts
 type MyProps = any;
 // ---cut---
-let { a, b, c, ...everythingElse } = $props<MyProps>();
+let { a, b, c, ...everythingElse }: MyProps = $props();
 ```
 
 Props cannot be mutated, unless the parent component uses `bind:`. During development, attempts to mutate props will result in an error.

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/03-snippets.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/03-snippets.md
@@ -229,11 +229,11 @@ Snippets implement the `Snippet` interface imported from `'svelte'`:
 +<script lang="ts">
 +	import type { Snippet } from 'svelte';
 +
-+	let { data, children, row } = $props<{
++	let { data, children, row }: {
 +		data: any[];
 +		children: Snippet;
 +		row: Snippet<[any]>;
-+	}>();
++	} = $props();
 </script>
 ```
 
@@ -246,13 +246,13 @@ We can tighten things up further by declaring a generic, so that `data` and `row
 +<script lang="ts" generics="T">
 	import type { Snippet } from 'svelte';
 
-	let { data, children, row } = $props<{
+	let { data, children, row }: {
 -		data: any[];
 +		data: T[];
 		children: Snippet;
 -		row: Snippet<[any]>;
 +		row: Snippet<[T]>;
-	}>();
+	} = $props();
 </script>
 ```
 

--- a/sites/svelte-5-preview/src/routes/docs/render.js
+++ b/sites/svelte-5-preview/src/routes/docs/render.js
@@ -166,7 +166,7 @@ const render_content = (filename, body) =>
 		twoslashBanner: (filename, source) => {
 			const injected = [
 				`// @filename: runes.d.ts`,
-				`declare function $props<T>(): T`,
+				`declare function $props(): any`,
 				`declare function $state<T>(initial: T): T`,
 				`declare function $derived<T>(value: T): T`,
 				`declare const $effect: ((callback: () => void | (() => void)) => void) & { pre: (callback: () => void | (() => void)) => void };`


### PR DESCRIPTION
The `$props()` rune should not accept a type argument. Instead, component authors should type their props like any other variable declaration:

```diff
-let { message } = $props<{ message: string }>();
+let { message }: { message: string } = $props();
```

Otherwise, [things can break](https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwBIAHGHIgZwB4AVeAXnilQE8A+ACgEoAueagbgBQggPQj4AWinCIIDPADe8LKkQgYcYPXgBGeAF9txUhUpKVajSGC9yGGCoDmBjpyHwPY+AD0A-DLlFeFBIWGttPX1eJRDoTVt7JwMjEjJyLndPcT8gA) because you're relying on inference:

<img width="401" alt="image" src="https://github.com/sveltejs/svelte/assets/1162160/20d9e3ad-75ef-445e-9ec3-a5f3a3842973">


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
