### PR TITLE
expand on effect sequencing with levels

### DIFF
--- a/packages/svelte/src/reactivity/set.test.ts
+++ b/packages/svelte/src/reactivity/set.test.ts
@@ -30,7 +30,7 @@ test('set.values()', () => {
 		set.clear();
 	});
 
-	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, [], false]); // TODO update when we fix effect ordering bug
+	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, false, []]);
 
 	cleanup();
 });

--- a/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-8/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-input-group-each-8/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 // https://github.com/sveltejs/svelte/issues/7884
@@ -27,11 +28,22 @@ export default test({
 		const event = new window.Event('change');
 
 		inputs[0].checked = true;
-		await inputs[0].dispatchEvent(event);
+
+		flushSync(() => {
+			inputs[0].dispatchEvent(event);
+		});
+
 		inputs[2].checked = true;
-		await inputs[2].dispatchEvent(event);
+
+		flushSync(() => {
+			inputs[2].dispatchEvent(event);
+		});
+
 		inputs[3].checked = true;
-		await inputs[3].dispatchEvent(event);
+
+		flushSync(() => {
+			inputs[3].dispatchEvent(event);
+		});
 
 		assert.htmlEqual(
 			target.innerHTML,
@@ -53,7 +65,8 @@ export default test({
 		);
 
 		await component.update();
-		await Promise.resolve();
+
+		flushSync();
 
 		assert.htmlEqual(
 			target.innerHTML,

--- a/packages/svelte/tests/runtime-legacy/samples/component-binding-reactive-statement/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/component-binding-reactive-statement/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -11,7 +12,10 @@ export default test({
 
 		const buttons = target.querySelectorAll('button');
 
-		await buttons[0].dispatchEvent(event);
+		flushSync(() => {
+			buttons[0].dispatchEvent(event);
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -20,7 +24,10 @@ export default test({
 		`
 		);
 
-		await buttons[1].dispatchEvent(event);
+		flushSync(() => {
+			buttons[1].dispatchEvent(event);
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -30,7 +37,10 @@ export default test({
 		);
 
 		// reactive update, reset to 2
-		await buttons[0].dispatchEvent(event);
+		flushSync(() => {
+			buttons[0].dispatchEvent(event);
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -40,7 +50,10 @@ export default test({
 		);
 
 		// bound to main, reset to 2
-		await buttons[1].dispatchEvent(event);
+		flushSync(() => {
+			buttons[1].dispatchEvent(event);
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-compound-operator/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-compound-operator/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { ok, test } from '../../test';
 
 export default test({
@@ -11,7 +12,9 @@ export default test({
 		const button = target.querySelector('button');
 		ok(button);
 
-		await button.dispatchEvent(click);
+		flushSync(() => {
+			button.dispatchEvent(click);
+		});
 
 		assert.equal(component.x, 2);
 		assert.htmlEqual(
@@ -22,7 +25,9 @@ export default test({
 		`
 		);
 
-		await button.dispatchEvent(click);
+		flushSync(() => {
+			button.dispatchEvent(click);
+		});
 
 		assert.equal(component.x, 6);
 		assert.htmlEqual(

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-import-statement/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-import-statement/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { ok, test } from '../../test';
 import { reset_numbers } from './data';
 
@@ -18,7 +19,9 @@ export default test({
 
 		const clickEvent = new window.MouseEvent('click', { bubbles: true });
 
-		await btn.dispatchEvent(clickEvent);
+		flushSync(() => {
+			btn.dispatchEvent(clickEvent);
+		});
 
 		assert.htmlEqual(
 			target.innerHTML,
@@ -31,7 +34,9 @@ export default test({
 		`
 		);
 
-		await btn.dispatchEvent(clickEvent);
+		flushSync(() => {
+			btn.dispatchEvent(clickEvent);
+		});
 
 		assert.htmlEqual(
 			target.innerHTML,

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-update-expression/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-update-expression/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { ok, test } from '../../test';
 
 export default test({
@@ -13,7 +14,9 @@ export default test({
 
 		assert.equal(component.x, 1);
 
-		await button.dispatchEvent(click);
+		flushSync(() => {
+			button.dispatchEvent(click);
+		});
 
 		assert.equal(component.x, 3);
 		assert.htmlEqual(
@@ -24,7 +27,9 @@ export default test({
 		`
 		);
 
-		await button.dispatchEvent(click);
+		flushSync(() => {
+			button.dispatchEvent(click);
+		});
 
 		assert.equal(component.x, 5);
 		assert.htmlEqual(


### PR DESCRIPTION
So today effects have something called "levels" which are their depth from the root effect. However, we also should care about their breath too – which is the order amongst their siblings inside an effect. Rather then introducing a new field to signals, we could just use levels and chunk up 256 increments to do that.

We have some sequencing bugs today, which can quite easily be solved by expanding on the existing levels logic. Today levels are increased by 1 for each nested effect. This isn't quite right though – as it means all effects in a component are the same level.

Instead what if we could increment the level by 256 each time we nest an effect within and effect. Of those 256 levels each time, we segment 32 levels for pre-effects, 128 levels for render effects and 96 levels for user effects? Each sibling gets incremented by 1, so now we have the correct ordering for components and their effects.

I've not yet wired up user effects to this logic, thus this is a draft so far.