### PR TITLE
chore: tidy up

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -8,7 +8,7 @@ import { reconcile_html, remove } from '../reconciler.js';
  * @returns {void}
  */
 export function html(dom, get_value, svg) {
-	/** @type {import('#client').TemplateNode | import('#client').TemplateNode[]} */
+	/** @type {import('#client').Dom} */
 	let html_dom;
 
 	/** @type {string} */

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -17,8 +17,8 @@ import { create_block } from './utils.js';
 /**
  * @param {Comment} anchor
  * @param {() => boolean} get_condition
- * @param {(anchor: Node) => import('#client').TemplateNode | import('#client').TemplateNode[]} consequent_fn
- * @param {null | ((anchor: Node) => import('#client').TemplateNode | import('#client').TemplateNode[])} alternate_fn
+ * @param {(anchor: Node) => import('#client').Dom} consequent_fn
+ * @param {null | ((anchor: Node) => import('#client').Dom)} alternate_fn
  * @param {boolean} [elseif] True if this is an `{:else if ...}` block rather than an `{#if ...}`, as that affects which transitions are considered 'local'
  * @returns {void}
  */
@@ -27,10 +27,10 @@ export function if_block(anchor, get_condition, consequent_fn, alternate_fn, els
 
 	hydrate_block_anchor(anchor);
 
-	/** @type {undefined | import('#client').TemplateNode | Array<import('#client').TemplateNode>} */
+	/** @type {undefined | import('#client').Dom} */
 	let consequent_dom;
 
-	/** @type {undefined | import('#client').TemplateNode | Array<import('#client').TemplateNode>} */
+	/** @type {undefined | import('#client').Dom} */
 	let alternate_dom;
 
 	/** @type {import('#client').Effect | null} */

--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -29,7 +29,7 @@ export function create_fragment_with_script_from_html(html) {
 }
 
 /**
- * @param {Array<import('../types.js').TemplateNode> | import('../types.js').TemplateNode} current
+ * @param {import('#client').Dom} current
  * @param {Text | Element | Comment} sibling
  * @returns {Text | Element | Comment}
  */
@@ -49,7 +49,7 @@ export function insert(current, sibling) {
 }
 
 /**
- * @param {Array<import('../types.js').TemplateNode> | import('../types.js').TemplateNode} current
+ * @param {import('#client').Dom} current
  */
 export function remove(current) {
 	if (is_array(current)) {

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -178,10 +178,10 @@ export function comment(anchor) {
  * @param {Element | Text} dom
  * @param {boolean} is_fragment
  * @param {null | Text | Comment | Element} anchor
- * @returns {import('#client').TemplateNode | import('#client').TemplateNode[]}
+ * @returns {import('#client').Dom}
  */
 function close_template(dom, is_fragment, anchor) {
-	/** @type {import('#client').TemplateNode | Array<import('#client').TemplateNode>} */
+	/** @type {import('#client').Dom} */
 	var current = is_fragment
 		? is_array(dom)
 			? dom

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -49,9 +49,11 @@ export type Equals = (this: Value, value: unknown) => boolean;
 
 export type TemplateNode = Text | Element | Comment;
 
+export type Dom = TemplateNode | TemplateNode[];
+
 export interface Block {
 	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
+	d: null | Dom;
 }
 
 export type EachState = {
@@ -65,7 +67,7 @@ export type EachItem = {
 	/** animation manager */
 	a: AnimationManager | null;
 	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
+	d: null | Dom;
 	/** effect */
 	e: Effect;
 	/** item */
@@ -138,15 +140,6 @@ export type StoreReferencesContainer = Record<
 >;
 
 export type ActionPayload<P> = { destroy?: () => void; update?: (value: P) => void };
-
-export type Render = {
-	/** dom */
-	d: null | TemplateNode | Array<TemplateNode>;
-	/** effect */
-	e: null | Effect;
-	/** prev */
-	p: Render | null;
-};
 
 export type Raf = {
 	/** Alias for `requestAnimationFrame`, exposed in such a way that we can override in tests */


### PR DESCRIPTION
small QOL fix — we have a lot of `TemplateNode | TemplateNode[]`, which is a pain to write in JSDoc. this simplifies things a bit

also got rid of unused `Render` interface