### PR TITLE
feat: improve each block controlled clearing performance

### DIFF
--- a/.changeset/bright-news-check.md
+++ b/.changeset/bright-news-check.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: improve each block controlled clearing performance


### PR DESCRIPTION
This brings back the each block controlled element cleardown optimization.

These two optimizations should provide a very nice performance improvement for each blocks when clearing content or when replacing the each block content.

This PR doesn't account for global transitions, so isn't ready to land. It might also make sense to hold off until we have a better generic approach that does – so this PR can be used as a reference point.