### PR TITLE
fix: more accurate default value handling

### DIFF
--- a/.changeset/selfish-socks-smile.md
+++ b/.changeset/selfish-socks-smile.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: more accurate default value handling

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -398,9 +398,10 @@ export function template(elements, expressions) {
 
 /**
  * @param {import('estree').Expression | import('estree').BlockStatement} expression
+ * @param {boolean} [async]
  * @returns {import('estree').Expression}
  */
-export function thunk(expression) {
+export function thunk(expression, async = false) {
 	if (
 		expression.type === 'CallExpression' &&
 		expression.callee.type !== 'Super' &&
@@ -411,7 +412,9 @@ export function thunk(expression) {
 		return expression.callee;
 	}
 
-	return arrow([], expression);
+	const fn = arrow([], expression);
+	if (async) fn.async = true;
+	return fn;
 }
 
 /**

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -107,6 +107,7 @@ export {
 	update,
 	update_pre,
 	value_or_fallback,
+	value_or_fallback_async,
 	exclude_from_object,
 	pop,
 	push,
@@ -136,7 +137,7 @@ export {
 	$window as window,
 	$document as document
 } from './dom/operations.js';
-export { noop } from '../shared/utils.js';
+export { noop, call_once } from '../shared/utils.js';
 export {
 	add_snippet_symbol,
 	validate_component,

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1025,11 +1025,21 @@ export function exclude_from_object(obj, keys) {
 /**
  * @template V
  * @param {V} value
- * @param {V} fallback
+ * @param {() => V} fallback lazy because could contain side effects
  * @returns {V}
  */
 export function value_or_fallback(value, fallback) {
-	return value === undefined ? fallback : value;
+	return value === undefined ? fallback() : value;
+}
+
+/**
+ * @template V
+ * @param {V} value
+ * @param {() => Promise<V>} fallback lazy because could contain side effects
+ * @returns {Promise<V>}
+ */
+export async function value_or_fallback_async(value, fallback) {
+	return value === undefined ? fallback() : value;
 }
 
 /**

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -514,11 +514,21 @@ export function unsubscribe_stores(store_values) {
 /**
  * @template V
  * @param {V} value
- * @param {V} fallback
+ * @param {() => V} fallback lazy because could contain side effects
  * @returns {V}
  */
 export function value_or_fallback(value, fallback) {
-	return value === undefined ? fallback : value;
+	return value === undefined ? fallback() : value;
+}
+
+/**
+ * @template V
+ * @param {V} value
+ * @param {() => Promise<V>} fallback lazy because could contain side effects
+ * @returns {Promise<V>}
+ */
+export async function value_or_fallback_async(value, fallback) {
+	return value === undefined ? fallback() : value;
 }
 
 /**

--- a/packages/svelte/src/internal/shared/utils.js
+++ b/packages/svelte/src/internal/shared/utils.js
@@ -23,3 +23,19 @@ export function run_all(arr) {
 		arr[i]();
 	}
 }
+
+/**
+ * @param {Function} fn
+ */
+export function call_once(fn) {
+	let called = false;
+	/** @type {unknown} */
+	let result;
+	return function () {
+		if (!called) {
+			called = true;
+			result = fn();
+		}
+		return result;
+	};
+}

--- a/packages/svelte/tests/runtime-runes/samples/destructure-async-assignments/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/destructure-async-assignments/_config.js
@@ -35,9 +35,7 @@ export default test({
 		const btn = target.querySelector('button');
 		const clickEvent = new window.Event('click', { bubbles: true });
 		await btn?.dispatchEvent(clickEvent);
-		for (let i = 1; i <= 42; i += 1) {
-			await Promise.resolve();
-		}
+		await new Promise((r) => setTimeout(() => r(0), 100));
 
 		assert.htmlEqual(
 			target.innerHTML,

--- a/packages/svelte/tests/runtime-runes/samples/each-block-default-arg/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-block-default-arg/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: false // or else the arg will be called eagerly anyway to check for dead zones
+	},
+	html: `
+	<div>1 1 1</div>
+	<div>2 2 2</div>
+	<div>1 1 1</div>
+	<p>2</p>
+	`
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-block-default-arg/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-block-default-arg/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { untrack } from 'svelte';
+
+	let count = $state(0);
+	function default_arg() {
+		untrack(() => count++);
+		return 1;
+	}
+</script>
+
+{#each [{}, { a: 2 }, {}] as { a = default_arg() }}
+	<div>{a} {a} {a}</div>
+{/each}
+<p>{count}</p>

--- a/packages/svelte/tests/runtime-runes/samples/snippet-default-arg/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-default-arg/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: false // or else the arg will be called eagerly anyway to check for dead zones
+	},
+	html: `
+	<div>1 1 1</div>
+	<div>2 2 2</div>
+	<div>1 1 1</div>
+	<p>2</p>
+	`
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-default-arg/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-default-arg/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	import { untrack } from 'svelte';
+
+	let count = $state(0);
+	function default_arg() {
+		untrack(() => count++);
+		return 1;
+	}
+</script>
+
+{#snippet item(id = default_arg())}
+	<div>{id} {id} {id}</div>
+{/snippet}
+
+{@render item()}
+{@render item(2)}
+{@render item()}
+<p>{count}</p>


### PR DESCRIPTION
- don't call fallback values eagerly, only when it's actually needed. Avoids potential unwanted side effects
- use derived_safe_equals to memoize results of destructured snippet/each context values with default values to ensure they're only recalculated when their dependencies change. Avoids unstable default values getting called multiple times yielding different results. Use derived_safe_equals to ensure new values are always set, even when mutated. fixes #11143

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
