### PR TITLE
fix: ensure no data loss occurs when using reactive Set methods

### DIFF
--- a/.changeset/honest-pans-kick.md
+++ b/.changeset/honest-pans-kick.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure no data loss occurs when using reactive Set methods

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -51,8 +51,11 @@ export class ReactiveSet extends Set {
 			// @ts-ignore
 			proto[method] = function (...v) {
 				get(this.#version);
+				// We don't populate the underlying Set, so we need to create a clone using
+				// our internal values and then pass that to the method.
+				var clone = new Set(this.values());
 				// @ts-ignore
-				return set_proto[method].apply(this, v);
+				return set_proto[method].apply(clone, v);
 			};
 		}
 
@@ -60,9 +63,11 @@ export class ReactiveSet extends Set {
 			// @ts-ignore
 			proto[method] = function (...v) {
 				get(this.#version);
-
+				// We don't populate the underlying Set, so we need to create a clone using
+				// our internal values and then pass that to the method.
+				var clone = new Set(this.values());
 				// @ts-ignore
-				var set = /** @type {Set<T>} */ (set_proto[method].apply(this, v));
+				var set = /** @type {Set<T>} */ (set_proto[method].apply(clone, v));
 				return new ReactiveSet(set);
 			};
 		}

--- a/packages/svelte/src/reactivity/set.test.ts
+++ b/packages/svelte/src/reactivity/set.test.ts
@@ -86,3 +86,23 @@ test('set.delete(...)', () => {
 
 	assert.deepEqual(Array.from(set.values()), [1, 2]);
 });
+
+test('set.forEach()', () => {
+	const set = new ReactiveSet([1, 2, 3, 4, 5]);
+
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			set.forEach((v) => log.push(v));
+		});
+	});
+
+	flushSync(() => {
+		set.add(6);
+	});
+
+	assert.deepEqual(log, [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6]);
+
+	cleanup();
+});


### PR DESCRIPTION
## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
