### PR TITLE
chore: compiler subpackage

### DIFF
--- a/.changeset/metal-clouds-raise.md
+++ b/.changeset/metal-clouds-raise.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: move compiler.cjs to compiler/index.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,7 @@
 **/vite.config.js
 **/vite.prod.config.js
 **/node_modules
+**/compiler/index.js
 
 **/tests/**
 
@@ -20,4 +21,4 @@ documentation/**
 # contains a fork of the REPL which doesn't adhere to eslint rules
 sites/svelte-5-preview/**
 # Wasn't checked previously, reenable at some point
-sites/svelte.dev/** 
+sites/svelte.dev/**

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,7 +15,7 @@ packages/svelte/tests/hydration/samples/*/_before_head.html
 packages/svelte/tests/hydration/samples/*/_after.html
 packages/svelte/tests/hydration/samples/*/_after_head.html
 packages/svelte/types
-packages/svelte/compiler.cjs
+packages/svelte/compiler/index.js
 playgrounds/demo/src
 playgrounds/sandbox/input/**.svelte
 playgrounds/sandbox/output

--- a/packages/svelte/.gitignore
+++ b/packages/svelte/.gitignore
@@ -1,6 +1,6 @@
 /types/*.map
 /types/compiler
-/compiler.cjs
+/compiler/index.js
 
 /action.d.ts
 /animate.d.ts

--- a/packages/svelte/compiler/package.json
+++ b/packages/svelte/compiler/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "commonjs"
+}

--- a/packages/svelte/compiler/package.json
+++ b/packages/svelte/compiler/package.json
@@ -1,3 +1,3 @@
 {
-	"type": "commonjs"
+  "type": "commonjs"
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -12,7 +12,7 @@
     "src",
     "!src/**/*.test.*",
     "types",
-    "compiler.cjs",
+    "compiler/index.js",
     "*.d.ts",
     "README.md"
   ],
@@ -34,7 +34,7 @@
     },
     "./compiler": {
       "types": "./types/index.d.ts",
-      "require": "./compiler.cjs",
+      "require": "./compiler/index.js",
       "default": "./src/compiler/index.js"
     },
     "./easing": {

--- a/packages/svelte/rollup.config.js
+++ b/packages/svelte/rollup.config.js
@@ -9,7 +9,7 @@ import './scripts/generate-version.js';
 export default defineConfig({
 	input: 'src/compiler/index.js',
 	output: {
-		file: 'compiler.cjs',
+		file: 'compiler/index.js',
 		format: 'umd',
 		name: 'svelte'
 	},

--- a/sites/svelte-5-preview/src/lib/workers/bundler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/bundler/index.js
@@ -48,10 +48,8 @@ self.addEventListener(
 				const { version } = await fetch(`${svelte_url}/package.json`).then((r) => r.json());
 				console.log(`Using Svelte compiler version ${version}`);
 
-				// unpkg doesn't set the correct MIME type for .cjs files
-				// https://github.com/mjackson/unpkg/issues/355
-				const compiler = await fetch(`${svelte_url}/compiler.cjs`).then((r) => r.text());
-				(0, eval)(compiler + '\n//# sourceURL=compiler.cjs@' + version);
+				const compiler = await fetch(`${svelte_url}/compiler/index.js`).then((r) => r.text());
+				(0, eval)(compiler + '\n//# sourceURL=compiler/index.js@' + version);
 
 				svelte = globalThis.svelte;
 

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -29,10 +29,8 @@ self.addEventListener(
 					.then((r) => r.json())
 					.catch(() => ({ version: 'experimental' }));
 
-				// unpkg doesn't set the correct MIME type for .cjs files
-				// https://github.com/mjackson/unpkg/issues/355
-				const compiler = await fetch(`${svelte_url}/compiler.cjs`).then((r) => r.text());
-				(0, eval)(compiler + '\n//# sourceURL=compiler.cjs@' + version);
+				const compiler = await fetch(`${svelte_url}/compiler/index.js`).then((r) => r.text());
+				(0, eval)(compiler + '\n//# sourceURL=compiler/index.js@' + version);
 
 				svelte = globalThis.svelte;
 

--- a/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
+++ b/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
@@ -1,10 +1,11 @@
-import compiler_cjs from '../../../../../../packages/svelte/compiler.cjs?url';
+import compiler_cjs from '../../../../../../packages/svelte/compiler/index.js?url';
 import package_json from '../../../../../../packages/svelte/package.json?url';
 import { read } from '$app/server';
 
 const files = import.meta.glob('../../../../../../packages/svelte/src/**/*.js', {
 	eager: true,
-	as: 'url'
+	query: '?url',
+	import: 'default'
 });
 
 const prefix = '../../../../../../packages/svelte/';
@@ -13,14 +14,14 @@ export const prerender = true;
 
 export function entries() {
 	const entries = Object.keys(files).map((path) => ({ path: path.replace(prefix, '') }));
-	entries.push({ path: 'compiler.cjs' }, { path: 'package.json' });
+	entries.push({ path: 'compiler/index.js' }, { path: 'package.json' });
 	return entries;
 }
 
 // service worker requests files under this path to load the compiler and runtime
 export async function GET({ params }) {
 	let url = '';
-	if (params.path === 'compiler.cjs') {
+	if (params.path === 'compiler/index.js') {
 		url = compiler_cjs;
 	} else if (params.path === 'package.json') {
 		url = package_json;


### PR DESCRIPTION
Moves `compiler.cjs` to `compiler/index.js`, per a previous decision. I had hoped to use `importScript` inside the REPL workers, but alas we can't do that because they're module workers (but only during development IIUC?) and I couldn't be bothered to fight with it