### PR TITLE
fix: allow for arrays in member access in directives

### DIFF
--- a/.changeset/ten-tables-speak.md
+++ b/.changeset/ten-tables-speak.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow for arrays in member access in directives

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -34,7 +34,10 @@ import {
 	TRANSITION_OUT
 } from '../../../../../constants.js';
 import { escape_html } from '../../../../../escaping.js';
-import { regex_is_valid_identifier } from '../../../patterns.js';
+import {
+	regex_is_valid_identifier,
+	regex_is_valid_member_access_directive
+} from '../../../patterns.js';
 import { javascript_visitors_runes } from './javascript-runes.js';
 import { sanitize_template_string } from '../../../../utils/sanitize_template_string.js';
 import { walk } from 'zimmerframe';
@@ -118,7 +121,7 @@ function parse_directive_name(name) {
 	let expression = b.id(part);
 
 	while ((part = /** @type {string} */ (parts.shift()))) {
-		const computed = !regex_is_valid_identifier.test(part);
+		const computed = !regex_is_valid_member_access_directive.test(part);
 		expression = b.member(expression, computed ? b.literal(part) : b.id(part), computed);
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -122,6 +122,16 @@ function parse_directive_name(name) {
 
 	while ((part = /** @type {string} */ (parts.shift()))) {
 		const computed = !regex_is_valid_member_access_directive.test(part);
+		const has_array_access = part.indexOf('[');
+		if (computed && has_array_access !== -1) {
+			const literal_part = part.substring(0, has_array_access);
+			const identifier_parts = part.substring(has_array_access).replaceAll('[', '').split(']');
+			expression = b.member(expression, b.literal(literal_part), computed);
+			for (const identifier_part of identifier_parts) {
+				if (identifier_part) expression = b.member(expression, b.id(identifier_part), computed);
+			}
+			continue;
+		}
 		expression = b.member(expression, computed ? b.literal(part) : b.id(part), computed);
 	}
 

--- a/packages/svelte/src/compiler/phases/patterns.js
+++ b/packages/svelte/src/compiler/phases/patterns.js
@@ -15,6 +15,8 @@ export const regex_only_whitespaces = /^[ \t\n\r\f]+$/;
 export const regex_not_newline_characters = /[^\n]/g;
 
 export const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
+export const regex_is_valid_member_access_directive =
+	/^[a-zA-Z_$][a-zA-Z_$0-9]*(\[[a-zA-Z_$0-9]+\])*$/;
 // used in replace all to remove all invalid chars from a literal identifier
 export const regex_invalid_identifier_chars = /(^[^a-zA-Z_$]|[^a-zA-Z0-9_$])/g;
 

--- a/packages/svelte/tests/runtime-runes/samples/directives-with-member-access/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/directives-with-member-access/main.svelte
@@ -5,7 +5,7 @@
 	 */
 	const fn = (node, options) => ({});
 
-	let a = { b: { 'c-d': fn } };
+	let a = { b: { 'c-d': fn, arr: [fn] } };
 
 	let directive = $derived(a);
 </script>
@@ -13,9 +13,35 @@
 <!-- these will yield TypeScript errors, because it looks like e.g. `nested.with - string`,
      in other words a number. Relatedly, people should not do this. It is stupid. -->
 <div use:directive.b.c-d></div>
+<div use:directive.b.arr[0]></div>
+{#each directive.b.arr as _, i}
+	<div use:directive.b.arr[i]></div>
+{/each}
+
 <div transition:directive.b.c-d></div>
+<div transition:directive.b.arr[0]></div>
+{#each directive.b.arr as _, i}
+	<div transition:directive.b.arr[i]></div>
+{/each}
+
 {#each [] as i (i)}
 	<div animate:directive.b.c-d></div>
 {/each}
+{#each [] as i (i)}
+	<div animate:directive.b.arr[0]></div>
+{/each}
+{#each directive.b.arr as _, i (i)}
+	<div animate:directive.b.arr[i]></div>
+{/each}
 <div in:directive.b.c-d></div>
+<div in:directive.b.arr[0]></div>
+{#each directive.b.arr as _, i}
+	<div in:directive.b.arr[i]></div>
+{/each}
+
 <div out:directive.b.c-d></div>
+<div out:directive.b.arr[0]></div>
+{#each directive.b.arr as _, i}
+	<div out:directive.b.arr[i]></div>
+{/each}
+

--- a/packages/svelte/tests/runtime-runes/samples/directives-with-member-access/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/directives-with-member-access/main.svelte
@@ -5,7 +5,7 @@
 	 */
 	const fn = (node, options) => ({});
 
-	let a = { b: { 'c-d': fn, arr: [fn] } };
+	let a = { b: { 'c-d': fn, 'my-arr': [fn] } };
 
 	let directive = $derived(a);
 </script>
@@ -13,35 +13,35 @@
 <!-- these will yield TypeScript errors, because it looks like e.g. `nested.with - string`,
      in other words a number. Relatedly, people should not do this. It is stupid. -->
 <div use:directive.b.c-d></div>
-<div use:directive.b.arr[0]></div>
-{#each directive.b.arr as _, i}
-	<div use:directive.b.arr[i]></div>
+<div use:directive.b.my-arr[0]></div>
+{#each directive.b['my-arr'] as _, i}
+	<div use:directive.b.my-arr[i]></div>
 {/each}
 
 <div transition:directive.b.c-d></div>
-<div transition:directive.b.arr[0]></div>
-{#each directive.b.arr as _, i}
-	<div transition:directive.b.arr[i]></div>
+<div transition:directive.b.my-arr[0]></div>
+{#each directive.b['my-arr'] as _, i}
+	<div transition:directive.b.my-arr[i]></div>
 {/each}
 
 {#each [] as i (i)}
 	<div animate:directive.b.c-d></div>
 {/each}
 {#each [] as i (i)}
-	<div animate:directive.b.arr[0]></div>
+	<div animate:directive.b.my-arr[0]></div>
 {/each}
-{#each directive.b.arr as _, i (i)}
-	<div animate:directive.b.arr[i]></div>
+{#each directive.b['my-arr'] as _, i (i)}
+	<div animate:directive.b.my-arr[i]></div>
 {/each}
 <div in:directive.b.c-d></div>
-<div in:directive.b.arr[0]></div>
-{#each directive.b.arr as _, i}
-	<div in:directive.b.arr[i]></div>
+<div in:directive.b.my-arr[0]></div>
+{#each directive.b['my-arr'] as _, i}
+	<div in:directive.b.my-arr[i]></div>
 {/each}
 
 <div out:directive.b.c-d></div>
-<div out:directive.b.arr[0]></div>
-{#each directive.b.arr as _, i}
-	<div out:directive.b.arr[i]></div>
+<div out:directive.b.my-arr[0]></div>
+{#each directive.b['my-arr'] as _, i}
+	<div out:directive.b.my-arr[i]></div>
 {/each}
 


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11467 ...this uses a slightly more advanced regex to determine if a part of a member access should use a literal or an identifier to access it.

I've also added the code to handle this absurd situation

```svelte
<div use:obj.my-arr[0] />
```
i don't know if actually want to remove this and just ignore this case 😄 

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
