### PR TITLE
simplify render_effect signature

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/key.js
+++ b/packages/svelte/src/internal/client/dom/blocks/key.js
@@ -36,19 +36,15 @@ export function key_block(anchor, get_key, render_fn) {
 				});
 			}
 
-			effect = render_effect(
-				() => {
-					const dom = render_fn(anchor);
+			effect = render_effect(() => {
+				const dom = render_fn(anchor);
 
-					return () => {
-						if (dom !== undefined) {
-							remove(dom);
-						}
-					};
-				},
-				true,
-				true
-			);
+				return () => {
+					if (dom !== undefined) {
+						remove(dom);
+					}
+				};
+			}, true);
 
 			effects.add(effect);
 		}

--- a/packages/svelte/src/internal/client/dom/elements/misc.js
+++ b/packages/svelte/src/internal/client/dom/elements/misc.js
@@ -1,5 +1,5 @@
 import { hydrating } from '../hydration.js';
-import { render_effect } from '../../reactivity/effects.js';
+import { user_effect } from '../../reactivity/effects.js';
 
 /**
  * @param {HTMLElement} dom
@@ -10,15 +10,12 @@ export function autofocus(dom, value) {
 	if (value) {
 		const body = document.body;
 		dom.autofocus = true;
-		render_effect(
-			() => {
-				if (document.activeElement === body) {
-					dom.focus();
-				}
-			},
-			true,
-			false
-		);
+
+		user_effect(() => {
+			if (document.activeElement === body) {
+				dom.focus();
+			}
+		});
 	}
 }
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -216,14 +216,13 @@ export function invalidate_effect(fn) {
 /**
  * @param {(() => void)} fn
  * @param {boolean} managed
- * @param {boolean} sync
  * @returns {import('#client').Effect}
  */
-export function render_effect(fn, managed = false, sync = true) {
+export function render_effect(fn, managed = false) {
 	let flags = RENDER_EFFECT;
 	if (managed) flags |= MANAGED;
 
-	return create_effect(flags, /** @type {any} */ (fn), sync);
+	return create_effect(flags, /** @type {any} */ (fn), true);
 }
 
 /**

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -22,13 +22,9 @@ function run_test(runes: boolean, fn: (runes: boolean) => () => void) {
 		$.push({}, runes);
 		// Create a render context so that effect validations etc don't fail
 		let execute: any;
-		const signal = render_effect(
-			() => {
-				execute = fn(runes);
-			},
-			true,
-			true
-		);
+		const signal = render_effect(() => {
+			execute = fn(runes);
+		}, true);
 		$.pop();
 		execute();
 		destroy_effect(signal);


### PR DESCRIPTION
there's only one `render_effect` call that uses the third argument — the one inside `autofocus`. better to implement it as a `user_effect`, and then we can simplify the `render_effect` signature.