### PR TITLE
fix: avoid duplication of content within each blocks when transitioning

### DIFF
--- a/.changeset/stupid-plums-invent.md
+++ b/.changeset/stupid-plums-invent.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: avoid duplication of content within each blocks when transitioning

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -75,8 +75,9 @@ function pause_effects(items, paused, controlled_anchor) {
 
 	run_out_transitions(transitions, () => {
 		for (var i = 0; i < length; i++) {
+			var item = items[i];
 			paused.delete(item.k);
-			destroy_effect(items[i].e);
+			destroy_effect(item.e);
 		}
 	});
 }
@@ -266,8 +267,6 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 		value = array[i];
 		item = a_items[i];
 		b_items[i] = item;
-		// Indexed each blocks use the index as the key
-		item.k = i;
 		update_item(item, value, i, flags);
 		resume_effect(item.e);
 	}
@@ -278,12 +277,12 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 			value = array[i];
 			item = paused.get(i);
 
-			if (item === undefined || item.e.dom === null) {
+			if (item === undefined) {
 				paused.delete(i);
 				item = create_item(anchor, value, i, i, render_fn, flags);
 			} else {
-				resume_effect(item.e);
 				move(/** @type {import('#client').Dom} */ (item.e.dom), anchor);
+				resume_effect(item.e);
 			}
 
 			b_items[i] = item;
@@ -380,12 +379,12 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 			key = keys[start];
 			item = paused.get(key);
 
-			if (item === undefined || item.e.dom === null) {
+			if (item === undefined) {
 				paused.delete(key);
 				item = create_item(anchor, array[start], key, start, render_fn, flags);
 			} else {
-				resume_effect(item.e);
 				move(/** @type {import('#client').Dom} */ (item.e.dom), anchor);
+				resume_effect(item.e);
 			}
 
 			b_items[start++] = item;
@@ -466,12 +465,12 @@ function reconcile_tracked_array(array, state, anchor, render_fn, flags, keys) {
 				key = keys[b];
 				item = paused.get(keys[b]);
 
-				if (item === undefined || item.e.dom === null) {
+				if (item === undefined) {
 					paused.delete(key);
 					item = create_item(anchor, array[b], key, b, render_fn, flags);
 				} else {
-					resume_effect(item.e);
 					move(/** @type {import('#client').Dom} */ (item.e.dom), anchor);
+					resume_effect(item.e);
 				}
 			} else {
 				item = b_items[b];

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -59,7 +59,7 @@ function pause_effects(items, paused, controlled_anchor) {
 		transitions_count = transitions.length;
 		pause_children(item.e, transitions, true);
 		if (transitions_count !== transitions.length) {
-			paused.set(item.k === null ? item.i : item.k, item);
+			paused.set(item.k, item);
 		}
 	}
 
@@ -75,7 +75,7 @@ function pause_effects(items, paused, controlled_anchor) {
 
 	run_out_transitions(transitions, () => {
 		for (var i = 0; i < length; i++) {
-			paused.delete(item.k === null ? item.i : item.k);
+			paused.delete(item.k);
 			destroy_effect(items[i].e);
 		}
 	});
@@ -266,6 +266,8 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 		value = array[i];
 		item = a_items[i];
 		b_items[i] = item;
+		// Indexed each blocks use the value as the key
+		item.k = value;
 		update_item(item, value, i, flags);
 		resume_effect(item.e);
 	}
@@ -274,11 +276,11 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 		// add items
 		for (; i < b; i += 1) {
 			value = array[i];
-			item = paused.get(i);
+			item = paused.get(value);
 
 			if (item === undefined || item.e.dom === null) {
-				paused.delete(i);
-				item = create_item(anchor, value, null, i, render_fn, flags);
+				paused.delete(value);
+				item = create_item(anchor, value, value, i, render_fn, flags);
 			} else {
 				resume_effect(item.e);
 				move(/** @type {import('#client').Dom} */ (item.e.dom), anchor);

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -120,7 +120,7 @@ function each(anchor, flags, get_collection, get_key, render_fn, fallback_fn, re
 				? []
 				: Array.from(collection);
 
-		var keys = get_key === null ? array : array.map(get_key);
+		var keys = get_key === null ? array.map((_, i) => i) : array.map(get_key);
 
 		var length = array.length;
 
@@ -170,7 +170,7 @@ function each(anchor, flags, get_collection, get_key, render_fn, fallback_fn, re
 				}
 
 				child_anchor = hydrate_anchor(child_anchor);
-				b_items[i] = create_item(child_anchor, array[i], keys?.[i], i, render_fn, flags);
+				b_items[i] = create_item(child_anchor, array[i], keys[i], i, render_fn, flags);
 				child_anchor = /** @type {Comment} */ (child_anchor.nextSibling);
 			}
 
@@ -266,8 +266,8 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 		value = array[i];
 		item = a_items[i];
 		b_items[i] = item;
-		// Indexed each blocks use the value as the key
-		item.k = value;
+		// Indexed each blocks use the index as the key
+		item.k = i;
 		update_item(item, value, i, flags);
 		resume_effect(item.e);
 	}
@@ -276,11 +276,11 @@ function reconcile_indexed_array(array, state, anchor, render_fn, flags) {
 		// add items
 		for (; i < b; i += 1) {
 			value = array[i];
-			item = paused.get(value);
+			item = paused.get(i);
 
 			if (item === undefined || item.e.dom === null) {
-				paused.delete(value);
-				item = create_item(anchor, value, value, i, render_fn, flags);
+				paused.delete(i);
+				item = create_item(anchor, value, i, i, render_fn, flags);
 			} else {
 				resume_effect(item.e);
 				move(/** @type {import('#client').Dom} */ (item.e.dom), anchor);

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -297,27 +297,8 @@ function animate(element, options, counterpart, t2, callback) {
 			fill: 'forwards'
 		});
 
-		animation.finished
-			.then(() => {
-				callback?.();
-			})
-			.catch((e) => {
-				// Error for DOMException: The user aborted a request. This results in two things:
-				// - startTime is `null`
-				// - currentTime is `null`
-				// We can't use the existence of an AbortError as this error and error code is shared
-				// with other Web APIs such as fetch().
-
-				if (animation.startTime !== null && animation.currentTime !== null) {
-					throw e;
-				}
-				// If we have an aborted request and the element is detached from the DOM, then that
-				// means that it's likely that the animation was paused upon the DOM element being
-				// removed. This won't trigger the finish logic, so we need to ensure the callback is fired.
-				if (!element.isConnected) {
-					callback?.();
-				}
-			});
+		// @ts-ignore
+		animation.onfinish = callback?.()
 	} else {
 		// Timer
 		if (t1 === 0) {

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -311,7 +311,9 @@ function animate(element, options, counterpart, t2, callback) {
 				if (animation.startTime !== null && animation.currentTime !== null) {
 					throw e;
 				}
-				callback?.();
+				if (!element.isConnected) {
+					callback?.();
+				}
 			});
 	} else {
 		// Timer

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -297,8 +297,8 @@ function animate(element, options, counterpart, t2, callback) {
 			fill: 'forwards'
 		});
 
-		// @ts-ignore
-		animation.onfinish = callback;
+		// we can't do `= callback` since the callback can change
+		animation.onfinish = () => callback?.();
 	} else {
 		// Timer
 		if (t1 === 0) {

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -311,6 +311,9 @@ function animate(element, options, counterpart, t2, callback) {
 				if (animation.startTime !== null && animation.currentTime !== null) {
 					throw e;
 				}
+				// If we have an aborted request and the element is detached from the DOM, then that
+				// means that it's likely that the animation was paused upon the DOM element being
+				// removed. This won't trigger the finish logic, so we need to ensure the callback is fired.
 				if (!element.isConnected) {
 					callback?.();
 				}

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -311,6 +311,7 @@ function animate(element, options, counterpart, t2, callback) {
 				if (animation.startTime !== null && animation.currentTime !== null) {
 					throw e;
 				}
+				callback?.();
 			});
 	} else {
 		// Timer

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -298,7 +298,7 @@ function animate(element, options, counterpart, t2, callback) {
 		});
 
 		// @ts-ignore
-		animation.onfinish = callback?.()
+		animation.onfinish = callback;
 	} else {
 		// Timer
 		if (t1 === 0) {

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -52,6 +52,8 @@ export type EachState = {
 	flags: number;
 	/** items */
 	items: EachItem[];
+  /** paused items */
+	paused: Map<unknown, EachItem>
 };
 
 export type EachItem = {

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -52,8 +52,8 @@ export type EachState = {
 	flags: number;
 	/** items */
 	items: EachItem[];
-  /** paused items */
-	paused: Map<unknown, EachItem>
+	/** paused items */
+	paused: Map<unknown, EachItem>;
 };
 
 export type EachItem = {

--- a/packages/svelte/tests/animation-helpers.js
+++ b/packages/svelte/tests/animation-helpers.js
@@ -123,12 +123,14 @@ class Animation {
 		if (this.currentTime > 0 && this.currentTime < this.#duration) {
 			this.#apply_keyframe(0);
 		}
-		// @ts-ignore
-		this.currentTime = null;
-		// @ts-ignore
-		this.startTime = null;
-		this.#cancelled();
-		raf.animations.delete(this);
+		if (this.currentTime !== null && this.startTime !== null) {
+			// @ts-ignore
+			this.currentTime = null;
+			// @ts-ignore
+			this.startTime = null;
+			this.#cancelled();
+			raf.animations.delete(this);
+		}
 	}
 }
 

--- a/packages/svelte/tests/animation-helpers.js
+++ b/packages/svelte/tests/animation-helpers.js
@@ -38,8 +38,7 @@ class Animation {
 
 	#offset = raf.time;
 
-	#finished = () => {};
-	#cancelled = () => {};
+	onfinish = () => {};
 
 	currentTime = 0;
 	startTime = 0;
@@ -54,21 +53,6 @@ class Animation {
 		this.#keyframes = keyframes;
 		this.#duration = duration;
 
-		// Promise-like semantics, but call callbacks immediately on raf.tick
-		this.finished = {
-			/** @param {() => void} callback */
-			then: (callback) => {
-				this.#finished = callback;
-
-				return {
-					/** @param {() => void} callback */
-					catch: (callback) => {
-						this.#cancelled = callback;
-					}
-				};
-			}
-		};
-
 		this._update();
 	}
 
@@ -78,7 +62,7 @@ class Animation {
 		this.#apply_keyframe(target_frame);
 
 		if (this.currentTime >= this.#duration) {
-			this.#finished();
+			this.onfinish();
 			raf.animations.delete(this);
 		}
 	}
@@ -128,7 +112,6 @@ class Animation {
 			this.currentTime = null;
 			// @ts-ignore
 			this.startTime = null;
-			this.#cancelled();
 			raf.animations.delete(this);
 		}
 	}

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-aborted-outro-in-each/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-aborted-outro-in-each/_config.js
@@ -23,7 +23,6 @@ export default test({
 		assert.equal(spans[1].foo, 0.25);
 		assert.equal(spans[2].foo, 0.75);
 
-		debugger;
 		component.things = things;
 
 		raf.tick(225);

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-aborted-outro-in-each/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-aborted-outro-in-each/_config.js
@@ -23,6 +23,7 @@ export default test({
 		assert.equal(spans[1].foo, 0.25);
 		assert.equal(spans[2].foo, 0.75);
 
+		debugger;
 		component.things = things;
 
 		raf.tick(225);


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/10918 and fixes https://github.com/sveltejs/svelte/issues/10919.

This tweaks the each block logic to use a Map for each block rows that are paused – so we can resume them later in the future if they're added again during reconciliation. I also noticed we were never triggering the callback when the animation was terminated, which was causing the animations on the DOM to get stuck.