### PR TITLE
fix: Add `elementtiming` HTMLAttribute, remove `crossorigin` from HTMLInputAttributes

### DIFF
--- a/.changeset/red-cycles-pretend.md
+++ b/.changeset/red-cycles-pretend.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: Add `elementtiming` HTMLAttribute, remove `crossorigin` from HTMLInputAttributes

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -712,6 +712,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	contextmenu?: string | undefined | null;
 	dir?: string | undefined | null;
 	draggable?: Booleanish | undefined | null;
+	elementtiming?: string | undefined | null;
 	enterkeyhint?:
 		| 'enter'
 		| 'done'

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1029,7 +1029,6 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	autocomplete?: string | undefined | null;
 	capture?: boolean | 'user' | 'environment' | undefined | null; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
 	checked?: boolean | undefined | null;
-	crossorigin?: string | undefined | null;
 	dirname?: string | undefined | null;
 	disabled?: boolean | undefined | null;
 	form?: string | undefined | null;


### PR DESCRIPTION
`elementtiming` is valid for all elements with a `background-image` so basically everything, which is why I've added it to HTMLAttributes.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/elementtiming

`crossorigin` is not a valid attribute for input elements:

> valid on the [`<audio>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio), [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img), [`<link>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link), [`<script>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script), and [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video) elements

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin

The current implementation for allowing it in every SVG element is a little footgun-y, as you can't use it with the `use` element inside a SVG, just the `script` and `image` ones, but I felt it was outside of the scope of this PR. I instead started issue #10924.