### PR TITLE
fix: custom element boolean attribute incorrectly converted to true

### DIFF
--- a/packages/svelte/src/runtime/internal/Component.js
+++ b/packages/svelte/src/runtime/internal/Component.js
@@ -362,7 +362,8 @@ if (typeof HTMLElement === 'function') {
  */
 function get_custom_element_value(prop, value, props_definition, transform) {
 	const type = props_definition[prop]?.type;
-	value = type === 'Boolean' && typeof value !== 'boolean' ? value != null : value;
+	value =
+		type === 'Boolean' && typeof value !== 'boolean' ? value != null && value !== 'false' : value;
 	if (!transform || !props_definition[prop]) {
 		return value;
 	} else if (transform === 'toAttribute') {

--- a/packages/svelte/test/runtime-browser/custom-elements-samples/camel-case-attribute/main.svelte
+++ b/packages/svelte/test/runtime-browser/custom-elements-samples/camel-case-attribute/main.svelte
@@ -5,6 +5,8 @@
 			camelCase: { attribute: "camel-case" },
 			camelCase2: { reflect: true },
 			anArray: { attribute: "an-array", type: "Array", reflect: true },
+			aNumber: { attribute: "a-number", type: "Number", reflect: true },
+			aBoolean: { attribute: "a-boolean", type: "Boolean", reflect: true },
 		},
 	}}
 />
@@ -13,9 +15,11 @@
 	export let camelCase;
 	export let camelCase2;
 	export let anArray;
+	export let aNumber;
+	export let aBoolean;
 </script>
 
-<h1>{camelCase2} {camelCase}!</h1>
+<h1>{camelCase2} {camelCase}! {aNumber} {aBoolean}</h1>
 {#each anArray as item}
 	<p>{item}</p>
 {/each}

--- a/packages/svelte/test/runtime-browser/custom-elements-samples/camel-case-attribute/test.js
+++ b/packages/svelte/test/runtime-browser/custom-elements-samples/camel-case-attribute/test.js
@@ -4,29 +4,33 @@ import './main.svelte';
 
 export default async function (target) {
 	target.innerHTML =
-		'<custom-element camelcase2="Hello" camel-case="world" an-array="[1,2]"></custom-element>';
+		'<custom-element camelcase2="Hello" camel-case="world" an-array="[1,2]" a-number="9" a-boolean="false"></custom-element>';
 	await tick();
 	const el = target.querySelector('custom-element');
 
-	assert.equal(el.shadowRoot.innerHTML, '<h1>Hello world!</h1> <p>1</p><p>2</p>');
+	assert.equal(el.shadowRoot.innerHTML, '<h1>Hello world! 9 false</h1> <p>1</p><p>2</p>');
 
 	el.setAttribute('camel-case', 'universe');
 	el.setAttribute('an-array', '[3,4]');
 	el.setAttribute('camelcase2', 'Hi');
+	el.setAttribute('a-number', '8');
+	el.setAttribute('a-boolean', 'true');
 	await tick();
-	assert.equal(el.shadowRoot.innerHTML, '<h1>Hi universe!</h1> <p>3</p><p>4</p>');
+	assert.equal(el.shadowRoot.innerHTML, '<h1>Hi universe! 8 true</h1> <p>3</p><p>4</p>');
 	assert.equal(
 		target.innerHTML,
-		'<custom-element camelcase2="Hi" camel-case="universe" an-array="[3,4]"></custom-element>'
+		'<custom-element camelcase2="Hi" camel-case="universe" an-array="[3,4]" a-number="8" a-boolean=""></custom-element>'
 	);
 
 	el.camelCase = 'galaxy';
 	el.camelCase2 = 'Hey';
 	el.anArray = [5, 6];
+	el.aNumber = 7;
+	el.aBoolean = false;
 	await tick();
-	assert.equal(el.shadowRoot.innerHTML, '<h1>Hey galaxy!</h1> <p>5</p><p>6</p>');
+	assert.equal(el.shadowRoot.innerHTML, '<h1>Hey galaxy! 7 false</h1> <p>5</p><p>6</p>');
 	assert.equal(
 		target.innerHTML,
-		'<custom-element camelcase2="Hey" camel-case="universe" an-array="[5,6]"></custom-element>'
+		'<custom-element camelcase2="Hey" camel-case="universe" an-array="[5,6]" a-number="7"></custom-element>'
 	);
 }


### PR DESCRIPTION
fixes #10871 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
