### PR TITLE
docs: Remove callback prop example from 02-runes.md

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -312,33 +312,6 @@ This also applies to more complex calculations that require more than a simple e
 </script>
 ```
 
-When reacting to a state change and writing to a different state as a result, think about if it's possible to use callback props instead.
-
-```svelte
-<!-- Don't do this -->
-<script>
-	let value = $state();
-	let value_uppercase = $state();
-	$effect(() => {
-		value_uppercase = value.toUpperCase();
-	});
-</script>
-
-<Text bind:value />
-
-<!-- Do this instead: -->
-<script>
-	let value = $state();
-	let value_uppercase = $state();
-	function onValueChange(new_text) {
-		value = new_text;
-		value_uppercase = new_text.toUpperCase();
-	}
-</script>
-
-<Text {value} {onValueChange}>
-```
-
 If you want to have something update from above but also modify it from below (i.e. you want some kind of "writable `$derived`"), and events aren't an option, you can also use an object with getters and setters.
 
 ```svelte


### PR DESCRIPTION
$: and $effect are not related to events and callback props.

Currently this example doesn't really make any sense AFAICT. It is not clear what it is trying to exemplify that is not already covered by the first to "Don't do this; Do this instead" examples showing using `$derived(.by)` for setting $state based on other $state. It looks like callback props are related to events, nothing really to do with bound values that are read in `$:`. Perhaps this was meant to be a third `$derived` example that shows use with `bind:` or something along those lines?

Please correct me if I'm wrong; perhaps this example exists for a reason I don't understand.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
