### PR TITLE
fix: ConstTag AST tweak

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -565,7 +565,7 @@ function special(parser) {
 				type: 'VariableDeclaration',
 				kind: 'const',
 				declarations: [{ type: 'VariableDeclarator', id, init }],
-				start: start + 1,
+				start: start + 2, // start at const, not at @const
 				end: parser.index - 1
 			}
 		});


### PR DESCRIPTION
VariableDeclaration should start at `const`, not at `@const`. As a side-effect, this will create less diff noise for language tools tests

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
