### PR TITLE
Fix: bind:scroll resets scroll state

### DIFF
--- a/.changeset/green-fishes-lie.md
+++ b/.changeset/green-fishes-lie.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only initiate scroll if scroll binding has existing value

--- a/packages/svelte/src/internal/client/dom/elements/bindings/window.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/window.js
@@ -32,7 +32,9 @@ export function bind_window_scroll(type, get_value, update) {
 	};
 
 	render_effect(() => {
-		latest_value = (get_value() ?? window[is_scrolling_x ? 'scrollX' : 'scrollY']) || 0;
+		latest_value = get_value();
+		if (latest_value === undefined) return;
+
 		if (!scrolling) {
 			scrolling = true;
 			clearTimeout(timeout);

--- a/packages/svelte/src/internal/client/dom/elements/bindings/window.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/window.js
@@ -32,7 +32,7 @@ export function bind_window_scroll(type, get_value, update) {
 	};
 
 	render_effect(() => {
-		latest_value = get_value() || 0;
+		latest_value = (get_value() ?? window[is_scrolling_x ? 'scrollX' : 'scrollY']) || 0;
 		if (!scrolling) {
 			scrolling = true;
 			clearTimeout(timeout);

--- a/packages/svelte/tests/runtime-legacy/samples/window-bind-scroll-update-2/Child.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/window-bind-scroll-update-2/Child.svelte
@@ -1,0 +1,5 @@
+<script>
+	let scrollY;
+</script>
+
+<svelte:window bind:scrollY/>

--- a/packages/svelte/tests/runtime-legacy/samples/window-bind-scroll-update-2/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/window-bind-scroll-update-2/_config.js
@@ -1,0 +1,30 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+/** @type {Window['scrollTo']} */
+let original_scrollTo;
+
+export default test({
+	before_test() {
+		original_scrollTo = window.scrollTo;
+
+		// @ts-ignore
+		window.scrollTo = (x, y) => {
+			window.scrollX = x;
+			window.scrollY = y;
+		};
+	},
+
+	after_test() {
+		window.scrollTo = original_scrollTo;
+	},
+
+	async test({ assert, component, window, target }) {
+		window.scrollTo(0, 500);
+
+		const button = target.querySelector('button');
+		flushSync(() => button?.click());
+
+		assert.equal(window.scrollY, 500);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/window-bind-scroll-update-2/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/window-bind-scroll-update-2/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Child from './Child.svelte';
+
+	let show = false;
+</script>
+
+<div style='width: 100%; height: 9999px;'></div>
+
+<button on:click={() => show = !show}>toggle</button>
+
+{#if show}
+	<Child />
+{/if}


### PR DESCRIPTION
This is simply fix to the issue [#11468]([https://github.com/sveltejs/svelte/issues/11468);
When initial state for $state() === undefined || null bind:scroll don't set window.scroll to 0;

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

closed #11468 