### PR TITLE
fix: add missing package.json in package

### DIFF
--- a/.changeset/wild-moose-compare.md
+++ b/.changeset/wild-moose-compare.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: include compiler/package.json in package

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -12,7 +12,7 @@
     "src",
     "!src/**/*.test.*",
     "types",
-    "compiler/index.js",
+    "compiler",
     "*.d.ts",
     "README.md"
   ],


### PR DESCRIPTION
`compiler/index.js` only works if `compiler/package.json` specifies `"type": "commonjs"` — it was previously missing from the package

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
