### PR TITLE
chore: apply each block controlled teardown optimization

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -418,9 +418,8 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 		if (moved) {
 			mark_lis(sources);
 		} else if (is_controlled && to_destroy.length === a_items.length) {
-			// We can optimize the case where we change all items of the each block to an entirely new set of items.
-			// In this case we can first clear the DOM fast, along with all their effect, then we can continue
-			// with the normal logic that appends them.
+			// We can optimize the case in which all items are replaced —
+			// destroy everything first, then append new items
 			pause_effects(to_destroy, anchor);
 			to_destroy = [];
 		}

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -17,7 +17,7 @@ import {
 	branch,
 	destroy_effect,
 	effect,
-	out,
+	run_out_transitions,
 	pause_children,
 	pause_effect,
 	resume_effect
@@ -65,7 +65,7 @@ function pause_effects(effects, controlled_anchor, callback) {
 		each_element.append(controlled_anchor);
 	}
 
-	out(transitions, () => {
+	run_out_transitions(transitions, () => {
 		for (var i = 0; i < length; i++) {
 			destroy_effect(effects[i]);
 		}

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -15,9 +15,11 @@ import { untrack } from '../../runtime.js';
 import {
 	block,
 	branch,
+	destroy_effect,
 	effect,
+	out,
+	pause_children,
 	pause_effect,
-	pause_effects,
 	resume_effect
 } from '../../reactivity/effects.js';
 import { source, mutable_source, set } from '../../reactivity/sources.js';
@@ -37,6 +39,38 @@ export let current_each_item = null;
 /** @param {import('#client').EachItem | null} item */
 export function set_current_each_item(item) {
 	current_each_item = item;
+}
+
+/**
+ * Pause multiple effects simultaneously, and coordinate their
+ * subsequent destruction. Used in each blocks
+ * @param {import('#client').Effect[]} effects
+ * @param {null | Node} controlled_anchor
+ * @param {() => void} [callback]
+ */
+function pause_effects(effects, controlled_anchor, callback) {
+	/** @type {import('#client').TransitionManager[]} */
+	var transitions = [];
+	var length = effects.length;
+
+	for (var i = 0; i < length; i++) {
+		pause_children(effects[i], transitions, true);
+	}
+
+	// If we have a controlled anchor, it means that the each block is inside a single
+	// DOM element, so we can apply a fast-path for clearing the contents of the element.
+	if (effects.length > 0 && transitions.length === 0 && controlled_anchor !== null) {
+		const each_element = /** @type {Element} */ (controlled_anchor.parentNode);
+		each_element.textContent = '';
+		each_element.append(controlled_anchor);
+	}
+
+	out(transitions, () => {
+		for (var i = 0; i < length; i++) {
+			destroy_effect(effects[i]);
+		}
+		if (callback !== undefined) callback();
+	});
 }
 
 /**
@@ -145,7 +179,6 @@ function each(anchor, flags, get_collection, get_key, render_fn, fallback_fn, re
 		}
 
 		if (!hydrating) {
-			// TODO add 'empty controlled block' optimisation here
 			reconcile_fn(array, state, anchor, render_fn, flags, keys);
 		}
 
@@ -244,7 +277,9 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 			effects.push(a_items[i].e);
 		}
 
-		pause_effects(effects, () => {
+		var controlled_anchor = (flags & EACH_IS_CONTROLLED) !== 0 && b === 0 ? anchor : null;
+
+		pause_effects(effects, controlled_anchor, () => {
 			state.items.length = b;
 		});
 	}
@@ -274,6 +309,7 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 
 	var is_animated = (flags & EACH_IS_ANIMATED) !== 0;
 	var should_update = (flags & (EACH_ITEM_REACTIVE | EACH_INDEX_REACTIVE)) !== 0;
+	var is_controlled = (flags & EACH_IS_CONTROLLED) !== 0;
 	var start = 0;
 	var item;
 
@@ -381,6 +417,12 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 		// I fully understand this part)
 		if (moved) {
 			mark_lis(sources);
+		} else if (is_controlled && to_destroy.length === a_items.length) {
+			// We can optimize the case where we change all items of the each block to an entirely new set of items.
+			// In this case we can first clear the DOM fast, along with all their effect, then we can continue
+			// with the normal logic that appends them.
+			pause_effects(to_destroy, anchor);
+			to_destroy = [];
 		}
 
 		// working from the back, insert new or moved items
@@ -421,9 +463,9 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 		});
 	}
 
-	// TODO: would be good to avoid this closure in the case where we have no
-	// transitions at all. It would make it far more JIT friendly in the hot cases.
-	pause_effects(to_destroy, () => {
+	var controlled_anchor = is_controlled && b === 0 ? anchor : null;
+
+	pause_effects(to_destroy, controlled_anchor, () => {
 		state.items = b_items;
 	});
 }

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -60,15 +60,16 @@ function pause_effects(effects, controlled_anchor, callback) {
 	// If we have a controlled anchor, it means that the each block is inside a single
 	// DOM element, so we can apply a fast-path for clearing the contents of the element.
 	if (effects.length > 0 && transitions.length === 0 && controlled_anchor !== null) {
-		const each_element = /** @type {Element} */ (controlled_anchor.parentNode);
-		each_element.textContent = '';
-		each_element.append(controlled_anchor);
+		var parent_node = /** @type {Element} */ (controlled_anchor.parentNode);
+		parent_node.textContent = '';
+		parent_node.append(controlled_anchor);
 	}
 
 	run_out_transitions(transitions, () => {
 		for (var i = 0; i < length; i++) {
 			destroy_effect(effects[i]);
 		}
+
 		if (callback !== undefined) callback();
 	});
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -27,7 +27,6 @@ import {
 	IS_ELSEIF
 } from '../constants.js';
 import { set } from './sources.js';
-import { noop } from '../../shared/utils.js';
 import { remove } from '../dom/reconciler.js';
 
 /**
@@ -295,9 +294,9 @@ export function destroy_effect(effect) {
  * completed, and if the state change is reversed then we _resume_ it.
  * A paused effect does not update, and the DOM subtree becomes inert.
  * @param {import('#client').Effect} effect
- * @param {() => void} callback
+ * @param {() => void} [callback]
  */
-export function pause_effect(effect, callback = noop) {
+export function pause_effect(effect, callback) {
 	/** @type {import('#client').TransitionManager[]} */
 	var transitions = [];
 
@@ -305,7 +304,7 @@ export function pause_effect(effect, callback = noop) {
 
 	out(transitions, () => {
 		destroy_effect(effect);
-		callback();
+		if (callback) callback();
 	});
 }
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -310,35 +310,10 @@ export function pause_effect(effect, callback = noop) {
 }
 
 /**
- * Pause multiple effects simultaneously, and coordinate their
- * subsequent destruction. Used in each blocks
- * @param {import('#client').Effect[]} effects
- * @param {() => void} callback
- */
-export function pause_effects(effects, callback = noop) {
-	/** @type {import('#client').TransitionManager[]} */
-	var transitions = [];
-	var length = effects.length;
-
-	for (var i = 0; i < length; i++) {
-		pause_children(effects[i], transitions, true);
-	}
-
-	// TODO: would be good to avoid this closure in the case where we have no
-	// transitions at all. It would make it far more JIT friendly in the hot cases.
-	out(transitions, () => {
-		for (var i = 0; i < length; i++) {
-			destroy_effect(effects[i]);
-		}
-		callback();
-	});
-}
-
-/**
  * @param {import('#client').TransitionManager[]} transitions
  * @param {() => void} fn
  */
-function out(transitions, fn) {
+export function out(transitions, fn) {
 	var remaining = transitions.length;
 	if (remaining > 0) {
 		var check = () => --remaining || fn();
@@ -355,7 +330,7 @@ function out(transitions, fn) {
  * @param {import('#client').TransitionManager[]} transitions
  * @param {boolean} local
  */
-function pause_children(effect, transitions, local) {
+export function pause_children(effect, transitions, local) {
 	if ((effect.f & INERT) !== 0) return;
 	effect.f ^= INERT;
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -302,7 +302,7 @@ export function pause_effect(effect, callback) {
 
 	pause_children(effect, transitions, true);
 
-	out(transitions, () => {
+	run_out_transitions(transitions, () => {
 		destroy_effect(effect);
 		if (callback) callback();
 	});
@@ -312,7 +312,7 @@ export function pause_effect(effect, callback) {
  * @param {import('#client').TransitionManager[]} transitions
  * @param {() => void} fn
  */
-export function out(transitions, fn) {
+export function run_out_transitions(transitions, fn) {
 	var remaining = transitions.length;
 	if (remaining > 0) {
 		var check = () => --remaining || fn();


### PR DESCRIPTION
This is a different take on the problem from https://github.com/sveltejs/svelte/pull/11000 which takes into account global transitions. Furthermore, unlike https://github.com/sveltejs/svelte/pull/11040, where we added quite a bit more code in – this keeps the code paths largely the same.

Given that `pause_effects` is exclusively used in each blocks, we can instead apply the controlled optimization there – as we know all the information we need at this point. I also moved this function into `each.js` so that its better coupled with what uses it.