### PR TITLE
feat: add support for webkitdirectory DOM boolean attribute

### DIFF
--- a/.changeset/beige-cobras-smoke.md
+++ b/.changeset/beige-cobras-smoke.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: add support for webkitdirectory DOM boolean attribute

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1056,6 +1056,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	type?: HTMLInputTypeAttribute | undefined | null;
 	value?: any;
 	width?: number | string | undefined | null;
+	webkitdirectory?: boolean | undefined | null;
 
 	'on:change'?: ChangeEventHandler<HTMLInputElement> | undefined | null;
 	onchange?: ChangeEventHandler<HTMLInputElement> | undefined | null;

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -83,7 +83,8 @@ export const DOMBooleanAttributes = [
 	'required',
 	'reversed',
 	'seamless',
-	'selected'
+	'selected',
+	'webkitdirectory'
 ];
 
 export const namespace_svg = 'http://www.w3.org/2000/svg';


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/7872. @dummdidumm is there anything else I'm missing here?