### PR TITLE
chore: use Svelte 5 for preview site

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,16 +252,16 @@ importers:
         version: 5.0.8
       '@sveltejs/adapter-static':
         specifier: ^3.0.1
-        version: 3.0.1(@sveltejs/kit@2.4.3)
+        version: 3.0.1(@sveltejs/kit@2.5.2)
       '@sveltejs/adapter-vercel':
-        specifier: ^4.0.0
-        version: 4.0.5(@sveltejs/kit@2.4.3)
+        specifier: ^5.0.0
+        version: 5.1.0(@sveltejs/kit@2.5.2)
       '@sveltejs/kit':
-        specifier: ^2.4.3
-        version: 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
+        specifier: ^2.5.0
+        version: 2.5.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
       '@sveltejs/site-kit':
         specifier: 6.0.0-next.59
-        version: 6.0.0-next.59(@sveltejs/kit@2.4.3)(svelte@packages+svelte)
+        version: 6.0.0-next.59(@sveltejs/kit@2.5.2)(svelte@packages+svelte)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
         version: 3.0.1(svelte@packages+svelte)(vite@5.0.12)
@@ -2456,12 +2456,12 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@sveltejs/adapter-static@3.0.1(@sveltejs/kit@2.4.3):
+  /@sveltejs/adapter-static@3.0.1(@sveltejs/kit@2.5.2):
     resolution: {integrity: sha512-6lMvf7xYEJ+oGeR5L8DFJJrowkefTK6ZgA4JiMqoClMkKq0s6yvsd3FZfCFvX1fQ0tpCD7fkuRVHsnUVgsHyNg==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
+      '@sveltejs/kit': 2.5.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
     dev: true
 
   /@sveltejs/adapter-vercel@4.0.5(@sveltejs/kit@2.4.3):
@@ -2469,7 +2469,20 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
+      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.9)(vite@5.0.12)
+      '@vercel/nft': 0.26.2
+      esbuild: 0.19.11
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@sveltejs/adapter-vercel@5.1.0(@sveltejs/kit@2.5.2):
+    resolution: {integrity: sha512-Z9yRJ4H2/7LcBlvN2/TKu1H0hWoRGonr8kPhP1GJ23LRW76IbiiX5gs/MLc6+ZGogCZYVJ4USmx6m+RFtvQTRw==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.4.0
+    dependencies:
+      '@sveltejs/kit': 2.5.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
       '@vercel/nft': 0.26.2
       esbuild: 0.19.11
     transitivePeerDependencies:
@@ -2523,8 +2536,8 @@ packages:
       tiny-glob: 0.2.9
       vite: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)(sass@1.70.0)
 
-  /@sveltejs/kit@2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12):
-    resolution: {integrity: sha512-nKNhUdt61vtD961kQpUk6vLDhpnV0yku5F1uYNWvrJYFV0+cGfmW7ol0JVMSjHMXlMtmmv2FTc+nPRrTFwb2UA==}
+  /@sveltejs/kit@2.5.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12):
+    resolution: {integrity: sha512-1Pm2lsBYURQsjnLyZa+jw75eVD4gYHxGRwPyFe4DAmB3FjTVR8vRNWGeuDLGFcKMh/B1ij6FTUrc9GrerogCng==}
     engines: {node: '>=18.13'}
     hasBin: true
     requiresBuild: true
@@ -2614,13 +2627,13 @@ packages:
       svelte-local-storage-store: 0.6.4(svelte@4.2.9)
     dev: true
 
-  /@sveltejs/site-kit@6.0.0-next.59(@sveltejs/kit@2.4.3)(svelte@packages+svelte):
+  /@sveltejs/site-kit@6.0.0-next.59(@sveltejs/kit@2.5.2)(svelte@packages+svelte):
     resolution: {integrity: sha512-nAUCuunhN0DmurQBxbsauqvdvv4mL0F/Aluxq0hFf6gB3iSn9WdaUZdPMXoujy+8cy+m6UvKuyhkgApZhmOLvw==}
     peerDependencies:
       '@sveltejs/kit': ^1.20.0
       svelte: ^4.0.0
     dependencies:
