### PR TITLE
experiment: legacy reactive statement ordering

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -5,9 +5,14 @@ import type {
 	Identifier,
 	PrivateIdentifier
 } from 'estree';
-import type { Namespace, SvelteNode, ValidatedCompileOptions } from '#compiler';
+import type { Binding, Namespace, SvelteNode, ValidatedCompileOptions } from '#compiler';
 import type { TransformState } from '../types.js';
 import type { ComponentAnalysis } from '../../types.js';
+
+export interface LegacyReactiveStatement {
+	dependencies: Binding[];
+	body: Statement;
+}
 
 export interface ClientTransformState extends TransformState {
 	readonly private_state: Map<string, StateField>;
@@ -20,7 +25,7 @@ export interface ClientTransformState extends TransformState {
 	readonly in_constructor: boolean;
 
 	/** The $: calls, which will be ordered in the end */
-	readonly legacy_reactive_statements: Map<LabeledStatement, Statement>;
+	readonly legacy_reactive_statements: Map<LabeledStatement, LegacyReactiveStatement>;
 }
 
 export interface ComponentClientTransformState extends ClientTransformState {

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -23,7 +23,7 @@ export interface Template {
 }
 
 export interface ReactiveStatement {
-	assignments: Set<Identifier>;
+	assignments: Set<Binding>;
 	dependencies: Set<Binding>;
 }
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -135,7 +135,7 @@ var uses_version_sum = false;
 export function get_version(fn) {
 	version_sum = 0;
 	uses_version_sum = true;
-	fn();
+	deep_read_state(untrack(fn));
 	return version_sum;
 }
 
@@ -1177,6 +1177,7 @@ export function deep_read(value, visited = new Set()) {
 			proto !== Date.prototype
 		) {
 			const descriptors = get_descriptors(proto);
+
 			for (let key in descriptors) {
 				const get = descriptors[key].get;
 				if (get) {

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -1,5 +1,6 @@
 export {
 	get,
+	get_version_sum,
 	invalidate_inner_signals,
 	flushSync,
 	tick,

--- a/packages/svelte/src/internal/index.js
+++ b/packages/svelte/src/internal/index.js
@@ -1,6 +1,6 @@
 export {
 	get,
-	get_version_sum,
+	get_version,
 	invalidate_inner_signals,
 	flushSync,
 	tick,


### PR DESCRIPTION
This is hilariously far from working — many tests failing — but I think it's basically directionally right, and so I'm pushing it up even though it's messy as all hell.

Quick brain dump while I still have context:

- #10949 is mostly working, with two test failures — `ondestroy-deep` and `reactive-assignment-prevent-loop`. I actually think the behaviour of `ondestroy-deep` in that PR (inner `onDestroy` callbacks run before outer ones) is preferable to the status quo, so I'm not too worried about that.
- The other failing test is much trickier. We jump through some hoops to make legacy `$:` assignments work the same in Svelte 5 as in 4, and those hoops don't quite work here (it previously relied on a distinction between pre and render effects that no longer exists)
- I think the real solution is to make `$:` _actually_ behave the same in 5 as it did in 4. Rather than juggling multiple effects, we need to put all of them into a single function. To take the example from the failing test:

    ```js
    $: if(count2 < 10) { increaseCount1() }
    $: if(count1 < 10) { count2++ }
    ```

  In Svelte 4, we get this:

    ```js
    $$self.$$.update = () => {
      if ($$self.$$.dirty & /*count1, count2*/ 3) {
        $: if (count1 < 10) {
          $$invalidate(1, count2++, count2);
        }
      }
  
      if ($$self.$$.dirty & /*count2*/ 2) {
        $: if (count2 < 10) {
          increaseCount1();
        }
      }
    };
    ```

    Currently in Svelte 5 we get this (which fails, now that `legacy_pre_effect_reset` uses `render_effect`:

    ```js
    $.legacy_pre_effect(() => ($.get(count2)), () => {
      if ($.get(count2) < 10) {
        increaseCount1();
      }
    });
    
    $.legacy_pre_effect(() => ($.get(count1), $.get(count2)), () => {
      if ($.get(count1) < 10) {
        $.update(count2);
      }
    });
    
    $.legacy_pre_effect_reset();
    ```

    To make it behave more like Svelte 4, this PR generates this instead:

    ```js
    var $$deps = [-1, -1];
    
    $.render_effect(() => {
      ($.get(count2), $.get(count1));
    
      if (count2.version !== $$deps[0] || count1.version !== $$deps[1]) {
        if ($.get(count1) < 10) {
          $.update(count2);
        }
      }
    
      if (count2.version !== $$deps[0]) {
        if ($.get(count2) < 10) {
          increaseCount1();
        }
      }
    
      $$deps[0] = count2.version;
      $$deps[1] = count1.version;
    });
    ```

  And that works! The test passes. But...
- ...we can't just read `.version` when dealing with props (though now that I'm writing this essay... maybe it's not so inaccessible? after all `current_version` inside the prop is just a normal `derived`. though there may be an edge case around proxied state passed into a legacy component)
- because of that (and maybe some other things?) many tests are failing
- I tried to solve it by adding a `get_version` function that gets the sum of all the versions of all the sources/deriveds read inside its callback, but that didn't seem to work
- man, I don't know. this shit is hard
- one thing I _am_ confident about — we weren't ordering `$:` statements correctly. This PR does at least fix that