### PR TITLE
fix: use valid HTML comment syntax

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1044,7 +1044,7 @@ function create_block(parent, name, nodes, context) {
 
 			process_children(trimmed, expression, false, { ...context, state });
 
-			const use_comment_template = state.template.length === 1 && state.template[0] === '<!>';
+			const use_comment_template = state.template.length === 1 && state.template[0] === '<!---->';
 
 			if (use_comment_template) {
 				// special case — we can use `$.comment` instead of creating a unique template
@@ -1563,7 +1563,7 @@ export const template_visitors = {
 		context.state.template.push(`<!--${node.data}-->`);
 	},
 	HtmlTag(node, context) {
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 
 		// push into init, so that bindings run afterwards, which might trigger another run and override hydration
 		context.state.init.push(
@@ -1667,7 +1667,7 @@ export const template_visitors = {
 		);
 	},
 	RenderTag(node, context) {
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 		const callee = unwrap_optional(node.expression).callee;
 		const raw_args = unwrap_optional(node.expression).arguments;
 		const is_reactive =
@@ -1741,7 +1741,7 @@ export const template_visitors = {
 	},
 	RegularElement(node, context) {
 		if (node.name === 'noscript') {
-			context.state.template.push('<!>');
+			context.state.template.push('<!---->');
 			return;
 		}
 		if (node.name === 'script') {
@@ -1968,7 +1968,7 @@ export const template_visitors = {
 		}
 	},
 	SvelteElement(node, context) {
-		context.state.template.push(`<!>`);
+		context.state.template.push(`<!---->`);
 
 		/** @type {Array<import('#compiler').Attribute | import('#compiler').SpreadAttribute>} */
 		const attributes = [];
@@ -2079,7 +2079,7 @@ export const template_visitors = {
 		let each_item_is_reactive = true;
 
 		if (!each_node_meta.is_controlled) {
-			context.state.template.push('<!>');
+			context.state.template.push('<!---->');
 		}
 
 		if (each_node_meta.array_name !== null) {
@@ -2339,7 +2339,7 @@ export const template_visitors = {
 		context.state.init.push(b.stmt(b.call(callee, ...args)));
 	},
 	IfBlock(node, context) {
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 
 		const consequent = /** @type {import('estree').BlockStatement} */ (
 			context.visit(node.consequent)
@@ -2390,7 +2390,7 @@ export const template_visitors = {
 		context.state.init.push(b.stmt(b.call('$.if', ...args)));
 	},
 	AwaitBlock(node, context) {
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 
 		context.state.init.push(
 			b.stmt(
@@ -2431,7 +2431,7 @@ export const template_visitors = {
 		);
 	},
 	KeyBlock(node, context) {
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 		const key = /** @type {import('estree').Expression} */ (context.visit(node.expression));
 		const body = /** @type {import('estree').Expression} */ (context.visit(node.fragment));
 		context.state.init.push(
@@ -2747,7 +2747,7 @@ export const template_visitors = {
 		}
 	},
 	Component(node, context) {
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 
 		const binding = context.state.scope.get(
 			node.name.includes('.') ? node.name.slice(0, node.name.indexOf('.')) : node.name
@@ -2775,12 +2775,12 @@ export const template_visitors = {
 		context.state.init.push(component);
 	},
 	SvelteSelf(node, context) {
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 		const component = serialize_inline_component(node, context.state.analysis.name, context);
 		context.state.init.push(component);
 	},
 	SvelteComponent(node, context) {
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 
 		let component = serialize_inline_component(node, '$$component', context);
 		if (context.state.options.dev) {
@@ -2880,7 +2880,7 @@ export const template_visitors = {
 	},
 	SlotElement(node, context) {
 		// <slot {a}>fallback</slot>  -->   $.slot($$slots.default, { get a() { .. } }, () => ...fallback);
-		context.state.template.push('<!>');
+		context.state.template.push('<!---->');
 
 		/** @type {import('estree').Property[]} */
 		const props = [];

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -27,8 +27,8 @@ import { regex_starts_with_newline, regex_whitespaces_strict } from '../../patte
 import { DOMBooleanAttributes } from '../../../../constants.js';
 import { sanitize_template_string } from '../../../utils/sanitize_template_string.js';
 
-const block_open = t_string('<![>');
-const block_close = t_string('<!]>');
+const block_open = t_string('<!--[-->');
+const block_close = t_string('<!--]-->');
 
 /**
  * @param {string} value
@@ -1502,7 +1502,7 @@ const template_visitors = {
 		if (node.fallback) {
 			const fallback_stmts = create_block(node, node.fallback.nodes, context);
 			fallback_stmts.unshift(
-				b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!ssr:each_else>')))
+				b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!--ssr:each_else-->')))
 			);
 			state.template.push(
 				t_statement(
@@ -1528,14 +1528,14 @@ const template_visitors = {
 
 		const consequent = create_block(node, node.consequent.nodes, context);
 		consequent.unshift(
-			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!ssr:if:true>')))
+			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!--ssr:if:true-->')))
 		);
 
 		const alternate = node.alternate
 			? /** @type {import('estree').BlockStatement} */ (context.visit(node.alternate))
 			: b.block([]);
 		alternate.body.unshift(
-			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!ssr:if:false>')))
+			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal('<!--ssr:if:false-->')))
 		);
 
 		state.template.push(

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -23,7 +23,7 @@ export function set_hydrate_nodes(nodes) {
 }
 
 /**
- * This function is only called when `hydrating` is true. If passed a `<![>` opening
+ * This function is only called when `hydrating` is true. If passed a `<!--[-->` opening
  * hydration marker, it finds the corresponding closing marker and sets `hydrate_nodes`
  * to everything between the markers, before returning the closing marker.
  * @param {Node} node

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -149,7 +149,7 @@ export function text(anchor) {
 	return node;
 }
 
-export const comment = template('<!>', TEMPLATE_FRAGMENT);
+export const comment = template('<!---->', TEMPLATE_FRAGMENT);
 
 /**
  * Assign the created (or in hydration mode, traversed) dom elements to the current block

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -161,11 +161,11 @@ export function element(payload, tag, attributes_fn, children_fn) {
 
 	if (!VoidElements.has(tag)) {
 		if (tag !== 'textarea') {
-			payload.out += '<![>';
+			payload.out += '<!--[-->';
 		}
 		children_fn();
 		if (tag !== 'textarea') {
-			payload.out += '<!]>';
+			payload.out += '<!--]-->';
 		}
 		payload.out += `</${tag}>`;
 	}
@@ -187,7 +187,7 @@ export function render(component, options) {
 
 	const prev_on_destroy = on_destroy;
 	on_destroy = [];
-	payload.out += '<![>';
+	payload.out += '<!--[-->';
 
 	if (options.context) {
 		push();
@@ -200,14 +200,14 @@ export function render(component, options) {
 		pop();
 	}
 
-	payload.out += '<!]>';
+	payload.out += '<!--]-->';
 	for (const cleanup of on_destroy) cleanup();
 	on_destroy = prev_on_destroy;
 
 	return {
 		head:
 			payload.head.out || payload.head.title
-				? payload.head.title + '<![>' + payload.head.out + '<!]>'
+				? payload.head.title + '<!--[-->' + payload.head.out + '<!--]-->'
 				: '',
 		html: payload.out
 	};
@@ -271,15 +271,15 @@ export function attr(name, value, boolean) {
 export function css_props(payload, is_html, props, component) {
 	const styles = style_object_to_string(props);
 	if (is_html) {
-		payload.out += `<div style="display: contents; ${styles}"><![>`;
+		payload.out += `<div style="display: contents; ${styles}"><!--[-->`;
 	} else {
-		payload.out += `<g style="${styles}"><![>`;
+		payload.out += `<g style="${styles}"><!--[-->`;
 	}
 	component();
 	if (is_html) {
-		payload.out += `<!]></div>`;
+		payload.out += `<!--]--></div>`;
 	} else {
-		payload.out += `<!]></g>`;
+		payload.out += `<!--]--></g>`;
 	}
 }
 

--- a/packages/svelte/tests/html_equal.js
+++ b/packages/svelte/tests/html_equal.js
@@ -77,7 +77,7 @@ export function normalize_html(
 	try {
 		const node = window.document.createElement('div');
 		node.innerHTML = html
-			.replace(/(<!(--)?.*?\2>)/g, preserveComments ? '$1' : '')
+			.replace(/(<!--.*?-->)/g, preserveComments ? '$1' : '')
 			.replace(/(data-svelte-h="[^"]+")/g, removeDataSvelte ? '' : '$1')
 			.replace(/>[ \t\n\r\f]+</g, '><')
 			.trim();
@@ -137,12 +137,12 @@ export function setup_html_equal(options = {}) {
 				withoutNormalizeHtml
 					? normalize_new_line(actual.trim())
 							.replace(/(\sdata-svelte-h="[^"]+")/g, options.removeDataSvelte ? '' : '$1')
-							.replace(/(<!(--)?.*?\2>)/g, preserveComments !== false ? '$1' : '')
+							.replace(/(<!--.*?-->)/g, preserveComments !== false ? '$1' : '')
 					: normalize_html(window, actual.trim(), { ...options, preserveComments }),
 				withoutNormalizeHtml
 					? normalize_new_line(expected.trim())
 							.replace(/(\sdata-svelte-h="[^"]+")/g, options.removeDataSvelte ? '' : '$1')
-							.replace(/(<!(--)?.*?\2>)/g, preserveComments !== false ? '$1' : '')
+							.replace(/(<!--.*?-->)/g, preserveComments !== false ? '$1' : '')
 					: normalize_html(window, expected.trim(), { ...options, preserveComments }),
 				message
 			);

--- a/packages/svelte/tests/server-side-rendering/samples/comment-preserve/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/comment-preserve/_expected.html
@@ -1,1 +1,1 @@
-<![><p>before</p><!-- a comment --><p>after</p><!]>
+<!--[--><p>before</p><!-- a comment --><p>after</p><!--]-->

--- a/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected-head.html
+++ b/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected-head.html
@@ -1,6 +1,6 @@
-<!ssr:0>
+<!--ssr:0-->
 <title>Some Title</title>
 <link rel="canonical" href="/">
 <meta name="description" content="some description">
 <meta name="keywords" content="some keywords">
-<!ssr:0>
+<!--ssr:0-->

--- a/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected.html
@@ -1,1 +1,1 @@
-<![><div>Just a dummy page.</div><!]>
+<!--[--><div>Just a dummy page.</div><!--]-->

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/server/index.svelte.js
@@ -4,8 +4,8 @@ import * as $ from "svelte/internal/server";
 
 export default function Bind_this($$payload, $$props) {
 	$.push(false);
-	$$payload.out += `<![>`;
+	$$payload.out += `<!--[-->`;
 	Foo($$payload, {});
-	$$payload.out += `<!]>`;
+	$$payload.out += `<!--]-->`;
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/server/index.svelte.js
@@ -7,16 +7,16 @@ export default function Each_string_template($$payload, $$props) {
 
 	const each_array = $.ensure_array_like(['foo', 'bar', 'baz']);
 
-	$$payload.out += `<![>`;
+	$$payload.out += `<!--[-->`;
 
 	for (let $$index = 0; $$index < each_array.length; $$index++) {
 		const thing = each_array[$$index];
 
-		$$payload.out += "<![>";
+		$$payload.out += "<!--[-->";
 		$$payload.out += `${$.escape(thing)}, `;
-		$$payload.out += "<!]>";
+		$$payload.out += "<!--]-->";
 	}
 
-	$$payload.out += `<!]>`;
+	$$payload.out += `<!--]-->`;
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/server/index.svelte.js
@@ -13,7 +13,7 @@ export default function Function_prop_no_getter($$payload, $$props) {
 
 	const plusOne = (num) => num + 1;
 
-	$$payload.out += `<![>`;
+	$$payload.out += `<!--[-->`;
 
 	Button($$payload, {
 		onmousedown: () => count += 1,
@@ -24,6 +24,6 @@ export default function Function_prop_no_getter($$payload, $$props) {
 		}
 	});
 
-	$$payload.out += `<!]>`;
+	$$payload.out += `<!--]-->`;
 	$.pop();
 }

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/server/index.svelte.js
@@ -7,8 +7,8 @@ export default function Svelte_element($$payload, $$props) {
 
 	let { tag = 'hr' } = $$props;
 
-	$$payload.out += `<![>`;
+	$$payload.out += `<!--[-->`;
 	if (tag) $.element($$payload, tag, () => {}, () => {});
-	$$payload.out += `<!]>`;
+	$$payload.out += `<!--]-->`;
 	$.pop();
 }


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/10976. While the shorter comment syntax saves a few bytes, [it's not standard-compliant](https://html.spec.whatwg.org/multipage/syntax.html#comments). This isn't generally that important, but it doesn't seem like a big enough gain to justify.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