-      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
+      '@sveltejs/kit': 2.5.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
       esm-env: 1.0.0
       svelte: link:packages/svelte
       svelte-local-storage-store: 0.6.4(svelte@packages+svelte)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,7 +221,7 @@ importers:
         version: 6.0.0(@codemirror/autocomplete@6.12.0)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.8)(@codemirror/lang-javascript@6.2.1)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0)
       '@rich_harris/svelte-split-pane':
         specifier: ^1.1.1
-        version: 1.1.1(svelte@4.2.9)
+        version: 1.1.1(svelte@packages+svelte)
       '@rollup/browser':
         specifier: ^3.28.0
         version: 3.29.4
@@ -242,7 +242,7 @@ importers:
         version: 2.0.2
       svelte-json-tree:
         specifier: ^2.1.0
-        version: 2.2.0(svelte@4.2.9)
+        version: 2.2.0(svelte@packages+svelte)
       zimmerframe:
         specifier: ^1.1.1
         version: 1.1.1
@@ -258,13 +258,13 @@ importers:
         version: 4.0.5(@sveltejs/kit@2.4.3)
       '@sveltejs/kit':
         specifier: ^2.4.3
-        version: 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.9)(vite@5.0.12)
+        version: 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
       '@sveltejs/site-kit':
         specifier: 6.0.0-next.59
-        version: 6.0.0-next.59(@sveltejs/kit@2.4.3)(svelte@4.2.9)
+        version: 6.0.0-next.59(@sveltejs/kit@2.4.3)(svelte@packages+svelte)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.0.1(svelte@4.2.9)(vite@5.0.12)
+        version: 3.0.1(svelte@packages+svelte)(vite@5.0.12)
       '@types/marked':
         specifier: ^6.0.0
         version: 6.0.0
@@ -281,11 +281,11 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2(typescript@5.3.3)
       svelte:
-        specifier: ^4.2.0
-        version: 4.2.9
+        specifier: workspace:^
+        version: link:../../packages/svelte
       svelte-check:
         specifier: ^3.6.3
-        version: 3.6.3(postcss@8.4.35)(sass@1.70.0)(svelte@4.2.9)
+        version: 3.6.3(postcss@8.4.35)(svelte@packages+svelte)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -2187,6 +2187,14 @@ packages:
       svelte: 4.2.9
     dev: false
 
+  /@rich_harris/svelte-split-pane@1.1.1(svelte@packages+svelte):
+    resolution: {integrity: sha512-y2RRLyrN6DCeIgwA423aAIv/T5JqQeOl2XogBQ/21DvA2IF7oyrLUtXMxmQL2va2NFdeJO6MDx6nDX5X7kau7A==}
+    peerDependencies:
+      svelte: ^3.54.0
+    dependencies:
+      svelte: link:packages/svelte
+    dev: false
+
   /@rollup/browser@3.29.4:
     resolution: {integrity: sha512-qkWkilNBn+90/9Xn2stuwFpXYhG/mZVPlDkTIPdQSEtJES0NS4o4atceEqeGeHOjQREY2jaIv7ld3IajA/Bmfw==}
     dev: false
@@ -2453,7 +2461,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.9)(vite@5.0.12)
+      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
     dev: true
 
   /@sveltejs/adapter-vercel@4.0.5(@sveltejs/kit@2.4.3):
@@ -2461,7 +2469,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.9)(vite@5.0.12)
+      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
       '@vercel/nft': 0.26.2
       esbuild: 0.19.11
     transitivePeerDependencies:
@@ -2514,6 +2522,33 @@ packages:
       svelte: 4.2.9
       tiny-glob: 0.2.9
       vite: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)(sass@1.70.0)
