### PR TITLE
feat: prevent unparenthesized sequence expressions in attributes

### DIFF
--- a/.changeset/long-humans-repair.md
+++ b/.changeset/long-humans-repair.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: prevent unparenthesized sequence expressions in attributes

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -282,7 +282,9 @@ const attributes = {
 	},
 	'invalid-let-directive-placement': () => 'let directive at invalid position',
 	'invalid-style-directive-modifier': () =>
-		`Invalid 'style:' modifier. Valid modifiers are: 'important'`
+		`Invalid 'style:' modifier. Valid modifiers are: 'important'`,
+	'invalid-sequence-expression': () =>
+		`Sequence expressions are not allowed as attribute/directive values in runes mode, unless wrapped in parentheses`
 };
 
 /** @satisfies {Errors} */

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -41,7 +41,7 @@ export function compile(source, options) {
 			};
 		}
 
-		const analysis = analyze_component(parsed, combined_options);
+		const analysis = analyze_component(parsed, source, combined_options);
 
 		const result = transform_component(analysis, source, combined_options);
 		return result;

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -258,10 +258,11 @@ export function analyze_module(ast, options) {
 
 /**
  * @param {import('#compiler').Root} root
+ * @param {string} source
  * @param {import('#compiler').ValidatedCompileOptions} options
  * @returns {import('../types.js').ComponentAnalysis}
  */
-export function analyze_component(root, options) {
+export function analyze_component(root, source, options) {
 	const scope_root = new ScopeRoot();
 
 	const module = js(root.module, scope_root, false, null);
@@ -396,7 +397,8 @@ export function analyze_component(root, options) {
 					})
 				: '',
 			keyframes: []
-		}
+		},
+		source
 	};
 
 	if (!options.customElement && root.options?.customElement) {

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -73,6 +73,7 @@ export interface ComponentAnalysis extends Analysis {
 		hash: string;
 		keyframes: string[];
 	};
+	source: string;
 }
 
 declare module 'estree' {

--- a/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-sequence-expression',
+		message:
+			'Sequence expressions are not allowed as attribute/directive values in runes mode, unless wrapped in parentheses',
+		position: [163, 170]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/attribute-sequence-expression/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Child from './Child.svelte';
+	let { x, y, z } = $props();
+</script>
+
+<!-- allowed -->
+<Child foo={(x, y, z)} />
+
+<!-- not allowed -->
+<Child foo={x, y, z} />


### PR DESCRIPTION
We'd like to reserve the possibility of doing something with sequence expressions in attributes in future, and this requires us to treat them as disallowed in the meantime. They still work but they need to be wrapped in parens.

Question: should this apply universally, or just in runes mode?

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
