### PR TITLE
feat: remove todo

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -352,8 +352,6 @@ const validation = {
 			if (context.state.analysis.runes && binding.kind === 'each') {
 				error(node, 'invalid-each-assignment');
 			}
-
-			// TODO handle mutations of non-state/props in runes mode
 		}
 
 		if (node.name === 'group') {


### PR DESCRIPTION
right now when binding a non state / props in runes mode, will have warnings at the variable declaration:

```
value is updated, but is not declared with $state(...). Changing its value will not correctly trigger updates.
```

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
