### PR TITLE
fix: ensure top level snippets are defined when binding to component prop

### DIFF
--- a/.changeset/gold-tools-nail.md
+++ b/.changeset/gold-tools-nail.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure top level snippets are defined when binding to component prop

--- a/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/client/index.svelte.js
@@ -1,0 +1,39 @@
+// index.svelte (Svelte VERSION)
+// Note: compiler output will change before 5.0 is released!
+import "svelte/internal/disclose-version";
+import * as $ from "svelte/internal/client";
+import TextInput from './Child.svelte';
+
+var root_1 = $.template(`Something`, 1);
+var root = $.template(`<!> `, 1);
+
+export default function Bind_component_snippet($$anchor, $$props) {
+	$.push($$props, true);
+
+	let value = $.source('');
+	const _snippet = snippet;
+	var fragment_1 = root();
+
+	function snippet($$anchor) {
+		var fragment = root_1();
+
+		$.append($$anchor, fragment);
+	}
+
+	var node = $.first_child(fragment_1);
+
+	TextInput(node, {
+		get value() {
+			return $.get(value);
+		},
+		set value($$value) {
+			$.set(value, $.proxy($$value));
+		}
+	});
+
+	var text = $.sibling(node, true);
+
+	$.render_effect(() => $.set_text(text, ` value: ${$.stringify($.get(value))}`));
+	$.append($$anchor, fragment_1);
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/server/index.svelte.js
@@ -1,0 +1,43 @@
+// index.svelte (Svelte VERSION)
+// Note: compiler output will change before 5.0 is released!
+import * as $ from "svelte/internal/server";
+import TextInput from './Child.svelte';
+
+export default function Bind_component_snippet($$payload, $$props) {
+	$.push(true);
+
+	let value = '';
+	const _snippet = snippet;
+
+	function snippet($$payload) {
+		$$payload.out += `Something`;
+	}
+
+	let $$settled = true;
+	let $$inner_payload;
+
+	function $$render_inner($$payload) {
+		$$payload.out += `<!--[-->`;
+
+		TextInput($$payload, {
+			get value() {
+				return value;
+			},
+			set value($$value) {
+				value = $$value;
+				$$settled = false;
+			}
+		});
+
+		$$payload.out += `<!--]--> value: ${$.escape(value)}`;
+	};
+
+	do {
+		$$settled = true;
+		$$inner_payload = $.copy_payload($$payload);
+		$$render_inner($$inner_payload);
+	} while (!$$settled);
+
+	$.assign_payload($$payload, $$inner_payload);
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/bind-component-snippet/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/bind-component-snippet/index.svelte
@@ -1,0 +1,13 @@
+<script>
+	import TextInput from './Child.svelte';
+
+	let value = $state('');
+	const _snippet = snippet;
+</script>
+
+{#snippet snippet()}
+	Something
+{/snippet}
+
+<TextInput bind:value />
+value: {value}


### PR DESCRIPTION
...by hoisting top level snippets out of the binding loop in ssr mode fixes #11086

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
