### PR TITLE
fix: missing classes after dynamic expressions in class attributes

### DIFF
--- a/.changeset/cool-comics-marry.md
+++ b/.changeset/cool-comics-marry.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix missing classes after dynamic expressions in class attribute

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -853,9 +853,7 @@ function serialize_attribute_value(
 	/** @type {import('estree').Expression[]} */
 	const expressions = [];
 
-	if (attribute_value[0].type !== 'Text') {
-		quasis.push(b.quasi('', false));
-	}
+	quasis.push(b.quasi('', false));
 
 	let i = 0;
 	for (const node of attribute_value) {
@@ -866,7 +864,8 @@ function serialize_attribute_value(
 				// don't trim, space could be important to separate from expression tag
 				data = data.replace(regex_whitespaces_strict, ' ');
 			}
-			quasis.push(b.quasi(data, i === attribute_value.length));
+			const last = /** @type {import('estree').TemplateElement} */ (quasis.at(-1));
+			last.value.raw += data;
 		} else {
 			expressions.push(
 				b.call(
@@ -874,9 +873,7 @@ function serialize_attribute_value(
 					/** @type {import('estree').Expression} */ (context.visit(node.expression))
 				)
 			);
-			if (i === attribute_value.length || attribute_value[i]?.type !== 'Text') {
-				quasis.push(b.quasi('', true));
-			}
+			quasis.push(b.quasi('', i + 1 === attribute_value.length));
 		}
 	}
 

--- a/packages/svelte/tests/server-side-rendering/samples/head-raw-elements-content/_config.js
+++ b/packages/svelte/tests/server-side-rendering/samples/head-raw-elements-content/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/server-side-rendering/samples/head-raw-elements-content/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/head-raw-elements-content/_expected.html
@@ -1,0 +1,2 @@
+<div class="bar baz svelte-m782ot">bar</div>
+<div class="foo bar baz svelte-m782ot">bar</div>

--- a/packages/svelte/tests/server-side-rendering/samples/head-raw-elements-content/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/head-raw-elements-content/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	const dynamic_value = 'bar';
+</script>
+<div class="{dynamic_value} baz">bar</div>
+<div class="foo {dynamic_value} baz">bar</div>
+
+<style>
+	.baz {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11076

The issue is that after adding `svelte-hash` class into the `class` attribute, the number of text node and expression node is incorrect (1 extra text node than expected), the resulting template literal node is incorrect, causing the text after dynamic expressions to be dropped.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
