### PR TITLE
fix: prevent false positive ownership warning

### DIFF
--- a/.changeset/two-dogs-accept.md
+++ b/.changeset/two-dogs-accept.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: prevent false positive ownership warning

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -2,7 +2,7 @@
 
 import { STATE_SYMBOL } from '../constants.js';
 import { render_effect, user_pre_effect } from '../reactivity/effects.js';
-import { dev_current_component_function, set_dev_current_component_function } from '../runtime.js';
+import { dev_current_component_function } from '../runtime.js';
 import { get_prototype_of } from '../utils.js';
 import * as w from '../warnings.js';
 
@@ -128,12 +128,8 @@ export function add_owner(object, owner, global = false) {
  * @param {any} Component
  */
 export function add_owner_effect(get_object, Component) {
-	var component = dev_current_component_function;
 	user_pre_effect(() => {
-		var prev = dev_current_component_function;
-		set_dev_current_component_function(component);
 		add_owner(get_object(), Component);
-		set_dev_current_component_function(prev);
 	});
 }
 

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -4,10 +4,12 @@ import {
 	flush_sync,
 	set_current_component_context,
 	set_current_effect,
-	set_current_reaction
+	set_current_reaction,
+	set_dev_current_component_function
 } from '../../runtime.js';
 import { block, branch, destroy_effect, pause_effect } from '../../reactivity/effects.js';
 import { INERT } from '../../constants.js';
+import { DEV } from 'esm-env';
 
 /**
  * @template V
@@ -20,6 +22,11 @@ import { INERT } from '../../constants.js';
  */
 export function await_block(anchor, get_input, pending_fn, then_fn, catch_fn) {
 	const component_context = current_component_context;
+	/** @type {any} */
+	let component_function;
+	if (DEV) {
+		component_function = component_context?.function ?? null;
+	}
 
 	/** @type {any} */
 	let input;
@@ -41,7 +48,13 @@ export function await_block(anchor, get_input, pending_fn, then_fn, catch_fn) {
 		set_current_effect(effect);
 		set_current_reaction(effect); // TODO do we need both?
 		set_current_component_context(component_context);
+		if (DEV) {
+			set_dev_current_component_function(component_function);
+		}
 		var e = branch(() => fn(anchor, value));
+		if (DEV) {
+			set_dev_current_component_function(null);
+		}
 		set_current_component_context(null);
 		set_current_reaction(null);
 		set_current_effect(null);

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -4,6 +4,7 @@ import {
 	current_effect,
 	current_reaction,
 	destroy_effect_children,
+	dev_current_component_function,
 	execute_effect,
 	get,
 	is_destroying_effect,
@@ -30,6 +31,7 @@ import {
 import { set } from './sources.js';
 import { remove } from '../dom/reconciler.js';
 import * as e from '../errors.js';
+import { DEV } from 'esm-env';
 
 /**
  * @param {import('#client').Effect | null} effect
@@ -85,6 +87,10 @@ function create_effect(type, fn, sync) {
 		teardown: null,
 		transitions: null
 	};
+
+	if (DEV) {
+		effect.component_function = dev_current_component_function;
+	}
 
 	if (current_reaction !== null && !is_root) {
 		push_effect(effect, current_reaction);

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -49,6 +49,8 @@ export interface Effect extends Reaction {
 	prev: null | Effect;
 	/** Next sibling child effect created inside the parent signal */
 	next: null | Effect;
+	/** Dev only */
+	component_function?: any;
 }
 
 export interface ValueDebug<V = unknown> extends Value<V> {

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-5/Inner.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-5/Inner.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { object = $bindable() } = $props();
+</script>
+
+<button onclick={() => object.count += 1}>
+	clicks: {object.count}
+</button>

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-5/Outer.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-5/Outer.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { children } = $props();
+</script>
+
+{@render children?.()}

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-5/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<button>clicks: 0</button>`,
+
+	compileOptions: {
+		dev: true
+	},
+
+	warnings: []
+});

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-5/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-5/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import Outer from './Outer.svelte';
+	import Inner from './Inner.svelte';
+
+	let object = $state({ count: 0 });
+	let test = $state(true);
+</script>
+
+<Outer>
+	<!-- check that render effects inside slotted content doesn't mess with ownership validation -->
+	{#if test}
+		<Inner bind:object />
+	{/if}
+</Outer>


### PR DESCRIPTION
fixes #11483
We need to keep track of the component function similar to how we keep track of the component context, so that effects etc have the correct one associated

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
