### PR TITLE
fix: resolve type definition error in `svelte/compiler`

### DIFF
--- a/.changeset/lucky-colts-remember.md
+++ b/.changeset/lucky-colts-remember.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: resolve type definition error in `svelte/compiler`

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -1,5 +1,5 @@
 import { getLocator } from 'locate-character';
-import { walk } from 'zimmerframe';
+import { walk as zimmerframe_walk } from 'zimmerframe';
 import { CompileError } from './errors.js';
 import { convert } from './legacy.js';
 import { parse as parse_acorn } from './phases/1-parse/acorn.js';
@@ -133,7 +133,7 @@ export function parse(source, options = {}) {
 function to_public_ast(source, ast, modern) {
 	if (modern) {
 		// remove things that we don't want to treat as public API
-		return walk(ast, null, {
+		return zimmerframe_walk(ast, null, {
 			_(node, { next }) {
 				// @ts-ignore
 				delete node.parent;
@@ -151,13 +151,11 @@ function to_public_ast(source, ast, modern) {
  * @deprecated Replace this with `import { walk } from 'estree-walker'`
  * @returns {never}
  */
-function _walk() {
+export function walk() {
 	throw new Error(
 		`'svelte/compiler' no longer exports a \`walk\` utility — please import it directly from 'estree-walker' instead`
 	);
 }
-
-export { _walk as walk };
 
 export { CompileError } from './errors.js';
 

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -507,7 +507,7 @@ declare module 'svelte/compiler' {
 	/**
 	 * @deprecated Replace this with `import { walk } from 'estree-walker'`
 	 * */
-	function walk(): never;
+	export function walk(): never;
 	/** The return value of `compile` from `svelte/compiler` */
 	interface CompileResult {
 		/** The compiled JavaScript */
@@ -1762,8 +1762,6 @@ declare module 'svelte/compiler' {
 		style?: Preprocessor;
 		script?: Preprocessor;
 	}
-
-	export { walk };
 }
 
 declare module 'svelte/easing' {


### PR DESCRIPTION
closes: https://github.com/sveltejs/svelte/issues/11282.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
