### PR TITLE
chore: simplify blocks

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1282,6 +1282,12 @@ function create_block(parent, name, nodes, context) {
 		// It's important that close is the last statement in the block, as any previous statements
 		// could contain element insertions into the template, which the close statement needs to
 		// know of when constructing the list of current inner elements.
+
+		if (context.path.length > 0) {
+			// this is a block — return DOM so it can be attached directly to the effect
+			close = b.return(close.expression);
+		}
+
 		body.push(close);
 	}
 

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -2,7 +2,6 @@ import { is_promise } from '../../../common.js';
 import { hydrate_block_anchor } from '../hydration.js';
 import { remove } from '../reconciler.js';
 import {
-	current_block,
 	current_component_context,
 	flushSync,
 	set_current_component_context,
@@ -11,20 +10,7 @@ import {
 } from '../../runtime.js';
 import { destroy_effect, pause_effect, render_effect } from '../../reactivity/effects.js';
 import { DESTROYED, INERT } from '../../constants.js';
-
-/** @returns {import('../../types.js').AwaitBlock} */
-export function create_await_block() {
-	return {
-		// dom
-		d: null,
-		// effect
-		e: null,
-		// parent
-		p: /** @type {import('../../types.js').Block} */ (current_block),
-		// pending
-		n: true
-	};
-}
+import { create_block } from './utils.js';
 
 /**
  * @template V
@@ -36,7 +22,7 @@ export function create_await_block() {
  * @returns {void}
  */
 export function await_block(anchor, get_input, pending_fn, then_fn, catch_fn) {
-	const block = create_await_block();
+	const block = create_block();
 
 	const component_context = current_component_context;
 

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -202,8 +202,6 @@ function each(anchor, get_collection, flags, get_key, render_fn, fallback_fn, re
 
 		if (fallback) destroy_effect(fallback);
 	};
-
-	block.e = effect;
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -6,27 +6,13 @@ import {
 	set_current_hydration_fragment
 } from '../hydration.js';
 import { remove } from '../reconciler.js';
-import { current_block } from '../../runtime.js';
 import {
 	destroy_effect,
 	pause_effect,
 	render_effect,
 	resume_effect
 } from '../../reactivity/effects.js';
-
-/** @returns {import('#client').IfBlock} */
-function create_if_block() {
-	return {
-		// dom
-		d: null,
-		// effect
-		e: null,
-		// parent
-		p: /** @type {import('#client').Block} */ (current_block),
-		// value
-		v: false
-	};
-}
+import { create_block } from './utils.js';
 
 /**
  * @param {Comment} anchor
@@ -37,7 +23,7 @@ function create_if_block() {
  * @returns {void}
  */
 export function if_block(anchor, get_condition, consequent_fn, alternate_fn, elseif = false) {
-	const block = create_if_block();
+	const block = create_block();
 
 	hydrate_block_anchor(anchor);
 

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -154,6 +154,4 @@ export function if_block(anchor, get_condition, consequent_fn, alternate_fn, els
 			destroy_effect(alternate_effect);
 		}
 	};
-
-	block.e = if_effect;
 }

--- a/packages/svelte/src/internal/client/dom/blocks/key.js
+++ b/packages/svelte/src/internal/client/dom/blocks/key.js
@@ -3,6 +3,7 @@ import { hydrate_block_anchor } from '../hydration.js';
 import { remove } from '../reconciler.js';
 import { pause_effect, render_effect } from '../../reactivity/effects.js';
 import { safe_not_equal } from '../../reactivity/equality.js';
+import { create_block } from './utils.js';
 
 /**
  * @template V
@@ -12,7 +13,7 @@ import { safe_not_equal } from '../../reactivity/equality.js';
  * @returns {void}
  */
 export function key_block(anchor, get_key, render_fn) {
-	const block = {};
+	const block = create_block();
 
 	hydrate_block_anchor(anchor);
 
@@ -43,7 +44,6 @@ export function key_block(anchor, get_key, render_fn) {
 					() => {
 						render_fn(anchor);
 
-						// @ts-expect-error TODO this should be unnecessary
 						const dom = block.d;
 
 						return () => {

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -1,6 +1,7 @@
 import { render_effect } from '../../reactivity/effects.js';
 import { remove } from '../reconciler.js';
-import { current_block, untrack } from '../../runtime.js';
+import { untrack } from '../../runtime.js';
+import { create_block } from './utils.js';
 
 /**
  * @param {() => Function | null | undefined} get_snippet
@@ -9,15 +10,7 @@ import { current_block, untrack } from '../../runtime.js';
  * @returns {void}
  */
 export function snippet(get_snippet, node, ...args) {
-	/** @type {import('#client').SnippetBlock} */
-	const block = {
-		// dom
-		d: null,
-		// parent
-		p: /** @type {import('#client').Block} */ (current_block),
-		// effect
-		e: null
-	};
+	const block = create_block();
 
 	render_effect(() => {
 		// Only rerender when the snippet function itself changes,

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
@@ -1,6 +1,7 @@
 import { hydrate_block_anchor } from '../hydration.js';
 import { pause_effect, render_effect } from '../../reactivity/effects.js';
 import { remove } from '../reconciler.js';
+import { create_block } from './utils.js';
 
 // TODO this is very similar to `key`, can we deduplicate?
 
@@ -13,7 +14,7 @@ import { remove } from '../reconciler.js';
  * @returns {void}
  */
 export function component(anchor, get_component, render_fn) {
-	const block = {};
+	const block = create_block();
 
 	hydrate_block_anchor(anchor);
 
@@ -46,7 +47,6 @@ export function component(anchor, get_component, render_fn) {
 					() => {
 						render_fn(component);
 
-						// @ts-expect-error TODO this should be unnecessary
 						const dom = block.d;
 
 						return () => {

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -12,6 +12,7 @@ import { is_array } from '../../utils.js';
 import { set_should_intro } from '../../render.js';
 import { current_each_item_block, set_current_each_item_block } from './each.js';
 import { create_block } from './utils.js';
+import { current_block } from '../../runtime.js';
 
 /**
  * @param {import('#client').Block} block
@@ -41,6 +42,7 @@ function swap_block_dom(block, from, to) {
  * @returns {void}
  */
 export function element(anchor, get_tag, is_svg, render_fn) {
+	const parent_block = /** @type {import('#client').Block} */ (current_block);
 	const block = create_block();
 
 	hydrate_block_anchor(anchor);
@@ -126,7 +128,7 @@ export function element(anchor, get_tag, is_svg, render_fn) {
 					anchor.before(element);
 
 					if (prev_element) {
-						swap_block_dom(block.p, prev_element, element);
+						swap_block_dom(parent_block, prev_element, element);
 						prev_element.remove();
 					}
 				},

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -8,10 +8,10 @@ import {
 	resume_effect
 } from '../../reactivity/effects.js';
 import { remove } from '../reconciler.js';
-import { current_block } from '../../runtime.js';
 import { is_array } from '../../utils.js';
 import { set_should_intro } from '../../render.js';
 import { current_each_item_block, set_current_each_item_block } from './each.js';
+import { create_block } from './utils.js';
 
 /**
  * @param {import('#client').Block} block
@@ -41,15 +41,7 @@ function swap_block_dom(block, from, to) {
  * @returns {void}
  */
 export function element(anchor, get_tag, is_svg, render_fn) {
-	/** @type {import('#client').DynamicElementBlock} */
-	const block = {
-		// dom
-		d: null,
-		// effect
-		e: null,
-		// parent
-		p: /** @type {import('#client').Block} */ (current_block)
-	};
+	const block = create_block();
 
 	hydrate_block_anchor(anchor);
 

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -155,6 +155,4 @@ export function element(anchor, get_tag, is_svg, render_fn) {
 			destroy_effect(effect);
 		}
 	};
-
-	block.e = wrapper;
 }

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
@@ -53,8 +53,6 @@ export function head(render_fn) {
 				remove(current);
 			}
 		};
-
-		block.e = head_effect;
 	} finally {
 		if (is_hydrating) {
 			set_current_hydration_fragment(previous_hydration_fragment);

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
@@ -7,22 +7,14 @@ import {
 import { empty } from '../operations.js';
 import { render_effect } from '../../reactivity/effects.js';
 import { remove } from '../reconciler.js';
-import { current_block } from '../../runtime.js';
+import { create_block } from './utils.js';
 
 /**
  * @param {(anchor: Node | null) => void} render_fn
  * @returns {void}
  */
 export function head(render_fn) {
-	/** @type {import('#client').HeadBlock} */
-	const block = {
-		// dom
-		d: null,
-		// effect
-		e: null,
-		// parent
-		p: /** @type {import('#client').Block} */ (current_block)
-	};
+	const block = create_block();
 
 	// The head function may be called after the first hydration pass and ssr comment nodes may still be present,
 	// therefore we need to skip that when we detect that we're not in hydration mode.

--- a/packages/svelte/src/internal/client/dom/blocks/utils.js
+++ b/packages/svelte/src/internal/client/dom/blocks/utils.js
@@ -1,0 +1,13 @@
+import { current_block } from '../../runtime.js';
+
+/** @returns {import('#client').NormalBlock} */
+export function create_block() {
+	return {
+		// dom
+		d: null,
+		// effect
+		e: null,
+		// parent
+		p: /** @type {import('#client').Block} */ (current_block)
+	};
+}

--- a/packages/svelte/src/internal/client/dom/blocks/utils.js
+++ b/packages/svelte/src/internal/client/dom/blocks/utils.js
@@ -2,8 +2,6 @@
 export function create_block() {
 	return {
 		// dom
-		d: null,
-		// effect
-		e: null
+		d: null
 	};
 }

--- a/packages/svelte/src/internal/client/dom/blocks/utils.js
+++ b/packages/svelte/src/internal/client/dom/blocks/utils.js
@@ -1,6 +1,6 @@
 import { current_block } from '../../runtime.js';
 
-/** @returns {import('#client').NormalBlock} */
+/** @returns {import('#client').Block} */
 export function create_block() {
 	return {
 		// dom

--- a/packages/svelte/src/internal/client/dom/blocks/utils.js
+++ b/packages/svelte/src/internal/client/dom/blocks/utils.js
@@ -1,13 +1,9 @@
-import { current_block } from '../../runtime.js';
-
 /** @returns {import('#client').Block} */
 export function create_block() {
 	return {
 		// dom
 		d: null,
 		// effect
-		e: null,
-		// parent
-		p: /** @type {import('#client').Block} */ (current_block)
+		e: null
 	};
 }

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -77,7 +77,7 @@ const linear = (t) => t;
  * @param {(() => P) | null} get_params
  */
 export function animation(element, get_fn, get_params) {
-	var block = /** @type {import('#client').EachItemBlock} */ (current_each_item_block);
+	var block = /** @type {import('#client').EachItem} */ (current_each_item_block);
 
 	/** @type {DOMRect} */
 	var from;

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -178,7 +178,7 @@ export function comment(anchor) {
  * @param {Element | Text} dom
  * @param {boolean} is_fragment
  * @param {null | Text | Comment | Element} anchor
- * @returns {void}
+ * @returns {import('#client').TemplateNode | import('#client').TemplateNode[]}
  */
 function close_template(dom, is_fragment, anchor) {
 	/** @type {import('#client').TemplateNode | Array<import('#client').TemplateNode>} */
@@ -193,22 +193,22 @@ function close_template(dom, is_fragment, anchor) {
 	}
 
 	/** @type {import('#client').Block} */ (current_block).d = current;
+
+	return current;
 }
 
 /**
  * @param {null | Text | Comment | Element} anchor
  * @param {Element | Text} dom
- * @returns {void}
  */
 export function close(anchor, dom) {
-	close_template(dom, false, anchor);
+	return close_template(dom, false, anchor);
 }
 
 /**
  * @param {null | Text | Comment | Element} anchor
  * @param {Element | Text} dom
- * @returns {void}
  */
 export function close_frag(anchor, dom) {
-	close_template(dom, true, anchor);
+	return close_template(dom, true, anchor);
 }

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -211,13 +211,14 @@ function _mount(Component, options) {
 
 	should_intro = options.intro ?? false;
 
-	/** @type {import('#client').RootBlock} */
+	/** @type {import('#client').Block} */
 	const block = {
 		// dom
 		d: null,
 		// effect
 		e: null,
 		// parent
+		// @ts-expect-error
 		p: null
 	};
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -217,8 +217,6 @@ function _mount(Component, options) {
 		d: null,
 		// effect
 		e: null,
-		// intro
-		i: options.intro || false,
 		// parent
 		p: null
 	};

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -214,9 +214,7 @@ function _mount(Component, options) {
 	/** @type {import('#client').Block} */
 	const block = {
 		// dom
-		d: null,
-		// effect
-		e: null
+		d: null
 	};
 
 	/** @type {Exports} */
@@ -247,7 +245,7 @@ function _mount(Component, options) {
 		block,
 		true
 	);
-	block.e = effect;
+
 	const bound_event_listener = handle_event_propagation.bind(null, container);
 	const bound_document_event_listener = handle_event_propagation.bind(null, document);
 
@@ -297,7 +295,7 @@ function _mount(Component, options) {
 		if (dom !== null) {
 			remove(dom);
 		}
-		destroy_effect(/** @type {import('./types.js').Effect} */ (block.e));
+		destroy_effect(effect);
 	});
 
 	return component;

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -216,10 +216,7 @@ function _mount(Component, options) {
 		// dom
 		d: null,
 		// effect
-		e: null,
-		// parent
-		// @ts-expect-error
-		p: null
+		e: null
 	};
 
 	/** @type {Exports} */

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -49,7 +49,7 @@ export type Equals = (this: Value, value: unknown) => boolean;
 
 export type TemplateNode = Text | Element | Comment;
 
-export interface NormalBlock {
+export interface Block {
 	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
 	/** effect */
@@ -58,29 +58,14 @@ export interface NormalBlock {
 	p: Block;
 }
 
-export interface RootBlock {
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
-	/** effect */
-	e: null | Effect;
-	/** parent */
-	p: null;
-}
-
-export type EachBlock = {
+export type EachState = {
 	/** flags */
-	f: number;
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
+	flags: number;
 	/** items */
-	v: EachItemBlock[];
-	/** effect */
-	e: null | Effect;
-	/** parent */
-	p: Block;
+	items: EachItem[];
 };
 
-export type EachItemBlock = {
+export type EachItem = {
 	/** animation manager */
 	a: AnimationManager | null;
 	/** dom */
@@ -94,8 +79,6 @@ export type EachItemBlock = {
 	/** key */
 	k: unknown;
 };
-
-export type Block = RootBlock | NormalBlock | EachBlock | EachItemBlock;
 
 export interface TransitionManager {
 	/** Whether the `global` modifier was used (i.e. `transition:fade|global`) */

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -52,8 +52,6 @@ export type TemplateNode = Text | Element | Comment;
 export interface Block {
 	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
-	/** effect */
-	e: null | Effect;
 }
 
 export type EachState = {

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -49,65 +49,23 @@ export type Equals = (this: Value, value: unknown) => boolean;
 
 export type TemplateNode = Text | Element | Comment;
 
-export type RootBlock = {
+export interface NormalBlock {
 	/** dom */
 	d: null | TemplateNode | Array<TemplateNode>;
 	/** effect */
 	e: null | Effect;
-	/** intro */
-	i: boolean;
+	/** parent */
+	p: Block;
+}
+
+export interface RootBlock {
+	/** dom */
+	d: null | TemplateNode | Array<TemplateNode>;
+	/** effect */
+	e: null | Effect;
 	/** parent */
 	p: null;
-};
-
-export type IfBlock = {
-	/** value */
-	v: boolean;
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
-	/** effect */
-	e: null | Effect;
-	/** parent */
-	p: Block;
-};
-
-export type HeadBlock = {
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
-	/** effect */
-	e: null | Effect;
-	/** parent */
-	p: Block;
-};
-
-export type DynamicElementBlock = {
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
-	/** effect */
-	e: null | Effect;
-	/** parent */
-	p: Block;
-};
-
-export type DynamicComponentBlock = {
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
-	/** effect */
-	e: null | Effect;
-	/** parent */
-	p: Block;
-};
-
-export type AwaitBlock = {
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
-	/** effect */
-	e: null | Effect;
-	/** parent */
-	p: Block;
-	/** pending */
-	n: boolean;
-};
+}
 
 export type EachBlock = {
 	/** flags */
@@ -116,7 +74,7 @@ export type EachBlock = {
 	d: null | TemplateNode | Array<TemplateNode>;
 	/** items */
 	v: EachItemBlock[];
-	/** effewct */
+	/** effect */
 	e: null | Effect;
 	/** parent */
 	p: Block;
@@ -137,25 +95,7 @@ export type EachItemBlock = {
 	k: unknown;
 };
 
-export type SnippetBlock = {
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
-	/** parent */
-	p: Block;
-	/** effect */
-	e: null | Effect;
-};
-
-export type Block =
-	| RootBlock
-	| IfBlock
-	| AwaitBlock
-	| DynamicElementBlock
-	| DynamicComponentBlock
-	| HeadBlock
-	| EachBlock
-	| EachItemBlock
-	| SnippetBlock;
+export type Block = RootBlock | NormalBlock | EachBlock | EachItemBlock;
 
 export interface TransitionManager {
 	/** Whether the `global` modifier was used (i.e. `transition:fade|global`) */

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -54,8 +54,6 @@ export interface Block {
 	d: null | TemplateNode | Array<TemplateNode>;
 	/** effect */
 	e: null | Effect;
-	/** parent */
-	p: Block;
 }
 
 export type EachState = {

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -21,7 +21,7 @@ export default function Each_string_template($$anchor, $$props) {
 
 			/* Update */
 			$.text_effect(text, () => `${$.stringify($.unwrap(thing))}, `);
-			$.close($$anchor, text);
+			return $.close($$anchor, text);
 		},
 		null
 	);

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -27,7 +27,7 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 
 			/* Update */
 			$.text_effect(text, () => `clicks: ${$.stringify($.get(count))}`);
-			$.close($$anchor, text);
+			return $.close($$anchor, text);
 		}
 	});
 


### PR DESCRIPTION
This simplifies the `Block` construct ahead of its eventual removal:

- blocks are always the same (no difference between an await block and an each block etc)
- they don't reference the parent block (this was only used in one place — `<svelte:element>` — and it's easier to just grab a reference to the parent block before creating the child block)
- they don't reference their effects
- `{#each ...}` blocks now have a separate `EachState` object containing `flags` and `items`
- each item in `state.items` is an `EachItem`, formerly known as `EachItemBlock`
- we return `$.close(...)` or `$.close_frag(...)` from blocks, which will eventually allow us to assign DOM directly to an effect, rather than doing the indirect thing where we look up the current block and assign it there

The goal, once this is done, is to make effects responsible for managing their own DOM. This should remove a lot of repetitive code and make `effect.ondestroy` unnecessary.