### PR TITLE
fix: ensure that CSS is generated for the final frame of a transition

### DIFF
--- a/.changeset/funny-ties-jump.md
+++ b/.changeset/funny-ties-jump.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure that CSS is generated for the final frame of a transition

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -322,7 +322,7 @@ function animate(element, options, counterpart, t2, callback) {
 	if (css) {
 		// WAAPI
 		var keyframes = [];
-		var n = duration / (1000 / 60);
+		var n = Math.ceil(duration / (1000 / 60)); // `n` must be an integer, or we risk missing the `t2` value
 
 		for (var i = 0; i <= n; i += 1) {
 			var t = t1 + delta * easing(i / n);

--- a/packages/svelte/tests/runtime-legacy/samples/transition-css-iframe/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-css-iframe/_config.js
@@ -19,6 +19,6 @@ export default test({
 		assert.equal(div.style.opacity, '0.25');
 
 		raf.tick(35);
-		assert.equal(div.style.opacity, '0.18333333333333335');
+		assert.equal(div.style.opacity, '0.15');
 	}
 });


### PR DESCRIPTION
fixes #11081. No test because it doesn't reproduce in our test suite — I added a comment instead that is hopefully clear enough to prevent careless regressions

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
