### PR TITLE
chore: tidy up effect init

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -39,7 +39,7 @@ import { remove } from '../dom/reconciler.js';
  */
 function create_effect(type, fn, sync, init = true) {
 	/** @type {import('#client').Effect} */
-	const signal = {
+	const effect = {
 		parent: current_effect,
 		dom: null,
 		deps: null,
@@ -55,34 +55,35 @@ function create_effect(type, fn, sync, init = true) {
 	};
 
 	if (current_effect !== null) {
-		signal.l = current_effect.l + 1;
+		effect.l = current_effect.l + 1;
 	}
 
 	if (current_reaction !== null) {
 		if (current_reaction.effects === null) {
-			current_reaction.effects = [signal];
+			current_reaction.effects = [effect];
 		} else {
-			current_reaction.effects.push(signal);
+			current_reaction.effects.push(effect);
 		}
 	}
 
 	if (init) {
 		if (sync) {
 			const previously_flushing_effect = is_flushing_effect;
+
 			try {
 				set_is_flushing_effect(true);
-				execute_effect(signal);
-				set_signal_status(signal, CLEAN);
-				signal.f |= EFFECT_RAN;
+				execute_effect(effect);
+				set_signal_status(effect, CLEAN);
+				effect.f |= EFFECT_RAN;
 			} finally {
 				set_is_flushing_effect(previously_flushing_effect);
 			}
 		} else {
-			schedule_effect(signal);
+			schedule_effect(effect);
 		}
 	}
 
-	return signal;
+	return effect;
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -73,7 +73,6 @@ function create_effect(type, fn, sync, init = true) {
 			try {
 				set_is_flushing_effect(true);
 				execute_effect(effect);
-				set_signal_status(effect, CLEAN);
 				effect.f |= EFFECT_RAN;
 			} finally {
 				set_is_flushing_effect(previously_flushing_effect);

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -23,7 +23,6 @@ import {
 	DESTROYED,
 	INERT,
 	IS_ELSEIF,
-	CLEAN,
 	EFFECT_RAN
 } from '../constants.js';
 import { set } from './sources.js';

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -135,7 +135,7 @@ export function set(signal, value) {
 		) {
 			if (current_dependencies !== null && current_dependencies.includes(signal)) {
 				set_signal_status(current_effect, DIRTY);
-				schedule_effect(current_effect, false);
+				schedule_effect(current_effect);
 			} else {
 				if (current_untracked_writes === null) {
 					set_current_untracked_writes([signal]);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -384,6 +384,8 @@ export function execute_effect(signal) {
 		return;
 	}
 
+	set_signal_status(signal, CLEAN);
+
 	const previous_effect = current_effect;
 	const previous_component_context = current_component_context;
 
@@ -439,7 +441,6 @@ function flush_queued_effects(effects) {
 
 			if ((signal.f & (DESTROYED | INERT)) === 0) {
 				if (check_dirtiness(signal)) {
-					set_signal_status(signal, CLEAN);
 					execute_effect(signal);
 				}
 			}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -216,9 +216,6 @@ export function check_dirtiness(reaction) {
  * @returns {V}
  */
 export function execute_reaction_fn(signal) {
-	const fn = signal.fn;
-	const flags = signal.f;
-
 	const previous_dependencies = current_dependencies;
 	const previous_dependencies_index = current_dependencies_index;
 	const previous_untracked_writes = current_untracked_writes;
@@ -230,11 +227,11 @@ export function execute_reaction_fn(signal) {
 	current_dependencies_index = 0;
 	current_untracked_writes = null;
 	current_reaction = signal;
-	current_skip_reaction = !is_flushing_effect && (flags & UNOWNED) !== 0;
+	current_skip_reaction = !is_flushing_effect && (signal.f & UNOWNED) !== 0;
 	current_untracking = false;
 
 	try {
-		let res = fn();
+		let res = signal.fn();
 		let dependencies = /** @type {import('./types.js').Value<unknown>[]} **/ (signal.deps);
 		if (current_dependencies !== null) {
 			let i;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -376,35 +376,35 @@ export function destroy_children(signal) {
 }
 
 /**
- * @param {import('./types.js').Effect} signal
+ * @param {import('./types.js').Effect} effect
  * @returns {void}
  */
-export function execute_effect(signal) {
-	if ((signal.f & DESTROYED) !== 0) {
+export function execute_effect(effect) {
+	if ((effect.f & DESTROYED) !== 0) {
 		return;
 	}
 
-	set_signal_status(signal, CLEAN);
+	set_signal_status(effect, CLEAN);
 
-	const previous_effect = current_effect;
-	const previous_component_context = current_component_context;
+	var component_context = effect.ctx;
 
-	const component_context = signal.ctx;
+	var previous_effect = current_effect;
+	var previous_component_context = current_component_context;
 
-	current_effect = signal;
+	current_effect = effect;
 	current_component_context = component_context;
 
 	try {
-		destroy_children(signal);
-		signal.teardown?.();
-		const teardown = execute_reaction_fn(signal);
-		signal.teardown = typeof teardown === 'function' ? teardown : null;
+		destroy_children(effect);
+		effect.teardown?.();
+		var teardown = execute_reaction_fn(effect);
+		effect.teardown = typeof teardown === 'function' ? teardown : null;
 	} finally {
 		current_effect = previous_effect;
 		current_component_context = previous_component_context;
 	}
 
-	if ((signal.f & PRE_EFFECT) !== 0 && current_queued_pre_and_render_effects.length > 0) {
+	if ((effect.f & PRE_EFFECT) !== 0 && current_queued_pre_and_render_effects.length > 0) {
 		flush_local_pre_effects(component_context);
 	}
 }


### PR DESCRIPTION
The only place we call `schedule_effect(effect, true)` is inside `create_effect`. We should therefore move the contents of the `if (sync)` block inside `schedule_effect` into `create_effect`, so that we only need to do that check once, instead of every time the effect is scheduled.

A couple of other small tweaks:

- moved the `effect.f |= EFFECT_RAN` into `create_effect` instead of `schedule_effect`. (We only care about this flag for sync effects)
- moved `set_signal_status(effect, CLEAN)` into `execute_effect` — previously, it was being called adjacently to `execute_effect`, but inconsistently (missing in one case, before `execute_effect` in another, after it in a third)