### PR TITLE
fix: adjust effect ordering

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../test';
+import { log } from './log.js';
+
+export default test({
+	get props() {
+		return { n: 0 };
+	},
+
+	before_test() {
+		log.length = 0;
+	},
+
+	async test({ assert, component }) {
+		assert.deepEqual(log, ['$effect.pre 0', 'another $effect.pre 1', 'render n0', 'render i1']);
+
+		log.length = 0;
+		component.n += 1;
+
+		assert.deepEqual(log, ['$effect.pre 1', 'another $effect.pre 2', 'render n1', 'render i2']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/log.js
@@ -1,0 +1,2 @@
+/** @type {any[]} */
+export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/main.svelte
@@ -1,0 +1,24 @@
+<script>
+	import { untrack } from 'svelte';
+	import { log } from './log.js';
+
+	let { n = 0 } = $props();
+
+	let i = $state(0);
+
+	function logRender(i) {
+		log.push(`render ${i}`);
+	}
+
+	$effect.pre(() => {
+		log.push(`$effect.pre ${n}`);
+		untrack(() => i++)
+	});
+
+	$effect.pre(() => {
+		log.push('another $effect.pre '+ i);
+	})
+</script>
+
+<p>{logRender(`n${n}`)}</p>
+<p>{logRender(`i${i}`)}</p>


### PR DESCRIPTION
This started out investigating a bug on the current preview site. When you navigate to the docs, then to something else than the introduction, then back to the introduction, you get an error. The culprit is the pre effects getting flushed by some render effect. We can fix this by adding a "is this legacy mode" check (which I removed in #10736; turns out we still need it). But then I realized that the whole logic is a bit flawed either way: Flushing render effects directly after pre effects and vice versa can get things out of order in runes mode, too. I've added a failing test in this PR. I don't have a good idea yet how to properly fix this, but I think it involves getting rid of the "eagerly flush this" and instead smartly inserting the render/pre effects in the right order, which means somehow honoring the currently flushed render/pre-effects when queuing new effects.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
