### PR TITLE
fix: handle reassignment of `$$props` and `$$restProps`

### DIFF
--- a/.changeset/lucky-teachers-exist.md
+++ b/.changeset/lucky-teachers-exist.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: handle reassignment of `$$props` and `$$restProps`

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -447,6 +447,9 @@ export function analyze_component(root, source, options) {
 			);
 		}
 	} else {
+		instance.scope.declare(b.id('$$props'), 'rest_prop', 'synthetic');
+		instance.scope.declare(b.id('$$restProps'), 'rest_prop', 'synthetic');
+
 		for (const { ast, scope, scopes } of [module, instance, template]) {
 			/** @type {import('./types').LegacyAnalysisState} */
 			const state = {

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -447,9 +447,6 @@ export function analyze_component(root, source, options) {
 			);
 		}
 	} else {
-		instance.scope.declare(b.id('$$props'), 'bindable_prop', 'synthetic');
-		instance.scope.declare(b.id('$$restProps'), 'rest_prop', 'synthetic');
-
 		for (const { ast, scope, scopes } of [module, instance, template]) {
 			/** @type {import('./types').LegacyAnalysisState} */
 			const state = {

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -418,9 +418,10 @@ export function client_component(source, analysis, options) {
 			b.const(
 				'$$restProps',
 				b.call(
-					'$.rest_props',
+					'$.legacy_rest_props',
 					b.id('$$sanitized_props'),
-					b.array(named_props.map((name) => b.literal(name)))
+					b.array(named_props.map((name) => b.literal(name))),
+					b.array([])
 				)
 			)
 		);
@@ -431,8 +432,34 @@ export function client_component(source, analysis, options) {
 		if (analysis.custom_element) {
 			to_remove.push(b.literal('$$host'));
 		}
+
+		// Find keys that are reassigned in the component because those can get out of sync
+		// with the parent and therefore need special handling. This currently doesn't handle
+		// dynamic keys, let's hope noone does that.
+		const reassigned = [];
+		const props = [
+			analysis.instance.scope.get('$$restProps'),
+			analysis.instance.scope.get('$$props')
+		];
+		for (const prop of props) {
+			for (const { path } of prop?.references ?? []) {
+				const reference = path.at(-1);
+				const parent = path.at(-2);
+				if (
+					reference?.type === 'MemberExpression' &&
+					reference.property.type === 'Identifier' &&
+					parent?.type === 'AssignmentExpression'
+				) {
+					reassigned.push(b.literal(reference.property.name));
+				}
+			}
+		}
+
 		component_block.body.unshift(
-			b.const('$$sanitized_props', b.call('$.rest_props', b.id('$$props'), b.array(to_remove)))
+			b.const(
+				'$$sanitized_props',
+				b.call('$.legacy_rest_props', b.id('$$props'), b.array(to_remove), b.array(reassigned))
+			)
 		);
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -420,8 +420,7 @@ export function client_component(source, analysis, options) {
 				b.call(
 					'$.legacy_rest_props',
 					b.id('$$sanitized_props'),
-					b.array(named_props.map((name) => b.literal(name))),
-					b.array([])
+					b.array(named_props.map((name) => b.literal(name)))
 				)
 			)
 		);
@@ -433,32 +432,10 @@ export function client_component(source, analysis, options) {
 			to_remove.push(b.literal('$$host'));
 		}
 
-		// Find keys that are reassigned in the component because those can get out of sync
-		// with the parent and therefore need special handling. This currently doesn't handle
-		// dynamic keys, let's hope noone does that.
-		const reassigned = [];
-		const props = [
-			analysis.instance.scope.get('$$restProps'),
-			analysis.instance.scope.get('$$props')
-		];
-		for (const prop of props) {
-			for (const { path } of prop?.references ?? []) {
-				const reference = path.at(-1);
-				const parent = path.at(-2);
-				if (
-					reference?.type === 'MemberExpression' &&
-					reference.property.type === 'Identifier' &&
-					parent?.type === 'AssignmentExpression'
-				) {
-					reassigned.push(b.literal(reference.property.name));
-				}
-			}
-		}
-
 		component_block.body.unshift(
 			b.const(
 				'$$sanitized_props',
-				b.call('$.legacy_rest_props', b.id('$$props'), b.array(to_remove), b.array(reassigned))
+				b.call('$.legacy_rest_props', b.id('$$props'), b.array(to_remove))
 			)
 		);
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -74,6 +74,11 @@ export function serialize_get_binding(node, state) {
 		return node;
 	}
 
+	if (binding.node.name === '$$props') {
+		// Special case for $$props which only exists in the old world
+		return b.id('$$sanitized_props');
+	}
+
 	if (binding.kind === 'store_sub') {
 		return b.call(node);
 	}
@@ -83,12 +88,6 @@ export function serialize_get_binding(node, state) {
 	}
 
 	if (binding.kind === 'prop' || binding.kind === 'bindable_prop') {
-		if (binding.node.name === '$$props') {
-			// Special case for $$props which only exists in the old world
-			// TODO this probably shouldn't have a 'prop' binding kind
-			return node;
-		}
-
 		if (
 			state.analysis.accessors ||
 			(state.analysis.immutable ? binding.reassigned : binding.mutated) ||

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -688,8 +688,16 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 
 	// we do this after the fact, so that we don't need to worry
 	// about encountering references before their declarations
-	for (const [scope, { node, path }] of references) {
-		scope.reference(node, path);
+	for (const [ref_scope, { node, path }] of references) {
+		// We need to declare the synthetic $$props and $$restProps bindings if they are used
+		// right here in order to get their references, which are important later on
+		if (node.name === '$$props' && !scope.get('$$props')) {
+			scope.declare(b.id('$$props'), 'rest_prop', 'synthetic');
+		} else if (node.name === '$$restProps' && !scope.get('$$restProps')) {
+			scope.declare(b.id('$$restProps'), 'rest_prop', 'synthetic');
+		}
+
+		ref_scope.reference(node, path);
 	}
 
 	for (const [scope, node] of updates) {

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -688,16 +688,8 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 
 	// we do this after the fact, so that we don't need to worry
 	// about encountering references before their declarations
-	for (const [ref_scope, { node, path }] of references) {
-		// We need to declare the synthetic $$props and $$restProps bindings if they are used
-		// right here in order to get their references, which are important later on
-		if (node.name === '$$props' && !scope.get('$$props')) {
-			scope.declare(b.id('$$props'), 'rest_prop', 'synthetic');
-		} else if (node.name === '$$restProps' && !scope.get('$$restProps')) {
-			scope.declare(b.id('$$restProps'), 'rest_prop', 'synthetic');
-		}
-
-		ref_scope.reference(node, path);
+	for (const [scope, { node, path }] of references) {
+		scope.reference(node, path);
 	}
 
 	for (const [scope, node] of updates) {

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -88,6 +88,7 @@ export { mutable_source, mutate, source, set } from './reactivity/sources.js';
 export {
 	prop,
 	rest_props,
+	legacy_rest_props,
 	spread_props,
 	update_pre_prop,
 	update_prop

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -111,7 +111,7 @@ const legacy_rest_props_handler = {
 		}
 
 		target.special[key](value);
-		update(target.version); // $$props is coarse-grained: when $$props.y is updated, usages of $$props.y etc are also rerun
+		update(target.version); // $$props is coarse-grained: when $$props.x is updated, usages of $$props.y etc are also rerun
 		return true;
 	},
 	getOwnPropertyDescriptor(target, key) {

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -136,10 +136,9 @@ const legacy_rest_props_handler = {
 /**
  * @param {Record<string, unknown>} props
  * @param {string[]} exclude
- * @param {string[]} reassigned
  * @returns {Record<string, unknown>}
  */
-export function legacy_rest_props(props, exclude, reassigned) {
+export function legacy_rest_props(props, exclude) {
 	return new Proxy({ props, exclude, special: {}, version: source(0) }, legacy_rest_props_handler);
 }
 

--- a/packages/svelte/tests/runtime-legacy/samples/props-reassign/App.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/props-reassign/App.svelte
@@ -1,0 +1,6 @@
+<script>
+	$: $$props.a = $$props.a * 2;
+</script>
+
+<p>{$$props.a} {$$props.b}</p>
+<button on:click={() => $$props.b = 'b'}>update</button>

--- a/packages/svelte/tests/runtime-legacy/samples/props-reassign/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/props-reassign/_config.js
@@ -27,7 +27,7 @@ export default test({
 			target.innerHTML,
 			`
 			<button>increment</button>
-			<p>2 b</p>
+			<p>4 b</p>
 			<button>update</button>
 		`
 		);

--- a/packages/svelte/tests/runtime-legacy/samples/props-reassign/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/props-reassign/_config.js
@@ -1,0 +1,35 @@
+import { test } from '../../test';
+
+export default test({
+	html: `
+		<button>increment</button>
+		<p>0 </p>
+		<button>update</button>
+	`,
+
+	async test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+
+		await btn1.click();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>increment</button>
+			<p>2 </p>
+			<button>update</button>
+		`
+		);
+
+		await btn2.click();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>increment</button>
+			<p>2 b</p>
+			<button>update</button>
+		`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/props-reassign/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/props-reassign/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import App from './App.svelte';
+	let a = 0;
+</script>
+
+<button on:click={() => a++}>increment</button>
+<App {a} />

--- a/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/App.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/App.svelte
@@ -1,6 +1,6 @@
 <script>
-	$: $$restProps.a = $$restProps.a * 2;
+	$: $$restProps.c = $$restProps.c ?? 'c';
 </script>
 
-<p>{$$restProps.a} {$$restProps.b}</p>
+<p>{$$restProps.a} {$$restProps.b} {$$restProps.c}</p>
 <button on:click={() => $$restProps.b = 'b'}>update</button>

--- a/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/App.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/App.svelte
@@ -1,0 +1,6 @@
+<script>
+	$: $$restProps.a = $$restProps.a * 2;
+</script>
+
+<p>{$$restProps.a} {$$restProps.b}</p>
+<button on:click={() => $$restProps.b = 'b'}>update</button>

--- a/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/_config.js
@@ -3,7 +3,7 @@ import { test } from '../../test';
 export default test({
 	html: `
 		<button>increment</button>
-		<p>0 </p>
+		<p>0 c</p>
 		<button>update</button>
 	`,
 
@@ -16,7 +16,7 @@ export default test({
 			target.innerHTML,
 			`
 			<button>increment</button>
-			<p>2 </p>
+			<p>1 c</p>
 			<button>update</button>
 		`
 		);
@@ -27,7 +27,7 @@ export default test({
 			target.innerHTML,
 			`
 			<button>increment</button>
-			<p>2 b</p>
+			<p>1 b c</p>
 			<button>update</button>
 		`
 		);

--- a/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/_config.js
@@ -1,0 +1,35 @@
+import { test } from '../../test';
+
+export default test({
+	html: `
+		<button>increment</button>
+		<p>0 </p>
+		<button>update</button>
+	`,
+
+	async test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+
+		await btn1.click();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>increment</button>
+			<p>2 </p>
+			<button>update</button>
+		`
+		);
+
+		await btn2.click();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>increment</button>
+			<p>2 b</p>
+			<button>update</button>
+		`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/rest-props-reassign/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import App from './App.svelte';
+	let a = 0;
+</script>
+
+<button on:click={() => a++}>increment</button>
+<App {a} />


### PR DESCRIPTION
Some libraries assign to properties of `$$props` and `$$restProps`. These were previously resulting in an error but are now handled properly

https://github.com/sveltejs/svelte/issues/10359#issuecomment-2080067464

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
