### PR TITLE
breaking: finer lazy reactivity for set

### DIFF
--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -11,6 +11,7 @@ var inited = false;
 
 /**
  * @template T
+ * @extends {Set<T>}
  */
 export class ReactiveSet extends Set {
 	/** @type {Map<T, import('#client').Source<boolean>>} */

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -72,11 +72,10 @@ export class ReactiveSet extends Set {
 
 	/** @param {T} value */
 	has(value) {
-		var exists = super.has(value);
 		var s = this.#tracked.get(value);
 
 		if (s === undefined) {
-			s = source(exists);
+			s = source(super.has(value));
 			this.#tracked.set(value, s);
 		}
 

--- a/packages/svelte/src/reactivity/set.test.ts
+++ b/packages/svelte/src/reactivity/set.test.ts
@@ -30,7 +30,7 @@ test('set.values()', () => {
 		set.clear();
 	});
 
-	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, false, []]);
+	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, []]);
 
 	cleanup();
 });
@@ -56,6 +56,10 @@ test('set.has(...)', () => {
 
 	flushSync(() => {
 		set.delete(2);
+	});
+
+	flushSync(() => {
+		set.add(4);
 	});
 
 	flushSync(() => {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1984,19 +1984,11 @@ declare module 'svelte/reactivity' {
 		constructor(...values: any[]);
 		#private;
 	}
-	class ReactiveSet<T> extends Set<any> {
+	class ReactiveSet<T> extends Set<T> {
 		
 		constructor(value?: Iterable<T> | null | undefined);
 		
-		has(value: T): boolean;
-		
 		add(value: T): this;
-		
-		delete(value: T): boolean;
-		keys(): IterableIterator<T>;
-		values(): IterableIterator<T>;
-		entries(): IterableIterator<[T, T]>;
-		[Symbol.iterator](): IterableIterator<T>;
 		#private;
 	}
 	class ReactiveMap<K, V> extends Map<any, any> {


### PR DESCRIPTION
## Svelte 5 rewrite

Following #11200, should fix #11222.

This implementation keeps all the data in the super set while maintaining minimal data duplication. This is achieved with lazy signal initialization. In set the only fine-grained method is `.has` therefore we can initialize signals only when requested by it. This also has a benefit of not firing effects when a value doesn't exist, hasn't been appended, but the version has changed (which is a **breaking change**, but it's a good one). Meaning:
```ts
$effect(() => set.has(2));
set.add(2); // cause update
set.delete(2); // cause update
set.add(4); // won't cause an update (did before)
set.add(2); // cause update
```

The implementation details are subject to discussion. Especially:
```ts
effect(() => () => {
	queueMicrotask(() => {
		if (s && !s.reactions) {
			this.#tracked.delete(value);
		}
	});
});
```
Is there a better way to cleanup unused signals?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
