### PR TITLE
chore: refactor `destroy_signal`

### DIFF
--- a/packages/svelte/src/internal/client/custom-element.js
+++ b/packages/svelte/src/internal/client/custom-element.js
@@ -1,6 +1,5 @@
 import { createClassComponent } from '../../legacy/legacy-client.js';
-import { destroy_signal } from './runtime.js';
-import { render_effect } from './reactivity/effects.js';
+import { destroy_effect, render_effect } from './reactivity/effects.js';
 import { open, close } from './render.js';
 import { define_property } from './utils.js';
 
@@ -199,7 +198,7 @@ if (typeof HTMLElement === 'function') {
 			Promise.resolve().then(() => {
 				if (!this.$$cn) {
 					this.$$c.$destroy();
-					destroy_signal(this.$$me);
+					destroy_effect(this.$$me);
 					this.$$c = undefined;
 				}
 			});

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -1,14 +1,8 @@
 import { is_promise } from '../../../common.js';
 import { hydrate_block_anchor } from '../../hydration.js';
 import { remove } from '../../reconciler.js';
-import {
-	current_block,
-	destroy_signal,
-	execute_effect,
-	flushSync,
-	push_destroy_fn
-} from '../../runtime.js';
-import { render_effect } from '../../reactivity/effects.js';
+import { current_block, execute_effect, flushSync, push_destroy_fn } from '../../runtime.js';
+import { destroy_effect, render_effect } from '../../reactivity/effects.js';
 import { trigger_transitions } from '../../transitions.js';
 import { AWAIT_BLOCK, UNINITIALIZED } from '../../constants.js';
 
@@ -74,7 +68,7 @@ export function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 							remove(render.d);
 							render.d = null;
 						}
-						destroy_signal(render.e);
+						destroy_effect(render.e);
 						render.e = null;
 					}
 				}
@@ -191,7 +185,7 @@ export function await_block(anchor_node, input, pending_fn, then_fn, catch_fn) {
 			}
 			const effect = render.e;
 			if (effect !== null) {
-				destroy_signal(effect);
+				destroy_effect(effect);
 			}
 			render = render.p;
 		}

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -16,8 +16,8 @@ import {
 } from '../../hydration.js';
 import { clear_text_content, empty, map_get, map_set } from '../../operations.js';
 import { insert, remove } from '../../reconciler.js';
-import { current_block, destroy_signal, execute_effect, push_destroy_fn } from '../../runtime.js';
-import { render_effect } from '../../reactivity/effects.js';
+import { current_block, execute_effect, push_destroy_fn } from '../../runtime.js';
+import { destroy_effect, render_effect } from '../../reactivity/effects.js';
 import { source, mutable_source, set } from '../../reactivity/sources.js';
 import { trigger_transitions } from '../../transitions.js';
 import { is_array, is_frozen } from '../../utils.js';
@@ -133,7 +133,7 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 							remove(fallback.d);
 							fallback.d = null;
 						}
-						destroy_signal(fallback.e);
+						destroy_effect(fallback.e);
 						fallback.e = null;
 					}
 				}
@@ -273,13 +273,13 @@ function each(anchor_node, collection, flags, key_fn, render_fn, fallback_fn, re
 			}
 			const effect = fallback.e;
 			if (effect !== null) {
-				destroy_signal(effect);
+				destroy_effect(effect);
 			}
 			fallback = fallback.p;
 		}
 		// Clear the array
 		reconcile_fn([], block, anchor_node, is_controlled, render_fn, flags, false, keys);
-		destroy_signal(/** @type {import('../../types.js').Effect} */ (render));
+		destroy_effect(/** @type {import('#client').Effect} */ (render));
 	});
 
 	block.e = each;
@@ -904,7 +904,7 @@ export function destroy_each_item_block(
 	if (!controlled && dom !== null) {
 		remove(dom);
 	}
-	destroy_signal(/** @type {import('../../types.js').Effect} */ (block.e));
+	destroy_effect(/** @type {import('#client').Effect} */ (block.e));
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -6,8 +6,8 @@ import {
 	set_current_hydration_fragment
 } from '../../hydration.js';
 import { remove } from '../../reconciler.js';
-import { current_block, destroy_signal, execute_effect, push_destroy_fn } from '../../runtime.js';
-import { render_effect } from '../../reactivity/effects.js';
+import { current_block, execute_effect, push_destroy_fn } from '../../runtime.js';
+import { destroy_effect, render_effect } from '../../reactivity/effects.js';
 import { trigger_transitions } from '../../transitions.js';
 
 /** @returns {import('../../types.js').IfBlock} */
@@ -174,8 +174,8 @@ export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn)
 		if (alternate_dom !== null) {
 			remove(alternate_dom);
 		}
-		destroy_signal(consequent_effect);
-		destroy_signal(alternate_effect);
+		destroy_effect(consequent_effect);
+		destroy_effect(alternate_effect);
 	});
 	block.e = if_effect;
 }