+
+  /@sveltejs/kit@2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12):
+    resolution: {integrity: sha512-nKNhUdt61vtD961kQpUk6vLDhpnV0yku5F1uYNWvrJYFV0+cGfmW7ol0JVMSjHMXlMtmmv2FTc+nPRrTFwb2UA==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^3.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.3
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@packages+svelte)(vite@5.0.12)
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      devalue: 4.3.2
+      esm-env: 1.0.0
+      import-meta-resolve: 4.0.0
+      kleur: 4.1.5
+      magic-string: 0.30.5
+      mrmime: 2.0.0
+      sade: 1.8.1
+      set-cookie-parser: 2.6.0
+      sirv: 2.0.4
+      svelte: link:packages/svelte
+      tiny-glob: 0.2.9
+      vite: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)(sass@1.70.0)
+    dev: true
 
   /@sveltejs/repl@0.6.0(@codemirror/lang-html@6.4.8)(@codemirror/search@6.5.6)(@lezer/common@1.2.1)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0)(@sveltejs/kit@2.4.3)(svelte@4.2.9):
     resolution: {integrity: sha512-NADKN0NZhLlSatTSh5CCsdzgf2KHJFRef/8krA/TVWAWos5kSwmZ5fF0UImuqs61Pu/SiMXksaWNTGTiOtr4fQ==}
@@ -2577,6 +2612,18 @@ packages:
       esm-env: 1.0.0
       svelte: 4.2.9
       svelte-local-storage-store: 0.6.4(svelte@4.2.9)
+    dev: true
+
+  /@sveltejs/site-kit@6.0.0-next.59(@sveltejs/kit@2.4.3)(svelte@packages+svelte):
+    resolution: {integrity: sha512-nAUCuunhN0DmurQBxbsauqvdvv4mL0F/Aluxq0hFf6gB3iSn9WdaUZdPMXoujy+8cy+m6UvKuyhkgApZhmOLvw==}
+    peerDependencies:
+      '@sveltejs/kit': ^1.20.0
+      svelte: ^4.0.0
+    dependencies:
+      '@sveltejs/kit': 2.4.3(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@packages+svelte)(vite@5.0.12)
+      esm-env: 1.0.0
+      svelte: link:packages/svelte
+      svelte-local-storage-store: 0.6.4(svelte@packages+svelte)
     dev: true
 
   /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.9)(vite@5.0.12):
@@ -7692,6 +7739,33 @@ packages:
       - sugarss
     dev: true
 
