### PR TITLE
feat: simplify HMR implementation

### DIFF
--- a/.changeset/fair-bags-smoke.md
+++ b/.changeset/fair-bags-smoke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: simplify HMR implementation

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -422,31 +422,24 @@ export function client_component(source, analysis, options) {
 		)
 	];
 
-	// In order for hmr to work correctly, we need associate each component with a unique key.
-	// This is because bundlers might put many components into a the same module (usuaully as a chunk).
-	// `import.meta.hot` will then be the same object for all components in that modules.
-	if (options.hmr && options.filename) {
+	if (options.hmr) {
 		body.push(
-			b.export_default(
-				b.conditional(
-					b.import_meta_hot(),
+			b.if(b.id('import.meta.hot'), b.block([
+				b.const(b.id('s'), b.call('$.source', b.id(analysis.name))),
+				b.stmt(b.assignment('=', b.id(analysis.name), b.call('$.hmr', b.id('s')))),
+				b.stmt(
 					b.call(
-						'$.hmr',
-						b.member(b.import_meta_hot(), b.id('data')),
-						b.id(analysis.name),
-						b.literal(options.filename)
-					),
-					b.id(analysis.name)
+						'import.meta.hot.accept',
+						b.arrow([b.id('module')], b.block([
+							b.stmt(b.call('$.set', b.id('s'), b.member(b.id('module'), b.id('default'))))
+						]))
+					)
 				)
-			),
-			b.if(
-				b.import_meta_hot(),
-				b.stmt(b.call('import.meta.hot.acceptExports', b.literal('default')))
-			)
+			]))
 		);
-	} else {
-		body.push(b.export_default(b.id(analysis.name)));
 	}
+
+	body.push(b.export_default(b.id(analysis.name)));
 
 	if (options.dev) {
 		if (options.filename) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -424,18 +424,24 @@ export function client_component(source, analysis, options) {
 
 	if (options.hmr) {
 		body.push(
-			b.if(b.id('import.meta.hot'), b.block([
-				b.const(b.id('s'), b.call('$.source', b.id(analysis.name))),
-				b.stmt(b.assignment('=', b.id(analysis.name), b.call('$.hmr', b.id('s')))),
-				b.stmt(
-					b.call(
-						'import.meta.hot.accept',
-						b.arrow([b.id('module')], b.block([
-							b.stmt(b.call('$.set', b.id('s'), b.member(b.id('module'), b.id('default'))))
-						]))
+			b.if(
+				b.id('import.meta.hot'),
+				b.block([
+					b.const(b.id('s'), b.call('$.source', b.id(analysis.name))),
+					b.stmt(b.assignment('=', b.id(analysis.name), b.call('$.hmr', b.id('s')))),
+					b.stmt(
+						b.call(
+							'import.meta.hot.accept',
+							b.arrow(
+								[b.id('module')],
+								b.block([
+									b.stmt(b.call('$.set', b.id('s'), b.member(b.id('module'), b.id('default'))))
+								])
+							)
+						)
 					)
-				)
-			]))
+				])
+			)
 		);
 	}
 

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -600,20 +600,6 @@ export function throw_error(str) {
 	};
 }
 
-/**
- * @return {import('estree').MemberExpression}
- */
-export function import_meta_hot() {
-	return member(
-		{
-			type: 'MetaProperty',
-			meta: id('import'),
-			property: id('meta')
-		},
-		id('hot')
-	);
-}
-
 export {
 	await_builder as await,
 	let_builder as let,

--- a/packages/svelte/tests/snapshot/samples/hmr/_config.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		hmr: true
+	}
+});

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
@@ -1,0 +1,28 @@
+// index.svelte (Svelte VERSION)
+// Note: compiler output will change before 5.0 is released!
+import "svelte/internal/disclose-version";
+import * as $ from "svelte/internal/client";
+
+var root = $.template(`<h1>hello world</h1>`);
+
+function Hmr($$anchor, $$props) {
+	$.push($$props, false);
+	$.init();
+
+	var h1 = root();
+
+	$.append($$anchor, h1);
+	$.pop();
+}
+
+if (import.meta.hot) {
+	const s = $.source(Hmr);
+
+	Hmr = $.hmr(s);
+
+	import.meta.hot.accept((module) => {
+		$.set(s, module.default);
+	});
+}
+
+export default Hmr;

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/server/index.svelte.js
@@ -1,0 +1,9 @@
+// index.svelte (Svelte VERSION)
+// Note: compiler output will change before 5.0 is released!
+import * as $ from "svelte/internal/server";
+
+export default function Hmr($$payload, $$props) {
+	$.push(false);
+	$$payload.out += `<h1>hello world</h1>`;
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/hmr/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/hmr/index.svelte
@@ -1,0 +1,1 @@
+<h1>hello world</h1>


### PR DESCRIPTION
We made a mistake with our initial HMR implementation. Instead of working around it with component IDs, we should just use `import.meta.hot.accept` as intended.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
