### PR TITLE
fix: improve order of pre-effect execution

### DIFF
--- a/.changeset/hot-jobs-tap.md
+++ b/.changeset/hot-jobs-tap.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: improve order of pre-effect execution

--- a/packages/svelte/src/internal/client/dom/legacy/lifecycle.js
+++ b/packages/svelte/src/internal/client/dom/legacy/lifecycle.js
@@ -2,6 +2,7 @@ import { run } from '../../../common.js';
 import { user_pre_effect, user_effect } from '../../reactivity/effects.js';
 import {
 	current_component_context,
+	current_effect,
 	deep_read_state,
 	flush_local_render_effects,
 	get,
@@ -25,7 +26,10 @@ export function init() {
 			// beforeUpdate might change state that affects rendering, ensure the render effects following from it
 			// are batched up with the current run. Avoids for example child components rerunning when they're
 			// now hidden because beforeUpdate did set an if block to false.
-			flush_local_render_effects();
+			const parent = current_effect?.parent;
+			if (parent != null) {
+				flush_local_render_effects(parent);
+			}
 		});
 	}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -552,45 +552,46 @@ export function schedule_effect(signal) {
  */
 function collect_effects(effect, filter_flags, collected) {
 	var effects = effect.effects;
-	if (effects !== null) {
-		var i, s, child, flags;
-		var render = [];
-		var user = [];
+	if (effects === null) {
+		return;
+	}
+	var i, s, child, flags;
+	var render = [];
+	var user = [];
 
-		for (i = 0; i < effects.length; i++) {
-			child = effects[i];
-			flags = child.f;
-			if ((flags & CLEAN) !== 0) {
-				continue;
-			}
-
-			if ((flags & PRE_EFFECT) !== 0) {
-				if ((filter_flags & PRE_EFFECT) !== 0) {
-					collected.push(child);
-				}
-				collect_effects(child, filter_flags, collected);
-			} else if ((flags & RENDER_EFFECT) !== 0) {
-				render.push(child);
-			} else if ((flags & EFFECT) !== 0) {
-				user.push(child);
-			}
+	for (i = 0; i < effects.length; i++) {
+		child = effects[i];
+		flags = child.f;
+		if ((flags & CLEAN) !== 0) {
+			continue;
 		}
 
-		if (render.length > 0) {
-			if ((filter_flags & RENDER_EFFECT) !== 0) {
-				collected.push(...render);
+		if ((flags & PRE_EFFECT) !== 0) {
+			if ((filter_flags & PRE_EFFECT) !== 0) {
+				collected.push(child);
 			}
-			for (s = 0; s < render.length; s++) {
-				collect_effects(render[s], filter_flags, collected);
-			}
+			collect_effects(child, filter_flags, collected);
+		} else if ((flags & RENDER_EFFECT) !== 0) {
+			render.push(child);
+		} else if ((flags & EFFECT) !== 0) {
+			user.push(child);
 		}
-		if (user.length > 0) {
-			if ((filter_flags & EFFECT) !== 0) {
-				collected.push(...user);
-			}
-			for (s = 0; s < user.length; s++) {
-				collect_effects(user[s], filter_flags, collected);
-			}
+	}
+
+	if (render.length > 0) {
+		if ((filter_flags & RENDER_EFFECT) !== 0) {
+			collected.push(...render);
+		}
+		for (s = 0; s < render.length; s++) {
+			collect_effects(render[s], filter_flags, collected);
+		}
+	}
+	if (user.length > 0) {
+		if ((filter_flags & EFFECT) !== 0) {
+			collected.push(...user);
+		}
+		for (s = 0; s < user.length; s++) {
+			collect_effects(user[s], filter_flags, collected);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -553,7 +553,7 @@ export function schedule_effect(signal) {
 function collect_effects(effect, filter_flags, collected) {
 	var effects = effect.effects;
 	if (effects !== null) {
-		var i, child, flags;
+		var i, s, child, flags;
 		var render = [];
 		var user = [];
 
@@ -580,16 +580,16 @@ function collect_effects(effect, filter_flags, collected) {
 			if ((filter_flags & RENDER_EFFECT) !== 0) {
 				collected.push(...render);
 			}
-			for (let i = 0; i < render.length; i++) {
-				collect_effects(render[i], filter_flags, collected);
+			for (s = 0; s < render.length; s++) {
+				collect_effects(render[s], filter_flags, collected);
 			}
 		}
 		if (user.length > 0) {
 			if ((filter_flags & EFFECT) !== 0) {
 				collected.push(...user);
 			}
-			for (let i = 0; i < user.length; i++) {
-				collect_effects(user[i], filter_flags, collected);
+			for (s = 0; s < user.length; s++) {
+				collect_effects(user[s], filter_flags, collected);
 			}
 		}
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -560,7 +560,7 @@ function collect_effects(effect, filter_flags, collected) {
 		for (i = 0; i < effects.length; i++) {
 			child = effects[i];
 			flags = child.f;
-			if (flags & CLEAN) {
+			if ((flags & CLEAN) !== 0) {
 				continue;
 			}
 

--- a/packages/svelte/src/reactivity/map.test.ts
+++ b/packages/svelte/src/reactivity/map.test.ts
@@ -36,7 +36,7 @@ test('map.values()', () => {
 		map.clear();
 	});
 
-	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, [], false]); // TODO update when we fix effect ordering bug
+	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, false, []]);
 
 	cleanup();
 });

--- a/packages/svelte/src/reactivity/set.test.ts
+++ b/packages/svelte/src/reactivity/set.test.ts
@@ -30,7 +30,7 @@ test('set.values()', () => {
 		set.clear();
 	});
 
-	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, [], false]); // TODO update when we fix effect ordering bug
+	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, false, []]);
 
 	cleanup();
 });


### PR DESCRIPTION
This is the start of the work to refactor how effects are scheduled and flushed. This PR introduces the notion of "collecting" signals recursively, and introduces into how the localized flushing logic works – fixing some tests along the way.