### PR TITLE
fix: `event.currentTarget` always being equal to `event.target`

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -122,22 +122,22 @@ export function handle_event_propagation(handler_element, event) {
 		}
 	});
 
-	/** @param {Element} current_target */
-	function next(current_target) {
+	/** @param {Element} next_target */
+	function next(next_target) {
+		current_target = next_target;
 		/** @type {null | Element} */
-		var parent_element =
-			current_target.parentNode || /** @type {any} */ (current_target).host || null;
+		var parent_element = next_target.parentNode || /** @type {any} */ (next_target).host || null;
 
 		try {
 			// @ts-expect-error
-			var delegated = current_target['__' + event_name];
+			var delegated = next_target['__' + event_name];
 
-			if (delegated !== undefined && !(/** @type {any} */ (current_target).disabled)) {
+			if (delegated !== undefined && !(/** @type {any} */ (next_target).disabled)) {
 				if (is_array(delegated)) {
 					var [fn, ...data] = delegated;
-					fn.apply(current_target, [event, ...data]);
+					fn.apply(next_target, [event, ...data]);
 				} else {
-					delegated.call(current_target, event);
+					delegated.call(next_target, event);
 				}
 			}
 		} finally {
@@ -145,7 +145,7 @@ export function handle_event_propagation(handler_element, event) {
 				!event.cancelBubble &&
 				parent_element !== handler_element &&
 				parent_element !== null &&
-				current_target !== handler_element
+				next_target !== handler_element
 			) {
 				next(parent_element);
 			}

--- a/packages/svelte/tests/runtime-runes/samples/event-prop-current-target/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-prop-current-target/_config.js
@@ -1,10 +1,6 @@
 import { test } from '../../test';
 
 export default test({
-	get props() {
-		return { item: { name: 'Dominic' } };
-	},
-
 	async test({ assert, target, logs }) {
 		const [s1] = target.querySelectorAll('span');
 

--- a/packages/svelte/tests/runtime-runes/samples/event-prop-current-target/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-prop-current-target/_config.js
@@ -1,0 +1,16 @@
+import { test } from '../../test';
+
+export default test({
+	get props() {
+		return { item: { name: 'Dominic' } };
+	},
+
+	async test({ assert, target, logs }) {
+		const [s1] = target.querySelectorAll('span');
+
+		s1?.click();
+		await Promise.resolve();
+
+		assert.deepEqual(logs, [false]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-prop-current-target/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-prop-current-target/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	function onclick(e) {
+		// should log false when we click the span
+		console.log(e.currentTarget === e.target)
+	}
+</script>
+
+
+<button {onclick}>
+	<span>
+		Click me
+	</span>
+</button>


### PR DESCRIPTION
Closes: #11328

We were just missing a reassignment of `current_target` in #11263 refactor.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
