### PR TITLE
chore: remove `$.space`

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1064,7 +1064,7 @@ function create_block(parent, name, nodes, context) {
 			trimmed.every((node) => node.type === 'Text' || node.type === 'ExpressionTag');
 
 		if (use_space_template) {
-			// special case — we can use `$.space_frag` instead of creating a unique template
+			// special case — we can use `$.text` instead of creating a unique template
 			const id = b.id(context.state.scope.generate('text'));
 
 			process_children(trimmed, () => id, false, {
@@ -1072,11 +1072,7 @@ function create_block(parent, name, nodes, context) {
 				state
 			});
 
-			body.push(
-				b.var(id, b.call('$.space_frag', b.id('$$anchor'))),
-				...state.before_init,
-				...state.init
-			);
+			body.push(b.var(id, b.call('$.text', b.id('$$anchor'))), ...state.before_init, ...state.init);
 			close = b.stmt(b.call('$.close', b.id('$$anchor'), id));
 		} else {
 			/** @type {(is_text: boolean) => import('estree').Expression} */

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1408,7 +1408,7 @@ function process_children(nodes, expression, is_element, { visit, state }) {
 
 			state.template.push(' ');
 
-			const text_id = get_node_id(b.call('$.space', expression(true)), state, 'text');
+			const text_id = get_node_id(expression(true), state, 'text');
 
 			const update = b.stmt(
 				b.call(

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -115,25 +115,23 @@ export function open_frag(template_element_fn, use_clone_node = true) {
 	return open_template(true, use_clone_node, template_element_fn);
 }
 
-const space_template = template(' ', false);
 const comment_template = template('<!>', true);
 
 /**
- * @param {Text | Comment | Element | null} anchor
+ * @param {Text | Comment | Element} anchor
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function space_frag(anchor) {
-	/** @type {Node | null} */
-	var node = /** @type {any} */ (open(space_template));
-	// if an {expression} is empty during SSR, there might be no
-	// text node to hydrate (or an anchor comment is falsely detected instead)
-	//  — we must therefore create one
-	if (hydrating && node?.nodeType !== 3) {
-		node = empty();
-		// @ts-ignore in this case the anchor should always be a comment,
-		// if not something more fundamental is wrong and throwing here is better to bail out early
-		anchor.before(node);
+	if (!hydrating) return empty();
+
+	var node = hydrate_nodes[0];
+
+	if (!node) {
+		// if an {expression} is empty during SSR, `hydrate_nodes` will be empty.
+		// we need to insert an empty text node
+		anchor.before((node = empty()));
 	}
+
 	return node;
 }
 

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -121,7 +121,7 @@ const comment_template = template('<!>', true);
  * @param {Text | Comment | Element} anchor
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function space_frag(anchor) {
+export function text(anchor) {
 	if (!hydrating) return empty();
 
 	var node = hydrate_nodes[0];

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -137,22 +137,6 @@ export function space_frag(anchor) {
 	return node;
 }
 
-/**
- * @param {Text | Comment | Element} anchor
- */
-/*#__NO_SIDE_EFFECTS__*/
-export function space(anchor) {
-	// if an {expression} is empty during SSR, there might be no
-	// text node to hydrate (or an anchor comment is falsely detected instead)
-	//  — we must therefore create one
-	if (hydrating && anchor.nodeType !== 3) {
-		const node = empty();
-		anchor.before(node);
-		return node;
-	}
-	return anchor;
-}
-
 /*#__NO_SIDE_EFFECTS__*/
 export function comment() {
 	return open_frag(comment_template);

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -11,7 +11,7 @@ export default function Each_string_template($$anchor, $$props) {
 	var node = $.first_child(fragment);
 
 	$.each_indexed(node, 1, () => ['foo', 'bar', 'baz'], ($$anchor, thing, $$index) => {
-		var text = $.space_frag($$anchor);
+		var text = $.text($$anchor);
 
 		$.render_effect(() => $.set_text(text, `${$.stringify($.unwrap(thing))}, `));
 		return $.close($$anchor, text);

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -21,7 +21,7 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 		onmouseup,
 		onmouseenter: () => $.set(count, $.proxy(plusOne($.get(count)))),
 		children: ($$anchor, $$slotProps) => {
-			var text = $.space_frag($$anchor);
+			var text = $.text($$anchor);
 
 			$.render_effect(() => $.set_text(text, `clicks: ${$.stringify($.get(count))}`));
 			return $.close($$anchor, text);


### PR DESCRIPTION
`$.space(...)` is now just the identity function (maybe it was before, not sure). we can get rid