--- a/packages/svelte/src/internal/client/dom/blocks/key.js
+++ b/packages/svelte/src/internal/client/dom/blocks/key.js
@@ -1,8 +1,8 @@
 import { UNINITIALIZED, KEY_BLOCK } from '../../constants.js';
 import { hydrate_block_anchor } from '../../hydration.js';
 import { remove } from '../../reconciler.js';
-import { current_block, destroy_signal, execute_effect, push_destroy_fn } from '../../runtime.js';
-import { render_effect } from '../../reactivity/effects.js';
+import { current_block, execute_effect, push_destroy_fn } from '../../runtime.js';
+import { destroy_effect, render_effect } from '../../reactivity/effects.js';
 import { trigger_transitions } from '../../transitions.js';
 import { safe_not_equal } from '../../reactivity/equality.js';
 
@@ -58,7 +58,7 @@ export function key_block(anchor_node, key, render_fn) {
 							remove(render.d);
 							render.d = null;
 						}
-						destroy_signal(render.e);
+						destroy_effect(render.e);
 						render.e = null;
 					}
 				}
@@ -131,7 +131,7 @@ export function key_block(anchor_node, key, render_fn) {
 			}
 			const effect = render.e;
 			if (effect !== null) {
-				destroy_signal(effect);
+				destroy_effect(effect);
 			}
 			render = render.p;
 		}

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -68,13 +68,8 @@ export function derived_safe_equal(fn) {
  * @returns {void}
  */
 export function destroy_derived(signal) {
-	const teardown = /** @type {null | (() => void)} */ (signal.v);
-	const flags = signal.f;
 	destroy_references(signal);
 	remove_consumers(signal, 0);
 	signal.i = signal.r = signal.x = signal.b = signal.d = signal.c = null;
 	set_signal_status(signal, DESTROYED);
-	if (teardown !== null && (flags & IS_EFFECT) !== 0) {
-		teardown();
-	}
 }

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -64,7 +64,7 @@ export function derived_safe_equal(fn) {
 }
 
 /**
- * @param {import('./types.js').Derived} signal
+ * @param {import('#client').Derived} signal
  * @returns {void}
  */
 export function destroy_derived(signal) {

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -69,19 +69,11 @@ export function derived_safe_equal(fn) {
  */
 export function destroy_derived(signal) {
 	const teardown = /** @type {null | (() => void)} */ (signal.v);
-	const destroy = signal.y;
 	const flags = signal.f;
 	destroy_references(signal);
 	remove_consumers(signal, 0);
-	signal.i = signal.r = signal.y = signal.x = signal.b = signal.d = signal.c = null;
+	signal.i = signal.r = signal.x = signal.b = signal.d = signal.c = null;
 	set_signal_status(signal, DESTROYED);
-	if (destroy !== null) {
-		if (is_array(destroy)) {
-			run_all(destroy);
-		} else {
-			destroy();
-		}
-	}
 	if (teardown !== null && (flags & IS_EFFECT) !== 0) {
 		teardown();
 	}

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -70,6 +70,7 @@ export function derived_safe_equal(fn) {
 export function destroy_derived(signal) {
 	destroy_references(signal);
 	remove_consumers(signal, 0);
+	// @ts-expect-error `signal.i` cannot be `null` while the signal is alive
 	signal.i = signal.r = signal.x = signal.b = signal.d = signal.c = null;
 	set_signal_status(signal, DESTROYED);
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -248,7 +248,7 @@ export function render_effect(fn, block = current_block, managed = false, sync =
 }
 
 /**
- * @param {import('./types.js').Effect} signal
+ * @param {import('#client').Effect} signal
  * @returns {void}
  */
 export function destroy_effect(signal) {

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -110,8 +110,6 @@ export function unsubscribe_on_destroy(stores) {
 		for (store_name in stores) {
 			const ref = stores[store_name];
 			ref.unsubscribe();
-			// TODO: can we remove this code? it was refactored out when we split up source/comptued signals
-			// destroy_signal(ref.value);
 		}
 	});
 }

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -40,8 +40,6 @@ export interface Derived<V = unknown> extends Source<V> {
 	b: null | Block;
 	/** context: The associated component if this signal is an effect/computed */
 	x: null | ComponentContext;
-	/** destroy: Thing(s) that need destroying */
-	y: null | (() => void) | Array<() => void>;
 }
 
 export interface DerivedDebug<V = unknown> extends Derived<V> {

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -35,7 +35,6 @@ import {
 	remove
 } from './reconciler.js';
 import {
-	destroy_signal,
 	push_destroy_fn,
 	execute_effect,
 	untrack,
@@ -55,7 +54,8 @@ import {
 	effect,
 	managed_effect,
 	pre_effect,
-	user_effect
+	user_effect,
+	destroy_effect
 } from './reactivity/effects.js';
 import {
 	current_hydration_fragment,
@@ -728,11 +728,11 @@ export function bind_playback_rate(media, get_value, update) {
 	// Needs to happen after the element is inserted into the dom, else playback will be set back to 1 by the browser.
 	// For hydration we could do it immediately but the additional code is not worth the lost microtask.
 
-	/** @type {import('./types.js').Reaction | undefined} */
+	/** @type {import('./types.js').Effect | undefined} */
 	let render;
 	let destroyed = false;
 	const effect = managed_effect(() => {
-		destroy_signal(effect);
+		destroy_effect(effect);
 		if (destroyed) return;
 		if (get_value() == null) {
 			callback();
@@ -750,7 +750,7 @@ export function bind_playback_rate(media, get_value, update) {
 	render_effect(() => () => {
 		destroyed = true;
 		if (render) {
-			destroy_signal(render);
+			destroy_effect(render);
 		}
 	});
 }
@@ -1672,7 +1672,7 @@ export function element(anchor_node, tag_fn, is_svg, render_fn) {
 			block.d = null;
 			element = null;
 		}
-		destroy_signal(render_effect_signal);
+		destroy_effect(render_effect_signal);
 	});
 	block.e = element_effect;
 }
@@ -1712,7 +1712,7 @@ export function component(anchor_node, component_fn, render_fn) {
 							remove(render.d);
 							render.d = null;
 						}
-						destroy_signal(render.e);
+						destroy_effect(render.e);
 						render.e = null;
 					}
 				}
@@ -1788,7 +1788,7 @@ export function component(anchor_node, component_fn, render_fn) {
 			}
 			const effect = render.e;
 			if (effect !== null) {
-				destroy_signal(effect);
+				destroy_effect(effect);
 			}
 			render = render.p;
 		}
@@ -2659,7 +2659,7 @@ function _mount(Component, options) {
 		if (dom !== null) {
 			remove(dom);
 		}
-		destroy_signal(/** @type {import('./types.js').Effect} */ (block.e));
+		destroy_effect(/** @type {import('./types.js').Effect} */ (block.e));
 	});
 
 	return component;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -924,7 +924,7 @@ export function untrack(fn) {
 }
 
 /**
- * @param {import('./types.js').Reaction} signal
+ * @param {import('./types.js').Effect} signal
  * @param {() => void} destroy_fn
  * @returns {void}
  */

--- a/packages/svelte/src/internal/client/transitions.js
+++ b/packages/svelte/src/internal/client/transitions.js
@@ -12,11 +12,15 @@ import {
 import { destroy_each_item_block, get_first_element } from './dom/blocks/each.js';
 import { schedule_raf_task } from './dom/task.js';
 import { append_child, empty } from './operations.js';
-import { effect, managed_effect, managed_pre_effect } from './reactivity/effects.js';
+import {
+	destroy_effect,
+	effect,
+	managed_effect,
+	managed_pre_effect
+} from './reactivity/effects.js';
 import {
 	current_block,
 	current_effect,
-	destroy_signal,
 	execute_effect,
 	mark_subtree_inert,
 	untrack
@@ -589,7 +593,7 @@ export function bind_transition(dom, get_transition_fn, props_fn, direction, glo
 		}
 
 		const effect = managed_pre_effect(() => {
-			destroy_signal(effect);
+			destroy_effect(effect);
 			dom.inert = false;
 
 			if (show_intro && !already_mounted) {
@@ -666,9 +670,9 @@ export function trigger_transitions(transitions, target_direction, from) {
 	if (outros.length > 0) {
 		// Defer the outros to a microtask
 		const e = managed_pre_effect(() => {
-			destroy_signal(e);
+			destroy_effect(e);
 			const e2 = managed_effect(() => {
-				destroy_signal(e2);
+				destroy_effect(e2);
 				run_all(outros);
 			});
 		}, false);

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -1,6 +1,11 @@
 import { describe, assert, it } from 'vitest';
 import * as $ from '../../src/internal/client/runtime';
-import { effect, render_effect, user_effect } from '../../src/internal/client/reactivity/effects';
+import {
+	destroy_effect,
+	effect,
+	render_effect,
+	user_effect
+} from '../../src/internal/client/reactivity/effects';
 import { source, set } from '../../src/internal/client/reactivity/sources';
 import type { Derived } from '../../src/internal/client/types';
 import { proxy } from '../../src/internal/client/proxy';
@@ -27,7 +32,7 @@ function run_test(runes: boolean, fn: (runes: boolean) => () => void) {
 		);
 		$.pop();
 		execute();
-		$.destroy_signal(signal);
+		destroy_effect(signal);
 	};
 }
 
@@ -261,7 +266,7 @@ describe('signals', () => {
 			// Ensure we're not leaking consumers
 			assert.deepEqual(count.c?.length, 1);
 			assert.deepEqual(log, [0, 2, 'limit', 0]);
-			$.destroy_signal(effect);
+			destroy_effect(effect);
 			// Ensure we're not leaking consumers
 			assert.deepEqual(count.c, null);
 		};


### PR DESCRIPTION
Applying more lessons from #10594 — it's very useful to know what _kind_ of signal you're dealing with at a given point in the codebase. `destroy_signal` takes a `Signal`, but in reality it's 99% used for destroying effects and 1% used for destroying deriveds. By splitting it into `destroy_effect` and `destroy_derived` it becomes clearer what's going on where, and we're able to get rid of the `derived.y` property (and possibly others as this refactor continues). Presumably it's also better insofar as both functions are monomorphic (something we otherwise lost by splitting `ComputationSignal` into `Derived` and `Effect`)