### PR TITLE
docs: Fix iframe link in Write Less Code blog post

### DIFF
--- a/documentation/blog/2019-04-20-write-less-code.md
+++ b/documentation/blog/2019-04-20-write-less-code.md
@@ -40,7 +40,7 @@ Reducing the amount of code you have to write is an explicit goal of Svelte. To 
 <div class="max">
 	<iframe
 		title="Simple component example"
-		src="/repl/embed?example=blog-write-less-code"
+		src="/repl/blog-write-less-code/embed?version=4.2.15"
 		scrolling="no"
 	></iframe>
 </div>

--- a/documentation/blog/2019-04-20-write-less-code.md
+++ b/documentation/blog/2019-04-20-write-less-code.md
@@ -40,7 +40,7 @@ Reducing the amount of code you have to write is an explicit goal of Svelte. To 
 <div class="max">
 	<iframe
 		title="Simple component example"
-		src="/repl/blog-write-less-code/embed?version=4.2.15"
+		src="/repl/blog-write-less-code/embed?version=3"
 		scrolling="no"
 	></iframe>
 </div>


### PR DESCRIPTION
The [Write Less Code](https://svelte.dev/blog/write-less-code) blog post has an embedded REPL, but it looks like the URL now redirects to the hello world example.

![O1AR5v8TzF](https://github.com/sveltejs/svelte/assets/15237366/7546d969-1a60-433d-badf-3e8823badb14)

The correct example [still exists](https://svelte.dev/repl/blog-write-less-code/embed?version=4.2.15), the URL just needs to be updated.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
