### PR TITLE
chore: code-golf a bit

### DIFF
--- a/packages/svelte/scripts/check-treeshakeability.js
+++ b/packages/svelte/scripts/check-treeshakeability.js
@@ -109,7 +109,7 @@ const bundle = await bundle_code(
 	).js.code
 );
 
-if (!bundle.includes('current_hydration_fragment')) {
+if (!bundle.includes('hydrate_nodes')) {
 	// eslint-disable-next-line no-console
 	console.error(`✅ Hydration code treeshakeable`);
 } else {

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -15,27 +15,26 @@ export function css_props(anchor, is_html, props, component) {
 	hydrate_block_anchor(anchor);
 
 	/** @type {HTMLElement | SVGElement} */
-	let tag;
+	let element;
 
 	/** @type {Text | Comment} */
 	let component_anchor;
 
 	if (hydrating) {
 		// Hydration: css props element is surrounded by a ssr comment ...
-		tag = /** @type {HTMLElement | SVGElement} */ (hydrate_nodes[0]);
+		element = /** @type {HTMLElement | SVGElement} */ (hydrate_nodes[0]);
 		// ... and the child(ren) of the css props element is also surround by a ssr comment
-		component_anchor = /** @type {Comment} */ (tag.firstChild);
+		component_anchor = /** @type {Comment} */ (element.firstChild);
 	} else {
 		if (is_html) {
-			tag = document.createElement('div');
-			tag.style.display = 'contents';
+			element = document.createElement('div');
+			element.style.display = 'contents';
 		} else {
-			tag = document.createElementNS(namespace_svg, 'g');
+			element = document.createElementNS(namespace_svg, 'g');
 		}
 
-		anchor.before(tag);
-		component_anchor = empty();
-		tag.appendChild(component_anchor);
+		anchor.before(element);
+		component_anchor = element.appendChild(empty());
 	}
 
 	component(component_anchor);
@@ -48,18 +47,18 @@ export function css_props(anchor, is_html, props, component) {
 
 		for (const key in current_props) {
 			if (!(key in next_props)) {
-				tag.style.removeProperty(key);
+				element.style.removeProperty(key);
 			}
 		}
 
 		for (const key in next_props) {
-			tag.style.setProperty(key, next_props[key]);
+			element.style.setProperty(key, next_props[key]);
 		}
 
 		current_props = next_props;
 	});
 
 	effect.ondestroy = () => {
-		remove(tag);
+		remove(element);
 	};
 }

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
@@ -18,6 +18,8 @@ export function head(render_fn) {
 		update_hydrate_nodes(document.head.firstChild);
 	}
 
+	var anchor = document.head.appendChild(empty());
+
 	try {
 		/** @type {import('#client').Dom | null} */
 		var dom = null;
@@ -28,13 +30,7 @@ export function head(render_fn) {
 				head_effect.dom = dom = null;
 			}
 
-			let anchor = null;
-			if (!hydrating) {
-				anchor = empty();
-				document.head.appendChild(anchor);
-			}
-
-			dom = render_fn(anchor) ?? null;
+			dom = render_fn(hydrating ? null : anchor) ?? null;
 		});
 
 		head_effect.ondestroy = () => {


### PR DESCRIPTION
a few more cosmetic changes, plus a couple of small fixes:

- `tag` should always be a `string`. If it's an `Element`, the variable should be `element`
- `node = parent.appendChild(empty())` minifies better than `node = empty(); parent.appendChild(node)`, and often allows us to simplify code by collapsing a sequence of statements into e.g. a single ternary expression
- we were appending an `empty()` to the `<head>` every time the `<svelte:head>` effect re-ran. oops
- i broke the treeshaking script in #10891. oops