### PR TITLE
breaking: always run pre effects synchronously

### DIFF
--- a/.changeset/few-clouds-shop.md
+++ b/.changeset/few-clouds-shop.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: always run pre effects immediately

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -142,9 +142,8 @@ export function pre_effect(fn) {
 					: '')
 		);
 	}
-	const sync = current_effect !== null && (current_effect.f & RENDER_EFFECT) !== 0;
 
-	return create_effect(PRE_EFFECT, fn, sync);
+	return create_effect(PRE_EFFECT, fn, true);
 }
 
 /**
@@ -206,7 +205,7 @@ export function render_effect(fn, managed = false) {
 	let flags = RENDER_EFFECT;
 	if (managed) flags |= MANAGED;
 
-	return create_effect(flags, /** @type {any} */ (fn), true);
+	return create_effect(flags, fn, true);
 }
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/pre-effect-ordering/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/pre-effect-ordering/_config.js
@@ -19,14 +19,14 @@ export default test({
 
 		assert.deepEqual(log, [
 			'Outer Effect Start (0)',
-			'Outer Effect End (0)',
 			'Inner Effect (0)',
+			'Outer Effect End (0)',
 			'Outer Effect Start (1)',
-			'Outer Effect End (1)',
 			'Inner Effect (1)',
+			'Outer Effect End (1)',
 			'Outer Effect Start (2)',
-			'Outer Effect End (2)',
-			'Inner Effect (2)'
+			'Inner Effect (2)',
+			'Outer Effect End (2)'
 		]);
 	}
 });


### PR DESCRIPTION
Currently doing a deep dive on effects, and found myself stumped as to why we treat `$effect.pre(...)` this way — given this...

```js
$effect.pre(() => {
  log.push(`Outer Effect Start (${count})`)

  $effect.pre(() => {
    log.push(`Inner Effect (${count})`)
  });

  log.push(`Outer Effect End (${count})`)
});
```

...and an incrementing count, we log this:

```
Outer Effect Start (0)
Outer Effect End (0)
Inner Effect (0)
---
Outer Effect Start (1)
Outer Effect End (1)
Inner Effect (1)
---
Outer Effect Start (2)
Outer Effect End (2)
Inner Effect (2)
```

This strikes me as rather strange. After all, if the user wanted `Inner Effect` to run after the other two logs, they'd just... put the inner effect at the bottom of the outer effect.

Is there some advantage to doing it the other way that I'm not seeing? Seems like it adds complexity and uncertainty for no gain.