### PR TITLE
monkey-patch console.log and console.warn for all tests

### DIFF
--- a/packages/svelte/tests/hydration/samples/ignore-mismatched-href/_config.js
+++ b/packages/svelte/tests/hydration/samples/ignore-mismatched-href/_config.js
@@ -11,5 +11,9 @@ export default test({
 
 	test(assert, target) {
 		assert.equal(target.querySelector('a')?.getAttribute('href'), '/bar');
-	}
+	},
+
+	errors: [
+		'Detected a href attribute value change during hydration. This will not be repaired during hydration, the href value that came from the server will be used. Related element:'
+	]
 });

--- a/packages/svelte/tests/runtime-browser/test.ts
+++ b/packages/svelte/tests/runtime-browser/test.ts
@@ -14,7 +14,6 @@ let browser: import('@playwright/test').Browser;
 
 beforeAll(async () => {
 	browser = await chromium.launch();
-	console.log('[runtime-browser] Launched browser');
 }, 20000);
 
 afterAll(async () => {

--- a/packages/svelte/tests/runtime-legacy/samples/binding-this-multiple/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-this-multiple/_config.js
@@ -2,11 +2,11 @@ import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	test({ assert, component, target }) {
+	test({ assert, target, logs }) {
 		const [b1, b2, b3] = target.querySelectorAll('button');
 		const first_h1 = target.querySelector('h1');
 
-		assert.deepEqual(component.log, [undefined, first_h1]);
+		assert.deepEqual(logs, [undefined, first_h1]);
 
 		flushSync(() => {
 			b3.click();
@@ -14,12 +14,12 @@ export default test({
 
 		const third_h1 = target.querySelector('h1');
 
-		assert.deepEqual(component.log, [undefined, first_h1, third_h1]);
+		assert.deepEqual(logs, [undefined, first_h1, third_h1]);
 
 		flushSync(() => {
 			b1.click();
 		});
 
-		assert.deepEqual(component.log, [undefined, first_h1, third_h1, target.querySelector('h1')]);
+		assert.deepEqual(logs, [undefined, first_h1, third_h1, target.querySelector('h1')]);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/binding-this-multiple/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-this-multiple/main.svelte
@@ -1,9 +1,8 @@
 <script>
 	let activeTab = 0;
 	let activeHeading;
-	export let log = [];
 
-	$: log.push(activeHeading);
+	$: console.log(activeHeading);
 </script>
 
 <div class="tabs">

--- a/packages/svelte/tests/runtime-legacy/samples/component-nested-deep/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/component-nested-deep/_config.js
@@ -4,5 +4,7 @@ import { unmount } from 'svelte';
 export default test({
 	test({ component }) {
 		unmount(component.l1);
-	}
+	},
+
+	warnings: ['Tried to unmount a component that was not mounted.']
 });

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each-nested/Nested.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each-nested/Nested.svelte
@@ -1,10 +1,10 @@
 <script>
 	let keys = ['a', 'b'];
 	let items = ['c', 'd'];
-  export let log;
+
 	function setKey(key, value, item) {
-		log.push(`setKey(${key}, ${value}, ${item})`);
-  }
+		console.log(`setKey(${key}, ${value}, ${item})`);
+	}
 </script>
 
 {#each items as item (item)}

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each-nested/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each-nested/_config.js
@@ -7,25 +7,26 @@ export default test({
 		<button type="button">Set a-d</button>
 		<button type="button">Set b-d</button>
 	`,
-	async test({ assert, target, window, component }) {
+
+	async test({ assert, target, window, logs }) {
 		const [btn1, btn2, btn3, btn4] = target.querySelectorAll('button');
 		const click = new window.MouseEvent('click', { bubbles: true });
 
 		await btn1.dispatchEvent(click);
-		assert.deepEqual(component.log, ['setKey(a, value-a-c, c)']);
+		assert.deepEqual(logs, ['setKey(a, value-a-c, c)']);
 
 		await btn2.dispatchEvent(click);
-		assert.deepEqual(component.log, ['setKey(a, value-a-c, c)', 'setKey(b, value-b-c, c)']);
+		assert.deepEqual(logs, ['setKey(a, value-a-c, c)', 'setKey(b, value-b-c, c)']);
 
 		await btn3.dispatchEvent(click);
-		assert.deepEqual(component.log, [
+		assert.deepEqual(logs, [
 			'setKey(a, value-a-c, c)',
 			'setKey(b, value-b-c, c)',
 			'setKey(a, value-a-d, d)'
 		]);
 
 		await btn4.dispatchEvent(click);
-		assert.deepEqual(component.log, [
+		assert.deepEqual(logs, [
 			'setKey(a, value-a-c, c)',
 			'setKey(b, value-b-c, c)',
 			'setKey(a, value-a-d, d)',

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each-nested/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each-nested/main.svelte
@@ -1,8 +1,7 @@
 <script>
 	import Nested from './Nested.svelte';
-	export let log = [];
 </script>
 
-<Nested {log} let:set let:key let:item>
+<Nested let:set let:key let:item>
 	<button type="button" on:click={() => set(`value-${key}-${item}`)}>Set {key}-{item}</button>
 </Nested>

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each/Nested.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each/Nested.svelte
@@ -1,9 +1,9 @@
 <script>
 	let keys = ['a', 'b'];
-  export let log;
+
 	function setKey(key, value) {
-		log.push(`setKey(${key}, ${value})`);
-  }
+		console.log(`setKey(${key}, ${value})`);
+	}
 </script>
 
 {#each keys as key (key)}

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each/_config.js
@@ -5,14 +5,15 @@ export default test({
 		<button type="button">Set a</button>
 		<button type="button">Set b</button>
 	`,
-	async test({ assert, target, window, component }) {
+
+	async test({ assert, target, window, logs }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 		const click = new window.MouseEvent('click', { bubbles: true });
 
 		await btn1.dispatchEvent(click);
-		assert.deepEqual(component.log, ['setKey(a, value-a)']);
+		assert.deepEqual(logs, ['setKey(a, value-a)']);
 
 		await btn2.dispatchEvent(click);
-		assert.deepEqual(component.log, ['setKey(a, value-a)', 'setKey(b, value-b)']);
+		assert.deepEqual(logs, ['setKey(a, value-a)', 'setKey(b, value-b)']);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-each/main.svelte
@@ -1,8 +1,7 @@
 <script>
 	import Nested from './Nested.svelte';
-	export let log = [];
 </script>
 
-<Nested {log} let:set let:key>
+<Nested let:set let:key>
 	<button type="button" on:click={() => set(`value-${key}`)}>Set {key}</button>
 </Nested>

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-let/Inner.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-let/Inner.svelte
@@ -1,8 +1,7 @@
 <script>
-  export let log;
 	function setKey(key, value) {
-		log.push(`setKey(${key}, ${value})`);
-  }
+		console.log(`setKey(${key}, ${value})`);
+	}
 </script>
 
 <slot key="a" set={setKey} />

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-let/Nested.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-let/Nested.svelte
@@ -1,8 +1,7 @@
 <script>
 	import Inner from './Inner.svelte';
-  export let log;
 </script>
 
-<Inner {log} let:key let:set>
+<Inner let:key let:set>
 	<slot {key} set={(value) => set(key, value)} />
 </Inner>

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-let/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-let/_config.js
@@ -5,14 +5,15 @@ export default test({
 		<button type="button">Set a</button>
 		<button type="button">Set b</button>
 	`,
-	async test({ assert, target, window, component }) {
+
+	async test({ assert, target, window, logs }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 		const click = new window.MouseEvent('click', { bubbles: true });
 
 		await btn1.dispatchEvent(click);
-		assert.deepEqual(component.log, ['setKey(a, value-a)']);
+		assert.deepEqual(logs, ['setKey(a, value-a)']);
 
 		await btn2.dispatchEvent(click);
-		assert.deepEqual(component.log, ['setKey(a, value-a)', 'setKey(b, value-b)']);
+		assert.deepEqual(logs, ['setKey(a, value-a)', 'setKey(b, value-b)']);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-let/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-slot-context-props-let/main.svelte
@@ -1,8 +1,7 @@
 <script>
 	import Nested from './Nested.svelte';
-	export let log = [];
 </script>
 
-<Nested {log} let:set let:key>
+<Nested let:set let:key>
 	<button type="button" on:click={() => set(`value-${key}`)}>Set {key}</button>
 </Nested>

--- a/packages/svelte/tests/runtime-legacy/samples/destroy-twice/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/destroy-twice/_config.js
@@ -5,5 +5,10 @@ export default test({
 	test({ component }) {
 		unmount(component);
 		unmount(component);
-	}
+	},
+
+	warnings: [
+		'Tried to unmount a component that was not mounted.',
+		'Tried to unmount a component that was not mounted.'
+	]
 });

--- a/packages/svelte/tests/runtime-legacy/samples/empty-component-destroy/Empty.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/empty-component-destroy/Empty.svelte
@@ -1,6 +1,6 @@
 
 <script>
-  import { onDestroy } from 'svelte';
+	import { onDestroy } from 'svelte';
 
 	onDestroy(() => {
 		console.log('destroy');

--- a/packages/svelte/tests/runtime-legacy/samples/empty-component-destroy/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/empty-component-destroy/_config.js
@@ -1,30 +1,14 @@
 import { test } from '../../test';
 
-/**
- * @type {{ (...data: any[]): void; (message?: any, ...optionalParams: any[]): void; (...data: any[]): void; (message?: any, ...optionalParams: any[]): void; }}
- */
-let log;
-
 export default test({
 	html: `
 	  <button>destroy component</button>
 	`,
 
-	before_test() {
-		log = console.log;
-	},
-	after_test() {
-		console.log = log;
-	},
-
-	async test({ assert, target, window }) {
+	async test({ assert, target, window, logs }) {
 		const button = target.querySelector('button');
 		const event = new window.MouseEvent('click');
-		/**
-		 * @type {any[]}
-		 */
-		const messages = [];
-		console.log = (msg) => messages.push(msg);
+
 		// @ts-ignore
 		await button.dispatchEvent(event);
 		assert.htmlEqual(
@@ -33,6 +17,6 @@ export default test({
 			<button>destroy component</button>
 		`
 		);
-		assert.deepEqual(messages, ['destroy']);
+		assert.deepEqual(logs, ['destroy']);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/empty-component-destroy/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/empty-component-destroy/main.svelte
@@ -3,6 +3,6 @@
 	let active = true;
 </script>
 
-<button on:click='{() => active = false }'>destroy component</button>
+<button on:click={() => active = false }>destroy component</button>
 
 <svelte:component this={active ? Empty : null} />

--- a/packages/svelte/tests/runtime-legacy/samples/event-handler-mutation-scope/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/event-handler-mutation-scope/_config.js
@@ -2,7 +2,7 @@ import { flushSync } from 'svelte';
 import { ok, test } from '../../test';
 
 export default test({
-	test({ assert, component, target, window }) {
+	test({ assert, logs, target }) {
 		const button = target.querySelector('button');
 		ok(button);
 
@@ -10,12 +10,12 @@ export default test({
 			button.click();
 		});
 
-		assert.deepEqual(component.log, ['1 - 1']);
+		assert.deepEqual(logs, ['1 - 1']);
 
 		flushSync(() => {
 			button.click();
 		});
 
-		assert.deepEqual(component.log, ['1 - 1', '2 - 2']);
+		assert.deepEqual(logs, ['1 - 1', '2 - 2']);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/event-handler-mutation-scope/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/event-handler-mutation-scope/main.svelte
@@ -1,5 +1,4 @@
 <script>
-	export let log = [];
 	let referenced_directly = 0;
 	let not_referenced_directly = 0;
 	let css_based_on_not_referenced = '';
@@ -8,7 +7,7 @@
 		referenced_directly += 1;
 		not_referenced_directly += 1;
 		css_based_on_not_referenced = not_referenced_directly % 2 == 1 ? 'background-color: red' : '';
-		log.push(referenced_directly + ' - ' + not_referenced_directly); //only referenced_directly is increasing
+		console.log(referenced_directly + ' - ' + not_referenced_directly); //only referenced_directly is increasing
 	}
 </script>
 

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/Child.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/Child.svelte
@@ -1,24 +1,23 @@
 <script>
 	import { beforeUpdate, afterUpdate } from "svelte";
-	import { log } from './log.js';
 
 	export let a;
 	export let b;
 
 	beforeUpdate(() => {
-		log.push('before');
+		console.log('before');
 	});
 
 	beforeUpdate(()=>{
-		log.push(`before ${a}, ${b}`);
+		console.log(`before ${a}, ${b}`);
 	});
 
 	afterUpdate(() => {
-		log.push('after');
+		console.log('after');
 	});
 
 	afterUpdate(()=>{
-		log.push(`after ${a}, ${b}`);
+		console.log(`after ${a}, ${b}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/_config.js
@@ -1,13 +1,8 @@
 import { flushSync } from 'svelte';
-import { log } from './log.js';
 import { test, ok } from '../../test';
 
 export default test({
-	before_test: () => {
-		log.length = 0;
-	},
-
-	test({ assert, target }) {
+	test({ assert, target, logs }) {
 		const [button1, button2] = target.querySelectorAll('button');
 		ok(button1);
 		ok(button2);
@@ -18,7 +13,7 @@ export default test({
 		button2.click();
 		flushSync();
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'before',
 			'before 0, 0',
 			'after',

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/log.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-afterUpdate2/log.js
@@ -1,2 +1,0 @@
-/** @type {string[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-beforeUpdate/Child.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-beforeUpdate/Child.svelte
@@ -1,7 +1,6 @@
 <script>
 	export let name;
-	export let log;
-	$: log.push('name in child: ' + name);
+	$: console.log('name in child: ' + name);
 </script>
 
 <p>welcome, dan</p>

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-beforeUpdate/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-beforeUpdate/_config.js
@@ -2,11 +2,11 @@ import { test } from '../../test';
 import { flushSync } from 'svelte';
 
 export default test({
-	async test({ assert, target, component }) {
+	async test({ assert, target, logs }) {
 		const input = /** @type {HTMLInputElement} */ (target.querySelector('input'));
 		assert.equal(input?.value, 'rich');
 
-		assert.deepEqual(component.log, []);
+		assert.deepEqual(logs, []);
 
 		const inputEvent = new window.InputEvent('input');
 		input.value = 'dan';
@@ -14,15 +14,15 @@ export default test({
 
 		flushSync();
 
-		assert.deepEqual(component.log, ['name in child: dan']);
+		assert.deepEqual(logs, ['name in child: dan']);
 
-		component.log.length = 0;
+		logs.length = 0;
 
 		input.value = 'da';
 		await input.dispatchEvent(inputEvent);
 
 		flushSync();
 
-		assert.deepEqual(component.log, []);
+		assert.deepEqual(logs, []);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-beforeUpdate/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/lifecycle-render-beforeUpdate/main.svelte
@@ -2,8 +2,6 @@
 	import { beforeUpdate } from 'svelte';
 	import Child from './Child.svelte';
 
-	export let log = [];
-	
 	let name = 'rich';
 	let allowed = false;
 
@@ -16,5 +14,5 @@
 <input bind:value={name} />
 
 {#if allowed}
-	<Child name={name} log={log} />
+	<Child name={name} />
 {/if}

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/_config.js
@@ -1,21 +1,16 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	html: '<button>1 / 1</button>',
 
-	before_test() {
-		log.length = 0;
-	},
-
-	test({ assert, target }) {
-		assert.deepEqual(log, [2, 1]);
+	test({ assert, target, logs }) {
+		assert.deepEqual(logs, [2, 1]);
 
 		const button = target.querySelector('button');
 
 		flushSync(() => button?.click());
-		assert.deepEqual(log, [2, 1, 2, 1]);
+		assert.deepEqual(logs, [2, 1, 2, 1]);
 
 		assert.htmlEqual(target.innerHTML, '<button>3 / 2</button>');
 	}

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/log.js
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/reactive-assignment-prevent-loop/main.svelte
@@ -1,6 +1,4 @@
 <script>
-	import { log } from './log.js';
-
 	let count1 = 0;
 	let count2 = 0;
 
@@ -9,12 +7,12 @@
 	}
 
 	$: if (count2 < 10) {
-		log.push(1);
+		console.log(1);
 		increaseCount1();
 	}
 
 	$: if (count1 < 10) {
-		log.push(2);
+		console.log(2);
 		count2++;
 	}
 </script>

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -176,7 +176,7 @@ async function run_test_variant(
 			console.log = (...args) => logs.push(...args);
 		}
 
-		if (str.slice(0, i).includes('warnings')) {
+		if (str.slice(0, i).includes('warnings') || config.warnings) {
 			// eslint-disable-next-line no-console
 			console.warn = (...args) => warnings.push(...args);
 		}

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -299,13 +299,6 @@ async function run_test_variant(
 				assert.fail('Expected a runtime error');
 			}
 
-			if (config.warnings) {
-				assert.deepEqual(warnings, config.warnings);
-			} else if (warnings.length) {
-				unintended_error = true;
-				assert.fail('Received unexpected warnings');
-			}
-
 			if (config.html) {
 				flushSync();
 				assert_html_equal_with_options(target.innerHTML, config.html, {
@@ -344,6 +337,14 @@ async function run_test_variant(
 				}
 			} finally {
 				instance.$destroy();
+
+				if (config.warnings) {
+					assert.deepEqual(warnings, config.warnings);
+				} else if (warnings.length && console.warn === warn) {
+					unintended_error = true;
+					warn.apply(console, warnings);
+					assert.fail('Received unexpected warnings');
+				}
 
 				assert_html_equal(
 					target.innerHTML,

--- a/packages/svelte/tests/runtime-runes/samples/action-context/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/action-context/_config.js
@@ -1,22 +1,17 @@
 import { ok, test } from '../../test';
-import { flushSync, tick } from 'svelte';
-import { log } from './log.js';
+import { flushSync } from 'svelte';
 
 export default test({
 	html: `<button>0</button>`,
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 		ok(btn);
 
 		flushSync(() => btn.click());
-		assert.deepEqual(log, ['update', 0, 1]);
+		assert.deepEqual(logs, ['update', 0, 1]);
 
 		flushSync(() => btn.click());
-		assert.deepEqual(log, ['update', 0, 1, 'destroy', 1]);
+		assert.deepEqual(logs, ['update', 0, 1, 'destroy', 1]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/action-context/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/action-context/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/action-context/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/action-context/main.svelte
@@ -1,6 +1,4 @@
 <script>
-	import { log } from './log.js';
-
 	let count = $state(0);
 
 	/**
@@ -12,10 +10,10 @@
 			count,
 			/** @param {number} count */
 			update(count) {
-				log.push('update', this.count, (this.count = count));
+				console.log('update', this.count, (this.count = count));
 			},
 			destroy() {
-				log.push('destroy', this.count);
+				console.log('destroy', this.count);
 			},
 		}
 	};

--- a/packages/svelte/tests/runtime-runes/samples/action-state-arg-deep/Task.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/action-state-arg-deep/Task.svelte
@@ -1,6 +1,4 @@
 <script>
-	import { log } from './log.js';
-
   const { prop } = $props()
 
   let trackedState = $state(0)
@@ -8,7 +6,7 @@
 
   function dummyAction(el, { getTrackedState, propFromComponent }) {
     $effect(() => {
-      log.push("action $effect: ", { buttonClicked: getTrackedState() })
+      console.log("action $effect: ", { buttonClicked: getTrackedState() })
     })
   }
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/action-state-arg-deep/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/action-state-arg-deep/_config.js
@@ -1,15 +1,10 @@
 import { test } from '../../test';
-import { flushSync, tick } from 'svelte';
-import { log } from './log.js';
+import { flushSync } from 'svelte';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
 	html: `<div class="container">{"text":"initial"}</div><button>update tracked state</button><button>Update prop</button>`,
 
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -30,7 +25,7 @@ export default test({
 			`<div class="container">{"text":"updated"}</div><button>update tracked state</button><button>Update prop</button>`
 		);
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'action $effect: ',
 			{ buttonClicked: 0 },
 			'action $effect: ',

--- a/packages/svelte/tests/runtime-runes/samples/action-state-arg-deep/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/action-state-arg-deep/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/Child.svelte
@@ -2,11 +2,10 @@
 
 <script>
 	import { beforeUpdate } from 'svelte';
-	import { logs } from './logs.js'
 
 	export let object;
 
 	beforeUpdate(() => {
-		logs.push('changed');
+		console.log('changed');
 	});
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/_config.js
@@ -1,20 +1,15 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { logs } from './logs.js';
 
 export default test({
 	html: `<button>clicks: 0</button>`,
 
-	test({ assert, target }) {
+	test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		flushSync(() => btn?.click());
 
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
 		assert.deepEqual(logs, ['changed', 'changed']);
-	},
-
-	after_test() {
-		logs.length = 0;
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/logs.js
+++ b/packages/svelte/tests/runtime-runes/samples/before-update-in-legacy-child/logs.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const logs = [];

--- a/packages/svelte/tests/runtime-runes/samples/bind-this-proxy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-this-proxy/_config.js
@@ -1,15 +1,10 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test: () => {
-		log.length = 0;
-	},
-
 	html: `<button>Toggle</button><div>Hello\nworld</div>`,
 
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [btn1] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -24,6 +19,6 @@ export default test({
 
 		assert.htmlEqual(target.innerHTML, `<button>Toggle</button><div>Hello\nworld</div>`);
 
-		assert.deepEqual(log, [{ a: {} }, null, { a: {} }]);
+		assert.deepEqual(logs, [{ a: {} }, null, { a: {} }]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/bind-this-proxy/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-this-proxy/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/bind-this-proxy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-this-proxy/main.svelte
@@ -1,12 +1,11 @@
 <script>
-	import { log } from './log.js';
 	import Component from './Component.svelte';
 
 	let type = $state(Component)
 	let elem = $state()
 
 	$effect(() => {
-		log.push(elem);
+		console.log(elem);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/class-frozen-state-object/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-frozen-state-object/_config.js
@@ -1,14 +1,9 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	html: `<button>0</button>`,
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		await btn?.click();
@@ -17,6 +12,6 @@ export default test({
 		await btn?.click();
 		assert.htmlEqual(target.innerHTML, `<button>0</button>`);
 
-		assert.deepEqual(log, ['read only', 'read only']);
+		assert.deepEqual(logs, ['read only', 'read only']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/class-frozen-state-object/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-frozen-state-object/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/class-frozen-state-object/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-frozen-state-object/main.svelte
@@ -1,6 +1,4 @@
 <script>
-	import { log } from './log.js';
-
 	class Counter {
 		count = $state.frozen({ a: 0 });
 	}
@@ -11,6 +9,6 @@
 	try {
 		counter.count.a++
 	} catch (e) {
-		log.push('read only')
+		console.log('read only')
 	}
 }}>{counter.count.a}</button>

--- a/packages/svelte/tests/runtime-runes/samples/class-private-frozen-state-object/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-private-frozen-state-object/_config.js
@@ -1,14 +1,9 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	html: `<button>0</button>`,
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		await btn?.click();
@@ -17,6 +12,6 @@ export default test({
 		await btn?.click();
 		assert.htmlEqual(target.innerHTML, `<button>0</button>`);
 
-		assert.deepEqual(log, ['read only', 'read only']);
+		assert.deepEqual(logs, ['read only', 'read only']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/class-private-frozen-state-object/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-private-frozen-state-object/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/class-private-frozen-state-object/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-private-frozen-state-object/main.svelte
@@ -1,6 +1,4 @@
 <script>
-	import { log } from './log.js';
-
 	class Counter {
 		#count = $state.frozen();
 
@@ -22,6 +20,6 @@
 	try {
 		counter.count.a++
 	} catch (e) {
-		log.push('read only')
+		console.log('read only')
 	}
 }}>{counter.count.a}</button>

--- a/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/_config.js
@@ -1,41 +1,36 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	// The component context class instance gets shared between tests, strangely, causing hydration to fail?
 	mode: ['client', 'server'],
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		flushSync(() => {
 			btn?.click();
 		});
 
-		assert.deepEqual(log, [0, 'class trigger false', 'local trigger false', 1]);
+		assert.deepEqual(logs, [0, 'class trigger false', 'local trigger false', 1]);
 
 		flushSync(() => {
 			btn?.click();
 		});
 
-		assert.deepEqual(log, [0, 'class trigger false', 'local trigger false', 1, 2]);
+		assert.deepEqual(logs, [0, 'class trigger false', 'local trigger false', 1, 2]);
 
 		flushSync(() => {
 			btn?.click();
 		});
 
-		assert.deepEqual(log, [0, 'class trigger false', 'local trigger false', 1, 2, 3]);
+		assert.deepEqual(logs, [0, 'class trigger false', 'local trigger false', 1, 2, 3]);
 
 		flushSync(() => {
 			btn?.click();
 		});
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			0,
 			'class trigger false',
 			'local trigger false',

--- a/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-derived-unowned/main.svelte
@@ -11,8 +11,6 @@
 </script>
 
 <script>
-	import { log } from './log.js';
-
 	function increment() {
 		someLogic.trigger();
 	}
@@ -20,13 +18,13 @@
 	let localDerived = $derived(someLogic.someValue > 3);
 
 	$effect(() => {
-		log.push(someLogic.someValue);
+		console.log(someLogic.someValue);
 	});
 	$effect(() => {
-		log.push('class trigger ' + someLogic.isAboveThree)
+		console.log('class trigger ' + someLogic.isAboveThree)
 	});
 	$effect(() => {
-		log.push('local trigger ' + localDerived)
+		console.log('local trigger ' + localDerived)
 	});
 
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-2/_config.js
@@ -1,14 +1,9 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	html: `<button>0</button>`,
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		await btn?.click();
@@ -17,6 +12,6 @@ export default test({
 		await btn?.click();
 		assert.htmlEqual(target.innerHTML, `<button>2</button>`);
 
-		assert.deepEqual(log, [undefined]);
+		assert.deepEqual(logs, [undefined]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-2/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-2/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-2/main.svelte
@@ -1,8 +1,6 @@
 <script>
-	import { log } from './log.js';
-
 	const logger = (obj) => {
-		log.push(obj.count)
+		console.log(obj.count)
 	}
 
 	class Counter {

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-3/_config.js
@@ -1,14 +1,9 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	html: `<button>0</button>`,
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		await btn?.click();
@@ -17,6 +12,6 @@ export default test({
 		await btn?.click();
 		assert.htmlEqual(target.innerHTML, `<button>2</button>`);
 
-		assert.deepEqual(log, [undefined]);
+		assert.deepEqual(logs, [undefined]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-3/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-3/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-3/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager-3/main.svelte
@@ -1,12 +1,10 @@
 <script>
-	import { log } from './log.js';
-
 	class Counter {
 		count = $state();
 		#count;
 
 		constructor(initial_count) {
-			log.push(this.count)
+			console.log(this.count)
 			this.count = initial_count;
 		}
 	}

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager/_config.js
@@ -1,14 +1,9 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	html: `<button>0</button>`,
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		await btn?.click();
@@ -17,6 +12,6 @@ export default test({
 		await btn?.click();
 		assert.htmlEqual(target.innerHTML, `<button>2</button>`);
 
-		assert.deepEqual(log, [100]);
+		assert.deepEqual(logs, [100]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/class-state-init-eager/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-init-eager/main.svelte
@@ -1,12 +1,10 @@
 <script>
-	import { log } from './log.js';
-
 	class Counter {
 		count = $state(100);
 		#count;
 
 		constructor(initial_count) {
-			log.push(this.count)
+			console.log(this.count)
 			this.count = initial_count;
 		}
 	}

--- a/packages/svelte/tests/runtime-runes/samples/derived-destructure/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-destructure/_config.js
@@ -1,28 +1,23 @@
 import { test } from '../../test';
 import { flushSync } from 'svelte';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1, b2, b3] = target.querySelectorAll('button');
-		log.length = 0;
+		logs.length = 0;
 		flushSync(() => {
 			b1.click();
 		});
-		assert.deepEqual(log, ['a', 1]);
-		log.length = 0;
+		assert.deepEqual(logs, ['a', 1]);
+		logs.length = 0;
 		flushSync(() => {
 			b2.click();
 		});
-		assert.deepEqual(log, ['b', 1]);
-		log.length = 0;
+		assert.deepEqual(logs, ['b', 1]);
+		logs.length = 0;
 		flushSync(() => {
 			b3.click();
 		});
-		assert.deepEqual(log, ['c', 1]);
+		assert.deepEqual(logs, ['c', 1]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/derived-destructure/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-destructure/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/derived-destructure/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-destructure/main.svelte
@@ -1,21 +1,19 @@
 <script>
-	import { log } from './log.js';
-
 	let a = $state(0);
 	let b = $state(0);
 	let c = $state(0);
 	const {a: a1, b: b1, c: c1} = $derived({a, b, c});
 
 	$effect(() => {
-		log.push('a', a1)
+		console.log('a', a1)
 	});
 
 	$effect(() => {
-		log.push('b', b1)
+		console.log('b', b1)
 	});
 
 	$effect(() => {
-		log.push('c', c1)
+		console.log('c', c1)
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-destructure/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-destructure/_config.js
@@ -1,19 +1,15 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
+	mode: ['server'],
 	html: `<button>0</button>`,
 
-	async test({ assert, target, window }) {
+	async test({ assert, target, window, logs }) {
 		const btn = target.querySelector('button');
 		const clickEvent = new window.Event('click', { bubbles: true });
 		await btn?.dispatchEvent(clickEvent);
 
 		assert.htmlEqual(target.innerHTML, `<button>2</button>`);
-		assert.deepEqual(log, ['create_derived']);
+		assert.deepEqual(logs, ['create_derived']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-destructure/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-destructure/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-destructure/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-destructure/main.svelte
@@ -1,9 +1,7 @@
 <script>
-	import {log} from './log.js'
-
   let count = $state(0);
 	function create_derived() {
-		log.push('create_derived');
+		console.log('create_derived');
 		return () => {
 			return {
 				get double() {

--- a/packages/svelte/tests/runtime-runes/samples/derived-stale-value/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-stale-value/_config.js
@@ -1,13 +1,8 @@
 import { test } from '../../test';
 import { flushSync } from 'svelte';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 		flushSync(() => {
 			b1.click();
@@ -21,6 +16,6 @@ export default test({
 		flushSync(() => {
 			b1.click();
 		});
-		assert.deepEqual(log, [0, 2, 4]);
+		assert.deepEqual(logs, [0, 2, 4]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/derived-stale-value/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-stale-value/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/derived-stale-value/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-stale-value/main.svelte
@@ -1,12 +1,10 @@
 <script>
-	import { log } from './log.js';
-
 	let count = $state(0);
 	const derived = $derived(Math.floor(count / 2));
 	const derived2 = $derived(derived * 2);
 
 	$effect(() => {
-		log.push(derived2);
+		console.log(derived2);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/destructure-derived-event/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/destructure-derived-event/_config.js
@@ -1,15 +1,10 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target, window }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 		await btn?.click();
 
-		assert.deepEqual(log, ['works!']);
+		assert.deepEqual(logs, ['works!']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/destructure-derived-event/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/destructure-derived-event/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/destructure-derived-event/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/destructure-derived-event/main.svelte
@@ -1,9 +1,7 @@
 <script>
-	import { log } from './log.js';
-
 	let structured = $state({
 		handler() {
-			log.push('works!')
+			console.log('works!')
 		}
 	});
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-transition/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-transition/_config.js
@@ -1,31 +1,26 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1, b2] = target.querySelectorAll('button');
 
 		flushSync(() => {
 			b1.click();
 		});
 
-		assert.deepEqual(log, ['transition 2']);
+		assert.deepEqual(logs, ['transition 2']);
 
 		flushSync(() => {
 			b2.click();
 		});
 
-		assert.deepEqual(log, ['transition 2']);
+		assert.deepEqual(logs, ['transition 2']);
 
 		flushSync(() => {
 			b1.click();
 		});
 
-		assert.deepEqual(log, ['transition 2', 'transition 1']);
+		assert.deepEqual(logs, ['transition 2', 'transition 1']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-transition/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-transition/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-transition/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-transition/main.svelte
@@ -1,8 +1,6 @@
 <script>
-	import { log } from './log.js';
-
 	function transition1() {
-		log.push('transition 1')
+		console.log('transition 1')
 		return {
 			tick() {
 
@@ -11,7 +9,7 @@
 	}
 
 	function transition2() {
-		log.push('transition 2')
+		console.log('transition 2')
 		return {
 			tick() {
 

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
@@ -1,13 +1,8 @@
 import { test } from '../../test';
 import { flushSync } from 'svelte';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 		flushSync(() => {
 			b1.click();
@@ -15,6 +10,6 @@ export default test({
 		flushSync(() => {
 			b1.click();
 		});
-		assert.deepEqual(log, ['init 0', 'cleanup 2', null, 'init 2', 'cleanup 4', null, 'init 4']);
+		assert.deepEqual(logs, ['init 0', 'cleanup 2', null, 'init 2', 'cleanup 4', null, 'init 4']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/main.svelte
@@ -1,17 +1,15 @@
 <script>
-	import { log } from './log.js';
-
 	let count = $state(0);
 
 	$effect(() => {
 		let double = $derived(count * 2)
 
-		log.push('init ' + double);
+		console.log('init ' + double);
 
 		return function() {
-			log.push('cleanup ' + double);
+			console.log('cleanup ' + double);
 			// @ts-expect-error
-			log.push(this);
+			console.log(this);
 		};
 	})
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/effect-order-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order-2/_config.js
@@ -1,13 +1,8 @@
 import { test } from '../../test';
 import { flushSync } from 'svelte';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 		flushSync(() => {
 			b1.click();
@@ -15,7 +10,7 @@ export default test({
 		flushSync(() => {
 			b1.click();
 		});
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			{ a: 1 },
 			{ b: 1 },
 			{ c: 1 },

--- a/packages/svelte/tests/runtime-runes/samples/effect-order-2/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order-2/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/effect-order-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order-2/main.svelte
@@ -1,19 +1,18 @@
 <script>
-	import { log } from './log.js';
 	let a = $state(1);
 	let b = $state(1);
 	let c = $state(1);
 
 	$effect(() => {
-		log.push({ a });
+		console.log({ a });
 	});
 
 	$effect(() => {
-		log.push({ b });
+		console.log({ b });
 	});
 
 	$effect(() => {
-		log.push({ c });
+		console.log({ c });
 	});
 
 	function increment() {

--- a/packages/svelte/tests/runtime-runes/samples/effect-order/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order/_config.js
@@ -1,13 +1,8 @@
 import { test } from '../../test';
 import { flushSync } from 'svelte';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 		flushSync(() => {
 			b1.click();
@@ -15,6 +10,6 @@ export default test({
 		flushSync(() => {
 			b1.click();
 		});
-		assert.deepEqual(log, ['A', 'B', 'A', 'B', 'A', 'B']);
+		assert.deepEqual(logs, ['A', 'B', 'A', 'B', 'A', 'B']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect-order/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/effect-order/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order/main.svelte
@@ -1,17 +1,15 @@
 <script>
-	import { log } from './log.js';
-
 	let s = $state(0);
 	let d = $derived(s)
 
 	$effect(() => {
 		s;
-		log.push('A')
+		console.log('A')
 	})
 
 	$effect(() => {
 		d;
-		log.push('B')
+		console.log('B')
 	})
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/effect-root-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root-2/_config.js
@@ -1,31 +1,26 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1, b2] = target.querySelectorAll('button');
 
 		flushSync(() => {
 			b1.click();
 		});
 
-		assert.deepEqual(log, [0]);
+		assert.deepEqual(logs, [0]);
 
 		flushSync(() => {
 			b2.click();
 		});
 
-		assert.deepEqual(log, [0, 'cleanup']);
+		assert.deepEqual(logs, [0, 'cleanup']);
 
 		flushSync(() => {
 			b1.click();
 		});
 
-		assert.deepEqual(log, [0, 'cleanup']);
+		assert.deepEqual(logs, [0, 'cleanup']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect-root-2/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root-2/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/effect-root-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root-2/main.svelte
@@ -1,11 +1,9 @@
 <script>
-	import { log } from './log.js';
-
 	let x = $state(0);
 
 	const cleanup = $effect.root(() => {
-		log.push(x);
-		return () => log.push('cleanup');
+		console.log(x);
+		return () => console.log('cleanup');
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/effect-root/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root/_config.js
@@ -1,13 +1,8 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1, b2, b3] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -15,19 +10,19 @@ export default test({
 			b2.click();
 		});
 
-		assert.deepEqual(log, [0, 1]);
+		assert.deepEqual(logs, [0, 1]);
 
 		flushSync(() => {
 			b3.click();
 		});
 
-		assert.deepEqual(log, [0, 1, 'cleanup 1', 'cleanup 2']);
+		assert.deepEqual(logs, [0, 1, 'cleanup 1', 'cleanup 2']);
 
 		flushSync(() => {
 			b1.click();
 			b2.click();
 		});
 
-		assert.deepEqual(log, [0, 1, 'cleanup 1', 'cleanup 2']);
+		assert.deepEqual(logs, [0, 1, 'cleanup 1', 'cleanup 2']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect-root/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/effect-root/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root/main.svelte
@@ -1,22 +1,20 @@
 <script>
-	import { log } from './log.js';
-
 	let x = $state(0);
 	let y = $state(0);
 
 	const cleanup = $effect.root(() => {
 		$effect(() => {
-			log.push(x);
+			console.log(x);
 		});
 
 		const nested_cleanup = $effect.root(() => {
 			return () => {
-				log.push('cleanup 2');
+				console.log('cleanup 2');
 			}
 		});
 
 		return () => {
-			log.push('cleanup 1');
+			console.log('cleanup 1');
 			nested_cleanup();
 		}
 	});

--- a/packages/svelte/tests/runtime-runes/samples/effect/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1, b2] = target.querySelectorAll('button');
 		b1.click();
 		b2.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, [0, 1]);
+		assert.deepEqual(logs, [0, 1]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/effect/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect/main.svelte
@@ -1,11 +1,9 @@
 <script>
-	import { log } from './log.js';
-
 	let x = $state(0);
 	let y = $state(0);
 
 	$effect(() => {
-		log.push(x);
+		console.log(x);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/effects-order/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effects-order/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1, b2] = target.querySelectorAll('button');
 		b1.click();
 		b2.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, ['first0', 'second0', 'first1', 'second1']);
+		assert.deepEqual(logs, ['first0', 'second0', 'first1', 'second1']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effects-order/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/effects-order/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/effects-order/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effects-order/main.svelte
@@ -1,15 +1,13 @@
 <script>
-	import { log } from './log.js';
-
 	let x = $state(0);
 	let y = $state(0);
 
 	$effect.pre(() => {
-		log.push('first'+x);
+		console.log('first'+x);
 	});
 
 	$effect(() => {
-		log.push('second'+x);
+		console.log('second'+x);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-2/_config.js
@@ -1,13 +1,8 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -15,6 +10,6 @@ export default test({
 		});
 
 		await Promise.resolve();
-		assert.deepEqual(log, ['clicked button']);
+		assert.deepEqual(logs, ['clicked button']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-2/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-2/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-2/main.svelte
@@ -1,8 +1,5 @@
-<script>
-	import { log } from './log.js';
-</script>
-<div on:click={(e) => { log.push('clicked div') }}>
-	<button onclick={(e) => { log.push('clicked button'); e.stopPropagation() }}>
+<div on:click={(e) => { console.log('clicked div') }}>
+	<button onclick={(e) => { console.log('clicked button'); e.stopPropagation() }}>
 		Button
 	</button>
 </div>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-3/_config.js
@@ -1,13 +1,8 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -15,6 +10,6 @@ export default test({
 		});
 
 		await Promise.resolve();
-		assert.deepEqual(log, ['clicked button']);
+		assert.deepEqual(logs, ['clicked button']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-3/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-3/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-3/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-3/main.svelte
@@ -1,11 +1,10 @@
 <script>
-	import { log } from './log.js';
 	const action = () => {}
 </script>
-<div use:action onclick={() => log.push('clicked container')} onkeydown={() => {}}>
-	<div use:action onclick={(e) => { log.push('clicked div 1') }}>
-		<div onclick={(e) => { log.push('clicked div 2') }}>
-			<button onclick={(e) => { log.push('clicked button'); e.stopPropagation() }}>
+<div use:action onclick={() => console.log('clicked container')} onkeydown={() => {}}>
+	<div use:action onclick={(e) => { console.log('clicked div 1') }}>
+		<div onclick={(e) => { console.log('clicked div 2') }}>
+			<button onclick={(e) => { console.log('clicked button'); e.stopPropagation() }}>
 				Button
 			</button>
 		</div>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
 		btn1?.click();
 		await Promise.resolve();
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'button main',
 			'div main 1',
 			'div main 2',
@@ -21,10 +16,10 @@ export default test({
 			'window sub'
 		]);
 
-		log.length = 0;
+		logs.length = 0;
 		btn2?.click();
 		await Promise.resolve();
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'button sub',
 			'document main',
 			'document sub',

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/main.svelte
@@ -3,11 +3,11 @@
 	import Sub from "./sub.svelte";
 </script>
 
-<svelte:window onclick="{() => log.push('window main')}" />
-<svelte:document onclick="{() => log.push('document main')}" />
+<svelte:window onclick="{() => console.log('window main')}" />
+<svelte:document onclick="{() => console.log('document main')}" />
 
-<div on:click={() => log.push('div main 1')} on:click={() => log.push('div main 2')}>
-	<button onclick={() => log.push('button main')}>main</button>
+<div on:click={() => console.log('div main 1')} on:click={() => console.log('div main 2')}>
+	<button onclick={() => console.log('button main')}>main</button>
 </div>
 
 <Sub />

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/main.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { log } from "./log";
 	import Sub from "./sub.svelte";
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/sub.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/sub.svelte
@@ -2,7 +2,7 @@
 	import { log } from "./log";
 </script>
 
-<svelte:window onclick={() => log.push('window sub')} />
-<svelte:document onclick={() => log.push('document sub')} />
+<svelte:window onclick={() => console.log('window sub')} />
+<svelte:document onclick={() => console.log('document sub')} />
 
-<button onclick={() => log.push('button sub')}>sub</button>
+<button onclick={() => console.log('button sub')}>sub</button>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/sub.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-4/sub.svelte
@@ -1,7 +1,3 @@
-<script>
-	import { log } from "./log";
-</script>
-
 <svelte:window onclick={() => console.log('window sub')} />
 <svelte:document onclick={() => console.log('document sub')} />
 

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		btn?.click();
 		await Promise.resolve();
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'button onclick',
 			'button on:click',
 			'inner div on:click',

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/main.svelte
@@ -1,7 +1,3 @@
-<script>
-	import { log } from "./log";
-</script>
-
 <div onclick={() => console.log('outer div onclick')}>
 	<div on:click={() => console.log('inner div on:click')}>
 		<button onclick={() => console.log('button onclick')} on:click={() => console.log('button on:click')}>main</button>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-5/main.svelte
@@ -2,8 +2,8 @@
 	import { log } from "./log";
 </script>
 
-<div onclick={() => log.push('outer div onclick')}>
-	<div on:click={() => log.push('inner div on:click')}>
-		<button onclick={() => log.push('button onclick')} on:click={() => log.push('button on:click')}>main</button>
+<div onclick={() => console.log('outer div onclick')}>
+	<div on:click={() => console.log('inner div on:click')}>
+		<button onclick={() => console.log('button onclick')} on:click={() => console.log('button on:click')}>main</button>
 	</div>
 </div>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-6/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-6/_config.js
@@ -1,16 +1,11 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		btn?.click();
 		await Promise.resolve();
-		assert.deepEqual(log, ['method']);
+		assert.deepEqual(logs, ['method']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-6/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-6/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-6/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-6/main.svelte
@@ -1,9 +1,7 @@
 <script>
-	import { log } from './log.js';
-
 	let method = $state('method');
 	function submitPay() {
-		log.push(method);
+		console.log(method);
 	}
 	let methods = [{method:1}];
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-7/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-7/_config.js
@@ -1,16 +1,11 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
 		btn?.click();
 		await Promise.resolve();
-		assert.deepEqual(log, ['div onclickcapture', 'button onclick']);
+		assert.deepEqual(logs, ['div onclickcapture', 'button onclick']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-7/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-7/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-7/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-7/main.svelte
@@ -2,6 +2,6 @@
 	import { log } from "./log";
 </script>
 
-<div onclickcapture={() => log.push('div onclickcapture')}>
-	<button onclick={() => log.push('button onclick')}>main</button>
+<div onclickcapture={() => console.log('div onclickcapture')}>
+	<button onclick={() => console.log('button onclick')}>main</button>
 </div>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-7/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-7/main.svelte
@@ -1,7 +1,3 @@
-<script>
-	import { log } from "./log";
-</script>
-
 <div onclickcapture={() => console.log('div onclickcapture')}>
 	<button onclick={() => console.log('button onclick')}>main</button>
 </div>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation/_config.js
@@ -1,13 +1,8 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -15,7 +10,7 @@ export default test({
 		});
 
 		await Promise.resolve();
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'clicked button',
 			'clicked div 2',
 			'clicked div 1',

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation/main.svelte
@@ -1,11 +1,10 @@
 <script>
-	import { log } from './log.js';
 	const action = () => {}
 </script>
-<div use:action onclick={() => log.push('clicked container')} onkeydown={() => {}}>
-	<div use:action onclick={(e) => { log.push('clicked div 1') }}>
-		<div onclick={(e) => { log.push('clicked div 2') }}>
-			<button onclick={(e) => { log.push('clicked button') }}>
+<div use:action onclick={() => console.log('clicked container')} onkeydown={() => {}}>
+	<div use:action onclick={(e) => { console.log('clicked div 1') }}>
+		<div onclick={(e) => { console.log('clicked div 2') }}>
+			<button onclick={(e) => { console.log('clicked button') }}>
 				Button
 			</button>
 		</div>

--- a/packages/svelte/tests/runtime-runes/samples/event-prop-reference/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-prop-reference/_config.js
@@ -1,21 +1,16 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
 	get props() {
 		return { item: { name: 'Dominic' } };
 	},
 
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 
 		b1?.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, ['Dominic']);
+		assert.deepEqual(logs, ['Dominic']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-prop-reference/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-prop-reference/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/event-prop-reference/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-prop-reference/main.svelte
@@ -1,10 +1,8 @@
 <script>
-	import { log } from './log.js';
-
 	let { item } = $props();
 
 	function onclick() {
-		log.push(item?.name);
+		console.log(item?.name);
 	}
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/inspect-derived-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-derived-2/_config.js
@@ -1,30 +1,12 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
-let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
-
 export default test({
 	compileOptions: {
 		dev: true
 	},
-	before_test() {
-		log = [];
-		original_log = console.log;
-		console.log = (...v) => {
-			log.push(...v);
-		};
-	},
-	after_test() {
-		console.log = original_log;
-	},
-	async test({ assert, target }) {
+
+	async test({ assert, target, logs }) {
 		const button = target.querySelector('button');
 
 		flushSync(() => {
@@ -32,7 +14,7 @@ export default test({
 		});
 
 		assert.htmlEqual(target.innerHTML, `<button>update</button>\n1`);
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'init',
 			{
 				data: {

--- a/packages/svelte/tests/runtime-runes/samples/inspect-multiple/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-multiple/_config.js
@@ -1,34 +1,16 @@
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
-let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
-
 export default test({
 	compileOptions: {
 		dev: true
 	},
-	before_test() {
-		log = [];
-		original_log = console.log;
-		console.log = (...v) => {
-			log.push(...v);
-		};
-	},
-	after_test() {
-		console.log = original_log;
-	},
-	async test({ assert, target }) {
+
+	async test({ assert, target, logs }) {
 		const [b1, b2] = target.querySelectorAll('button');
 		b1.click();
 		b2.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, ['init', 0, 0, 'update', 1, 0, 'update', 1, 1]);
+		assert.deepEqual(logs, ['init', 0, 0, 'update', 1, 0, 'update', 1, 1]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-nested-state/_config.js
@@ -1,34 +1,16 @@
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
-let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
-
 export default test({
 	compileOptions: {
 		dev: true
 	},
-	before_test() {
-		log = [];
-		original_log = console.log;
-		console.log = (...v) => {
-			log.push(...v);
-		};
-	},
-	after_test() {
-		console.log = original_log;
-	},
-	async test({ assert, target }) {
+
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 		b1.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'init',
 			{ x: { count: 0 } },
 			[{ count: 0 }],

--- a/packages/svelte/tests/runtime-runes/samples/inspect-new-property/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-new-property/_config.js
@@ -1,33 +1,15 @@
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
-let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
-
 export default test({
 	compileOptions: {
 		dev: true
 	},
-	before_test() {
-		log = [];
-		original_log = console.log;
-		console.log = (...v) => {
-			log.push(...v);
-		};
-	},
-	after_test() {
-		console.log = original_log;
-	},
-	async test({ assert, target }) {
+
+	async test({ assert, target, logs }) {
 		const [btn] = target.querySelectorAll('button');
 		btn.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, ['init', {}, 'init', [], 'update', { x: 'hello' }, 'update', ['hello']]);
+		assert.deepEqual(logs, ['init', {}, 'init', [], 'update', { x: 'hello' }, 'update', ['hello']]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/inspect-trace/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-trace/_config.js
@@ -1,37 +1,19 @@
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
-let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
-
 export default test({
 	compileOptions: {
 		dev: true
 	},
-	before_test() {
-		log = [];
-		original_log = console.log;
-		console.log = (...v) => {
-			log.push(...v);
-		};
-	},
-	after_test() {
-		console.log = original_log;
-	},
-	async test({ assert, target }) {
-		assert.deepEqual(log, []);
+
+	async test({ assert, target, logs }) {
+		assert.deepEqual(logs, []);
 
 		const [b1, b2] = target.querySelectorAll('button');
 		b1.click();
 		b2.click();
 		await Promise.resolve();
 
-		assert.ok(log[0].stack.startsWith('Error:') && log[0].stack.includes('HTMLButtonElement.'));
-		assert.deepEqual(log[1], 1);
+		assert.ok(logs[0].stack.startsWith('Error:') && logs[0].stack.includes('HTMLButtonElement.'));
+		assert.deepEqual(logs[1], 1);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/inspect/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect/_config.js
@@ -1,34 +1,16 @@
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
-let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
-
 export default test({
 	compileOptions: {
 		dev: true
 	},
-	before_test() {
-		log = [];
-		original_log = console.log;
-		console.log = (...v) => {
-			log.push(...v);
-		};
-	},
-	after_test() {
-		console.log = original_log;
-	},
-	async test({ assert, target }) {
+
+	async test({ assert, target, logs }) {
 		const [b1, b2] = target.querySelectorAll('button');
 		b1.click();
 		b2.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, ['init', 0, 'update', 1]);
+		assert.deepEqual(logs, ['init', 0, 'update', 1]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-2/Item.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-2/Item.svelte
@@ -1,23 +1,21 @@
 <script>
-	import { log } from './log.js';
-
 	let { index, n } = $props();
 
 	function logRender () {
-		log.push(`${index}: render ${n}`);
+		console.log(`${index}: render ${n}`);
 		return index;
 	}
 
 	$effect.pre(() => {
-		log.push(`${index}: $effect.pre ${n}`);
+		console.log(`${index}: $effect.pre ${n}`);
 	});
 
 	$effect.pre(() => {
-		log.push(`${index}: $effect.pre (2) ${n}`);
+		console.log(`${index}: $effect.pre (2) ${n}`);
 	});
 
 	$effect(() => {
-		log.push(`${index}: $effect ${n}`);
+		console.log(`${index}: $effect ${n}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-2/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	get props() {
 		return { n: 0 };
 	},
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, component }) {
-		assert.deepEqual(log, [
+	async test({ assert, component, logs }) {
+		assert.deepEqual(logs, [
 			'parent: $effect.pre 0',
 			'parent: $effect.pre (2) 0',
 			'parent: render 0',
@@ -30,11 +25,11 @@ export default test({
 			'parent: $effect 0'
 		]);
 
-		log.length = 0;
+		logs.length = 0;
 
 		component.n += 1;
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'parent: $effect.pre 1',
 			'parent: $effect.pre (2) 1',
 			'parent: render 1',

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-2/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-2/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-2/main.svelte
@@ -1,24 +1,23 @@
 <script>
 	import Item from './Item.svelte';
-	import { log } from './log.js';
 
 	let { n = 0 } = $props();
 
 	function logRender () {
-		log.push(`parent: render ${n}`);
+		console.log(`parent: render ${n}`);
 		return 'parent';
 	}
 
 	$effect.pre(() => {
-		log.push(`parent: $effect.pre ${n}`);
+		console.log(`parent: $effect.pre ${n}`);
 	});
 
 	$effect.pre(() => {
-		log.push(`parent: $effect.pre (2) ${n}`);
+		console.log(`parent: $effect.pre (2) ${n}`);
 	});
 
 	$effect(() => {
-		log.push(`parent: $effect ${n}`);
+		console.log(`parent: $effect ${n}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-3/Item.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-3/Item.svelte
@@ -1,19 +1,17 @@
 <script>
-	import { log } from './log.js';
-
 	let { index, n } = $props();
 
 	function logRender () {
-		log.push(`${index}: render ${n}`);
+		console.log(`${index}: render ${n}`);
 		return index;
 	}
 
 	$effect.pre(() => {
-		log.push(`${index}: $effect.pre ${n}`);
+		console.log(`${index}: $effect.pre ${n}`);
 	});
 
 	$effect(() => {
-		log.push(`${index}: $effect ${n}`);
+		console.log(`${index}: $effect ${n}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-3/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	get props() {
 		return { n: 0 };
 	},
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, component }) {
-		assert.deepEqual(log, [
+	async test({ assert, component, logs }) {
+		assert.deepEqual(logs, [
 			'parent: render 0',
 			'1: $effect.pre 0',
 			'1: render 0',
@@ -25,11 +20,11 @@ export default test({
 			'parent: $effect 0'
 		]);
 
-		log.length = 0;
+		logs.length = 0;
 
 		component.n += 1;
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'parent: render 1',
 			'1: $effect.pre 1',
 			'1: render 1',

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-3/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-3/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-3/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-3/main.svelte
@@ -1,16 +1,15 @@
 <script>
 	import Item from './Item.svelte';
-	import { log } from './log.js';
 
 	let { n = 0 } = $props();
 
 	function logRender () {
-		log.push(`parent: render ${n}`);
+		console.log(`parent: render ${n}`);
 		return 'parent';
 	}
 
 	$effect(() => {
-		log.push(`parent: $effect ${n}`);
+		console.log(`parent: $effect ${n}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-4/Item.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-4/Item.svelte
@@ -1,23 +1,21 @@
 <script>
-	import { log } from './log.js';
-
 	let { index, n } = $props();
 
 	function logRender () {
-		log.push(`${index}: render ${n}`);
+		console.log(`${index}: render ${n}`);
 		return index;
 	}
 
 	$effect.pre(() => {
-		log.push(`${index}: $effect.pre ${n}`);
+		console.log(`${index}: $effect.pre ${n}`);
 
 		$effect.pre(() => {
-			log.push(`${index}: nested $effect.pre ${n}`);
+			console.log(`${index}: nested $effect.pre ${n}`);
 		});
 	});
 
 	$effect(() => {
-		log.push(`${index}: $effect ${n}`);
+		console.log(`${index}: $effect ${n}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-4/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	get props() {
 		return { n: 0 };
 	},
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, component }) {
-		assert.deepEqual(log, [
+	async test({ assert, component, logs }) {
+		assert.deepEqual(logs, [
 			'parent: $effect.pre 0',
 			'parent: nested $effect.pre 0',
 			'parent: render 0',
@@ -30,11 +25,11 @@ export default test({
 			'parent: $effect 0'
 		]);
 
-		log.length = 0;
+		logs.length = 0;
 
 		component.n += 1;
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'parent: $effect.pre 1',
 			'parent: nested $effect.pre 1',
 			'parent: render 1',

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-4/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-4/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-4/main.svelte
@@ -1,24 +1,23 @@
 <script>
 	import Item from './Item.svelte';
-	import { log } from './log.js';
 
 	let { n = 0 } = $props();
 
 	function logRender () {
-		log.push(`parent: render ${n}`);
+		console.log(`parent: render ${n}`);
 		return 'parent';
 	}
 
 	$effect.pre(() => {
-		log.push(`parent: $effect.pre ${n}`);
+		console.log(`parent: $effect.pre ${n}`);
 
 		$effect.pre(() => {
-			log.push(`parent: nested $effect.pre ${n}`);
+			console.log(`parent: nested $effect.pre ${n}`);
 		});
 	});
 
 	$effect(() => {
-		log.push(`parent: $effect ${n}`);
+		console.log(`parent: $effect ${n}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/_config.js
@@ -1,21 +1,16 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	get props() {
 		return { n: 0 };
 	},
 
-	before_test() {
-		log.length = 0;
-	},
+	async test({ assert, component, logs }) {
+		assert.deepEqual(logs, ['$effect.pre 0', 'another $effect.pre 1', 'render n0', 'render i1']);
 
-	async test({ assert, component }) {
-		assert.deepEqual(log, ['$effect.pre 0', 'another $effect.pre 1', 'render n0', 'render i1']);
-
-		log.length = 0;
+		logs.length = 0;
 		component.n += 1;
 
-		assert.deepEqual(log, ['$effect.pre 1', 'another $effect.pre 2', 'render n1', 'render i2']);
+		assert.deepEqual(logs, ['$effect.pre 1', 'another $effect.pre 2', 'render n1', 'render i2']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-5/main.svelte
@@ -1,17 +1,20 @@
 <script>
 	import { untrack } from 'svelte';
-	import { log } from './log.js';
+
 	let { n = 0 } = $props();
 	let i = $state(0);
+
 	function logRender(i) {
-		log.push(`render ${i}`);
+		console.log(`render ${i}`);
 	}
+
 	$effect.pre(() => {
-		log.push(`$effect.pre ${n}`);
+		console.log(`$effect.pre ${n}`);
 		untrack(() => i++)
 	});
+
 	$effect.pre(() => {
-		log.push('another $effect.pre '+ i);
+		console.log('another $effect.pre '+ i);
 	})
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children/Item.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children/Item.svelte
@@ -1,19 +1,17 @@
 <script>
-	import { log } from './log.js';
-
 	let { index, n } = $props();
 
 	function logRender () {
-		log.push(`${index}: render ${n}`);
+		console.log(`${index}: render ${n}`);
 		return index;
 	}
 
 	$effect.pre(() => {
-		log.push(`${index}: $effect.pre ${n}`);
+		console.log(`${index}: $effect.pre ${n}`);
 	});
 
 	$effect(() => {
-		log.push(`${index}: $effect ${n}`);
+		console.log(`${index}: $effect ${n}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	get props() {
 		return { n: 0 };
 	},
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, component }) {
-		assert.deepEqual(log, [
+	async test({ assert, component, logs }) {
+		assert.deepEqual(logs, [
 			'parent: $effect.pre 0',
 			'parent: render 0',
 			'1: $effect.pre 0',
@@ -26,11 +21,11 @@ export default test({
 			'parent: $effect 0'
 		]);
 
-		log.length = 0;
+		logs.length = 0;
 
 		component.n += 1;
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'parent: $effect.pre 1',
 			'parent: render 1',
 			'1: $effect.pre 1',

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children/main.svelte
@@ -1,20 +1,19 @@
 <script>
 	import Item from './Item.svelte';
-	import { log } from './log.js';
 
 	let { n = 0 } = $props();
 
 	function logRender () {
-		log.push(`parent: render ${n}`);
+		console.log(`parent: render ${n}`);
 		return 'parent';
 	}
 
 	$effect.pre(() => {
-		log.push(`parent: $effect.pre ${n}`);
+		console.log(`parent: $effect.pre ${n}`);
 	});
 
 	$effect(() => {
-		log.push(`parent: $effect ${n}`);
+		console.log(`parent: $effect ${n}`);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/_config.js
@@ -1,13 +1,8 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -15,7 +10,7 @@ export default test({
 		});
 
 		await Promise.resolve();
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'top level',
 			'inner',
 			0,

--- a/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/main.svelte
@@ -1,18 +1,17 @@
 <script>
-	import { log } from './log.js';
 	let c = $state({ a: 0 });
 
 	$effect(() => {
-		log.push('top level')
-			$effect(() => {
-					if (c) {
-							$effect(() => {
-								log.push('inner',c.a);
-									return () => log.push('destroy inner', c?.a);
-							});
-					}
-					return () => log.push('destroy outer', c?.a);
-			})
+		console.log('top level')
+		$effect(() => {
+			if (c) {
+				$effect(() => {
+					console.log('inner',c.a);
+					return () => console.log('destroy inner', c?.a);
+				});
+			}
+			return () => console.log('destroy outer', c?.a);
+		});
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/nested-script-tag/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/nested-script-tag/_config.js
@@ -1,28 +1,9 @@
 import { test } from '../../test';
 
-/**
- * @type {any[]}
- */
-let log;
-/**
- * @type {typeof console.log}}
- */
-let original_log;
-
 export default test({
 	mode: ['client'],
 
-	before_test() {
-		log = [];
-		original_log = console.log;
-		console.log = (...v) => {
-			log.push(...v);
-		};
-	},
-	after_test() {
-		console.log = original_log;
-	},
-	async test({ assert }) {
-		assert.deepEqual(log, ['init']);
+	async test({ assert, logs }) {
+		assert.deepEqual(logs, ['init']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-3/_config.js
@@ -1,14 +1,8 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
 
-/** @type {typeof console.warn} */
-let warn;
-
 /** @type {typeof console.trace} */
 let trace;
-
-/** @type {any[]} */
-let warnings = [];
 
 export default test({
 	html: `<button>clicks: 0</button><button>clicks: 0</button>`,
@@ -18,24 +12,16 @@ export default test({
 	},
 
 	before_test: () => {
-		warn = console.warn;
 		trace = console.trace;
-
-		console.warn = (...args) => {
-			warnings.push(...args);
-		};
 
 		console.trace = () => {};
 	},
 
 	after_test: () => {
-		console.warn = warn;
 		console.trace = trace;
-
-		warnings = [];
 	},
 
-	async test({ assert, target }) {
+	async test({ assert, target, warnings }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
 		flushSync(() => btn1.click());

--- a/packages/svelte/tests/runtime-runes/samples/nullish-operator/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/nullish-operator/_config.js
@@ -1,14 +1,9 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert }) {
+	async test({ assert, logs }) {
 		await Promise.resolve();
 		await Promise.resolve();
-		assert.deepEqual(log, ['a1: ', true, 'b1: ', true]);
+		assert.deepEqual(logs, ['a1: ', true, 'b1: ', true]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/nullish-operator/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/nullish-operator/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/nullish-operator/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/nullish-operator/main.svelte
@@ -1,15 +1,13 @@
 <script>
-	import { log } from './log.js';
-
 	let a1 = $state();
 	let b1 = $state();
 
 	$effect(() => {
-		log.push('a1: ', a1);
+		console.log('a1: ', a1);
 	});
 
 	$effect(() => {
-		log.push('b1: ', b1);
+		console.log('b1: ', b1);
 	});
 
 	a();

--- a/packages/svelte/tests/runtime-runes/samples/pre-effect-ordering/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/pre-effect-ordering/_config.js
@@ -1,13 +1,8 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -17,7 +12,7 @@ export default test({
 			b1.click();
 		});
 
-		assert.deepEqual(log, [
+		assert.deepEqual(logs, [
 			'Outer Effect Start (0)',
 			'Inner Effect (0)',
 			'Outer Effect End (0)',

--- a/packages/svelte/tests/runtime-runes/samples/pre-effect-ordering/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/pre-effect-ordering/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/pre-effect-ordering/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/pre-effect-ordering/main.svelte
@@ -1,6 +1,4 @@
 <script>
-    import { log } from './log.js';
-
 	let count = $state(0);
 
 	function increment() {
@@ -8,13 +6,13 @@
 	}
 
 	$effect.pre(() => {
-		log.push(`Outer Effect Start (${count})`)
+		console.log(`Outer Effect Start (${count})`)
 
 		$effect.pre(() => {
-			log.push(`Inner Effect (${count})`)
+			console.log(`Inner Effect (${count})`)
 		});
 
-		log.push(`Outer Effect End (${count})`)
+		console.log(`Outer Effect End (${count})`)
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/pre-effect/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/pre-effect/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1, b2] = target.querySelectorAll('button');
 		b1.click();
 		b2.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, [0, 1]);
+		assert.deepEqual(logs, [0, 1]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/pre-effect/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/pre-effect/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/pre-effect/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/pre-effect/main.svelte
@@ -1,11 +1,9 @@
 <script>
-	import { log } from './log.js';
-
 	let x = $state(0);
 	let y = $state(0);
 
 	$effect.pre(() => {
-		log.push(x);
+		console.log(x);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/props-derived-2/Item.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived-2/Item.svelte
@@ -1,9 +1,7 @@
 <script>
-	import { log } from './log.js';
-
 	const {active} = $props();
 	$effect.pre(() => {
-		log.push('active changed', active)
+		console.log('active changed', active)
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/props-derived-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived-2/_config.js
@@ -1,19 +1,14 @@
 import { test } from '../../test';
 import { flushSync } from 'svelte';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
-		log.length = 0;
+	async test({ assert, target, logs }) {
+		logs.length = 0;
 
 		const input = /** @type {HTMLInputElement} */ (target.querySelector('input'));
 		input.value = '1';
 		flushSync(() => input.dispatchEvent(new window.Event('input')));
 
-		assert.deepEqual(log, ['active changed', false, 'active changed', true]);
+		assert.deepEqual(logs, ['active changed', false, 'active changed', true]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/props-derived-2/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived-2/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/props-equality/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-equality/main.svelte
@@ -11,7 +11,7 @@
 {/each}
 
 {#each items as item (item.name)}
-	<Item {item} {items} onclick={() => {console.log('hello'); item.name = item.name + '+'}} />
+	<Item {item} {items} onclick={() => item.name = item.name + '+'} />
 {/each}
 
 {#each items as item}

--- a/packages/svelte/tests/runtime-runes/samples/readonly-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/readonly-state/_config.js
@@ -1,17 +1,12 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const [b1, b2] = target.querySelectorAll('button');
 		b1.click();
 		b2.click();
 		await Promise.resolve();
 
-		assert.deepEqual(log, [0, 1]);
+		assert.deepEqual(logs, [0, 1]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/readonly-state/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/readonly-state/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/readonly-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/readonly-state/main.svelte
@@ -1,11 +1,9 @@
 <script>
-	import { log } from './log.js';
-
 	let x = $state.frozen(0);
 	let y = $state.frozen(0);
 
 	$effect(() => {
-		log.push(x);
+		console.log(x);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/snippet-reactive-args/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-reactive-args/_config.js
@@ -6,13 +6,8 @@ export default test({
 		<button>toggle</button>
 		<button>increase count</button>
 	`,
-	props: {
-		get log() {
-			return [];
-		}
-	},
 
-	async test({ assert, target, component }) {
+	async test({ assert, target, logs }) {
 		const [toggle, increment] = target.querySelectorAll('button');
 
 		await increment?.click();
@@ -24,7 +19,7 @@ export default test({
 				<button>increase count</button>
 			`
 		);
-		assert.deepEqual(component.log, []);
+		assert.deepEqual(logs, []);
 
 		await toggle?.click();
 		assert.htmlEqual(
@@ -35,7 +30,7 @@ export default test({
 				<button>increase count</button>
 			`
 		);
-		assert.deepEqual(component.log, [1]);
+		assert.deepEqual(logs, [1]);
 
 		await increment?.click();
 		assert.htmlEqual(
@@ -46,7 +41,7 @@ export default test({
 				<button>increase count</button>
 			`
 		);
-		assert.deepEqual(component.log, [1]);
+		assert.deepEqual(logs, [1]);
 
 		await toggle?.click();
 		assert.htmlEqual(
@@ -57,6 +52,6 @@ export default test({
 				<button>increase count</button>
 			`
 		);
-		assert.deepEqual(component.log, [1]);
+		assert.deepEqual(logs, [1]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/snippet-reactive-args/inner.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-reactive-args/inner.svelte
@@ -1,6 +1,6 @@
 <script>
-    let { count, log } = $props();
-    log.push(count);
+    let { count } = $props();
+    console.log(count);
 </script>
 
 <p>component: {count}</p>

--- a/packages/svelte/tests/runtime-runes/samples/snippet-reactive-args/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-reactive-args/main.svelte
@@ -1,8 +1,6 @@
 <script>
 	import Inner from "./inner.svelte";
 
-	let { log } = $props();
-
 	let count = $state(0);
 	let show_foo = $state(true);
 	let snippet = $derived(show_foo ? foo : bar);
@@ -16,7 +14,7 @@
 	<Inner {...props}></Inner>
 {/snippet}
 
-{@render snippet({ count, log })}
+{@render snippet({ count })}
 
 <button onclick={() => show_foo = !show_foo}>toggle</button>
 <button onclick={() => count++}>increase count</button>

--- a/packages/svelte/tests/runtime-runes/samples/store-subscribe-effect-init/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-subscribe-effect-init/_config.js
@@ -1,22 +1,17 @@
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
 	html: `<button>increment</button>`,
 
-	before_test() {
-		log.length = 0;
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, logs }) {
 		const btn = target.querySelector('button');
 
-		assert.deepEqual(log, [1]);
+		assert.deepEqual(logs, [1]);
 
 		await btn?.click();
-		assert.deepEqual(log, [1, 2]);
+		assert.deepEqual(logs, [1, 2]);
 
 		await btn?.click();
-		assert.deepEqual(log, [1, 2, 3]);
+		assert.deepEqual(logs, [1, 2, 3]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/store-subscribe-effect-init/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-subscribe-effect-init/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/store-subscribe-effect-init/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-subscribe-effect-init/main.svelte
@@ -1,6 +1,5 @@
 <script>
 	import { writable } from 'svelte/store';
-	import { log } from './log';
 
 	const count = writable(0);
 	let ran = 0;

--- a/packages/svelte/tests/runtime-runes/samples/store-subscribe-effect-init/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-subscribe-effect-init/main.svelte
@@ -7,7 +7,7 @@
 
 	$effect(() => {
 		$count;
-		log.push(++ran);
+		console.log(++ran);
 	});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/text-multiple-call-expression/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/text-multiple-call-expression/_config.js
@@ -1,13 +1,10 @@
 import { flushSync } from 'svelte';
 import { test } from '../../test';
-import { log } from './log.js';
 
 export default test({
-	before_test() {
-		log.length = 0;
-	},
+	async test({ assert, target, logs }) {
+		assert.deepEqual(logs, ['x', 'y']);
 
-	async test({ assert, target }) {
 		const [b1, b2] = target.querySelectorAll('button');
 
 		flushSync(() => {
@@ -18,6 +15,6 @@ export default test({
 			b2.click();
 		});
 
-		assert.deepEqual(log, ['x', 'y', 'x', 'y']);
+		assert.deepEqual(logs, ['x', 'y', 'x', 'y']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/text-multiple-call-expression/log.js
+++ b/packages/svelte/tests/runtime-runes/samples/text-multiple-call-expression/log.js
@@ -1,2 +1,0 @@
-/** @type {any[]} */
-export const log = [];

--- a/packages/svelte/tests/runtime-runes/samples/text-multiple-call-expression/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/text-multiple-call-expression/main.svelte
@@ -1,16 +1,14 @@
 <script>
-	import { log } from './log.js';
-
 	let x = $state(0);
 	let y = $state(0);
 
 	function getX() {
-		log.push('x')
+		console.log('x')
 		return x;
 	}
 
 	function getY() {
-		log.push('y')
+		console.log('y')
 		return y;
 	}
 </script>


### PR DESCRIPTION
At present we do one of two things with logs in tests:

- monkey-patch `console.log` and `console.warn` on a per-test basis. this involves lots of repetitious ugly code
- have a separate `log.js` file that exports a `log` array and do `log.push` instead of `console.log`. this is also repetitious (and requires a `before_test` or `after_test` hook to reset between different test modes), and is particularly annoying because in order to quickly try something out in the playground you need to rewrite the test if you want to actually see the logs

This PR makes things much simpler: we can access `logs` and `warnings` directly inside the `test` function.

If something gets logged before the test runs, and the test _doesn't_ use `logs`, then the logs get stashed away, and replayed when either `console.log` is first called inside the test or, if that doesn't happen, after the test has run, meaning that temporary logs will always be visible and in the correct order.

Draft because I haven't yet converted all the tests that use the old way of doing things