### PR TITLE
feat: optimize object property mutations in compilation

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/global.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/global.js
@@ -105,6 +105,8 @@ export const global_visitors = {
 			if (serialized_assignment === assignment) {
 				// No change to output -> nothing to transform -> we can keep the original update expression
 				return next();
+			} else if (context.state.analysis.runes) {
+				return serialized_assignment;
 			} else {
 				/** @type {import('estree').Statement[]} */
 				let statements;


### PR DESCRIPTION
Currently, when compiling Svelte code containing object property mutations such as `object.count++`, the Svelte compiler generates verbose JavaScript output involving a closure and unnecessary variable assignment, as demonstrated in the example provided. This PR addresses this inefficiency by optimizing the generated JavaScript output for object property mutations.

During my investigation, I observed that earlier versions of Svelte utilized the `mutate` function for updating values, which returned the value after modification. Consequently, logic akin to the current compiler-generated output was implemented. However, with the new Svelte version, this output is unnecessary, as simple expressions like `object.count++` or `object.count += 1` suffice.

The proposed solution involves enhancing the compiler to detect object property mutations and generate streamlined JavaScript output directly corresponding to the intended operation, without the need for additional closures or variable assignments. To achieve this, the compiler now checks the context when converting the code, specifically for the usage of `runes`.

Closes #10546 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`