### PR TITLE
feat: faster HTML tags

### DIFF
--- a/.changeset/swift-poets-carry.md
+++ b/.changeset/swift-poets-carry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: faster HTML tags

--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -1,7 +1,8 @@
 import { derived } from '../../reactivity/deriveds.js';
 import { render_effect } from '../../reactivity/effects.js';
 import { get } from '../../runtime.js';
-import { reconcile_html, remove } from '../reconciler.js';
+import { hydrate_nodes, hydrating } from '../hydration.js';
+import { create_fragment_from_html, remove } from '../reconciler.js';
 
 /**
  * @param {Element | Text | Comment} anchor
@@ -13,10 +14,53 @@ export function html(anchor, get_value, svg) {
 	let value = derived(get_value);
 
 	render_effect(() => {
-		var dom = reconcile_html(anchor, get(value), svg);
+		var dom = html_to_dom(anchor, get(value), svg);
 
 		if (dom) {
 			return () => remove(dom);
 		}
 	});
+}
+
+/**
+ * Creates the content for a `@html` tag from its string value,
+ * inserts it before the target anchor and returns the new nodes.
+ * @template V
+ * @param {Element | Text | Comment} target
+ * @param {V} value
+ * @param {boolean} svg
+ * @returns {Element | Comment | (Element | Comment | Text)[]}
+ */
+function html_to_dom(target, value, svg) {
+	if (hydrating) return hydrate_nodes;
+
+	var html = value + '';
+	if (svg) html = `<svg>${html}</svg>`;
+
+	// Don't use create_fragment_with_script_from_html here because that would mean script tags are executed.
+	// @html is basically `.innerHTML = ...` and that doesn't execute scripts either due to security reasons.
+	/** @type {DocumentFragment | Element} */
+	var node = create_fragment_from_html(html);
+
+	if (svg) {
+		node = /** @type {Element} */ (node.firstChild);
+	}
+
+	if (node.childNodes.length === 1) {
+		var child = /** @type {Text | Element | Comment} */ (node.firstChild);
+		target.before(child);
+		return child;
+	}
+
+	var nodes = /** @type {Array<Text | Element | Comment>} */ ([...node.childNodes]);
+
+	if (svg) {
+		while (node.firstChild) {
+			target.before(node.firstChild);
+		}
+	} else {
+		target.before(node);
+	}
+
+	return nodes;
 }

--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -1,4 +1,3 @@
-import { hydrate_nodes, hydrating } from './hydration.js';
 import { is_array } from '../utils.js';
 
 /** @param {string} html */
@@ -22,47 +21,4 @@ export function remove(current) {
 	} else if (current.isConnected) {
 		current.remove();
 	}
-}
-
-/**
- * Creates the content for a `@html` tag from its string value,
- * inserts it before the target anchor and returns the new nodes.
- * @template V
- * @param {Element | Text | Comment} target
- * @param {V} value
- * @param {boolean} svg
- * @returns {Element | Comment | (Element | Comment | Text)[]}
- */
-export function reconcile_html(target, value, svg) {
-	if (hydrating) return hydrate_nodes;
-
-	var html = value + '';
-	if (svg) html = `<svg>${html}</svg>`;
-
-	// Don't use create_fragment_with_script_from_html here because that would mean script tags are executed.
-	// @html is basically `.innerHTML = ...` and that doesn't execute scripts either due to security reasons.
-	/** @type {DocumentFragment | Element} */
-	var node = create_fragment_from_html(html);
-
-	if (svg) {
-		node = /** @type {Element} */ (node.firstChild);
-	}
-
-	if (node.childNodes.length === 1) {
-		var child = /** @type {Text | Element | Comment} */ (node.firstChild);
-		target.before(child);
-		return child;
-	}
-
-	var nodes = /** @type {Array<Text | Element | Comment>} */ ([...node.childNodes]);
-
-	if (svg) {
-		while (node.firstChild) {
-			target.before(node.firstChild);
-		}
-	} else {
-		target.before(node);
-	}
-
-	return nodes;
 }


### PR DESCRIPTION
some missed opportunities with `{@html ...}`:

- if it's a single node (not uncommon), insert and return directly. no sense in wrapping it in an array
- there's no need to clone the fragment
- if it's not SVG, then we have a document fragment — we can just insert it as-is rather than inserting child nodes one at a time

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
