### PR TITLE
chore: tidy up

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -184,17 +184,19 @@ export function check_dirtiness(reaction) {
 					}
 				}
 
-				// If we're working with an unowned derived signal, then we need to check
-				// if our dependency write version is higher. If it is then we can assume
-				// that state has changed to a newer version and thus this unowned signal
-				// is also dirty.
-				var version = dependency.version;
-
 				if (is_unowned) {
+					// If we're working with an unowned derived signal, then we need to check
+					// if our dependency write version is higher. If it is then we can assume
+					// that state has changed to a newer version and thus this unowned signal
+					// is also dirty.
+					var version = dependency.version;
+
 					if (version > /** @type {import('#client').Derived} */ (reaction).version) {
 						/** @type {import('#client').Derived} */ (reaction).version = version;
 						return true;
-					} else if (!current_skip_reaction && !dependency?.reactions?.includes(reaction)) {
+					}
+
+					if (!current_skip_reaction && !dependency?.reactions?.includes(reaction)) {
 						// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
 						// and the version hasn't changed, we still need to check that this reaction
 						// if linked to the dependency source – otherwise future updates will not be caught.


### PR DESCRIPTION
minor thing spotted while looking into #11402 — we read `dependency.version` before we know if we care about its value. the code is clearer and more efficient if we put everything inside the `if (is_unowned)` block. also, there's no need to have an `else` after a `return`

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
