### PR TITLE
Feat: Add read-only binding focused

### DIFF
--- a/.changeset/thick-swans-type.md
+++ b/.changeset/thick-swans-type.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: add read-only `bind:focused`

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2727,7 +2727,9 @@ export const template_visitors = {
 				case 'checked':
 					call_expr = b.call(`$.bind_checked`, state.node, getter, setter);
 					break;
-
+				case 'focused':
+					call_expr = b.call(`$.bind_focused`, state.node, setter);
+					break;
 				case 'group': {
 					/** @type {import('estree').CallExpression[]} */
 					const indexes = [];

--- a/packages/svelte/src/compiler/phases/bindings.js
+++ b/packages/svelte/src/compiler/phases/bindings.js
@@ -21,6 +21,7 @@ export const binding_properties = {
 		event: 'durationchange',
 		omit_in_ssr: true
 	},
+	focused: {},
 	paused: {
 		valid_elements: ['audio', 'video'],
 		omit_in_ssr: true

--- a/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
@@ -76,10 +76,10 @@ export function bind_property(property, event_name, type, element, get_value, up
 export function bind_focused(element, update) {
 	var focus_handler = () => {
 		update(true);
-	}
+	};
 	var blur_handler = () => {
 		update(false);
-	}
+	};
 
 	element.addEventListener('focus', focus_handler);
 	element.addEventListener('blur', blur_handler);
@@ -87,11 +87,10 @@ export function bind_focused(element, update) {
 	/** @type {ReturnType<typeof setTimeout>} */
 
 	render_effect(() => {
-		if(element === document.activeElement) {
-			update(true)
+		if (element === document.activeElement) {
+			update(true);
 		} else {
-			update(false)
+			update(false);
 		}
-
 	});
 }

--- a/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
@@ -67,3 +67,31 @@ export function bind_property(property, event_name, type, element, get_value, up
 		}
 	});
 }
+
+/**
+ * @param {HTMLElement} element
+ * @param {(value: unknown) => void} update
+ * @returns {void}
+ */
+export function bind_focused(element, update) {
+	var focus_handler = () => {
+		update(true);
+	}
+	var blur_handler = () => {
+		update(false);
+	}
+
+	element.addEventListener('focus', focus_handler);
+	element.addEventListener('blur', blur_handler);
+
+	/** @type {ReturnType<typeof setTimeout>} */
+
+	render_effect(() => {
+		if(element === document.activeElement) {
+			update(true)
+		} else {
+			update(false)
+		}
+
+	});
+}

--- a/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
@@ -1,4 +1,5 @@
 import { render_effect } from '../../../reactivity/effects.js';
+import { listen } from './shared.js';
 
 /**
  * @param {'innerHTML' | 'textContent' | 'innerText'} property
@@ -74,23 +75,7 @@ export function bind_property(property, event_name, type, element, get_value, up
  * @returns {void}
  */
 export function bind_focused(element, update) {
-	var focus_handler = () => {
-		update(true);
-	};
-	var blur_handler = () => {
-		update(false);
-	};
-
-	element.addEventListener('focus', focus_handler);
-	element.addEventListener('blur', blur_handler);
-
-	/** @type {ReturnType<typeof setTimeout>} */
-
-	render_effect(() => {
-		if (element === document.activeElement) {
-			update(true);
-		} else {
-			update(false);
-		}
+	listen(element, ['focus', 'blur'], () => {
+		update(element === document.activeElement);
 	});
 }

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -25,7 +25,6 @@ export function event(event_name, dom, handler, capture, passive) {
 			return handler.call(this, event);
 		}
 	}
-
 	dom.addEventListener(event_name, target_handler, options);
 
 	// @ts-ignore
@@ -149,7 +148,6 @@ export function handle_event_propagation(handler_element, event) {
 
 		current_target = parent_element;
 	}
-
 	// @ts-expect-error is used above
 	event.__root = handler_element;
 	// @ts-expect-error is used above

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -25,6 +25,7 @@ export function event(event_name, dom, handler, capture, passive) {
 			return handler.call(this, event);
 		}
 	}
+
 	dom.addEventListener(event_name, target_handler, options);
 
 	// @ts-ignore
@@ -148,6 +149,7 @@ export function handle_event_propagation(handler_element, event) {
 
 		current_target = parent_element;
 	}
+
 	// @ts-expect-error is used above
 	event.__root = handler_element;
 	// @ts-expect-error is used above

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -44,7 +44,11 @@ export { bind_prop } from './dom/elements/bindings/props.js';
 export { bind_select_value, init_select, select_option } from './dom/elements/bindings/select.js';
 export { bind_element_size, bind_resize_observer } from './dom/elements/bindings/size.js';
 export { bind_this } from './dom/elements/bindings/this.js';
-export { bind_content_editable, bind_property, bind_focused } from './dom/elements/bindings/universal.js';
+export {
+	bind_content_editable,
+	bind_property,
+	bind_focused
+} from './dom/elements/bindings/universal.js';
 export { bind_window_scroll, bind_window_size } from './dom/elements/bindings/window.js';
 export {
 	once,

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -44,7 +44,7 @@ export { bind_prop } from './dom/elements/bindings/props.js';
 export { bind_select_value, init_select, select_option } from './dom/elements/bindings/select.js';
 export { bind_element_size, bind_resize_observer } from './dom/elements/bindings/size.js';
 export { bind_this } from './dom/elements/bindings/this.js';
-export { bind_content_editable, bind_property } from './dom/elements/bindings/universal.js';
+export { bind_content_editable, bind_property, bind_focused } from './dom/elements/bindings/universal.js';
 export { bind_window_scroll, bind_window_size } from './dom/elements/bindings/window.js';
 export {
 	once,

--- a/packages/svelte/tests/runtime-legacy/samples/binding-focused/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-focused/_config.js
@@ -1,70 +1,19 @@
-import { tick } from 'svelte';
+import { flushSync } from 'svelte';
 
-import { ok, test } from '../../test';
+import { test } from '../../test';
 
 export default test({
-	html: `
-		<div>false</div>
-		<div>false</div>
-		<input type="number">
-		<input type="number">
-		<button>click</button>
-	`,
-
-	ssrHtml: `
-		<div></div>
-		<div></div>
-		<input type="number">
-		<input type="number">
-		<button>click</button>
-	`,
-
 	async test({ assert, component, target, window }) {
-		const [d1, d2] = target.querySelectorAll('div');
 		const [in1, in2] = target.querySelectorAll('input');
-		const button = target.querySelector('button');
-		ok(in1);
-		ok(in2);
-		ok(button);
-		ok(d1);
-		ok(d2);
-		assert.equal(d1.textContent, 'false');
-		assert.equal(d2.textContent, 'false');
-		const event1 = new window.MouseEvent('click', { bubbles: true });
-		in1.value = '1';
-		await in1.dispatchEvent(event1);
-		await tick();
+
+		flushSync(() => in1.focus());
 		assert.equal(window.document.activeElement, in1);
 		assert.equal(component.a, true);
 		assert.equal(component.b, false);
-		assert.equal(d1.textContent, 'true');
-		assert.equal(d2.textContent, 'false');
 
-		in2.value = '1';
-		const event2 = new window.MouseEvent('click', { bubbles: true });
-		await in2.dispatchEvent(event2);
-		await tick();
+		flushSync(() => in2.focus());
+		assert.equal(window.document.activeElement, in2);
 		assert.equal(component.a, false);
 		assert.equal(component.b, true);
-		assert.equal(d1.textContent, 'false');
-		assert.equal(d2.textContent, 'true');
-
-		const event3 = new window.MouseEvent('click', { bubbles: true });
-		await button.dispatchEvent(event3);
-		await tick();
-
-		assert.equal(d1.textContent, 'false');
-		assert.equal(d2.textContent, 'false');
-
-		assert.htmlEqual(
-			target.innerHTML,
-			`
-				<div>false</div>
-				<div>false</div>
-				<input type="number">
-				<input type="number">
-				<button>click</button>
-			`
-		);
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/binding-focused/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-focused/_config.js
@@ -1,0 +1,70 @@
+import { tick } from 'svelte';
+
+import { ok, test } from '../../test';
+
+export default test({
+	html: `
+		<div>false</div>
+		<div>false</div>
+		<input type="number">
+		<input type="number">
+		<button>click</button>
+	`,
+
+	ssrHtml: `
+		<div></div>
+		<div></div>
+		<input type="number">
+		<input type="number">
+		<button>click</button>
+	`,
+
+	async test({ assert, component, target, window }) {
+		const [d1, d2] = target.querySelectorAll('div');
+		const [in1, in2] = target.querySelectorAll('input');
+		const button = target.querySelector('button');
+		ok(in1);
+		ok(in2);
+		ok(button);
+		ok(d1);
+		ok(d2);
+		assert.equal(d1.textContent, 'false');
+		assert.equal(d2.textContent, 'false');
+		const event1 = new window.MouseEvent('click', { bubbles: true });
+		in1.value = '1';
+		await in1.dispatchEvent(event1);
+		await tick();
+		assert.equal(window.document.activeElement, in1);
+		assert.equal(component.a, true);
+		assert.equal(component.b, false);
+		assert.equal(d1.textContent, 'true');
+		assert.equal(d2.textContent, 'false');
+
+		in2.value = '1';
+		const event2 = new window.MouseEvent('click', { bubbles: true });
+		await in2.dispatchEvent(event2);
+		await tick();
+		assert.equal(component.a, false);
+		assert.equal(component.b, true);
+		assert.equal(d1.textContent, 'false');
+		assert.equal(d2.textContent, 'true');
+
+		const event3 = new window.MouseEvent('click', { bubbles: true });
+		await button.dispatchEvent(event3);
+		await tick();
+
+		assert.equal(d1.textContent, 'false');
+		assert.equal(d2.textContent, 'false');
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<div>false</div>
+				<div>false</div>
+				<input type="number">
+				<input type="number">
+				<button>click</button>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/binding-focused/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-focused/main.svelte
@@ -2,8 +2,6 @@
 	export let a;
 	export let b;
 </script>
-<div>{a}</div>
-<div>{b}</div>
-<input type="number" bind:focused={a} onclick='{e => e.target.focus()}' />
-<input type="number" bind:focused={b} onclick='{e => e.target.focus()}' />
-<button onclick='{e => e.target.focus()}'>click</button>
+
+<input bind:focused={a} />
+<input bind:focused={b} />

--- a/packages/svelte/tests/runtime-legacy/samples/binding-focused/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-focused/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	export let a;
+	export let b;
+</script>
+<div>{a}</div>
+<div>{b}</div>
+<input type="number" bind:focused={a} onclick='{e => e.target.focus()}' />
+<input type="number" bind:focused={b} onclick='{e => e.target.focus()}' />
+<button onclick='{e => e.target.focus()}'>click</button>


### PR DESCRIPTION
## Svelte 5 rewrite

Add new readonly `focused` binding
Feat: https://github.com/sveltejs/svelte/issues/8949

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
