### PR TITLE
chore: refactor `$inspect`

### DIFF
--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -1,6 +1,6 @@
 import { snapshot } from '../proxy.js';
-import { user_pre_effect } from '../reactivity/effects.js';
-import { deep_read } from '../runtime.js';
+import { render_effect } from '../reactivity/effects.js';
+import { current_effect, deep_read } from '../runtime.js';
 import { array_prototype, get_prototype_of, object_prototype } from '../utils.js';
 
 /** @type {Function | null} */
@@ -16,18 +16,27 @@ export let inspect_captured_signals = [];
 
 /**
  * @param {() => any[]} get_value
- * @param {Function} [inspect]
+ * @param {Function} [inspector]
  */
 // eslint-disable-next-line no-console
-export function inspect(get_value, inspect = console.log) {
+export function inspect(get_value, inspector = console.log) {
+	if (!current_effect) {
+		throw new Error(
+			'$inspect can only be used inside an effect (e.g. during component initialisation)'
+		);
+	}
+
 	let initial = true;
 
-	user_pre_effect(() => {
-		const fn = () => {
-			const value = deep_snapshot(get_value());
-			inspect(initial ? 'init' : 'update', ...value);
-		};
+	// we assign the function directly to signals, rather than just
+	// calling `inspector` directly inside the effect, so that
+	// we get useful stack traces
+	var fn = () => {
+		const value = deep_snapshot(get_value());
+		inspector(initial ? 'init' : 'update', ...value);
+	};
 
+	render_effect(() => {
 		inspect_fn = fn;
 		deep_read(get_value());
 		inspect_fn = null;

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -1,0 +1,89 @@
+import { snapshot } from '../proxy.js';
+import { user_pre_effect } from '../reactivity/effects.js';
+import { deep_read } from '../runtime.js';
+import { array_prototype, get_prototype_of, object_prototype } from '../utils.js';
+
+/** @type {Function | null} */
+export let inspect_fn = null;
+
+/** @param {Function | null} fn */
+export function set_inspect_fn(fn) {
+	inspect_fn = fn;
+}
+
+/** @type {Array<import('#client').ValueDebug>} */
+export let inspect_captured_signals = [];
+
+/**
+ * @param {() => any[]} get_value
+ * @param {Function} [inspect]
+ */
+// eslint-disable-next-line no-console
+export function inspect(get_value, inspect = console.log) {
+	let initial = true;
+
+	user_pre_effect(() => {
+		const fn = () => {
+			const value = deep_snapshot(get_value());
+			inspect(initial ? 'init' : 'update', ...value);
+		};
+
+		inspect_fn = fn;
+		deep_read(get_value());
+		inspect_fn = null;
+
+		const signals = inspect_captured_signals.slice();
+		inspect_captured_signals = [];
+
+		if (initial) {
+			fn();
+			initial = false;
+		}
+
+		return () => {
+			for (const s of signals) {
+				s.inspect.delete(fn);
+			}
+		};
+	});
+}
+
+/**
+ * Like `snapshot`, but recursively traverses into normal arrays/objects to find potential states in them.
+ * @param {any} value
+ * @param {Map<any, any>} visited
+ * @returns {any}
+ */
+function deep_snapshot(value, visited = new Map()) {
+	if (typeof value === 'object' && value !== null && !visited.has(value)) {
+		const unstated = snapshot(value);
+
+		if (unstated !== value) {
+			visited.set(value, unstated);
+			return unstated;
+		}
+
+		const prototype = get_prototype_of(value);
+
+		// Only deeply snapshot plain objects and arrays
+		if (prototype === object_prototype || prototype === array_prototype) {
+			let contains_unstated = false;
+			/** @type {any} */
+			const nested_unstated = Array.isArray(value) ? [] : {};
+
+			for (let key in value) {
+				const result = deep_snapshot(value[key], visited);
+				nested_unstated[key] = result;
+				if (result !== value[key]) {
+					contains_unstated = true;
+				}
+			}
+
+			visited.set(value, contains_unstated ? nested_unstated : value);
+		} else {
+			visited.set(value, value);
+		}
+	}
+
+	return visited.get(value) ?? value;
+}

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -1,5 +1,6 @@
 export { hmr } from './dev/hmr.js';
 export { ADD_OWNER, add_owner, mark_module_start, mark_module_end } from './dev/ownership.js';
+export { inspect } from './dev/inspect.js';
 export { await_block as await } from './dom/blocks/await.js';
 export { if_block as if } from './dom/blocks/if.js';
 export { key_block as key } from './dom/blocks/key.js';
@@ -111,7 +112,6 @@ export {
 	exclude_from_object,
 	pop,
 	push,
-	inspect,
 	unwrap,
 	freeze,
 	deep_read,

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -8,8 +8,9 @@ import {
 import { get_descriptor, is_function } from '../utils.js';
 import { mutable_source, set } from './sources.js';
 import { derived } from './deriveds.js';
-import { get, inspect_fn, is_signals_recorded, untrack } from '../runtime.js';
+import { get, is_signals_recorded, untrack } from '../runtime.js';
 import { safe_equals } from './equality.js';
+import { inspect_fn } from '../dev/inspect.js';
 
 /**
  * @param {((value?: number) => number)} fn

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1,19 +1,7 @@
 import { DEV } from 'esm-env';
-import {
-	array_prototype,
-	get_descriptors,
-	get_prototype_of,
-	is_frozen,
-	object_freeze,
-	object_prototype
-} from './utils.js';
+import { get_descriptors, get_prototype_of, is_frozen, object_freeze } from './utils.js';
 import { snapshot } from './proxy.js';
-import {
-	destroy_effect,
-	effect,
-	execute_effect_teardown,
-	user_pre_effect
-} from './reactivity/effects.js';
+import { destroy_effect, effect, execute_effect_teardown } from './reactivity/effects.js';
 import {
 	EFFECT,
 	RENDER_EFFECT,

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -33,6 +33,7 @@ import { flush_tasks } from './dom/task.js';
 import { add_owner } from './dev/ownership.js';
 import { mutate, set, source } from './reactivity/sources.js';
 import { update_derived } from './reactivity/deriveds.js';
+import { inspect_captured_signals, inspect_fn, set_inspect_fn } from './dev/inspect.js';
 
 const FLUSH_MICROTASK = 0;
 const FLUSH_SYNC = 1;
@@ -114,12 +115,6 @@ export let current_skip_reaction = false;
 // Handle collecting all signals which are read during a specific time frame
 export let is_signals_recorded = false;
 let captured_signals = new Set();
-
-/** @type {Function | null} */
-export let inspect_fn = null;
-
-/** @type {Array<import('./types.js').ValueDebug>} */
-let inspect_captured_signals = [];
 
 // Handling runtime component context
 /** @type {import('./types.js').ComponentContext | null} */
@@ -700,11 +695,10 @@ export async function tick() {
  * @returns {V}
  */
 export function get(signal) {
-	// @ts-expect-error
-	if (DEV && signal.inspect && inspect_fn) {
-		/** @type {import('./types.js').ValueDebug} */ (signal).inspect.add(inspect_fn);
-		// @ts-expect-error
-		inspect_captured_signals.push(signal);
+	if (DEV && inspect_fn) {
+		var s = /** @type {import('#client').ValueDebug} */ (signal);
+		s.inspect.add(inspect_fn);
+		inspect_captured_signals.push(s);
 	}
 
 	const flags = signal.f;
@@ -761,9 +755,9 @@ export function get(signal) {
 		if (DEV) {
 			// we want to avoid tracking indirect dependencies
 			const previous_inspect_fn = inspect_fn;
-			inspect_fn = null;
+			set_inspect_fn(null);
 			update_derived(/** @type {import('./types.js').Derived} **/ (signal), false);
-			inspect_fn = previous_inspect_fn;
+			set_inspect_fn(previous_inspect_fn);
 		} else {
 			update_derived(/** @type {import('./types.js').Derived} **/ (signal), false);
 		}
@@ -1184,86 +1178,6 @@ export function deep_read(value, visited = new Set()) {
 			}
 		}
 	}
-}
-
-/**
- * Like `snapshot`, but recursively traverses into normal arrays/objects to find potential states in them.
- * @param {any} value
- * @param {Map<any, any>} visited
- * @returns {any}
- */
-function deep_snapshot(value, visited = new Map()) {
-	if (typeof value === 'object' && value !== null && !visited.has(value)) {
-		const unstated = snapshot(value);
-		if (unstated !== value) {
-			visited.set(value, unstated);
-			return unstated;
-		}
-		const prototype = get_prototype_of(value);
-		// Only deeply snapshot plain objects and arrays
-		if (prototype === object_prototype || prototype === array_prototype) {
-			let contains_unstated = false;
-			/** @type {any} */
-			const nested_unstated = Array.isArray(value) ? [] : {};
-			for (let key in value) {
-				const result = deep_snapshot(value[key], visited);
-				nested_unstated[key] = result;
-				if (result !== value[key]) {
-					contains_unstated = true;
-				}
-			}
-			visited.set(value, contains_unstated ? nested_unstated : value);
-		} else {
-			visited.set(value, value);
-		}
-	}
-
-	return visited.get(value) ?? value;
-}
-
-// TODO remove in a few versions, before 5.0 at the latest
-let warned_inspect_changed = false;
-
-/**
- * @param {() => any[]} get_value
- * @param {Function} [inspect]
- */
-// eslint-disable-next-line no-console
-export function inspect(get_value, inspect = console.log) {
-	let initial = true;
-
-	user_pre_effect(() => {
-		const fn = () => {
-			const value = untrack(() => get_value().map((v) => deep_snapshot(v)));
-			if (value.length === 2 && typeof value[1] === 'function' && !warned_inspect_changed) {
-				// eslint-disable-next-line no-console
-				console.warn(
-					'$inspect() API has changed. See https://svelte-5-preview.vercel.app/docs/runes#$inspect for more information.'
-				);
-				warned_inspect_changed = true;
-			}
-			inspect(initial ? 'init' : 'update', ...value);
-		};
-
-		inspect_fn = fn;
-		const value = get_value();
-		deep_read(value);
-		inspect_fn = null;
-
-		const signals = inspect_captured_signals.slice();
-		inspect_captured_signals = [];
-
-		if (initial) {
-			fn();
-			initial = false;
-		}
-
-		return () => {
-			for (const s of signals) {
-				s.inspect.delete(fn);
-			}
-		};
-	});
 }
 
 /**


### PR DESCRIPTION
This is a precursor to a more useful `$inspect` rune (or more accurately, a more useful `$state.snapshot` rune). It's mostly just moving some code around (making `runtime.js` less hilariously overstuffed), but also provides a better error when `$inspect` is used in the wrong place. (Side-note: the error we print when using `$effect` or `$effect.pre` outside an effect is wrong — it says you can only use them during component initialisation which is obviously untrue. Will open a PR to fix.)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
