### PR TITLE
fix: ensure effect cleanup functions are called with null `this`

### DIFF
--- a/.changeset/fuzzy-donuts-provide.md
+++ b/.changeset/fuzzy-donuts-provide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure effect cleanup functions are called with null `this`

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -245,7 +245,7 @@ export function destroy_effect(effect) {
 		}
 	}
 
-	effect.teardown?.();
+	effect.teardown?.call(null);
 
 	if (effect.dom !== null) {
 		remove(effect.dom);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -390,7 +390,7 @@ export function execute_effect(effect) {
 			destroy_effect_children(effect);
 		}
 
-		effect.teardown?.();
+		effect.teardown?.call(null);
 		var teardown = execute_reaction_fn(effect);
 		effect.teardown = typeof teardown === 'function' ? teardown : null;
 	} finally {

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
@@ -15,6 +15,6 @@ export default test({
 		flushSync(() => {
 			b1.click();
 		});
-		assert.deepEqual(log, ['init 0', 'cleanup 2', 'init 2', 'cleanup 4', 'init 4']);
+		assert.deepEqual(log, ['init 0', 'cleanup 2', null, 'init 2', 'cleanup 4', null, 'init 4']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/main.svelte
@@ -8,8 +8,10 @@
 
 		log.push('init ' + double);
 
-		return () => {
+		return function() {
 			log.push('cleanup ' + double);
+			// @ts-expect-error
+			log.push(this);
 		};
 	})
 </script>


### PR DESCRIPTION
Noticed while looking into #11023 that effect cleanup functions are called with the effect as `this`, which we definitely don't want

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
