### PR TITLE
fix: ensure reactions are kept dirty when marking them again

### DIFF
--- a/.changeset/empty-geckos-pretend.md
+++ b/.changeset/empty-geckos-pretend.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure reactions are kept dirty when marking them again

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -780,7 +780,7 @@ export function invalidate_inner_signals(fn) {
 
 /**
  * @param {import('#client').Value} signal
- * @param {number} to_status
+ * @param {number} to_status should be DIRTY or MAYBE_DIRTY
  * @param {boolean} force_schedule
  * @returns {void}
  */
@@ -793,15 +793,15 @@ export function mark_reactions(signal, to_status, force_schedule) {
 
 	for (var i = 0; i < length; i++) {
 		var reaction = reactions[i];
+		var flags = reaction.f;
 
-		// We skip any effects that are already dirty (but not unowned). Additionally, we also
+		// We skip any effects that are already dirty. Additionally, we also
 		// skip if the reaction is the same as the current effect (except if we're not in runes or we
 		// are in force schedule mode).
-		if ((!force_schedule || !runes) && reaction === current_effect) {
+		if ((flags & DIRTY) !== 0 || ((!force_schedule || !runes) && reaction === current_effect)) {
 			continue;
 		}
 
-		var flags = reaction.f;
 		set_signal_status(reaction, to_status);
 
 		// If the signal is not clean, then skip over it – with the exception of unowned signals that

--- a/packages/svelte/tests/runtime-runes/samples/derived-write-read-write-read/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-write-read-write-read/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await target.querySelector('button')?.click();
+		assert.htmlEqual(target.innerHTML, `<button>0</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-write-read-write-read/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-write-read-write-read/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let x = $state(1);
+	let y = $state(1);
+	let z = $derived(x*y);
+</script>
+
+<button onclick={() => {
+	x = 0;
+	// reading a derived value and then setting another source contributing to the derived
+	// resulting in the same value should not prevent pending render effects from updating
+	z;
+	y = 0;
+}}>{z}</button>


### PR DESCRIPTION
previously a reaction could be marked as DIRTY and subsequently as MAYBE_DIRTY before running, resulting in false negatives. Ensure that DIRTY flag can never be lowered to MAYBE_DIRTY
fixes #11363
fixes #11352
fixes #11368

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
