### PR TITLE
fix: rework bindable types strategy

### DIFF
--- a/.changeset/yellow-pugs-raise.md
+++ b/.changeset/yellow-pugs-raise.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: rework binding type-checking strategy

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -95,7 +95,7 @@ export function stringify(value) {
  * @param {{
  * 		target: Document | Element | ShadowRoot;
  * 		anchor?: Node;
- * 		props?: import('../types.js').RemoveBindable<Props>;
+ * 		props?: Props;
  * 		events?: { [Property in keyof Events]: (e: Events[Property]) => any };
  * 		context?: Map<any, any>;
  * 		intro?: boolean;
@@ -121,7 +121,7 @@ export function mount(component, options) {
  * @param {import('../../index.js').ComponentType<import('../../index.js').SvelteComponent<Props, Events>>} component
  * @param {{
  * 		target: Document | Element | ShadowRoot;
- * 		props?: import('../types.js').RemoveBindable<Props>;
+ * 		props?: Props;
  * 		events?: { [Property in keyof Events]: (e: Events[Property]) => any };
  *  	context?: Map<any, any>;
  * 		intro?: boolean;

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -1,4 +1,3 @@
-import type { Bindable, Binding } from '../../index.js';
 import type { Store } from '#shared';
 import { STATE_SYMBOL } from './constants.js';
 import type { Effect, Source, Value } from './reactivity/types.js';

--- a/packages/svelte/src/internal/types.d.ts
+++ b/packages/svelte/src/internal/types.d.ts
@@ -1,8 +1,2 @@
-import type { Bindable } from '../index.js';
-
 /** Anything except a function */
 export type NotFunction<T> = T extends Function ? never : T;
-
-export type RemoveBindable<Props extends Record<string, any>> = {
-	[Key in keyof Props]: Props[Key] extends Bindable<infer Value> ? Value : Props[Key];
-};

--- a/packages/svelte/tests/types/component.ts
+++ b/packages/svelte/tests/types/component.ts
@@ -5,10 +5,7 @@ import {
 	type ComponentProps,
 	type ComponentType,
 	mount,
-	hydrate,
-	type Bindable,
-	type Binding,
-	type ComponentConstructorOptions
+	hydrate
 } from 'svelte';
 
 SvelteComponent.element === HTMLElement;
@@ -176,54 +173,4 @@ const x: typeof asLegacyComponent = createClassComponent({
 	target: null as any,
 	hydrate: true,
 	component: NewComponent
-});
-
-// --------------------------------------------------------------------------- bindable
-
-// Test that
-// - everything's bindable unless the component constructor is specifically set telling otherwise (for backwards compatibility)
-// - when using mount etc the props are never bindable because this is language-tools only concept
-
-function binding<T>(value: T): Binding<T> {
-	return value as any;
-}
-
-class Explicit extends SvelteComponent<{
-	foo: string;
-	bar: Bindable<boolean>;
-}> {
-	constructor(options: ComponentConstructorOptions<{ foo: string; bar: Bindable<boolean> }>) {
-		super(options);
-	}
-}
-new Explicit({ target: null as any, props: { foo: 'foo', bar: binding(true) } });
-new Explicit({ target: null as any, props: { foo: 'foo', bar: true } });
-new Explicit({
-	target: null as any,
-	props: {
-		// @ts-expect-error
-		foo: binding(''),
-		bar: true
-	}
-});
-mount(Explicit, { target: null as any, props: { foo: 'foo', bar: true } });
-mount(Explicit, {
-	target: null as any,
-	props: {
-		// @ts-expect-error
-		bar: binding(true)
-	}
-});
-
-class Implicit extends SvelteComponent<{ foo: string; bar: boolean }> {}
-new Implicit({ target: null as any, props: { foo: 'foo', bar: true } });
-new Implicit({ target: null as any, props: { foo: binding(''), bar: binding(true) } });
-mount(Implicit, { target: null as any, props: { foo: 'foo', bar: true } });
-mount(Implicit, {
-	target: null as any,
-	props: {
-		foo: 'foo',
-		// @ts-expect-error
-		bar: binding(true)
-	}
 });


### PR DESCRIPTION
Instead of using types that declare whether or not a type is bindable directly as part of the property, we're introducing a new for-types-only field to `SvelteComponent`: `$$bindings`, which is typed as the keys of the properties that are bindable (string by default, i.e. everything's bindable; for backwards compat). language-tools can then produce code that assigns to this property which results in an error we can display if the binding is invalid
closes #11356
related language tools PR: https://github.com/sveltejs/language-tools/pull/2361
draft because I need to test this out some more

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
