### PR TITLE
fix: ensure event delegation stops after an error

### DIFF
--- a/.changeset/calm-taxis-promise.md
+++ b/.changeset/calm-taxis-promise.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure event delegation stops after an error

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -131,11 +131,19 @@ export function handle_event_propagation(handler_element, event) {
 		var delegated = current_target[internal_prop_name];
 
 		if (delegated !== undefined && !(/** @type {any} */ (current_target).disabled)) {
-			if (is_array(delegated)) {
-				var [fn, ...data] = delegated;
-				fn.apply(current_target, [event, ...data]);
-			} else {
-				delegated.call(current_target, event);
+			try {
+				if (is_array(delegated)) {
+					var [fn, ...data] = delegated;
+					fn.apply(current_target, [event, ...data]);
+				} else {
+					delegated.call(current_target, event);
+				}
+			} catch (e) {
+				// @ts-expect-error ensure we don't run other handlers. Strictly speaking this is different
+				// from attaching multiple separate event listeners because those above would still run,
+				// but it's impossible for us to simulate this behavior here.
+				event.__root = document;
+				throw e;
 			}
 		}
 

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-error/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-error/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+
+		await btn?.click();
+		assert.htmlEqual(target.innerHTML, `<div><button>1</button></div>`);
+	},
+	runtime_error: 'nope'
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-error/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-error/main.svelte
@@ -1,0 +1,19 @@
+<script>
+	let count = $state(0);
+
+	function yep() {
+		count++;
+	}
+
+	function nope() {
+		count++;
+		throw new Error('nope');
+	}
+</script>
+
+<div onclick={yep}>
+	<button onclick={nope}>
+		{count}
+	</button>
+</div>
+


### PR DESCRIPTION
When a delegated event handler throws an error, ensure that delegated event handlers above it don't run. Strictly speaking this is different from attaching multiple separate event listeners because those above would still run, but it's impossible for us to simulate this behavior here. Fixes #8403

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