+  /svelte-check@3.6.3(postcss@8.4.35)(svelte@packages+svelte):
+    resolution: {integrity: sha512-Q2nGnoysxUnB9KjnjpQLZwdjK62DHyW6nuH/gm2qteFnDk0lCehe/6z8TsIvYeKjC6luKaWxiNGyOcWiLLPSwA==}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.22
+      chokidar: 3.5.3
+      fast-glob: 3.3.2
+      import-fresh: 3.3.0
+      picocolors: 1.0.0
+      sade: 1.8.1
+      svelte: link:packages/svelte
+      svelte-preprocess: 5.1.3(postcss@8.4.35)(svelte@packages+svelte)(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+    dev: true
+
   /svelte-eslint-parser@0.33.1(svelte@packages+svelte):
     resolution: {integrity: sha512-vo7xPGTlKBGdLH8T5L64FipvTrqv3OQRx9d2z5X05KKZDlF4rQk8KViZO4flKERY+5BiVdOh7zZ7JGJWo5P0uA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7734,6 +7808,14 @@ packages:
       svelte: 4.2.9
     dev: false
 
+  /svelte-json-tree@2.2.0(svelte@packages+svelte):
+    resolution: {integrity: sha512-zcfepTrJ6xhpdgRZEujmiFh+ainRw7HO4Bsoh8PMAsm7fkgUPtnrZi3An8tmCFY8jajYhMrauHsd1S1XTeuiCw==}
+    peerDependencies:
+      svelte: ^4.0.0
+    dependencies:
+      svelte: link:packages/svelte
+    dev: false
+
   /svelte-local-storage-store@0.4.0(svelte@4.2.9):
     resolution: {integrity: sha512-ctPykTt4S3BE5bF0mfV0jKiUR1qlmqLvnAkQvYHLeb9wRyO1MdIFDVI23X+TZEFleATHkTaOpYZswIvf3b2tWA==}
     engines: {node: '>=0.14'}
@@ -7750,6 +7832,15 @@ packages:
       svelte: ^3.48.0 || >4.0.0
     dependencies:
       svelte: 4.2.9
+    dev: true
+
+  /svelte-local-storage-store@0.6.4(svelte@packages+svelte):
+    resolution: {integrity: sha512-45WoY2vSGPQM1sIQJ9jTkPPj20hYeqm+af6mUGRFSPP5WglZf36YYoZqwmZZ8Dt/2SU8lem+BTA8/Z/8TkqNLg==}
+    engines: {node: '>=0.14'}
+    peerDependencies:
+      svelte: ^3.48.0 || >4.0.0
+    dependencies:
+      svelte: link:packages/svelte
     dev: true
 
   /svelte-preprocess@5.1.3(postcss@8.4.35)(sass@1.70.0)(svelte@4.2.9)(typescript@5.3.3):
@@ -7798,6 +7889,54 @@ packages:
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 4.2.9
+      typescript: 5.3.3
+    dev: true
+
+  /svelte-preprocess@5.1.3(postcss@8.4.35)(svelte@packages+svelte)(typescript@5.3.3):
+    resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
+    engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0
+      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
+      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@types/pug': 2.0.10
+      detect-indent: 6.1.0
+      magic-string: 0.30.5
+      postcss: 8.4.35
+      sorcery: 0.11.0
+      strip-indent: 3.0.0
+      svelte: link:packages/svelte
       typescript: 5.3.3
     dev: true
 

--- a/sites/svelte-5-preview/package.json
+++ b/sites/svelte-5-preview/package.json
@@ -24,7 +24,7 @@
     "publint": "^0.2.7",
     "shiki": "^0.14.7",
     "shiki-twoslash": "^3.1.2",
-    "svelte": "^4.2.0",
+    "svelte": "workspace:^",
     "svelte-check": "^3.6.3",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",

--- a/sites/svelte-5-preview/package.json
+++ b/sites/svelte-5-preview/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@fontsource/fira-mono": "^5.0.8",
     "@sveltejs/adapter-static": "^3.0.1",
-    "@sveltejs/adapter-vercel": "^4.0.0",
-    "@sveltejs/kit": "^2.4.3",
+    "@sveltejs/adapter-vercel": "^5.0.0",
+    "@sveltejs/kit": "^2.5.0",
     "@sveltejs/site-kit": "6.0.0-next.59",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@types/marked": "^6.0.0",

--- a/sites/svelte-5-preview/src/lib/Output/console/ConsoleLine.svelte
+++ b/sites/svelte-5-preview/src/lib/Output/console/ConsoleLine.svelte
@@ -25,9 +25,16 @@
 	{/if}
 
 	{#if log.level === 'trace' || log.level === 'assert'}
-		<button class="arrow" class:expand={!log.collapsed} on:click={toggle_group_collapse}>
+		<span
+			class="arrow"
+			role="button"
+			tabindex="0"
+			class:expand={!log.collapsed}
+			on:keyup={toggle_group_collapse}
+			on:click={toggle_group_collapse}
+		>
 			▶
-		</button>
+		</span>
 	{/if}
 
 	{#if log.level === 'assert'}

--- a/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
+++ b/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
@@ -7,6 +7,16 @@ const files = import.meta.glob('../../../../../../packages/svelte/src/**/*.js', 
 	as: 'url'
 });
 
+const prefix = '../../../../../../packages/svelte/';
+
+export const prerender = true;
+
+export function entries() {
+	const entries = Object.keys(files).map((path) => ({ path: path.replace(prefix, '') }));
+	entries.push({ path: 'compiler.cjs' }, { path: 'package.json' });
+	return entries;
+}
+
 // service worker requests files under this path to load the compiler and runtime
 export async function GET({ params }) {
 	let url = '';
@@ -15,17 +25,8 @@ export async function GET({ params }) {
 	} else if (params.path === 'package.json') {
 		url = package_json;
 	} else {
-		const path = '../../../../../../packages/svelte/' + params.path;
-		url = files[path];
+		url = files[prefix + params.path];
 	}
 
-	const response = read(url);
-	return new Response(response.body, {
-		status: response.status,
-		statusText: response.statusText,
-		headers: {
-			...response.headers,
-			'Cache-Control': 'public, max-age=30' // 30 seconds so that redeploys are picked up quickly
-		}
-	});
+	return read(url);
 }

--- a/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
+++ b/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
@@ -25,7 +25,7 @@ export async function GET({ params }) {
 		statusText: response.statusText,
 		headers: {
 			...response.headers,
-			'Cache-Control': 'public, max-age=10' // 10 seconds so that redeploys are picked up quickly
+			'Cache-Control': 'public, max-age=30' // 30 seconds so that redeploys are picked up quickly
 		}
 	});
 }

--- a/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
+++ b/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
@@ -8,7 +8,7 @@ const files = import.meta.glob('../../../../../../packages/svelte/src/**/*.js', 
 });
 
 // service worker requests files under this path to load the compiler and runtime
