### PR TITLE
chore: add hmr compiler flag

### DIFF
--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -178,6 +178,12 @@ export interface CompileOptions extends ModuleCompileOptions {
 	 * @default null
 	 */
 	cssOutputFilename?: string;
+	/**
+	 * If `true`, compiles components with hot reloading support.
+	 *
+	 * @default false
+	 */
+	hmr?: boolean;
 }
 
 export interface ModuleCompileOptions {
@@ -225,6 +231,7 @@ export type ValidatedCompileOptions = ValidatedModuleCompileOptions &
 		legacy: Required<Required<CompileOptions>['legacy']>;
 		runes: CompileOptions['runes'];
 		customElementOptions: SvelteOptions['customElement'];
+		hmr: CompileOptions['hmr'];
 	};
 
 export type DeclarationKind =

--- a/packages/svelte/src/compiler/validate-options.js
+++ b/packages/svelte/src/compiler/validate-options.js
@@ -95,6 +95,8 @@ export const validate_component_options =
 
 			runes: boolean(undefined),
 
+			hmr: boolean(false),
+
 			sourcemap: validator(undefined, (input) => {
 				// Source maps can take on a variety of values, including string, JSON, map objects from magic-string and source-map,
 				// so there's no good way to check type validity here

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -670,6 +670,12 @@ declare module 'svelte/compiler' {
 		 * @default null
 		 */
 		cssOutputFilename?: string;
+		/**
+		 * If `true`, compiles components with hot reloading support.
+		 *
+		 * @default false
+		 */
+		hmr?: boolean;
 	}
 
 	interface ModuleCompileOptions {
@@ -1003,15 +1009,15 @@ declare module 'svelte/compiler' {
 		filename?: string | undefined;
 	} | undefined): Promise<Processed>;
 	export class CompileError extends Error {
-		
+
 		constructor(code: string, message: string, position: [number, number] | undefined);
-		
+
 		filename: CompileError_1['filename'];
-		
+
 		position: CompileError_1['position'];
-		
+
 		start: CompileError_1['start'];
-		
+
 		end: CompileError_1['end'];
 		code: string;
 	}
@@ -1022,9 +1028,9 @@ declare module 'svelte/compiler' {
 	 * */
 	export const VERSION: string;
 	class Scope {
-		
+
 		constructor(root: ScopeRoot, parent: Scope | null, porous: boolean);
-		
+
 		root: ScopeRoot;
 		/**
 		 * The immediate parent scope
@@ -1052,25 +1058,25 @@ declare module 'svelte/compiler' {
 		 * which is usually an error. Block statements do not increase this value
 		 */
 		function_depth: number;
-		
+
 		declare(node: import('estree').Identifier, kind: Binding['kind'], declaration_kind: DeclarationKind, initial?: null | import('estree').Expression | import('estree').FunctionDeclaration | import('estree').ClassDeclaration | import('estree').ImportDeclaration | EachBlock): Binding;
 		child(porous?: boolean): Scope;
-		
+
 		generate(preferred_name: string): string;
-		
+
 		get(name: string): Binding | null;
-		
+
 		get_bindings(node: import('estree').VariableDeclarator | LetDirective): Binding[];
-		
+
 		owner(name: string): Scope | null;
-		
+
 		reference(node: import('estree').Identifier, path: SvelteNode[]): void;
 		#private;
 	}
 	class ScopeRoot {
-		
+
 		conflicts: Set<string>;
-		
+
 		unique(preferred_name: string): import("estree").Identifier;
 	}
 	namespace Css {
@@ -1960,18 +1966,18 @@ declare module 'svelte/motion' {
 
 declare module 'svelte/reactivity' {
 	export class Date extends Date {
-		
+
 		constructor(...values: any[]);
 		#private;
 	}
 	export class Set<T> extends Set<any> {
-		
+
 		constructor(value?: Iterable<T> | null | undefined);
-		
+
 		has(value: T): boolean;
-		
+
 		add(value: T): this;
-		
+
 		delete(value: T): boolean;
 		keys(): IterableIterator<T>;
 		values(): IterableIterator<T>;
@@ -1980,17 +1986,17 @@ declare module 'svelte/reactivity' {
 		#private;
 	}
 	export class Map<K, V> extends Map<any, any> {
-		
+
 		constructor(value?: Iterable<readonly [K, V]> | null | undefined);
-		
+
 		has(key: K): boolean;
-		
+
 		forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, this_arg?: any): void;
-		
+
 		get(key: K): V | undefined;
-		
+
 		set(key: K, value: V): this;
-		
+
 		delete(key: K): boolean;
 		keys(): IterableIterator<K>;
 		values(): IterableIterator<V>;
@@ -2449,6 +2455,12 @@ declare module 'svelte/types/compiler/interfaces' {
 		 * @default null
 		 */
 		cssOutputFilename?: string;
+		/**
+		 * If `true`, compiles components with hot reloading support.
+		 *
+		 * @default false
+		 */
+		hmr?: boolean;
 	}
 
 	interface ModuleCompileOptions {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1009,15 +1009,15 @@ declare module 'svelte/compiler' {
 		filename?: string | undefined;
 	} | undefined): Promise<Processed>;
 	export class CompileError extends Error {
-
+		
 		constructor(code: string, message: string, position: [number, number] | undefined);
-
+		
 		filename: CompileError_1['filename'];
-
+		
 		position: CompileError_1['position'];
-
+		
 		start: CompileError_1['start'];
-
+		
 		end: CompileError_1['end'];
 		code: string;
 	}
@@ -1028,9 +1028,9 @@ declare module 'svelte/compiler' {
 	 * */
 	export const VERSION: string;
 	class Scope {
-
+		
 		constructor(root: ScopeRoot, parent: Scope | null, porous: boolean);
-
+		
 		root: ScopeRoot;
 		/**
 		 * The immediate parent scope
@@ -1058,25 +1058,25 @@ declare module 'svelte/compiler' {
 		 * which is usually an error. Block statements do not increase this value
 		 */
 		function_depth: number;
-
+		
 		declare(node: import('estree').Identifier, kind: Binding['kind'], declaration_kind: DeclarationKind, initial?: null | import('estree').Expression | import('estree').FunctionDeclaration | import('estree').ClassDeclaration | import('estree').ImportDeclaration | EachBlock): Binding;
 		child(porous?: boolean): Scope;
-
+		
 		generate(preferred_name: string): string;
-
+		
 		get(name: string): Binding | null;
-
+		
 		get_bindings(node: import('estree').VariableDeclarator | LetDirective): Binding[];
-
+		
 		owner(name: string): Scope | null;
-
+		
 		reference(node: import('estree').Identifier, path: SvelteNode[]): void;
 		#private;
 	}
 	class ScopeRoot {
-
+		
 		conflicts: Set<string>;
-
+		
 		unique(preferred_name: string): import("estree").Identifier;
 	}
 	namespace Css {
@@ -1966,18 +1966,18 @@ declare module 'svelte/motion' {
 
 declare module 'svelte/reactivity' {
 	export class Date extends Date {
-
+		
 		constructor(...values: any[]);
 		#private;
 	}
 	export class Set<T> extends Set<any> {
-
+		
 		constructor(value?: Iterable<T> | null | undefined);
-
+		
 		has(value: T): boolean;
-
+		
 		add(value: T): this;
-
+		
 		delete(value: T): boolean;
 		keys(): IterableIterator<T>;
 		values(): IterableIterator<T>;
@@ -1986,17 +1986,17 @@ declare module 'svelte/reactivity' {
 		#private;
 	}
 	export class Map<K, V> extends Map<any, any> {
-
+		
 		constructor(value?: Iterable<readonly [K, V]> | null | undefined);
-
+		
 		has(key: K): boolean;
-
+		
 		forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, this_arg?: any): void;
-
+		
 		get(key: K): V | undefined;
-
+		
 		set(key: K, value: V): this;
-
+		
 		delete(key: K): boolean;
 		keys(): IterableIterator<K>;
 		values(): IterableIterator<V>;


### PR DESCRIPTION
extracted from https://github.com/sveltejs/svelte/pull/11106

This adds the `hmr` compiler flag, but no implementation for it. This should stop any errors when using it with vps, avoiding constant version matching madness with the plugin.