### PR TITLE
fix: add `name` to HTMLDetailsAttributes

### DIFF
--- a/.changeset/late-peaches-mate.md
+++ b/.changeset/late-peaches-mate.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+Add `name` to HTMLDetailsAttributes

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -906,6 +906,7 @@ export interface HTMLDataAttributes extends HTMLAttributes<HTMLDataElement> {
 
 export interface HTMLDetailsAttributes extends HTMLAttributes<HTMLDetailsElement> {
 	open?: boolean | undefined | null;
+	name?: string | undefined | null;
 
 	'bind:open'?: boolean | undefined | null;
 


### PR DESCRIPTION
Group multiple `<details>` elements with the `name` attribute
 
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#name