### PR TITLE
chore: simplify templates

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1088,12 +1088,6 @@ function create_block(parent, name, nodes, context) {
 		// It's important that close is the last statement in the block, as any previous statements
 		// could contain element insertions into the template, which the close statement needs to
 		// know of when constructing the list of current inner elements.
-
-		if (context.path.length > 0) {
-			// this is a block — return DOM so it can be attached directly to the effect
-			close = b.return(close.expression);
-		}
-
 		body.push(close);
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1072,7 +1072,7 @@ function create_block(parent, name, nodes, context) {
 
 			body.push(...state.before_init, ...state.init);
 
-			close = b.stmt(b.call('$.close_frag', b.id('$$anchor'), id));
+			close = b.stmt(b.call('$.close', b.id('$$anchor'), id));
 		}
 	} else {
 		body.push(...state.before_init, ...state.init);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -933,7 +933,7 @@ function serialize_bind_this(bind_this, context, node) {
  * // for the main block:
  * const id = block_name();
  * // init stuff and possibly render effect
- * $.close($$anchor, id);
+ * $.append($$anchor, id);
  * ```
  * Adds the hoisted parts to `context.state.hoisted` and returns the statements of the main block.
  * @param {import('#compiler').SvelteNode} parent
@@ -1015,7 +1015,7 @@ function create_block(parent, name, nodes, context) {
 		);
 
 		body.push(b.var(id, b.call(template_name)), ...state.before_init, ...state.init);
-		close = b.stmt(b.call('$.close', b.id('$$anchor'), id));
+		close = b.stmt(b.call('$.append', b.id('$$anchor'), id));
 	} else if (is_single_child_not_needing_template) {
 		context.visit(trimmed[0], state);
 		body.push(...state.before_init, ...state.init);
@@ -1036,7 +1036,7 @@ function create_block(parent, name, nodes, context) {
 			});
 
 			body.push(b.var(id, b.call('$.text', b.id('$$anchor'))), ...state.before_init, ...state.init);
-			close = b.stmt(b.call('$.close', b.id('$$anchor'), id));
+			close = b.stmt(b.call('$.append', b.id('$$anchor'), id));
 		} else {
 			/** @type {(is_text: boolean) => import('estree').Expression} */
 			const expression = (is_text) =>
@@ -1072,7 +1072,7 @@ function create_block(parent, name, nodes, context) {
 
 			body.push(...state.before_init, ...state.init);
 
-			close = b.stmt(b.call('$.close', b.id('$$anchor'), id));
+			close = b.stmt(b.call('$.append', b.id('$$anchor'), id));
 		}
 	} else {
 		body.push(...state.before_init, ...state.init);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1555,7 +1555,7 @@ function serialize_template_literal(values, visit) {
 /** @type {import('../types').ComponentVisitors} */
 export const template_visitors = {
 	Fragment(node, context) {
-		const body = create_block(node, 'frag', node.nodes, context);
+		const body = create_block(node, 'root', node.nodes, context);
 		return b.block(body);
 	},
 	Comment(node, context) {

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -16,6 +16,9 @@ export const TRANSITION_IN = 1;
 export const TRANSITION_OUT = 1 << 1;
 export const TRANSITION_GLOBAL = 1 << 2;
 
+export const TEMPLATE_FRAGMENT = 1;
+export const TEMPLATE_USE_IMPORT_NODE = 1 << 1;
+
 /** List of Element events that will be delegated */
 export const DelegatedEvents = [
 	'beforeinput',

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -8,7 +8,7 @@ import {
 } from '../../../../constants.js';
 import { hydrate_anchor, hydrate_nodes, hydrating, set_hydrating } from '../hydration.js';
 import { empty } from '../operations.js';
-import { insert, remove } from '../reconciler.js';
+import { remove } from '../reconciler.js';
 import { untrack } from '../../runtime.js';
 import {
 	block,
@@ -389,7 +389,7 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 
 				if (moved && index !== LIS_ITEM) {
 					if (last_item !== undefined) anchor = get_first_child(last_item);
-					insert(/** @type {import('#client').Dom} */ (item.e.dom), anchor);
+					move(/** @type {import('#client').Dom} */ (item.e.dom), anchor);
 				}
 			}
 
@@ -558,5 +558,19 @@ function create_item(anchor, value, key, index, render_fn, flags) {
 		return item;
 	} finally {
 		current_each_item = previous_each_item;
+	}
+}
+
+/**
+ * @param {import('#client').Dom} current
+ * @param {Text | Element | Comment} anchor
+ */
+function move(current, anchor) {
+	if (is_array(current)) {
+		for (var i = 0; i < current.length; i++) {
+			anchor.before(current[i]);
+		}
+	} else {
+		anchor.before(current);
 	}
 }

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -1,6 +1,4 @@
-import { render_effect } from '../../reactivity/effects.js';
-import { remove } from '../reconciler.js';
-import { untrack } from '../../runtime.js';
+import { branch, render_effect } from '../../reactivity/effects.js';
 
 /**
  * @template {(node: import('#client').TemplateNode, ...args: any[]) => import('#client').Dom} SnippetFn
@@ -11,19 +9,13 @@ import { untrack } from '../../runtime.js';
  */
 export function snippet(get_snippet, node, ...args) {
 	/** @type {SnippetFn | null | undefined} */
-	var snippet_fn;
+	var snippet;
 
 	render_effect(() => {
-		if (snippet_fn === (snippet_fn = get_snippet())) return;
+		if (snippet === (snippet = get_snippet())) return;
 
-		if (snippet_fn) {
-			// Untrack so we only rerender when the snippet function itself changes,
-			// not when an eagerly-read prop inside the snippet function changes
-			var dom = untrack(() => /** @type {SnippetFn} */ (snippet_fn)(node, ...args));
-
-			if (dom !== undefined) {
-				return () => remove(dom);
-			}
+		if (snippet) {
+			branch(() => /** @type {SnippetFn} */ (snippet)(node, ...args));
 		}
 	});
 }

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -1,6 +1,6 @@
 import { createClassComponent } from '../../../../legacy/legacy-client.js';
 import { destroy_effect, render_effect } from '../../reactivity/effects.js';
-import { open, close } from '../template.js';
+import { close } from '../template.js';
 import { define_property } from '../../utils.js';
 
 /**
@@ -98,14 +98,10 @@ if (typeof HTMLElement === 'function') {
 					 * @param {Element} anchor
 					 */
 					return (anchor) => {
-						const node = open(() => {
-							const slot = document.createElement('slot');
-							if (name !== 'default') {
-								slot.name = name;
-							}
-							return slot;
-						});
-						close(anchor, /** @type {Element} */ (node));
+						const slot = document.createElement('slot');
+						if (name !== 'default') slot.name = name;
+
+						close(anchor, slot);
 					};
 				}
 				/** @type {Record<string, any>} */

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -1,6 +1,6 @@
 import { createClassComponent } from '../../../../legacy/legacy-client.js';
 import { destroy_effect, render_effect } from '../../reactivity/effects.js';
-import { close } from '../template.js';
+import { append } from '../template.js';
 import { define_property } from '../../utils.js';
 
 /**
@@ -101,7 +101,7 @@ if (typeof HTMLElement === 'function') {
 						const slot = document.createElement('slot');
 						if (name !== 'default') slot.name = name;
 
-						close(anchor, slot);
+						append(anchor, slot);
 					};
 				}
 				/** @type {Record<string, any>} */

--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -10,22 +10,6 @@ export function create_fragment_from_html(html) {
 
 /**
  * @param {import('#client').Dom} current
- * @param {Text | Element | Comment} sibling
- */
-export function insert(current, sibling) {
-	if (!current) return sibling;
-
-	if (is_array(current)) {
-		for (var i = 0; i < current.length; i++) {
-			sibling.before(/** @type {Node} */ (current[i]));
-		}
-	} else {
-		sibling.before(/** @type {Node} */ (current));
-	}
-}
-
-/**
- * @param {import('#client').Dom} current
  */
 export function remove(current) {
 	if (is_array(current)) {

--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -9,25 +9,6 @@ export function create_fragment_from_html(html) {
 }
 
 /**
- * Creating a document fragment from HTML that contains script tags will not execute
- * the scripts. We need to replace the script tags with new ones so that they are executed.
- * @param {string} html
- */
-export function create_fragment_with_script_from_html(html) {
-	var content = create_fragment_from_html(html);
-	var scripts = content.querySelectorAll('script');
-	for (const script of scripts) {
-		var new_script = document.createElement('script');
-		for (var i = 0; i < script.attributes.length; i++) {
-			new_script.setAttribute(script.attributes[i].name, script.attributes[i].value);
-		}
-		new_script.textContent = script.textContent;
-		/** @type {Node} */ (script.parentNode).replaceChild(new_script, script);
-	}
-	return content;
-}
-
-/**
  * @param {import('#client').Dom} current
  * @param {Text | Element | Comment} sibling
  */

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -155,16 +155,15 @@ export const comment = template('<!>', TEMPLATE_FRAGMENT);
 /**
  * Assign the created (or in hydration mode, traversed) dom elements to the current block
  * and insert the elements into the dom (in client mode).
- * @param {import('#client').Dom} dom
- * @param {boolean} is_fragment
  * @param {Text | Comment | Element} anchor
+ * @param {import('#client').Dom} dom
  * @returns {import('#client').Dom}
  */
-function close_template(dom, is_fragment, anchor) {
+export function close(anchor, dom) {
 	var current = dom;
 
 	if (!hydrating) {
-		if (is_fragment) {
+		if (/** @type {Node} */ (dom).nodeType === 11) {
 			// if hydrating, `dom` is already an array of nodes, but if not then
 			// we need to create an array to store it on the current effect
 			current = /** @type {import('#client').Dom} */ ([.../** @type {Node} */ (dom).childNodes]);
@@ -177,20 +176,4 @@ function close_template(dom, is_fragment, anchor) {
 	/** @type {import('#client').Effect} */ (current_effect).dom = current;
 
 	return current;
-}
-
-/**
- * @param {Text | Comment | Element} anchor
- * @param {Element | Text} dom
- */
-export function close(anchor, dom) {
-	return close_template(dom, false, anchor);
-}
-
-/**
- * @param {Text | Comment | Element} anchor
- * @param {Element | Text} dom
- */
-export function close_frag(anchor, dom) {
-	return close_template(dom, true, anchor);
 }

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -157,7 +157,6 @@ export const comment = template('<!>', TEMPLATE_FRAGMENT);
  * and insert the elements into the dom (in client mode).
  * @param {Text | Comment | Element} anchor
  * @param {import('#client').Dom} dom
- * @returns {import('#client').Dom}
  */
 export function append(anchor, dom) {
 	var current = dom;
@@ -175,6 +174,4 @@ export function append(anchor, dom) {
 	}
 
 	/** @type {import('#client').Effect} */ (current_effect).dom = current;
-
-	return current;
 }

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -62,6 +62,7 @@ export function template_with_script(content, flags) {
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function svg_template(content, flags) {
+	var is_fragment = (flags & TEMPLATE_FRAGMENT) !== 0;
 	var fn = template(`<svg>${content}</svg>`, 0); // we don't need to worry about using importNode for SVGs
 
 	/** @type {Element | DocumentFragment} */
@@ -69,7 +70,7 @@ export function svg_template(content, flags) {
 
 	return () => {
 		if (hydrating) {
-			return fn();
+			return is_fragment ? hydrate_nodes : /** @type {Node} */ (hydrate_nodes[0]);
 		}
 
 		if (!node) {
@@ -85,7 +86,7 @@ export function svg_template(content, flags) {
 			}
 		}
 
-		return node;
+		return clone_node(node, true);
 	};
 }
 

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -163,10 +163,12 @@ export function append(anchor, dom) {
 	var current = dom;
 
 	if (!hydrating) {
-		if (/** @type {Node} */ (dom).nodeType === 11) {
+		var node = /** @type {Node} */ (dom);
+
+		if (node.nodeType === 11) {
 			// if hydrating, `dom` is already an array of nodes, but if not then
 			// we need to create an array to store it on the current effect
-			current = /** @type {import('#client').Dom} */ ([.../** @type {Node} */ (dom).childNodes]);
+			current = /** @type {import('#client').Dom} */ ([...node.childNodes]);
 		}
 
 		// TODO ideally we'd do `anchor.before(dom)`, but that fails because `dom` can be an array of nodes in the SVG case

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -1,6 +1,6 @@
 import { hydrate_nodes, hydrating } from './hydration.js';
 import { clone_node, empty } from './operations.js';
-import { create_fragment_from_html, insert } from './reconciler.js';
+import { create_fragment_from_html } from './reconciler.js';
 import { current_effect } from '../runtime.js';
 import { TEMPLATE_FRAGMENT, TEMPLATE_USE_IMPORT_NODE } from '../../../constants.js';
 
@@ -171,8 +171,7 @@ export function append(anchor, dom) {
 			current = /** @type {import('#client').Dom} */ ([...node.childNodes]);
 		}
 
-		// TODO ideally we'd do `anchor.before(dom)`, but that fails because `dom` can be an array of nodes in the SVG case
-		insert(current, anchor);
+		anchor.before(node);
 	}
 
 	/** @type {import('#client').Effect} */ (current_effect).dom = current;

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -1,121 +1,134 @@
 import { hydrate_nodes, hydrating } from './hydration.js';
-import { child, clone_node, empty } from './operations.js';
-import {
-	create_fragment_from_html,
-	create_fragment_with_script_from_html,
-	insert
-} from './reconciler.js';
+import { clone_node, empty } from './operations.js';
+import { create_fragment_from_html, insert } from './reconciler.js';
 import { current_effect } from '../runtime.js';
-import { is_array } from '../utils.js';
+import { TEMPLATE_FRAGMENT, TEMPLATE_USE_IMPORT_NODE } from '../../../constants.js';
 
 /**
  * @param {string} html
- * @param {boolean} return_fragment
- * @returns {() => Node}
+ * @param {number} flags
+ * @returns {() => Node | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function template(html, return_fragment) {
-	/** @type {undefined | Node} */
-	let cached_content;
+export function template(html, flags) {
+	var is_fragment = (flags & TEMPLATE_FRAGMENT) !== 0;
+	var use_import_node = (flags & TEMPLATE_USE_IMPORT_NODE) !== 0;
+
+	/** @type {Node} */
+	var node;
+
 	return () => {
-		if (cached_content === undefined) {
-			const content = create_fragment_from_html(html);
-			cached_content = return_fragment ? content : /** @type {Node} */ (child(content));
+		if (hydrating) {
+			return is_fragment ? hydrate_nodes : /** @type {Node} */ (hydrate_nodes[0]);
 		}
-		return cached_content;
+
+		if (!node) {
+			node = create_fragment_from_html(html);
+			if (!is_fragment) node = /** @type {Node} */ (node.firstChild);
+		}
+
+		return use_import_node ? document.importNode(node, true) : clone_node(node, true);
 	};
 }
 
 /**
  * @param {string} html
- * @param {boolean} return_fragment
- * @returns {() => Node}
+ * @param {number} flags
+ * @returns {() => Node | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function template_with_script(html, return_fragment) {
-	/** @type {undefined | Node} */
-	let cached_content;
+export function template_with_script(html, flags) {
+	var first = true;
+	var fn = template(html, flags);
+
 	return () => {
-		if (cached_content === undefined) {
-			const content = create_fragment_with_script_from_html(html);
-			cached_content = return_fragment ? content : /** @type {Node} */ (child(content));
+		if (hydrating) return fn();
+
+		var node = /** @type {Element | DocumentFragment} */ (fn());
+
+		if (first) {
+			first = false;
+			run_scripts(node);
 		}
-		return cached_content;
+
+		return node;
 	};
 }
 
 /**
  * @param {string} svg
- * @param {boolean} return_fragment
- * @returns {() => Node}
+ * @param {number} flags
+ * @returns {() => Node | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function svg_template(svg, return_fragment) {
-	/** @type {undefined | Node} */
-	let cached_content;
+export function svg_template(svg, flags) {
+	var fn = template(`<svg>${svg}</svg>`, flags & ~TEMPLATE_FRAGMENT);
+
+	/** @type {Element | DocumentFragment} */
+	var node;
+
 	return () => {
-		if (cached_content === undefined) {
-			const content = /** @type {Node} */ (child(create_fragment_from_html(`<svg>${svg}</svg>`)));
-			cached_content = return_fragment ? content : /** @type {Node} */ (child(content));
+		if (hydrating) {
+			return fn();
 		}
-		return cached_content;
+
+		if (!node) {
+			var element = /** @type {Element} */ (fn());
+
+			if ((flags & TEMPLATE_FRAGMENT) === 0) {
+				node = /** @type {Element} */ (element.firstChild);
+			} else {
+				node = document.createDocumentFragment();
+				while (element.firstChild) {
+					node.appendChild(element.firstChild);
+				}
+			}
+		}
+
+		return node;
 	};
 }
 
 /**
  * @param {string} svg
- * @param {boolean} return_fragment
- * @returns {() => Node}
+ * @param {number} flags
+ * @returns {() => Node | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function svg_template_with_script(svg, return_fragment) {
-	/** @type {undefined | Node} */
-	let cached_content;
+export function svg_template_with_script(svg, flags) {
+	var first = true;
+	var fn = svg_template(svg, flags);
+
 	return () => {
-		if (cached_content === undefined) {
-			const content = /** @type {Node} */ (child(create_fragment_from_html(`<svg>${svg}</svg>`)));
-			cached_content = return_fragment ? content : /** @type {Node} */ (child(content));
+		if (hydrating) return fn();
+
+		var node = /** @type {Element | DocumentFragment} */ (fn());
+
+		if (first) {
+			first = false;
+			run_scripts(node);
 		}
-		return cached_content;
+
+		return node;
 	};
 }
 
 /**
- * @param {boolean} is_fragment
- * @param {boolean} use_clone_node
- * @param {() => Node} [template_element_fn]
- * @returns {Element | DocumentFragment | Node[]}
+ * Creating a document fragment from HTML that contains script tags will not execute
+ * the scripts. We need to replace the script tags with new ones so that they are executed.
+ * @param {Element | DocumentFragment} node
  */
-/*#__NO_SIDE_EFFECTS__*/
-function open_template(is_fragment, use_clone_node, template_element_fn) {
-	if (hydrating) {
-		return is_fragment ? hydrate_nodes : /** @type {Element} */ (hydrate_nodes[0]);
+function run_scripts(node) {
+	for (const script of node.querySelectorAll('script')) {
+		var clone = document.createElement('script');
+		for (var attribute of script.attributes) {
+			clone.setAttribute(attribute.name, attribute.value);
+		}
+
+		clone.textContent = script.textContent;
+		script.replaceWith(clone);
 	}
-
-	return use_clone_node
-		? clone_node(/** @type {() => Element} */ (template_element_fn)(), true)
-		: document.importNode(/** @type {() => Element} */ (template_element_fn)(), true);
 }
-
-/**
- * @param {() => Node} template_element_fn
- * @param {boolean} [use_clone_node]
- * @returns {Element}
- */
-export function open(template_element_fn, use_clone_node = true) {
-	return /** @type {Element} */ (open_template(false, use_clone_node, template_element_fn));
-}
-
-/**
- * @param {() => Node} template_element_fn
- * @param {boolean} [use_clone_node]
- * @returns {Element | DocumentFragment | Node[]}
- */
-export function open_frag(template_element_fn, use_clone_node = true) {
-	return open_template(true, use_clone_node, template_element_fn);
-}
-
-const comment_template = template('<!>', true);
 
 /**
  * @param {Text | Comment | Element} anchor
@@ -136,9 +149,7 @@ export function text(anchor) {
 }
 
 /*#__NO_SIDE_EFFECTS__*/
-export function comment() {
-	return open_frag(comment_template);
-}
+export const comment = template('<!>', TEMPLATE_FRAGMENT);
 
 /**
  * Assign the created (or in hydration mode, traversed) dom elements to the current block

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -159,7 +159,7 @@ export const comment = template('<!>', TEMPLATE_FRAGMENT);
  * @param {import('#client').Dom} dom
  * @returns {import('#client').Dom}
  */
-export function close(anchor, dom) {
+export function append(anchor, dom) {
 	var current = dom;
 
 	if (!hydrating) {

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -5,12 +5,12 @@ import { current_effect } from '../runtime.js';
 import { TEMPLATE_FRAGMENT, TEMPLATE_USE_IMPORT_NODE } from '../../../constants.js';
 
 /**
- * @param {string} html
+ * @param {string} content
  * @param {number} flags
  * @returns {() => Node | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function template(html, flags) {
+export function template(content, flags) {
 	var is_fragment = (flags & TEMPLATE_FRAGMENT) !== 0;
 	var use_import_node = (flags & TEMPLATE_USE_IMPORT_NODE) !== 0;
 
@@ -23,7 +23,7 @@ export function template(html, flags) {
 		}
 
 		if (!node) {
-			node = create_fragment_from_html(html);
+			node = create_fragment_from_html(content);
 			if (!is_fragment) node = /** @type {Node} */ (node.firstChild);
 		}
 
@@ -32,14 +32,14 @@ export function template(html, flags) {
 }
 
 /**
- * @param {string} html
+ * @param {string} content
  * @param {number} flags
  * @returns {() => Node | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function template_with_script(html, flags) {
+export function template_with_script(content, flags) {
 	var first = true;
-	var fn = template(html, flags);
+	var fn = template(content, flags);
 
 	return () => {
 		if (hydrating) return fn();
@@ -56,13 +56,13 @@ export function template_with_script(html, flags) {
 }
 
 /**
- * @param {string} svg
+ * @param {string} content
  * @param {number} flags
  * @returns {() => Node | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function svg_template(svg, flags) {
-	var fn = template(`<svg>${svg}</svg>`, flags & ~TEMPLATE_FRAGMENT);
+export function svg_template(content, flags) {
+	var fn = template(`<svg>${content}</svg>`, 0); // we don't need to worry about using importNode for SVGs
 
 	/** @type {Element | DocumentFragment} */
 	var node;
@@ -73,14 +73,14 @@ export function svg_template(svg, flags) {
 		}
 
 		if (!node) {
-			var element = /** @type {Element} */ (fn());
+			var svg = /** @type {Element} */ (fn());
 
 			if ((flags & TEMPLATE_FRAGMENT) === 0) {
-				node = /** @type {Element} */ (element.firstChild);
+				node = /** @type {Element} */ (svg.firstChild);
 			} else {
 				node = document.createDocumentFragment();
-				while (element.firstChild) {
-					node.appendChild(element.firstChild);
+				while (svg.firstChild) {
+					node.appendChild(svg.firstChild);
 				}
 			}
 		}
@@ -90,14 +90,14 @@ export function svg_template(svg, flags) {
 }
 
 /**
- * @param {string} svg
+ * @param {string} content
  * @param {number} flags
  * @returns {() => Node | Node[]}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function svg_template_with_script(svg, flags) {
+export function svg_template_with_script(content, flags) {
 	var first = true;
-	var fn = svg_template(svg, flags);
+	var fn = svg_template(content, flags);
 
 	return () => {
 		if (hydrating) return fn();

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
@@ -11,6 +11,6 @@ export default function Bind_this($$anchor, $$props) {
 	var node = $.first_child(fragment);
 
 	$.bind_this(Foo(node, {}), ($$value) => foo = $$value, () => foo);
-	$.close_frag($$anchor, fragment);
+	$.close($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
@@ -11,6 +11,6 @@ export default function Bind_this($$anchor, $$props) {
 	var node = $.first_child(fragment);
 
 	$.bind_this(Foo(node, {}), ($$value) => foo = $$value, () => foo);
-	$.close($$anchor, fragment);
+	$.append($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -33,6 +33,6 @@ export default function Main($$anchor, $$props) {
 		$.set_custom_element_data(custom_element, "fooBar", x);
 	});
 
-	$.close($$anchor, fragment);
+	$.append($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -3,7 +3,7 @@
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal";
 
-var frag = $.template(`<div></div> <svg></svg> <custom-element></custom-element> <div></div> <svg></svg> <custom-element></custom-element>`, 3);
+var root = $.template(`<div></div> <svg></svg> <custom-element></custom-element> <div></div> <svg></svg> <custom-element></custom-element>`, 3);
 
 export default function Main($$anchor, $$props) {
 	$.push($$props, true);
@@ -11,7 +11,7 @@ export default function Main($$anchor, $$props) {
 	// needs to be a snapshot test because jsdom does auto-correct the attribute casing
 	let x = 'test';
 	let y = () => 'test';
-	var fragment = frag();
+	var fragment = root();
 	var div = $.first_child(fragment);
 	var svg = $.sibling($.sibling(div, true));
 	var custom_element = $.sibling($.sibling(svg, true));

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -3,7 +3,7 @@
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal";
 
-var frag = $.template(`<div></div> <svg></svg> <custom-element></custom-element> <div></div> <svg></svg> <custom-element></custom-element>`, true);
+var frag = $.template(`<div></div> <svg></svg> <custom-element></custom-element> <div></div> <svg></svg> <custom-element></custom-element>`, 3);
 
 export default function Main($$anchor, $$props) {
 	$.push($$props, true);
@@ -11,7 +11,7 @@ export default function Main($$anchor, $$props) {
 	// needs to be a snapshot test because jsdom does auto-correct the attribute casing
 	let x = 'test';
 	let y = () => 'test';
-	var fragment = $.open_frag(frag, false);
+	var fragment = frag();
 	var div = $.first_child(fragment);
 	var svg = $.sibling($.sibling(div, true));
 	var custom_element = $.sibling($.sibling(svg, true));

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -33,6 +33,6 @@ export default function Main($$anchor, $$props) {
 		$.set_custom_element_data(custom_element, "fooBar", x);
 	});
 
-	$.close_frag($$anchor, fragment);
+	$.close($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -17,6 +17,6 @@ export default function Each_string_template($$anchor, $$props) {
 		return $.close($$anchor, text);
 	});
 
-	$.close_frag($$anchor, fragment);
+	$.close($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -14,7 +14,7 @@ export default function Each_string_template($$anchor, $$props) {
 		var text = $.text($$anchor);
 
 		$.render_effect(() => $.set_text(text, `${$.stringify($.unwrap(thing))}, `));
-		return $.append($$anchor, text);
+		$.append($$anchor, text);
 	});
 
 	$.append($$anchor, fragment);

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -14,9 +14,9 @@ export default function Each_string_template($$anchor, $$props) {
 		var text = $.text($$anchor);
 
 		$.render_effect(() => $.set_text(text, `${$.stringify($.unwrap(thing))}, `));
-		return $.close($$anchor, text);
+		return $.append($$anchor, text);
 	});
 
-	$.close($$anchor, fragment);
+	$.append($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -28,6 +28,6 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 		}
 	});
 
-	$.close_frag($$anchor, fragment);
+	$.close($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -24,7 +24,7 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 			var text = $.text($$anchor);
 
 			$.render_effect(() => $.set_text(text, `clicks: ${$.stringify($.get(count))}`));
-			return $.append($$anchor, text);
+			$.append($$anchor, text);
 		}
 	});
 

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -24,10 +24,10 @@ export default function Function_prop_no_getter($$anchor, $$props) {
 			var text = $.text($$anchor);
 
 			$.render_effect(() => $.set_text(text, `clicks: ${$.stringify($.get(count))}`));
-			return $.close($$anchor, text);
+			return $.append($$anchor, text);
 		}
 	});
 
-	$.close($$anchor, fragment);
+	$.append($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -9,7 +9,7 @@ export default function Hello_world($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
-	var h1 = $.open(frag);
+	var h1 = frag();
 
 	$.close($$anchor, h1);
 	$.pop();

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -11,6 +11,6 @@ export default function Hello_world($$anchor, $$props) {
 
 	var h1 = frag();
 
-	$.close($$anchor, h1);
+	$.append($$anchor, h1);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -3,13 +3,13 @@
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal";
 
-var frag = $.template(`<h1>hello world</h1>`);
+var root = $.template(`<h1>hello world</h1>`);
 
 export default function Hello_world($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
-	var h1 = frag();
+	var h1 = root();
 
 	$.append($$anchor, h1);
 	$.pop();

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -31,7 +31,7 @@ export default function State_proxy_literal($$anchor, $$props) {
 	button.__click = [reset, str, tpl];
 	$.bind_value(input, () => $.get(str), ($$value) => $.set(str, $$value));
 	$.bind_value(input_1, () => $.get(tpl), ($$value) => $.set(tpl, $$value));
-	$.close_frag($$anchor, fragment);
+	$.close($$anchor, fragment);
 	$.pop();
 }
 

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -10,14 +10,14 @@ function reset(_, str, tpl) {
 	$.set(tpl, ``);
 }
 
-var frag = $.template(`<input> <input> <button>reset</button>`, true);
+var frag = $.template(`<input> <input> <button>reset</button>`, 1);
 
 export default function State_proxy_literal($$anchor, $$props) {
 	$.push($$props, true);
 
 	let str = $.source('');
 	let tpl = $.source(``);
-	var fragment = $.open_frag(frag);
+	var fragment = frag();
 	var input = $.first_child(fragment);
 
 	$.remove_input_attr_defaults(input);

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -31,7 +31,7 @@ export default function State_proxy_literal($$anchor, $$props) {
 	button.__click = [reset, str, tpl];
 	$.bind_value(input, () => $.get(str), ($$value) => $.set(str, $$value));
 	$.bind_value(input_1, () => $.get(tpl), ($$value) => $.set(tpl, $$value));
-	$.close($$anchor, fragment);
+	$.append($$anchor, fragment);
 	$.pop();
 }
 

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -10,14 +10,14 @@ function reset(_, str, tpl) {
 	$.set(tpl, ``);
 }
 
-var frag = $.template(`<input> <input> <button>reset</button>`, 1);
+var root = $.template(`<input> <input> <button>reset</button>`, 1);
 
 export default function State_proxy_literal($$anchor, $$props) {
 	$.push($$props, true);
 
 	let str = $.source('');
 	let tpl = $.source(``);
-	var fragment = frag();
+	var fragment = root();
 	var input = $.first_child(fragment);
 
 	$.remove_input_attr_defaults(input);

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
@@ -11,6 +11,6 @@ export default function Svelte_element($$anchor, $$props) {
 	var node = $.first_child(fragment);
 
 	$.element(node, tag, false);
-	$.close($$anchor, fragment);
+	$.append($$anchor, fragment);
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
@@ -11,6 +11,6 @@ export default function Svelte_element($$anchor, $$props) {
 	var node = $.first_child(fragment);
 
 	$.element(node, tag, false);
-	$.close_frag($$anchor, fragment);
+	$.close($$anchor, fragment);
 	$.pop();
 }


### PR DESCRIPTION
This simplifies the template logic — fewer function calls, and shorter compiled output (particularly when mixing and matching fragments and elements etc)

```diff
-var frag = $.template(`<button> </button>`);
+var root = $.template(`<button> </button>`);

export default function App($$anchor, $$props) {
  $.push($$props, true);

  let count = $.source(0);
-  var button = $.open(frag);
+  var button = root();

  button.__click = [increment, count];

  var text = $.child(button);

  $.render_effect(() => $.set_text(text, `clicks: ${$.stringify($.get(count))}`));
-  $.close($$anchor, button);
+  $.append($$anchor, button);
  $.pop();
}
```



### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
