### PR TITLE
chore: remove deopts and refactor code for controlled optimizations

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -19,7 +19,8 @@ import {
 	pause_effect,
 	get_pause_transitons,
 	resume_effect,
-	pause_effects_with_transitions
+	pause_effects_with_transitions,
+	destroy_effects
 } from '../../reactivity/effects.js';
 import { source, mutable_source, set } from '../../reactivity/sources.js';
 import { is_array, is_frozen, map_get, map_set } from '../../utils.js';
@@ -249,6 +250,7 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 		var items = state.items;
 
 		if (transitions.length === 0) {
+			destroy_effects(effects);
 			items.length = b;
 		} else {
 			pause_effects_with_transitions(effects, transitions, () => {
@@ -432,6 +434,7 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 	var transitions = get_pause_transitons(to_destroy);
 
 	if (transitions.length === 0) {
+		destroy_effects(to_destroy);
 		state.items = b_items;
 	} else {
 		pause_effects_with_transitions(to_destroy, transitions, () => {

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -246,11 +246,13 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 		}
 
 		var transitions = get_pause_transitons(effects);
+		var items = state.items;
+
 		if (transitions.length === 0) {
-			state.items.length = b;
+			items.length = b;
 		} else {
 			pause_effects_with_transitions(effects, transitions, () => {
-				state.items.length = b;
+				items.length = b;
 			});
 		}
 	}
@@ -428,6 +430,7 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 	}
 
 	var transitions = get_pause_transitons(to_destroy);
+
 	if (transitions.length === 0) {
 		state.items = b_items;
 	} else {

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -19,7 +19,7 @@ import {
 	pause_effect,
 	get_pause_transitons,
 	resume_effect,
-	pause_effects_with_transitions,
+	pause_effects,
 	destroy_effects
 } from '../../reactivity/effects.js';
 import { source, mutable_source, set } from '../../reactivity/sources.js';
@@ -253,7 +253,7 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 			destroy_effects(effects);
 			items.length = b;
 		} else {
-			pause_effects_with_transitions(effects, transitions, () => {
+			pause_effects(effects, transitions, () => {
 				items.length = b;
 			});
 		}
@@ -437,7 +437,7 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 		destroy_effects(to_destroy);
 		state.items = b_items;
 	} else {
-		pause_effects_with_transitions(to_destroy, transitions, () => {
+		pause_effects(to_destroy, transitions, () => {
 			state.items = b_items;
 		});
 	}

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -17,7 +17,7 @@ import {
 	branch,
 	effect,
 	pause_effect,
-	get_pause_transitons,
+	get_out_transitions,
 	resume_effect,
 	pause_effects,
 	destroy_effects
@@ -246,7 +246,7 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 			effects.push(a_items[i].e);
 		}
 
-		var transitions = get_pause_transitons(effects);
+		var transitions = get_out_transitions(effects);
 		var items = state.items;
 
 		if (transitions.length === 0) {
@@ -431,7 +431,7 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 		});
 	}
 
-	var transitions = get_pause_transitons(to_destroy);
+	var transitions = get_out_transitions(to_destroy);
 
 	if (transitions.length === 0) {
 		destroy_effects(to_destroy);

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -327,6 +327,15 @@ export function get_pause_transitons(effects) {
 }
 
 /**
+ * @param {import('#client').Effect[]} effects
+ */
+export function destroy_effects(effects) {
+	for (var i = 0; i < effects.length; i++) {
+		destroy_effect(effects[i]);
+	}
+}
+
+/**
  * Pause multiple effects simultaneously, and coordinate their
  * subsequent destruction. Used in each blocks
  * @param {import('#client').Effect[]} effects
@@ -335,9 +344,7 @@ export function get_pause_transitons(effects) {
  */
 export function pause_effects_with_transitions(effects, transitions, callback = noop) {
 	out(transitions, () => {
-		for (var i = 0; i < effects.length; i++) {
-			destroy_effect(effects[i]);
-		}
+		destroy_effects(effects);
 		callback();
 	});
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -348,7 +348,6 @@ export function pause_effects_with_transitions(effects, transitions, callback = 
  */
 function out(transitions, fn) {
 	var remaining = transitions.length;
-	// TODO: do we still needs this if statement?
 	if (remaining > 0) {
 		var check = () => --remaining || fn();
 		for (var transition of transitions) {

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -315,7 +315,7 @@ export function pause_effect(effect, callback = noop) {
  * @param {import('#client').Effect[]} effects
  * @returns {import('#client').TransitionManager[]}
  */
-export function get_pause_transitons(effects) {
+export function get_out_transitions(effects) {
 	/** @type {import('#client').TransitionManager[]} */
 	var transitions = [];
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -342,7 +342,7 @@ export function destroy_effects(effects) {
  * @param {import('#client').TransitionManager[]} transitions
  * @param {() => void} callback
  */
-export function pause_effects_with_transitions(effects, transitions, callback = noop) {
+export function pause_effects(effects, transitions, callback = noop) {
 	out(transitions, () => {
 		destroy_effects(effects);
 		callback();

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -385,13 +385,12 @@ function pause_children(effect, transitions, local) {
 	var child = effect.first;
 
 	while (child !== null) {
-		var sibling = child.next;
 		var transparent = (child.f & IS_ELSEIF) !== 0 || (child.f & BRANCH_EFFECT) !== 0;
 		// TODO we don't need to call pause_children recursively with a linked list in place
 		// it's slightly more involved though as we have to account for `transparent` changing
 		// through the tree.
 		pause_children(child, transitions, transparent ? local : false);
-		child = sibling;
+		child = child.next;
 	}
 }
 


### PR DESCRIPTION
We can improve the efficiency of each blocks by removing the dynamic closure. Furthermore, this sets us up nicely to reuse this logic for better handling how we can better clear controlled each blocks.