### PR TITLE
fix: prevent ownership validation from infering with component context

### DIFF
--- a/.changeset/two-candles-move.md
+++ b/.changeset/two-candles-move.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: prevent ownership validation from infering with component context

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -746,12 +746,7 @@ function serialize_inline_component(node, component_name, context) {
 
 				if (context.state.options.dev) {
 					binding_initializers.push(
-						b.stmt(
-							b.call(
-								b.id('$.user_pre_effect'),
-								b.thunk(b.call(b.id('$.add_owner'), expression, b.id(component_name)))
-							)
-						)
+						b.stmt(b.call(b.id('$.add_owner_effect'), b.thunk(expression), b.id(component_name)))
 					);
 				}
 

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -1,8 +1,8 @@
 /** @typedef {{ file: string, line: number, column: number }} Location */
 
 import { STATE_SYMBOL } from '../constants.js';
-import { render_effect } from '../reactivity/effects.js';
-import { current_component_context, untrack } from '../runtime.js';
+import { render_effect, user_pre_effect } from '../reactivity/effects.js';
+import { dev_current_component_function, set_dev_current_component_function } from '../runtime.js';
 import { get_prototype_of } from '../utils.js';
 import * as w from '../warnings.js';
 
@@ -109,8 +109,7 @@ export function mark_module_end(component) {
  */
 export function add_owner(object, owner, global = false) {
 	if (object && !global) {
-		// @ts-expect-error
-		const component = current_component_context.function;
+		const component = dev_current_component_function;
 		const metadata = object[STATE_SYMBOL];
 		if (metadata && !has_owner(metadata, component)) {
 			let original = get_owner(metadata);
@@ -122,6 +121,20 @@ export function add_owner(object, owner, global = false) {
 	}
 
 	add_owner_to_object(object, owner, new Set());
+}
+
+/**
+ * @param {() => unknown} get_object
+ * @param {any} Component
+ */
+export function add_owner_effect(get_object, Component) {
+	var component = dev_current_component_function;
+	user_pre_effect(() => {
+		var prev = dev_current_component_function;
+		set_dev_current_component_function(component);
+		add_owner(get_object(), Component);
+		set_dev_current_component_function(prev);
+	});
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -1,7 +1,11 @@
 import { add_snippet_symbol } from '../../../shared/validate.js';
 import { EFFECT_TRANSPARENT } from '../../constants.js';
 import { branch, block, destroy_effect } from '../../reactivity/effects.js';
-import { current_component_context, set_current_component_context } from '../../runtime.js';
+import {
+	current_component_context,
+	dev_current_component_function,
+	set_dev_current_component_function
+} from '../../runtime.js';
 
 /**
  * @template {(node: import('#client').TemplateNode, ...args: any[]) => import('#client').Dom} SnippetFn
@@ -38,17 +42,17 @@ export function snippet(get_snippet, node, ...args) {
  * @returns
  */
 export function wrap_snippet(fn) {
-	let component = current_component_context;
+	let component = /** @type {import('#client').ComponentContext} */ (current_component_context);
 
 	return add_snippet_symbol(
 		(/** @type {import('#client').TemplateNode} */ node, /** @type {any[]} */ ...args) => {
-			var previous_component_context = current_component_context;
-			set_current_component_context(component);
+			var previous_component_function = dev_current_component_function;
+			set_dev_current_component_function(component.function);
 
 			try {
 				return fn(node, ...args);
 			} finally {
-				set_current_component_context(previous_component_context);
+				set_dev_current_component_function(previous_component_function);
 			}
 		}
 	);

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -1,5 +1,11 @@
 export { hmr } from './dev/hmr.js';
-export { ADD_OWNER, add_owner, mark_module_start, mark_module_end } from './dev/ownership.js';
+export {
+	ADD_OWNER,
+	add_owner,
+	mark_module_start,
+	mark_module_end,
+	add_owner_effect
+} from './dev/ownership.js';
 export { inspect } from './dev/inspect.js';
 export { await_block as await } from './dom/blocks/await.js';
 export { if_block as if } from './dom/blocks/if.js';

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -75,8 +75,7 @@ export function proxy(value, immutable = true, parent = null) {
 				value[STATE_SYMBOL].owners =
 					parent === null
 						? current_component_context !== null
-							? // @ts-expect-error
-								new Set([current_component_context.function])
+							? new Set([current_component_context.function])
 							: null
 						: new Set();
 			}

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -49,6 +49,10 @@ export type ComponentContext = {
 		/** This tracks whether `$:` statements have run in the current cycle, to ensure they only run once */
 		r2: Source<boolean>;
 	};
+	/**
+	 * dev mode only: the component function
+	 */
+	function?: any;
 };
 
 export type ComponentContextLegacy = ComponentContext & {

--- a/packages/svelte/tests/runtime-legacy/samples/context-api/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/context-api/_config.js
@@ -1,6 +1,9 @@
 import { test } from '../../test';
 
 export default test({
+	compileOptions: {
+		dev: true // to ensure dev mode does not break context in some way
+	},
 	html: `
 		<div class="tabs">
 			<div class="tab-list">


### PR DESCRIPTION
Ownership validation had a false positive when rendering a component as slotted content of another component. To fix this, #11401 did set the current component context to the context the snippet was declared in, not to the context it is rendered in. This was flawed because it means that component context was altered in a way that setContext/getContext failed because the parent chain was incorrect. This fixes that by introducing a separate global (dev time only) which tracks the component function the ownership needs.

fixes #11429

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
