### PR TITLE
feat: provide migration function

### DIFF
--- a/.changeset/orange-zoos-heal.md
+++ b/.changeset/orange-zoos-heal.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: provide migration helper

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -190,5 +190,5 @@ export function walk() {
 }
 
 export { CompileError } from './errors.js';
-
 export { VERSION } from '../version.js';
+export { migrate } from './migrate/index.js';

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -41,7 +41,8 @@ export function migrate(source) {
 			props_insertion_point: 0,
 			has_props_rune: false,
 			props_name: analysis.root.unique('props').name,
-			rest_props_name: analysis.root.unique('rest').name
+			rest_props_name: analysis.root.unique('rest').name,
+			end: parsed.end
 		};
 
 		if (parsed.instance) {
@@ -113,6 +114,7 @@ export function migrate(source) {
  *  has_props_rune: boolean;
  * 	props_name: string;
  * 	rest_props_name: string;
+ *  end: number;
  * }} State
  */
 
@@ -290,10 +292,7 @@ const instance_script = {
 			state.str.indent(state.indent, {
 				exclude: [
 					[0, /** @type {number} */ (node.body.start)],
-					[
-						/** @type {number} */ (node.body.end),
-						/** @type {number} */ (/** @type {import('estree').Program} */ (path.at(-1)).end)
-					]
+					[/** @type {number} */ (node.body.end), state.end]
 				]
 			});
 			state.str.appendRight(/** @type {number} */ (node.end), `\n${state.indent}});`);

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1,0 +1,369 @@
+import MagicString from 'magic-string';
+import { walk } from 'zimmerframe';
+import { parse } from '../phases/1-parse/index.js';
+import { analyze_component } from '../phases/2-analyze/index.js';
+import { validate_component_options } from '../validate-options.js';
+import { get_rune } from '../phases/scope.js';
+import { reset_warnings } from '../warnings.js';
+
+/**
+ * Does a best-effort migration of Svelte code towards using runes, event attributes and render tags.
+ * @param {string} source
+ * @returns {string}
+ */
+export function migrate(source) {
+	try {
+		reset_warnings({ source, filename: 'migrate.svelte' });
+
+		let parsed = parse(source);
+
+		const { customElement: customElementOptions, ...parsed_options } = parsed.options || {};
+
+		/** @type {import('#compiler').ValidatedCompileOptions} */
+		const combined_options = {
+			...validate_component_options({}, ''),
+			...parsed_options,
+			customElementOptions
+		};
+
+		const str = new MagicString(source);
+		const analysis = analyze_component(parsed, source, combined_options);
+
+		/** @type {State} */
+		let state = {
+			scope: analysis.instance.scope,
+			analysis,
+			str,
+			props: [],
+			props_insertion_point: 0,
+			has_props_rune: false,
+			props_name: analysis.root.unique('props').name,
+			rest_props_name: analysis.root.unique('rest').name
+		};
+
+		if (parsed.instance) {
+			walk(parsed.instance.content, state, instance_script);
+		}
+
+		state = { ...state, scope: analysis.template.scope };
+		walk(parsed.fragment, state, template);
+
+		if (state.props.length > 0 || analysis.uses_rest_props || analysis.uses_props) {
+			let props = '';
+			if (analysis.uses_props) {
+				props = `...${state.props_name}`;
+			} else {
+				props = state.props
+					.map((prop) => {
+						let prop_str =
+							prop.local === prop.exported ? prop.local : `${prop.exported}: ${prop.local}`;
+						if (prop.bindable) {
+							prop_str += ` = $bindable(${prop.init})`;
+						} else if (prop.init) {
+							prop_str += ` = ${prop.init}`;
+						}
+						return prop_str;
+					})
+					.join(', ');
+
+				if (analysis.uses_rest_props) {
+					props += `, ...${state.rest_props_name}`;
+				}
+			}
+
+			if (state.has_props_rune) {
+				// some render tags or forwarded event attributes to add
+				str.appendRight(state.props_insertion_point, ` ${props},`);
+			} else {
+				const props_declaration = `let { ${props} } = $props();`;
+				if (parsed.instance) {
+					if (state.props_insertion_point === 0) {
+						// no regular props found, but render tags or events to forward found, $props() will be first in the script tag
+						str.appendRight(
+							/** @type {number} */ (parsed.instance.content.start),
+							`\n\t${props_declaration}`
+						);
+					} else {
+						str.appendRight(state.props_insertion_point, props_declaration);
+					}
+				} else {
+					str.prepend(`<script>${props_declaration}</script>`);
+				}
+			}
+		}
+
+		return str.toString();
+	} catch (e) {
+		console.error('Error while migrating Svelte code');
+		throw e;
+	}
+}
+
+/**
+ * @typedef {{
+ *  scope: import('../phases/scope.js').Scope;
+ *  str: MagicString;
+ *  analysis: import('../phases/types.js').ComponentAnalysis;
+ *  props: Array<{ local: string; exported: string; init: string; bindable: boolean }>;
+ *  props_insertion_point: number;
+ *  has_props_rune: boolean;
+ * 	props_name: string;
+ * 	rest_props_name: string;
+ * }} State
+ */
+
+/** @type {import('zimmerframe').Visitors<import('../types/template.js').SvelteNode, State>} */
+const instance_script = {
+	Identifier(node, { state }) {
+		handle_identifier(node, state);
+	},
+	VariableDeclaration(node, { state, path }) {
+		if (state.scope !== state.analysis.instance.scope) {
+			return;
+		}
+
+		let nr_of_props = 0;
+
+		for (const declarator of node.declarations) {
+			if (state.analysis.runes) {
+				if (get_rune(declarator.init, state.scope) === '$props') {
+					state.props_insertion_point = /** @type {number} */ (declarator.id.start) + 1;
+					state.has_props_rune = true;
+				}
+				continue;
+			}
+
+			const bindings = state.scope.get_bindings(declarator);
+			const has_state = bindings.some((binding) => binding.kind === 'state');
+			const has_props = bindings.some((binding) => binding.kind === 'bindable_prop');
+
+			if (!has_state && !has_props) {
+				continue;
+			}
+
+			if (has_props) {
+				nr_of_props++;
+
+				if (declarator.id.type !== 'Identifier') {
+					// TODO
+					// Turn export let into props. It's really really weird because export let { x: foo, z: [bar]} = ..
+					// means that foo and bar are the props (i.e. the leafs are the prop names), not x and z.
+					// const tmp = state.scope.generate('tmp');
+					// const paths = extract_paths(declarator.id);
+					// state.props_pre.push(
+					// 	b.declaration('const', b.id(tmp), visit(declarator.init!) as Expression)
+					// );
+					// for (const path of paths) {
+					// 	const name = (path.node as Identifier).name;
+					// 	const binding = state.scope.get(name)!;
+					// 	const value = path.expression!(b.id(tmp));
+					// 	if (binding.kind === 'bindable_prop' || binding.kind === 'rest_prop') {
+					// 		state.props.push({
+					// 			local: name,
+					// 			exported: binding.prop_alias ? binding.prop_alias : name,
+					// 			init: value
+					// 		});
+					// 		state.props_insertion_point = /** @type {number} */(declarator.end);
+					// 	} else {
+					// 		declarations.push(b.declarator(path.node, value));
+					// 	}
+					// }
+					continue;
+				}
+
+				const binding = /** @type {import('#compiler').Binding} */ (
+					state.scope.get(declarator.id.name)
+				);
+
+				if (
+					state.analysis.uses_props &&
+					(declarator.init || binding.mutated || binding.reassigned)
+				) {
+					throw new Error(
+						'$$props is used together with named props in a way that cannot be automatically migrated.'
+					);
+				}
+
+				state.props.push({
+					local: declarator.id.name,
+					exported: binding.prop_alias ? binding.prop_alias : declarator.id.name,
+					init: declarator.init
+						? state.str.original.substring(
+								/** @type {number} */ (declarator.init.start),
+								/** @type {number} */ (declarator.init.end)
+							)
+						: '',
+					bindable: binding.mutated || binding.reassigned
+				});
+				state.props_insertion_point = /** @type {number} */ (declarator.end);
+				state.str.update(
+					/** @type {number} */ (declarator.start),
+					/** @type {number} */ (declarator.end),
+					''
+				);
+
+				continue;
+			}
+
+			// state
+			if (declarator.init) {
+				state.str.prependLeft(/** @type {number} */ (declarator.init.start), '$state(');
+				state.str.appendRight(/** @type {number} */ (declarator.init.end), ')');
+			} else {
+				state.str.prependLeft(/** @type {number} */ (declarator.id.end), ' = $state()');
+			}
+		}
+
+		if (nr_of_props === node.declarations.length) {
+			let start = /** @type {number} */ (node.start);
+			let end = /** @type {number} */ (node.end);
+
+			const parent = path.at(-1);
+			if (parent?.type === 'ExportNamedDeclaration') {
+				start = /** @type {number} */ (parent.start);
+				end = /** @type {number} */ (parent.end);
+			}
+			state.str.update(start, end, '');
+		}
+	},
+	LabeledStatement(node, { path, state }) {
+		if (state.analysis.runes) return;
+		if (path.length > 1) return;
+		if (node.label.name !== '$') return;
+
+		if (
+			node.body.type === 'ExpressionStatement' &&
+			node.body.expression.type === 'AssignmentExpression'
+		) {
+			// $derived
+			// TODO $: ({ x } = ...)
+			state.str.update(
+				/** @type {number} */ (node.start),
+				/** @type {number} */ (node.body.expression.start),
+				'let '
+			);
+			state.str.prependLeft(/** @type {number} */ (node.body.expression.right.start), '$derived(');
+			state.str.appendRight(/** @type {number} */ (node.body.expression.right.end), ')');
+		} else {
+			// $effect.pre, to be precise, but we gloss over that
+			// TODO try to find out if we can use $derived.by instead?
+			// TODO SSR mode variant needed
+			state.str.update(
+				/** @type {number} */ (node.start),
+				/** @type {number} */ (node.body.start),
+				'$effect(() => {'
+			);
+			state.str.appendRight(/** @type {number} */ (node.end), '})');
+		}
+	}
+};
+
+/** @type {import('zimmerframe').Visitors<import('../types/template.js').SvelteNode, State>} */
+const template = {
+	Identifier(node, { state }) {
+		handle_identifier(node, state);
+	},
+	OnDirective(node, { state, path }) {
+		const parent = path.at(-1);
+		if (
+			parent?.type === 'SvelteSelf' ||
+			parent?.type === 'SvelteComponent' ||
+			parent?.type === 'Component'
+		) {
+			return;
+		}
+
+		if (node.expression) {
+			// remove : from on:click
+			state.str.update(node.start, node.start + 3, 'on');
+		} else {
+			// turn on:click into a prop
+			// Check if prop already set, could happen when on:click on different elements
+			// TODO what to do when this results in a variable name clash?
+			if (!state.props.some((prop) => prop.local === node.name)) {
+				state.props.push({
+					local: node.name,
+					exported: node.name,
+					init: '',
+					bindable: false
+				});
+			}
+
+			state.str.update(node.start, node.end, `{${node.name}}`);
+		}
+	},
+	SlotElement(node, { state }) {
+		let name = 'children';
+		let slot_props = '{ ';
+
+		for (const attr of node.attributes) {
+			if (attr.type === 'SpreadAttribute') {
+				slot_props += `...${state.str.original.substring(/** @type {number} */ (attr.expression.start), attr.expression.end)}, `;
+			} else if (attr.type === 'Attribute') {
+				if (attr.name === 'name') {
+					name = /** @type {any} */ (attr.value)[0].data;
+				} else {
+					const value =
+						attr.value !== true
+							? state.str.original.substring(
+									attr.value[0].start,
+									attr.value[attr.value.length - 1].end
+								)
+							: 'true';
+					slot_props += value === attr.name ? `${value}, ` : `${attr.name}: ${value}, `;
+				}
+			}
+		}
+
+		slot_props += '}';
+		if (slot_props === '{ }') {
+			slot_props = '';
+		}
+
+		state.props.push({
+			local: name,
+			exported: name,
+			init: '',
+			bindable: false
+		});
+
+		if (node.fragment.nodes.length > 0) {
+			state.str.update(
+				node.start,
+				node.fragment.nodes[0].start,
+				`{#if ${name}}{@render ${name}(${slot_props})}{:else}`
+			);
+			state.str.update(node.fragment.nodes[node.fragment.nodes.length - 1].end, node.end, '{/if}');
+		} else {
+			state.str.update(node.start, node.end, `{@render ${name}?.(${slot_props})}`);
+		}
+	}
+};
+
+/**
+ * @param {import('estree').Identifier} node
+ * @param {State} state
+ */
+function handle_identifier(node, state) {
+	if (state.analysis.uses_props) {
+		if (node.name === '$$props' || node.name === '$$restProps') {
+			// not 100% correct for $$restProps but it'll do
+			state.str.update(
+				/** @type {number} */ (node.start),
+				/** @type {number} */ (node.end),
+				state.props_name
+			);
+		} else {
+			const binding = state.scope.get(node.name);
+			if (binding?.kind === 'bindable_prop') {
+				state.str.prependLeft(/** @type {number} */ (node.start), `${state.props_name}.`);
+			}
+		}
+	} else if (node.name === '$$restProps' && state.analysis.uses_rest_props) {
+		state.str.update(
+			/** @type {number} */ (node.start),
+			/** @type {number} */ (node.end),
+			state.rest_props_name
+		);
+	}
+}

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -10,8 +10,10 @@ import { regex_is_valid_identifier } from '../phases/patterns.js';
 
 /**
  * Does a best-effort migration of Svelte code towards using runes, event attributes and render tags.
+ * May throw an error if the code is too complex to migrate automatically.
+ *
  * @param {string} source
- * @returns {string}
+ * @returns {{ code: string; }}
  */
 export function migrate(source) {
 	try {
@@ -145,7 +147,7 @@ export function migrate(source) {
 			}
 		}
 
-		return str.toString();
+		return { code: str.toString() };
 	} catch (e) {
 		// eslint-disable-next-line no-console
 		console.error('Error while migrating Svelte code');

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -305,10 +305,21 @@ const instance_script = {
 			state.str.update(start, end, '');
 		}
 	},
-	LabeledStatement(node, { path, state }) {
+	BreakStatement(node, { state, path }) {
+		if (path[1].type !== 'LabeledStatement') return;
+		if (node.label?.name !== '$') return;
+		state.str.update(
+			/** @type {number} */ (node.start),
+			/** @type {number} */ (node.end),
+			'return;'
+		);
+	},
+	LabeledStatement(node, { path, state, next }) {
 		if (state.analysis.runes) return;
 		if (path.length > 1) return;
 		if (node.label.name !== '$') return;
+
+		next();
 
 		if (
 			node.body.type === 'ExpressionStatement' &&

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -647,11 +647,11 @@ function handle_events(node, state) {
 
 					const needs_curlies = last.expression.body.type !== 'BlockStatement';
 					state.str.prependRight(
-						/** @type {number} */ (pos),
+						/** @type {number} */ (pos) + (needs_curlies ? 0 : 1),
 						`${needs_curlies ? '{' : ''}${prepend}${state.indent}`
 					);
 					state.str.appendRight(
-						/** @type {number} */ (last.expression.body.end),
+						/** @type {number} */ (last.expression.body.end) - (needs_curlies ? 0 : 1),
 						`\n${needs_curlies ? '}' : ''}`
 					);
 				} else {

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -547,7 +547,7 @@ function handle_events(node, state) {
 			last.expression?.type === 'ArrowFunctionExpression' &&
 			last.expression.params[0]?.type === 'Identifier'
 				? last.expression.params[0].name
-				: state.scope.generate('payload');
+				: generate_event_name(last, state);
 		let prepend = '';
 
 		for (let i = 0; i < nodes.length - 1; i += 1) {
@@ -587,7 +587,7 @@ function handle_events(node, state) {
 						init: '',
 						bindable: false,
 						optional: true,
-						type: '(payload: any) => void'
+						type: '(event: any) => void'
 					});
 				}
 				prepend += `\n${state.indent}${local}?.(${payload_name});\n`;
@@ -676,7 +676,7 @@ function handle_events(node, state) {
 					init: '',
 					bindable: false,
 					optional: true,
-					type: '(payload: any) => void'
+					type: '(event: any) => void'
 				});
 			}
 
@@ -694,6 +694,22 @@ function handle_events(node, state) {
 			state.str.update(last.start, last.end, replacement);
 		}
 	}
+}
+
+/**
+ * @param {import('#compiler').OnDirective} last
+ * @param {State} state
+ */
+function generate_event_name(last, state) {
+	const scope =
+		(last.expression && state.analysis.template.scopes.get(last.expression)) || state.scope;
+
+	let name = 'event';
+	if (!scope.get(name)) return name;
+
+	let i = 1;
+	while (scope.get(`${name}${i}`)) i += 1;
+	return `${name}${i}`;
 }
 
 /**

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -239,14 +239,17 @@ const instance_script = {
 			node.body.expression.type === 'AssignmentExpression'
 		) {
 			// $derived
-			// TODO $: ({ x } = ...)
 			state.str.update(
 				/** @type {number} */ (node.start),
 				/** @type {number} */ (node.body.expression.start),
 				'let '
 			);
 			state.str.prependLeft(/** @type {number} */ (node.body.expression.right.start), '$derived(');
