### PR TITLE
fix: Add `dirname` to HTMLInputAttributes

### DIFF
--- a/.changeset/ten-singers-cough.md
+++ b/.changeset/ten-singers-cough.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: Add `dirname` to HTMLInputAttributes

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1030,6 +1030,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	capture?: boolean | 'user' | 'environment' | undefined | null; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
 	checked?: boolean | undefined | null;
 	crossorigin?: string | undefined | null;
+	dirname?: string | undefined | null;
 	disabled?: boolean | undefined | null;
 	form?: string | undefined | null;
 	formaction?: string | undefined | null;


### PR DESCRIPTION
`dirname` is a valid attribute for `input`. This adds it to the typings.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/dirname:

> The `dirname` attribute can be used on [`<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) and [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) elements
