### PR TITLE
feat: allow $inspect reactivity map, set, date

### DIFF
--- a/.changeset/tiny-poems-doubt.md
+++ b/.changeset/tiny-poems-doubt.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: allow inspect reactivity map, set, date

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -14,3 +14,4 @@ export const IS_ELSEIF = 1 << 13;
 export const EFFECT_RAN = 1 << 14;
 
 export const STATE_SYMBOL = Symbol('$state');
+export const INSPECT_SYMBOL = Symbol('$inspect');

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -22,7 +22,8 @@ import {
 	BRANCH_EFFECT,
 	STATE_SYMBOL,
 	BLOCK_EFFECT,
-	ROOT_EFFECT
+	ROOT_EFFECT,
+	INSPECT_SYMBOL
 } from './constants.js';
 import { flush_tasks } from './dom/task.js';
 import { add_owner } from './dev/ownership.js';
@@ -1097,6 +1098,24 @@ export function pop(component) {
 }
 
 /**
+ *
+ * This is called from the inspect.
+ * Deeply traverse every item in the array with `deep_read` to register for inspect callback
+ * If the item implements INSPECT_SYMBOL, will use that instead
+ * @param {Array<any>} value
+ * @returns {void}
+ */
+function deep_read_inpect(value) {
+	for (const item of value) {
+		if (item && typeof item[INSPECT_SYMBOL] === 'function') {
+			item[INSPECT_SYMBOL]();
+		} else {
+			deep_read(item);
+		}
+	}
+}
+
+/**
  * Possibly traverse an object and read all its properties so that they're all reactive in case this is `$state`.
  * Does only check first level of an object for performance reasons (heuristic should be good for 99% of all cases).
  * @param {any} value
@@ -1226,7 +1245,7 @@ export function inspect(get_value, inspect = console.log) {
 
 		inspect_fn = fn;
 		const value = get_value();
-		deep_read(value);
+		deep_read_inpect(value);
 		inspect_fn = null;
 
 		const signals = inspect_captured_signals.slice();

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -1,3 +1,4 @@
+import { INSPECT_SYMBOL } from '../internal/client/constants.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 
@@ -98,5 +99,9 @@ export class ReactiveDate extends Date {
 		// @ts-ignore
 		super(...values);
 		this.#init();
+	}
+
+	[INSPECT_SYMBOL]() {
+		get(this.#raw_time);
 	}
 }

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -1,3 +1,4 @@
+import { DEV } from 'esm-env';
 import { INSPECT_SYMBOL } from '../internal/client/constants.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
@@ -89,6 +90,12 @@ export class ReactiveDate extends Date {
 					return v;
 				};
 			}
+
+			if (DEV) {
+				proto[INSPECT_SYMBOL] = function () {
+					get(this.#raw_time);
+				};
+			}
 		}
 	}
 
@@ -99,9 +106,5 @@ export class ReactiveDate extends Date {
 		// @ts-ignore
 		super(...values);
 		this.#init();
-	}
-
-	[INSPECT_SYMBOL]() {
-		get(this.#raw_time);
 	}
 }

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -92,6 +92,7 @@ export class ReactiveDate extends Date {
 			}
 
 			if (DEV) {
+				// @ts-ignore
 				proto[INSPECT_SYMBOL] = function () {
 					get(this.#raw_time);
 				};

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -13,7 +13,6 @@ export class ReactiveMap extends Map {
 	/** @type {Map<K, import('#client').Source<V>>} */
 	#sources = new Map();
 	#version = source(0);
-	#inspect_version = source(0);
 	#size = source(0);
 
 	/**
@@ -39,9 +38,6 @@ export class ReactiveMap extends Map {
 
 	#increment_version() {
 		set(this.#version, this.#version.v + 1);
-	}
-	#increment_inspect_version() {
-		set(this.#inspect_version, this.#inspect_version.v + 1);
 	}
 
 	/** @param {K} key */
