### PR TITLE
chore: revert "check treeshakeability in CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,18 +60,3 @@ jobs:
       - name: build and check generated types
         if: (${{ success() }} || ${{ failure() }}) # ensures this step runs even if previous steps fail
         run: pnpm build && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please regenerate types locally and commit the changes after you have reviewed them"; git diff; exit 1); }
-
-  Treeshaking:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: pnpm
-      - name: install
-        run: pnpm install --frozen-lockfile
-      - name: check
-        run: cd packages/svelte && node scripts/check-treeshakeability.js


### PR DESCRIPTION
Turns out this is unnecessary — the check already happens, it was just erroneously passing prior to #10862 