### PR TITLE
chore: root effects should not have parents

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -58,7 +58,7 @@ function create_effect(type, fn, sync, init = true) {
 		effect.l = current_effect.l + 1;
 	}
 
-	if (current_reaction !== null) {
+	if (current_reaction !== null && (type & ROOT_EFFECT) === 0) {
 		if (current_reaction.effects === null) {
 			current_reaction.effects = [effect];
 		} else {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -359,13 +359,10 @@ export function remove_reactions(signal, start_index) {
  */
 export function destroy_children(signal) {
 	if (signal.effects) {
-		for (var i = 0; i < signal.effects.length; i += 1) {
-			var effect = signal.effects[i];
-
-			// TODO ideally root effects would be parentless
-			if ((effect.f & ROOT_EFFECT) === 0) {
-				destroy_effect(effect);
-			}
+		var effect, i;
+		for (i = 0; i < signal.effects.length; i += 1) {
+			effect = signal.effects[i];
+			destroy_effect(effect);
 		}
 		signal.effects = null;
 	}


### PR DESCRIPTION
## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
