### PR TITLE
fix: define `valueasdate` as a valid attribute on input elements

### DIFF
--- a/.changeset/empty-spies-study.md
+++ b/.changeset/empty-spies-study.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: define `valueAsDate` as a valid attribute on input elements

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -839,6 +839,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	step?: number | string | undefined | null;
 	type?: HTMLInputTypeAttribute | undefined | null;
 	value?: any;
+	valueAsDate?: Date | undefined | null;
 	width?: number | string | undefined | null;
 
 	'on:change'?: ChangeEventHandler<HTMLInputElement> | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -839,7 +839,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	step?: number | string | undefined | null;
 	type?: HTMLInputTypeAttribute | undefined | null;
 	value?: any;
-	valueAsDate?: Date | undefined | null;
+	valueasdate?: Date | undefined | null;
 	width?: number | string | undefined | null;
 
 	'on:change'?: ChangeEventHandler<HTMLInputElement> | undefined | null;


### PR DESCRIPTION
This PR adds the missing type field for the `valueAsDate` attribute on HTML `input` elements (mainly used with inputs of type `datetime-local`). [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#valueasdate)

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs (I didn't think this would be needed for such a minor change as this)
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
