### PR TITLE
feat: implement `:global {...}` CSS blocks

### DIFF
--- a/.changeset/small-apples-eat.md
+++ b/.changeset/small-apples-eat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: implement `:global {...}` CSS blocks

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -103,6 +103,14 @@ const css = {
 	/** @param {string} message */
 	'css-parse-error': (message) => message,
 	'invalid-css-empty-declaration': () => `Declaration cannot be empty`,
+	'invalid-css-global-block-list': () =>
+		`A :global {...} block cannot be part of a selector list with more than one item`,
+	'invalid-css-global-block-modifier': () =>
+		`A :global {...} block cannot modify an existing selector`,
+	'invalid-css-global-block-combinator': (name) =>
+		`A :global {...} block cannot follow a ${name} combinator`,
+	'invalid-css-global-block-declaration': () =>
+		`A :global {...} block can only contain rules, not declarations`,
 	'invalid-css-global-placement': () =>
 		`:global(...) can be at the start or end of a selector sequence, but not in the middle`,
 	'invalid-css-global-selector': () => `:global(...) must contain exactly one selector`,

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -107,6 +107,7 @@ const css = {
 		`A :global {...} block cannot be part of a selector list with more than one item`,
 	'invalid-css-global-block-modifier': () =>
 		`A :global {...} block cannot modify an existing selector`,
+	/** @param {string} name */
 	'invalid-css-global-block-combinator': (name) =>
 		`A :global {...} block cannot follow a ${name} combinator`,
 	'invalid-css-global-block-declaration': () =>

--- a/packages/svelte/src/compiler/phases/1-parse/read/style.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/style.js
@@ -3,7 +3,6 @@ import { error } from '../../../errors.js';
 const REGEX_MATCHER = /^[~^$*|]?=/;
 const REGEX_CLOSING_BRACKET = /[\s\]]/;
 const REGEX_ATTRIBUTE_FLAGS = /^[a-zA-Z]+/; // only `i` and `s` are valid today, but make it future-proof
-const REGEX_COMBINATOR_WHITESPACE = /^\s*(\+|~|>|\|\|)\s*/;
 const REGEX_COMBINATOR = /^(\+|~|>|\|\|)/;
 const REGEX_PERCENTAGE = /^\d+(\.\d+)?%/;
 const REGEX_NTH_OF =
@@ -116,7 +115,8 @@ function read_rule(parser) {
 		end: parser.index,
 		metadata: {
 			parent_rule: null,
-			has_local_selectors: false
+			has_local_selectors: false,
+			is_global_block: false
 		}
 	};
 }
