### PR TITLE
breaking: apply fallback value every time in runes mode

### DIFF
--- a/.changeset/small-spiders-fail.md
+++ b/.changeset/small-spiders-fail.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+breaking: apply fallback value every time in runes mode

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -257,7 +257,13 @@ export function client_component(source, analysis, options) {
 
 			properties.push(
 				b.get(key, [b.return(b.call(b.id(name)))]),
-				b.set(key, [b.stmt(b.call(b.id(name), b.id('$$value'))), b.stmt(b.call('$.flushSync'))])
+				b.set(
+					key,
+					[b.stmt(b.call(b.id(name), b.id('$$value'))), b.stmt(b.call('$.flushSync'))],
+					analysis.runes && binding.initial
+						? /** @type {import('estree').Expression} */ (binding.initial)
+						: undefined
+				)
 			);
 		}
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -262,7 +262,7 @@ export function client_component(source, analysis, options) {
 				b.stmt(b.call('$.flushSync'))
 			]);
 
-			if (binding.initial) {
+			if (analysis.runes && binding.initial) {
 				// turn `set foo($$value)` into `set foo($$value = expression)`
 				setter.value.params[0] = {
 					type: 'AssignmentPattern',

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -355,10 +355,23 @@ export function sequence(expressions) {
 /**
  * @param {string} name
  * @param {import('estree').Statement[]} body
+ * @param {import('estree').Expression | null} [fallback]
  * @returns {import('estree').Property}
  */
-export function set(name, body) {
-	return prop('set', key(name), function_builder(null, [id('$$value')], block(body)));
+export function set(name, body, fallback) {
+	return prop(
+		'set',
+		key(name),
+		function_builder(
+			null,
+			[
+				fallback
+					? { type: 'AssignmentPattern', left: id('$$value'), right: fallback }
+					: id('$$value')
+			],
+			block(body)
+		)
+	);
 }
 
 /**

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -210,7 +210,7 @@ export function function_declaration(id, params, body) {
 /**
  * @param {string} name
  * @param {import('estree').Statement[]} body
- * @returns {import('estree').Property}
+ * @returns {import('estree').Property & { value: import('estree').FunctionExpression}}}
  */
 export function get(name, body) {
 	return prop('get', key(name), function_builder(null, [], block(body)));
@@ -305,11 +305,12 @@ export function object_pattern(properties) {
 }
 
 /**
+ * @template {import('estree').Expression} Value
  * @param {'init' | 'get' | 'set'} kind
  * @param {import('estree').Expression} key
- * @param {import('estree').Expression} value
+ * @param {Value} value
  * @param {boolean} computed
- * @returns {import('estree').Property}
+ * @returns {import('estree').Property & { value: Value }}
  */
 export function prop(kind, key, value, computed = false) {
 	return { type: 'Property', kind, key, value, method: false, shorthand: false, computed };
@@ -355,23 +356,10 @@ export function sequence(expressions) {
 /**
  * @param {string} name
  * @param {import('estree').Statement[]} body
- * @param {import('estree').Expression | null} [fallback]
- * @returns {import('estree').Property}
+ * @returns {import('estree').Property & { value: import('estree').FunctionExpression}}
  */
-export function set(name, body, fallback) {
-	return prop(
-		'set',
-		key(name),
-		function_builder(
-			null,
-			[
-				fallback
-					? { type: 'AssignmentPattern', left: id('$$value'), right: fallback }
-					: id('$$value')
-			],
-			block(body)
-		)
-	);
+export function set(name, body) {
+	return prop('set', key(name), function_builder(null, [id('$$value')], block(body)));
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -8,7 +8,7 @@ import {
 import { get_descriptor, is_function } from '../utils.js';
 import { mutable_source, set } from './sources.js';
 import { derived } from './deriveds.js';
-import { get, inspect_fn, is_signals_recorded } from '../runtime.js';
+import { get, inspect_fn, is_signals_recorded, untrack } from '../runtime.js';
 import { safe_equals, safe_not_equal } from './equality.js';
 
 /**
@@ -133,16 +133,26 @@ export function spread_props(...props) {
  * @param {Record<string, unknown>} props
  * @param {string} key
  * @param {number} flags
- * @param {V | (() => V)} [initial]
+ * @param {V | (() => V)} [fallback]
  * @returns {(() => V | ((arg: V) => V) | ((arg: V, mutation: boolean) => V))}
  */
-export function prop(props, key, flags, initial) {
+export function prop(props, key, flags, fallback) {
 	var immutable = (flags & PROPS_IS_IMMUTABLE) !== 0;
 	var runes = (flags & PROPS_IS_RUNES) !== 0;
 	var prop_value = /** @type {V} */ (props[key]);
 	var setter = get_descriptor(props, key)?.set;
 
-	if (prop_value === undefined && initial !== undefined) {
+	var needs_new_fallback_value = true;
+	/** @type {V} */
+	var fallback_value;
+	var get_fallback = () =>
+		fallback !== undefined
+			? (flags & PROPS_IS_LAZY_INITIAL) !== 0
+				? /** @type {Function} */ (fallback)()
+				: fallback
+			: undefined;
+
+	if (prop_value === undefined && fallback !== undefined) {
 		if (setter && runes) {
 			// TODO consolidate all these random runtime errors
 			throw new Error(
@@ -153,19 +163,30 @@ export function prop(props, key, flags, initial) {
 			);
 		}
 
-		// @ts-expect-error would need a cumbersome method overload to type this
-		if ((flags & PROPS_IS_LAZY_INITIAL) !== 0) initial = initial();
-
-		prop_value = /** @type {V} */ (initial);
+		prop_value = fallback_value = get_fallback();
+		needs_new_fallback_value = false;
 
 		if (setter) setter(prop_value);
 	}
 
-	var getter = () => {
-		var value = /** @type {V} */ (props[key]);
-		if (value !== undefined) initial = undefined;
-		return value === undefined ? /** @type {V} */ (initial) : value;
-	};
+	var getter = runes
+		? () => {
+				var value = /** @type {V} */ (props[key]);
+				if (value === undefined) {
+					if (needs_new_fallback_value) {
+						needs_new_fallback_value = false;
+						fallback_value = untrack(get_fallback);
+					}
+					return fallback_value;
+				}
+				needs_new_fallback_value = true;
+				return value;
+			}
+		: () => {
+				var value = /** @type {V} */ (props[key]);
+				if (value !== undefined) fallback_value = /** @type {V} */ (undefined);
+				return value === undefined ? fallback_value : value;
+			};
 
 	// easy mode — prop is never written to
 	if ((flags & PROPS_IS_UPDATED) === 0) {

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-behavior/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-behavior/_config.js
@@ -1,6 +1,6 @@
 import { test } from '../../test';
 
-// Tests that default values apply only initially and that they propagate back correctly for bindings
+// Tests that default values apply every time and that they propagate back correctly for bindings
 export default test({
 	// set accessors to false so that $.prop() is also created
 	accessors: false,
@@ -267,7 +267,7 @@ export default test({
 			<p>props undefined:</p>
 			<p>
 				readonly:
-				readonlyWithDefault:
+				readonlyWithDefault: 1
 				binding:
 			</p>
 			<button>set bindings to 5</button>
@@ -276,7 +276,7 @@ export default test({
 			<p>props defined:</p>
 			<p>
 				readonly:
-				readonlyWithDefault:
+				readonlyWithDefault: 1
 				binding:
 			</p>
 			<button>set bindings to 5</button>
@@ -285,7 +285,7 @@ export default test({
 			<p>bindings undefined:</p>
 			<p>
 				readonly:
-				readonlyWithDefault:
+				readonlyWithDefault: 1
 				binding:
 			</p>
 			<button>set bindings to 5</button>
@@ -294,7 +294,7 @@ export default test({
 			<p>bindings defined:</p>
 			<p>
 				readonly:
-				readonlyWithDefault:
+				readonlyWithDefault: 1
 				binding:
 			</p>
 			<button>set bindings to 5</button>

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy-accessors/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy-accessors/_config.js
@@ -1,0 +1,29 @@
+import { test } from '../../test';
+
+// Tests that default values only fire lazily when the prop is undefined, and every time
+export default test({
+	props: {
+		p0: 0,
+		p1: 0,
+		p2: 0,
+		p3: 0
+	},
+	html: `<p>props: 0 0 0 0 1 1 1 1</p><p>log: nested.fallback_value,fallback_fn`,
+	async test({ assert, target, component }) {
+		component.p0 = undefined;
+		component.p1 = undefined;
+		component.p2 = undefined;
+		component.p3 = undefined;
+		// Nuance: these are already undefined in the props, but we're setting them to undefined again,
+		// which calls the fallback value again, even if it will result in the same value. There's no way
+		// to prevent this, and in practise it won't matter - and you shouldn't use accessors in runes mode anyway.
+		component.p4 = undefined;
+		component.p5 = undefined;
+		component.p6 = undefined;
+		component.p7 = undefined;
+		assert.htmlEqual(
+			target.innerHTML,
+			`<p>props: 1 1 1 1 1 1 1 1</p><p>log: nested.fallback_value,fallback_fn,nested.fallback_value,fallback_fn,nested.fallback_value,fallback_fn`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy-accessors/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy-accessors/main.svelte
@@ -1,0 +1,29 @@
+<script>
+	let log = $state([]);
+
+	const fallback_value = 1;
+	const nested = {
+		get fallback_value() {
+			log.push('nested.fallback_value');
+			return fallback_value;
+		}
+	}
+	const fallback_fn = () => {
+		log.push('fallback_fn');
+		return fallback_value;
+	}
+
+	const {
+		p0 = 1,
+		p1 = fallback_value,
+		p2 = nested.fallback_value,
+		p3 = fallback_fn(),
+		p4 = 1,
+		p5 = fallback_value,
+		p6 = nested.fallback_value,
+		p7 = fallback_fn()
+	} = $props();
+</script>
+
+<p>props: {p0} {p1} {p2} {p3} {p4} {p5} {p6} {p7}</p>
+<p>log: {log}</p>

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/_config.js
@@ -1,29 +1,24 @@
+import { tick } from 'svelte';
 import { test } from '../../test';
 
 // Tests that default values only fire lazily when the prop is undefined, and every time
 export default test({
-	props: {
-		p0: 0,
-		p1: 0,
-		p2: 0,
-		p3: 0
-	},
-	html: `<p>props: 0 0 0 0 1 1 1 1</p><p>log: nested.fallback_value,fallback_fn`,
-	async test({ assert, target, component }) {
-		// using component.p0 etc would set it to undefined, because the setter forgoes the default value
-		await component.$set({
-			p0: undefined,
-			p1: undefined,
-			p2: undefined,
-			p3: undefined,
-			p4: undefined,
-			p5: undefined,
-			p6: undefined,
-			p7: undefined
-		});
+	html: `
+	<p>props: 0 0 0 0 1 1 1 1</p>
+	<p>log: nested.fallback_value,fallback_fn</p>
+	<button>Set all to undefined</button>
+	`,
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+		btn?.click();
+		await tick();
 		assert.htmlEqual(
 			target.innerHTML,
-			`<p>props: 1 1 1 1 1 1 1 1</p><p>log: nested.fallback_value,fallback_fn,nested.fallback_value,fallback_fn`
+			`
+			<p>props: 1 1 1 1 1 1 1 1</p>
+			<p>log: nested.fallback_value,fallback_fn,nested.fallback_value,fallback_fn</p>
+			<button>Set all to undefined</button>
+			`
 		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/_config.js
@@ -1,6 +1,6 @@
 import { test } from '../../test';
 
-// Tests that default values only fire lazily when the prop is undefined, and only initially
+// Tests that default values only fire lazily when the prop is undefined, and every time
 export default test({
 	props: {
 		p0: 0,
@@ -10,14 +10,20 @@ export default test({
 	},
 	html: `<p>props: 0 0 0 0 1 1 1 1</p><p>log: nested.fallback_value,fallback_fn`,
 	async test({ assert, target, component }) {
-		component.p0 = undefined;
-		component.p1 = undefined;
-		component.p2 = undefined;
-		component.p3 = undefined;
-		component.p4 = undefined;
-		component.p5 = undefined;
-		component.p6 = undefined;
-		component.p7 = undefined;
-		assert.htmlEqual(target.innerHTML, `<p>props: </p><p>log: nested.fallback_value,fallback_fn`);
+		// using component.p0 etc would set it to undefined, because the setter forgoes the default value
+		await component.$set({
+			p0: undefined,
+			p1: undefined,
+			p2: undefined,
+			p3: undefined,
+			p4: undefined,
+			p5: undefined,
+			p6: undefined,
+			p7: undefined
+		});
+		assert.htmlEqual(
+			target.innerHTML,
+			`<p>props: 1 1 1 1 1 1 1 1</p><p>log: nested.fallback_value,fallback_fn,nested.fallback_value,fallback_fn`
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/main.svelte
@@ -5,13 +5,11 @@
 	const nested = {
 		get fallback_value() {
 			log.push('nested.fallback_value');
-			log = log;
 			return fallback_value;
 		}
 	}
 	const fallback_fn = () => {
 		log.push('fallback_fn');
-			log = log;
 		return fallback_value;
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/main.svelte
@@ -1,29 +1,25 @@
 <script>
-	let log = $state([]);
+	import Sub from "./sub.svelte";
 
-	const fallback_value = 1;
-	const nested = {
-		get fallback_value() {
-			log.push('nested.fallback_value');
-			return fallback_value;
-		}
-	}
-	const fallback_fn = () => {
-		log.push('fallback_fn');
-		return fallback_value;
-	}
-
-	const {
-		p0 = 1,
-		p1 = fallback_value,
-		p2 = nested.fallback_value,
-		p3 = fallback_fn(),
-		p4 = 1,
-		p5 = fallback_value,
-		p6 = nested.fallback_value,
-		p7 = fallback_fn()
-	} = $props();
+	let p0 = $state(0);
+	let p1 = $state(0);
+	let p2 = $state(0);
+	let p3 = $state(0);
+	let p4 = $state();
+	let p5 = $state();
+	let p6 = $state();
+	let p7 = $state();
 </script>
 
-<p>props: {p0} {p1} {p2} {p3} {p4} {p5} {p6} {p7}</p>
-<p>log: {log}</p>
+<Sub {p0} {p1} {p2} {p3} {p4} {p5} {p6} {p7} />
+
+<button onclick={() => {
+  p0 = undefined;
+  p1 = undefined;
+  p2 = undefined;
+  p3 = undefined;
+  p4 = undefined;
+  p5 = undefined;
+  p6 = undefined;
+  p7 = undefined;
+}}>Set all to undefined</button>

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/sub.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-lazy/sub.svelte
@@ -1,0 +1,29 @@
+<script>
+	let log = $state([]);
+
+	const fallback_value = 1;
+	const nested = {
+		get fallback_value() {
+			log.push('nested.fallback_value');
+			return fallback_value;
+		}
+	}
+	const fallback_fn = () => {
+		log.push('fallback_fn');
+		return fallback_value;
+	}
+
+	const {
+		p0 = 1,
+		p1 = fallback_value,
+		p2 = nested.fallback_value,
+		p3 = fallback_fn(),
+		p4 = 1,
+		p5 = fallback_value,
+		p6 = nested.fallback_value,
+		p7 = fallback_fn()
+	} = $props();
+</script>
+
+<p>props: {p0} {p1} {p2} {p3} {p4} {p5} {p6} {p7}</p>
+<p>log: {log}</p>

--- a/packages/svelte/tests/runtime-runes/samples/props-spread-fallback/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-spread-fallback/_config.js
@@ -48,7 +48,7 @@ export default test({
 			`
 				<button>change propA</button>
 				<button>change propB</button>
-				<p>true</p>
+				<p>true fallback</p>
 			`
 		);
 	}


### PR DESCRIPTION
closes #9948

~Draft mode because~ I came across an interesting question with regards to accessors and default values. Right now, setting a component property to `undefined` through its accessor (`component.property = undefined`) will set it to actually `undefined` instead of the default value. One could argue this is correct since implementation-wise this isn't looking for what's coming in from the property, instead it's updating the internal state with a new value. Semantically one could argue it should apply the fallback value (change should be straightforward, change the setter from `set x($$value) {..}` to `set x($$value = fallback) {..}`) since it's setting the property, just through another path. Semantically one could also argue that setting it through the accessor is more direct than through a property, and so it shouldn't apply.
We need to make a decision here. I slightly lean towards "applies default value".
Update: decided

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
