### PR TITLE
Blockless redux

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -70,126 +70,119 @@ export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn)
 	/** @type {import('#client').Effect} */
 	let alternate_effect;
 
-	const if_effect = render_effect(
-		() => {
-			const result = !!condition_fn();
+	const if_effect = render_effect(() => {
+		const result = !!condition_fn();
 
-			if (block.v !== result || !has_mounted) {
-				block.v = result;
+		if (block.v !== result || !has_mounted) {
+			block.v = result;
 
-				if (has_mounted) {
-					const consequent_transitions = block.c;
-					const alternate_transitions = block.a;
+			if (has_mounted) {
+				const consequent_transitions = block.c;
+				const alternate_transitions = block.a;
 
-					if (result) {
-						if (alternate_transitions === null || alternate_transitions.size === 0) {
-							execute_effect(alternate_effect);
-						} else {
-							trigger_transitions(alternate_transitions, 'out');
-						}
-
-						if (consequent_transitions === null || consequent_transitions.size === 0) {
-							execute_effect(consequent_effect);
-						} else {
-							trigger_transitions(consequent_transitions, 'in');
-						}
+				if (result) {
+					if (alternate_transitions === null || alternate_transitions.size === 0) {
+						execute_effect(alternate_effect);
 					} else {
-						if (consequent_transitions === null || consequent_transitions.size === 0) {
-							execute_effect(consequent_effect);
-						} else {
-							trigger_transitions(consequent_transitions, 'out');
-						}
-
-						if (alternate_transitions === null || alternate_transitions.size === 0) {
-							execute_effect(alternate_effect);
-						} else {
-							trigger_transitions(alternate_transitions, 'in');
-						}
+						trigger_transitions(alternate_transitions, 'out');
 					}
-				} else if (hydrating) {
-					const comment_text = /** @type {Comment} */ (current_hydration_fragment?.[0])?.data;
 
-					if (
-						!comment_text ||
-						(comment_text === 'ssr:if:true' && !result) ||
-						(comment_text === 'ssr:if:false' && result)
-					) {
-						// Hydration mismatch: remove everything inside the anchor and start fresh.
-						// This could happen using when `{#if browser} .. {/if}` in SvelteKit.
-						remove(current_hydration_fragment);
-						set_current_hydration_fragment(null);
-						mismatch = true;
+					if (consequent_transitions === null || consequent_transitions.size === 0) {
+						execute_effect(consequent_effect);
 					} else {
-						// Remove the ssr:if comment node or else it will confuse the subsequent hydration algorithm
-						current_hydration_fragment.shift();
+						trigger_transitions(consequent_transitions, 'in');
+					}
+				} else {
+					if (consequent_transitions === null || consequent_transitions.size === 0) {
+						execute_effect(consequent_effect);
+					} else {
+						trigger_transitions(consequent_transitions, 'out');
+					}
+
+					if (alternate_transitions === null || alternate_transitions.size === 0) {
+						execute_effect(alternate_effect);
+					} else {
+						trigger_transitions(alternate_transitions, 'in');
 					}
 				}
+			} else if (hydrating) {
+				const comment_text = /** @type {Comment} */ (current_hydration_fragment?.[0])?.data;
 
-				has_mounted = true;
+				if (
+					!comment_text ||
+					(comment_text === 'ssr:if:true' && !result) ||
+					(comment_text === 'ssr:if:false' && result)
+				) {
+					// Hydration mismatch: remove everything inside the anchor and start fresh.
+					// This could happen using when `{#if browser} .. {/if}` in SvelteKit.
+					remove(current_hydration_fragment);
+					set_current_hydration_fragment(null);
+					mismatch = true;
+				} else {
+					// Remove the ssr:if comment node or else it will confuse the subsequent hydration algorithm
+					current_hydration_fragment.shift();
+				}
 			}
 
-			// create these here so they have the correct parent/child relationship
-			consequent_effect ??= render_effect(
-				(
-					/** @type {any} */ _,
-					/** @type {import('#client').Effect | null} */ consequent_effect
-				) => {
-					const result = block.v;
+			has_mounted = true;
+		}
 
-					if (!result && consequent_dom !== null) {
-						remove(consequent_dom);
-						consequent_dom = null;
+		// create these here so they have the correct parent/child relationship
+		consequent_effect ??= render_effect(
+			(/** @type {any} */ _, /** @type {import('#client').Effect | null} */ consequent_effect) => {
+				const result = block.v;
+
+				if (!result && consequent_dom !== null) {
+					remove(consequent_dom);
+					consequent_dom = null;
+				}
+
+				if (result && current_branch_effect !== consequent_effect) {
+					consequent_fn(anchor_node);
+					if (mismatch && current_branch_effect === null) {
+						// Set fragment so that Svelte continues to operate in hydration mode
+						set_current_hydration_fragment([]);
+					}
+					current_branch_effect = consequent_effect;
+					consequent_dom = block.d;
+				}
+
+				block.d = null;
+			},
+			block,
+			true
+		);
+		block.ce = consequent_effect;
+
+		alternate_effect ??= render_effect(
+			(/** @type {any} */ _, /** @type {import('#client').Effect | null} */ alternate_effect) => {
+				const result = block.v;
+
+				if (result && alternate_dom !== null) {
+					remove(alternate_dom);
+					alternate_dom = null;
+				}
+
+				if (!result && current_branch_effect !== alternate_effect) {
+					if (alternate_fn !== null) {
+						alternate_fn(anchor_node);
 					}
 
-					if (result && current_branch_effect !== consequent_effect) {
-						consequent_fn(anchor_node);
-						if (mismatch && current_branch_effect === null) {
-							// Set fragment so that Svelte continues to operate in hydration mode
-							set_current_hydration_fragment([]);
-						}
-						current_branch_effect = consequent_effect;
-						consequent_dom = block.d;
+					if (mismatch && current_branch_effect === null) {
+						// Set fragment so that Svelte continues to operate in hydration mode
+						set_current_hydration_fragment([]);
 					}
 
-					block.d = null;
-				},
-				block,
-				true
-			);
-			block.ce = consequent_effect;
-
-			alternate_effect ??= render_effect(
-				(/** @type {any} */ _, /** @type {import('#client').Effect | null} */ alternate_effect) => {
-					const result = block.v;
-
-					if (result && alternate_dom !== null) {
-						remove(alternate_dom);
-						alternate_dom = null;
-					}
-
-					if (!result && current_branch_effect !== alternate_effect) {
-						if (alternate_fn !== null) {
-							alternate_fn(anchor_node);
-						}
-
-						if (mismatch && current_branch_effect === null) {
-							// Set fragment so that Svelte continues to operate in hydration mode
-							set_current_hydration_fragment([]);
-						}
-
-						current_branch_effect = alternate_effect;
-						alternate_dom = block.d;
-					}
-					block.d = null;
-				},
-				block,
-				true
-			);
-			block.ae = alternate_effect;
-		},
-		block,
-		false
-	);
+					current_branch_effect = alternate_effect;
+					alternate_dom = block.d;
+				}
+				block.d = null;
+			},
+			block,
+			true
+		);
+		block.ae = alternate_effect;
+	}, block);
 
 	if_effect.ondestroy = () => {
 		if (consequent_dom !== null) {

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -82,6 +82,7 @@ export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn)
 						} else {
 							trigger_transitions(alternate_transitions, 'out');
 						}
+
 						if (consequent_transitions === null || consequent_transitions.size === 0) {
 							execute_effect(consequent_effect);
 						} else {
@@ -93,6 +94,7 @@ export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn)
 						} else {
 							trigger_transitions(consequent_transitions, 'out');
 						}
+
 						if (alternate_transitions === null || alternate_transitions.size === 0) {
 							execute_effect(alternate_effect);
 						} else {

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -45,15 +45,20 @@ function create_if_block() {
  */
 export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn) {
 	const block = create_if_block();
+
 	hydrate_block_anchor(anchor_node);
+
 	/** Whether or not there was a hydration mismatch. Needs to be a `let` or else it isn't treeshaken out */
 	let mismatch = false;
 
 	/** @type {null | import('#client').TemplateNode | Array<import('#client').TemplateNode>} */
 	let consequent_dom = null;
+
 	/** @type {null | import('#client').TemplateNode | Array<import('#client').TemplateNode>} */
 	let alternate_dom = null;
+
 	let has_mounted = false;
+
 	/**
 	 * @type {import('#client').Effect | null}
 	 */
@@ -131,10 +136,12 @@ export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn)
 	consequent_effect = render_effect(
 		(/** @type {any} */ _, /** @type {import('#client').Effect | null} */ consequent_effect) => {
 			const result = block.v;
+
 			if (!result && consequent_dom !== null) {
 				remove(consequent_dom);
 				consequent_dom = null;
 			}
+
 			if (result && current_branch_effect !== consequent_effect) {
 				consequent_fn(anchor_node);
 				if (mismatch && current_branch_effect === null) {
@@ -144,6 +151,7 @@ export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn)
 				current_branch_effect = consequent_effect;
 				consequent_dom = block.d;
 			}
+
 			block.d = null;
 		},
 		block,
@@ -155,18 +163,22 @@ export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn)
 	alternate_effect = render_effect(
 		(/** @type {any} */ _, /** @type {import('#client').Effect | null} */ alternate_effect) => {
 			const result = block.v;
+
 			if (result && alternate_dom !== null) {
 				remove(alternate_dom);
 				alternate_dom = null;
 			}
+
 			if (!result && current_branch_effect !== alternate_effect) {
 				if (alternate_fn !== null) {
 					alternate_fn(anchor_node);
 				}
+
 				if (mismatch && current_branch_effect === null) {
 					// Set fragment so that Svelte continues to operate in hydration mode
 					set_current_hydration_fragment([]);
 				}
+
 				current_branch_effect = alternate_effect;
 				alternate_dom = block.d;
 			}
@@ -181,9 +193,11 @@ export function if_block(anchor_node, condition_fn, consequent_fn, alternate_fn)
 		if (consequent_dom !== null) {
 			remove(consequent_dom);
 		}
+
 		if (alternate_dom !== null) {
 			remove(alternate_dom);
 		}
+
 		destroy_effect(consequent_effect);
 		destroy_effect(alternate_effect);
 	};

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -5,7 +5,6 @@ import {
 	current_effect,
 	current_reaction,
 	destroy_children,
-	flush_local_render_effects,
 	get,
 	remove_reactions,
 	schedule_effect,
@@ -42,13 +41,11 @@ function create_effect(type, fn, sync, block = current_block, init = true) {
 		signal.l = current_effect.l + 1;
 	}
 
-	if ((type & MANAGED) === 0) {
-		if (current_reaction !== null) {
-			if (current_reaction.effects === null) {
-				current_reaction.effects = [signal];
-			} else {
-				current_reaction.effects.push(signal);
-			}
+	if (current_reaction !== null) {
+		if (current_reaction.effects === null) {
+			current_reaction.effects = [signal];
+		} else {
+			current_reaction.effects.push(signal);
 		}
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -230,5 +230,12 @@ export function destroy_effect(signal) {
 
 	signal.teardown?.();
 	signal.ondestroy?.();
-	signal.fn = signal.effects = signal.ondestroy = signal.ctx = signal.block = signal.deps = null;
+	signal.fn =
+		signal.effects =
+		signal.teardown =
+		signal.ondestroy =
+		signal.ctx =
+		signal.block =
+		signal.deps =
+			null;
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -365,7 +365,10 @@ export function remove_reactions(signal, start_index) {
 export function destroy_children(signal) {
 	if (signal.effects) {
 		for (var i = 0; i < signal.effects.length; i += 1) {
-			destroy_effect(signal.effects[i]);
+			var effect = signal.effects[i];
+			if ((effect.f & MANAGED) === 0) {
+				destroy_effect(effect);
+			}
 		}
 		signal.effects = null;
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -10,7 +10,6 @@ import {
 import { unstate } from './proxy.js';
 import { destroy_effect, pre_effect } from './reactivity/effects.js';
 import {
-	EACH_BLOCK,
 	EFFECT,
 	PRE_EFFECT,
 	RENDER_EFFECT,

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -762,10 +762,10 @@ export function invalidate_inner_signals(fn) {
  */
 function mark_subtree_children_inert(signal, inert) {
 	const effects = signal.effects;
+
 	if (effects !== null) {
 		for (var i = 0; i < effects.length; i++) {
-			const effect = effects[i];
-			mark_subtree_inert(effect, inert);
+			mark_subtree_inert(effects[i], inert);
 		}
 	}
 }
@@ -778,12 +778,14 @@ function mark_subtree_children_inert(signal, inert) {
 export function mark_subtree_inert(signal, inert) {
 	const flags = signal.f;
 	const is_already_inert = (flags & INERT) !== 0;
+
 	if (is_already_inert !== inert) {
 		signal.f ^= INERT;
 		if (!inert && (flags & CLEAN) === 0) {
 			schedule_effect(signal, false);
 		}
 	}
+
 	mark_subtree_children_inert(signal, inert);
 }
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -786,25 +786,11 @@ export function mark_subtree_inert(signal, inert, visited_blocks = new Set()) {
 		if (!inert && (flags & CLEAN) === 0) {
 			schedule_effect(signal, false);
 		}
-		// Nested if block effects
+
 		const block = signal.block;
 		if (block !== null && !visited_blocks.has(block)) {
 			visited_blocks.add(block);
-			const type = block.t;
-			if (type === IF_BLOCK) {
-				const condition_effect = block.e;
-				if (condition_effect !== null && block !== current_block) {
-					mark_subtree_inert(condition_effect, inert, visited_blocks);
-				}
-				const consequent_effect = block.ce;
-				if (consequent_effect !== null && block.v) {
-					mark_subtree_inert(consequent_effect, inert, visited_blocks);
-				}
-				const alternate_effect = block.ae;
-				if (alternate_effect !== null && !block.v) {
-					mark_subtree_inert(alternate_effect, inert, visited_blocks);
-				}
-			} else if (type === EACH_BLOCK) {
+			if (block.t === EACH_BLOCK) {
 				const items = block.v;
 				for (let { e: each_item_effect } of items) {
 					if (each_item_effect !== null) {


### PR DESCRIPTION
This marks the start of another run at #10594 — trying to do it in a more incremental fashion this time. This does mean that things may look suboptimal initially.

Right now, _block_ effects and their _branch_ effects (still workshopping these names) are created as siblings. Because of that, we have to do things like this:

```js
if (type === IF_BLOCK) {
  // a bunch of special logic, far from the if block definition
}
```

If we just construct the tree correctly in the first place, that becomes unnecessary. Eventually, the block construct itself (as distinct from the block effect) also becomes unnecessary, and we can greatly simplify things like transitions.