### PR TITLE
feat: allow state and derived declarations inside class constructors

### DIFF
--- a/.changeset/funny-icons-flash.md
+++ b/.changeset/funny-icons-flash.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: allow state and derived declarations inside class constructors

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -821,7 +821,8 @@ function validate_call_expression(node, scope, path) {
 	) {
 		if (parent.type === 'VariableDeclarator') return;
 		if (parent.type === 'PropertyDefinition' && !parent.static && !parent.computed) return;
-		e.state_invalid_placement(node, rune);
+		// TODO
+		// e.state_invalid_placement(node, rune);
 	}
 
 	if (rune === '$effect' || rune === '$effect.pre') {

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -3,7 +3,8 @@ import type {
 	Statement,
 	LabeledStatement,
 	Identifier,
-	PrivateIdentifier
+	PrivateIdentifier,
+	Literal
 } from 'estree';
 import type { Namespace, SvelteNode, ValidatedCompileOptions } from '#compiler';
 import type { TransformState } from '../types.js';
@@ -66,6 +67,8 @@ export interface ComponentClientTransformState extends ClientTransformState {
 
 export interface StateField {
 	kind: 'state' | 'frozen_state' | 'derived' | 'derived_call';
+	public_id: Identifier | Literal | null;
+	declared_in_constructor: boolean;
 	id: PrivateIdentifier;
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/class-state-in-constructor/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-in-constructor/_config.js
@@ -1,0 +1,31 @@
+import { test } from '../../test';
+
+export default test({
+	solo: true,
+	html: `
+		<button>0</button>
+		<button>0</button>
+	`,
+
+	async test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+
+		await btn1?.click();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>1</button>
+				<button>0</button>
+			`
+		);
+
+		await btn2?.click();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>2</button>
+				<button>1</button>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/class-state-in-constructor/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/class-state-in-constructor/main.svelte
@@ -1,0 +1,24 @@
+<script>
+	class Counter {
+		#count;
+		get secretCount() {
+			return this.#count;
+		}
+
+		constructor() {
+			this.#count = $state(0); // TODO
+			this.count = $state(0);
+			this.double = $derived(this.count * 2);
+		}
+
+		increment() {
+			this.#count++;
+			this.count++;
+		}
+	}
+
+	const counter = new Counter();
+</script>
+
+<button on:click={() => counter.count++}>{counter.count}</button>
+<button on:click={counter.increment}>{counter.secretCount}</button>


### PR DESCRIPTION
This is a POC to test the feasability of allowing `$state` and `$derived` inside the constructor. Some cases still missing, and validation needs to adjusted to allow `this.x = $state(0)` inside the constructor but only at the top level of it.

Uncanney-valley-wise I think it's fine. TypeScript for example didn't have the ability to know that something was definitely initialized unless you either directly declared it or did so in the constructor (it did not follow method invocations inside the constructor) and it was honestly fine. I think the rule of only allowing it inside the constructor at the top level (i.e. not nested in an if block) is understandable and intuitive.

I'll proceed with this once we agreed on whether or not we want to do this.

closes #11116
closes #11339

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
