### PR TITLE
simplify pre_effect logic

### DIFF
--- a/packages/svelte/src/internal/client/dom/legacy/lifecycle.js
+++ b/packages/svelte/src/internal/client/dom/legacy/lifecycle.js
@@ -1,6 +1,6 @@
 import { run } from '../../../common.js';
 import { pre_effect, user_effect } from '../../reactivity/effects.js';
-import { current_component_context, deep_read_state, get, untrack } from '../../runtime.js';
+import { current_component_context, deep_read_state, flush_local_render_effects, get, untrack } from '../../runtime.js';
 
 /**
  * Legacy-mode only: Call `onMount` callbacks and set up `beforeUpdate`/`afterUpdate` effects
@@ -16,6 +16,7 @@ export function init() {
 		pre_effect(() => {
 			observe_all(context);
 			callbacks.b.forEach(run);
+			flush_local_render_effects();
 		});
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -148,18 +148,9 @@ export function pre_effect(fn) {
 					: '')
 		);
 	}
-
 	const sync = current_effect !== null && (current_effect.f & RENDER_EFFECT) !== 0;
 
-	return create_effect(
-		PRE_EFFECT,
-		() => {
-			const val = fn();
-			flush_local_render_effects();
-			return val;
-		},
-		sync
-	);
+	return create_effect(PRE_EFFECT, fn, sync);
 }
 
 /**


### PR DESCRIPTION
We can simplify pre effects by not doing the flush logic at all now. Instead we can move the flushing logic to the only place its needed – for `beforeUpdate`.