### PR TITLE
chore: remove ignore_mutation_validation

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -1,7 +1,7 @@
 import { subscribe_to_store } from '../../../store/utils.js';
 import { noop } from '../../common.js';
 import { UNINITIALIZED } from '../constants.js';
-import { get, set_ignore_mutation_validation, untrack } from '../runtime.js';
+import { get, untrack } from '../runtime.js';
 import { user_effect } from './effects.js';
 import { mutable_source, set } from './sources.js';
 
@@ -74,13 +74,7 @@ function connect_store_to_signal(store, source) {
 		return noop;
 	}
 
-	/** @param {V} v */
-	const run = (v) => {
-		set_ignore_mutation_validation(true);
-		set(source, v);
-		set_ignore_mutation_validation(false);
-	};
-	return subscribe_to_store(store, run);
+	return subscribe_to_store(store, (v) => set(source, v));
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -84,12 +84,6 @@ export function set_last_inspected_signal(signal) {
 
 /** If `true`, `get`ting the signal should not register it as a dependency */
 export let current_untracking = false;
-/** Exists to opt out of the mutation validation for stores which may be set for the first time during a derivation */
-export let ignore_mutation_validation = false;
-/** @param {boolean} value */
-export function set_ignore_mutation_validation(value) {
-	ignore_mutation_validation = value;
-}
 
 // If we are working with a get() chain that has no active container,
 // to prevent memory leaks, we skip adding the reaction.


### PR DESCRIPTION
we can make our lives simpler here — one less piece of global state. a nice bonus of avoiding global state is that when we eventually remove non-runes code from the codebase, it'll be much more obvious what we can delete