### PR TITLE
chore: add css regression test

### DIFF
--- a/packages/svelte/tests/css/samples/at-rule-nested-class/_config.js
+++ b/packages/svelte/tests/css/samples/at-rule-nested-class/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/css/samples/at-rule-nested-class/expected.css
+++ b/packages/svelte/tests/css/samples/at-rule-nested-class/expected.css
@@ -1,0 +1,9 @@
+
+	@starting-style {
+		.card.svelte-xyz{
+			height: 0;
+		}
+	}	
+	.card.svelte-xyz {
+		color: red;
+	}

--- a/packages/svelte/tests/css/samples/at-rule-nested-class/input.svelte
+++ b/packages/svelte/tests/css/samples/at-rule-nested-class/input.svelte
@@ -1,0 +1,12 @@
+<div class="card"></div>
+
+<style>
+	@starting-style {
+		.card{
+			height: 0;
+		}
+	}	
+	.card {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
at rules are now left alone and you can have nested css in them which is scoped correctly. This just adds a test so we don't regress in the future

closes #9267

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
