### PR TITLE
chore: directly export function in non-HMR mode

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -430,18 +430,17 @@ export function client_component(source, analysis, options) {
 		component_block.body.unshift(b.const('$$slots', b.call('$.sanitize_slots', b.id('$$props'))));
 	}
 
-	const body = [
-		...state.hoisted,
-		...module.body,
-		b.function_declaration(
-			b.id(analysis.name),
-			[b.id('$$anchor'), b.id('$$props')],
-			component_block
-		)
-	];
+	const body = [...state.hoisted, ...module.body];
+
+	const component = b.function_declaration(
+		b.id(analysis.name),
+		[b.id('$$anchor'), b.id('$$props')],
+		component_block
+	);
 
 	if (options.hmr) {
 		body.push(
+			component,
 			b.if(
 				b.id('import.meta.hot'),
 				b.block([
@@ -459,11 +458,13 @@ export function client_component(source, analysis, options) {
 						)
 					)
 				])
-			)
-		);
-	}
+			),
 
-	body.push(b.export_default(b.id(analysis.name)));
+			b.export_default(b.id(analysis.name))
+		);
+	} else {
+		body.push(b.export_default(component));
+	}
 
 	if (options.dev) {
 		if (options.filename) {

--- a/packages/svelte/src/compiler/phases/3-transform/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/index.js
@@ -30,20 +30,6 @@ export function transform_component(analysis, source, options) {
 			? server_component(analysis, options)
 			: client_component(source, analysis, options);
 
-	const basename = (options.filename ?? 'Component').split(/[/\\]/).at(-1);
-	if (program.body.length > 0) {
-		program.body[0].leadingComments = [
-			{
-				type: 'Line',
-				value: ` ${basename} (Svelte v${VERSION})`
-			},
-			{
-				type: 'Line',
-				value: ' Note: compiler output will change before 5.0 is released!'
-			}
-		];
-	}
-
 	const js_source_name = get_source_name(options.filename, options.outputFilename, 'input.svelte');
 	const js = print(program, {
 		// include source content; makes it easier/more robust looking up the source map code

--- a/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/client/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 import TextInput from './Child.svelte';
@@ -7,7 +5,7 @@ import TextInput from './Child.svelte';
 var root_1 = $.template(`Something`, 1);
 var root = $.template(`<!> `, 1);
 
-function Bind_component_snippet($$anchor, $$props) {
+export default function Bind_component_snippet($$anchor, $$props) {
 	$.push($$props, true);
 
 	let value = $.source('');
@@ -37,5 +35,3 @@ function Bind_component_snippet($$anchor, $$props) {
 	$.append($$anchor, fragment_1);
 	$.pop();
 }
-
-export default Bind_component_snippet;

--- a/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 import TextInput from './Child.svelte';
 

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
@@ -1,9 +1,7 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
-function Bind_this($$anchor, $$props) {
+export default function Bind_this($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
@@ -14,5 +12,3 @@ function Bind_this($$anchor, $$props) {
 	$.append($$anchor, fragment);
 	$.pop();
 }
-
-export default Bind_this;

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function Bind_this($$payload, $$props) {

--- a/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/client/index.svelte.js
@@ -1,9 +1,7 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
-function Class_state_field_constructor_assignment($$anchor, $$props) {
+export default function Class_state_field_constructor_assignment($$anchor, $$props) {
 	$.push($$props, true);
 
 	class Foo {
@@ -27,5 +25,3 @@ function Class_state_field_constructor_assignment($$anchor, $$props) {
 
 	$.pop();
 }
-
-export default Class_state_field_constructor_assignment;

--- a/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function Class_state_field_constructor_assignment($$payload, $$props) {

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -1,11 +1,9 @@
-// main.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
 var root = $.template(`<div></div> <svg></svg> <custom-element></custom-element> <div></div> <svg></svg> <custom-element></custom-element>`, 3);
 
-function Main($$anchor, $$props) {
+export default function Main($$anchor, $$props) {
 	$.push($$props, true);
 
 	// needs to be a snapshot test because jsdom does auto-correct the attribute casing
@@ -36,5 +34,3 @@ function Main($$anchor, $$props) {
 	$.append($$anchor, fragment);
 	$.pop();
 }
-
-export default Main;

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/server/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/server/main.svelte.js
@@ -1,5 +1,3 @@
-// main.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function Main($$payload, $$props) {

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -1,9 +1,7 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
-function Each_string_template($$anchor, $$props) {
+export default function Each_string_template($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
@@ -20,5 +18,3 @@ function Each_string_template($$anchor, $$props) {
 	$.append($$anchor, fragment);
 	$.pop();
 }
-
-export default Each_string_template;

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function Each_string_template($$payload, $$props) {

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -1,9 +1,7 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
-function Function_prop_no_getter($$anchor, $$props) {
+export default function Function_prop_no_getter($$anchor, $$props) {
 	$.push($$props, true);
 
 	let count = $.source(0);
@@ -31,5 +29,3 @@ function Function_prop_no_getter($$anchor, $$props) {
 	$.append($$anchor, fragment);
 	$.pop();
 }
-
-export default Function_prop_no_getter;

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function Function_prop_no_getter($$payload, $$props) {

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -1,11 +1,9 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
 var root = $.template(`<h1>hello world</h1>`);
 
-function Hello_world($$anchor, $$props) {
+export default function Hello_world($$anchor, $$props) {
 	$.push($$props, false);
 	$.init();
 
@@ -14,5 +12,3 @@ function Hello_world($$anchor, $$props) {
 	$.append($$anchor, h1);
 	$.pop();
 }
-
-export default Hello_world;

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function Hello_world($$payload, $$props) {

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function Hmr($$payload, $$props) {

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
@@ -12,7 +10,7 @@ function reset(_, str, tpl) {
 
 var root = $.template(`<input> <input> <button>reset</button>`, 1);
 
-function State_proxy_literal($$anchor, $$props) {
+export default function State_proxy_literal($$anchor, $$props) {
 	$.push($$props, true);
 
 	let str = $.source('');
@@ -34,7 +32,5 @@ function State_proxy_literal($$anchor, $$props) {
 	$.append($$anchor, fragment);
 	$.pop();
 }
-
-export default State_proxy_literal;
 
 $.delegate(["click"]);

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function State_proxy_literal($$payload, $$props) {

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
@@ -1,9 +1,7 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
-function Svelte_element($$anchor, $$props) {
+export default function Svelte_element($$anchor, $$props) {
 	$.push($$props, true);
 
 	let tag = $.prop($$props, "tag", 3, 'hr');
@@ -14,5 +12,3 @@ function Svelte_element($$anchor, $$props) {
 	$.append($$anchor, fragment);
 	$.pop();
 }
-
-export default Svelte_element;

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/server/index.svelte.js
@@ -1,5 +1,3 @@
-// index.svelte (Svelte VERSION)
-// Note: compiler output will change before 5.0 is released!
 import * as $ from "svelte/internal/server";
 
 export default function Svelte_element($$payload, $$props) {

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -60,7 +60,7 @@ function compile({ id, source, options, return_ast }) {
 				filename: options.filename,
 				generate: options.generate,
 				dev: options.dev,
-				discloseVersion: false
+				discloseVersion: false // less visual noise in the output tab
 			});
 
 			const { js, css, warnings, metadata } = compiled;

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -59,7 +59,8 @@ function compile({ id, source, options, return_ast }) {
 			const compiled = svelte.compile(source, {
 				filename: options.filename,
 				generate: options.generate,
-				dev: options.dev
+				dev: options.dev,
+				discloseVersion: false
 			});
 
 			const { js, css, warnings, metadata } = compiled;


### PR DESCRIPTION
this is vain, but it'd be cool if the 'JS output' tab had as little noise as possible. Right now a `<h1>Hello world!</h1>` component yields [this](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAE6tWSsvMSS1WsoquVspLzE1VslJyLChQ0lEqqSwAcYrLUnNKUoH84vzSomSQiE2GoZ1Hak5OvkJ5flFOiqKNPlAgJg-oJDc_JTMtMzVFyaqkqDS1NrYWAMssMTBdAAAA):

```js
// App.svelte (Svelte v5.0.0-next.115)
// Note: compiler output will change before 5.0 is released!
import "svelte/internal/disclose-version";
import * as $ from "svelte/internal/client";

var root = $.template(`<h1>Hello world!</h1>`);

function App($$anchor, $$props) {
	$.push($$props, false);
	$.init();

	var h1 = root();

	$.append($$anchor, h1);
	$.pop();
}

export default App;
```

Between this PR and #11319, it becomes this:

```js
import * as $ from "svelte/internal/client";

var root = $.template(`<h1>Hello world!</h1>`);

export default function App($$anchor) {
	var h1 = root();

	$.append($$anchor, h1);
}
```