### PR TITLE
feat: include `script` and `svelte:options` attributes in ast

### DIFF
--- a/.changeset/serious-crabs-punch.md
+++ b/.changeset/serious-crabs-punch.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: include `script` and `svelte:options` attributes in ast

--- a/packages/svelte/src/compiler/legacy.js
+++ b/packages/svelte/src/compiler/legacy.js
@@ -86,11 +86,15 @@ export function convert(source, ast) {
 				if (instance) {
 					// @ts-ignore
 					delete instance.parent;
+					// @ts-ignore
+					delete instance.attributes;
 				}
 
 				if (module) {
 					// @ts-ignore
 					delete module.parent;
+					// @ts-ignore
+					delete module.attributes;
 				}
 
 				return {

--- a/packages/svelte/src/compiler/phases/1-parse/read/options.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/options.js
@@ -12,6 +12,7 @@ export default function read_options(node) {
 	const component_options = {
 		start: node.start,
 		end: node.end,
+		// @ts-ignore
 		attributes: node.attributes
 	};
 

--- a/packages/svelte/src/compiler/phases/1-parse/read/options.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/options.js
@@ -11,7 +11,8 @@ export default function read_options(node) {
 	/** @type {import('#compiler').SvelteOptions} */
 	const component_options = {
 		start: node.start,
-		end: node.end
+		end: node.end,
+		attributes: node.attributes
 	};
 
 	if (!node) {

--- a/packages/svelte/src/compiler/phases/1-parse/read/script.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/script.js
@@ -63,6 +63,7 @@ export function read_script(parser, start, attributes) {
 		end: parser.index,
 		context: get_context(attributes),
 		content: ast,
-		parent: null
+		parent: null,
+		attributes: attributes
 	};
 }

--- a/packages/svelte/src/compiler/phases/1-parse/read/script.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/script.js
@@ -64,6 +64,7 @@ export function read_script(parser, start, attributes) {
 		context: get_context(attributes),
 		content: ast,
 		parent: null,
+		// @ts-ignore
 		attributes: attributes
 	};
 }

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -93,6 +93,7 @@ export interface SvelteOptions {
 		 */
 		extend?: ArrowFunctionExpression | Identifier;
 	};
+	attributes: Array<Attribute | SpreadAttribute | Directive>;
 }
 
 /** Static text */

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -467,6 +467,7 @@ export interface Script extends BaseNode {
 	type: 'Script';
 	context: string;
 	content: Program;
+	attributes: Array<Attribute | SpreadAttribute | Directive>;
 }
 
 declare module 'estree' {

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -93,7 +93,7 @@ export interface SvelteOptions {
 		 */
 		extend?: ArrowFunctionExpression | Identifier;
 	};
-	attributes: Array<Attribute | SpreadAttribute | Directive>;
+	attributes: Attribute[];
 }
 
 /** Static text */
@@ -468,7 +468,7 @@ export interface Script extends BaseNode {
 	type: 'Script';
 	context: string;
 	content: Program;
-	attributes: Array<Attribute | SpreadAttribute | Directive>;
+	attributes: Attribute[];
 }
 
 declare module 'estree' {

--- a/packages/svelte/tests/parser-modern/samples/comment-before-script/output.json
+++ b/packages/svelte/tests/parser-modern/samples/comment-before-script/output.json
@@ -133,6 +133,23 @@
 					"value": "should not error out"
 				}
 			]
-		}
+		},
+		"attributes": [
+			{
+				"type": "Attribute",
+				"start": 36,
+				"end": 45,
+				"name": "lang",
+				"value": [
+					{
+						"start": 42,
+						"end": 44,
+						"type": "Text",
+						"raw": "ts",
+						"data": "ts"
+					}
+				]
+			}
+		]
 	}
 }

--- a/packages/svelte/tests/parser-modern/samples/options/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/options/input.svelte
@@ -1,0 +1,7 @@
+<svelte:options customElement="my-custom-element" runes={true} />
+
+<script context="module" lang="ts">
+</script>
+
+<script lang="ts">
+</script>