-			state.str.appendRight(/** @type {number} */ (node.body.expression.right.end), ')');
+			state.str.update(
+				/** @type {number} */ (node.body.expression.right.end),
+				/** @type {number} */ (node.end),
+				');'
+			);
 		} else {
 			const is_block_stmt = node.body.type === 'BlockStatement';
 			const start_end = /** @type {number} */ (node.body.start);

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -421,7 +421,7 @@ const template = {
 				slot_props += `...${state.str.original.substring(/** @type {number} */ (attr.expression.start), attr.expression.end)}, `;
 			} else if (attr.type === 'Attribute') {
 				if (attr.name === 'name') {
-					name = /** @type {any} */ (attr.value)[0].data;
+					name = state.scope.generate(/** @type {any} */ (attr.value)[0].data);
 				} else {
 					const value =
 						attr.value !== true

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -64,7 +64,9 @@ export class Parser {
 
 		this.root = {
 			css: null,
-			js: [],
+			instance: null,
+			module: null,
+			parent: null,
 			// @ts-ignore
 			start: null,
 			// @ts-ignore

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -64,9 +64,7 @@ export class Parser {
 
 		this.root = {
 			css: null,
-			instance: null,
-			module: null,
-			parent: null,
+			js: [],
 			// @ts-ignore
 			start: null,
 			// @ts-ignore

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -704,7 +704,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 		} else {
 			extract_identifiers(node).forEach((identifier) => {
 				const binding = scope.get(identifier.name);
-				if (binding) {
+				if (binding && identifier !== binding.node) {
 					binding.mutated = true;
 					binding.reassigned = true;
 				}

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -1,4 +1,5 @@
 import { proxy } from '../internal/client/proxy.js';
+import { user_pre_effect } from '../internal/client/reactivity/effects.js';
 import { hydrate, mount, unmount } from '../internal/client/render.js';
 import { define_property } from '../internal/client/utils.js';
 
@@ -127,4 +128,15 @@ class Svelte4Component {
 	$destroy() {
 		this.#instance.$destroy();
 	}
+}
+
+/**
+ * Runs the given function once immediately on the server, and works like `$effect.pre` on the client.
+ *
+ * @deprecated Use this only as a temporary solution to migrate your component code to Svelte 5.
+ * @param {() => void | (() => void)} fn
+ * @returns {void}
+ */
+export function run(fn) {
+	user_pre_effect(fn);
 }

--- a/packages/svelte/src/legacy/legacy-server.js
+++ b/packages/svelte/src/legacy/legacy-server.js
@@ -36,3 +36,14 @@ export function asClassComponent(component) {
 	// @ts-ignore
 	return component_constructor;
 }
+
+/**
+ * Runs the given function once immediately on the server, and works like `$effect.pre` on the client.
+ *
+ * @deprecated Use this only as a temporary solution to migrate your component code to Svelte 5.
+ * @param {() => void | (() => void)} fn
+ * @returns {void}
+ */
+export function run(fn) {
+	fn();
+}

--- a/packages/svelte/tests/migrate/samples/derivations/input.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	let count = 0;
+	$: doubled = count * 2;
+	$: ({ quadrupled } = { quadrupled: count * 4 });
+</script>
+
+{count} / {doubled} / {quadrupled}

--- a/packages/svelte/tests/migrate/samples/derivations/output.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations/output.svelte
@@ -1,0 +1,7 @@
+<script>
+	let count = 0;
+	let doubled = $derived(count * 2);
+	let { quadrupled } = $derived({ quadrupled: count * 4 });
+</script>
+
+{count} / {doubled} / {quadrupled}

--- a/packages/svelte/tests/migrate/samples/effects/input.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/input.svelte
@@ -1,0 +1,10 @@
+<script>
+	let count = 0;
+	$: console.log(count);
+	$: if (count > 10) {
+		alert('too high')
+	}
+	$: {
+		console.log('foo');
+	}
+</script>

--- a/packages/svelte/tests/migrate/samples/effects/input.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/input.svelte
@@ -7,4 +7,5 @@
 	$: {
 		console.log('foo');
 	}
+	$: $count = 1;
 </script>

--- a/packages/svelte/tests/migrate/samples/effects/input.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/input.svelte
@@ -6,6 +6,8 @@
 	}
 	$: {
 		console.log('foo');
+		if (x) break $;
+		console.log('bar');
 	}
 	$: $count = 1;
 </script>

--- a/packages/svelte/tests/migrate/samples/effects/output.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/output.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { run } from 'svelte/legacy';
+
+	let count = 0;
+	run(() => {
+		console.log(count);
+	});
+	run(() => {
+		if (count > 10) {
+			alert('too high')
+		}
+	});
+	run(() => {
+		console.log('foo');
+	});
+</script>

--- a/packages/svelte/tests/migrate/samples/effects/output.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/output.svelte
@@ -12,6 +12,8 @@
 	});
 	run(() => {
 		console.log('foo');
+		if (x) return;
+		console.log('bar');
 	});
 	run(() => {
 		$count = 1;

--- a/packages/svelte/tests/migrate/samples/effects/output.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/output.svelte
@@ -13,4 +13,7 @@
 	run(() => {
 		console.log('foo');
 	});
+	run(() => {
+		$count = 1;
+	});
 </script>

--- a/packages/svelte/tests/migrate/samples/event-handlers/input.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/input.svelte
@@ -1,0 +1,11 @@
+<button on:click={() => console.log('hi')} on:click>click me</button>
+<button on:click={() => console.log('before')} on:click on:click={() => console.log('after')}>click me</button>
+<button on:click on:click={foo}>click me</button>
+<button on:click>click me</button>
+
+<button on:dblclick={() => console.log('hi')}>click me</button>
+<button on:toggle>click me</button>
+<button on:custom-event={() => 'hi'}>click me</button>
+<button on:custom-event-bubble>click me</button>
+
+<Button on:click={() => 'leave untouched'} on:click>click me</Button>

--- a/packages/svelte/tests/migrate/samples/event-handlers/input.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/input.svelte
@@ -8,4 +8,10 @@
 <button on:custom-event={() => 'hi'}>click me</button>
 <button on:custom-event-bubble>click me</button>
 
+<button on:click|preventDefault={() => ''}>click me</button>
+<button on:click|stopPropagation={() => ''}>click me</button>
+<button on:click|stopImmediatePropagation={() => ''}>click me</button>
+<button on:click|capture={() => ''}>click me</button>
+<button on:click|self={() => ''}>click me</button>
+
 <Button on:click={() => 'leave untouched'} on:click>click me</Button>

--- a/packages/svelte/tests/migrate/samples/event-handlers/input.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/input.svelte
@@ -9,7 +9,7 @@
 <button on:custom-event-bubble>click me</button>
 
 <button on:click|preventDefault={() => ''}>click me</button>
-<button on:click|stopPropagation={() => ''}>click me</button>
+<button on:click|stopPropagation={() => {}}>click me</button>
 <button on:click|stopImmediatePropagation={() => ''}>click me</button>
 <button on:click|capture={() => ''}>click me</button>
 <button on:click|self={() => ''}>click me</button>

--- a/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
@@ -1,23 +1,23 @@
 <script>
-	/** @type {{onclick?: (payload: any) => void, ontoggle?: (payload: any) => void, 'oncustom-event-bubble'?: (payload: any) => void}} */
+	/** @type {{onclick?: (event: any) => void, ontoggle?: (event: any) => void, 'oncustom-event-bubble'?: (event: any) => void}} */
 	let { onclick, ontoggle, 'oncustom-event-bubble': oncustom_event_bubble } = $props();
 </script>
 
-<button  onclick={(payload) => {
+<button  onclick={(event) => {
 	console.log('hi')
 
-	onclick?.(payload);
+	onclick?.(event);
 }}>click me</button>
-<button   onclick={(payload_1) => {
+<button   onclick={(event) => {
 	console.log('before')
 
-	onclick?.(payload_1);
+	onclick?.(event);
 	console.log('after')
 }}>click me</button>
-<button  onclick={(payload_2) => {
-	onclick?.(payload_2);
+<button  onclick={(event) => {
+	onclick?.(event);
 
-	foo?.(payload_2);
+	foo?.(event);
 }}>click me</button>
 <button {onclick}>click me</button>
 
@@ -26,20 +26,20 @@
 <button oncustom-event={() => 'hi'}>click me</button>
 <button oncustom-event-bubble={oncustom_event_bubble}>click me</button>
 
-<button onclick={(payload_8) => {
-	payload_8.preventDefault();
+<button onclick={(event) => {
+	event.preventDefault();
 	''
 }}>click me</button>
-<button onclick={(payload_9) => {
-	payload_9.stopPropagation();
+<button onclick={(event) => {
+	event.stopPropagation();
 	
 }}>click me</button>
-<button onclick={(payload_10) => {
-	payload_10.stopImmediatePropagation();
+<button onclick={(event) => {
+	event.stopImmediatePropagation();
 	''
 }}>click me</button>
 <button onclickcapture={() => ''}>click me</button>
-<button onclick={(payload_12) => {
+<button onclick={(event) => {
 	// @migration-task: incorporate self modifier
 	''
 }}>click me</button>

--- a/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
@@ -1,0 +1,28 @@
+<script>
+	let { onclick, ontoggle, 'custom-event-bubble': oncustom_event_bubble } = $props();
+</script>
+
+<button  onclick={(payload) => {
+	console.log('hi')
+
+	onclick?.(payload);
+}}>click me</button>
+<button   onclick={(payload_1) => {
+	console.log('before')
+
+	onclick?.(payload_1);
+	console.log('after')
+}}>click me</button>
+<button  onclick={(payload_2) => {
+	onclick?.(payload_2);
+
+	foo?.(payload_2);
+}}>click me</button>
+<button {onclick}>click me</button>
+
+<button ondblclick={() => console.log('hi')}>click me</button>
+<button {ontoggle}>click me</button>
+<button oncustom-event={() => 'hi'}>click me</button>
+<button oncustom-event-bubble={oncustom_event_bubble}>click me</button>
+
+<Button on:click={() => 'leave untouched'} on:click>click me</Button>

--- a/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
@@ -32,7 +32,7 @@
 }}>click me</button>
 <button onclick={(payload_9) => {
 	payload_9.stopPropagation();
-	''
+	
 }}>click me</button>
 <button onclick={(payload_10) => {
 	payload_10.stopImmediatePropagation();

--- a/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
@@ -26,4 +26,22 @@
 <button oncustom-event={() => 'hi'}>click me</button>
 <button oncustom-event-bubble={oncustom_event_bubble}>click me</button>
 
+<button onclick={(payload_8) => {
+	payload_8.preventDefault();
+	''
+}}>click me</button>
+<button onclick={(payload_9) => {
+	payload_9.stopPropagation();
+	''
+}}>click me</button>
+<button onclick={(payload_10) => {
+	payload_10.stopImmediatePropagation();
+	''
+}}>click me</button>
+<button onclickcapture={() => ''}>click me</button>
+<button onclick={(payload_12) => {
+	// @migration-task: incorporate self modifier
+	''
+}}>click me</button>
+
 <Button on:click={() => 'leave untouched'} on:click>click me</Button>

--- a/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
@@ -1,5 +1,6 @@
 <script>
-	let { onclick, ontoggle, 'custom-event-bubble': oncustom_event_bubble } = $props();
+	/** @type {{onclick?: (payload: any) => void, ontoggle?: (payload: any) => void, 'oncustom-event-bubble'?: (payload: any) => void}} */
+	let { onclick, ontoggle, 'oncustom-event-bubble': oncustom_event_bubble } = $props();
 </script>
 
 <button  onclick={(payload) => {

--- a/packages/svelte/tests/migrate/samples/props-export-alias/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-export-alias/input.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	let klass = '';
+	export { klass as class }
+</script>
+
+{klass}

--- a/packages/svelte/tests/migrate/samples/props-export-alias/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-export-alias/output.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	interface Props { class?: string }
+
+	let { class: klass = '' }: Props = $props();
+	
+</script>
+
+{klass}

--- a/packages/svelte/tests/migrate/samples/props-rest-props/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-rest-props/input.svelte
@@ -1,0 +1,5 @@
+<script>
+    export let foo;
+</script>
+
+<button {foo} {...$$restProps}>click me</button>

--- a/packages/svelte/tests/migrate/samples/props-rest-props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-rest-props/output.svelte
@@ -1,0 +1,5 @@
+<script>
+    let { foo, ...rest } = $props();
+</script>
+
+<button {foo} {...rest}>click me</button>

--- a/packages/svelte/tests/migrate/samples/props-rest-props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-rest-props/output.svelte
@@ -1,4 +1,5 @@
 <script>
+    /** @type {{Record<string, any>}} */
     let { foo, ...rest } = $props();
 </script>
 

--- a/packages/svelte/tests/migrate/samples/props-ts/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/input.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    export let readonly: number;
+    export let optional = 'foo';
+    export let binding: string;
+    export let bindingOptional: string | undefined = 'bar';
+</script>
+
+{readonly}
+{optional}
+<input bind:value={binding} />
+<input bind:value={bindingOptional} />

--- a/packages/svelte/tests/migrate/samples/props-ts/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/output.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
-    
-    
-    
-    let { readonly, optional = 'foo', binding = $bindable(), bindingOptional = $bindable('bar') } : { readonly: number, optional?: string, binding: string, bindingOptional?: string | undefined } = $props();
+    interface Props {
+        readonly: number,
+        optional?: string,
+        binding: string,
+        bindingOptional?: string | undefined
+    }
+
+    let {
+        readonly,
+        optional = 'foo',
+        binding = $bindable(),
+        bindingOptional = $bindable('bar')
+    }: Props = $props();
 </script>
 
 {readonly}

--- a/packages/svelte/tests/migrate/samples/props-ts/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/output.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    
+    
+    
+    let { readonly, optional = 'foo', binding = $bindable(), bindingOptional = $bindable('bar') } : { readonly: number, optional?: string, binding: string, bindingOptional?: string | undefined } = $props();
+</script>
+
+{readonly}
+{optional}
+<input bind:value={binding} />
+<input bind:value={bindingOptional} />

--- a/packages/svelte/tests/migrate/samples/props/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props/input.svelte
@@ -1,0 +1,11 @@
+<script>
+    export let readonly;
+    export let optional = 'foo';
+    export let binding;
+    export let bindingOptional = 'bar';
+</script>
+
+{readonly}
+{optional}
+<input bind:value={binding} />
+<input bind:value={bindingOptional} />

--- a/packages/svelte/tests/migrate/samples/props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props/output.svelte
@@ -1,0 +1,11 @@
+<script>
+    
+    
+    
+    let { readonly, optional = 'foo', binding = $bindable(), bindingOptional = $bindable('bar') } = $props();
+</script>
+
+{readonly}
+{optional}
+<input bind:value={binding} />
+<input bind:value={bindingOptional} />

--- a/packages/svelte/tests/migrate/samples/props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props/output.svelte
@@ -1,8 +1,10 @@
 <script>
-    
-    
-    
-    let { readonly, optional = 'foo', binding = $bindable(), bindingOptional = $bindable('bar') } = $props();
+    let {
+        readonly,
+        optional = 'foo',
+        binding = $bindable(),
+        bindingOptional = $bindable('bar')
+    } = $props();
 </script>
 
 {readonly}

--- a/packages/svelte/tests/migrate/samples/props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props/output.svelte
@@ -1,4 +1,5 @@
 <script>
+    /** @type {{readonly: any, optional?: string, binding: any, bindingOptional?: string}} */
     let {
         readonly,
         optional = 'foo',

--- a/packages/svelte/tests/migrate/samples/slots/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/input.svelte
@@ -3,3 +3,5 @@
 {#if foo}
 	<slot name="foo" {foo} />
 {/if}
+
+<slot name="dashed-name" />

--- a/packages/svelte/tests/migrate/samples/slots/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/input.svelte
@@ -1,0 +1,5 @@
+<button><slot /></button>
+
+{#if foo}
+	<slot name="foo" {foo} />
+{/if}

--- a/packages/svelte/tests/migrate/samples/slots/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/output.svelte
@@ -1,0 +1,9 @@
+<script>
+	let { children, foo } = $props();
+</script>
+
+<button>{@render children?.()}</button>
+
+{#if foo}
+	{@render foo?.({ foo, })}
+{/if}

--- a/packages/svelte/tests/migrate/samples/slots/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/output.svelte
@@ -1,9 +1,11 @@
 <script>
-	let { children, foo } = $props();
+	let { children, foo_1, dashed_name } = $props();
 </script>
 
 <button>{@render children?.()}</button>
 
 {#if foo}
-	{@render foo?.({ foo, })}
+	{@render foo_1?.({ foo, })}
 {/if}
+
+{@render dashed_name?.()}

--- a/packages/svelte/tests/migrate/samples/slots/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/output.svelte
@@ -1,4 +1,5 @@
 <script>
+	/** @type {{children?: import('svelte').Snippet, foo_1?: import('svelte').Snippet<[any]>, dashed_name?: import('svelte').Snippet}} */
 	let { children, foo_1, dashed_name } = $props();
 </script>
 

--- a/packages/svelte/tests/migrate/test.ts
+++ b/packages/svelte/tests/migrate/test.ts
@@ -12,7 +12,7 @@ const { test, run } = suite<ParserTest>(async (config, cwd) => {
 		.replace(/\s+$/, '')
 		.replace(/\r/g, '');
 
-	const actual = migrate(input);
+	const actual = migrate(input).code;
 
 	// run `UPDATE_SNAPSHOTS=true pnpm test migrate` to update parser tests
 	if (process.env.UPDATE_SNAPSHOTS || !fs.existsSync(`${cwd}/output.svelte`)) {

--- a/packages/svelte/tests/migrate/test.ts
+++ b/packages/svelte/tests/migrate/test.ts
@@ -1,0 +1,30 @@
+import * as fs from 'node:fs';
+import { assert } from 'vitest';
+import { migrate } from 'svelte/compiler';
+import { try_read_file } from '../helpers.js';
+import { suite, type BaseTest } from '../suite.js';
+
+interface ParserTest extends BaseTest {}
+
+const { test, run } = suite<ParserTest>(async (config, cwd) => {
+	const input = fs
+		.readFileSync(`${cwd}/input.svelte`, 'utf-8')
+		.replace(/\s+$/, '')
+		.replace(/\r/g, '');
+
+	const actual = migrate(input);
+
+	// run `UPDATE_SNAPSHOTS=true pnpm test migrate` to update parser tests
+	if (process.env.UPDATE_SNAPSHOTS || !fs.existsSync(`${cwd}/output.svelte`)) {
+		fs.writeFileSync(`${cwd}/output.svelte`, actual);
+	} else {
+		fs.writeFileSync(`${cwd}/_actual.svelte`, actual);
+
+		const expected = try_read_file(`${cwd}/output.svelte`);
+		assert.deepEqual(actual, expected);
+	}
+});
+
+export { test };
+
+await run(__dirname);

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1963,6 +1963,12 @@ declare module 'svelte/legacy' {
 	 *
 	 * */
 	export function asClassComponent<Props extends Record<string, any>, Exports extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>>(component: import("svelte").SvelteComponent<Props, Events, Slots>): import("svelte").ComponentType<import("svelte").SvelteComponent<Props, Events, Slots> & Exports>;
+	/**
+	 * Runs the given function once immediately on the server, and works like `$effect.pre` on the client.
+	 *
+	 * @deprecated Use this only as a temporary solution to migrate your component code to Svelte 5.
+	 * */
+	export function run(fn: () => void | (() => void)): void;
 }
 
 declare module 'svelte/motion' {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1088,8 +1088,12 @@ declare module 'svelte/compiler' {
 	export const VERSION: string;
 	/**
 	 * Does a best-effort migration of Svelte code towards using runes, event attributes and render tags.
+	 * May throw an error if the code is too complex to migrate automatically.
+	 *
 	 * */
-	export function migrate(source: string): string;
+	export function migrate(source: string): {
+		code: string;
+	};
 	class Scope {
 		
 		constructor(root: ScopeRoot, parent: Scope | null, porous: boolean);

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1086,6 +1086,10 @@ declare module 'svelte/compiler' {
 	 * https://svelte.dev/docs/svelte-compiler#svelte-version
 	 * */
 	export const VERSION: string;
+	/**
+	 * Does a best-effort migration of Svelte code towards using runes, event attributes and render tags.
+	 * */
+	export function migrate(source: string): string;
 	class Scope {
 		
 		constructor(root: ScopeRoot, parent: Scope | null, porous: boolean);

--- a/playgrounds/sandbox/run.js
+++ b/playgrounds/sandbox/run.js
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import glob from 'tiny-glob/sync.js';
 import minimist from 'minimist';
-import { compile, compileModule, parse } from 'svelte/compiler';
+import { compile, compileModule, parse, migrate } from 'svelte/compiler';
 
 const argv = minimist(process.argv.slice(2));
 
@@ -47,6 +47,13 @@ for (const generate of ['client', 'server']) {
 			});
 
 			fs.writeFileSync(`${cwd}/output/${file}.json`, JSON.stringify(ast, null, '\t'));
+
+			try {
+				const migrated = migrate(source);
+				fs.writeFileSync(`${cwd}/output/${file}.migrated.svelte`, migrated);
+			} catch (e) {
+				console.warn(`Error migrating ${file}`, e);
+			}
 		}
 
 		const compiled = compile(source, {

--- a/sites/svelte-5-preview/src/lib/Input/ComponentSelector.svelte
+++ b/sites/svelte-5-preview/src/lib/Input/ComponentSelector.svelte
@@ -3,6 +3,7 @@
 	import { get_full_filename } from '$lib/utils.js';
 	import { createEventDispatcher, tick } from 'svelte';
 	import RunesInfo from './RunesInfo.svelte';
+	import Migrate from './Migrate.svelte';
 
 	/** @type {boolean}  */
 	export let show_modified;
@@ -296,6 +297,8 @@
 	</button>
 
 	<div class="runes-info"><RunesInfo {runes} /></div>
+
+	<div class="migrate-info"><Migrate /></div>
 </div>
 
 <style>
@@ -408,6 +411,13 @@
 
 	.runes-info {
 		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+	}
+
+	.migrate-info {
+		flex: 0 1 0;
 		display: flex;
 		align-items: center;
 		justify-content: flex-end;

--- a/sites/svelte-5-preview/src/lib/Input/Migrate.svelte
+++ b/sites/svelte-5-preview/src/lib/Input/Migrate.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { get_repl_context } from '$lib/context.js';
+
+	const { migrate } = get_repl_context();
+</script>
+
+<div class="container">
+	<button on:click={migrate} title="Migrate this component towards the new syntax">migrate</button>
+</div>
+
+<style>
+	button {
+		position: relative;
+		display: flex;
+		text-transform: uppercase;
+		font-size: 1.4rem;
+		padding: 0.8rem;
+		gap: 0.5rem;
+		margin-right: 0.3rem;
+		z-index: 9999;
+	}
+</style>

--- a/sites/svelte-5-preview/src/lib/Output/Compiler.js
+++ b/sites/svelte-5-preview/src/lib/Output/Compiler.js
@@ -67,6 +67,24 @@ export default class Compiler {
 		});
 	}
 
+	/**
+	 * @param {import('$lib/types').File} file
+	 * @returns {Promise<import('$lib/workers/workers').MigrateMessageData>}
+	 */
+	migrate(file) {
+		return new Promise((fulfil) => {
+			const id = uid++;
+
+			this.handlers.set(id, fulfil);
+
+			this.worker.postMessage({
+				id,
+				type: 'migrate',
+				source: file.source
+			});
+		});
+	}
+
 	destroy() {
 		this.worker.terminate();
 	}

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -170,7 +170,7 @@
 			if (file.name === $selected?.name) {
 				return {
 					...file,
-					source: result.source
+					source: result.result.code
 				};
 			}
 			return file;

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -137,6 +137,7 @@
 		EDITOR_STATE_MAP,
 
 		rebundle,
+		migrate,
 		clear_state,
 		go_to_warning_pos,
 		handle_change,
@@ -154,6 +155,27 @@
 		const result = await $bundler?.bundle($files);
 		if (result && token === current_token) $bundle = result;
 		resolver();
+	}
+
+	async function migrate() {
+		if (!compiler || $selected?.type !== 'svelte') return;
+
+		const result = await compiler.migrate($selected);
+		if (result.error) {
+			// TODO show somehow
+			return;
+		}
+
+		const new_files = $files.map((file) => {
+			if (file.name === $selected?.name) {
+				return {
+					...file,
+					source: result.source
+				};
+			}
+			return file;
+		});
+		set({ files: new_files });
 	}
 
 	let is_select_changing = false;

--- a/sites/svelte-5-preview/src/lib/types.d.ts
+++ b/sites/svelte-5-preview/src/lib/types.d.ts
@@ -65,6 +65,7 @@ export type ReplContext = {
 
 	// Methods
 	rebundle(): Promise<void>;
+	migrate(): Promise<void>;
 	handle_select(filename: string): Promise<void>;
 	handle_change(
 		event: CustomEvent<{

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -41,6 +41,11 @@ self.addEventListener(
 				await ready;
 				postMessage(compile(event.data));
 				break;
+
+			case 'migrate':
+				await ready;
+				postMessage(migrate(event.data));
+				break;
 		}
 	}
 );
@@ -124,6 +129,27 @@ function compile({ id, source, options, return_ast }) {
 				warnings: [],
 				metadata: null
 			}
+		};
+	}
+}
+
+/** @param {import("../workers").MigrateMessageData} param0 */
+function migrate({ id, source }) {
+	try {
+		source = svelte.migrate(source);
+
+		return {
+			id,
+			source
+		};
+	} catch (err) {
+		// @ts-ignore
+		let message = `/*\nError migrating ${err.filename ?? 'component'}:\n${err.message}\n*/`;
+
+		return {
+			id,
+			source,
+			error: message
 		};
 	}
 }

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -136,11 +136,11 @@ function compile({ id, source, options, return_ast }) {
 /** @param {import("../workers").MigrateMessageData} param0 */
 function migrate({ id, source }) {
 	try {
-		source = svelte.migrate(source);
+		const result = svelte.migrate(source);
 
 		return {
 			id,
-			source
+			result
 		};
 	} catch (err) {
 		// @ts-ignore
@@ -148,7 +148,7 @@ function migrate({ id, source }) {
 
 		return {
 			id,
-			source,
+			result: { code: source },
 			error: message
 		};
 	}

--- a/sites/svelte-5-preview/src/lib/workers/workers.d.ts
+++ b/sites/svelte-5-preview/src/lib/workers/workers.d.ts
@@ -26,3 +26,9 @@ export type BundleMessageData = {
 	svelte_url: string;
 	files: File[];
 };
+
+export type MigrateMessageData = {
+	id: number;
+	source: string;
+	error?: string;
+};

--- a/sites/svelte-5-preview/src/lib/workers/workers.d.ts
+++ b/sites/svelte-5-preview/src/lib/workers/workers.d.ts
@@ -29,6 +29,6 @@ export type BundleMessageData = {
 
 export type MigrateMessageData = {
 	id: number;
-	source: string;
+	result: { code: string };
 	error?: string;
 };


### PR DESCRIPTION
Provides the start of a migration function, exported as `migrate` from `svelte/compiler`, which tries its best to automatically migrate towards runes, render tags (instead of slots) and event attributes (instead of event handlers)

The preview REPL was updated with a migrate button so people can try it out in the playground. [Conveniently-chosen example that works nicely (click on migrate and see it happening)](https://svelte-5-preview-git-auto-migrate-svelte.vercel.app/#H4sIAAAAAAAACkWP3U7DMAyFX8WyuNigYsBlaCfxHAsXW-qiiNSOEmcCVX13lHTA5fnOj-wFJx8oozktyOeZ0OBbjNihfscq8pWCEnaYpSRXSZ9d8lGPlq3SV5SkEEjBs1d_Dq8VV-2ksMIAT43cGRilXALBcHPu4eXXccJZAj0G-dg1s7uF9zXBVqfCTr0weHaJZmLd7WGpjtVt7WGA5za3Wu4P_xdyfymqwiBsXPDuc1j-Ntb2QqPZwNKGWn2rbPUcROFwtIwdzjL6ydOIRlOh9X39AevwIUM9AQAA)

closes #9239

TODO
- [x] figure out what do do for `$:` that don't get turned into `$derived`. Right now I'm just doing `$effect` but that's not equivalent because it doesn't run in SSR. Ideas:
  - expose an immediately-deprecated `effect_or_once` (I don't know how to call this) function which basically runs the code immediately on the server and as an effect on the client
  - make `$effect.pre` run on the server and use that (there's some issue somewhere that requests this because there are some code paths where this may be unavoidable to have an if-server-run-immediately-version)
  - duplicate the code and have an if-else written out in the migrated code
- [x] tests
- [x] handle more cases

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
