### PR TITLE
fix: remove `bind_prop` in runes mode

### DIFF
--- a/.changeset/lucky-geckos-swim.md
+++ b/.changeset/lucky-geckos-swim.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove `bind_prop` in runes mode


### PR DESCRIPTION
Following #11238, `bind_prop` is no longer useful in runes mode. This removes it

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
