### PR TITLE
chore: replace unpkg with jsdelivr

### DIFF
--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -13,7 +13,7 @@
 	import { get_full_filename } from './utils.js';
 	import Compiler from './Output/Compiler.js';
 
-	export let packagesUrl = 'https://unpkg.com';
+	export let packagesUrl = 'https://cdn.jsdelivr.net/npm';
 	export let svelteUrl = `${BROWSER ? location.origin : ''}/svelte`;
 	export let embedded = false;
 	/** @type {'columns' | 'rows'} */

--- a/sites/svelte-5-preview/src/lib/workers/bundler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/bundler/index.js
@@ -48,8 +48,7 @@ self.addEventListener(
 				const { version } = await fetch(`${svelte_url}/package.json`).then((r) => r.json());
 				console.log(`Using Svelte compiler version ${version}`);
 
-				// unpkg doesn't set the correct MIME type for .cjs files
-				// https://github.com/mjackson/unpkg/issues/355
+				// .cjs files have an unhelpful MIME type
 				const compiler = await fetch(`${svelte_url}/compiler.cjs`).then((r) => r.text());
 				(0, eval)(compiler + '\n//# sourceURL=compiler.cjs@' + version);
 
@@ -308,7 +307,7 @@ async function get_bundle(uid, mode, cache, local_files_lookup) {
 					return await follow_redirects(url, uid);
 				}
 			} else {
-				// fetch from unpkg
+				// fetch from jsdelivr
 				self.postMessage({ type: 'status', uid, message: `resolving ${importee}` });
 
 				const match = /^((?:@[^/]+\/)?[^/]+)(\/.+)?$/.exec(importee);
@@ -343,7 +342,7 @@ async function get_bundle(uid, mode, cache, local_files_lookup) {
 							pkg_url_base
 						};
 					} catch (_e) {
-						throw new Error(`Error fetching "${pkg_name}" from unpkg. Does the package exist?`);
+						throw new Error(`Error fetching "${pkg_name}" from jsdelivr. Does the package exist?`);
 					}
 				};
 

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -29,8 +29,7 @@ self.addEventListener(
 					.then((r) => r.json())
 					.catch(() => ({ version: 'experimental' }));
 
-				// unpkg doesn't set the correct MIME type for .cjs files
-				// https://github.com/mjackson/unpkg/issues/355
+				// .cjs files have an unhelpful MIME type
 				const compiler = await fetch(`${svelte_url}/compiler.cjs`).then((r) => r.text());
 				(0, eval)(compiler + '\n//# sourceURL=compiler.cjs@' + version);
 


### PR DESCRIPTION
I've found unpkg to be a bit flaky lately. It's completely unmaintained (last commit was three years ago). We should just use [jsdelivr](https://www.jsdelivr.com/) instead