### PR TITLE
fix: make `$effect.active()` true when updating deriveds

### DIFF
--- a/.changeset/serious-goats-tap.md
+++ b/.changeset/serious-goats-tap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make `$effect.active()` true when updating deriveds

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -20,6 +20,10 @@
 
 > `%rune%` cannot be used inside an effect cleanup function
 
+## effect_in_unowned_derived
+
+> Effect cannot be created inside a `$derived` value that was not itself created inside an effect
+
 ## effect_orphan
 
 > `%rune%` can only be used inside an effect (e.g. during component initialisation)

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -20,7 +20,7 @@ export let inspect_captured_signals = [];
  */
 // eslint-disable-next-line no-console
 export function inspect(get_value, inspector = console.log) {
-	validate_effect(current_effect, '$inspect');
+	validate_effect('$inspect');
 
 	let initial = true;
 

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -93,6 +93,22 @@ export function effect_in_teardown(rune) {
 }
 
 /**
+ * Effect cannot be created inside a `$derived` value that was not itself created inside an effect
+ * @returns {never}
+ */
+export function effect_in_unowned_derived() {
+	if (DEV) {
+		const error = new Error(`${"effect_in_unowned_derived"}\n${"Effect cannot be created inside a `$derived` value that was not itself created inside an effect"}`);
+
+		error.name = 'Svelte error';
+		throw error;
+	} else {
+		// TODO print a link to the documentation
+		throw new Error("effect_in_unowned_derived");
+	}
+}
+
+/**
  * `%rune%` can only be used inside an effect (e.g. during component initialisation)
  * @param {string} rune
  * @returns {never}

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -117,6 +117,7 @@ export function update_derived(derived, force_schedule) {
  */
 export function destroy_derived(signal) {
 	destroy_derived_children(signal);
+	destroy_effect_children(signal);
 	remove_reactions(signal, 0);
 	set_signal_status(signal, DESTROYED);
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -93,8 +93,16 @@ function create_effect(type, fn, sync) {
 	}
 
 	if (current_reaction !== null && !is_root) {
-		if ((current_reaction.f & (DERIVED | UNOWNED)) === (DERIVED | UNOWNED)) {
-			e.effect_in_unowned_derived();
+		var flags = current_reaction.f;
+		if ((flags & DERIVED) !== 0) {
+			if ((flags & UNOWNED) !== 0) {
+				e.effect_in_unowned_derived();
+			}
+			// If we are inside a derived, then we also need to attach the
+			// effect to the parent effect too.
+			if (current_effect !== null) {
+				push_effect(effect, current_effect);
+			}
 		}
 
 		push_effect(effect, current_reaction);

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -93,6 +93,10 @@ function create_effect(type, fn, sync) {
 	}
 
 	if (current_reaction !== null && !is_root) {
+		if ((current_reaction.f & (DERIVED | UNOWNED)) === (DERIVED | UNOWNED)) {
+			e.effect_in_unowned_derived();
+		}
+
 		push_effect(effect, current_reaction);
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -36,12 +36,10 @@ import * as e from '../errors.js';
 import { DEV } from 'esm-env';
 
 /**
- * @param {import('#client').Effect | null} effect
  * @param {'$effect' | '$effect.pre' | '$inspect'} rune
- * @returns {asserts effect}
  */
-export function validate_effect(effect, rune) {
-	if (effect === null && current_reaction === null) {
+export function validate_effect(rune) {
+	if (current_effect === null && current_reaction === null) {
 		e.effect_orphan(rune);
 	}
 
@@ -136,12 +134,13 @@ export function effect_active() {
  * @param {() => void | (() => void)} fn
  */
 export function user_effect(fn) {
-	validate_effect(current_effect, '$effect');
+	validate_effect('$effect');
 
 	// Non-nested `$effect(...)` in a component should be deferred
 	// until the component is mounted
 	const defer =
-		current_effect.f & RENDER_EFFECT &&
+		current_effect !== null &&
+		(current_effect.f & RENDER_EFFECT) !== 0 &&
 		// TODO do we actually need this? removing them changes nothing
 		current_component_context !== null &&
 		!current_component_context.m;
@@ -160,7 +159,7 @@ export function user_effect(fn) {
  * @returns {import('#client').Effect}
  */
 export function user_pre_effect(fn) {
-	validate_effect(current_effect, '$effect.pre');
+	validate_effect('$effect.pre');
 	return render_effect(fn);
 }
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -26,7 +26,8 @@ import {
 	EFFECT_RAN,
 	BLOCK_EFFECT,
 	ROOT_EFFECT,
-	EFFECT_TRANSPARENT
+	EFFECT_TRANSPARENT,
+	DERIVED
 } from '../constants.js';
 import { set } from './sources.js';
 import { remove } from '../dom/reconciler.js';
@@ -118,7 +119,9 @@ function create_effect(type, fn, sync) {
  * @returns {boolean}
  */
 export function effect_active() {
-	return current_effect ? (current_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 : false;
+	if (current_effect) return (current_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0;
+	if (current_reaction) return (current_reaction.f & DERIVED) !== 0;
+	return false;
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -27,7 +27,8 @@ import {
 	BLOCK_EFFECT,
 	ROOT_EFFECT,
 	EFFECT_TRANSPARENT,
-	DERIVED
+	DERIVED,
+	UNOWNED
 } from '../constants.js';
 import { set } from './sources.js';
 import { remove } from '../dom/reconciler.js';
@@ -40,7 +41,7 @@ import { DEV } from 'esm-env';
  * @returns {asserts effect}
  */
 export function validate_effect(effect, rune) {
-	if (effect === null) {
+	if (effect === null && current_reaction === null) {
 		e.effect_orphan(rune);
 	}
 
@@ -119,8 +120,14 @@ function create_effect(type, fn, sync) {
  * @returns {boolean}
  */
 export function effect_active() {
-	if (current_effect) return (current_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0;
-	if (current_reaction) return (current_reaction.f & DERIVED) !== 0;
+	if (current_reaction && (current_reaction.f & DERIVED) !== 0) {
+		return (current_reaction.f & UNOWNED) === 0;
+	}
+
+	if (current_effect) {
+		return (current_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0;
+	}
+
 	return false;
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/effect-active-derived/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-active-derived/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<button>toggle (false)</button>`,
+
+	test({ assert, target }) {
+		const btn = target.querySelector('button');
+		flushSync(() => btn?.click());
+
+		assert.htmlEqual(target.innerHTML, `<button>toggle (true)</button><p>bar is true</p>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-active-derived/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-active-derived/_config.js
@@ -2,12 +2,40 @@ import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	html: `<button>toggle (false)</button>`,
+	html: `
+		<button>toggle outer</button>
+		<button>toggle inner</button>
+		<button>reset</button>
+	`,
 
 	test({ assert, target }) {
-		const btn = target.querySelector('button');
-		flushSync(() => btn?.click());
+		const [outer, inner, reset] = target.querySelectorAll('button');
 
-		assert.htmlEqual(target.innerHTML, `<button>toggle (true)</button><p>bar is true</p>`);
+		flushSync(() => outer?.click());
+		flushSync(() => inner?.click());
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>toggle outer</button>
+				<button>toggle inner</button>
+				<button>reset</button>
+				<p>v is true</p>
+			`
+		);
+
+		flushSync(() => reset?.click());
+		flushSync(() => inner?.click());
+		flushSync(() => outer?.click());
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>toggle outer</button>
+				<button>toggle inner</button>
+				<button>reset</button>
+				<p>v is true</p>
+			`
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect-active-derived/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-active-derived/main.svelte
@@ -1,6 +1,17 @@
 <script>
+	let value = $state(false);
+
+	const fn = () => {
+		if ($effect.active()) {
+			$effect(() => {
+				value = true;
+			});
+		}
+		return value;
+	};
+
 	let foo = $state(false)
-	let bar = $derived(foo ? $effect.active() : false);
+	let bar = $derived(foo ? fn() : false);
 </script>
 
 <button onclick={() => foo = !foo}>

--- a/packages/svelte/tests/runtime-runes/samples/effect-active-derived/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-active-derived/main.svelte
@@ -1,6 +1,5 @@
 <script>
 	let value = $state(false);
-
 	const fn = () => {
 		if ($effect.active()) {
 			$effect(() => {
@@ -10,14 +9,23 @@
 		return value;
 	};
 
-	let foo = $state(false)
-	let bar = $derived(foo ? fn() : false);
+	let outer = $state(false);
+	let inner = $state(false);
+	let v = $derived(inner ? fn() : false);
 </script>
 
-<button onclick={() => foo = !foo}>
-	toggle ({foo})
+<button onclick={() => outer = !outer}>
+	toggle outer
 </button>
 
-{#if bar}
-	<p>bar is true</p>
+<button onclick={() => inner = !inner}>
+	toggle inner
+</button>
+
+<button onclick={() => outer = inner = value = false}>
+	reset
+</button>
+
+{#if outer && v}
+	<p>v is true</p>
 {/if}

--- a/packages/svelte/tests/runtime-runes/samples/effect-active-derived/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-active-derived/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let foo = $state(false)
+	let bar = $derived(foo ? $effect.active() : false);
+</script>
+
+<button onclick={() => foo = !foo}>
+	toggle ({foo})
+</button>
+
+{#if bar}
+	<p>bar is true</p>
+{/if}


### PR DESCRIPTION
Inside a derived expression, `$effect.active()` should be true, since this likely determines whether or not effects that affect the derived value are created

[Demo here](https://svelte-5-preview-git-effect-active-derived-svelte.vercel.app/#H4sIAAAAAAAAE41Uy27bMBD8lYUQQBTsyE7b9OCHjB5yKYr00N7qApGlVcKEIgVyZdQQ9O8l9bIEx0BAwBA5u7Ozy6ErL-MCjbf6U3kyztFbed-Kwpt7dCrcxhxRENq9UaVO3MnGJJoXFO3lnnheKE1QQZwQP-KDwBwlQQ2ZVjn44aIkLkzYkoSvxl_bLJsnkOCglIAt3BiKCVkWC4OBwwzSb56jKomxALZRH0i6xDncLZfLJixR0hAkHUmK2tZPWRO7m8oJk1JrJ2sFpUwx4xJTS7FZnBuRm0JjVH3_9fMxNKS5fObZiVWOrQ7qzcKhLihqiVdQucK7sBBxgi9K2PKw28HT5qYDhEpi8Wjn6Y79MAz9OnpyRG01LouSYJS93Xt3ey-6An26Dn2-Dn25Dt1fh742kAUPJZGSUQztx2bRHTSgoZPA1gINR-U-95RyY9lOKzjYAbyt28M81s9crmDpVniPOTRA3VxBwwNgDZarlGccU2_lbrqeD34ce-hszFczNuVgROLJ2-C_Nsdfg9OM_5qQ1jdTv25BY5zGB4Gd5VKVlI11JnFzYGWRWrc2MU3L58A0fTjajx_cEErUzM8sZLj059AlrT-SYG0_zbA5GqnUEti57IhHY66swo_U_lDWhQCq7W_daslKaQei5HlemZyDfcGaglaZe9lH1MYFDY972RI5THTVjEWXw6khVUyb7dp8tmD3fFnQH1rTZcBuMMsw6a-IBSN4Tx3IJjM75w4qZjPYbq2SYBpj_4WsIiuxaa1j6dqazfpptqtudffrvcvqlzMnC0J6Qfmesl7d7e1oSu-q6xXuQjYV0wsaby_lXiKjJro2B6hrKJNDqXpwxeWz_Vv_BxCrHY1SBgAA)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
