### PR TITLE
fix: require whitespace after `@const` tag

### DIFF
--- a/.changeset/six-boats-shave.md
+++ b/.changeset/six-boats-shave.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: require whitespace after `@const` tag

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -543,7 +543,7 @@ function special(parser) {
 	}
 
 	if (parser.eat('const')) {
-		parser.allow_whitespace();
+		parser.require_whitespace();
 
 		const id = read_pattern(parser);
 		parser.allow_whitespace();

--- a/packages/svelte/tests/compiler-errors/samples/const-tag-whitespace/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/const-tag-whitespace/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'expected_whitespace',
+		message: 'Expected whitespace',
+		position: [19, 19]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/const-tag-whitespace/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/const-tag-whitespace/main.svelte
@@ -1,0 +1,3 @@
+{#if true}
+	{@constfoo = 'bar'}
+{/if}


### PR DESCRIPTION
Currently, `{@constfoo = 'bar'}` is a valid declaration of `foo`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
