### PR TITLE
fix: Realistic spring behavior at low framerates

### DIFF
--- a/packages/svelte/src/runtime/motion/spring.js
+++ b/packages/svelte/src/runtime/motion/spring.js
@@ -103,7 +103,7 @@ export function spring(value, opts = {}) {
 					inv_mass,
 					opts: spring,
 					settled: true,
-					dt: ((now - last_time) * 60) / 1000
+					dt: ((Math.min(now - last_time, 1000 / 24)) * 60) / 1000 // limit delta time to 24fps for realistic spring behavior at low framerates
 				};
 				const next_value = tick_spring(ctx, last_value, value, target_value);
 				last_time = now;


### PR DESCRIPTION
Fix for bug described here: #7010

This is a fix for a bug caused by too long deltaTime between requestAnimationFrame callbacks; the spring physics calculation is not designed for such a long “prediction”. Since requestAnimationFrame does not fire callback while the page tab is invisible or the cpu is heavily loaded, deltaTime becomes too large.

I added deltaTime limit to 24fps