### PR TITLE
feat: use short comments

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -1521,7 +1521,7 @@ const template_visitors = {
 		if (node.fallback) {
 			const fallback_stmts = create_block(node, node.fallback.nodes, context);
 			fallback_stmts.unshift(
-				b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!--ssr:each_else-->')))
+				b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!ssr:each_else>')))
 			);
 			state.template.push(
 				t_statement(
@@ -1549,14 +1549,14 @@ const template_visitors = {
 
 		const consequent = create_block(node, node.consequent.nodes, context);
 		consequent.unshift(
-			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!--ssr:if:true-->')))
+			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!ssr:if:true>')))
 		);
 
 		const alternate = node.alternate
 			? /** @type {import('estree').BlockStatement} */ (context.visit(node.alternate))
 			: b.block([]);
 		alternate.body.unshift(
-			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!--ssr:if:false-->')))
+			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!ssr:if:false>')))
 		);
 
 		state.template.push(

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -637,7 +637,7 @@ export function ensure_array_like(array_like_or_iterator) {
 /** @param {{ anchor: number }} payload */
 export function create_anchor(payload) {
 	const depth = payload.anchor++;
-	return `<!--ssr:${depth}-->`;
+	return `<!ssr:${depth}>`;
 }
 
 /** @returns {[() => false, (value: boolean) => void]} */

--- a/packages/svelte/tests/html_equal.js
+++ b/packages/svelte/tests/html_equal.js
@@ -77,7 +77,7 @@ export function normalize_html(
 	try {
 		const node = window.document.createElement('div');
 		node.innerHTML = html
-			.replace(/(<!--.*?-->)/g, preserveComments ? '$1' : '')
+			.replace(/(<!(--)?.*?\2>)/g, preserveComments ? '$1' : '')
 			.replace(/(data-svelte-h="[^"]+")/g, removeDataSvelte ? '' : '$1')
 			.replace(/>[ \t\n\r\f]+</g, '><')
 			.trim();
@@ -137,12 +137,12 @@ export function setup_html_equal(options = {}) {
 				withoutNormalizeHtml
 					? normalize_new_line(actual)
 							.replace(/(\sdata-svelte-h="[^"]+")/g, options.removeDataSvelte ? '' : '$1')
-							.replace(/(<!--.*?-->)/g, preserveComments !== false ? '$1' : '')
+							.replace(/(<!(--)?.*?\2>)/g, preserveComments !== false ? '$1' : '')
 					: normalize_html(window, actual, { ...options, preserveComments }),
 				withoutNormalizeHtml
 					? normalize_new_line(expected)
 							.replace(/(\sdata-svelte-h="[^"]+")/g, options.removeDataSvelte ? '' : '$1')
-							.replace(/(<!--.*?-->)/g, preserveComments !== false ? '$1' : '')
+							.replace(/(<!(--)?.*?\2>)/g, preserveComments !== false ? '$1' : '')
 					: normalize_html(window, expected, { ...options, preserveComments }),
 				message
 			);

--- a/packages/svelte/tests/html_equal.js
+++ b/packages/svelte/tests/html_equal.js
@@ -135,15 +135,15 @@ export function setup_html_equal(options = {}) {
 		try {
 			assert.deepEqual(
 				withoutNormalizeHtml
-					? normalize_new_line(actual)
+					? normalize_new_line(actual.trim())
 							.replace(/(\sdata-svelte-h="[^"]+")/g, options.removeDataSvelte ? '' : '$1')
 							.replace(/(<!(--)?.*?\2>)/g, preserveComments !== false ? '$1' : '')
-					: normalize_html(window, actual, { ...options, preserveComments }),
+					: normalize_html(window, actual.trim(), { ...options, preserveComments }),
 				withoutNormalizeHtml
-					? normalize_new_line(expected)
+					? normalize_new_line(expected.trim())
 							.replace(/(\sdata-svelte-h="[^"]+")/g, options.removeDataSvelte ? '' : '$1')
 							.replace(/(<!(--)?.*?\2>)/g, preserveComments !== false ? '$1' : '')
-					: normalize_html(window, expected, { ...options, preserveComments }),
+					: normalize_html(window, expected.trim(), { ...options, preserveComments }),
 				message
 			);
 		} catch (e) {

--- a/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected-head.html
+++ b/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected-head.html
@@ -1,6 +1,6 @@
-<!--ssr:0-->
+<!ssr:0>
 <title>Some Title</title>
 <link rel="canonical" href="/">
 <meta name="description" content="some description">
 <meta name="keywords" content="some keywords">
-<!--ssr:0-->
+<!ssr:0>

--- a/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected.html
@@ -1,1 +1,1 @@
-<!--ssr:0--><div>Just a dummy page.</div><!--ssr:0-->
+<!ssr:0><div>Just a dummy page.</div><!ssr:0>


### PR DESCRIPTION
Closes #10609. So far, this just replaces `<!--x-->` with `<!x>`. I seem to recall there being some issue with JSDOM (or something) not recognising these as comments, but it appears to no longer be an issue.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
