### PR TITLE
fix: legacy style shorthand for a variable only declared

### DIFF
--- a/.changeset/ninety-dots-train.md
+++ b/.changeset/ninety-dots-train.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: legacy style shorthand for a variable only declared

--- a/.changeset/ninety-dots-train.md
+++ b/.changeset/ninety-dots-train.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: legacy style shorthand for a variable only declared
+fix: detect style shorthands as stateful variables in legacy mode

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -870,6 +870,16 @@ const legacy_scope_tweaker = {
 				}
 			}
 		}
+	},
+	StyleDirective(node, { state }) {
+		// the case for node.value different from true is already covered by the Identifier visitor
+		if (node.value === true) {
+			// get the binding for node.name and change the binding to state
+			let binding = state.scope.get(node.name);
+			if (binding?.mutated && binding.kind === 'normal') {
+				binding.kind = 'state';
+			}
+		}
 	}
 };
 

--- a/packages/svelte/tests/runtime-legacy/samples/inline-style-directive-shorthand-declaration-only/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/inline-style-directive-shorthand-declaration-only/_config.js
@@ -1,0 +1,33 @@
+import { test } from '../../test';
+
+export default test({
+	html: `
+		<p style="color: red;"></p>
+		<p style="color: red;"></p>
+		<button></button>
+	`,
+
+	async test({ assert, target, window }) {
+		const [p1, p2] = target.querySelectorAll('p');
+
+		assert.equal(window.getComputedStyle(p1).color, 'red');
+		assert.equal(window.getComputedStyle(p2).color, 'red');
+
+		const btn = target.querySelector('button');
+		console.log(btn);
+		btn?.click();
+		await Promise.resolve();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<p style="color: green;"></p>
+			<p style="color: green;"></p>
+			<button></button>
+		`
+		);
+
+		assert.equal(window.getComputedStyle(p1).color, 'green');
+		assert.equal(window.getComputedStyle(p2).color, 'green');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/inline-style-directive-shorthand-declaration-only/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/inline-style-directive-shorthand-declaration-only/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	let color = "red";
+
+	function change(){
+		color = "green";
+	}
+</script>
+
+<p style:color></p>
+
+{#each [1] as _}
+	<p style:color></p>
+{/each}
+
+<button on:click={change}></button>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11417. The shorthand was not an Identifier in `legacy_scope_tweaker` so if the style shorthand was the only place where a declared variable was used the compiler was wrongly keep that variable as "normal" instead of "state" thus not updating the style on change.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
