### PR TITLE
fix: bump specificity on all members of a selector list

### DIFF
--- a/.changeset/dull-coins-vanish.md
+++ b/.changeset/dull-coins-vanish.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: bump specificity on all members of a selector list

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -191,6 +191,8 @@ const visitors = {
 		next({ ...state, specificity });
 	},
 	ComplexSelector(node, context) {
+		const before_bumped = context.state.specificity.bumped;
+
 		/** @param {import('#compiler').Css.SimpleSelector} selector */
 		function remove_global_pseudo_class(selector) {
 			context.state.code
@@ -261,6 +263,8 @@ const visitors = {
 		}
 
 		context.next();
+
+		context.state.specificity.bumped = before_bumped;
 	},
 	PseudoClassSelector(node, context) {
 		if (node.name === 'is' || node.name === 'where') {

--- a/packages/svelte/tests/css/samples/selector-list/expected.css
+++ b/packages/svelte/tests/css/samples/selector-list/expected.css
@@ -1,0 +1,6 @@
+	div.svelte-xyz {
+		color: red;
+	}
+	div.svelte-xyz span:where(.svelte-xyz), div.svelte-xyz div:where(.svelte-xyz) {
+		color: blue;
+	}

--- a/packages/svelte/tests/css/samples/selector-list/expected.html
+++ b/packages/svelte/tests/css/samples/selector-list/expected.html
@@ -1,0 +1,1 @@
+<div class="svelte-xyz"><span class="svelte-xyz">text</span><div class="svelte-xyz">text</div></div>

--- a/packages/svelte/tests/css/samples/selector-list/input.svelte
+++ b/packages/svelte/tests/css/samples/selector-list/input.svelte
@@ -1,0 +1,13 @@
+<div>
+	<span>text</span>
+	<div>text</div>
+</div>
+
+<style>
+	div {
+		color: red;
+	}
+	div span, div div {
+		color: blue;
+	}
+</style>


### PR DESCRIPTION
Previously, only `div span` in `div span, div div { .. }` would've gotten the specificity bump

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