-export function GET({ params }) {
+export async function GET({ params }) {
 	let url = '';
 	if (params.path === 'compiler.cjs') {
 		url = compiler_cjs;
@@ -19,5 +19,13 @@ export function GET({ params }) {
 		url = files[path];
 	}
 
-	return read(url);
+	const response = read(url);
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: {
+			...response.headers,
+			'Cache-Control': 'public, max-age=10' // 10 seconds so that redeploys are picked up quickly
+		}
+	});
 }

--- a/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
+++ b/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
@@ -1,0 +1,23 @@
+import compiler_cjs from '../../../../../../packages/svelte/compiler.cjs?url';
+import package_json from '../../../../../../packages/svelte/package.json?url';
+import { read } from '$app/server';
+
+const files = import.meta.glob('../../../../../../packages/svelte/src/**/*.js', {
+	eager: true,
+	as: 'url'
+});
+
+// service worker requests files under this path to load the compiler and runtime
+export function GET({ params }) {
+	let url = '';
+	if (params.path === 'compiler.cjs') {
+		url = compiler_cjs;
+	} else if (params.path === 'package.json') {
+		url = package_json;
+	} else {
+		const path = '../../../../../../packages/svelte/' + params.path;
+		url = files[path];
+	}
+
+	return read(url);
+}

--- a/sites/svelte-5-preview/static/svelte
+++ b/sites/svelte-5-preview/static/svelte
@@ -1,1 +1,0 @@
-../../../packages/svelte

--- a/sites/svelte-5-preview/svelte.config.js
+++ b/sites/svelte-5-preview/svelte.config.js
@@ -2,6 +2,12 @@ import adapter from '@sveltejs/adapter-vercel';
 
 /** @type {import('@sveltejs/kit').Config} */
 export default {
+	compilerOptions: {
+		legacy: {
+			// site-kit manually instantiates components inside an action
+			componentApi: true
+		}
+	},
 	kit: {
 		adapter: adapter({
 			runtime: 'nodejs18.x'


### PR DESCRIPTION
- had to enable `legacy.compilerApi` because site-kit uses actions that instantiate components manually with `new Component(..)`
- fixed some invalid code (button inside a button)
- added a server route to load the Svelte compiler and the runtime, enables this to work on windows locally, and avoids loading all our test files (could've done this independently, but whatever)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