@@ -252,8 +252,6 @@ function read_selector(parser, inside_pseudo_class = false) {
 			if (parser.eat('(')) {
 				args = read_selector_list(parser, true);
 				parser.eat(')', true);
-			} else if (name === 'global') {
-				error(parser.index, 'invalid-css-global-selector');
 			}
 
 			relative_selector.selectors.push({

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -1,7 +1,6 @@
 import { walk } from 'zimmerframe';
 import { get_possible_values } from './utils.js';
 import { regex_ends_with_whitespace, regex_starts_with_whitespace } from '../../patterns.js';
-import { error } from '../../../errors.js';
 
 /**
  * @typedef {{
@@ -60,6 +59,13 @@ export function prune(stylesheet, element) {
 
 /** @type {import('zimmerframe').Visitors<import('#compiler').Css.Node, State>} */
 const visitors = {
+	Rule(node, context) {
+		if (node.metadata.is_global_block) {
+			context.visit(node.prelude);
+		} else {
+			context.next();
+		}
+	},
 	ComplexSelector(node, context) {
 		const selectors = truncate(node);
 		const inner = selectors[selectors.length - 1];

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-warn.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-warn.js
@@ -30,5 +30,12 @@ const visitors = {
 		}
 
 		context.next();
+	},
+	Rule(node, context) {
+		if (node.metadata.is_global_block) {
+			context.visit(node.prelude);
+		} else {
+			context.next();
+		}
 	}
 };

--- a/packages/svelte/src/compiler/types/css.d.ts
+++ b/packages/svelte/src/compiler/types/css.d.ts
@@ -33,6 +33,7 @@ export namespace Css {
 		metadata: {
 			parent_rule: null | Rule;
 			has_local_selectors: boolean;
+			is_global_block: boolean;
 		};
 	}
 

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-combinator/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-combinator/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-css-global-block-combinator',
+		message: 'A :global {...} block cannot follow a > combinator',
+		position: [12, 21]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-combinator/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-combinator/main.svelte
@@ -1,0 +1,3 @@
+<style>
+	.x > :global {}
+</style>

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-declaration/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-declaration/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-css-global-block-declaration',
+		message: 'A :global {...} block can only contain rules, not declarations',
+		position: [24, 34]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-declaration/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-declaration/main.svelte
@@ -1,0 +1,5 @@
+<style>
+	.x :global {
+		color: red;
+	}
+</style>

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-modifier/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-modifier/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-css-global-block-modifier',
+		message: 'A :global {...} block cannot modify an existing selector',
+		position: [14, 21]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-modifier/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-modifier/main.svelte
@@ -1,3 +1,3 @@
 <style>
-	:global {}
+	.x .y:global {}
 </style>

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-multiple/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-multiple/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'invalid-css-global-block-list',
+		message: 'A :global {...} block cannot be part of a selector list with more than one item',
+		position: [9, 31]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-multiple/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-multiple/main.svelte
@@ -1,0 +1,3 @@
+<style>
+	.x :global, .y :global {}
+</style>

--- a/packages/svelte/tests/compiler-errors/samples/css-global-without-selector/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-without-selector/_config.js
@@ -1,9 +1,0 @@
-import { test } from '../../test';
-
-export default test({
-	error: {
-		code: 'invalid-css-global-selector',
-		message: ':global(...) must contain exactly one selector',
-		position: [16, 16]
-	}
-});

--- a/packages/svelte/tests/css/samples/global-block/_config.js
+++ b/packages/svelte/tests/css/samples/global-block/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../test';
+
+export default test({
+	warnings: [
+		{
+			filename: 'SvelteComponent.svelte',
+			code: 'css-unused-selector',
+			message: 'Unused CSS selector ".unused :global"',
+			start: {
+				line: 16,
+				column: 1,
+				character: 128
+			},
+			end: {
+				line: 16,
+				column: 16,
+				character: 143
+			}
+		}
+	]
+});

--- a/packages/svelte/tests/css/samples/global-block/expected.css
+++ b/packages/svelte/tests/css/samples/global-block/expected.css
@@ -1,0 +1,17 @@
+	/* :global {*/
+		.x {
+			color: green;
+		}
+	/*}*/
+
+	div.svelte-xyz {
+		.y {
+			color: green;
+		}
+	}
+
+	/* (unused) .unused :global {
+		.z {
+			color: red;
+		}
+	}*/

--- a/packages/svelte/tests/css/samples/global-block/input.svelte
+++ b/packages/svelte/tests/css/samples/global-block/input.svelte
@@ -1,0 +1,21 @@
+<div>{@html whatever}</div>
+
+<style>
+	:global {
+		.x {
+			color: green;
+		}
+	}
+
+	div :global {
+		.y {
+			color: green;
+		}
+	}
+
+	.unused :global {
+		.z {
+			color: red;
+		}
+	}
+</style>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1122,6 +1122,7 @@ declare module 'svelte/compiler' {
 			metadata: {
 				parent_rule: null | Rule;
 				has_local_selectors: boolean;
+				is_global_block: boolean;
 			};
 		}
 


### PR DESCRIPTION
closes #10815.

This makes it possible to define global (or child global) styles in a block. Instead of this...

```svelte
<div class="post">
  {@html post.content}
</div>

<style>
  .post :global(p) {...}
  .post :global(ul) {...}
  .post :global(li) {...}
  .post :global(code) {...}
</style>
```

...you can now write this:

```svelte
<div class="post">
  {@html post.content}
</div>

<style>
  .post :global {
    p {...}
    ul {...}
    li {...}
    code {...}
  }
</style>
```

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
