### PR TITLE
chore: remove parent DOM before children DOM

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -234,6 +234,12 @@ export function branch(fn) {
  * @returns {void}
  */
 export function destroy_effect(effect) {
+	var dom = effect.dom;
+
+	if (dom !== null) {
+		remove(dom);
+	}
+
 	destroy_effect_children(effect);
 	remove_reactions(effect, 0);
 	set_signal_status(effect, DESTROYED);
@@ -245,10 +251,6 @@ export function destroy_effect(effect) {
 	}
 
 	effect.teardown?.call(null);
-
-	if (effect.dom !== null) {
-		remove(effect.dom);
-	}
 
 	var parent = effect.parent;
 


### PR DESCRIPTION
Whilst looking into https://github.com/sveltejs/svelte/pull/11037, I noticed it didn't do anything. That's because we weren't properly removing the parent DOM before the child DOM, which is highly inefficient. Let's fix that first.

More PRs to come to improve this.