### PR TITLE
fix: store from props hoist wrong param

### DIFF
--- a/.changeset/tiny-moose-kiss.md
+++ b/.changeset/tiny-moose-kiss.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: store from props hoist wrong param
+fix: ensure store from props is hoisted correctly

--- a/.changeset/tiny-moose-kiss.md
+++ b/.changeset/tiny-moose-kiss.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: store from props hoist wrong param

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -473,8 +473,20 @@ function get_hoistable_params(node, context) {
 
 		if (binding !== null && !scope.declarations.has(reference) && binding.initial !== node) {
 			if (binding.kind === 'store_sub') {
-				// We need both the subscription for getting the value and the store for updating
-				safe_push(b.id(binding.node.name.slice(1)));
+				const is_from_prop =
+					binding.declaration_kind === 'synthetic' &&
+					[...binding.scope.declarations.values()].find(
+						(declaration) => declaration.kind === 'prop' || declaration.kind === 'bindable_prop'
+					);
+				if (is_from_prop && !added_props) {
+					// if the store come from props we want $$props to be pushed rather than the name
+					// of the store since that variable doesn't exist
+					added_props = true;
+					safe_push(b.id('$$props'));
+				} else {
+					// We need both the subscription for getting the value and the store for updating
+					safe_push(b.id(binding.node.name.slice(1)));
+				}
 				safe_push(b.id(binding.node.name));
 			} else if (
 				// If it's a destructured derived binding, then we can extract the derived signal reference and use that.

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+	recover: true,
+	mode: ['client']
+});

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/_config.js
@@ -4,6 +4,15 @@ export default test({
 	compileOptions: {
 		dev: true
 	},
-	recover: true,
-	mode: ['client']
+	async test({ assert, target }) {
+		const button = target.querySelector('button');
+		await button?.click();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>1</button>
+		`
+		);
+	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/child.svelte
@@ -1,0 +1,8 @@
+<script>
+	const { attrs } = $props();
+	function increment() {
+		$attrs.count++;
+	}
+</script>
+
+<button onclick={increment}>{$attrs.count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/main.svelte
@@ -1,10 +1,7 @@
 <script>
-	const { attrs } = $props();
-	function increment() {
-		$attrs.count++;
-	}
+	import { writable } from "svelte/store";
+	import Child from "./child.svelte";
+	const attrs = writable({ count: 0 });
 </script>
 
-<button onclick={increment}>
-	+
-</button>
+<Child {attrs} />

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	const { attrs } = $props();
+	function increment() {
+		$attrs.count++;
+	}
+</script>
+
+<button onclick={increment}>
+	+
+</button>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11355. I'm not entirely sure if the check i used to see if it was coming from a prop is valid but it seems to work. If there's a better way up to change it.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
