### PR TITLE
chore: follow-up to #11197

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -79,7 +79,7 @@ function html_to_dom(target, effect, value, svg) {
 		var child = /** @type {Text | Element | Comment} */ (node.firstChild);
 		target.before(child);
 		if (effect !== null) {
-			push_template_node(effect, child);
+			push_template_node(child, effect);
 		}
 		return child;
 	}
@@ -95,7 +95,7 @@ function html_to_dom(target, effect, value, svg) {
 	}
 
 	if (effect !== null) {
-		push_template_node(effect, nodes);
+		push_template_node(nodes, effect);
 	}
 
 	return nodes;

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -133,7 +133,7 @@ export function element(anchor, get_tag, is_svg, render_fn) {
 						swap_block_dom(parent_effect, prev_element, element);
 						prev_element.remove();
 					} else if (!hydrating) {
-						push_template_node(parent_effect, element);
+						push_template_node(element, parent_effect);
 					}
 				});
 			}

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -21,18 +21,11 @@ export function push_template_node(
 		if (!is_array(current_dom)) {
 			current_dom = effect.dom = [current_dom];
 		}
-		var anchor;
-		// If we're working with an anchor, then remove it and put it at the end.
-		if (current_dom[0].nodeType === 8) {
-			anchor = current_dom.pop();
-		}
+
 		if (is_array(dom)) {
 			current_dom.push(...dom);
 		} else {
 			current_dom.push(dom);
-		}
-		if (anchor !== undefined) {
-			current_dom.push(anchor);
 		}
 	}
 	return dom;

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -7,10 +7,13 @@ import { effect } from '../reactivity/effects.js';
 import { is_array } from '../utils.js';
 
 /**
- * @param {import("#client").Effect} effect
  * @param {import("#client").TemplateNode | import("#client").TemplateNode[]} dom
+ * @param {import("#client").Effect} effect
  */
-export function push_template_node(effect, dom) {
+export function push_template_node(
+	dom,
+	effect = /** @type {import('#client').Effect} */ (current_effect)
+) {
 	var current_dom = effect.dom;
 	if (current_dom === null) {
 		effect.dom = dom;
@@ -51,10 +54,7 @@ export function template(content, flags) {
 	return () => {
 		var effect = /** @type {import('#client').Effect} */ (current_effect);
 		if (hydrating) {
-			var hydration_content = push_template_node(
-				effect,
-				is_fragment ? hydrate_nodes : hydrate_nodes[0]
-			);
+			var hydration_content = push_template_node(is_fragment ? hydrate_nodes : hydrate_nodes[0]);
 			return /** @type {Node} */ (hydration_content);
 		}
 
@@ -64,14 +64,11 @@ export function template(content, flags) {
 		}
 		var clone = use_import_node ? document.importNode(node, true) : clone_node(node, true);
 
-		if (is_fragment) {
-			push_template_node(
-				effect,
-				/** @type {import('#client').TemplateNode[]} */ ([...clone.childNodes])
-			);
-		} else {
-			push_template_node(effect, /** @type {import('#client').TemplateNode} */ (clone));
-		}
+		push_template_node(
+			is_fragment
+				? /** @type {import('#client').TemplateNode[]} */ ([...clone.childNodes])
+				: /** @type {import('#client').TemplateNode} */ (clone)
+		);
 
 		return clone;
 	};
@@ -117,10 +114,7 @@ export function svg_template(content, flags) {
 	return () => {
 		var effect = /** @type {import('#client').Effect} */ (current_effect);
 		if (hydrating) {
-			var hydration_content = push_template_node(
-				effect,
-				is_fragment ? hydrate_nodes : hydrate_nodes[0]
-			);
+			var hydration_content = push_template_node(is_fragment ? hydrate_nodes : hydrate_nodes[0]);
 			return /** @type {Node} */ (hydration_content);
 		}
 
@@ -139,14 +133,11 @@ export function svg_template(content, flags) {
 
 		var clone = clone_node(node, true);
 
-		if (is_fragment) {
-			push_template_node(
-				effect,
-				/** @type {import('#client').TemplateNode[]} */ ([...clone.childNodes])
-			);
-		} else {
-			push_template_node(effect, /** @type {import('#client').TemplateNode} */ (clone));
-		}
+		push_template_node(
+			is_fragment
+				? /** @type {import('#client').TemplateNode[]} */ ([...clone.childNodes])
+				: /** @type {import('#client').TemplateNode} */ (clone)
+		);
 
 		return clone;
 	};
@@ -213,8 +204,7 @@ function run_scripts(node) {
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function text(anchor) {
-	var effect = /** @type {import('#client').Effect} */ (current_effect);
-	if (!hydrating) return push_template_node(effect, empty());
+	if (!hydrating) return push_template_node(empty());
 
 	var node = hydrate_nodes[0];
 
@@ -224,7 +214,7 @@ export function text(anchor) {
 		anchor.before((node = empty()));
 	}
 
-	return push_template_node(effect, node);
+	return push_template_node(node);
 }
 
 export const comment = template('<!>', TEMPLATE_FRAGMENT);

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -45,7 +45,6 @@ export function template(content, flags) {
 	var node;
 
 	return () => {
-		var effect = /** @type {import('#client').Effect} */ (current_effect);
 		if (hydrating) {
 			var hydration_content = push_template_node(is_fragment ? hydrate_nodes : hydrate_nodes[0]);
 			return /** @type {Node} */ (hydration_content);
@@ -105,7 +104,6 @@ export function svg_template(content, flags) {
 	var node;
 
 	return () => {
-		var effect = /** @type {import('#client').Effect} */ (current_effect);
 		if (hydrating) {
 			var hydration_content = push_template_node(is_fragment ? hydrate_nodes : hydrate_nodes[0]);
 			return /** @type {Node} */ (hydration_content);

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -67,6 +67,8 @@ export type EachItem = {
 	i: number | Source<number>;
 	/** key */
 	k: unknown;
+	/** anchor for items inserted before this */
+	o: Comment | Text;
 	prev: EachItem | EachState;
 	next: EachItem | null;
 };


### PR DESCRIPTION
couple of small follow-ups to #11197:

- in `push_template_node`, `effect` is almost always the `current_effect`. we can use a default value and make the callsites more concise
- the `if (current_dom[0].nodeType === 8)` stuff makes me very nervous. feels like the sort of thing that could break easily, e.g. if `preserveComments` was enabled. I've felt for a while that we should probably just have a field on `EachItem` containing the opening anchor. This PR adds one. It means that an additional empty text node is created per each item (except during hydration, when the existing comments can be used), but it feels a bit more robust to me and avoids all the `get_first_child` calls