### PR TITLE
chore: tidy up tests

### DIFF
--- a/packages/svelte/tests/runtime-legacy/samples/component-transition/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/component-transition/_config.js
@@ -3,25 +3,18 @@ import { ok, test } from '../../test';
 
 export default test({
 	async test({ assert, target, raf }) {
-		const button = target.querySelector('#button');
+		const button = /** @type {HTMLButtonElement} */ (target.querySelector('#button'));
 		const container = target.querySelector('#container');
 		ok(button);
 		ok(container);
 
 		// Multiple click on button
-		// @ts-ignore
 		button.click();
-		// @ts-ignore
 		button.click();
-		// @ts-ignore
 		button.click();
-		// @ts-ignore
 		button.click();
-		// @ts-ignore
 		button.click();
-		// @ts-ignore
 		button.click();
-		// @ts-ignore
 		button.click();
 
 		raf.tick(0);


### PR DESCRIPTION
tangent: we should probably replace every `@ts-ignore` with a `@ts-expect-error`. I'm not aware of any situation where the former is preferred