### PR TITLE
chore: create `#client` types alias

### DIFF
--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -24,7 +24,8 @@
 			"svelte/motion": ["./src/motion/public.d.ts"],
 			"svelte/server": ["./src/server/index.js"],
 			"svelte/store": ["./src/store/public.d.ts"],
-			"#compiler": ["./src/compiler/types/index.d.ts"]
+			"#compiler": ["./src/compiler/types/index.d.ts"],
+			"#client": ["./src/internal/client/types.d.ts"]
 		}
 	},
 	"include": [


### PR DESCRIPTION
Another small part of #10594 extracted into its own PR. This allows us to reference internal client types via `import('#client')` instead of `import('../../../types.js')` or whatever. I haven't actually changed those imports, because that would create filthy merge conflicts until #10594 is resolved, but we can start using it piecemeal and then eventually migrate everything in one go