### PR TITLE
fix: support parsing camel case in container queries

### DIFF
--- a/.changeset/witty-adults-fold.md
+++ b/.changeset/witty-adults-fold.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix parsing camelcase container query name

--- a/packages/svelte/src/compiler/parse/read/css-tree-cq/node/container_query.js
+++ b/packages/svelte/src/compiler/parse/read/css-tree-cq/node/container_query.js
@@ -26,7 +26,7 @@ export function parse() {
 		// Container name doesn't match a query keyword, so assign it as container name.
 		if (!CONTAINER_QUERY_KEYWORDS.has(container_name.toLowerCase())) {
 			name = container_name;
-			this.eatIdent(container_name);
+			this.eat(Ident);
 		}
 	}
 

--- a/packages/svelte/test/css/samples/container-query-camel-case/expected.css
+++ b/packages/svelte/test/css/samples/container-query-camel-case/expected.css
@@ -1,0 +1,1 @@
+.main.svelte-xyz{container-name:myContainer;container-type:inline-size}@container myContainer (min-width: 300px){h1.svelte-xyz{color:red}}

--- a/packages/svelte/test/css/samples/container-query-camel-case/input.svelte
+++ b/packages/svelte/test/css/samples/container-query-camel-case/input.svelte
@@ -1,0 +1,13 @@
+<h1 class="main">hello</h1>
+
+<style lang="css">
+  .main {
+    container-name: myContainer;
+    container-type: inline-size;
+  }
+  @container myContainer (min-width: 300px) {
+    h1 {
+      color: red;
+    }
+  }
+</style>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/10845

The `eatIdent(...)` method from `css-tree` somehow expects lowercase identifiers only, and thus not working for camel case container names. switching to a more generic `eat(Ident)` would work. Since we already know the current token is an identifier with the name, we dont have to assert the content of the identifier via `eatIdent()`

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
