### PR TITLE
chore: update sequencing inside blocks

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -52,7 +52,8 @@ export function client_component(source, analysis, options) {
 		get before_init() {
 			/** @type {any[]} */
 			const a = [];
-			a.push = () => error(null, 'INTERNAL', 'before_init.push should not be called outside create_block');
+			a.push = () =>
+				error(null, 'INTERNAL', 'before_init.push should not be called outside create_block');
 			return a;
 		},
 		get init() {

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -49,6 +49,12 @@ export function client_component(source, analysis, options) {
 		hoisted: [b.import_all('$', 'svelte/internal')],
 		node: /** @type {any} */ (null), // populated by the root node
 		// these should be set by create_block - if they're called outside, it's a bug
+		get before_init() {
+			/** @type {any[]} */
+			const a = [];
+			a.push = () => error(null, 'INTERNAL', 'before_init.push should not be called outside create_block');
+			return a;
+		},
 		get init() {
 			/** @type {any[]} */
 			const a = [];

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -30,6 +30,8 @@ export interface ComponentClientTransformState extends ClientTransformState {
 	readonly events: Set<string>;
 
 	/** Stuff that happens before the render effect(s) */
+	readonly before_init: Statement[];
+	/** Stuff that happens before the render effect(s) */
 	readonly init: Statement[];
 	/** Stuff that happens inside the render effect */
 	readonly update: Statement[];

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1291,7 +1291,7 @@ function serialize_event(node, context) {
 				delegated_assignment = handler;
 			}
 
-			state.after_update.push(
+			state.init.push(
 				b.stmt(
 					b.assignment(
 						'=',
@@ -1720,11 +1720,9 @@ export const template_visitors = {
 		}
 
 		if (is_reactive) {
-			context.state.after_update.push(
-				b.stmt(b.call('$.snippet', b.thunk(snippet_function), ...args))
-			);
+			context.state.init.push(b.stmt(b.call('$.snippet', b.thunk(snippet_function), ...args)));
 		} else {
-			context.state.after_update.push(
+			context.state.init.push(
 				b.stmt(
 					(node.expression.type === 'CallExpression' ? b.call : b.maybe_call)(
 						snippet_function,
@@ -2091,7 +2089,7 @@ export const template_visitors = {
 				}
 			})
 		);
-		context.state.after_update.push(
+		context.state.init.push(
 			b.stmt(
 				b.call(
 					'$.element',
@@ -2344,7 +2342,7 @@ export const template_visitors = {
 				);
 			}
 
-			context.state.after_update.push(
+			context.state.init.push(
 				b.stmt(
 					b.call(
 						'$.each_keyed',
@@ -2358,7 +2356,7 @@ export const template_visitors = {
 				)
 			);
 		} else {
-			context.state.after_update.push(
+			context.state.init.push(
 				b.stmt(
 					b.call(
 						'$.each_indexed',
@@ -2421,12 +2419,12 @@ export const template_visitors = {
 			args.push(b.literal(true));
 		}
 
-		context.state.after_update.push(b.stmt(b.call('$.if', ...args)));
+		context.state.init.push(b.stmt(b.call('$.if', ...args)));
 	},
 	AwaitBlock(node, context) {
 		context.state.template.push('<!>');
 
-		context.state.after_update.push(
+		context.state.init.push(
 			b.stmt(
 				b.call(
 					'$.await',
@@ -2468,7 +2466,7 @@ export const template_visitors = {
 		context.state.template.push('<!>');
 		const key = /** @type {import('estree').Expression} */ (context.visit(node.expression));
 		const body = /** @type {import('estree').Expression} */ (context.visit(node.fragment));
-		context.state.after_update.push(
+		context.state.init.push(
 			b.stmt(b.call('$.key', context.state.node, b.thunk(key), b.arrow([b.id('$$anchor')], body)))
 		);
 	},
@@ -2789,7 +2787,7 @@ export const template_visitors = {
 		if (binding !== null && binding.kind !== 'normal') {
 			// Handle dynamic references to what seems like static inline components
 			const component = serialize_inline_component(node, '$$component', context);
-			context.state.after_update.push(
+			context.state.init.push(
 				b.stmt(
 					b.call(
 						'$.component',
@@ -2806,12 +2804,12 @@ export const template_visitors = {
 			return;
 		}
 		const component = serialize_inline_component(node, node.name, context);
-		context.state.after_update.push(component);
+		context.state.init.push(component);
 	},
 	SvelteSelf(node, context) {
 		context.state.template.push('<!>');
 		const component = serialize_inline_component(node, context.state.analysis.name, context);
-		context.state.after_update.push(component);
+		context.state.init.push(component);
 	},
 	SvelteComponent(node, context) {
 		context.state.template.push('<!>');
@@ -2820,7 +2818,7 @@ export const template_visitors = {
 		if (context.state.options.dev) {
 			component = b.stmt(b.call('$.validate_dynamic_component', b.thunk(b.block([component]))));
 		}
-		context.state.after_update.push(
+		context.state.init.push(
 			b.stmt(
 				b.call(
 					'$.component',
@@ -2972,7 +2970,7 @@ export const template_visitors = {
 			: b.member(b.member(b.id('$$props'), b.id('$$slots')), name, true, true);
 
 		const slot = b.call('$.slot', context.state.node, expression, props_expression, fallback);
-		context.state.after_update.push(b.stmt(slot));
+		context.state.init.push(b.stmt(slot));
 	},
 	SvelteHead(node, context) {
 		// TODO attributes?

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -113,7 +113,7 @@ export function capture_fragment_from_node(node) {
 	if (
 		node.nodeType === 8 &&
 		/** @type {Comment} */ (node).data === '[' &&
-		hydrate_nodes[hydrate_nodes.length - 1] !== node
+		hydrate_nodes?.[hydrate_nodes.length - 1] !== node
 	) {
 		const nodes = /** @type {Node[]} */ (get_hydrate_nodes(node));
 		const last_child = nodes[nodes.length - 1] || node;

--- a/packages/svelte/tests/runtime-legacy/samples/deconflict-contextual-action/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/deconflict-contextual-action/_config.js
@@ -14,6 +14,6 @@ export default test({
 		};
 	},
 	test({ assert }) {
-		assert.deepEqual(result, ['import_action', 'each_action']);
+		assert.deepEqual(result, ['each_action', 'import_action']); // ideally this would be reversed, but it doesn't matter a whole lot
 	}
 });

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -28,9 +28,9 @@ export default function State_proxy_literal($$anchor, $$props) {
 
 	var button = $.sibling($.sibling(input_1, true));
 
+	button.__click = [reset, str, tpl];
 	$.bind_value(input, () => $.get(str), ($$value) => $.set(str, $$value));
 	$.bind_value(input_1, () => $.get(tpl), ($$value) => $.set(tpl, $$value));
-	button.__click = [reset, str, tpl];
 	$.close_frag($$anchor, fragment);
 	$.pop();
 }


### PR DESCRIPTION
Right now, blocks are created _after_ local updates have been applied. Given something like this...

```svelte
<script>
  let number = $state(0);
</script>

<!-- 1 -->
<input type="number" bind:value={number} />

<!-- 2 -->
{#if number % 2 === 0}
  <p>{number} is even</p>
{:else}
  <p>{number} is odd</p>
{/if}

<!-- 3 -->
<p>{number} * 2 = {number * 2}</p>
```

...the compiler spits out something like this:

```js
let number = $.source(0);
var fragment = $.open_frag($$anchor, frag);

/* 1 */
var input = $.first_child(fragment);
$.remove_input_attr_defaults(input);

/* 2 */
var node = $.sibling($.sibling(input, true));

/* 3 */
var p_2 = $.sibling($.sibling(node, true));
var text_2 = $.child(p_2);
$.render_effect(() => $.set_text(text_2, `${$.stringify($.get(number))} * 2 = ${$.stringify($.get(number) * 2)}`));

/* 1 */
$.bind_value(input, () => $.get(number), ($$value) => $.set(number, $$value));

/* 2 */
$.if(
  node,
  () => $.get(number) % 2 === 0,
  ($$anchor) => {
    var p = $.open($$anchor, frag_1);
    var text = $.child(p);

    $.render_effect(() => $.set_text(text, `${$.stringify($.get(number))} is even`));
    return $.close($$anchor, p);
  },
  ($$anchor) => {
    var p_1 = $.open($$anchor, frag_2);
    var text_1 = $.child(p_1);

    $.render_effect(() => $.set_text(text_1, `${$.stringify($.get(number))} is odd`));
    return $.close($$anchor, p_1);
  }
);
```

This is... fine, but it would perhaps be clearer if we got something like this instead:

```js
/* 1 */
var input = $.first_child(fragment);
$.remove_input_attr_defaults(input);
$.bind_value(input, () => $.get(number), ($$value) => $.set(number, $$value));

/* 2 */
var node = $.sibling($.sibling(input, true));

$.if(
  node,
  () => $.get(number) % 2 === 0,
  ($$anchor) => {
    var p = $.open($$anchor, frag_1);
    var text = $.child(p);

    $.render_effect(() => $.set_text(text, `${$.stringify($.get(number))} is even`));
    return $.close($$anchor, p);
  },
  ($$anchor) => {
    var p_1 = $.open($$anchor, frag_2);
    var text_1 = $.child(p_1);

    $.render_effect(() => $.set_text(text_1, `${$.stringify($.get(number))} is odd`));
    return $.close($$anchor, p_1);
  }
);

/* 3 */
var p_2 = $.sibling($.sibling(node, true));
var text_2 = $.child(p_2);
$.render_effect(() => $.set_text(text_2, `${$.stringify($.get(number))} * 2 = ${$.stringify($.get(number) * 2)}`));
```

This PR doesn't produce _exactly_ that order, since it turns out we need to apply actions/bindings/events after the final `render_effect`, otherwise things go awry. But it's very close to that ideal.

The reason this is valuable is that it _should_, if my hunch is correct, unlock a slightly simpler approach to hydration. (It might be worth waiting until we can actually test that theory before merging this, to avoid needless changes.)

Note that I had to compromise in one place: an action inside a block (such as an `{#if ...}` or `{#each ...}` will run _before_ an action in an earlier element. In other words `b` will run before `a`:

```svelte
<div use:a>...</div>

{#if foo}
  <div use:b>...</div>
{/if}
```

I don't consider that a big problem — actions ought to be independent of one another — but it's worth noting.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
