### PR TITLE
chore: remove isConnected usage

### DIFF
--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -14,11 +14,9 @@ export function remove(current) {
 	if (is_array(current)) {
 		for (var i = 0; i < current.length; i++) {
 			var node = current[i];
-			if (node.isConnected) {
-				node.remove();
-			}
+			node.remove();
 		}
-	} else if (current.isConnected) {
+	} else {
 		current.remove();
 	}
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -246,11 +246,11 @@ export function destroy_effect(effect) {
 
 	effect.teardown?.call(null);
 
-	if (effect.dom !== null) {
+	var parent = effect.parent;
+
+	if (effect.dom !== null && (parent === null || (parent.f & DESTROYED) === 0)) {
 		remove(effect.dom);
 	}
-
-	var parent = effect.parent;
 
 	// If the parent doesn't have any children, then skip this work altogether
 	if (parent !== null && (effect.f & BRANCH_EFFECT) !== 0 && parent.first !== null) {


### PR DESCRIPTION
`isConnected` is fairly cheap, but it's just overhead we don't need anymore.