### PR TITLE
fix: revert shorthand ssr comments

### DIFF
--- a/.changeset/serious-poems-brake.md
+++ b/.changeset/serious-poems-brake.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: revert SSR shorthand comments

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -161,11 +161,11 @@ export function element(payload, tag, attributes_fn, children_fn) {
 
 	if (!VoidElements.has(tag)) {
 		if (tag !== 'textarea') {
-			payload.out += '<![>';
+			payload.out += '<!--[-->';
 		}
 		children_fn();
 		if (tag !== 'textarea') {
-			payload.out += '<!]>';
+			payload.out += '<!--]-->';
 		}
 		payload.out += `</${tag}>`;
 	}
@@ -187,7 +187,7 @@ export function render(component, options) {
 
 	const prev_on_destroy = on_destroy;
 	on_destroy = [];
-	payload.out += '<![>';
+	payload.out += '<!--[-->';
 
 	if (options.context) {
 		push();
@@ -200,14 +200,14 @@ export function render(component, options) {
 		pop();
 	}
 
-	payload.out += '<!]>';
+	payload.out += '<!--]-->';
 	for (const cleanup of on_destroy) cleanup();
 	on_destroy = prev_on_destroy;
 
 	return {
 		head:
 			payload.head.out || payload.head.title
-				? payload.head.title + '<![>' + payload.head.out + '<!]>'
+				? payload.head.title + '<!--[-->' + payload.head.out + '<!--]-->'
 				: '',
 		html: payload.out
 	};
@@ -271,15 +271,15 @@ export function attr(name, value, boolean) {
 export function css_props(payload, is_html, props, component) {
 	const styles = style_object_to_string(props);
 	if (is_html) {
-		payload.out += `<div style="display: contents; ${styles}"><![>`;
+		payload.out += `<div style="display: contents; ${styles}"><!--[-->`;
 	} else {
-		payload.out += `<g style="${styles}"><![>`;
+		payload.out += `<g style="${styles}"><!--[-->`;
 	}
 	component();
 	if (is_html) {
-		payload.out += `<!]></div>`;
+		payload.out += `<!--]--></div>`;
 	} else {
-		payload.out += `<!]></g>`;
+		payload.out += `<!--]--></g>`;
 	}
 }
 

--- a/packages/svelte/tests/parser-modern/samples/comment-before-script/output.json
+++ b/packages/svelte/tests/parser-modern/samples/comment-before-script/output.json
@@ -44,7 +44,6 @@
 					"column": 0
 				}
 			},
-			"leadingComments": [{ "type": "Line", "value": "should not error out" }],
 			"body": [
 				{
 					"type": "VariableDeclaration",
@@ -127,7 +126,13 @@
 					"kind": "let"
 				}
 			],
-			"sourceType": "module"
+			"sourceType": "module",
+			"leadingComments": [
+				{
+					"type": "Line",
+					"value": "should not error out"
+				}
+			]
 		}
 	}
 }

--- a/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/head-meta-hydrate-duplicate/_expected.html
@@ -1,1 +1,1 @@
-<![><div>Just a dummy page.</div><!]>
+<!--[--><div>Just a dummy page.</div><!--]-->


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/10976

Apparently the shorthand comments break some svg cases and also causes validation errors. Leaving this up there in case we want to revert the SSR comment changes.