### PR TITLE
chore: use #client instead of ./types.js

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -67,7 +67,7 @@ export function derived_safe_equal(fn) {
 }
 
 /**
- * @param {import('./types.js').Derived} signal
+ * @param {import('#client').Derived} signal
  * @returns {void}
  */
 function destroy_derived_children(signal) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -49,47 +49,47 @@ let is_inspecting_signal = false;
 
 // Handle effect queues
 
-/** @type {import('./types.js').Effect[]} */
+/** @type {import('#client').Effect[]} */
 let current_queued_root_effects = [];
 
 let flush_count = 0;
 // Handle signal reactivity tree dependencies and reactions
 
-/** @type {null | import('./types.js').Reaction} */
+/** @type {null | import('#client').Reaction} */
 export let current_reaction = null;
 
-/** @param {null | import('./types.js').Reaction} reaction */
+/** @param {null | import('#client').Reaction} reaction */
 export function set_current_reaction(reaction) {
 	current_reaction = reaction;
 }
 
-/** @type {null | import('./types.js').Effect} */
+/** @type {null | import('#client').Effect} */
 export let current_effect = null;
 
-/** @param {null | import('./types.js').Effect} effect */
+/** @param {null | import('#client').Effect} effect */
 export function set_current_effect(effect) {
 	current_effect = effect;
 }
 
-/** @type {null | import('./types.js').Value[]} */
+/** @type {null | import('#client').Value[]} */
 export let current_dependencies = null;
 let current_dependencies_index = 0;
 /**
  * Tracks writes that the effect it's executed in doesn't listen to yet,
  * so that the dependency can be added to the effect later on if it then reads it
- * @type {null | import('./types.js').Source[]}
+ * @type {null | import('#client').Source[]}
  */
 export let current_untracked_writes = null;
 
-/** @param {null | import('./types.js').Source[]} value */
+/** @param {null | import('#client').Source[]} value */
 export function set_current_untracked_writes(value) {
 	current_untracked_writes = value;
 }
 
-/** @type {null | import('./types.js').ValueDebug} */
+/** @type {null | import('#client').ValueDebug} */
 export let last_inspected_signal = null;
 
-/** @param {null | import('./types.js').ValueDebug} signal */
+/** @param {null | import('#client').ValueDebug} signal */
 export function set_last_inspected_signal(signal) {
 	last_inspected_signal = signal;
 }
@@ -105,10 +105,10 @@ export let is_signals_recorded = false;
 let captured_signals = new Set();
 
 // Handling runtime component context
-/** @type {import('./types.js').ComponentContext | null} */
+/** @type {import('#client').ComponentContext | null} */
 export let current_component_context = null;
 
-/** @param {import('./types.js').ComponentContext | null} context */
+/** @param {import('#client').ComponentContext | null} context */
 export function set_current_component_context(context) {
 	current_component_context = context;
 }
@@ -119,7 +119,7 @@ export function is_runes() {
 }
 
 /**
- * @param {import('./types.js').ProxyStateObject} target
+ * @param {import('#client').ProxyStateObject} target
  * @param {string | symbol} prop
  * @param {any} receiver
  */
