### PR TITLE
fix: ensure performance.now() and requestAnimationFrame() don't fail during SSR

### DIFF
--- a/.changeset/pink-bikes-agree.md
+++ b/.changeset/pink-bikes-agree.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure performance.now() and requestAnimationFrame() are polyfilled in ssr

--- a/packages/svelte/src/internal/client/timing.js
+++ b/packages/svelte/src/internal/client/timing.js
@@ -1,5 +1,13 @@
+import { noop } from '../common.js';
+
+const is_client = typeof window !== 'undefined';
+
+const request_animation_frame = is_client ? requestAnimationFrame : noop;
+
+const now = is_client ? () => performance.now() : () => Date.now();
+
 /** @type {import('./types.js').Raf} */
 export const raf = {
-	tick: /** @param {any} _ */ (_) => requestAnimationFrame(_),
-	now: () => performance.now()
+	tick: /** @param {any} _ */ (_) => request_animation_frame(_),
+	now: () => now()
 };


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/9534