### PR TITLE
fix: remove memory leak from bind:this

### DIFF
--- a/.changeset/itchy-eels-marry.md
+++ b/.changeset/itchy-eels-marry.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: remove memory leak from bind:this

--- a/packages/svelte/src/internal/client/dom/elements/bindings/this.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/this.js
@@ -1,5 +1,5 @@
 import { STATE_SYMBOL } from '../../../constants.js';
-import { destroy_effect, effect, render_effect } from '../../../reactivity/effects.js';
+import { branch, effect, render_effect } from '../../../reactivity/effects.js';
 import { untrack } from '../../../runtime.js';
 
 /**
@@ -47,12 +47,10 @@ export function bind_this(element_or_component, update, get_value, get_parts) {
 		});
 
 		return () => {
-			const e = effect(() => {
+			branch(() => {
 				if (parts && is_bound_this(get_value(...parts), element_or_component)) {
 					update(null, ...parts);
 				}
-				// Prevent leaking memory by ensuring we tidy up this effect
-				destroy_effect(e);
 			});
 		};
 	});

--- a/packages/svelte/src/internal/client/dom/elements/bindings/this.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/this.js
@@ -1,6 +1,12 @@
 import { STATE_SYMBOL } from '../../../constants.js';
 import { branch, effect, render_effect } from '../../../reactivity/effects.js';
-import { current_effect, current_reaction, set_current_effect, set_current_reaction, untrack } from '../../../runtime.js';
+import {
+	current_effect,
+	current_reaction,
+	set_current_effect,
+	set_current_reaction,
+	untrack
+} from '../../../runtime.js';
 
 /**
  * @param {any} bound_value

--- a/packages/svelte/src/internal/client/dom/elements/bindings/this.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/this.js
@@ -1,5 +1,5 @@
 import { STATE_SYMBOL } from '../../../constants.js';
-import { effect, render_effect } from '../../../reactivity/effects.js';
+import { destroy_effect, effect, render_effect } from '../../../reactivity/effects.js';
 import { untrack } from '../../../runtime.js';
 
 /**
@@ -47,10 +47,12 @@ export function bind_this(element_or_component, update, get_value, get_parts) {
 		});
 
 		return () => {
-			effect(() => {
+			const e = effect(() => {
 				if (parts && is_bound_this(get_value(...parts), element_or_component)) {
 					update(null, ...parts);
 				}
+				// Prevent leaking memory by ensuring we tidy up this effect
+				destroy_effect(e);
 			});
 		};
 	});

--- a/packages/svelte/src/internal/client/dom/elements/bindings/this.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/this.js
@@ -1,6 +1,6 @@
 import { STATE_SYMBOL } from '../../../constants.js';
 import { branch, effect, render_effect } from '../../../reactivity/effects.js';
-import { untrack } from '../../../runtime.js';
+import { current_effect, current_reaction, set_current_effect, set_current_reaction, untrack } from '../../../runtime.js';
 
 /**
  * @param {any} bound_value
@@ -47,11 +47,18 @@ export function bind_this(element_or_component, update, get_value, get_parts) {
 		});
 
 		return () => {
+			const previous_effect = current_effect;
+			const previous_reaction = current_reaction;
+			// TODO: maybe we should use something other an effect branch here to emulate the microtask behaviour.
+			set_current_effect(null);
+			set_current_reaction(null);
 			branch(() => {
 				if (parts && is_bound_this(get_value(...parts), element_or_component)) {
 					update(null, ...parts);
 				}
 			});
+			set_current_effect(previous_effect);
+			set_current_reaction(previous_reaction);
 		};
 	});
 }

--- a/packages/svelte/src/internal/client/dom/task.js
+++ b/packages/svelte/src/internal/client/dom/task.js
@@ -1,12 +1,9 @@
 import { run_all } from '../../shared/utils.js';
 
 let is_task_queued = false;
-let is_raf_queued = false;
 
 /** @type {Array<() => void>} */
 let current_queued_tasks = [];
-/** @type {Array<() => void>} */
-let current_raf_tasks = [];
 
 function process_task() {
 	is_task_queued = false;
@@ -15,11 +12,15 @@ function process_task() {
 	run_all(tasks);
 }
 
-function process_raf_task() {
-	is_raf_queued = false;
-	const tasks = current_raf_tasks.slice();
-	current_raf_tasks = [];
-	run_all(tasks);
+/**
+ * @param {() => void} fn
+ */
+export function queue_task(fn) {
+	if (!is_task_queued) {
+		is_task_queued = true;
+		queueMicrotask(process_task);
+	}
+	current_queued_tasks.push(fn);
 }
 
 /**
@@ -28,8 +29,5 @@ function process_raf_task() {
 export function flush_tasks() {
 	if (is_task_queued) {
 		process_task();
-	}
-	if (is_raf_queued) {
-		process_raf_task();
 	}
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -11,8 +11,6 @@ import {
 	is_flushing_effect,
 	remove_reactions,
 	schedule_effect,
-	set_current_effect,
-	set_current_reaction,
 	set_is_destroying_effect,
 	set_is_flushing_effect,
 	set_signal_status,

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -8,7 +8,12 @@ import {
 	object_prototype
 } from './utils.js';
 import { snapshot } from './proxy.js';
-import { destroy_effect, effect, user_pre_effect } from './reactivity/effects.js';
+import {
+	destroy_effect,
+	effect,
+	execute_effect_teardown,
+	user_pre_effect
+} from './reactivity/effects.js';
 import {
 	EFFECT,
 	RENDER_EFFECT,
@@ -412,7 +417,7 @@ export function execute_effect(effect) {
 			destroy_effect_children(effect);
 		}
 
-		effect.teardown?.call(null);
+		execute_effect_teardown(effect);
 		var teardown = execute_reaction_fn(effect);
 		effect.teardown = typeof teardown === 'function' ? teardown : null;
 	} finally {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -37,10 +37,16 @@ let current_scheduler_mode = FLUSH_MICROTASK;
 // Used for handling scheduling
 let is_micro_task_queued = false;
 export let is_flushing_effect = false;
+export let is_destroying_effect = false;
 
 /** @param {boolean} value */
 export function set_is_flushing_effect(value) {
 	is_flushing_effect = value;
+}
+
+/** @param {boolean} value */
+export function set_is_destroying_effect(value) {
+	is_destroying_effect = value;
 }
 
 // Used for $inspect

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -669,11 +669,11 @@ export function flush_sync(fn, flush_previous = true) {
 
 		var result = fn?.();
 
+		flush_tasks();
 		if (current_queued_root_effects.length > 0 || root_effects.length > 0) {
 			flush_sync();
 		}
 
-		flush_tasks();
 		flush_count = 0;
 
 		return result;

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-before-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-before-cleanup/_config.js
@@ -8,6 +8,6 @@ export default test({
 		const div = target.querySelector('div');
 
 		component.visible = false;
-		assert.equal(container.div, div);
+		assert.equal(container.div, null);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-before-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-before-cleanup/_config.js
@@ -8,6 +8,6 @@ export default test({
 		const div = target.querySelector('div');
 
 		component.visible = false;
-		assert.equal(container.div, null);
+		assert.equal(container.div, div);
 	}
 });


### PR DESCRIPTION
This removes a nasty memory leak to do with `bind:this`. The PR also adds a runtime invariant for trying to create effects inside the teardown phase of an effect – as people shouldn't be creating new effects in something that's meant to be getting garbage collected.