### PR TITLE
chore: only specify use_clone_node when necessary

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1169,18 +1169,14 @@ function create_block(parent, name, nodes, context) {
 			)
 		);
 
-		body.push(
-			b.var(
-				id,
-				b.call(
-					'$.open',
-					b.id('$$anchor'),
-					b.literal(!state.metadata.context.template_needs_import_node),
-					template_name
-				)
-			),
-			...state.init
-		);
+		/** @type {import('estree').Expression[]} */
+		const args = [b.id('$$anchor'), template_name];
+
+		if (state.metadata.context.template_needs_import_node) {
+			args.push(b.false);
+		}
+
+		body.push(b.var(id, b.call('$.open', ...args)), ...state.init);
 		close = b.stmt(b.call('$.close', b.id('$$anchor'), id));
 	} else if (is_single_child_not_needing_template) {
 		context.visit(trimmed[0], state);
@@ -1227,17 +1223,14 @@ function create_block(parent, name, nodes, context) {
 					)
 				);
 
-				body.push(
-					b.var(
-						id,
-						b.call(
-							'$.open_frag',
-							b.id('$$anchor'),
-							b.literal(!state.metadata.context.template_needs_import_node),
-							template_name
-						)
-					)
-				);
+				/** @type {import('estree').Expression[]} */
+				const args = [b.id('$$anchor'), template_name];
+
+				if (state.metadata.context.template_needs_import_node) {
+					args.push(b.false);
+				}
+
+				body.push(b.var(id, b.call('$.open_frag', ...args)));
 			}
 
 			body.push(...state.init);

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -98,7 +98,7 @@ if (typeof HTMLElement === 'function') {
 					 * @param {Element} anchor
 					 */
 					return (anchor) => {
-						const node = open(anchor, true, () => {
+						const node = open(anchor, () => {
 							const slot = document.createElement('slot');
 							if (name !== 'default') {
 								slot.name = name;

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -106,23 +106,23 @@ function open_template(is_fragment, use_clone_node, anchor, template_element_fn)
 
 /**
  * @param {null | Text | Comment | Element} anchor
- * @param {boolean} use_clone_node
- * @param {() => Node} [template_element_fn]
+ * @param {() => Node} template_element_fn
+ * @param {boolean} [use_clone_node]
  * @returns {Element | DocumentFragment | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function open(anchor, use_clone_node, template_element_fn) {
+export function open(anchor, template_element_fn, use_clone_node = true) {
 	return open_template(false, use_clone_node, anchor, template_element_fn);
 }
 
 /**
  * @param {null | Text | Comment | Element} anchor
- * @param {boolean} use_clone_node
- * @param {() => Node} [template_element_fn]
+ * @param {() => Node} template_element_fn
+ * @param {boolean} [use_clone_node]
  * @returns {Element | DocumentFragment | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function open_frag(anchor, use_clone_node, template_element_fn) {
+export function open_frag(anchor, template_element_fn, use_clone_node = true) {
 	return open_template(true, use_clone_node, anchor, template_element_fn);
 }
 
@@ -135,7 +135,7 @@ const comment_template = template('<!>', true);
 /*#__NO_SIDE_EFFECTS__*/
 export function space_frag(anchor) {
 	/** @type {Node | null} */
-	var node = /** @type {any} */ (open(anchor, true, space_template));
+	var node = /** @type {any} */ (open(anchor, space_template));
 	// if an {expression} is empty during SSR, there might be no
 	// text node to hydrate (or an anchor comment is falsely detected instead)
 	//  — we must therefore create one
@@ -169,7 +169,7 @@ export function space(anchor) {
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function comment(anchor) {
-	return open_frag(anchor, true, comment_template);
+	return open_frag(anchor, comment_template);
 }
 
 /**

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -12,7 +12,7 @@ export default function Main($$anchor, $$props) {
 	let x = 'test';
 	let y = () => 'test';
 	/* Init */
-	var fragment = $.open_frag($$anchor, false, frag);
+	var fragment = $.open_frag($$anchor, frag, false);
 	var div = $.child_frag(fragment);
 	var svg = $.sibling($.sibling(div, true));
 	var custom_element = $.sibling($.sibling(svg, true));

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -10,7 +10,7 @@ export default function Hello_world($$anchor, $$props) {
 	$.init();
 
 	/* Init */
-	var h1 = $.open($$anchor, true, frag);
+	var h1 = $.open($$anchor, frag);
 
 	$.close($$anchor, h1);
 	$.pop();

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -18,7 +18,7 @@ export default function State_proxy_literal($$anchor, $$props) {
 	let str = $.source('');
 	let tpl = $.source(``);
 	/* Init */
-	var fragment = $.open_frag($$anchor, true, frag);
+	var fragment = $.open_frag($$anchor, frag);
 	var input = $.child_frag(fragment);
 
 	$.remove_input_attr_defaults(input);


### PR DESCRIPTION
rather than always doing `$.open($$anchor, true, frag)` — where the `true` means 'it is safe to use `cloneNode`' — we should treat custom elements as the irritating edge case they are and avoiding polluting everyone else's bundles