### PR TITLE
fix: avoid hoisting error by using 'let' instead of 'var'

### DIFF
--- a/.changeset/plenty-starfishes-dress.md
+++ b/.changeset/plenty-starfishes-dress.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: avoid hoisting error by using 'let' instead of 'var'

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -120,8 +120,8 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 
 		if (prefix === 'on') {
 			/** @type {{ capture?: true }} */
-			var opts = {};
-			var event_name = key.slice(2);
+			const opts = {};
+			let event_name = key.slice(2);
 			var delegated = DelegatedEvents.includes(event_name);
 
 			if (

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -111,7 +111,7 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 	var events = [];
 
 	for (key in next) {
-		var value = next[key];
+		let value = next[key];
 		if (value === prev?.[key]) continue;
 
 		var prefix = key[0] + key[1]; // this is faster than key.slice(0, 2)

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -111,6 +111,7 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 	var events = [];
 
 	for (key in next) {
+		// let instead of var because referenced in a closure
 		let value = next[key];
 		if (value === prev?.[key]) continue;
 

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-after-spread/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-after-spread/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const input = target.querySelector('input');
+
+		input?.dispatchEvent(new Event('input', { bubbles: true }));
+
+		await Promise.resolve();
+
+		assert.htmlEqual(target.innerHTML, 'true <input class="hello">');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-after-spread/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-after-spread/main.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	const props = {};
+	let changed = $state(false);
+</script>
+
+{changed}
+<input {...props} oninput={() => (changed = true)} class="hello" />


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11284

There was a small bug introduced by https://github.com/sveltejs/svelte/pull/11230 where it referenced `value` within a closure, but `value` was declared with `var` instead of `let`. This created a situation where `value` was hoisted and thus any changes to `value` would be propagated to the closure rather than it maintaining the intended value. Using `let` instead of `var` here keeps the scoping of `value` correct for the closure.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
