### PR TITLE
fix: apply animate on prefix/suffix each block mutations

### DIFF
--- a/.changeset/three-foxes-relax.md
+++ b/.changeset/three-foxes-relax.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: apply animate on prefix/suffix each block mutations


### PR DESCRIPTION
Turns out we weren't applying animations to elements that update in index when only the prefix/suffix of the each block changes.