### PR TITLE
feat: implement message overloads

### DIFF
--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -5,3 +5,9 @@
 ## ownership_invalid_binding
 
 > %parent% passed a value to %child% with `bind:`, but the value is owned by %owner%. Consider creating a binding between %owner% and %parent%
+
+## ownership_invalid_mutation
+
+> Mutating a value outside the component that created it is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead
+
+> %component% mutated a value owned by %owner%. This is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead

--- a/packages/svelte/messages/compile-errors/bindings.md
+++ b/packages/svelte/messages/compile-errors/bindings.md
@@ -14,8 +14,6 @@
 
 > `bind:%name%` is not a valid binding
 
-## bind_invalid_detailed
-
 > `bind:%name%` is not a valid binding. %explanation%
 
 ## invalid_type_attribute

--- a/packages/svelte/messages/compile-warnings/a11y.md
+++ b/packages/svelte/messages/compile-warnings/a11y.md
@@ -6,8 +6,6 @@
 
 > Unknown aria attribute 'aria-%attribute%'
 
-## a11y_unknown_aria_attribute_suggestion
-
 > Unknown aria attribute 'aria-%attribute%'. Did you mean '%suggestion%'?
 
 ## a11y_hidden
@@ -61,8 +59,6 @@
 ## a11y_unknown_role
 
 > Unknown role '%role%'
-
-## a11y_unknown_role_suggestion
 
 > Unknown role '%role%'. Did you mean '%suggestion%'?
 

--- a/packages/svelte/messages/compile-warnings/options.md
+++ b/packages/svelte/messages/compile-warnings/options.md
@@ -1,6 +1,6 @@
 ## options_deprecated_accessors
 
-The `accessors` option has been deprecated. It will have no effect in runes mode
+> The `accessors` option has been deprecated. It will have no effect in runes mode
 
 ## options_deprecated_immutable
 

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -228,24 +228,14 @@ export function bind_invalid_target(node, name, elements) {
 }
 
 /**
- * `bind:%name%` is not a valid binding
- * @param {null | number | NodeLike} node
- * @param {string} name
- * @returns {never}
- */
-export function bind_invalid(node, name) {
-	e(node, "bind_invalid", `\`bind:${name}\` is not a valid binding`);
-}
-
-/**
  * `bind:%name%` is not a valid binding. %explanation%
  * @param {null | number | NodeLike} node
  * @param {string} name
- * @param {string} explanation
+ * @param {string | undefined | null} [explanation]
  * @returns {never}
  */
