### PR TITLE
chore: get property setters lazily

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -103,9 +103,6 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 		next.class = '';
 	}
 
-	var setters = map_get(setters_cache, element.nodeName);
-	if (!setters) map_set(setters_cache, element.nodeName, (setters = get_setters(element)));
-
 	// @ts-expect-error
 	var attributes = /** @type {Record<string, unknown>} **/ (element.__attributes ??= {});
 	/** @type {Array<() => void>} */
@@ -167,6 +164,9 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 				name = name.toLowerCase();
 				name = AttributeAliases[name] || name;
 			}
+
+			var setters = map_get(setters_cache, element.nodeName);
+			if (!setters) map_set(setters_cache, element.nodeName, (setters = get_setters(element)));
 
 			if (setters.includes(name)) {
 				if (hydrating && (name === 'src' || name === 'href' || name === 'srcset')) {


### PR DESCRIPTION
super minor tweak but i noticed we're getting/generating the `setters` object even in cases where we don't need it

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
