### PR TITLE
chore: simplify updates

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -62,13 +62,6 @@ export function client_component(source, analysis, options) {
 				error(null, 'INTERNAL', 'update.push should not be called outside create_block');
 			return a;
 		},
-		get update_effects() {
-			/** @type {any[]} */
-			const a = [];
-			a.push = () =>
-				error(null, 'INTERNAL', 'update_effects.push should not be called outside create_block');
-			return a;
-		},
 		get after_update() {
 			/** @type {any[]} */
 			const a = [];

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -31,11 +31,8 @@ export interface ComponentClientTransformState extends ClientTransformState {
 
 	/** Stuff that happens before the render effect(s) */
 	readonly init: Statement[];
-	/** Stuff that happens inside separate render effects (due to call expressions) */
-	readonly update_effects: Statement[];
 	/** Stuff that happens inside the render effect */
 	readonly update: {
-		init?: Statement;
 		/** If the update array only contains a single entry, this singular entry will be used, if present */
 		singular?: Statement;
 		/** Used if condition for singular prop is false (see comment above) */

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
@@ -7,7 +7,6 @@ export default function Bind_this($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
-	/* Init */
 	var fragment = $.comment($$anchor);
 	var node = $.first_child(fragment);
 

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -11,23 +11,24 @@ export default function Main($$anchor, $$props) {
 	// needs to be a snapshot test because jsdom does auto-correct the attribute casing
 	let x = 'test';
 	let y = () => 'test';
-	/* Init */
 	var fragment = $.open_frag($$anchor, frag, false);
 	var div = $.first_child(fragment);
+	var div_foobar;
 	var svg = $.sibling($.sibling(div, true));
+	var svg_viewBox;
 	var custom_element = $.sibling($.sibling(svg, true));
+	var custom_element_fooBar;
 	var div_1 = $.sibling($.sibling(custom_element, true));
+
+	$.attr_effect(div_1, "foobar", y);
+
 	var svg_1 = $.sibling($.sibling(div_1, true));
+
+	$.attr_effect(svg_1, "viewBox", y);
+
 	var custom_element_1 = $.sibling($.sibling(svg_1, true));
 
-	/* Update */
-	$.attr_effect(div_1, "foobar", y);
-	$.attr_effect(svg_1, "viewBox", y);
 	$.set_custom_element_data_effect(custom_element_1, "fooBar", y);
-
-	var div_foobar;
-	var svg_viewBox;
-	var custom_element_fooBar;
 
 	$.render_effect(() => {
 		if (div_foobar !== (div_foobar = x)) {

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -7,7 +7,6 @@ export default function Each_string_template($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
-	/* Init */
 	var fragment = $.comment($$anchor);
 	var node = $.first_child(fragment);
 
@@ -16,10 +15,8 @@ export default function Each_string_template($$anchor, $$props) {
 		() => ['foo', 'bar', 'baz'],
 		1,
 		($$anchor, thing, $$index) => {
-			/* Init */
 			var text = $.space_frag($$anchor);
 
-			/* Update */
 			$.text_effect(text, () => `${$.stringify($.unwrap(thing))}, `);
 			return $.close($$anchor, text);
 		},

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -13,7 +13,6 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 	}
 
 	const plusOne = (num) => num + 1;
-	/* Init */
 	var fragment = $.comment($$anchor);
 	var node = $.first_child(fragment);
 
@@ -22,10 +21,8 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 		onmouseup,
 		onmouseenter: () => $.set(count, $.proxy(plusOne($.get(count)))),
 		children: ($$anchor, $$slotProps) => {
-			/* Init */
 			var text = $.space_frag($$anchor);
 
-			/* Update */
 			$.text_effect(text, () => `clicks: ${$.stringify($.get(count))}`);
 			return $.close($$anchor, text);
 		}

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -9,7 +9,6 @@ export default function Hello_world($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
-	/* Init */
 	var h1 = $.open($$anchor, frag);
 
 	$.close($$anchor, h1);

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -17,7 +17,6 @@ export default function State_proxy_literal($$anchor, $$props) {
 
 	let str = $.source('');
 	let tpl = $.source(``);
-	/* Init */
 	var fragment = $.open_frag($$anchor, frag);
 	var input = $.first_child(fragment);
 

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
@@ -7,7 +7,6 @@ export default function Svelte_element($$anchor, $$props) {
 	$.push($$props, true);
 
 	let tag = $.prop($$props, "tag", 3, 'hr');
-	/* Init */
 	var fragment = $.comment($$anchor);
 	var node = $.first_child(fragment);
 


### PR DESCRIPTION
There's more where this came from, but this is the immediate low-hanging fruit.

At the moment we separate things into an 'init' and 'update' phase but it's really quite unnecessary — we can make our lives simpler by putting everything except groupable render effects into the init phase.

I have a hunch that this will eventually also unlock a simpler hydration algorithm (that doesn't for example rely on `$$fragment`) but this is worthwhile independently of that.