-export function bind_invalid_detailed(node, name, explanation) {
-	e(node, "bind_invalid_detailed", `\`bind:${name}\` is not a valid binding. ${explanation}`);
+export function bind_invalid(node, name, explanation) {
+	e(node, "bind_invalid", explanation ? `\`bind:${name}\` is not a valid binding. ${explanation}` : `\`bind:${name}\` is not a valid binding`);
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/2-analyze/a11y.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/a11y.js
@@ -739,12 +739,7 @@ function check_element(node, state) {
 			const type = name.slice(5);
 			if (!aria_attributes.includes(type)) {
 				const match = fuzzymatch(type, aria_attributes);
-				if (match) {
-					// TODO allow 'overloads' in messages, so that we can use the same code with and without suggestions
-					w.a11y_unknown_aria_attribute_suggestion(attribute, type, match);
-				} else {
-					w.a11y_unknown_aria_attribute(attribute, type);
-				}
+				w.a11y_unknown_aria_attribute(attribute, type, match);
 			}
 
 			if (name === 'aria-hidden' && regex_heading_tags.test(node.name)) {
@@ -792,11 +787,7 @@ function check_element(node, state) {
 						w.a11y_no_abstract_role(attribute, current_role);
 					} else if (current_role && !aria_roles.includes(current_role)) {
 						const match = fuzzymatch(current_role, aria_roles);
-						if (match) {
-							w.a11y_unknown_role_suggestion(attribute, current_role, match);
-						} else {
-							w.a11y_unknown_role(attribute, current_role);
-						}
+						w.a11y_unknown_role(attribute, current_role, match);
 					}
 
 					// no-redundant-roles

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -373,7 +373,7 @@ const validation = {
 			parent?.type === 'SvelteBody'
 		) {
 			if (context.state.options.namespace === 'foreign' && node.name !== 'this') {
-				e.bind_invalid_detailed(node, node.name, 'Foreign elements only support `bind:this`');
+				e.bind_invalid(node, node.name, 'Foreign elements only support `bind:this`');
 			}
 
 			if (node.name in binding_properties) {
@@ -442,7 +442,7 @@ const validation = {
 				if (match) {
 					const property = binding_properties[match];
 					if (!property.valid_elements || property.valid_elements.includes(parent.name)) {
-						e.bind_invalid_detailed(node, node.name, `Did you mean '${match}'?`);
+						e.bind_invalid(node, node.name, `Did you mean '${match}'?`);
 					}
 				}
 				e.bind_invalid(node, node.name);

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -50,22 +50,13 @@ export function a11y_aria_attributes(node, name) {
 }
 
 /**
- * Unknown aria attribute 'aria-%attribute%'
- * @param {null | NodeLike} node
- * @param {string} attribute
- */
-export function a11y_unknown_aria_attribute(node, attribute) {
-	w(node, "a11y_unknown_aria_attribute", `Unknown aria attribute 'aria-${attribute}'`);
-}
-
-/**
  * Unknown aria attribute 'aria-%attribute%'. Did you mean '%suggestion%'?
  * @param {null | NodeLike} node
  * @param {string} attribute
- * @param {string} suggestion
+ * @param {string | undefined | null} [suggestion]
  */
-export function a11y_unknown_aria_attribute_suggestion(node, attribute, suggestion) {
-	w(node, "a11y_unknown_aria_attribute_suggestion", `Unknown aria attribute 'aria-${attribute}'. Did you mean '${suggestion}'?`);
+export function a11y_unknown_aria_attribute(node, attribute, suggestion) {
+	w(node, "a11y_unknown_aria_attribute", suggestion ? `Unknown aria attribute 'aria-${attribute}'. Did you mean '${suggestion}'?` : `Unknown aria attribute 'aria-${attribute}'`);
 }
 
 /**
@@ -179,22 +170,13 @@ export function a11y_no_abstract_role(node, role) {
 }
 
 /**
- * Unknown role '%role%'
- * @param {null | NodeLike} node
- * @param {string} role
- */
-export function a11y_unknown_role(node, role) {
-	w(node, "a11y_unknown_role", `Unknown role '${role}'`);
-}
-
-/**
  * Unknown role '%role%'. Did you mean '%suggestion%'?
  * @param {null | NodeLike} node
  * @param {string} role
- * @param {string} suggestion
+ * @param {string | undefined | null} [suggestion]
  */
-export function a11y_unknown_role_suggestion(node, role, suggestion) {
-	w(node, "a11y_unknown_role_suggestion", `Unknown role '${role}'. Did you mean '${suggestion}'?`);
+export function a11y_unknown_role(node, role, suggestion) {
+	w(node, "a11y_unknown_role", suggestion ? `Unknown role '${role}'. Did you mean '${suggestion}'?` : `Unknown role '${role}'`);
 }
 
 /**
@@ -545,11 +527,11 @@ export function invalid_self_closing_tag(node, name) {
 }
 
 /**
- * e `accessors` option has been deprecated. It will have no effect in runes mode
+ * The `accessors` option has been deprecated. It will have no effect in runes mode
  * @param {null | NodeLike} node
  */
 export function options_deprecated_accessors(node) {
-	w(node, "options_deprecated_accessors", "e `accessors` option has been deprecated. It will have no effect in runes mode");
+	w(node, "options_deprecated_accessors", "The `accessors` option has been deprecated. It will have no effect in runes mode");
 }
 
 /**

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -225,18 +225,13 @@ export function check_ownership(metadata) {
 	if (component && !has_owner(metadata, component)) {
 		let original = get_owner(metadata);
 
-		let message =
+		// @ts-expect-error
+		if (original.filename !== component.filename) {
 			// @ts-expect-error
-			original.filename !== component.filename
-				? // @ts-expect-error
-					`${component.filename} mutated a value owned by ${original.filename}. This is strongly discouraged`
-				: 'Mutating a value outside the component that created it is strongly discouraged';
-
-		// TODO get rid of this, but implement message overloads first
-		// eslint-disable-next-line no-console
-		console.warn(
-			`${message}. Consider passing values to child components with \`bind:\`, or use a callback instead.`
-		);
+			w.ownership_invalid_mutation(component.filename, original.filename);
+		} else {
+			w.ownership_invalid_mutation();
+		}
 
 		// eslint-disable-next-line no-console
 		console.trace();

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -31,3 +31,17 @@ export function ownership_invalid_binding(parent, child, owner) {
 		console.warn("ownership_invalid_binding");
 	}
 }
+
+/**
+ * %component% mutated a value owned by %owner%. This is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead
+ * @param {string | undefined | null} [component]
+ * @param {string | undefined | null} [owner]
+ */
+export function ownership_invalid_mutation(component, owner) {
+	if (DEV) {
+		console.warn(`%c[svelte] ${"ownership_invalid_mutation"}\n%c${`${component} mutated a value owned by ${owner}. This is strongly discouraged. Consider passing values to child components with \`bind:\`, or use a callback instead`}`, bold, normal);
+	} else {
+		// TODO print a link to the documentation
+		console.warn("ownership_invalid_mutation");
+	}
+}

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-discouraged/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-discouraged/_config.js
@@ -1,13 +1,7 @@
 import { test } from '../../test';
 
-/** @type {typeof console.warn} */
-let warn;
-
 /** @type {typeof console.trace} */
 let trace;
-
-/** @type {any[]} */
-let warnings = [];
 
 export default test({
 	html: `<button>clicks: 0</button>`,
@@ -17,31 +11,22 @@ export default test({
 	},
 
 	before_test: () => {
-		warn = console.warn;
 		trace = console.trace;
-
-		console.warn = (...args) => {
-			warnings.push(...args);
-		};
-
 		console.trace = () => {};
 	},
 
 	after_test: () => {
-		console.warn = warn;
 		console.trace = trace;
-
-		warnings = [];
 	},
 
-	async test({ assert, target }) {
+	async test({ assert, target, warnings }) {
 		const btn = target.querySelector('button');
 		await btn?.click();
 
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
 
 		assert.deepEqual(warnings, [
-			'.../samples/non-local-mutation-discouraged/Counter.svelte mutated a value owned by .../samples/non-local-mutation-discouraged/main.svelte. This is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead.'
+			'.../samples/non-local-mutation-discouraged/Counter.svelte mutated a value owned by .../samples/non-local-mutation-discouraged/main.svelte. This is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead'
 		]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-5/_config.js
@@ -1,31 +1,12 @@
 import { tick } from 'svelte';
 import { test } from '../../test';
 
-/** @type {typeof console.warn} */
-let warn;
-
-/** @type {any[]} */
-let warnings = [];
-
 export default test({
 	compileOptions: {
 		dev: true
 	},
 
-	before_test: () => {
-		warn = console.warn;
-
-		console.warn = (...args) => {
-			warnings.push(...args);
-		};
-	},
-
-	after_test: () => {
-		console.warn = warn;
-		warnings = [];
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, warnings }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
 		await btn1.click();

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-7/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-7/_config.js
@@ -1,31 +1,12 @@
 import { tick } from 'svelte';
 import { test } from '../../test';
 
-/** @type {typeof console.warn} */
-let warn;
-
-/** @type {any[]} */
-let warnings = [];
-
 export default test({
 	compileOptions: {
 		dev: true
 	},
 
-	before_test: () => {
-		warn = console.warn;
-
-		console.warn = (...args) => {
-			warnings.push(...args);
-		};
-	},
-
-	after_test: () => {
-		console.warn = warn;
-		warnings = [];
-	},
-
-	async test({ assert, target }) {
+	async test({ assert, target, warnings }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
 		btn1.click();

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-3/_config.js
@@ -33,7 +33,7 @@ export default test({
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button><button>clicks: 1</button>`);
 
 		assert.deepEqual(warnings, [
-			'.../samples/non-local-mutation-with-binding-3/Counter.svelte mutated a value owned by .../samples/non-local-mutation-with-binding-3/main.svelte. This is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead.'
+			'.../samples/non-local-mutation-with-binding-3/Counter.svelte mutated a value owned by .../samples/non-local-mutation-with-binding-3/main.svelte. This is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead'
 		]);
 	}
 });

--- a/packages/svelte/tests/validator/samples/a11y-aria-props/warnings.json
+++ b/packages/svelte/tests/validator/samples/a11y-aria-props/warnings.json
@@ -1,6 +1,6 @@
 [
 	{
-		"code": "a11y_unknown_aria_attribute_suggestion",
+		"code": "a11y_unknown_aria_attribute",
 		"message": "Unknown aria attribute 'aria-labeledby'. Did you mean 'labelledby'?",
 		"start": {
 			"line": 1,

--- a/packages/svelte/tests/validator/samples/a11y-aria-role/warnings.json
+++ b/packages/svelte/tests/validator/samples/a11y-aria-role/warnings.json
@@ -1,6 +1,6 @@
 [
 	{
-		"code": "a11y_unknown_role_suggestion",
+		"code": "a11y_unknown_role",
 		"message": "Unknown role 'toooltip'. Did you mean 'tooltip'?",
 		"start": {
 			"line": 6,
@@ -12,7 +12,7 @@
 		}
 	},
 	{
-		"code": "a11y_unknown_role_suggestion",
+		"code": "a11y_unknown_role",
 		"message": "Unknown role 'toooltip'. Did you mean 'tooltip'?",
 		"start": {
 			"line": 7,

--- a/packages/svelte/tests/validator/samples/binding-invalid-foreign-namespace/errors.json
+++ b/packages/svelte/tests/validator/samples/binding-invalid-foreign-namespace/errors.json
@@ -1,6 +1,6 @@
 [
 	{
-		"code": "bind_invalid_detailed",
+		"code": "bind_invalid",
 		"message": "`bind:value` is not a valid binding. Foreign elements only support `bind:this`",
 		"start": {
 			"line": 6,

--- a/packages/svelte/tests/validator/samples/window-binding-invalid-innerwidth/errors.json
+++ b/packages/svelte/tests/validator/samples/window-binding-invalid-innerwidth/errors.json
@@ -1,6 +1,6 @@
 [
 	{
-		"code": "bind_invalid_detailed",
+		"code": "bind_invalid",
 		"message": "`bind:innerwidth` is not a valid binding. Did you mean 'innerWidth'?",
 		"start": {
 			"line": 5,


### PR DESCRIPTION
See #11305.

This makes it possible for an error/warning message to have multiple variants, to satisfy the common pattern of appending 'Did you mean %suggestion%?' with incorrect bindings etc, without needing multiple codes for what is essentially the same issue.

It also adds the ability have a separate prose section, which isn't currently used anywhere but can be in future:

```md
## error_code

> Incorrect thing %thing%

> Incorrect thing %thing%. Did you mean %suggestion%?

Here is a longer explanation of this thing.
```

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
