### PR TITLE
feat: more efficient `if` block compiler output

### DIFF
--- a/.changeset/many-rockets-give.md
+++ b/.changeset/many-rockets-give.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: more efficient if block compiler output

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2573,14 +2573,19 @@ export const template_visitors = {
 		const args = [
 			context.state.node,
 			b.thunk(/** @type {import('estree').Expression} */ (context.visit(node.test))),
-			b.arrow([b.id('$$anchor')], consequent),
-			node.alternate
-				? b.arrow(
-						[b.id('$$anchor')],
-						/** @type {import('estree').BlockStatement} */ (context.visit(node.alternate))
-					)
-				: b.literal(null)
+			b.arrow([b.id('$$anchor')], consequent)
 		];
+
+		if (node.alternate || node.elseif) {
+			args.push(
+				node.alternate
+					? b.arrow(
+							[b.id('$$anchor')],
+							/** @type {import('estree').BlockStatement} */ (context.visit(node.alternate))
+						)
+					: b.literal(null)
+			);
+		}
 
 		if (node.elseif) {
 			// We treat this...

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -12,11 +12,17 @@ import {
  * @param {Comment} anchor
  * @param {() => boolean} get_condition
  * @param {(anchor: Node) => import('#client').Dom} consequent_fn
- * @param {null | ((anchor: Node) => import('#client').Dom)} alternate_fn
+ * @param {null | ((anchor: Node) => import('#client').Dom)} [alternate_fn]
  * @param {boolean} [elseif] True if this is an `{:else if ...}` block rather than an `{#if ...}`, as that affects which transitions are considered 'local'
  * @returns {void}
  */
-export function if_block(anchor, get_condition, consequent_fn, alternate_fn, elseif = false) {
+export function if_block(
+	anchor,
+	get_condition,
+	consequent_fn,
+	alternate_fn = null,
+	elseif = false
+) {
 	hydrate_block_anchor(anchor);
 
 	/** @type {import('#client').Effect | null} */


### PR DESCRIPTION
Small tweak. Given this input...

```svelte
{#if condition}
  <p>hello</p>
{/if}
```

...we currently generate this:

```js
$.if(
  node,
  () => $.get(condition),
  ($$anchor) => {
    /* Init */
    var p = $.open($$anchor, frag_1);

    return $.close($$anchor, p);
  },
  null
);
```

With this PR:

```js
$.if(node, () => $.get(condition), ($$anchor) => {
  /* Init */
  var p = $.open($$anchor, frag_1);

  return $.close($$anchor, p);
});
```

My eventual goal (will take some time to get there):

```js
$.if(node, () => $.get(condition), ($$anchor) => $.append($$anchor, frag_1()));
```


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
