### PR TITLE
fix: better await block scope analysis

### DIFF
--- a/packages/svelte/tests/runtime-legacy/samples/binding-select-late-4/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-select-late-4/_config.js
@@ -1,0 +1,12 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await new Promise((r) => setTimeout(r, 200)); // wait for await block to resolve
+
+		const options = target.querySelectorAll('option');
+		assert.ok(!options[0].selected);
+		assert.ok(options[1].selected);
+		assert.ok(!options[2].selected);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/binding-select-late-4/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-select-late-4/main.svelte
@@ -1,0 +1,19 @@
+<script>
+	let promise = getNumbers();
+	let selected = 2;
+
+	async function getNumbers() {
+		await new Promise(resolve => setTimeout(resolve, 100));
+		return [1, 2, 3];
+	}
+</script>
+
+<select bind:value={selected}>
+	{#await promise}
+		<option>-1</option>
+	{:then numbers}
+		{#each numbers as number}
+			<option>{number}</option>
+		{/each}
+	{/await}
+</select>


### PR DESCRIPTION
The await block scope analysis was flawed because it did not set the scope for the value/error field before visiting those nodes, resulting in the wrong scopes getting references
as a byproduct, this fixes #8141

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