@@ -153,7 +153,7 @@ export function batch_inspect(target, prop, receiver) {
 /**
  * Determines whether a derived or effect is dirty.
  * If it is MAYBE_DIRTY, will set the status to CLEAN
- * @param {import('./types.js').Reaction} reaction
+ * @param {import('#client').Reaction} reaction
  * @returns {boolean}
  */
 export function check_dirtiness(reaction) {
@@ -218,7 +218,7 @@ export function check_dirtiness(reaction) {
 
 /**
  * @template V
- * @param {import('./types.js').Reaction} signal
+ * @param {import('#client').Reaction} signal
  * @returns {V}
  */
 export function execute_reaction_fn(signal) {
@@ -229,7 +229,7 @@ export function execute_reaction_fn(signal) {
 	const previous_skip_reaction = current_skip_reaction;
 	const previous_untracking = current_untracking;
 
-	current_dependencies = /** @type {null | import('./types.js').Value[]} */ (null);
+	current_dependencies = /** @type {null | import('#client').Value[]} */ (null);
 	current_dependencies_index = 0;
 	current_untracked_writes = null;
 	current_reaction = signal;
@@ -238,7 +238,7 @@ export function execute_reaction_fn(signal) {
 
 	try {
 		let res = signal.fn();
-		let dependencies = /** @type {import('./types.js').Value<unknown>[]} **/ (signal.deps);
+		let dependencies = /** @type {import('#client').Value<unknown>[]} **/ (signal.deps);
 		if (current_dependencies !== null) {
 			let i;
 			if (dependencies !== null) {
@@ -273,7 +273,7 @@ export function execute_reaction_fn(signal) {
 					dependencies[current_dependencies_index + i] = current_dependencies[i];
 				}
 			} else {
-				signal.deps = /** @type {import('./types.js').Value<V>[]} **/ (
+				signal.deps = /** @type {import('#client').Value<V>[]} **/ (
 					dependencies = current_dependencies
 				);
 			}
@@ -311,8 +311,8 @@ export function execute_reaction_fn(signal) {
 
 /**
  * @template V
- * @param {import('./types.js').Reaction} signal
- * @param {import('./types.js').Value<V>} dependency
+ * @param {import('#client').Reaction} signal
+ * @param {import('#client').Value<V>} dependency
  * @returns {void}
  */
 function remove_reaction(signal, dependency) {
@@ -334,12 +334,12 @@ function remove_reaction(signal, dependency) {
 	if (reactions_length === 0 && (dependency.f & UNOWNED) !== 0) {
 		// If the signal is unowned then we need to make sure to change it to dirty.
 		set_signal_status(dependency, DIRTY);
-		remove_reactions(/** @type {import('./types.js').Derived} **/ (dependency), 0);
+		remove_reactions(/** @type {import('#client').Derived} **/ (dependency), 0);
 	}
 }
 
 /**
- * @param {import('./types.js').Reaction} signal
+ * @param {import('#client').Reaction} signal
  * @param {number} start_index
  * @returns {void}
  */
@@ -359,7 +359,7 @@ export function remove_reactions(signal, start_index) {
 }
 
 /**
- * @param {import('./types.js').Reaction} signal
+ * @param {import('#client').Reaction} signal
  * @returns {void}
  */
 export function destroy_effect_children(signal) {
@@ -375,7 +375,7 @@ export function destroy_effect_children(signal) {
 }
 
 /**
- * @param {import('./types.js').Effect} effect
+ * @param {import('#client').Effect} effect
  * @returns {void}
  */
 export function execute_effect(effect) {
@@ -424,7 +424,7 @@ function infinite_loop_guard() {
 }
 
 /**
- * @param {Array<import('./types.js').Effect>} root_effects
+ * @param {Array<import('#client').Effect>} root_effects
  * @returns {void}
  */
 function flush_queued_root_effects(root_effects) {
@@ -435,7 +435,7 @@ function flush_queued_root_effects(root_effects) {
 }
 
 /**
- * @param {Array<import('./types.js').Effect>} effects
+ * @param {Array<import('#client').Effect>} effects
  * @returns {void}
  */
 function flush_queued_effects(effects) {
@@ -466,7 +466,7 @@ function process_microtask() {
 }
 
 /**
- * @param {import('./types.js').Effect} signal
+ * @param {import('#client').Effect} signal
  * @returns {void}
  */
 export function schedule_effect(signal) {
@@ -499,10 +499,10 @@ export function schedule_effect(signal) {
  * bitwise flag passed in only. The collected effects array will be populated with all the user
  * effects to be flushed.
  *
- * @param {import('./types.js').Effect} effect
+ * @param {import('#client').Effect} effect
  * @param {number} filter_flags
  * @param {boolean} shallow
- * @param {import('./types.js').Effect[]} collected_effects
+ * @param {import('#client').Effect[]} collected_effects
  * @returns {void}
  */
 function process_effects(effect, filter_flags, shallow, collected_effects) {
@@ -591,7 +591,7 @@ function process_effects(effect, filter_flags, shallow, collected_effects) {
  * Effects will be collected when they match the filtered bitwise flag passed in only. The collected
  * array will be populated with all the effects.
  *
- * @param {import('./types.js').Effect} effect
+ * @param {import('#client').Effect} effect
  * @param {number} filter_flags
  * @param {boolean} [shallow]
  * @returns {void}
@@ -617,7 +617,7 @@ function flush_nested_effects(effect, filter_flags, shallow = false) {
 }
 
 /**
- * @param {import('./types.js').Effect} effect
+ * @param {import('#client').Effect} effect
  * @returns {void}
  */
 export function flush_local_render_effects(effect) {
@@ -640,7 +640,7 @@ export function flush_sync(fn, flush_previous = true) {
 	try {
 		infinite_loop_guard();
 
-		/** @type {import('./types.js').Effect[]} */
+		/** @type {import('#client').Effect[]} */
 		const root_effects = [];
 
 		current_scheduler_mode = FLUSH_SYNC;
@@ -679,7 +679,7 @@ export async function tick() {
 
 /**
  * @template V
- * @param {import('./types.js').Value<V>} signal
+ * @param {import('#client').Value<V>} signal
  * @returns {V}
  */
 export function get(signal) {
@@ -744,10 +744,10 @@ export function get(signal) {
 			// we want to avoid tracking indirect dependencies
 			const previous_inspect_fn = inspect_fn;
 			set_inspect_fn(null);
-			update_derived(/** @type {import('./types.js').Derived} **/ (signal), false);
+			update_derived(/** @type {import('#client').Derived} **/ (signal), false);
 			set_inspect_fn(previous_inspect_fn);
 		} else {
-			update_derived(/** @type {import('./types.js').Derived} **/ (signal), false);
+			update_derived(/** @type {import('#client').Derived} **/ (signal), false);
 		}
 	}
 
@@ -849,7 +849,7 @@ export function untrack(fn) {
 const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
 
 /**
- * @param {import('./types.js').Signal} signal
+ * @param {import('#client').Signal} signal
  * @param {number} status
  * @returns {void}
  */
@@ -859,14 +859,14 @@ export function set_signal_status(signal, status) {
 
 /**
  * @template V
- * @param {V | import('./types.js').Value<V>} val
- * @returns {val is import('./types.js').Value<V>}
+ * @param {V | import('#client').Value<V>} val
+ * @returns {val is import('#client').Value<V>}
  */
 export function is_signal(val) {
 	return (
 		typeof val === 'object' &&
 		val !== null &&
-		typeof (/** @type {import('./types.js').Value<V>} */ (val).f) === 'number'
+		typeof (/** @type {import('#client').Value<V>} */ (val).f) === 'number'
 	);
 }
 
@@ -964,7 +964,7 @@ function get_or_init_context_map() {
 }
 
 /**
- * @param {import('./types.js').ComponentContext} component_context
+ * @param {import('#client').ComponentContext} component_context
  * @returns {Map<unknown, unknown> | null}
  */
 function get_parent_context(component_context) {
@@ -980,7 +980,7 @@ function get_parent_context(component_context) {
 }
 
 /**
- * @param {import('./types.js').Value<number>} signal
+ * @param {import('#client').Value<number>} signal
  * @param {1 | -1} [d]
  * @returns {number}
  */
@@ -991,7 +991,7 @@ export function update(signal, d = 1) {
 }
 
 /**
- * @param {import('./types.js').Value<number>} signal
+ * @param {import('#client').Value<number>} signal
  * @param {1 | -1} [d]
  * @returns {number}
  */


### PR DESCRIPTION
I think this is the last of these — all remaining `import('./types.js')` occurrences are for local types, not ones that are shared throughout the codebase