### PR TITLE
fix: run render functions for dynamic void elements

### DIFF
--- a/.changeset/fifty-masks-give.md
+++ b/.changeset/fifty-masks-give.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: run render functions for dynamic void elements

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -40,7 +40,7 @@ function swap_block_dom(effect, from, to) {
  * @param {Comment} anchor
  * @param {() => string} get_tag
  * @param {boolean} is_svg
- * @param {undefined | ((element: Element, anchor: Node) => void)} render_fn,
+ * @param {undefined | ((element: Element, anchor: Node | null) => void)} render_fn,
  * @param {undefined | (() => string)} get_namespace
  * @returns {void}
  */
@@ -115,13 +115,11 @@ export function element(anchor, get_tag, is_svg, render_fn, get_namespace) {
 							? element.firstChild && hydrate_anchor(/** @type {Comment} */ (element.firstChild))
 							: element.appendChild(empty());
 
-						if (child_anchor) {
-							// `child_anchor` can be undefined if this is a void element with children,
-							// i.e. `<svelte:element this={"hr"}>...</svelte:element>`. This is
-							// user error, but we warn on it elsewhere (in dev) so here we just
-							// silently ignore it
-							render_fn(element, child_anchor);
-						}
+						// `child_anchor` is undefined if this is a void element, but we still,
+						// need to call `render_fn` in order to run actions etc. If the element
+						// contains children, it's a user error (which is warned on elsewhere)
+						// and the DOM will be silently discarded
+						render_fn(element, child_anchor);
 					}
 
 					anchor.before(element);

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -115,7 +115,7 @@ export function element(anchor, get_tag, is_svg, render_fn, get_namespace) {
 							? element.firstChild && hydrate_anchor(/** @type {Comment} */ (element.firstChild))
 							: element.appendChild(empty());
 
-						// `child_anchor` is undefined if this is a void element, but we still,
+						// `child_anchor` is undefined if this is a void element, but we still
 						// need to call `render_fn` in order to run actions etc. If the element
 						// contains children, it's a user error (which is warned on elsewhere)
 						// and the DOM will be silently discarded

--- a/packages/svelte/tests/runtime-runes/samples/action-void-element/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/action-void-element/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<input><input>`,
+
+	async test({ assert, target }) {
+		const inputs = target.querySelectorAll('input');
+		assert.equal(inputs[0].value, 'set from action');
+		assert.equal(inputs[1].value, 'set from action');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/action-void-element/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/action-void-element/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	/** @param {HTMLInputElement} node */
+	function action(node) {
+		node.value = 'set from action';
+	}
+</script>
+
+<input use:action>
+<svelte:element this={'input'} use:action />


### PR DESCRIPTION
This would have errored prior #11197, which is why the `if` block was in place, but it's fine now

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
