### PR TITLE
fix: only destroy snippets when they have changed

### DIFF
--- a/.changeset/shiny-mayflies-clean.md
+++ b/.changeset/shiny-mayflies-clean.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only destroy snippets when they have changed

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -28,7 +28,7 @@ export function if_block(
 	/** @type {boolean | null} */
 	let condition = null;
 
-	const effect = block(() => {
+	block(() => {
 		if (condition === (condition = !!get_condition())) return;
 
 		/** Whether or not there was a hydration mismatch. Needs to be a `let` or else it isn't treeshaken out */
@@ -76,9 +76,5 @@ export function if_block(
 			// continue in hydration mode
 			set_hydrating(true);
 		}
-	});
-
-	if (elseif) {
-		effect.f |= EFFECT_TRANSPARENT;
-	}
+	}, EFFECT_TRANSPARENT);
 }

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -15,19 +15,16 @@ export function snippet(get_snippet, node, ...args) {
 	/** @type {import('#client').Effect | null} */
 	var snippet_effect;
 
-	block(
-		() => {
-			if (snippet === (snippet = get_snippet())) return;
+	block(() => {
+		if (snippet === (snippet = get_snippet())) return;
 
-			if (snippet_effect) {
-				destroy_effect(snippet_effect);
-				snippet_effect = null;
-			}
+		if (snippet_effect) {
+			destroy_effect(snippet_effect);
+			snippet_effect = null;
+		}
 
-			if (snippet) {
-				snippet_effect = branch(() => /** @type {SnippetFn} */ (snippet)(node, ...args));
-			}
-		},
-		EFFECT_TRANSPARENT | (1 << 20)
-	);
+		if (snippet) {
+			snippet_effect = branch(() => /** @type {SnippetFn} */ (snippet)(node, ...args));
+		}
+	}, EFFECT_TRANSPARENT);
 }

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -7,7 +7,7 @@ import { should_intro } from '../../render.js';
 import { is_function } from '../../utils.js';
 import { current_each_item } from '../blocks/each.js';
 import { TRANSITION_GLOBAL, TRANSITION_IN, TRANSITION_OUT } from '../../../../constants.js';
-import { BLOCK_EFFECT, EFFECT_RAN } from '../../constants.js';
+import { BLOCK_EFFECT, EFFECT_RAN, EFFECT_TRANSPARENT } from '../../constants.js';
 
 /**
  * @template T
@@ -241,18 +241,26 @@ export function transition(flags, element, get_fn, get_params) {
 
 	(e.transitions ??= []).push(transition);
 
-	// if this is a local transition, we only want to run it if the parent (block) effect's
-	// parent (branch) effect is where the state change happened. we can determine that by
-	// looking at whether the branch effect is currently initializing
+	// if this is a local transition, we only want to run it if the parent (branch) effect's
+	// parent (block) effect is where the state change happened. we can determine that by
+	// looking at whether the block effect is currently initializing
 	if (is_intro && should_intro) {
-		var parent = /** @type {import('#client').Effect} */ (e.parent);
+		let run = is_global;
 
-		// e.g snippets are implemented as render effects — keep going until we find the parent block
-		while ((parent.f & BLOCK_EFFECT) === 0 && parent.parent) {
-			parent = parent.parent;
+		if (!run) {
+			var block = /** @type {import('#client').Effect} */ (e.parent);
+
+			// skip over transparent blocks (e.g. snippets, else-if blocks)
+			while (block && (block.f & EFFECT_TRANSPARENT) !== 0) {
+				while ((block = /** @type {import('#client').Effect} */ (block.parent))) {
+					if ((block.f & BLOCK_EFFECT) !== 0) break;
+				}
+			}
+
+			run = (block.f & EFFECT_RAN) !== 0;
 		}
 
-		if (is_global || (parent.f & EFFECT_RAN) !== 0) {
+		if (run) {
 			effect(() => {
 				untrack(() => transition.in());
 			});

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -248,16 +248,16 @@ export function transition(flags, element, get_fn, get_params) {
 		let run = is_global;
 
 		if (!run) {
-			var block = /** @type {import('#client').Effect} */ (e.parent);
+			var block = /** @type {import('#client').Effect | null} */ (e.parent);
 
 			// skip over transparent blocks (e.g. snippets, else-if blocks)
 			while (block && (block.f & EFFECT_TRANSPARENT) !== 0) {
-				while ((block = /** @type {import('#client').Effect} */ (block.parent))) {
+				while ((block = block.parent)) {
 					if ((block.f & BLOCK_EFFECT) !== 0) break;
 				}
 			}
 
-			run = (block.f & EFFECT_RAN) !== 0;
+			run = !block || (block.f & EFFECT_RAN) !== 0;
 		}
 
 		if (run) {

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -230,9 +230,12 @@ export function render_effect(fn) {
 	return create_effect(RENDER_EFFECT, fn, true);
 }
 
-/** @param {(() => void)} fn */
-export function block(fn) {
-	return create_effect(RENDER_EFFECT | BLOCK_EFFECT, fn, true);
+/**
+ * @param {(() => void)} fn
+ * @param {number} flags
+ */
+export function block(fn, flags = 0) {
+	return create_effect(RENDER_EFFECT | BLOCK_EFFECT | flags, fn, true);
 }
 
 /** @param {(() => void)} fn */


### PR DESCRIPTION
Fixes #11266. For the life of me I can't reproduce the bug in our test suite — I've been tearing my hair out for a while, and can't afford to waste any more time on it — and as such there's no test with this PR.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
