### PR TITLE
more effect ordering stuff

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/bindings/this.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/this.js
@@ -22,7 +22,7 @@ function is_bound_this(bound_value, element_or_component) {
  * @returns {void}
  */
 export function bind_this(element_or_component, update, get_value, get_parts) {
-	render_effect(() => {
+	effect(() => {
 		/** @type {unknown[]} */
 		var old_parts;
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -34,10 +34,9 @@ import { remove } from '../dom/reconciler.js';
  * @param {import('./types.js').EffectType} type
  * @param {(() => void | (() => void))} fn
  * @param {boolean} sync
- * @param {boolean} init
  * @returns {import('#client').Effect}
  */
-export function create_effect(type, fn, sync, init = true) {
+function create_effect(type, fn, sync) {
 	var is_root = (type & ROOT_EFFECT) !== 0;
 	/** @type {import('#client').Effect} */
 	var effect = {
@@ -61,20 +60,18 @@ export function create_effect(type, fn, sync, init = true) {
 		}
 	}
 
-	if (init) {
-		if (sync) {
-			var previously_flushing_effect = is_flushing_effect;
+	if (sync) {
+		var previously_flushing_effect = is_flushing_effect;
 
-			try {
-				set_is_flushing_effect(true);
-				execute_effect(effect);
-				effect.f |= EFFECT_RAN;
-			} finally {
-				set_is_flushing_effect(previously_flushing_effect);
-			}
-		} else {
-			schedule_effect(effect);
+		try {
+			set_is_flushing_effect(true);
+			execute_effect(effect);
+			effect.f |= EFFECT_RAN;
+		} finally {
+			set_is_flushing_effect(previously_flushing_effect);
 		}
+	} else {
+		schedule_effect(effect);
 	}
 
 	return effect;
@@ -112,7 +109,7 @@ export function user_effect(fn) {
 		const context = /** @type {import('#client').ComponentContext} */ (current_component_context);
 		(context.e ??= []).push(fn);
 	} else {
-		create_effect(EFFECT, fn, false, true);
+		effect(fn);
 	}
 }
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -8,7 +8,7 @@ import {
 	object_prototype
 } from './utils.js';
 import { unstate } from './proxy.js';
-import { destroy_effect, user_pre_effect } from './reactivity/effects.js';
+import { create_effect, destroy_effect, user_pre_effect } from './reactivity/effects.js';
 import {
 	EFFECT,
 	RENDER_EFFECT,
@@ -1094,6 +1094,8 @@ export function push(props, runes = false, fn) {
 		x: null,
 		// context
 		c: null,
+		// effects
+		e: null,
 		// mounted
 		m: false,
 		// parent
@@ -1128,6 +1130,13 @@ export function pop(component) {
 	if (context_stack_item !== null) {
 		if (component !== undefined) {
 			context_stack_item.x = component;
+		}
+		const effects = context_stack_item.e;
+		if (effects !== null) {
+			context_stack_item.e = null;
+			for (let i = 0; i < effects.length; i++) {
+				create_effect(EFFECT, effects[i], false, true);
+			}
 		}
 		current_component_context = context_stack_item.p;
 		context_stack_item.m = true;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -8,7 +8,7 @@ import {
 	object_prototype
 } from './utils.js';
 import { unstate } from './proxy.js';
-import { create_effect, destroy_effect, user_pre_effect } from './reactivity/effects.js';
+import { destroy_effect, effect, user_pre_effect } from './reactivity/effects.js';
 import {
 	EFFECT,
 	RENDER_EFFECT,
@@ -1135,7 +1135,7 @@ export function pop(component) {
 		if (effects !== null) {
 			context_stack_item.e = null;
 			for (let i = 0; i < effects.length; i++) {
-				create_effect(EFFECT, effects[i], false, true);
+				effect(effects[i]);
 			}
 		}
 		current_component_context = context_stack_item.p;

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -20,6 +20,8 @@ export type ComponentContext = {
 	s: Record<string, unknown>;
 	/** exports (and props, if `accessors: true`) */
 	x: Record<string, any> | null;
+	/** deferred effects */
+	e: null | Array<() => void | (() => void)>;
 	/** mounted */
 	m: boolean;
 	/** parent */

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-deep/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-deep/_config.js
@@ -2,14 +2,13 @@ import { test } from '../../test';
 import { destroyed, reset } from './destroyed.js';
 
 export default test({
-	test({ assert, component }) {
-		// for hydration, ssr may have pushed to `destroyed`
+	before_test() {
 		reset();
+	},
 
+	test({ assert, component }) {
 		component.visible = false;
 		assert.deepEqual(destroyed, ['A', 'B', 'C']);
-
-		reset();
 	},
 
 	test_ssr({ assert }) {

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -1,7 +1,6 @@
 import { describe, assert, it } from 'vitest';
 import * as $ from '../../src/internal/client/runtime';
 import {
-	destroy_effect,
 	effect,
 	effect_root,
 	render_effect,
@@ -23,12 +22,12 @@ function run_test(runes: boolean, fn: (runes: boolean) => () => void) {
 		$.push({}, runes);
 		// Create a render context so that effect validations etc don't fail
 		let execute: any;
-		const signal = render_effect(() => {
+		const destroy = effect_root(() => {
 			execute = fn(runes);
 		});
 		$.pop();
 		execute();
-		destroy_effect(signal);
+		destroy();
 	};
 }
 

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -3,6 +3,7 @@ import * as $ from '../../src/internal/client/runtime';
 import {
 	destroy_effect,
 	effect,
+	effect_root,
 	render_effect,
 	user_effect
 } from '../../src/internal/client/reactivity/effects';
@@ -248,8 +249,10 @@ describe('signals', () => {
 	test('effect with derived using unowned derived every time', () => {
 		const log: Array<number | string> = [];
 
-		const effect = user_effect(() => {
-			log.push($.get(calc));
+		const destroy = effect_root(() => {
+			user_effect(() => {
+				log.push($.get(calc));
+			});
 		});
 
 		return () => {
@@ -261,7 +264,7 @@ describe('signals', () => {
 			// Ensure we're not leaking consumers
 			assert.deepEqual(count.reactions?.length, 1);
 			assert.deepEqual(log, [0, 2, 'limit', 0]);
-			destroy_effect(effect);
+			destroy();
 			// Ensure we're not leaking consumers
 			assert.deepEqual(count.reactions, null);
 		};


### PR DESCRIPTION
some suggested changes to #10949. WIP. two categories of failures:

- infinite effect loops
- `onDestroy` appears to happen in backwards order now? see `ondestroy-deep`