### PR TITLE
Feat: Binding focused state to elements

### DIFF
--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -325,6 +325,7 @@ const bindings = {
 		(elements
 			? `'${binding}' binding can only be used with ${elements}`
 			: `'${binding}' is not a valid binding`) + post,
+	'invalid-binding-reference': (binding) => `'${binding}' binding doesn't support multiple element`,
 	'invalid-type-attribute': () =>
 		`'type' attribute must be a static text value if input uses two-way binding`,
 	'invalid-multiple-attribute': () =>

--- a/packages/svelte/src/compiler/phases/2-analyze/a11y.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/a11y.js
@@ -718,6 +718,11 @@ function check_element(node, state, path) {
 			ContentEditableBindings.includes(attribute.name)
 		) {
 			has_contenteditable_binding = true;
+		} else if (
+			attribute.type === 'BindDirective' &&
+			attribute.name === 'focused'
+		) {
+			push_warning(attribute, 'a11y-binding-focused', attribute.name);
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -358,6 +358,11 @@ const validation = {
 			}
 		}
 
+		debugger;
+		if (node.name === 'focused' && binding?.references.length && binding?.references.length > 2) {
+			error(node, 'invalid-binding-reference', node.name);
+		}
+
 		if (node.name === 'group') {
 			if (!binding) {
 				error(node, 'INTERNAL', 'Cannot find declaration for bind:group');

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2699,7 +2699,9 @@ export const template_visitors = {
 				case 'checked':
 					call_expr = b.call(`$.bind_checked`, state.node, getter, setter);
 					break;
-
+				case 'focused':
+					call_expr = b.call(`$.bind_focused`, state.node, getter, setter);
+					break;
 				case 'group': {
 					/** @type {import('estree').CallExpression[]} */
 					const indexes = [];

--- a/packages/svelte/src/compiler/phases/bindings.js
+++ b/packages/svelte/src/compiler/phases/bindings.js
@@ -21,6 +21,7 @@ export const binding_properties = {
 		event: 'durationchange',
 		omit_in_ssr: true
 	},
+	focused: {},
 	paused: {
 		valid_elements: ['audio', 'video'],
 		omit_in_ssr: true

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -198,7 +198,8 @@ const a11y = {
 	'a11y-mouse-events-have-key-events': (event, accompanied_by) =>
 		`A11y: '${event}' event must be accompanied by '${accompanied_by}' event`,
 	/** @param {string} name */
-	'a11y-missing-content': (name) => `A11y: <${name}> element should have child content`
+	'a11y-missing-content': (name) => `A11y: <${name}> element should have child content`,
+	'a11y-binding-focused': (name) => `Avoid use of binding '${name}' for screen reader`,
 };
 
 /** @satisfies {Warnings} */

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-debugger */
 import { DEV } from 'esm-env';
 import { render_effect, effect } from '../../../reactivity/effects.js';
 import { stringify } from '../../../render.js';

--- a/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
@@ -67,3 +67,39 @@ export function bind_property(property, event_name, type, element, get_value, up
 		}
 	});
 }
+
+/**
+ * @param {HTMLElement} element
+ * @param {() => unknown} get_value
+ * @param {(value: unknown) => void} update
+ * @returns {void}
+ */
+export function bind_focused(element, get_value, update) {
+	element.addEventListener('focus', () => {
+		update(true)
+	});
+
+	element.addEventListener('blur', () => {
+		update(false)
+	});
+
+
+	if (get_value() == undefined) {
+		update(false);
+	}
+
+	/** @type {ReturnType<typeof setTimeout>} */
+	var timeout;
+
+	render_effect(() => {
+		if (timeout) {
+			clearTimeout(timeout)
+		}
+		var value = get_value();
+		if (value) {
+			timeout = setTimeout(() => element.focus(), 0)
+		} else {
+			timeout = setTimeout(() => element.blur(), 0)
+		}
+	});
+}

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -43,7 +43,7 @@ export { bind_prop } from './dom/elements/bindings/props.js';
 export { bind_select_value, init_select, select_option } from './dom/elements/bindings/select.js';
 export { bind_element_size, bind_resize_observer } from './dom/elements/bindings/size.js';
 export { bind_this } from './dom/elements/bindings/this.js';
-export { bind_content_editable, bind_property } from './dom/elements/bindings/universal.js';
+export { bind_content_editable, bind_property, bind_focused } from './dom/elements/bindings/universal.js';
 export { bind_window_scroll, bind_window_size } from './dom/elements/bindings/window.js';
 export {
 	once,

--- a/packages/svelte/tests/validator/samples/a11y-binding-focused/input.svelte
+++ b/packages/svelte/tests/validator/samples/a11y-binding-focused/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	let a = $state(0);
+</script>
+
+<input type="number" bind:focused={a} />

--- a/packages/svelte/tests/validator/samples/a11y-binding-focused/warnings.json
+++ b/packages/svelte/tests/validator/samples/a11y-binding-focused/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "a11y-binding-focused",
+		"end": {
+			"column": 37,
+			"line": 5
+		},
+		"message": "Avoid use of binding 'focused' for screen reader",
+		"start": {
+			"column": 21,
+			"line": 5
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/binding-invalid-references/errors.json
+++ b/packages/svelte/tests/validator/samples/binding-invalid-references/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "invalid-binding-reference",
+		"message": "'focused' binding doesn't support multiple element",
+		"start": {
+			"line": 5,
+			"column": 21
+		},
+		"end": {
+			"line": 5,
+			"column": 37
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/binding-invalid-references/input.svelte
+++ b/packages/svelte/tests/validator/samples/binding-invalid-references/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let a = $state("");
+</script>
+
+<input type="number" bind:focused={a} />
+<input type="text" bind:focused={a} />


### PR DESCRIPTION
## Svelte 5 rewrite

Feat: https://github.com/sveltejs/svelte/issues/8949

- Introduced new binding name `focused`.
- Added warning which says no to use, for screen reader.
- To avoid edge case, added error to not reference multiple `bind:focused` with same state/props/variable

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
