### PR TITLE
fix: take outroing elements out of the flow when animating siblings

### DIFF
--- a/.changeset/proud-pets-hang.md
+++ b/.changeset/proud-pets-hang.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: take outroing elements out of the flow when animating siblings

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -24,7 +24,7 @@ import {
 } from '../../reactivity/effects.js';
 import { source, mutable_source, set } from '../../reactivity/sources.js';
 import { is_array, is_frozen } from '../../utils.js';
-import { STATE_SYMBOL } from '../../constants.js';
+import { INERT, STATE_SYMBOL } from '../../constants.js';
 
 /**
  * The row of a keyed each block that is currently updating. We track this
@@ -70,7 +70,7 @@ function pause_effects(items, controlled_anchor, callback) {
 		parent_node.append(controlled_anchor);
 	}
 
-	run_out_transitions(transitions, () => {
+	run_out_transitions(transitions, true, () => {
 		for (var i = 0; i < length; i++) {
 			destroy_effect(items[i].e);
 		}
@@ -238,8 +238,8 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 	/** @type {import('#client').EachState | import('#client').EachItem} */
 	var prev = state;
 
-	/** @type {import('#client').EachItem[]} */
-	var to_animate = [];
+	/** @type {Set<import('#client').EachItem>} */
+	var to_animate = new Set();
 
 	/** @type {import('#client').EachItem[]} */
 	var matched = [];
@@ -267,7 +267,7 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 
 			if (item !== undefined) {
 				item.a?.measure();
-				to_animate.push(item);
+				to_animate.add(item);
 			}
 		}
 	}
@@ -302,7 +302,10 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 			update_item(item, value, i, flags);
 		}
 
-		resume_effect(item.e);
+		if ((item.e.f & INERT) !== 0) {
+			resume_effect(item.e);
+			to_animate.delete(item);
+		}
 
 		if (item !== current) {
 			if (seen.has(item)) {

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -302,7 +302,7 @@ export function pause_effect(effect, callback) {
 
 	pause_children(effect, transitions, true);
 
-	run_out_transitions(transitions, () => {
+	run_out_transitions(transitions, false, () => {
 		destroy_effect(effect);
 		if (callback) callback();
 	});
@@ -310,14 +310,15 @@ export function pause_effect(effect, callback) {
 
 /**
  * @param {import('#client').TransitionManager[]} transitions
+ * @param {boolean} position_absolute
  * @param {() => void} fn
  */
-export function run_out_transitions(transitions, fn) {
+export function run_out_transitions(transitions, position_absolute, fn) {
 	var remaining = transitions.length;
 	if (remaining > 0) {
 		var check = () => --remaining || fn();
 		for (var transition of transitions) {
-			transition.out(check);
+			transition.out(check, position_absolute);
 		}
 	} else {
 		fn();

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -77,7 +77,7 @@ export interface TransitionManager {
 	/** Called inside `resume_effect` */
 	in: () => void;
 	/** Called inside `pause_effect` */
-	out: (callback?: () => void) => void;
+	out: (callback?: () => void, position_absolute?: boolean) => void;
 	/** Called inside `destroy_effect` */
 	stop: () => void;
 }


### PR DESCRIPTION
No test because you can't really test for this stuff in JSDOM. Fixes #10867 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
