### PR TITLE
fix: use keys for hmr modules

### DIFF
--- a/.changeset/brave-gorillas-end.md
+++ b/.changeset/brave-gorillas-end.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: use keys for hmr modules

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -427,7 +427,12 @@ export function client_component(source, analysis, options) {
 			b.export_default(
 				b.conditional(
 					b.import_meta_hot(),
-					b.call('$.hmr', b.member(b.import_meta_hot(), b.id('data')), b.id(analysis.name)),
+					b.call(
+						'$.hmr',
+						b.member(b.import_meta_hot(), b.id('data')),
+						b.id(analysis.name),
+						b.member(b.member(b.literal('import'), b.literal('meta')), b.literal('url'))
+					),
 					b.id(analysis.name)
 				)
 			),

--- a/packages/svelte/src/internal/client/dev/hmr.js
+++ b/packages/svelte/src/internal/client/dev/hmr.js
@@ -11,7 +11,7 @@ import { get } from '../runtime.js';
  */
 export function hmr(hot_data, component, key) {
 	var components = (hot_data.components ??= new Map());
-	let data = components.get(key);
+	var data = components.get(key);
 
 	if (data === undefined) {
 		components.set(
@@ -24,6 +24,7 @@ export function hmr(hot_data, component, key) {
 	} else {
 		set(data.source, component);
 	}
+	const component_source = data.source;
 
 	return (data.wrapper ??= /** @type {Component} */ (
 		(anchor, props) => {
@@ -33,7 +34,7 @@ export function hmr(hot_data, component, key) {
 			let effect;
 
 			block(() => {
-				const component = get(data.source);
+				const component = get(component_source);
 
 				if (effect) {
 					// @ts-ignore

--- a/packages/svelte/src/internal/client/dev/hmr.js
+++ b/packages/svelte/src/internal/client/dev/hmr.js
@@ -5,7 +5,7 @@ import { get } from '../runtime.js';
 
 /**
  * @template {(anchor: Comment, props: any) => any} Component
- * @param {{ components: Map<string, { source: import("#client").Source<Component>; wrapper: null | Component; }>}} hot_data
+ * @param {{ components: Map<string, { source: import("#client").Source<Component>; wrapper: null | Component; }> }} hot_data
  * @param {string} key
  * @param {Component} component
  */

--- a/packages/svelte/src/internal/client/dev/hmr.js
+++ b/packages/svelte/src/internal/client/dev/hmr.js
@@ -1,5 +1,5 @@
 import { block, branch, destroy_effect } from '../reactivity/effects.js';
-import { set, source as create_source } from '../reactivity/sources.js';
+import { set, source } from '../reactivity/sources.js';
 import { set_should_intro } from '../render.js';
 import { get } from '../runtime.js';
 
@@ -17,7 +17,7 @@ export function hmr(hot_data, component, key) {
 		components.set(
 			key,
 			(data = {
-				source: create_source(component),
+				source: source(component),
 				wrapper: null
 			})
 		);


### PR DESCRIPTION
This should hopefully fix the issues with hot module reloading. Previously, we weren't using keys for each of the component modules – this PR addresses that.