### PR TITLE
chore: simplify hydration

### DIFF
--- a/packages/svelte/scripts/check-treeshakeability.js
+++ b/packages/svelte/scripts/check-treeshakeability.js
@@ -109,7 +109,7 @@ const bundle = await bundle_code(
 	).js.code
 );
 
-if (!bundle.includes('hydrate_nodes')) {
+if (!bundle.includes('hydrate_nodes') && !bundle.includes('hydrate_anchor')) {
 	// eslint-disable-next-line no-console
 	console.error(`✅ Hydration code treeshakeable`);
 } else {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1045,7 +1045,7 @@ function create_block(parent, name, nodes, context) {
 		);
 
 		/** @type {import('estree').Expression[]} */
-		const args = [b.id('$$anchor'), template_name];
+		const args = [template_name];
 
 		if (state.metadata.context.template_needs_import_node) {
 			args.push(b.false);
@@ -1089,7 +1089,7 @@ function create_block(parent, name, nodes, context) {
 
 			if (use_comment_template) {
 				// special case — we can use `$.comment` instead of creating a unique template
-				body.push(b.var(id, b.call('$.comment', b.id('$$anchor'))));
+				body.push(b.var(id, b.call('$.comment')));
 			} else {
 				state.hoisted.push(
 					b.var(
@@ -1103,7 +1103,7 @@ function create_block(parent, name, nodes, context) {
 				);
 
 				/** @type {import('estree').Expression[]} */
-				const args = [b.id('$$anchor'), template_name];
+				const args = [template_name];
 
 				if (state.metadata.context.template_needs_import_node) {
 					args.push(b.false);

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -1,5 +1,4 @@
 import { is_promise } from '../../../common.js';
-import { hydrate_block_anchor } from '../hydration.js';
 import { remove } from '../reconciler.js';
 import {
 	current_component_context,
@@ -22,8 +21,6 @@ import { INERT } from '../../constants.js';
  */
 export function await_block(anchor, get_input, pending_fn, then_fn, catch_fn) {
 	const component_context = current_component_context;
-
-	hydrate_block_anchor(anchor);
 
 	/** @type {any} */
 	let input;

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -1,5 +1,5 @@
 import { namespace_svg } from '../../../../constants.js';
-import { hydrate_nodes, hydrate_block_anchor, hydrating } from '../hydration.js';
+import { hydrate_nodes, hydrating } from '../hydration.js';
 import { empty } from '../operations.js';
 import { render_effect } from '../../reactivity/effects.js';
 import { remove } from '../reconciler.js';
@@ -12,8 +12,6 @@ import { remove } from '../reconciler.js';
  * @returns {void}
  */
 export function css_props(anchor, is_html, props, component) {
-	hydrate_block_anchor(anchor);
-
 	/** @type {HTMLElement | SVGElement} */
 	let element;
 

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -1,5 +1,5 @@
 import { namespace_svg } from '../../../../constants.js';
-import { hydrate_nodes, hydrating } from '../hydration.js';
+import { hydrate_anchor, hydrate_nodes, hydrating } from '../hydration.js';
 import { empty } from '../operations.js';
 import { render_effect } from '../../reactivity/effects.js';
 import { remove } from '../reconciler.js';
@@ -22,7 +22,9 @@ export function css_props(anchor, is_html, props, component) {
 		// Hydration: css props element is surrounded by a ssr comment ...
 		element = /** @type {HTMLElement | SVGElement} */ (hydrate_nodes[0]);
 		// ... and the child(ren) of the css props element is also surround by a ssr comment
-		component_anchor = /** @type {Comment} */ (element.firstChild);
+		component_anchor = /** @type {Comment} */ (
+			hydrate_anchor(/** @type {Comment} */ (element.firstChild))
+		);
 	} else {
 		if (is_html) {
 			element = document.createElement('div');

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -129,10 +129,12 @@ function each(anchor, flags, get_collection, get_key, render_fn, fallback_fn, re
 			}
 
 			// remove excess nodes
-			while (child_anchor !== anchor) {
-				var next = /** @type {import('#client').TemplateNode} */ (child_anchor.nextSibling);
-				/** @type {import('#client').TemplateNode} */ (child_anchor).remove();
-				child_anchor = next;
+			if (length > 0) {
+				while (child_anchor !== anchor) {
+					var next = /** @type {import('#client').TemplateNode} */ (child_anchor.nextSibling);
+					/** @type {import('#client').TemplateNode} */ (child_anchor).remove();
+					child_anchor = next;
+				}
 			}
 
 			state.items = b_items;

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -6,13 +6,7 @@ import {
 	EACH_ITEM_REACTIVE,
 	EACH_KEYED
 } from '../../../../constants.js';
-import {
-	hydrate_anchor,
-	hydrate_nodes,
-	hydrating,
-	set_hydrating,
-	update_hydrate_nodes
-} from '../hydration.js';
+import { hydrate_anchor, hydrate_nodes, hydrating, set_hydrating } from '../hydration.js';
 import { empty } from '../operations.js';
 import { insert, remove } from '../reconciler.js';
 import { untrack } from '../../runtime.js';

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -57,9 +57,11 @@ function each(anchor, flags, get_collection, get_key, render_fn, fallback_fn, re
 	if (is_controlled) {
 		var parent_node = /** @type {Element} */ (anchor);
 
-		anchor = /** @type {Comment | Text} */ (
-			hydrate_anchor(parent_node.firstChild ?? parent_node.appendChild(empty()))
-		);
+		anchor = hydrating
+			? /** @type {Comment | Text} */ (
+					hydrate_anchor(/** @type {Comment | Text} */ (parent_node.firstChild))
+				)
+			: parent_node.appendChild(empty());
 	}
 
 	/** @type {import('#client').Effect | null} */

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -1,5 +1,5 @@
 import { IS_ELSEIF } from '../../constants.js';
-import { hydrate_nodes, hydrate_block_anchor, hydrating, set_hydrating } from '../hydration.js';
+import { hydrate_nodes, hydrating, set_hydrating } from '../hydration.js';
 import { remove } from '../reconciler.js';
 import {
 	destroy_effect,
@@ -23,8 +23,6 @@ export function if_block(
 	alternate_fn = null,
 	elseif = false
 ) {
-	hydrate_block_anchor(anchor);
-
 	/** @type {import('#client').Effect | null} */
 	let consequent_effect = null;
 

--- a/packages/svelte/src/internal/client/dom/blocks/key.js
+++ b/packages/svelte/src/internal/client/dom/blocks/key.js
@@ -1,5 +1,4 @@
 import { UNINITIALIZED } from '../../constants.js';
-import { hydrate_block_anchor } from '../hydration.js';
 import { remove } from '../reconciler.js';
 import { pause_effect, render_effect } from '../../reactivity/effects.js';
 import { safe_not_equal } from '../../reactivity/equality.js';
@@ -12,8 +11,6 @@ import { safe_not_equal } from '../../reactivity/equality.js';
  * @returns {void}
  */
 export function key_block(anchor, get_key, render_fn) {
-	hydrate_block_anchor(anchor);
-
 	/** @type {V | typeof UNINITIALIZED} */
 	let key = UNINITIALIZED;
 

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
@@ -1,4 +1,3 @@
-import { hydrate_block_anchor } from '../hydration.js';
 import { pause_effect, render_effect } from '../../reactivity/effects.js';
 import { remove } from '../reconciler.js';
 import { current_effect } from '../../runtime.js';
@@ -14,8 +13,6 @@ import { current_effect } from '../../runtime.js';
  * @returns {void}
  */
 export function component(anchor, get_component, render_fn) {
-	hydrate_block_anchor(anchor);
-
 	/** @type {C} */
 	let component;
 

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -1,5 +1,5 @@
 import { namespace_svg } from '../../../../constants.js';
-import { hydrate_nodes, hydrating } from '../hydration.js';
+import { hydrate_anchor, hydrate_nodes, hydrating } from '../hydration.js';
 import { empty } from '../operations.js';
 import {
 	destroy_effect,
@@ -112,7 +112,7 @@ export function element(anchor, get_tag, is_svg, render_fn) {
 					// If hydrating, use the existing ssr comment as the anchor so that the
 					// inner open and close methods can pick up the existing nodes correctly
 					var child_anchor = hydrating
-						? /** @type {Comment} */ (element.firstChild)
+						? element.firstChild && hydrate_anchor(/** @type {Comment} */ (element.firstChild))
 						: element.appendChild(empty());
 
 					if (child_anchor) {

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -1,5 +1,5 @@
 import { namespace_svg } from '../../../../constants.js';
-import { hydrate_nodes, hydrate_block_anchor, hydrating } from '../hydration.js';
+import { hydrate_nodes, hydrating } from '../hydration.js';
 import { empty } from '../operations.js';
 import {
 	destroy_effect,
@@ -43,8 +43,6 @@ function swap_block_dom(effect, from, to) {
  */
 export function element(anchor, get_tag, is_svg, render_fn) {
 	const parent_effect = /** @type {import('#client').Effect} */ (current_effect);
-
-	hydrate_block_anchor(anchor);
 
 	/** @type {string | null} */
 	let tag;

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
@@ -1,4 +1,4 @@
-import { hydrate_nodes, hydrating, set_hydrate_nodes, update_hydrate_nodes } from '../hydration.js';
+import { hydrate_anchor, hydrate_nodes, hydrating, set_hydrate_nodes } from '../hydration.js';
 import { empty } from '../operations.js';
 import { render_effect } from '../../reactivity/effects.js';
 import { remove } from '../reconciler.js';
@@ -15,7 +15,13 @@ export function head(render_fn) {
 
 	if (hydrating) {
 		previous_hydrate_nodes = hydrate_nodes;
-		update_hydrate_nodes(document.head.firstChild);
+
+		let anchor = /** @type {import('#client').TemplateNode} */ (document.head.firstChild);
+		while (anchor.nodeType !== 8 || /** @type {Comment} */ (anchor).data !== '[') {
+			anchor = /** @type {import('#client').TemplateNode} */ (anchor.nextSibling);
+		}
+
+		anchor = /** @type {import('#client').TemplateNode} */ (hydrate_anchor(anchor));
 	}
 
 	var anchor = document.head.appendChild(empty());

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -98,7 +98,7 @@ if (typeof HTMLElement === 'function') {
 					 * @param {Element} anchor
 					 */
 					return (anchor) => {
-						const node = open(anchor, () => {
+						const node = open(() => {
 							const slot = document.createElement('slot');
 							if (name !== 'default') {
 								slot.name = name;

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -26,16 +26,6 @@ export function set_hydrate_nodes(nodes) {
 }
 
 /**
- * @param {Node | null} first
- * @param {boolean} [insert_text] Whether to insert an empty text node if `nodes` is empty
- */
-export function update_hydrate_nodes(first, insert_text) {
-	const nodes = get_hydrate_nodes(first, insert_text);
-	set_hydrate_nodes(nodes);
-	return nodes;
-}
-
-/**
  * Returns all nodes between the first `<![>...<!]>` comment tag pair encountered.
  * @param {Node} node
  * @returns {Node}

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -1,6 +1,3 @@
-import { schedule_task } from './task.js';
-import { empty } from './operations.js';
-
 /**
  * Use this variable to guard everything related to hydration code so it can be treeshaken out
  * if the user doesn't use the `hydrate` method and these code paths are therefore not needed.

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -26,7 +26,9 @@ export function set_hydrate_nodes(nodes) {
 }
 
 /**
- * Returns all nodes between the first `<![>...<!]>` comment tag pair encountered.
+ * This function is only called when `hydrating` is true. If passed a `<![>` opening
+ * hydration marker, it finds the corresponding closing marker and sets `hydrate_nodes`
+ * to everything between the markers, before returning the closing marker.
  * @param {Node} node
  * @returns {Node}
  */

--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -1,5 +1,4 @@
-import { append_child } from './operations.js';
-import { hydrate_nodes, hydrate_block_anchor, hydrating } from './hydration.js';
+import { hydrate_nodes, hydrating } from './hydration.js';
 import { is_array } from '../utils.js';
 
 /** @param {string} html */
@@ -74,7 +73,6 @@ export function remove(current) {
  * @returns {Element | Comment | (Element | Comment | Text)[]}
  */
 export function reconcile_html(target, value, svg) {
-	hydrate_block_anchor(target);
 	if (hydrating) {
 		return hydrate_nodes;
 	}

--- a/packages/svelte/src/internal/client/dom/task.js
+++ b/packages/svelte/src/internal/client/dom/task.js
@@ -26,18 +26,6 @@ function process_raf_task() {
  * @param {() => void} fn
  * @returns {void}
  */
-export function schedule_task(fn) {
-	if (!is_task_queued) {
-		is_task_queued = true;
-		setTimeout(process_task, 0);
-	}
-	current_queued_tasks.push(fn);
-}
-
-/**
- * @param {() => void} fn
- * @returns {void}
- */
 export function schedule_raf_task(fn) {
 	if (!is_raf_queued) {
 		is_raf_queued = true;

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -83,12 +83,11 @@ export function svg_template_with_script(svg, return_fragment) {
 /**
  * @param {boolean} is_fragment
  * @param {boolean} use_clone_node
- * @param {null | Text | Comment | Element} anchor
  * @param {() => Node} [template_element_fn]
  * @returns {Element | DocumentFragment | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-function open_template(is_fragment, use_clone_node, anchor, template_element_fn) {
+function open_template(is_fragment, use_clone_node, template_element_fn) {
 	if (hydrating) {
 		return is_fragment ? hydrate_nodes : /** @type {Element} */ (hydrate_nodes[0]);
 	}
@@ -99,23 +98,21 @@ function open_template(is_fragment, use_clone_node, anchor, template_element_fn)
 }
 
 /**
- * @param {null | Text | Comment | Element} anchor
  * @param {() => Node} template_element_fn
  * @param {boolean} [use_clone_node]
  * @returns {Element}
  */
-export function open(anchor, template_element_fn, use_clone_node = true) {
-	return /** @type {Element} */ (open_template(false, use_clone_node, anchor, template_element_fn));
+export function open(template_element_fn, use_clone_node = true) {
+	return /** @type {Element} */ (open_template(false, use_clone_node, template_element_fn));
 }
 
 /**
- * @param {null | Text | Comment | Element} anchor
  * @param {() => Node} template_element_fn
  * @param {boolean} [use_clone_node]
  * @returns {Element | DocumentFragment | Node[]}
  */
-export function open_frag(anchor, template_element_fn, use_clone_node = true) {
-	return open_template(true, use_clone_node, anchor, template_element_fn);
+export function open_frag(template_element_fn, use_clone_node = true) {
+	return open_template(true, use_clone_node, template_element_fn);
 }
 
 const space_template = template(' ', false);
@@ -127,7 +124,7 @@ const comment_template = template('<!>', true);
 /*#__NO_SIDE_EFFECTS__*/
 export function space_frag(anchor) {
 	/** @type {Node | null} */
-	var node = /** @type {any} */ (open(anchor, space_template));
+	var node = /** @type {any} */ (open(space_template));
 	// if an {expression} is empty during SSR, there might be no
 	// text node to hydrate (or an anchor comment is falsely detected instead)
 	//  — we must therefore create one
@@ -156,12 +153,9 @@ export function space(anchor) {
 	return anchor;
 }
 
-/**
- * @param {null | Text | Comment | Element} anchor
- */
 /*#__NO_SIDE_EFFECTS__*/
-export function comment(anchor) {
-	return open_frag(anchor, comment_template);
+export function comment() {
+	return open_frag(comment_template);
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -1,4 +1,4 @@
-import { hydrate_nodes, hydrate_block_anchor, hydrating } from './hydration.js';
+import { hydrate_nodes, hydrating } from './hydration.js';
 import { child, clone_node, empty } from './operations.js';
 import {
 	create_fragment_from_html,
@@ -90,11 +90,6 @@ export function svg_template_with_script(svg, return_fragment) {
 /*#__NO_SIDE_EFFECTS__*/
 function open_template(is_fragment, use_clone_node, anchor, template_element_fn) {
 	if (hydrating) {
-		if (anchor !== null) {
-			// TODO why is this sometimes null and sometimes not? needs clear documentation
-			hydrate_block_anchor(anchor);
-		}
-
 		return is_fragment ? hydrate_nodes : /** @type {Element} */ (hydrate_nodes[0]);
 	}
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -15,8 +15,7 @@ import {
 	hydrate_nodes,
 	hydrating,
 	set_hydrate_nodes,
-	set_hydrating,
-	update_hydrate_nodes
+	set_hydrating
 } from './dom/hydration.js';
 import { array_from } from './utils.js';
 import { handle_event_propagation } from './dom/elements/events.js';

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -154,8 +154,6 @@ export function hydrate(component, options) {
 			return instance;
 		}, false);
 	} catch (error) {
-		console.error(error.stack);
-
 		if (!hydrated && options.recover !== false) {
 			// eslint-disable-next-line no-console
 			console.error(

--- a/packages/svelte/tests/runtime-browser/driver.js
+++ b/packages/svelte/tests/runtime-browser/driver.js
@@ -25,7 +25,8 @@ export default async function (target) {
 				target,
 				props: config.props,
 				intro: config.intro,
-				hydrate: __HYDRATE__
+				hydrate: __HYDRATE__,
+				recover: false
 			},
 			config.options || {}
 		);

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -261,7 +261,7 @@ async function run_test_variant(
 				target,
 				immutable: config.immutable,
 				intro: config.intro,
-				recover: config.recover === undefined ? false : config.recover,
+				recover: config.recover ?? false,
 				hydrate: variant === 'hydrate'
 			});
 

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
@@ -7,7 +7,7 @@ export default function Bind_this($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
-	var fragment = $.comment($$anchor);
+	var fragment = $.comment();
 	var node = $.first_child(fragment);
 
 	$.bind_this(Foo(node, {}), ($$value) => foo = $$value, () => foo);

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -11,7 +11,7 @@ export default function Main($$anchor, $$props) {
 	// needs to be a snapshot test because jsdom does auto-correct the attribute casing
 	let x = 'test';
 	let y = () => 'test';
-	var fragment = $.open_frag($$anchor, frag, false);
+	var fragment = $.open_frag(frag, false);
 	var div = $.first_child(fragment);
 	var svg = $.sibling($.sibling(div, true));
 	var custom_element = $.sibling($.sibling(svg, true));

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -7,7 +7,7 @@ export default function Each_string_template($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
-	var fragment = $.comment($$anchor);
+	var fragment = $.comment();
 	var node = $.first_child(fragment);
 
 	$.each_indexed(node, 1, () => ['foo', 'bar', 'baz'], ($$anchor, thing, $$index) => {

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -13,7 +13,7 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 	}
 
 	const plusOne = (num) => num + 1;
-	var fragment = $.comment($$anchor);
+	var fragment = $.comment();
 	var node = $.first_child(fragment);
 
 	Button(node, {

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -9,7 +9,7 @@ export default function Hello_world($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
-	var h1 = $.open($$anchor, frag);
+	var h1 = $.open(frag);
 
 	$.close($$anchor, h1);
 	$.pop();

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -17,7 +17,7 @@ export default function State_proxy_literal($$anchor, $$props) {
 
 	let str = $.source('');
 	let tpl = $.source(``);
-	var fragment = $.open_frag($$anchor, frag);
+	var fragment = $.open_frag(frag);
 	var input = $.first_child(fragment);
 
 	$.remove_input_attr_defaults(input);

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
@@ -7,7 +7,7 @@ export default function Svelte_element($$anchor, $$props) {
 	$.push($$props, true);
 
 	let tag = $.prop($$props, "tag", 3, 'hr');
-	var fragment = $.comment($$anchor);
+	var fragment = $.comment();
 	var node = $.first_child(fragment);
 
 	$.element(node, tag, false);


### PR DESCRIPTION
Following #10939, we can simplify the hydration algorithm quite a bit. I need to add some comments to the code, but the basic idea is 'just in time hydration' — we call `child(...)` or `sibling(...)` or whatever to get the anchor node for the (if/each/await/etc) block that we're about to create, and if the child/sibling is a `<!--[-->` hydration opening marker, we populate `hydrate_nodes` and return the corresponding _closing_ marker. We therefore never need to cache stuff on `$$fragment`, and `anchor` is always truthy. We also don't need to call `hydrate_block_anchor` inside blocks.

Follow-ups:

- get rid of `$.open(...)` and `$.open_frag(...)`, we don't need them — we can just call the template function directly (and rename `$.close(...)` to something like `$.append(...)`, since there's no longer any symmetry)
- get rid of `ssr:if:true` and `ssr:each_else`. just put that information in the closing hydration marker
- make each blocks more efficient — we don't need to wrap every item in hydration markers
- extend the 'controlled' optimisation to non-each blocks
- more useful errors when hydration fails (not yet sure what this looks like)
- disallow user comments that look like hydration markers
- see if we can make the types easier to work with. we're constantly having to cast to `Node` or `TemplateNode`, it would be nice if that was unnecessary

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
