### PR TITLE
feat: add $lazy rune

### DIFF
--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -252,3 +252,21 @@ declare function $inspect<T extends any[]>(
  * https://svelte-5-preview.vercel.app/docs/runes#$host
  */
 declare function $host<El extends HTMLElement = HTMLElement>(): El;
+
+/**
+ * Creates a lazy object or array property binding, similar to that of a getter/setter. If passed
+ * a single argument, the lazy property binding with be read-only.
+ *
+ * ```svelte
+ * let count = $state(0);
+ * let double = $derived(count * 2);
+ *
+ * let object = {
+ *   count: $lazy(count, value => count = value),
+ *   double: $lazy(double),
+ * };
+ * ```
+ *
+ * https://svelte-5-preview.vercel.app/docs/runes#$lazy
+ */
+declare function $lazy<V>(value: V, setter: (value: V) => unknown): V;

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -189,6 +189,8 @@ const runes = {
 	'invalid-effect-location': () => `$effect() can only be used as an expression statement`,
 	'invalid-host-location': () =>
 		`$host() can only be used inside custom element component instances`,
+	'invalid-lazy-location': () =>
+		`$lazy() can only be used as the property value within an object or array literal expression`,
 	/**
 	 * @param {boolean} is_binding
 	 * @param {boolean} show_details

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -808,6 +808,14 @@ function validate_call_expression(node, scope, path) {
 		error(node, 'invalid-props-location');
 	}
 
+	if (rune === '$lazy') {
+		if (node.arguments.length === 0 || node.arguments.length > 2) {
+			error(node, 'invalid-rune-args-length', rune, [1, 2]);
+		}
+		if (parent.type === 'Property' || parent.type === 'ArrayExpression') return;
+		error(node, 'invalid-lazy-location');
+	}
+
 	if (rune === '$bindable') {
 		if (parent.type === 'AssignmentPattern' && path.at(-3)?.type === 'ObjectPattern') {
 			const declarator = path.at(-4);

--- a/packages/svelte/src/compiler/phases/constants.js
+++ b/packages/svelte/src/compiler/phases/constants.js
@@ -42,7 +42,8 @@ export const Runes = /** @type {const} */ ([
 	'$effect.root',
 	'$inspect',
 	'$inspect().with',
-	'$host'
+	'$host',
+	'$lazy'
 ]);
 
 /**

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -145,3 +145,4 @@ export {
 	validate_snippet,
 	validate_void_dynamic_element
 } from '../shared/validate.js';
+export { lazy_array } from './reactivity/lazy.js';

--- a/packages/svelte/src/internal/client/reactivity/lazy.js
+++ b/packages/svelte/src/internal/client/reactivity/lazy.js
@@ -1,0 +1,24 @@
+import { is_array } from '../utils';
+
+/**
+ * @param {Array<unknown[] | { get: () => unknown, set: (v: unknown) => unknown }>} parts
+ * @returns {unknown[]}
+ */
+export function lazy_array(...parts) {
+	const arr = [];
+
+	for (var i = 0; i < parts.length; i++) {
+		var part = parts[i];
+
+		if (is_array(part)) {
+			arr.push(...part);
+		} else {
+			Object.defineProperty(arr, arr.length, {
+				enumerable: true,
+				...part
+			});
+		}
+	}
+
+	return arr;
+}

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2777,4 +2777,6 @@ declare function $inspect<T extends any[]>(
  */
 declare function $host<El extends HTMLElement = HTMLElement>(): El;
 
+declare function $lazy<V>(value: V, setter: (value: V) => unknown): V;
+
 //# sourceMappingURL=index.d.ts.map

--- a/sites/svelte-5-preview/src/lib/CodeMirror.svelte
+++ b/sites/svelte-5-preview/src/lib/CodeMirror.svelte
@@ -205,33 +205,34 @@
 		return {
 			from: word.from - 1,
 			options: [
-				{ label: '$state', type: 'keyword', boost: 12 },
-				{ label: '$props', type: 'keyword', boost: 11 },
-				{ label: '$derived', type: 'keyword', boost: 10 },
+				{ label: '$state', type: 'keyword', boost: 13 },
+				{ label: '$props', type: 'keyword', boost: 12 },
+				{ label: '$derived', type: 'keyword', boost: 11 },
 				snip('$derived.by(() => {\n\t${}\n});', {
 					label: '$derived.by',
 					type: 'keyword',
-					boost: 9
+					boost: 10
 				}),
-				snip('$effect(() => {\n\t${}\n});', { label: '$effect', type: 'keyword', boost: 8 }),
+				snip('$effect(() => {\n\t${}\n});', { label: '$effect', type: 'keyword', boost: 9 }),
 				snip('$effect.pre(() => {\n\t${}\n});', {
 					label: '$effect.pre',
 					type: 'keyword',
-					boost: 7
+					boost: 8
 				}),
-				{ label: '$state.frozen', type: 'keyword', boost: 6 },
-				{ label: '$bindable', type: 'keyword', boost: 5 },
+				{ label: '$state.frozen', type: 'keyword', boost: 7 },
+				{ label: '$bindable', type: 'keyword', boost: 6 },
 				snip('$effect.root(() => {\n\t${}\n});', {
 					label: '$effect.root',
 					type: 'keyword',
-					boost: 4
+					boost: 5
 				}),
-				{ label: '$state.snapshot', type: 'keyword', boost: 3 },
+				{ label: '$state.snapshot', type: 'keyword', boost: 4 },
 				snip('$effect.active()', {
 					label: '$effect.active',
 					type: 'keyword',
-					boost: 2
+					boost: 3
 				}),
+				{ label: '$lazy', type: 'keyword', boost: 2 },
 				{ label: '$inspect', type: 'keyword', boost: 1 }
 			]
 		};


### PR DESCRIPTION
> This is an experimental rune and we might not go ahead with it

This PR introduces a new rune called `$lazy`. It's designed to be a shorthand replacement for writing out getters/setters on object expressions (although, this rune is also supported on arrays too, which is much harder to write with getters/setters). The rune has double meaning, as the property itself is a lazy property descriptor binding, and also people who don't want to write getters/setters by hand are probably a bit lazy.

The `$lazy` rune can only be used in object/array expressions. If there it is only passed a single argument than the object property is read-only. If you pass the second argument, it must be a function setter. As shown:

  ```svelte
  let count = $state(0);
  let double = $derived(count * 2);
 
  let object = {
    count: $lazy(count, value => count = value),
    double: $lazy(double),
  };
  ```

Or arrays:

  ```svelte
  let count = $state(0);
  let double = $derived(count * 2);
 
  let array = [
    $lazy(count, value => count = value),
    $lazy(double),
  ];
  ```