### PR TITLE
fix: replace span with button (a11y)

### DIFF
--- a/sites/svelte-5-preview/src/lib/Output/console/ConsoleLine.svelte
+++ b/sites/svelte-5-preview/src/lib/Output/console/ConsoleLine.svelte
@@ -15,26 +15,15 @@
 	<ConsoleTable data={log.args[0]} columns={log.args[1]} />
 {/if}
 
-<button
-	class="log console-{log.level}"
-	style="padding-left: {level * 15}px"
-	on:click={log.level === 'group' ? toggle_group_collapse : undefined}
->
+<span class="log console-{log.level}" style="padding-left: {level * 15}px">
 	{#if log.count && log.count > 1}
 		<span class="count">{log.count}x</span>
 	{/if}
 
-	{#if log.level === 'trace' || log.level === 'assert'}
-		<span
-			class="arrow"
-			role="button"
-			tabindex="0"
-			class:expand={!log.collapsed}
-			on:keyup={toggle_group_collapse}
-			on:click={toggle_group_collapse}
-		>
+	{#if log.level === 'trace' || log.level === 'assert' || log.level === 'group'}
+		<button class="arrow" class:expand={!log.collapsed} on:click={toggle_group_collapse}>
 			▶
-		</span>
+		</button>
 	{/if}
 
 	{#if log.level === 'assert'}
@@ -46,7 +35,6 @@
 	{:else if log.level === 'unclonable'}
 		<span class="info error">Message could not be cloned. Open devtools to see it</span>
 	{:else if log.level === 'group'}
-		<div class="arrow" class:expand={!log.collapsed}>▶</div>
 		<span class="title">{log.label}</span>
 	{:else if log.level.startsWith('system')}
 		{#each log.args ?? [] as arg}
@@ -62,7 +50,7 @@
 	{#each new Array(level - 1) as _, idx}
 		<div class="outline" style="left: {idx * 15 + 15}px" />
 	{/each}
-</button>
+</span>
 
 {#if log.level === 'group' && !log.collapsed}
 	{#each log.logs ?? [] as childLog}

--- a/sites/svelte-5-preview/src/lib/Output/console/ConsoleLine.svelte
+++ b/sites/svelte-5-preview/src/lib/Output/console/ConsoleLine.svelte
@@ -21,8 +21,11 @@
 	{/if}
 
 	{#if log.level === 'trace' || log.level === 'assert' || log.level === 'group'}
-		<button class="arrow" class:expand={!log.collapsed} on:click={toggle_group_collapse}>
-			▶
+		<button on:click={toggle_group_collapse}>
+			<span class="arrow" class:expand={!log.collapsed}> ▶️ </span>
+			{#if log.level === 'group'}
+				<span class="title">{log.label}</span>
+			{/if}
 		</button>
 	{/if}
 
@@ -34,8 +37,6 @@
 		<span class="info">Console was cleared</span>
 	{:else if log.level === 'unclonable'}
 		<span class="info error">Message could not be cloned. Open devtools to see it</span>
-	{:else if log.level === 'group'}
-		<span class="title">{log.label}</span>
 	{:else if log.level.startsWith('system')}
 		{#each log.args ?? [] as arg}
 			{arg}


### PR DESCRIPTION
- swaps a fake button with a real one
	- also add `{log.label}` as part of button
- context: https://twitter.com/dummdidumm_/status/1767272209523818585

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
