### PR TITLE
breaking: don't allow children in svelte:options

### DIFF
--- a/.changeset/smooth-kids-protect.md
+++ b/.changeset/smooth-kids-protect.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+breaking: don't allow children in svelte:options

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -101,7 +101,7 @@ export default function tag(parser) {
 	if (root_only_meta_tags.has(name)) {
 		if (is_closing_tag) {
 			if (
-				(name === 'svelte:window' || name === 'svelte:body' || name === 'svelte:document') &&
+				['svelte:options', 'svelte:window', 'svelte:body', 'svelte:document'].includes(name) &&
 				/** @type {import('#compiler').ElementLike} */ (parent).fragment.nodes.length
 			) {
 				error(

--- a/packages/svelte/tests/compiler-errors/samples/options-children/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/options-children/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-element-content',
+		message: '<svelte:options> cannot have children',
+		position: [16, 16]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/options-children/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/options-children/main.svelte
@@ -1,0 +1,1 @@
+<svelte:options>contents</svelte:options>


### PR DESCRIPTION
Throw compiler error if `<svelte:options>` has children (currently they will be silently ignored). This is the same validation that's applied to `svelte:window`, `svelte:body` and `svelte:document`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
