### PR TITLE
breaking: warn on self-closing non-void special elements

### DIFF
--- a/.changeset/gentle-hairs-confess.md
+++ b/.changeset/gentle-hairs-confess.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+breaking: warn on self-closing non-void special elements

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -676,10 +676,20 @@ const validation = {
 			error(node, 'invalid-style-directive-modifier');
 		}
 	},
-	SvelteHead(node) {
+	SvelteHead(node, context) {
 		const attribute = node.attributes[0];
 		if (attribute) {
 			error(attribute, 'illegal-svelte-head-attribute');
+		}
+
+		if (context.state.analysis.source[node.end - 2] === '/') {
+			warn(
+				context.state.analysis.warnings,
+				node,
+				context.path,
+				'invalid-self-closing-tag',
+				node.name
+			);
 		}
 	},
 	SvelteElement(node, context) {
@@ -703,6 +713,16 @@ const validation = {
 			} else if (attribute.type !== 'LetDirective') {
 				error(attribute, 'invalid-svelte-fragment-attribute');
 			}
+		}
+
+		if (context.state.analysis.source[node.end - 2] === '/') {
+			warn(
+				context.state.analysis.warnings,
+				node,
+				context.path,
+				'invalid-self-closing-tag',
+				node.name
+			);
 		}
 	},
 	SlotElement(node) {

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -253,7 +253,7 @@ const options = {
 const misc = {
 	/** @param {string} name */
 	'invalid-self-closing-tag': (name) =>
-		`Self-closing HTML tags for non-void elements are ambiguous — use <${name} ...></${name}> rather than <${name} ... />`
+		`Self-closing tags for non-void elements are ambiguous — use <${name} ...></${name}> rather than <${name} ... />`
 };
 
 /** @satisfies {Warnings} */

--- a/packages/svelte/tests/validator/samples/invalid-self-closing-tag/input.svelte
+++ b/packages/svelte/tests/validator/samples/invalid-self-closing-tag/input.svelte
@@ -1,7 +1,31 @@
-<!-- valid -->
-<link />
+<!-- valid - foreign namespace -->
 <svg><g /></svg>
 
-<!-- invalid -->
+<!-- not reported - void tags -->
+<link />
+<br/>
+<svelte:options />
+<svelte:window on:event={() => null} />
+<svelte:document on:event={() => null} />
+<svelte:body on:event={() => null} />
+
+<!-- not reported - deprecated -->
+<slot />
+
+<!-- not reported - components -->
+{#if true}
+	<svelte:self />
+{/if}
+<Foo />
+<svelte:component this={"foo"} />
+
+<!-- not reported - `this` can be bound to both void and non-void tags -->
+<svelte:element this="dif" />
+
+<!-- invalid and reported -->
 <div />
 <my-thing />
+<svelte:head />
+<Foo>
+	<svelte:fragment slot="footer" />
+</Foo>

--- a/packages/svelte/tests/validator/samples/invalid-self-closing-tag/warnings.json
+++ b/packages/svelte/tests/validator/samples/invalid-self-closing-tag/warnings.json
@@ -1,26 +1,50 @@
 [
 	{
 		"code": "invalid-self-closing-tag",
-		"message": "Self-closing HTML tags for non-void elements are ambiguous — use <div ...></div> rather than <div ... />",
+		"message": "Self-closing tags for non-void elements are ambiguous — use <div ...></div> rather than <div ... />",
 		"start": {
-			"line": 6,
+			"line": 26,
 			"column": 0
 		},
 		"end": {
-			"line": 6,
+			"line": 26,
 			"column": 7
 		}
 	},
 	{
 		"code": "invalid-self-closing-tag",
-		"message": "Self-closing HTML tags for non-void elements are ambiguous — use <my-thing ...></my-thing> rather than <my-thing ... />",
+		"message": "Self-closing tags for non-void elements are ambiguous — use <my-thing ...></my-thing> rather than <my-thing ... />",
 		"start": {
-			"line": 7,
+			"line": 27,
 			"column": 0
 		},
 		"end": {
-			"line": 7,
+			"line": 27,
 			"column": 12
+		}
+	},
+	{
+		"code": "invalid-self-closing-tag",
+		"message": "Self-closing tags for non-void elements are ambiguous — use <svelte:head ...></svelte:head> rather than <svelte:head ... />",
+		"start": {
+			"line": 28,
+			"column": 0
+		},
+		"end": {
+			"line": 28,
+			"column": 15
+		}
+	},
+	{
+		"code": "invalid-self-closing-tag",
+		"message": "Self-closing tags for non-void elements are ambiguous — use <svelte:fragment ...></svelte:fragment> rather than <svelte:fragment ... />",
+		"start": {
+			"line": 30,
+			"column": 1
+		},
+		"end": {
+			"line": 30,
+			"column": 34
 		}
 	}
 ]


### PR DESCRIPTION
#11114, but for special elements, so that they're treated more consistently with HTML elements.

I should have opened an issue for that first, so please treat it like a place for discussion. No hard feelings if it doesn't get merged :)

This PR adds warnings only for `<svelte:head>` and `<svelte:fragment>`, since these are the only elements that don't really make sense without content.

`<svelte:options>`, `<svelte:window>`, `<svelte:document>` and `<svelte:body>` should never have content, so I've opened #11245 to treat them like void tags.

`<slot>` is deprecated anyway.

Other special elements sometimes feel like void tags, and sometimes not, so I didn't touch them:
```svelte
<!-- components -->
<svelte:self />
<Foo />
<svelte:component this={"foo"} />

<!-- `this` can be bound to both void and non-void tags -->
<svelte:element this="dif" />
```

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
