### PR TITLE
fix: prevent reactive statement reruns

### DIFF
--- a/.changeset/moody-houses-argue.md
+++ b/.changeset/moody-houses-argue.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: prevent reactive statement reruns when they have indirect cyclic dependencies

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -214,6 +214,10 @@ export function client_component(source, analysis, options) {
 		instance.body.push(statement[1]);
 	}
 
+	if (analysis.reactive_statements.size > 0) {
+		instance.body.push(b.stmt(b.call('$.legacy_pre_effect_reset')));
+	}
+
 	/**
 	 * Used to store the group nodes
 	 * @type {import('estree').VariableDeclaration[]}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-legacy.js
@@ -157,7 +157,6 @@ export const javascript_visitors_legacy = {
 		}
 
 		const body = serialized_body.body;
-		const new_body = [];
 
 		/** @type {import('estree').Expression[]} */
 		const sequence = [];
@@ -176,18 +175,16 @@ export const javascript_visitors_legacy = {
 			sequence.push(serialized);
 		}
 
-		if (sequence.length > 0) {
-			new_body.push(b.stmt(b.sequence(sequence)));
-		}
-
-		new_body.push(b.stmt(b.call('$.untrack', b.thunk(b.block(body)))));
-
-		serialized_body.body = new_body;
-
 		// these statements will be topologically ordered later
 		state.legacy_reactive_statements.set(
 			node,
-			b.stmt(b.call('$.pre_effect', b.thunk(serialized_body)))
+			b.stmt(
+				b.call(
+					'$.legacy_pre_effect',
+					sequence.length > 0 ? b.thunk(b.sequence(sequence)) : b.thunk(b.block([])),
+					b.thunk(b.block(body))
+				)
+			)
 		);
 
 		return b.empty;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -30,7 +30,7 @@ import {
 } from './constants.js';
 import { flush_tasks } from './dom/task.js';
 import { add_owner } from './dev/ownership.js';
-import { mutate, set } from './reactivity/sources.js';
+import { mutate, set, source } from './reactivity/sources.js';
 
 const IS_EFFECT = EFFECT | PRE_EFFECT | RENDER_EFFECT;
 
@@ -430,11 +430,7 @@ export function execute_effect(signal) {
 		current_effect = previous_effect;
 	}
 	const component_context = signal.x;
-	if (
-		is_runes(component_context) && // Don't rerun pre effects more than once to accomodate for "$: only runs once" behavior
-		(signal.f & PRE_EFFECT) !== 0 &&
-		current_queued_pre_and_render_effects.length > 0
-	) {
+	if ((signal.f & PRE_EFFECT) !== 0 && current_queued_pre_and_render_effects.length > 0) {
 		flush_local_pre_effects(component_context);
 	}
 }
@@ -1163,6 +1159,9 @@ export function push(props, runes = false, fn) {
 		s: props,
 		// runes
 		r: runes,
+		// legacy $:
+		l1: [],
+		l2: source(false),
 		// update_callbacks
 		u: null
 	};

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -42,6 +42,10 @@ export type ComponentContext = {
 	c: null | Map<unknown, unknown>;
 	/** runes */
 	r: boolean;
+	/** legacy mode: if `$:` statements are allowed to run (ensures they only run once per render) */
+	l1: any[];
+	/** legacy mode: if `$:` statements are allowed to run (ensures they only run once per render) */
+	l2: Source<boolean>;
 	/** update_callbacks */
 	u: null | {
 		/** afterUpdate callbacks */

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-in-complex-declaration-with-store-2/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-in-complex-declaration-with-store-2/_config.js
@@ -1,10 +1,12 @@
+import { tick } from 'svelte';
 import { test } from '../../test';
 
 // destructure to store value
 export default test({
 	html: '<h1>2 2 xxx 5 6 9 10 2</h1>',
 	async test({ assert, target, component }) {
-		await component.update();
+		component.update();
+		await tick();
 		assert.htmlEqual(target.innerHTML, '<h1>11 11 yyy 12 13 14 15 11</h1>');
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-in-complex-declaration-with-store/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-in-complex-declaration-with-store/_config.js
@@ -1,10 +1,12 @@
+import { tick } from 'svelte';
 import { test } from '../../test';
 
 // destructure to store
 export default test({
 	html: '<h1>2 2 xxx 5 6 9 10 2</h1>',
 	async test({ assert, target, component }) {
-		await component.update();
+		component.update();
+		await tick();
 		assert.htmlEqual(target.innerHTML, '<h1>11 11 yyy 12 13 14 15 11</h1>');
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/_config.js
@@ -1,0 +1,13 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: '<button>1 / 1</button>',
+	async test({ assert, target }) {
+		const button = target.querySelector('button');
+		button?.click();
+		await tick();
+
+		assert.htmlEqual(target.innerHTML, '<button>3 / 2</button>');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let count1 = 0;
+	let count2 = 0;
+	function increaseCount1() { count1++ }
+	$: if(count2 < 10) { increaseCount1() }
+	$: if(count1 < 10) { count2++ }
+</script>
+
+<button on:click={() => count1++}>{count1} / {count2}</button>


### PR DESCRIPTION
- run reactive statements only once per tick, even when they have indirect cyclic dependencies. Made possible by adding an array to the component context, which is filled with identifiers of the reactive statements, and which is cleared after all have run. Reactive statements rerunning before that will bail early if they detect they're still in the list
- part of the solution is to run all reactive statements, and then all render effects, which also fixes #10597 

FYI @Rich-Harris - okay to merge? This touches some of the stuff you're refactoring

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
