### PR TITLE
chore: remove managed_effect

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/bindings/media.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/media.js
@@ -1,5 +1,5 @@
 import { hydrating } from '../../hydration.js';
-import { destroy_effect, managed_effect, render_effect } from '../../../reactivity/effects.js';
+import { render_effect, user_effect } from '../../../reactivity/effects.js';
 import { listen } from './shared.js';
 
 /** @param {TimeRanges} ranges */
@@ -115,47 +115,21 @@ export function bind_ready_state(media, update) {
 export function bind_playback_rate(media, get_value, update) {
 	var updating = false;
 
-	var callback = () => {
-		if (!updating) {
-			update(media.playbackRate);
-		}
-		updating = false;
-	};
-
 	// Needs to happen after the element is inserted into the dom, else playback will be set back to 1 by the browser.
 	// For hydration we could do it immediately but the additional code is not worth the lost microtask.
+	user_effect(() => {
+		var value = get_value();
 
-	/** @type {import('#client').Effect | undefined} */
-	var render;
-	var destroyed = false;
-
-	var effect = managed_effect(() => {
-		destroy_effect(effect);
-
-		if (destroyed) return;
-
-		if (get_value() == null) {
-			callback();
+		// through isNaN we also allow number strings, which is more robust
+		if (!isNaN(/** @type {any} */ (value)) && value !== media.playbackRate) {
+			updating = true;
+			media.playbackRate = /** @type {number} */ (value);
 		}
 
-		listen(media, ['ratechange'], callback, false);
-
-		render = render_effect(() => {
-			var value = get_value();
-
-			// through isNaN we also allow number strings, which is more robust
-			if (!isNaN(/** @type {any} */ (value)) && value !== media.playbackRate) {
-				updating = true;
-				media.playbackRate = /** @type {number} */ (value);
-			}
+		listen(media, ['ratechange'], () => {
+			if (!updating) update(media.playbackRate);
+			updating = false;
 		});
-	});
-
-	render_effect(() => () => {
-		destroyed = true;
-		if (render) {
-			destroy_effect(render);
-		}
 	});
 }
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -129,14 +129,6 @@ export function effect(fn) {
 }
 
 /**
- * @param {() => void | (() => void)} fn
- * @returns {import('#client').Effect}
- */
-export function managed_pre_effect(fn) {
-	return create_effect(PRE_EFFECT | MANAGED, fn, false);
-}
-
-/**
  * Internal representation of `$effect.pre(...)`
  * @param {() => void | (() => void)} fn
  * @returns {import('#client').Effect}

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -132,14 +132,6 @@ export function effect(fn) {
  * @param {() => void | (() => void)} fn
  * @returns {import('#client').Effect}
  */
-export function managed_effect(fn) {
-	return create_effect(EFFECT | MANAGED, fn, false);
-}
-
-/**
- * @param {() => void | (() => void)} fn
- * @returns {import('#client').Effect}
- */
 export function managed_pre_effect(fn) {
 	return create_effect(PRE_EFFECT | MANAGED, fn, false);
 }

--- a/playgrounds/demo/src/entry-client.ts
+++ b/playgrounds/demo/src/entry-client.ts
@@ -1,8 +1,8 @@
 // @ts-ignore
-import { hydrate, unmount } from 'svelte';
+import { mount, unmount } from 'svelte';
 // @ts-ignore you need to create this file
 import App from './App.svelte';
-const component = hydrate(App, {
+const component = mount(App, {
 	target: document.getElementById('root')!
 });
 // @ts-ignore


### PR DESCRIPTION
we're using `managed_effect` in precisely one place — `bind:playbackRate`. This is much better implemented as a `user_effect`. we're not using `managed_pre_effect` at all.