### PR TITLE
fix: additional check for component on destroy

### DIFF
--- a/.changeset/olive-apples-lick.md
+++ b/.changeset/olive-apples-lick.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Check if svelte component exists on custom element destroy
+fix: check if svelte component exists on custom element destroy

--- a/.changeset/olive-apples-lick.md
+++ b/.changeset/olive-apples-lick.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Check if svelte component exists on custom element destroy

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -193,7 +193,7 @@ if (typeof HTMLElement === 'function') {
 			this.$$cn = false;
 			// In a microtask, because this could be a move within the DOM
 			Promise.resolve().then(() => {
-				if (!this.$$cn && this.$$c) { // this.$$c may be undefined if element was removed from DOM right after attaching
+				if (!this.$$cn && this.$$c) {
 					this.$$c.$destroy();
 					destroy_effect(this.$$me);
 					this.$$c = undefined;

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -193,7 +193,7 @@ if (typeof HTMLElement === 'function') {
 			this.$$cn = false;
 			// In a microtask, because this could be a move within the DOM
 			Promise.resolve().then(() => {
-				if (!this.$$cn) {
+				if (!this.$$cn && this.$$c) { // this.$$c may be undefined if element was removed from DOM right after attaching
 					this.$$c.$destroy();
 					destroy_effect(this.$$me);
 					this.$$c = undefined;


### PR DESCRIPTION
fix for https://github.com/sveltejs/svelte/issues/10454

this.$$c may be undefined if element was removed from DOM right after attaching, before svelte component was instanciated