### PR TITLE
fix: refine css `:global()` selector checks in a compound selector

### DIFF
--- a/.changeset/dry-fans-march.md
+++ b/.changeset/dry-fans-march.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: refine css `:global()` selector checks in a compound selector

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -108,6 +108,8 @@ const css = {
 	'invalid-css-global-selector': () => `:global(...) must contain exactly one selector`,
 	'invalid-css-global-selector-list': () =>
 		`:global(...) must not contain type or universal selectors when used in a compound selector`,
+	'invalid-css-type-selector-placement': () =>
+		`:global(...) must not be followed with a type selector`,
 	'invalid-css-selector': () => `Invalid selector`,
 	'invalid-css-identifier': () => 'Expected a valid CSS identifier',
 	'invalid-nesting-selector': () => `Nesting selectors can only be used inside a rule`,

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -230,7 +230,7 @@ const visitors = {
 
 				context.state.specificity.bumped = true;
 
-				// TODO err... can this happen?
+				// for any :global() at the middle of compound selector
 				for (const selector of relative_selector.selectors) {
 					if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
 						remove_global_pseudo_class(selector);

--- a/packages/svelte/tests/validator/samples/css-invalid-global-selector-list/errors.json
+++ b/packages/svelte/tests/validator/samples/css-invalid-global-selector-list/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "invalid-css-global-selector-list",
+		"message": ":global(...) must not contain type or universal selectors when used in a compound selector",
+		"start": {
+			"line": 20,
+			"column": 6
+		},
+		"end": {
+			"line": 20,
+			"column": 17
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/css-invalid-global-selector-list/input.svelte
+++ b/packages/svelte/tests/validator/samples/css-invalid-global-selector-list/input.svelte
@@ -1,0 +1,27 @@
+<style>
+	::foo:global([data-state='checked']) {
+		color: red;
+	}
+	::foo:global(.foo) {
+		color: red;
+	}
+	::foo:global(#foo) {
+		color: red;
+	}
+	::foo:global(::foo) {
+		color: red;
+	}
+	::foo:global(:foo) {
+		color: red;
+	}
+	:global(h1) {
+		color: red;
+	}
+	::foo:global(h1) {
+		color: red;
+	}
+</style>
+
+<div>
+	<h1>hello world</h1>
+</div>

--- a/packages/svelte/tests/validator/samples/css-invalid-type-selector-placement/errors.json
+++ b/packages/svelte/tests/validator/samples/css-invalid-type-selector-placement/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "invalid-css-type-selector-placement",
+		"message": ":global(...) must not be followed with a type selector",
+		"start": {
+			"line": 17,
+			"column": 14
+		},
+		"end": {
+			"line": 17,
+			"column": 16
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/css-invalid-type-selector-placement/input.svelte
+++ b/packages/svelte/tests/validator/samples/css-invalid-type-selector-placement/input.svelte
@@ -1,0 +1,24 @@
+<style>
+	:global(.foo):foo {
+		color: red;
+	}
+	:global(.foo)::foo {
+		color: red;
+	}
+	:global(.foo).bar {
+		color: red;
+	}
+	:global(.foo)#baz {
+		color: red;
+	}
+	:global(.foo)[id] {
+		color: red;
+	}
+	:global(.foo)h1 {
+		color: red;
+	}
+</style>
+
+<div>
+	<h1 class="bar" id="baz">hello world</h1>
+</div>


### PR DESCRIPTION
Relates to https://github.com/sveltejs/svelte/issues/9207

- Added test case for https://github.com/sveltejs/svelte/issues/9207
- Improve the `:global` selector checks logic

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
