### PR TITLE
fix: adjust order of `derived` function definition overloads

### DIFF
--- a/.changeset/giant-bananas-turn.md
+++ b/.changeset/giant-bananas-turn.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: adjust order of `derived` function definition overloads

--- a/packages/svelte/src/store/index.js
+++ b/packages/svelte/src/store/index.js
@@ -111,7 +111,7 @@ export function writable(value, start = noop) {
  * @template T
  * @overload
  * @param {S} stores
- * @param {(values: import('./private.js').StoresValues<S>) => T} fn
+ * @param {(values: import('./private.js').StoresValues<S>, set: (value: T) => void, update: (fn: import('./public.js').Updater<T>) => void) => import('./public.js').Unsubscriber | void} fn
  * @param {T} [initial_value]
  * @returns {import('./public.js').Readable<T>}
  */
@@ -124,7 +124,7 @@ export function writable(value, start = noop) {
  * @template T
  * @overload
  * @param {S} stores
- * @param {(values: import('./private.js').StoresValues<S>, set: (value: T) => void, update: (fn: import('./public.js').Updater<T>) => void) => import('./public.js').Unsubscriber | void} fn
+ * @param {(values: import('./private.js').StoresValues<S>) => T} fn
  * @param {T} [initial_value]
  * @returns {import('./public.js').Readable<T>}
  */

--- a/packages/svelte/tests/store/test.ts
+++ b/packages/svelte/tests/store/test.ts
@@ -272,7 +272,6 @@ describe('derived', () => {
 		const number = writable(1);
 		const evens = derived(
 			number,
-			// @ts-expect-error TODO feels like inference should work here
 			(n, set) => {
 				if (n % 2 === 0) set(n);
 			},
@@ -303,10 +302,8 @@ describe('derived', () => {
 		const number = writable(1);
 		const evensAndSquaresOf4 = derived(
 			number,
-			// @ts-expect-error TODO feels like inference should work here
 			(n, set, update) => {
 				if (n % 2 === 0) set(n);
-				// @ts-expect-error TODO feels like inference should work here
 				if (n % 4 === 0) update((n) => n * n);
 			},
 			0
@@ -442,7 +439,6 @@ describe('derived', () => {
 		const values: number[] = [];
 		const cleaned_up: number[] = [];
 
-		// @ts-expect-error TODO feels like inference should work here
 		const d = derived(num, ($num, set) => {
 			set($num * 2);
 
@@ -516,7 +512,6 @@ describe('derived', () => {
 		const a = writable(true);
 		let b_started = false;
 
-		// @ts-expect-error TODO feels like inference should work here
 		const b = derived(a, (_, __) => {
 			b_started = true;
 			return () => {
@@ -525,7 +520,6 @@ describe('derived', () => {
 			};
 		});
 
-		// @ts-expect-error TODO feels like inference should work here
 		const c = derived(a, ($a, set) => {
 			if ($a) return b.subscribe(set);
 		});

--- a/packages/svelte/tests/types/store.ts
+++ b/packages/svelte/tests/types/store.ts
@@ -11,3 +11,17 @@ derived([a], ([aVal]) => {
 	aVal === '';
 	return aVal === true;
 });
+
+derived(
+	a,
+	(value, set) => {
+		set('works');
+		// @ts-expect-error
+		set(true);
+
+		value === true;
+		// @ts-expect-error
+		value === '';
+	},
+	''
+);

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2157,14 +2157,14 @@ declare module 'svelte/store' {
 	 *
 	 * https://svelte.dev/docs/svelte-store#derived
 	 * */
-	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>) => T, initial_value?: T | undefined): Readable<T>;
+	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>, set: (value: T) => void, update: (fn: Updater<T>) => void) => Unsubscriber | void, initial_value?: T | undefined): Readable<T>;
 	/**
 	 * Derived value store by synchronizing one or more readable stores and
 	 * applying an aggregation function over its input values.
 	 *
 	 * https://svelte.dev/docs/svelte-store#derived
 	 * */
-	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>, set: (value: T) => void, update: (fn: Updater<T>) => void) => Unsubscriber | void, initial_value?: T | undefined): Readable<T>;
+	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>) => T, initial_value?: T | undefined): Readable<T>;
 	/**
 	 * Takes a store and returns a new one derived from the old one that is readable.
 	 *


### PR DESCRIPTION
Turns out the order is crucial for not getting a type error
fixes #11415

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
