### PR TITLE
chore: fix local dev

### DIFF
--- a/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
+++ b/sites/svelte-5-preview/src/routes/svelte/[...path]/+server.js
@@ -1,4 +1,4 @@
-import compiler_cjs from '../../../../../../packages/svelte/compiler/index.js?url';
+import compiler_js from '../../../../../../packages/svelte/compiler/index.js?url';
 import package_json from '../../../../../../packages/svelte/package.json?url';
 import { read } from '$app/server';
 
@@ -20,14 +20,18 @@ export function entries() {
 
 // service worker requests files under this path to load the compiler and runtime
 export async function GET({ params }) {
-	let url = '';
+	let file = '';
+
 	if (params.path === 'compiler/index.js') {
-		url = compiler_cjs;
+		file = compiler_js;
 	} else if (params.path === 'package.json') {
-		url = package_json;
+		file = package_json;
 	} else {
-		url = files[prefix + params.path];
+		file = /** @type {string} */ (files[prefix + params.path]);
+
+		// remove query string added by Vite when changing source code locally
+		file = file.split('?')[0];
 	}
 
-	return read(url);
+	return read(file);
 }


### PR DESCRIPTION
At the moment, if you edit source code while working in the playground locally, the result of `import.meta.glob` will include timestamp query params for the changed files. This causes `read(file)` to fail until you restart the dev server.

It's incredibly annoying and I can't believe it took me this long to implement this very simple fix