### PR TITLE
fix: run event attributes after binding event listeners

### DIFF
--- a/.changeset/seven-garlics-serve.md
+++ b/.changeset/seven-garlics-serve.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: make sure event attributes run after bindings

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -274,7 +274,8 @@ function serialize_element_spread_attributes(
 
 			if (
 				is_event_attribute(attribute) &&
-				attribute.value[0].expression.type === 'ArrowFunctionExpression'
+				(attribute.value[0].expression.type === 'ArrowFunctionExpression' ||
+					attribute.value[0].expression.type === 'FunctionExpression')
 			) {
 				// Give the event handler a stable ID so it isn't removed and readded on every update
 				const id = context.state.scope.generate('event_handler');
@@ -370,7 +371,8 @@ function serialize_dynamic_element_attributes(attributes, context, element_id) {
 
 			if (
 				is_event_attribute(attribute) &&
-				attribute.value[0].expression.type === 'ArrowFunctionExpression'
+				(attribute.value[0].expression.type === 'ArrowFunctionExpression' ||
+					attribute.value[0].expression.type === 'FunctionExpression')
 			) {
 				// Give the event handler a stable ID so it isn't removed and readded on every update
 				const id = context.state.scope.generate('event_handler');

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -263,7 +263,7 @@ function serialize_element_spread_attributes(
 ) {
 	let needs_isolation = false;
 
-	/** @type {import('estree').Expression[]} */
+	/** @type {import('estree').ObjectExpression['properties']} */
 	const values = [];
 
 	for (const attribute of attributes) {
@@ -271,9 +271,20 @@ function serialize_element_spread_attributes(
 			const name = get_attribute_name(element, attribute, context);
 			// TODO: handle contains_call_expression
 			const [, value] = serialize_attribute_value(attribute.value, context);
-			values.push(b.object([b.init(name, value)]));
+
+			if (
+				is_event_attribute(attribute) &&
+				attribute.value[0].expression.type === 'ArrowFunctionExpression'
+			) {
+				// Give the event handler a stable ID so it isn't removed and readded on every update
+				const id = context.state.scope.generate('event_handler');
+				context.state.init.push(b.var(id, value));
+				values.push(b.init(attribute.name, b.id(id)));
+			} else {
+				values.push(b.init(name, value));
+			}
 		} else {
-			values.push(/** @type {import('estree').Expression} */ (context.visit(attribute)));
+			values.push(b.spread(/** @type {import('estree').Expression} */ (context.visit(attribute))));
 		}
 
 		needs_isolation ||=
@@ -292,7 +303,7 @@ function serialize_element_spread_attributes(
 				'$.set_attributes',
 				element_id,
 				b.id(id),
-				b.array(values),
+				b.object(values),
 				lowercase_attributes,
 				b.literal(context.state.analysis.css.hash)
 			)
@@ -350,15 +361,26 @@ function serialize_dynamic_element_attributes(attributes, context, element_id) {
 	let needs_isolation = false;
 	let is_reactive = false;
 
-	/** @type {import('estree').Expression[]} */
+	/** @type {import('estree').ObjectExpression['properties']} */
 	const values = [];
 
 	for (const attribute of attributes) {
 		if (attribute.type === 'Attribute') {
 			const [, value] = serialize_attribute_value(attribute.value, context);
-			values.push(b.object([b.init(attribute.name, value)]));
+
+			if (
+				is_event_attribute(attribute) &&
+				attribute.value[0].expression.type === 'ArrowFunctionExpression'
+			) {
+				// Give the event handler a stable ID so it isn't removed and readded on every update
+				const id = context.state.scope.generate('event_handler');
+				context.state.init.push(b.var(id, value));
+				values.push(b.init(attribute.name, b.id(id)));
+			} else {
+				values.push(b.init(attribute.name, value));
+			}
 		} else {
-			values.push(/** @type {import('estree').Expression} */ (context.visit(attribute)));
+			values.push(b.spread(/** @type {import('estree').Expression} */ (context.visit(attribute))));
 		}
 
 		is_reactive ||=
@@ -381,7 +403,7 @@ function serialize_dynamic_element_attributes(attributes, context, element_id) {
 					'$.set_dynamic_element_attributes',
 					element_id,
 					b.id(id),
-					b.array(values),
+					b.object(values),
 					b.literal(context.state.analysis.css.hash)
 				)
 			)
@@ -402,7 +424,7 @@ function serialize_dynamic_element_attributes(attributes, context, element_id) {
 				'$.set_dynamic_element_attributes',
 				element_id,
 				b.literal(null),
-				b.array(values),
+				b.object(values),
 				b.literal(context.state.analysis.css.hash)
 			)
 		)

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -83,14 +83,13 @@ export function set_custom_element_data(node, prop, value) {
 /**
  * Spreads attributes onto a DOM element, taking into account the currently set attributes
  * @param {Element & ElementCSSInlineStyle} element
- * @param {Record<string, unknown> | undefined} prev
- * @param {Record<string, unknown>[]} attrs
+ * @param {Record<string, any> | undefined} prev
+ * @param {Record<string, any>} next New attributes - this function mutates this object
  * @param {boolean} lowercase_attributes
  * @param {string} css_hash
- * @returns {Record<string, unknown>}
+ * @returns {Record<string, any>}
  */
-export function set_attributes(element, prev, attrs, lowercase_attributes, css_hash) {
-	var next = object_assign({}, ...attrs);
+export function set_attributes(element, prev, next, lowercase_attributes, css_hash) {
 	var has_hash = css_hash.length !== 0;
 
 	for (var key in prev) {
@@ -196,14 +195,12 @@ export function set_attributes(element, prev, attrs, lowercase_attributes, css_h
 
 /**
  * @param {Element} node
- * @param {Record<string, unknown> | undefined} prev
- * @param {Record<string, unknown>[]} attrs
+ * @param {Record<string, any> | undefined} prev
+ * @param {Record<string, any>} next The new attributes - this function mutates this object
  * @param {string} css_hash
  */
-export function set_dynamic_element_attributes(node, prev, attrs, css_hash) {
+export function set_dynamic_element_attributes(node, prev, next, css_hash) {
 	if (node.tagName.includes('-')) {
-		var next = object_assign({}, ...attrs);
-
 		for (var key in prev) {
 			if (!(key in next)) {
 				next[key] = null;
@@ -220,7 +217,7 @@ export function set_dynamic_element_attributes(node, prev, attrs, css_hash) {
 	return set_attributes(
 		/** @type {Element & ElementCSSInlineStyle} */ (node),
 		prev,
-		attrs,
+		next,
 		node.namespaceURI !== namespace_svg,
 		css_hash
 	);

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-after-binding/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-after-binding/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const [i1, i2] = target.querySelectorAll('input');
+
+		i1?.click();
+		await Promise.resolve();
+		assert.htmlEqual(
+			target.innerHTML,
+			'true true <input type="checkbox"> false false <input type="checkbox">'
+		);
+
+		i2?.click();
+		await Promise.resolve();
+		assert.htmlEqual(
+			target.innerHTML,
+			'true true <input type="checkbox"> true true <input type="checkbox">'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-after-binding/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-after-binding/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	let checked_simple = $state(false);
+	let checked_simple_copy = $state(false);
+	
+	let checked_rest = $state(false);
+	let checked_rest_copy = $state(false);
+	let rest = $state(() => ({}));
+</script>
+
+{checked_simple} {checked_simple_copy}
+<input type="checkbox" onchange={() => {checked_simple_copy = checked_simple}} bind:checked={checked_simple} />
+
+{checked_rest} {checked_rest_copy}
+<!-- {...rest()} in order to force an isolated render effect -->
+<input type="checkbox" onchange={() => {checked_rest_copy = checked_rest}} {...rest()} bind:checked={checked_rest} />


### PR DESCRIPTION
By running the event listener logic inside an effect on the first run we guarantee that they're attached after binding listeners.
Fixes #11138
Fixes #11160
In contrast to #11229 this is a hilariously simple change, though it does not ensure that event attributes run after event listeners added inside action attributes. If we wanted that, we would need to return the list of events from the function, and then run them in an effect we can place at the very end of the current block. Should we that or not?

While working on this I noticed two things:
- generated spreading code can be optimized, instead of `[{ foo: .. }, rest, { bar: .. }]` we should be able to do `{ foo: .., ...rest, bar: .. }`
- when you use lambda functions for event handlers, they'll be removed and added again as listeners on every rerun, completely unnecessary. We should detect this case and put the lambdas into variables so their identity is stable between reruns, avoiding this

~Both can happen in a followup PR or as part of this one, depending on what the response here is by tomorrow.~ Added both these improvements.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
