### PR TITLE
fix: possible name clash in hoisted functions

### DIFF
--- a/.changeset/stupid-parents-crash.md
+++ b/.changeset/stupid-parents-crash.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: possible name clash in hoisted functions

--- a/packages/svelte/tests/runtime-runes/samples/name-clash-hoisting/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/name-clash-hoisting/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+	recover: true,
+	mode: ['client']
+});

--- a/packages/svelte/tests/runtime-runes/samples/name-clash-hoisting/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/name-clash-hoisting/main.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { writable } from 'svelte/store';
+	const store = writable(0);
+	
+	async function logStore() {
+		console.log($store)
+		store.set(100);
+	}
+</script>
+
+<button onclick={logStore}>Click me</button>


### PR DESCRIPTION
## Svelte 5 rewrite

This come up on Discord [here](https://discord.com/channels/457912077277855764/1153350350158450758/1230633118474702888). Basically if you are accessing a store with the auto-subscription AND normal store object in a hoisted function it will generate the parameters with double the occurences of `store` leading to a Syntax error.

<details>
<summary><strong>See the problematic code</strong></summary>

```svelte
<script lang="ts">
	import { writable } from 'svelte/store';
	const store = writable(0);
	
	async function logStore() {
		console.log($store)
		store.set(100);
	}
</script>

<button onclick={logStore}>Click me</button>
```

</details>

This fixes this by safe pushing an identifier in the parameter array only if it's not already present.

I've also added a test that is failing before the fix...i was not super sure how to properly do it so i just left the config basically void without asserting anything but it was failing before and it is not failing now.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
