### PR TITLE
only run render effect for children of non-void <svelte:element>

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -34,6 +34,20 @@ function swap_block_dom(effect, from, to) {
 	}
 }
 
+let void_elements = new Map();
+
+/**
+ * @param {Element} element
+ * @returns {boolean}
+ */
+function is_void(element) {
+	if (!void_elements.has(element.nodeName)) {
+		void_elements.set(element.nodeName, !element.outerHTML.includes('/'));
+	}
+
+	return void_elements.get(element.nodeName);
+}
+
 /**
  * @param {Comment} anchor
  * @param {() => string} get_tag
@@ -110,7 +124,7 @@ export function element(anchor, get_tag, is_svg, render_fn) {
 						? document.createElementNS(ns, next_tag)
 						: document.createElement(next_tag);
 
-				if (render_fn) {
+				if (render_fn && !is_void(element)) {
 					let anchor;
 					if (hydrating) {
 						// Use the existing ssr comment as the anchor so that the inner open and close
@@ -120,6 +134,7 @@ export function element(anchor, get_tag, is_svg, render_fn) {
 						anchor = empty();
 						element.appendChild(anchor);
 					}
+
 					render_fn(element, anchor);
 				}
 


### PR DESCRIPTION
I don't know if this is a good idea or not, but I encountered it while looking at the `hydrate_block_anchor` function:

https://github.com/sveltejs/svelte/blob/fe7c45ba13961f275758984d54061d4897fdde3a/packages/svelte/src/internal/client/dom/hydration.js#L79-L98

In all but 5 tests, `anchor` is a `Comment`. 3 of those tests relate to this... 

```svelte
<svelte:element this={somethingvoid}>
  <p>invalid children (because this is a void element)</p>
</svelte:element>
```

...and if we can avoid creating the children for these elements then there'll only be 2 tests where `anchor` isn't a `Comment`, and if we can figure out those edge cases then maybe we can simplify that function by enforcing that its argument is _always_ a `Comment`. Fewer `if` branches makes everything more understandable, and every microsecond counts during hydration.

It turns out we can determine which elements are void by checking to see if `element.outerHTML` contains a solidus (`/`). Admittedly, this trades work in one place for work in another. Just putting it up for discussion for now.