### PR TITLE
chore: remove signal field from effects

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -46,7 +46,6 @@ function create_effect(type, fn, sync) {
 		f: type | DIRTY,
 		fn,
 		effects: null,
-		deriveds: null,
 		teardown: null,
 		ctx: current_component_context,
 		transitions: null

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -23,13 +23,13 @@ export interface Reaction extends Signal {
 	deps: null | Value[];
 	/** Effects created inside this signal */
 	effects: null | Effect[];
-	/** Deriveds created inside this signal */
-	deriveds: null | Derived[];
 }
 
 export interface Derived<V = unknown> extends Value<V>, Reaction {
 	/** The derived function */
 	fn: () => V;
+	/** Deriveds created inside this signal */
+	deriveds: null | Derived[];
 }
 
 export interface Effect extends Reaction {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -349,7 +349,7 @@ export function remove_reactions(signal, start_index) {
 }
 
 /**
- * @param {import('./types.js').Reaction} signal
+ * @param {import('./types.js').Effect} signal
  * @returns {void}
  */
 export function destroy_children(signal) {
@@ -358,13 +358,6 @@ export function destroy_children(signal) {
 			destroy_effect(signal.effects[i]);
 		}
 		signal.effects = null;
-	}
-
-	if (signal.deriveds) {
-		for (i = 0; i < signal.deriveds.length; i += 1) {
-			destroy_derived(signal.deriveds[i]);
-		}
-		signal.deriveds = null;
 	}
 }
 


### PR DESCRIPTION
Given we're going to be adding more fields for doubly linked list effects, let's remove the deriveds field from effects – as it's never used anywhere.