### PR TITLE
fix: allow events to continue propagating following an error

### DIFF
--- a/.changeset/light-penguins-invent.md
+++ b/.changeset/light-penguins-invent.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow events to continue propagating following an error

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -122,36 +122,44 @@ export function handle_event_propagation(handler_element, event) {
 		}
 	});
 
-	while (current_target !== null) {
+	/** @param {Element} current_target */
+	function next(current_target) {
 		/** @type {null | Element} */
 		var parent_element =
 			current_target.parentNode || /** @type {any} */ (current_target).host || null;
-		var internal_prop_name = '__' + event_name;
-		// @ts-ignore
-		var delegated = current_target[internal_prop_name];
 
-		if (delegated !== undefined && !(/** @type {any} */ (current_target).disabled)) {
-			if (is_array(delegated)) {
-				var [fn, ...data] = delegated;
-				fn.apply(current_target, [event, ...data]);
-			} else {
-				delegated.call(current_target, event);
+		try {
+			// @ts-expect-error
+			var delegated = current_target['__' + event_name];
+
+			if (delegated !== undefined && !(/** @type {any} */ (current_target).disabled)) {
+				if (is_array(delegated)) {
+					var [fn, ...data] = delegated;
+					fn.apply(current_target, [event, ...data]);
+				} else {
+					delegated.call(current_target, event);
+				}
 			}
-		}
+		} finally {
+			if (
+				event.cancelBubble ||
+				parent_element === handler_element ||
+				parent_element === null ||
+				current_target === handler_element
+			) {
+				return;
+			}
 
-		if (
-			event.cancelBubble ||
-			parent_element === handler_element ||
-			current_target === handler_element
-		) {
-			break;
+			next(parent_element);
 		}
-
-		current_target = parent_element;
 	}
 
-	// @ts-expect-error is used above
-	event.__root = handler_element;
-	// @ts-expect-error is used above
-	current_target = handler_element;
+	try {
+		next(current_target);
+	} finally {
+		// @ts-expect-error is used above
+		event.__root = handler_element;
+		// @ts-expect-error is used above
+		current_target = handler_element;
+	}
 }

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -142,15 +142,13 @@ export function handle_event_propagation(handler_element, event) {
 			}
 		} finally {
 			if (
-				event.cancelBubble ||
-				parent_element === handler_element ||
-				parent_element === null ||
-				current_target === handler_element
+				!event.cancelBubble &&
+				parent_element !== handler_element &&
+				parent_element !== null &&
+				current_target !== handler_element
 			) {
-				return;
+				next(parent_element);
 			}
-
-			next(parent_element);
 		}
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/event-propagation-with-error/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-propagation-with-error/_config.js
@@ -1,0 +1,15 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<div><button>0 0</button>`,
+
+	async test({ assert, target }) {
+		const button1 = target.querySelector('button');
+
+		flushSync(() => button1?.click());
+		assert.htmlEqual(target.innerHTML, `<div><button>1 1</button></div>`);
+	},
+
+	runtime_error: 'nope'
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-propagation-with-error/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-propagation-with-error/main.svelte
@@ -1,0 +1,19 @@
+<script>
+	let y = $state(0);
+	let n = $state(0);
+
+	function yep() {
+		y += 1;
+	}
+
+	function nope() {
+		n += 1;
+		throw new Error('nope');
+	}
+</script>
+
+<div onclick={yep}>
+	<button onclick={nope}>
+		{y} {n}
+	</button>
+</div>


### PR DESCRIPTION
This is an alternative to #11239. It's technically a breaking change, but I think the behaviour is much more reasonable than that of Svelte 4: if an event handler throws, propagation continues.

Fixes #8403. [Demo](https://svelte-5-preview-git-gh-8403-svelte.vercel.app/#H4sIAAAAAAAAE3WQ0U7DMAxFf8WKkNYJxOC1tJN44CsoDyN1ISKzo8TdFEX5d5IONk2Ihyi699ondpKajMWg2tekaLdH1apn59SdkuiqCAe0gkUHnr2uThe0N062Aw1iUSBCDzdBdoLNw_rp16U_bj3TTFoME0R0zRrS4otmCmzx3vJHsyrJ6qdBItz28LiIfNVO7PCf_hqdAXQBDCKfno9AeIQX79lflRZ8t7ksRt1oDsCkrdFffSoz5WXf7n0WKe-fk4o4RYOkmCHRMmi3ORVuK7agyl2-cM-jmQyOqhU_Y37L3xRitmR9AQAA)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