--- a/packages/svelte/tests/parser-modern/samples/options/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/options/input.svelte
@@ -3,5 +3,5 @@
 <script context="module" lang="ts">
 </script>
 
-<script lang="ts">
+<script lang="ts" generics="T extends { foo: number }">
 </script>

--- a/packages/svelte/tests/parser-modern/samples/options/output.json
+++ b/packages/svelte/tests/parser-modern/samples/options/output.json
@@ -1,0 +1,193 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 112,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "Text",
+				"start": 65,
+				"end": 67,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Text",
+				"start": 112,
+				"end": 114,
+				"raw": "\n\n",
+				"data": "\n\n"
+			}
+		],
+		"transparent": false
+	},
+	"options": {
+		"start": 0,
+		"end": 65,
+		"attributes": [
+			{
+				"type": "Attribute",
+				"start": 16,
+				"end": 49,
+				"name": "customElement",
+				"value": [
+					{
+						"start": 31,
+						"end": 48,
+						"type": "Text",
+						"raw": "my-custom-element",
+						"data": "my-custom-element",
+						"parent": null
+					}
+				],
+				"parent": null,
+				"metadata": {
+					"dynamic": false,
+					"delegated": null
+				}
+			},
+			{
+				"type": "Attribute",
+				"start": 50,
+				"end": 62,
+				"name": "runes",
+				"value": [
+					{
+						"type": "ExpressionTag",
+						"start": 56,
+						"end": 62,
+						"expression": {
+							"type": "Literal",
+							"start": 57,
+							"end": 61,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 57
+								},
+								"end": {
+									"line": 1,
+									"column": 61
+								}
+							},
+							"value": true,
+							"raw": "true"
+						},
+						"parent": null,
+						"metadata": {
+							"contains_call_expression": false,
+							"dynamic": false
+						}
+					}
+				],
+				"parent": null,
+				"metadata": {
+					"dynamic": false,
+					"delegated": null
+				}
+			}
+		],
+		"customElement": {
+			"tag": "my-custom-element"
+		},
+		"runes": true
+	},
+	"module": {
+		"type": "Script",
+		"start": 67,
+		"end": 112,
+		"context": "module",
+		"content": {
+			"type": "Program",
+			"start": 102,
+			"end": 103,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 4,
+					"column": 0
+				}
+			},
+			"body": [],
+			"sourceType": "module"
+		},
+		"attributes": [
+			{
+				"type": "Attribute",
+				"start": 75,
+				"end": 91,
+				"name": "context",
+				"value": [
+					{
+						"start": 84,
+						"end": 90,
+						"type": "Text",
+						"raw": "module",
+						"data": "module"
+					}
+				]
+			},
+			{
+				"type": "Attribute",
+				"start": 92,
+				"end": 101,
+				"name": "lang",
+				"value": [
+					{
+						"start": 98,
+						"end": 100,
+						"type": "Text",
+						"raw": "ts",
+						"data": "ts"
+					}
+				]
+			}
+		]
+	},
+	"instance": {
+		"type": "Script",
+		"start": 114,
+		"end": 142,
+		"context": "default",
+		"content": {
+			"type": "Program",
+			"start": 132,
+			"end": 133,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 7,
+					"column": 0
+				}
+			},
+			"body": [],
+			"sourceType": "module"
+		},
+		"attributes": [
+			{
+				"type": "Attribute",
+				"start": 122,
+				"end": 131,
+				"name": "lang",
+				"value": [
+					{
+						"start": 128,
+						"end": 130,
+						"type": "Text",
+						"raw": "ts",
+						"data": "ts"
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/svelte/tests/parser-modern/samples/options/output.json
+++ b/packages/svelte/tests/parser-modern/samples/options/output.json
@@ -153,12 +153,12 @@
 	"instance": {
 		"type": "Script",
 		"start": 114,
-		"end": 142,
+		"end": 179,
 		"context": "default",
 		"content": {
 			"type": "Program",
-			"start": 132,
-			"end": 133,
+			"start": 169,
+			"end": 170,
 			"loc": {
 				"start": {
 					"line": 1,
@@ -185,6 +185,21 @@
 						"type": "Text",
 						"raw": "ts",
 						"data": "ts"
+					}
+				]
+			},
+			{
+				"type": "Attribute",
+				"start": 132,
+				"end": 168,
+				"name": "generics",
+				"value": [
+					{
+						"start": 142,
+						"end": 167,
+						"type": "Text",
+						"raw": "T extends { foo: number }",
+						"data": "T extends { foo: number }"
 					}
 				]
 			}

--- a/packages/svelte/tests/parser-modern/samples/snippets/output.json
+++ b/packages/svelte/tests/parser-modern/samples/snippets/output.json
@@ -206,6 +206,23 @@
 			},
 			"body": [],
 			"sourceType": "module"
-		}
+		},
+		"attributes": [
+			{
+				"type": "Attribute",
+				"start": 8,
+				"end": 17,
+				"name": "lang",
+				"value": [
+					{
+						"start": 14,
+						"end": 16,
+						"type": "Text",
+						"raw": "ts",
+						"data": "ts"
+					}
+				]
+			}
+		]
 	}
 }

