### PR TITLE
chore: more hydration stuff

### DIFF
--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -90,22 +90,19 @@ function get_hydrate_nodes(node, insert_text = false) {
 export function hydrate_block_anchor(node) {
 	if (!hydrating) return;
 
-	if (node.nodeType === 8) {
-		// @ts-ignore
-		let nodes = node.$$fragment;
-		if (nodes === undefined) {
-			nodes = get_hydrate_nodes(node);
-		} else {
-			schedule_task(() => {
-				// @ts-expect-error clean up memory
-				node.$$fragment = undefined;
-			});
-		}
-		set_hydrate_nodes(nodes);
+	// if hydrating, `node` is a `Comment`
+
+	// @ts-ignore
+	let nodes = node.$$fragment;
+	if (nodes === undefined) {
+		nodes = get_hydrate_nodes(node);
 	} else {
-		const first_child = /** @type {Element | null} */ (node.firstChild);
-		set_hydrate_nodes(first_child === null ? [] : [first_child]);
+		schedule_task(() => {
+			// @ts-expect-error clean up memory
+			node.$$fragment = undefined;
+		});
 	}
+	set_hydrate_nodes(nodes);
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -90,18 +90,8 @@ function get_hydrate_nodes(node, insert_text = false) {
 export function hydrate_block_anchor(node) {
 	if (!hydrating) return;
 
-	// if hydrating, `node` is a `Comment`
-
 	// @ts-ignore
-	let nodes = node.$$fragment;
-	if (nodes === undefined) {
-		nodes = get_hydrate_nodes(node);
-	} else {
-		schedule_task(() => {
-			// @ts-expect-error clean up memory
-			node.$$fragment = undefined;
-		});
-	}
+	var nodes = node.$$fragment ?? get_hydrate_nodes(node);
 	set_hydrate_nodes(nodes);
 }
 
@@ -121,6 +111,10 @@ export function capture_fragment_from_node(node) {
 		const target = /** @type {Node} */ (last_child.nextSibling);
 		// @ts-ignore
 		target.$$fragment = nodes;
+		schedule_task(() => {
+			// @ts-expect-error clean up memory
+			target.$$fragment = undefined;
+		});
 		return target;
 	}
 	return node;


### PR DESCRIPTION
another small PR that tidies things up a bit:

- after recent hydration changes, `hydrate_block_anchor` is only ever called with a `Comment` during hydration, which means we can simplify that function
- the cleanup (`node.$$fragment = undefined`) should go in the place where it is initially set, not in an unrelated function

As a result of this change, `hydrate_block_anchor` and `update_hydrate_nodes` are almost identical, so I'm not 100% clear on why we have both, but I figured we could make this innocuous change as a starting point