### PR TITLE
fix: ensure derived is detected as dirty correctly

### DIFF
--- a/.changeset/shiny-melons-love.md
+++ b/.changeset/shiny-melons-love.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure derived is detected as dirty correctly

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -200,11 +200,6 @@ export function check_dirtiness(reaction) {
 
 				if (!is_dirty && check_dirtiness(/** @type {import('#client').Derived} */ (dependency))) {
 					update_derived(/** @type {import('#client').Derived} **/ (dependency), true);
-
-					// `signal` might now be dirty, as a result of calling `update_derived`
-					if ((reaction.f & DIRTY) !== 0) {
-						return true;
-					}
 				}
 
 				if (is_unowned) {
@@ -230,6 +225,9 @@ export function check_dirtiness(reaction) {
 							reactions.push(reaction);
 						}
 					}
+				} else if ((reaction.f & DIRTY) !== 0) {
+					// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
+					return true;
 				}
 			}
 		}

--- a/packages/svelte/tests/runtime-runes/samples/derived-cascade/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-cascade/_config.js
@@ -1,0 +1,12 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<button>00</button>`,
+
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+		await btn?.click();
+
+		assert.htmlEqual(target.innerHTML, `<button>01</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-cascade/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-cascade/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let shouldShow01 = $state(false);
+
+	let der1 = $derived(shouldShow01)
+	// der2 must depend on der1 and its output shouldn't change
+	let der2 = $derived(typeof der1 === "string");
+	let der3 = $derived(der2 ? "1" : "0");
+	// der3 must be read before der1
+	let der4 = $derived(der3 + (der1 ? "1" : "0"));
+</script>
+
+<button onclick={() => (shouldShow01 = true)}>{der4}</button>


### PR DESCRIPTION
Deriveds where under certain conditions not detected as dirty correctly. The reason is that a transitive check_dirtiness call could update the flag of a derived, even if the condition doesn't ulimately result to true. That's why the check for "is now dirty" needs to be moved out of the inner if block. Fixes #11481

This may also fix a yet undetected overfiring bug in the "is unowned" case because the previous inner "is now dirty?" check didn't take unowned into account.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