--- a/packages/svelte/tests/parser-modern/samples/typescript-in-event-handler/output.json
+++ b/packages/svelte/tests/parser-modern/samples/typescript-in-event-handler/output.json
@@ -477,6 +477,23 @@
 				}
 			],
 			"sourceType": "module"
-		}
+		},
+		"attributes": [
+			{
+				"type": "Attribute",
+				"start": 8,
+				"end": 17,
+				"name": "lang",
+				"value": [
+					{
+						"start": 14,
+						"end": 16,
+						"type": "Text",
+						"raw": "ts",
+						"data": "ts"
+					}
+				]
+			}
+		]
 	}
 }

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1690,6 +1690,7 @@ declare module 'svelte/compiler' {
 		type: 'Script';
 		context: string;
 		content: Program;
+		attributes: Array<Attribute | SpreadAttribute | Directive>;
 	}
 	/**
 	 * The result of a preprocessor run. If the preprocessor does not return a result, it is assumed that the code is unchanged.

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1316,6 +1316,7 @@ declare module 'svelte/compiler' {
 			 */
 			extend?: ArrowFunctionExpression | Identifier;
 		};
+		attributes: Array<Attribute | SpreadAttribute | Directive>;
 	}
 
 	/** Static text */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1316,7 +1316,7 @@ declare module 'svelte/compiler' {
 			 */
 			extend?: ArrowFunctionExpression | Identifier;
 		};
-		attributes: Array<Attribute | SpreadAttribute | Directive>;
+		attributes: Attribute[];
 	}
 
 	/** Static text */
@@ -1691,7 +1691,7 @@ declare module 'svelte/compiler' {
 		type: 'Script';
 		context: string;
 		content: Program;
-		attributes: Array<Attribute | SpreadAttribute | Directive>;
+		attributes: Attribute[];
 	}
 	/**
 	 * The result of a preprocessor run. If the preprocessor does not return a result, it is assumed that the code is unchanged.


### PR DESCRIPTION

In Svelte 4 AST, `script` tags (`root.instance` and `root.module`) do not have attributes, and `prettier-plugin-svelte` has to extract them using regex (https://github.com/sveltejs/prettier-plugin-svelte/blob/b120c4de5faa6ca6fa0c6867d6048e1dd1b958ca/src/lib/extractAttributes.ts).

With Svelte 5 (modern AST), the same now applies to `svelte:options` tag. However, unlike `script`, it can also have expression attributes:

```svelte
<!-- only string attributes are allowed on `script` -->
<script lang="ts" context="module"></script>
<!-- svelte:options allows expressions in attributes -->
<svelte:options immutable={true}>
```

Currently, [`extractAttributes`](https://github.com/sveltejs/prettier-plugin-svelte/blob/b120c4de5faa6ca6fa0c6867d6048e1dd1b958ca/src/lib/extractAttributes.ts) can only handle string attributes. If we included attributes for these elements in AST, we could remove this function altogether, instead of improving it to also parse expression attributes.

###	 Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
