### PR TITLE
chore: use internal doubly linked listed for effect tree

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -11,7 +11,6 @@ import {
 	destroy_effect_children
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
-import { destroy_effect } from './effects.js';
 
 export let updating_derived = false;
 
@@ -27,14 +26,14 @@ export function derived(fn) {
 
 	/** @type {import('#client').Derived<V>} */
 	const signal = {
-		reactions: null,
 		deps: null,
+		deriveds: null,
 		equals,
 		f: flags,
-		fn,
 		first: null,
+		fn,
 		last: null,
-		deriveds: null,
+		reactions: null,
 		v: /** @type {V} */ (null),
 		version: 0
 	};

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -120,6 +120,8 @@ export function destroy_derived(signal) {
 	remove_reactions(signal, 0);
 	set_signal_status(signal, DESTROYED);
 
+	// TODO we need to ensure we remove the derived from any parent derives
+
 	signal.first =
 		signal.last =
 		signal.deps =

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -21,8 +21,10 @@ export interface Reaction extends Signal {
 	fn: Function;
 	/** Signals that this signal reads from */
 	deps: null | Value[];
-	/** Effects created inside this signal */
-	effects: null | Effect[];
+	/** First child effect created inside this signal */
+	first: null | Effect;
+	/** Last child effect created inside this signal */
+	last: null | Effect;
 }
 
 export interface Derived<V = unknown> extends Value<V>, Reaction {
@@ -43,6 +45,10 @@ export interface Effect extends Reaction {
 	teardown: null | (() => void);
 	/** Transition managers created with `$.transition` */
 	transitions: null | TransitionManager[];
+	/** Next sibling child effect created inside the parent signal */
+	prev: null | Effect;
+	/** Next sibling child effect created inside the parent signal */
+	next: null | Effect;
 }
 
 export interface ValueDebug<V = unknown> extends Value<V> {


### PR DESCRIPTION
By adopting a doubly linked list, we can improve performance of effect removals and also streamline a bunch of logic that is currently recursive (I added TODOs).