### PR TITLE
feat: better `$state.snapshot`

### DIFF
--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -16,3 +16,4 @@ export const EFFECT_RAN = 1 << 13;
 export const EFFECT_TRANSPARENT = 1 << 14;
 
 export const STATE_SYMBOL = Symbol('$state');
+export const STATE_SNAPSHOT_SYMBOL = Symbol('$state.snapshot');

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -37,6 +37,9 @@ export function inspect(get_value, inspector = console.log) {
 
 	render_effect(() => {
 		inspect_fn = fn;
+		// TODO ideally we'd use `snapshot` here instead of `deep_read`, and pass
+		// the result to `fn` on the initial run, but it doesn't work because
+		// of some weird (and possibly buggy?) behaviour around `batch_inspect`
 		deep_read(get_value());
 		inspect_fn = null;
 

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -31,7 +31,7 @@ export function inspect(get_value, inspector = console.log) {
 	// calling `inspector` directly inside the effect, so that
 	// we get useful stack traces
 	var fn = () => {
-		const value = snapshot(get_value());
+		const value = snapshot(get_value(), true);
 		inspector(initial ? 'init' : 'update', ...value);
 	};
 

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -1,7 +1,6 @@
-import { snapshot } from '../proxy.js';
+import { snapshot } from '../reactivity/snapshot.js';
 import { render_effect } from '../reactivity/effects.js';
 import { current_effect, deep_read } from '../runtime.js';
-import { array_prototype, get_prototype_of, object_prototype } from '../utils.js';
 
 /** @type {Function | null} */
 export let inspect_fn = null;
@@ -32,7 +31,7 @@ export function inspect(get_value, inspector = console.log) {
 	// calling `inspector` directly inside the effect, so that
 	// we get useful stack traces
 	var fn = () => {
-		const value = deep_snapshot(get_value());
+		const value = snapshot(get_value());
 		inspector(initial ? 'init' : 'update', ...value);
 	};
 
@@ -55,44 +54,4 @@ export function inspect(get_value, inspector = console.log) {
 			}
 		};
 	});
-}
-
-/**
- * Like `snapshot`, but recursively traverses into normal arrays/objects to find potential states in them.
- * @param {any} value
- * @param {Map<any, any>} visited
- * @returns {any}
- */
-function deep_snapshot(value, visited = new Map()) {
-	if (typeof value === 'object' && value !== null && !visited.has(value)) {
-		const unstated = snapshot(value);
-
-		if (unstated !== value) {
-			visited.set(value, unstated);
-			return unstated;
-		}
-
-		const prototype = get_prototype_of(value);
-
-		// Only deeply snapshot plain objects and arrays
-		if (prototype === object_prototype || prototype === array_prototype) {
-			let contains_unstated = false;
-			/** @type {any} */
-			const nested_unstated = Array.isArray(value) ? [] : {};
-
-			for (let key in value) {
-				const result = deep_snapshot(value[key], visited);
-				nested_unstated[key] = result;
-				if (result !== value[key]) {
-					contains_unstated = true;
-				}
-			}
-
-			visited.set(value, contains_unstated ? nested_unstated : value);
-		} else {
-			visited.set(value, value);
-		}
-	}
-
-	return visited.get(value) ?? value;
 }

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -88,6 +88,7 @@ export {
 	update_pre_prop,
 	update_prop
 } from './reactivity/props.js';
+export { snapshot } from './reactivity/snapshot.js';
 export {
 	invalidate_store,
 	mutate_store,
@@ -128,7 +129,7 @@ export {
 	validate_store
 } from './validate.js';
 export { raf } from './timing.js';
-export { proxy, snapshot } from './proxy.js';
+export { proxy } from './proxy.js';
 export { create_custom_element } from './dom/elements/custom-element.js';
 export {
 	child,

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -10,7 +10,6 @@ import {
 	array_prototype,
 	define_property,
 	get_descriptor,
-	get_descriptors,
 	get_prototype_of,
 	is_array,
 	is_frozen,
@@ -85,63 +84,6 @@ export function proxy(value, immutable = true, parent = null) {
 	}
 
 	return value;
-}
-
-/**
- * @template {import('#client').ProxyStateObject} T
- * @param {T} value
- * @param {Map<T, Record<string | symbol, any>>} already_unwrapped
- * @returns {Record<string | symbol, any>}
- */
-function unwrap(value, already_unwrapped) {
-	if (typeof value === 'object' && value != null && STATE_SYMBOL in value) {
-		const unwrapped = already_unwrapped.get(value);
-		if (unwrapped !== undefined) {
-			return unwrapped;
-		}
-
-		if (is_array(value)) {
-			/** @type {Record<string | symbol, any>} */
-			const array = [];
-			already_unwrapped.set(value, array);
-			for (const element of value) {
-				array.push(unwrap(element, already_unwrapped));
-			}
-			return array;
-		} else {
-			/** @type {Record<string | symbol, any>} */
-			const obj = {};
-			const keys = Reflect.ownKeys(value);
-			const descriptors = get_descriptors(value);
-			already_unwrapped.set(value, obj);
-
-			for (const key of keys) {
-				if (key === STATE_SYMBOL) continue;
-				if (descriptors[key].get) {
-					define_property(obj, key, descriptors[key]);
-				} else {
-					/** @type {T} */
-					const property = value[key];
-					obj[key] = unwrap(property, already_unwrapped);
-				}
-			}
-
-			return obj;
-		}
-	}
-
-	return value;
-}
-
-/**
- * @template T
- * @param {T} value
- * @returns {T}
- */
-export function snapshot(value) {
-	return /** @type {T} */ (
-		unwrap(/** @type {import('#client').ProxyStateObject} */ (value), new Map())
-	);
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/snapshot.js
+++ b/packages/svelte/src/internal/client/reactivity/snapshot.js
@@ -1,4 +1,4 @@
-import { STATE_SYMBOL } from '../constants.js';
+import { STATE_SNAPSHOT_SYMBOL, STATE_SYMBOL } from '../constants.js';
 import { array_prototype, get_prototype_of, is_array, object_prototype } from '../utils.js';
 
 /**
@@ -13,17 +13,22 @@ export function snapshot(value, deep = false, values = new Map()) {
 		return value;
 	}
 
+	var unwrapped = /** @type {T} */ (values.get(value));
+	if (unwrapped !== undefined) {
+		return unwrapped;
+	}
+
+	if (STATE_SNAPSHOT_SYMBOL in value) {
+		// @ts-expect-error
+		return value[STATE_SNAPSHOT_SYMBOL](deep);
+	}
+
 	var proto = get_prototype_of(value);
 
 	if (
 		(proto === object_prototype || proto === array_prototype) &&
 		(deep || STATE_SYMBOL in value)
 	) {
-		var unwrapped = /** @type {T} */ (values.get(value));
-		if (unwrapped !== undefined) {
-			return unwrapped;
-		}
-
 		if (is_array(value)) {
 			var length = value.length;
 			var array = Array(length);

--- a/packages/svelte/src/internal/client/reactivity/snapshot.js
+++ b/packages/svelte/src/internal/client/reactivity/snapshot.js
@@ -1,0 +1,46 @@
+import { STATE_SYMBOL } from '../constants.js';
+import { is_array } from '../utils.js';
+
+/**
+ * @template {any} T
+ * @param {T} value
+ * @param {Map<any, any>} values
+ * @returns {T}
+ */
+export function snapshot(value, values = new Map()) {
+	if (typeof value !== 'object' || value === null) {
+		return value;
+	}
+
+	if (STATE_SYMBOL in value) {
+		var unwrapped = /** @type {T} */ (values.get(value));
+		if (unwrapped !== undefined) {
+			return unwrapped;
+		}
+
+		if (is_array(value)) {
+			var length = value.length;
+			var array = Array(length);
+
+			values.set(value, array);
+
+			for (var i = 0; i < length; i += 1) {
+				array[i] = snapshot(value[i], values);
+			}
+
+			return /** @type {T} */ (array);
+		}
+
+		/** @type {Record<string | symbol, any>} */
+		var obj = {};
+		values.set(value, obj);
+
+		for (var [k, v] of Object.entries(value)) {
+			obj[k] = snapshot(v, values);
+		}
+
+		return /** @type {T} */ (obj);
+	}
+
+	return value;
+}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -125,9 +125,8 @@ export function is_runes() {
  */
 export function batch_inspect(target, prop, receiver) {
 	const value = Reflect.get(target, prop, receiver);
-	/**
-	 * @this {any}
-	 */
+
+	/** @this {any} */
 	return function () {
 		const previously_batching_effect = is_batching_effect;
 		is_batching_effect = true;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -15,7 +15,8 @@ import {
 	BRANCH_EFFECT,
 	STATE_SYMBOL,
 	BLOCK_EFFECT,
-	ROOT_EFFECT
+	ROOT_EFFECT,
+	STATE_SNAPSHOT_SYMBOL
 } from './constants.js';
 import { flush_tasks } from './dom/task.js';
 import { add_owner } from './dev/ownership.js';
@@ -1137,6 +1138,12 @@ export function deep_read(value, visited = new Set()) {
 		!visited.has(value)
 	) {
 		visited.add(value);
+
+		if (STATE_SNAPSHOT_SYMBOL in value) {
+			value[STATE_SNAPSHOT_SYMBOL](true);
+			return;
+		}
+
 		for (let key in value) {
 			try {
 				deep_read(value[key], visited);
@@ -1144,6 +1151,7 @@ export function deep_read(value, visited = new Set()) {
 				// continue
 			}
 		}
+
 		const proto = get_prototype_of(value);
 		if (
 			proto !== Object.prototype &&

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1,6 +1,6 @@
 import { DEV } from 'esm-env';
 import { get_descriptors, get_prototype_of, is_frozen, object_freeze } from './utils.js';
-import { snapshot } from './proxy.js';
+import { snapshot } from './reactivity/snapshot.js';
 import { destroy_effect, effect, execute_effect_teardown } from './reactivity/effects.js';
 import {
 	EFFECT,

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -1,3 +1,4 @@
+import { STATE_SNAPSHOT_SYMBOL } from '../internal/client/constants.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 
@@ -98,5 +99,9 @@ export class ReactiveDate extends Date {
 		// @ts-ignore
 		super(...values);
 		this.#init();
+	}
+
+	[STATE_SNAPSHOT_SYMBOL]() {
+		return new Date(get(this.#raw_time));
 	}
 }

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -3,6 +3,8 @@ import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { UNINITIALIZED } from '../constants.js';
 import { map } from './utils.js';
+import { STATE_SNAPSHOT_SYMBOL } from '../internal/client/constants.js';
+import { snapshot } from '../internal/client/reactivity/snapshot.js';
 
 /**
  * @template K
@@ -154,5 +156,16 @@ export class ReactiveMap extends Map {
 
 	get size() {
 		return get(this.#size);
+	}
+
+	/** @param {boolean} deep */
+	[STATE_SNAPSHOT_SYMBOL](deep) {
+		return new Map(
+			map(
+				this.#sources.entries(),
+				([key, source]) => /** @type {[K, V]} */ ([key, snapshot(get(source), deep)]),
+				'Map Iterator'
+			)
+		);
 	}
 }

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -2,6 +2,8 @@ import { DEV } from 'esm-env';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { map } from './utils.js';
+import { STATE_SNAPSHOT_SYMBOL } from '../internal/client/constants.js';
+import { snapshot } from '../internal/client/reactivity/snapshot.js';
 
 var read_methods = ['forEach', 'isDisjointFrom', 'isSubsetOf', 'isSupersetOf'];
 var set_like_methods = ['difference', 'intersection', 'symmetricDifference', 'union'];
@@ -148,5 +150,10 @@ export class ReactiveSet extends Set {
 
 	get size() {
 		return get(this.#size);
+	}
+
+	/** @param {boolean} deep */
+	[STATE_SNAPSHOT_SYMBOL](deep) {
+		return new Set(map(this.keys(), (key) => snapshot(key, deep), 'Set Iterator'));
 	}
 }

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -1,3 +1,4 @@
+import { STATE_SNAPSHOT_SYMBOL } from '../internal/client/constants.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 
@@ -149,6 +150,10 @@ export class ReactiveURL extends URL {
 
 	toJSON() {
 		return this.href;
+	}
+
+	[STATE_SNAPSHOT_SYMBOL]() {
+		return new URL(this.href);
 	}
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/inspect-derived-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-derived-2/_config.js
@@ -25,13 +25,6 @@ export default test({
 		console.log = original_log;
 	},
 	async test({ assert, target }) {
-		const button = target.querySelector('button');
-
-		flushSync(() => {
-			button?.click();
-		});
-
-		assert.htmlEqual(target.innerHTML, `<button>update</button>\n1`);
 		assert.deepEqual(log, [
 			'init',
 			{
@@ -40,7 +33,19 @@ export default test({
 					list: []
 				},
 				derived: []
-			},
+			}
+		]);
+
+		log.length = 0;
+
+		const button = target.querySelector('button');
+
+		flushSync(() => {
+			button?.click();
+		});
+
+		assert.htmlEqual(target.innerHTML, `<button>update</button>\n1`);
+		assert.deepEqual(log, [
 			'update',
 			{
 				data: {

--- a/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/_config.js
@@ -1,40 +1,34 @@
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
+/** @type {any[]} */
 let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
+
+let original_log = console.log;
 
 export default test({
 	compileOptions: {
 		dev: true
 	},
+
 	before_test() {
 		log = [];
-		original_log = console.log;
 		console.log = (...v) => {
 			log.push(...v);
 		};
 	},
+
 	after_test() {
 		console.log = original_log;
 	},
+
 	async test({ assert, target }) {
+		assert.deepEqual(log, ['init', { x: { count: 0 } }, [{ count: 0 }]]);
+		log.length = 0;
+
 		const [b1] = target.querySelectorAll('button');
 		b1.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, [
-			'init',
-			{ x: { count: 0 } },
-			[{ count: 0 }],
-			'update',
-			{ x: { count: 1 } },
-			[{ count: 1 }]
-		]);
+		assert.deepEqual(log, ['update', { x: { count: 1 } }, [{ count: 1 }]]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/main.svelte
@@ -1,5 +1,5 @@
 <script>
-	let x = $state({count: 0});
+	let x = $state({ count: 0 });
 
 	$inspect({x}, [x]);
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/inspect-new-property/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-new-property/_config.js
@@ -1,33 +1,34 @@
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
+/** @type {any[]} */
 let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
+
+let original_log = console.log;
 
 export default test({
 	compileOptions: {
 		dev: true
 	},
+
 	before_test() {
 		log = [];
-		original_log = console.log;
 		console.log = (...v) => {
 			log.push(...v);
 		};
 	},
+
 	after_test() {
 		console.log = original_log;
 	},
+
 	async test({ assert, target }) {
+		assert.deepEqual(log, ['init', {}, 'init', []]);
+		log.length = 0;
+
 		const [btn] = target.querySelectorAll('button');
 		btn.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, ['init', {}, 'init', [], 'update', { x: 'hello' }, 'update', ['hello']]);
+		assert.deepEqual(log, ['update', { x: 'hello' }, 'update', ['hello']]);
 	}
 });


### PR DESCRIPTION
This updates `$inspect` to use `snapshot` directly rather than `deep_snapshot` (which is no longer required), and makes reactive `Map`, `Set`, `Date` and `URL` snapshottable, which means that instead of seeing this sort of thing in your console...

```
init Map {  }
```

...you see an actual `Map` instance:

```
init Map { foo => 'bar' }
```

If the `Map` or `Set` contains state proxies, these too will be snapshotted.

One downside of the current implementation: the `snapshot` code is automatically bundled when you import `Map` or `Set` (this doesn't apply to `Date` and `URL`, since nothing inside them could need snapshotting). I'd like to make the `snapshot` code treeshakeable if you use `Map` or `Set` but _not_ `$state.snapshot`, which is one reason this is in draft.

Another reason: it would be nice if we could do this for classes with state fields too. Today, if you inspect a class like `Counter`...

```svelte
<script>
  class Counter {
    count = $state(0);
    double = $derived(this.count * 2);
  }

  let counter = new Counter;

  $inspect(counter);
</script>
```

...you see this sort of thing:

<img width="369" alt="image" src="https://github.com/sveltejs/svelte/assets/1162160/8d01b77e-bbc3-4ac7-a3c1-25ebaf7a4ab0">

Note that we're leaking the signal implementation behind those private fields. It would be nice if it looked like this instead:

<img width="300" alt="image" src="https://github.com/sveltejs/svelte/assets/1162160/b4348bcf-da98-4992-8cb0-1b2774de3502">

We can do that, but we want to avoid making the generated code too bloaty. The best way is probably be to extend an internal class, i.e. `class Counter {...}` becomes something like `class Counter extends $.Class {...}`, but that doesn't work if the user already extended a class. So there's three options:

1. don't extend, just add everything to the prototype. minimum fuss, maximum bloat
2. extend classes that aren't _already_ extended, add to the prototype in other cases. quite fussy, but not too bloaty
3. new rule: you can't use `extends` when declaring classes with state fields. I don't hate this, but I suspect a lot of people would

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
