### PR TITLE
feat: add warning when using $bindable runes without calling it

### DIFF
--- a/.changeset/shiny-rats-heal.md
+++ b/.changeset/shiny-rats-heal.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: add warning when using `$bindable` rune without calling it

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -1113,6 +1113,7 @@ export const validation_runes = merge(validation, a11y_validators, {
 			if (init?.type === 'Identifier' && init.name === '$props' && !state.scope.get('props')) {
 				warn(state.analysis.warnings, node, path, 'invalid-props-declaration');
 			}
+			// console.log({init, p: !state.scope.get('bindable')});
 			return;
 		}
 
@@ -1166,6 +1167,11 @@ export const validation_runes = merge(validation, a11y_validators, {
 			) {
 				warn(state.analysis.warnings, node, path, 'derived-iife');
 			}
+		}
+	},
+	AssignmentPattern(node, { state, path }) {
+		if (node.right.type === 'Identifier' && node.right.name === '$bindable' && !state.scope.get('bindable')) {
+			warn(state.analysis.warnings, node, path, 'invalid-bindable-declaration');
 		}
 	},
 	// TODO this is a code smell. need to refactor this stuff

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -1113,7 +1113,6 @@ export const validation_runes = merge(validation, a11y_validators, {
 			if (init?.type === 'Identifier' && init.name === '$props' && !state.scope.get('props')) {
 				warn(state.analysis.warnings, node, path, 'invalid-props-declaration');
 			}
-			// console.log({init, p: !state.scope.get('bindable')});
 			return;
 		}
 
@@ -1170,7 +1169,11 @@ export const validation_runes = merge(validation, a11y_validators, {
 		}
 	},
 	AssignmentPattern(node, { state, path }) {
-		if (node.right.type === 'Identifier' && node.right.name === '$bindable' && !state.scope.get('bindable')) {
+		if (
+			node.right.type === 'Identifier' &&
+			node.right.name === '$bindable' &&
+			!state.scope.get('bindable')
+		) {
 			warn(state.analysis.warnings, node, path, 'invalid-bindable-declaration');
 		}
 	},

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -39,7 +39,9 @@ const runes = {
 	'derived-iife': () =>
 		`Use \`$derived.by(() => {...})\` instead of \`$derived((() => {...})());\``,
 	'invalid-props-declaration': () =>
-		`Component properties are declared using $props() in runes mode. Did you forget to call the function?`
+		`Component properties are declared using $props() in runes mode. Did you forget to call the function?`,
+	'invalid-bindable-declaration': () =>
+		`Bindable component properties are declared using $bindable() in runes mode. Did you forget to call the function?`
 };
 
 /** @satisfies {Warnings} */

--- a/packages/svelte/tests/validator/samples/runes-bindable-not-called/_config.js
+++ b/packages/svelte/tests/validator/samples/runes-bindable-not-called/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/validator/samples/runes-bindable-not-called/input.svelte
+++ b/packages/svelte/tests/validator/samples/runes-bindable-not-called/input.svelte
@@ -1,0 +1,3 @@
+<script>
+	let { a = $bindable } = $props();
+</script>

--- a/packages/svelte/tests/validator/samples/runes-bindable-not-called/warnings.json
+++ b/packages/svelte/tests/validator/samples/runes-bindable-not-called/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "invalid-bindable-declaration",
+		"message": "Bindable component properties are declared using $bindable() in runes mode. Did you forget to call the function?",
+		"start": {
+			"column": 7,
+			"line": 2
+		},
+		"end": {
+			"column": 20,
+			"line": 2
+		}
+	}
+]


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11173

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
