### PR TITLE
fix: improve unowned derived signal behaviour

### DIFF
--- a/.changeset/wise-ties-clap.md
+++ b/.changeset/wise-ties-clap.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: improve unowned derived signal behaviour

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-6/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-6/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		let [btn1] = target.querySelectorAll('button');
+
+		flushSync(() => {
+			btn1.click();
+		});
+
+		assert.deepEqual(logs, ['computing', 'a', 'a', 'computing', 'bb', 'bb']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-6/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-6/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	function run(){
+		let cond = $state(true);
+		let a = $state("a");
+		let b = $state("b");
+		let c = $derived.by(() => {
+			console.log('computing')
+			return cond ? a : b
+		});
+
+		console.log(c);
+		b = "bb";
+		console.log(c)
+		cond = false;
+		console.log(c)
+		a = "aaa";
+		console.log(c)
+	}
+</script>
+
+<button onclick={run}>RUN THE THING</button>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11402. If an unowned signal was dirty, then we previously never bothered to update its version to that of it's dependencies – meaning the unowned derived would likely overfire, even if read in a effect context.