### PR TITLE
chore: use `effect(...)` instead of `user_effect(...)`

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -18,11 +18,11 @@ import { insert, remove } from '../reconciler.js';
 import { untrack } from '../../runtime.js';
 import {
 	destroy_effect,
+	effect,
 	pause_effect,
 	pause_effects,
 	render_effect,
-	resume_effect,
-	user_effect
+	resume_effect
 } from '../../reactivity/effects.js';
 import { source, mutable_source, set } from '../../reactivity/sources.js';
 import { is_array, is_frozen, map_get, map_set } from '../../utils.js';
@@ -425,7 +425,7 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 			// we can figure out the eventual destination of the animating elements
 			// - https://github.com/sveltejs/svelte/pull/10798#issuecomment-2013681778
 			// - https://svelte.dev/repl/6e891305e9644a7ca7065fa95c79d2d2?version=4.2.9
-			user_effect(() => {
+			effect(() => {
 				untrack(() => {
 					for (item of to_animate) {
 						item.a?.apply();

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -1,5 +1,5 @@
 import { DEV } from 'esm-env';
-import { render_effect, user_effect } from '../../../reactivity/effects.js';
+import { render_effect, effect } from '../../../reactivity/effects.js';
 import { stringify } from '../../../render.js';
 import { listen_to_event_and_reset_event } from './shared.js';
 
@@ -103,11 +103,6 @@ export function bind_group(inputs, group_index, input, get_value, update) {
 		}
 	});
 
-	user_effect(() => {
-		// necessary to maintain binding group order in all insertion scenarios. TODO optimise
-		binding_group.sort((a, b) => (a.compareDocumentPosition(b) === 4 ? -1 : 1));
-	});
-
 	render_effect(() => {
 		return () => {
 			var index = binding_group.indexOf(input);
@@ -116,6 +111,11 @@ export function bind_group(inputs, group_index, input, get_value, update) {
 				binding_group.splice(index, 1);
 			}
 		};
+	});
+
+	effect(() => {
+		// necessary to maintain binding group order in all insertion scenarios. TODO optimise
+		binding_group.sort((a, b) => (a.compareDocumentPosition(b) === 4 ? -1 : 1));
 	});
 }
 

--- a/packages/svelte/src/internal/client/dom/elements/bindings/media.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/media.js
@@ -1,5 +1,5 @@
 import { hydrating } from '../../hydration.js';
-import { render_effect, user_effect } from '../../../reactivity/effects.js';
+import { render_effect, effect } from '../../../reactivity/effects.js';
 import { listen } from './shared.js';
 
 /** @param {TimeRanges} ranges */
@@ -117,7 +117,7 @@ export function bind_playback_rate(media, get_value, update) {
 
 	// Needs to happen after the element is inserted into the dom, else playback will be set back to 1 by the browser.
 	// For hydration we could do it immediately but the additional code is not worth the lost microtask.
-	user_effect(() => {
+	effect(() => {
 		var value = get_value();
 
 		// through isNaN we also allow number strings, which is more robust

--- a/packages/svelte/src/internal/client/dom/elements/misc.js
+++ b/packages/svelte/src/internal/client/dom/elements/misc.js
@@ -1,5 +1,5 @@
 import { hydrating } from '../hydration.js';
-import { user_effect } from '../../reactivity/effects.js';
+import { effect } from '../../reactivity/effects.js';
 
 /**
  * @param {HTMLElement} dom
@@ -11,7 +11,7 @@ export function autofocus(dom, value) {
 		const body = document.body;
 		dom.autofocus = true;
 
-		user_effect(() => {
+		effect(() => {
 			if (document.activeElement === body) {
 				dom.focus();
 			}

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -1,5 +1,5 @@
 import { noop } from '../../../common.js';
-import { user_effect } from '../../reactivity/effects.js';
+import { effect } from '../../reactivity/effects.js';
 import { current_effect, untrack } from '../../runtime.js';
 import { raf } from '../../timing.js';
 import { loop } from '../../loop.js';
@@ -202,18 +202,18 @@ export function transition(flags, element, get_fn, get_params) {
 		}
 	};
 
-	var effect = /** @type {import('#client').Effect} */ (current_effect);
+	var e = /** @type {import('#client').Effect} */ (current_effect);
 
-	(effect.transitions ??= []).push(transition);
+	(e.transitions ??= []).push(transition);
 
 	// if this is a local transition, we only want to run it if the parent (block) effect's
 	// parent (branch) effect is where the state change happened. we can determine that by
 	// looking at whether the branch effect is currently initializing
 	if (is_intro && should_intro) {
-		var parent = /** @type {import('#client').Effect} */ (effect.parent);
+		var parent = /** @type {import('#client').Effect} */ (e.parent);
 
 		if (is_global || (parent.f & EFFECT_RAN) !== 0) {
-			user_effect(() => {
+			effect(() => {
 				untrack(() => transition.in());
 			});
 		}
@@ -237,7 +237,7 @@ function animate(element, options, counterpart, t2, callback) {
 		/** @type {import('#client').Animation} */
 		var a;
 
-		user_effect(() => {
+		effect(() => {
 			var o = untrack(() => options({ direction: t2 === 1 ? 'in' : 'out' }));
 			a = animate(element, o, counterpart, t2, callback);
 		});

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -2,7 +2,7 @@ import { subscribe_to_store } from '../../../store/utils.js';
 import { noop } from '../../common.js';
 import { UNINITIALIZED } from '../constants.js';
 import { get, untrack } from '../runtime.js';
-import { user_effect } from './effects.js';
+import { effect } from './effects.js';
 import { mutable_source, set } from './sources.js';
 
 /**
@@ -155,5 +155,5 @@ export function update_pre_store(store, store_value, d = 1) {
  * @returns {void}
  */
 function on_destroy(fn) {
-	user_effect(() => () => untrack(fn));
+	effect(() => () => untrack(fn));
 }


### PR DESCRIPTION
realised that `user_effect(...)` is just `effect(...)` with extra steps, that are unnecessary when calling it internally