### PR TITLE
fix: add `anchor` support to mount() API

### DIFF
--- a/.changeset/afraid-geckos-dance.md
+++ b/.changeset/afraid-geckos-dance.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: add `anchor` support to mount() API

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -89,8 +89,8 @@ export function stringify(value) {
  * @template {Record<string, any>} Events
  * @param {import('../../index.js').ComponentType<import('../../index.js').SvelteComponent<Props, Events>>} component
  * @param {{
- * 		anchor?: Node;
  * 		target: Document | Element | ShadowRoot;
+ * 		anchor?: Node;
  * 		props?: Props;
  * 		events?: { [Property in keyof Events]: (e: Events[Property]) => any };
  * 		context?: Map<any, any>;

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -99,7 +99,7 @@ export function stringify(value) {
  * @returns {Exports}
  */
 export function mount(component, options) {
-	const anchor = options.anchor || options.target.appendChild(empty());
+	const anchor = options.anchor ?? options.target.appendChild(empty());
 	// Don't flush previous effects to ensure order of outer effects stays consistent
 	return flush_sync(() => _mount(component, { ...options, anchor }), false);
 }

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -89,6 +89,7 @@ export function stringify(value) {
  * @template {Record<string, any>} Events
  * @param {import('../../index.js').ComponentType<import('../../index.js').SvelteComponent<Props, Events>>} component
  * @param {{
+ *    anchor?: Node;
  * 		target: Document | Element | ShadowRoot;
  * 		props?: Props;
  * 		events?: { [Property in keyof Events]: (e: Events[Property]) => any };
@@ -98,7 +99,7 @@ export function stringify(value) {
  * @returns {Exports}
  */
 export function mount(component, options) {
-	const anchor = options.target.appendChild(empty());
+	const anchor = options.anchor || options.target.appendChild(empty());
 	// Don't flush previous effects to ensure order of outer effects stays consistent
 	return flush_sync(() => _mount(component, { ...options, anchor }), false);
 }

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -89,11 +89,11 @@ export function stringify(value) {
  * @template {Record<string, any>} Events
  * @param {import('../../index.js').ComponentType<import('../../index.js').SvelteComponent<Props, Events>>} component
  * @param {{
- *    anchor?: Node;
+ * 		anchor?: Node;
  * 		target: Document | Element | ShadowRoot;
  * 		props?: Props;
  * 		events?: { [Property in keyof Events]: (e: Events[Property]) => any };
- *  	context?: Map<any, any>;
+ * 		context?: Map<any, any>;
  * 		intro?: boolean;
  * 	}} options
  * @returns {Exports}
@@ -188,7 +188,7 @@ export function hydrate(component, options) {
  * 		anchor: Node;
  * 		props?: Props;
  * 		events?: { [Property in keyof Events]: (e: Events[Property]) => any };
- *  	context?: Map<any, any>;
+ * 		context?: Map<any, any>;
  * 		intro?: boolean;
  * 	}} options
  * @returns {Exports}

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -299,8 +299,8 @@ declare module 'svelte' {
 	 *
 	 * */
 	export function mount<Props extends Record<string, any>, Exports extends Record<string, any>, Events extends Record<string, any>>(component: ComponentType<SvelteComponent<Props, Events, any>>, options: {
-		anchor?: Node | undefined;
 		target: Document | Element | ShadowRoot;
+		anchor?: Node | undefined;
 		props?: Props | undefined;
 		events?: { [Property in keyof Events]: (e: Events[Property]) => any; } | undefined;
 		context?: Map<any, any> | undefined;

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -299,6 +299,7 @@ declare module 'svelte' {
 	 *
 	 * */
 	export function mount<Props extends Record<string, any>, Exports extends Record<string, any>, Events extends Record<string, any>>(component: ComponentType<SvelteComponent<Props, Events, any>>, options: {
+		anchor?: Node | undefined;
 		target: Document | Element | ShadowRoot;
 		props?: Props | undefined;
 		events?: { [Property in keyof Events]: (e: Events[Property]) => any; } | undefined;


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11021.