### PR TITLE
fix: Correct scoping for `ReactiveSet` prototype method applications

### DIFF
--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -47,10 +47,7 @@ export class ReactiveSet extends Set {
 		var proto = ReactiveSet.prototype;
 		var set_proto = Set.prototype;
 
-		/** @type {string} */
-		var method;
-
-		for (method of read_methods) {
+		for (let method of read_methods) {
 			// @ts-ignore
 			proto[method] = function (...v) {
 				get(this.#version);
@@ -59,7 +56,7 @@ export class ReactiveSet extends Set {
 			};
 		}
 
-		for (method of set_like_methods) {
+		for (let method of set_like_methods) {
 			// @ts-ignore
 			proto[method] = function (...v) {
 				get(this.#version);


### PR DESCRIPTION
Fixes #11118. There was some incorrect scoping due to `var` usage in the `ReactiveSet` implementation.

I'm not sure how tests for this should be added, as node doesn't support these methods yet. So they'd need to run a browser, but adding them to `runtime-browser` or something seems not ideal? Happy to add them if given some guidance on where they should go, though.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