@@ -97,11 +93,8 @@ export class ReactiveMap extends Map {
 			sources.set(key, source(value));
 			set(this.#size, sources.size);
 			this.#increment_version();
-			this.#increment_inspect_version();
 		} else {
-			const old_version = s.version;
 			set(s, value);
-			if (s.version !== old_version) this.#increment_inspect_version();
 		}
 
 		return super.set(key, value);
@@ -117,7 +110,6 @@ export class ReactiveMap extends Map {
 			set(this.#size, sources.size);
 			set(s, /** @type {V} */ (UNINITIALIZED));
 			this.#increment_version();
-			this.#increment_inspect_version();
 		}
 
 		return super.delete(key);
@@ -132,7 +124,6 @@ export class ReactiveMap extends Map {
 				set(s, /** @type {V} */ (UNINITIALIZED));
 			}
 			this.#increment_version();
-			this.#increment_inspect_version();
 		}
 
 		sources.clear();
@@ -167,6 +158,12 @@ export class ReactiveMap extends Map {
 	}
 
 	[INSPECT_SYMBOL]() {
-		get(this.#inspect_version);
+		// changes could either introduced by
+		// - modifying the value, or
+		// - add / remove entries to the map
+		for (const [, source] of this.#sources) {
+			get(source);
+		}
+		get(this.#size);
 	}
 }

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -26,6 +26,7 @@ export class ReactiveMap extends Map {
 		if (DEV) {
 			if (!inited) {
 				inited = true;
+				// @ts-ignore
 				ReactiveMap.prototype[INSPECT_SYMBOL] = function () {
 					// changes could either introduced by
 					// - modifying the value, or

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -69,6 +69,7 @@ export class ReactiveSet extends Set {
 		}
 
 		if (DEV) {
+			// @ts-ignore
 			proto[INSPECT_SYMBOL] = function () {
 				get(this.#version);
 			};

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -2,6 +2,7 @@ import { DEV } from 'esm-env';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { map } from './utils.js';
+import { INSPECT_SYMBOL } from '../internal/client/constants.js';
 
 var read_methods = ['forEach', 'isDisjointFrom', 'isSubsetOf', 'isSupersetOf'];
 var set_like_methods = ['difference', 'intersection', 'symmetricDifference', 'union'];
@@ -149,5 +150,8 @@ export class ReactiveSet extends Set {
 
 	get size() {
 		return get(this.#size);
+	}
+	[INSPECT_SYMBOL]() {
+		get(this.#version);
 	}
 }

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -67,6 +67,12 @@ export class ReactiveSet extends Set {
 				return new ReactiveSet(set);
 			};
 		}
+
+		if (DEV) {
+			proto[INSPECT_SYMBOL] = function () {
+				get(this.#version);
+			};
+		}
 	}
 
 	#increment_version() {
@@ -150,8 +156,5 @@ export class ReactiveSet extends Set {
 
 	get size() {
 		return get(this.#size);
-	}
-	[INSPECT_SYMBOL]() {
-		get(this.#version);
 	}
 }

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -1,3 +1,4 @@
+import { INSPECT_SYMBOL } from '../internal/client/constants.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 
@@ -149,6 +150,10 @@ export class ReactiveURL extends URL {
 
 	toJSON() {
 		return this.href;
+	}
+
+	[INSPECT_SYMBOL]() {
+		this.href;
 	}
 }
 

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -1,8 +1,11 @@
+import { DEV } from 'esm-env';
 import { INSPECT_SYMBOL } from '../internal/client/constants.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 
 const REPLACE = Symbol();
+var inited_url = false;
+var inited_search_params = false;
 
 export class ReactiveURL extends URL {
 	#protocol = source(super.protocol);
@@ -22,6 +25,14 @@ export class ReactiveURL extends URL {
 		url = new URL(url, base);
 		super(url);
 		this.#searchParams[REPLACE](url.searchParams);
+
+		if (DEV && !inited_url) {
+			inited_url = true;
+			// @ts-ignore
+			ReactiveURL.prototype[INSPECT_SYMBOL] = function () {
+				this.href;
+			};
+		}
 	}
 
 	get hash() {
@@ -151,10 +162,6 @@ export class ReactiveURL extends URL {
 	toJSON() {
 		return this.href;
 	}
-
-	[INSPECT_SYMBOL]() {
-		this.href;
-	}
 }
 
 export class ReactiveURLSearchParams extends URLSearchParams {
@@ -162,6 +169,17 @@ export class ReactiveURLSearchParams extends URLSearchParams {
 
 	#increment_version() {
 		set(this.#version, this.#version.v + 1);
+	}
+
+	constructor() {
+		super();
+		if (DEV && !inited_search_params) {
+			inited_search_params = true;
+			// @ts-ignore
+			ReactiveURLSearchParams.prototype[INSPECT_SYMBOL] = function () {
+				get(this.#version);
+			};
+		}
 	}
 
 	/**

--- a/packages/svelte/tests/runtime-runes/samples/inspect-reactivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-reactivity/_config.js
@@ -1,0 +1,81 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+import { log } from './log';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+	before_test() {
+		log.length = 0;
+	},
+	async test({ assert, target }) {
+		const [in1, in2] = target.querySelectorAll('input');
+		const [b1, b2, b3] = target.querySelectorAll('button');
+
+		assert.deepEqual(log, [
+			{ label: 'map', type: 'init', values: [] },
+			{ label: 'set', type: 'init', values: [] },
+			{ label: 'date', type: 'init', values: 1712966400000 }
+		]);
+		log.length = 0;
+
+		b1.click(); // map.set('key', 'value')
+
+		in1.value = 'name';
+		in2.value = 'Svelte';
+		in1.dispatchEvent(new window.Event('input', { bubbles: true }));
+		in2.dispatchEvent(new window.Event('input', { bubbles: true }));
+		flushSync(() => b1.click()); // map.set('name', 'Svelte')
+
+		in2.value = 'World';
+		in2.dispatchEvent(new window.Event('input', { bubbles: true }));
+		flushSync(() => b1.click()); // map.set('name', 'World')
+		flushSync(() => b1.click()); // map.set('name', 'World')
+
+		assert.deepEqual(log, [
+			{ label: 'map', type: 'update', values: [['key', 'value']] },
+			{
+				label: 'map',
+				type: 'update',
+				values: [
+					['key', 'value'],
+					['name', 'Svelte']
+				]
+			},
+			{
+				label: 'map',
+				type: 'update',
+				values: [
+					['key', 'value'],
+					['name', 'World']
+				]
+			}
+		]);
+		log.length = 0;
+
+		b2.click(); // set.add('name');
+
+		in1.value = 'Svelte';
+		in1.dispatchEvent(new window.Event('input', { bubbles: true }));
+		b2.click(); // set.add('Svelte');
+
+		b2.click(); // set.add('Svelte');
+
+		assert.deepEqual(log, [
+			{ label: 'set', type: 'update', values: ['name'] },
+			{ label: 'set', type: 'update', values: ['name', 'Svelte'] }
+		]);
+		log.length = 0;
+
+		b3.click(); // date.minutes++
+		b3.click(); // date.minutes++
+		b3.click(); // date.minutes++
+
+		assert.deepEqual(log, [
+			{ label: 'date', type: 'update', values: 1712966460000 },
+			{ label: 'date', type: 'update', values: 1712966520000 },
+			{ label: 'date', type: 'update', values: 1712966580000 }
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/inspect-reactivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-reactivity/_config.js
@@ -20,7 +20,7 @@ export default test({
 		]);
 		log.length = 0;
 
-		b1.click(); // map.set('key', 'value')
+		flushSync(() => b1.click()); // map.set('key', 'value')
 
 		in1.value = 'name';
 		in2.value = 'Svelte';
@@ -54,13 +54,13 @@ export default test({
 		]);
 		log.length = 0;
 
-		b2.click(); // set.add('name');
+		flushSync(() => b2.click()); // set.add('name');
 
 		in1.value = 'Svelte';
 		in1.dispatchEvent(new window.Event('input', { bubbles: true }));
-		b2.click(); // set.add('Svelte');
+		flushSync(() => b2.click()); // set.add('Svelte');
 
-		b2.click(); // set.add('Svelte');
+		flushSync(() => b2.click()); // set.add('Svelte');
 
 		assert.deepEqual(log, [
 			{ label: 'set', type: 'update', values: ['name'] },
@@ -68,9 +68,9 @@ export default test({
 		]);
 		log.length = 0;
 
-		b3.click(); // date.minutes++
-		b3.click(); // date.minutes++
-		b3.click(); // date.minutes++
+		flushSync(() => b3.click()); // date.minutes++
+		flushSync(() => b3.click()); // date.minutes++
+		flushSync(() => b3.click()); // date.minutes++
 
 		assert.deepEqual(log, [
 			{ label: 'date', type: 'update', values: 1712966460000 },

--- a/packages/svelte/tests/runtime-runes/samples/inspect-reactivity/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-reactivity/log.js
@@ -1,0 +1,2 @@
+/** @type {any[]} */
+export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/inspect-reactivity/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-reactivity/main.svelte
@@ -1,0 +1,27 @@
+<script>
+	import { Map, Set, Date } from 'svelte/reactivity';
+	import { log } from './log';
+
+	const map = new Map();
+	const set = new Set();
+	const date = new Date('2024-04-13 00:00:00+0000');
+	let key = $state('key');
+	let value = $state('value');
+
+	$inspect(map).with((type, map) => {
+		log.push({ label: 'map', type, values: [...map] });
+	});
+	$inspect(set).with((type, set) => {
+		log.push({ label: 'set', type, values: [...set] });
+	});
+	$inspect(date).with((type, date) => {
+		log.push({ label: 'date', type, values: date.getTime() });
+	});
+</script>
+
+<input bind:value={key} />
+<input bind:value={value} />
+
+<button on:click={() => map.set(key, value)}>map</button>
+<button on:click={() => set.add(key)}>set</button>
+<button on:click={() => date.setMinutes(date.getMinutes() + 1)}>date</button>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1972,6 +1972,7 @@ declare module 'svelte/reactivity' {
 	class ReactiveDate extends Date {
 		
 		constructor(...values: any[]);
+		[INSPECT_SYMBOL](): void;
 		#private;
 	}
 	class ReactiveSet<T> extends Set<any> {
@@ -1987,6 +1988,7 @@ declare module 'svelte/reactivity' {
 		values(): IterableIterator<T>;
 		entries(): IterableIterator<[T, T]>;
 		[Symbol.iterator](): IterableIterator<T>;
+		[INSPECT_SYMBOL](): void;
 		#private;
 	}
 	class ReactiveMap<K, V> extends Map<any, any> {
@@ -2006,6 +2008,7 @@ declare module 'svelte/reactivity' {
 		values(): IterableIterator<V>;
 		entries(): IterableIterator<[K, V]>;
 		[Symbol.iterator](): IterableIterator<[K, V]>;
+		[INSPECT_SYMBOL](): void;
 		#private;
 	}
 	class ReactiveURL extends URL {
@@ -2018,6 +2021,7 @@ declare module 'svelte/reactivity' {
 		#private;
 	}
 	const REPLACE: unique symbol;
+	const INSPECT_SYMBOL: unique symbol;
 
 	export { ReactiveDate as Date, ReactiveSet as Set, ReactiveMap as Map, ReactiveURL as URL, ReactiveURLSearchParams as URLSearchParams };
 }

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1972,7 +1972,6 @@ declare module 'svelte/reactivity' {
 	class ReactiveDate extends Date {
 		
 		constructor(...values: any[]);
-		[INSPECT_SYMBOL](): void;
 		#private;
 	}
 	class ReactiveSet<T> extends Set<any> {
@@ -1988,7 +1987,6 @@ declare module 'svelte/reactivity' {
 		values(): IterableIterator<T>;
 		entries(): IterableIterator<[T, T]>;
 		[Symbol.iterator](): IterableIterator<T>;
-		[INSPECT_SYMBOL](): void;
 		#private;
 	}
 	class ReactiveMap<K, V> extends Map<any, any> {
@@ -2008,7 +2006,6 @@ declare module 'svelte/reactivity' {
 		values(): IterableIterator<V>;
 		entries(): IterableIterator<[K, V]>;
 		[Symbol.iterator](): IterableIterator<[K, V]>;
-		[INSPECT_SYMBOL](): void;
 		#private;
 	}
 	class ReactiveURL extends URL {
@@ -2016,12 +2013,12 @@ declare module 'svelte/reactivity' {
 		#private;
 	}
 	class ReactiveURLSearchParams extends URLSearchParams {
+		constructor();
 		
 		[REPLACE](params: URLSearchParams): void;
 		#private;
 	}
 	const REPLACE: unique symbol;
-	const INSPECT_SYMBOL: unique symbol;
 
 	export { ReactiveDate as Date, ReactiveSet as Set, ReactiveMap as Map, ReactiveURL as URL, ReactiveURLSearchParams as URLSearchParams };
 }


### PR DESCRIPTION
Relates to https://github.com/sveltejs/svelte/issues/11151.

Currently the `$inspect` runes work based on `deep_read` the state through properties and getters. This seems to work with `ReactiveSet` and `ReactiveMap` because it has a `get size()` getter.
And it doesn't work with the `ReactiveDate` because it has neither state properties nor getters.

This PR attempts to fix this by introduce a `Symbol('$inspect')` method to the reactivity objects. This allow the reactivity objects to implements its own logic to trigger the inspect callbacks.

We could export the `Symbol('$inspect')` to allow it to work for user defined reactivity object.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
