### PR TITLE
fix: improve each keyed block handling of item used as key

### DIFF
--- a/.changeset/silly-eggs-cross.md
+++ b/.changeset/silly-eggs-cross.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: improve each keyed block handling of item used as key

--- a/.changeset/silly-eggs-cross.md
+++ b/.changeset/silly-eggs-cross.md
@@ -1,5 +1,0 @@
----
-"svelte": patch
----
-
-fix: improve each keyed block handling of item used as key

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2393,7 +2393,7 @@ export const template_visitors = {
 		const binding = /** @type {import('#compiler').Binding} */ (context.state.scope.get(item.name));
 		binding.expression = (id) => {
 			const item_with_loc = with_loc(item, id);
-			return each_item_is_reactive ? b.call('$.unwrap', item_with_loc) : item_with_loc;
+			return b.call('$.unwrap', item_with_loc);
 		};
 		if (node.index) {
 			const index_binding = /** @type {import('#compiler').Binding} */ (
@@ -2401,7 +2401,7 @@ export const template_visitors = {
 			);
 			index_binding.expression = (id) => {
 				const index_with_loc = with_loc(index, id);
-				return each_item_is_reactive ? b.call('$.unwrap', index_with_loc) : index_with_loc;
+				return b.call('$.unwrap', index_with_loc);
 			};
 		}
 

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -458,6 +458,10 @@ function reconcile_tracked_array(
 	// are treated as reactive, so they get wrapped in a signal.
 	if ((flags & EACH_IS_STRICT_EQUALS) !== 0 && !is_frozen(array) && !(STATE_SYMBOL in array)) {
 		flags ^= EACH_IS_STRICT_EQUALS;
+		// Additionally as we're in an keyed each block, we'll need ensure the itens are all wrapped in signals.
+		if ((flags & EACH_ITEM_REACTIVE) === 0) {
+			flags ^= EACH_ITEM_REACTIVE;
+		}
 	}
 	var a_blocks = each_block.v;
 	const is_computed_key = keys !== null;

--- a/packages/svelte/tests/runtime-runes/samples/each-updates-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-updates-5/_config.js
@@ -2,7 +2,7 @@ import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	html: `1\n1\n<button>+</button>`,
+	html: `1\n1\n1\n1\n<button>+</button>`,
 
 	async test({ assert, target }) {
 		/**
@@ -16,6 +16,6 @@ export default test({
 			btn1.click();
 		});
 
-		assert.htmlEqual(target.innerHTML, `2\n2\n<button>+</button>`);
+		assert.htmlEqual(target.innerHTML, `2\n2\n2\n2\n<button>+</button>`);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/each-updates-5/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-updates-5/main.svelte
@@ -10,6 +10,12 @@
 	}
 </script>
 
+{#each $store as item (item)}
+	{item.value}
+{/each}
+{#each $storeDeeper.items as item (item)}
+	{item.value}
+{/each}
 {#each $store as item}
 	{item.value}
 {/each}


### PR DESCRIPTION
Following up again to https://github.com/sveltejs/svelte/pull/10702. If we encounter a keyed each block where the key is the item itself, then we also need to account for it being mutable.