### PR TITLE
fix: fix transition breaking the css layout

### DIFF
--- a/.changeset/nervous-needles-shave.md
+++ b/.changeset/nervous-needles-shave.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+Fixed transition not allowing animated style properties from being changed after it was finished

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -294,7 +294,7 @@ function animate(element, options, counterpart, t2, callback) {
 			delay,
 			duration,
 			easing: 'linear',
-			fill: 'forwards'
+			fill: 'none'
 		});
 
 		animation.finished


### PR DESCRIPTION
Related to https://github.com/sveltejs/svelte/issues/11165 (includes example)

Remove unnecessary `fill: "forwards"` which prevents any future modification of animated properties. This is discouraged as stated in the [official spec](https://www.w3.org/TR/web-animations-1/#fill-behavior). This animation property breaks the layout in a very confusing manner since there's no way to see inside devtools why styles no longer have any effect on the element.

I couldn't find the commit that explains why `forwards` was used in this case, but `fill: 'none'` seems to work perfectly fine for transitions and makes it behave as expected.

Alternative [approach](https://developer.mozilla.org/en-US/docs/Web/API/Animation/commitStyles) didn't seem to work, simply using `.cancel()` at finish doesn't fix the behavior and `.commitStyles()` applies the styles to the element which is not a desired result. 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
