### PR TITLE
chore: failing test for out-of-order `$:` execution

### DIFF
--- a/packages/svelte/tests/runtime-legacy/samples/reactive-statement-store/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-statement-store/_config.js
@@ -1,0 +1,13 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	skip: true, // failing test for https://github.com/sveltejs/svelte/issues/10787
+	html: `<button>3</button>`,
+	async test({ assert, target }) {
+		target.querySelector('button')?.click();
+		await tick();
+
+		assert.htmlEqual(target.innerHTML, `<button>1</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-statement-store/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-statement-store/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	let x = 1;
+	let y = true;
+	$: array = y ? [1, 2] : [1];
+	$: count = array.length === 2 && x ? 1 : 0;
+	$: sum = count + array.length;
+</script>
+
+<button
+	on:click={() => {
+		// order is important here: x must be updated before y
+		// in order to test that $: still runs in the correct order
+		x = 2;
+		y = false;
+	}}>{sum}</button
+>


### PR DESCRIPTION
pre effects, which also contain `$:` statements, are more controlled in legacy mode and should only run once per tick, in their defined order. Flushing them out of order can result in bugs. Related to #10795 and #10787
