### PR TITLE
feat: add support for svelte inspector (alternative approach)

### DIFF
--- a/.changeset/cool-jobs-scream.md
+++ b/.changeset/cool-jobs-scream.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add support for svelte inspector

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -8,6 +8,7 @@ import { javascript_visitors_runes } from './visitors/javascript-runes.js';
 import { javascript_visitors_legacy } from './visitors/javascript-legacy.js';
 import { serialize_get_binding } from './utils.js';
 import { render_stylesheet } from '../css/index.js';
+import { getLocator } from 'locate-character';
 
 /**
  * This function ensures visitor sets don't accidentally clobber each other
@@ -47,6 +48,7 @@ export function client_component(source, analysis, options) {
 		scopes: analysis.template.scopes,
 		hoisted: [b.import_all('$', 'svelte/internal/client')],
 		node: /** @type {any} */ (null), // populated by the root node
+		source_locator: getLocator(source, { offsetLine: 1 }),
 		// these should be set by create_block - if they're called outside, it's a bug
 		get before_init() {
 			/** @type {any[]} */
@@ -85,6 +87,14 @@ export function client_component(source, analysis, options) {
 			const a = [];
 			a.push = () => {
 				throw new Error('template.push should not be called outside create_block');
+			};
+			return a;
+		},
+		get locations() {
+			/** @type {any[]} */
+			const a = [];
+			a.push = () => {
+				throw new Error('locations.push should not be called outside create_block');
 			};
 			return a;
 		},
@@ -466,7 +476,7 @@ export function client_component(source, analysis, options) {
 			}
 
 			// add `App.filename = 'App.svelte'` so that we can print useful messages later
-			body.push(
+			body.unshift(
 				b.stmt(
 					b.assignment('=', b.member(b.id(analysis.name), b.id('filename')), b.literal(filename))
 				)

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -8,6 +8,7 @@ import type {
 import type { Namespace, SvelteNode, ValidatedCompileOptions } from '#compiler';
 import type { TransformState } from '../types.js';
 import type { ComponentAnalysis } from '../../types.js';
+import type { Location } from 'locate-character';
 
 export interface ClientTransformState extends TransformState {
 	readonly private_state: Map<string, StateField>;
@@ -23,11 +24,19 @@ export interface ClientTransformState extends TransformState {
 	readonly legacy_reactive_statements: Map<LabeledStatement, Statement>;
 }
 
+export type SourceLocation =
+	| [line: number, column: number]
+	| [line: number, column: number, SourceLocation[]];
+
 export interface ComponentClientTransformState extends ClientTransformState {
 	readonly analysis: ComponentAnalysis;
 	readonly options: ValidatedCompileOptions;
 	readonly hoisted: Array<Statement | ModuleDeclaration>;
 	readonly events: Set<string>;
+	readonly source_locator: (
+		search: string | number,
+		index?: number | undefined
+	) => Location | undefined;
 
 	/** Stuff that happens before the render effect(s) */
 	readonly before_init: Statement[];
@@ -39,6 +48,7 @@ export interface ComponentClientTransformState extends ClientTransformState {
 	readonly after_update: Statement[];
 	/** The HTML template string */
 	readonly template: string[];
+	readonly locations: SourceLocation[];
 	readonly metadata: {
 		namespace: Namespace;
 		bound_contenteditable: boolean;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2180,19 +2180,21 @@ export const template_visitors = {
 			})
 		);
 
-		const args = [
-			context.state.node,
-			get_tag,
-			node.metadata.svg || node.metadata.mathml ? b.true : b.false
-		];
-		if (inner.length > 0) {
-			args.push(b.arrow([element_id, b.id('$$anchor')], b.block(inner)));
-		}
-		if (dynamic_namespace) {
-			if (inner.length === 0) args.push(b.id('undefined'));
-			args.push(b.thunk(serialize_attribute_value(dynamic_namespace, context)[1]));
-		}
-		context.state.init.push(b.stmt(b.call('$.element', ...args)));
+		const location = context.state.options.dev && context.state.source_locator(node.start);
+
+		context.state.init.push(
+			b.stmt(
+				b.call(
+					'$.element',
+					context.state.node,
+					get_tag,
+					node.metadata.svg || node.metadata.mathml ? b.true : b.false,
+					inner.length > 0 && b.arrow([element_id, b.id('$$anchor')], b.block(inner)),
+					dynamic_namespace && b.thunk(serialize_attribute_value(dynamic_namespace, context)[1]),
+					location && b.array([b.literal(location.line), b.literal(location.column)])
+				)
+			)
+		);
 	},
 	EachBlock(node, context) {
 		const each_node_meta = node.metadata;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -960,6 +960,23 @@ function serialize_bind_this(bind_this, context, node) {
 }
 
 /**
+ * @param {import('../types.js').SourceLocation[]} locations
+ */
+function serialize_locations(locations) {
+	return b.array(
+		locations.map((loc) => {
+			const expression = b.array([b.literal(loc[0]), b.literal(loc[1])]);
+
+			if (loc.length === 3) {
+				expression.elements.push(serialize_locations(loc[2]));
+			}
+
+			return expression;
+		})
+	);
+}
+
+/**
  * Creates a new block which looks roughly like this:
  * ```js
  * // hoisted:
@@ -1014,6 +1031,7 @@ function create_block(parent, name, nodes, context) {
 		update: [],
 		after_update: [],
 		template: [],
+		locations: [],
 		metadata: {
 			context: {
 				template_needs_import_node: false,
@@ -1027,6 +1045,24 @@ function create_block(parent, name, nodes, context) {
 	for (const node of hoisted) {
 		context.visit(node, state);
 	}
+
+	/**
+	 * @param {import('estree').Identifier} template_name
+	 * @param {import('estree').Expression[]} args
+	 */
+	const add_template = (template_name, args) => {
+		let call = b.call(get_template_function(namespace, state), ...args);
+		if (context.state.options.dev) {
+			call = b.call(
+				'$.add_locations',
+				call,
+				b.member(b.id(context.state.analysis.name), b.id('filename')),
+				serialize_locations(state.locations)
+			);
+		}
+
+		context.state.hoisted.push(b.var(template_name, call));
+	};
 
 	if (is_single_element) {
 		const element = /** @type {import('#compiler').RegularElement} */ (trimmed[0]);
@@ -1045,9 +1081,7 @@ function create_block(parent, name, nodes, context) {
 			args.push(b.literal(TEMPLATE_USE_IMPORT_NODE));
 		}
 
-		context.state.hoisted.push(
-			b.var(template_name, b.call(get_template_function(namespace, state), ...args))
-		);
+		add_template(template_name, args);
 
 		body.push(b.var(id, b.call(template_name)), ...state.before_init, ...state.init);
 		close = b.stmt(b.call('$.append', b.id('$$anchor'), id));
@@ -1091,16 +1125,10 @@ function create_block(parent, name, nodes, context) {
 					flags |= TEMPLATE_USE_IMPORT_NODE;
 				}
 
-				state.hoisted.push(
-					b.var(
-						template_name,
-						b.call(
-							get_template_function(namespace, state),
-							b.template([b.quasi(state.template.join(''), true)], []),
-							b.literal(flags)
-						)
-					)
-				);
+				add_template(template_name, [
+					b.template([b.quasi(state.template.join(''), true)], []),
+					b.literal(flags)
+				]);
 
 				body.push(b.var(id, b.call(template_name)));
 			}
@@ -1809,6 +1837,18 @@ export const template_visitors = {
 		state.init.push(b.stmt(b.call('$.transition', ...args)));
 	},
 	RegularElement(node, context) {
+		/** @type {import('../types.js').SourceLocation} */
+		let location = [-1, -1];
+
+		if (context.state.options.dev) {
+			const loc = context.state.source_locator(node.start);
+			if (loc) {
+				location[0] = loc.line;
+				location[1] = loc.column;
+				context.state.locations.push(location);
+			}
+		}
+
 		if (node.name === 'noscript') {
 			context.state.template.push('<!>');
 			return;
@@ -1993,10 +2033,14 @@ export const template_visitors = {
 
 		context.state.template.push('>');
 
+		/** @type {import('../types.js').SourceLocation[]} */
+		const child_locations = [];
+
 		/** @type {import('../types').ComponentClientTransformState} */
 		const state = {
 			...context.state,
 			metadata: child_metadata,
+			locations: child_locations,
 			scope: /** @type {import('../../../scope').Scope} */ (
 				context.state.scopes.get(node.fragment)
 			),
@@ -2031,6 +2075,11 @@ export const template_visitors = {
 			true,
 			{ ...context, state }
 		);
+
+		if (child_locations.length > 0) {
+			// @ts-expect-error
+			location.push(child_locations);
+		}
 
 		if (!VoidElements.includes(node.name)) {
 			context.state.template.push(`</${node.name}>`);

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -99,19 +99,34 @@ export function labeled(name, body) {
 
 /**
  * @param {string | import('estree').Expression} callee
- * @param {...(import('estree').Expression | import('estree').SpreadElement)} args
+ * @param {...(import('estree').Expression | import('estree').SpreadElement | false | undefined)} args
  * @returns {import('estree').CallExpression}
  */
 export function call(callee, ...args) {
 	if (typeof callee === 'string') callee = id(callee);
 	args = args.slice();
 
-	while (args.length > 0 && !args.at(-1)) args.pop();
+	// replacing missing arguments with `undefined`, unless they're at the end in which case remove them
+	let i = args.length;
+	let popping = true;
+	while (i--) {
+		if (!args[i]) {
+			if (popping) {
+				args.pop();
+			} else {
+				args[i] = id('undefined');
+			}
+		} else {
+			popping = false;
+		}
+	}
 
 	return {
 		type: 'CallExpression',
 		callee,
-		arguments: args,
+		arguments: /** @type {Array<import('estree').Expression | import('estree').SpreadElement>} */ (
+			args
+		),
 		optional: false
 	};
 }

--- a/packages/svelte/src/internal/client/dev/elements.js
+++ b/packages/svelte/src/internal/client/dev/elements.js
@@ -1,0 +1,71 @@
+import { HYDRATION_END, HYDRATION_START } from '../../../constants.js';
+import { hydrating } from '../dom/hydration.js';
+import { is_array } from '../utils.js';
+
+/**
+ * @param {any} fn
+ * @param {string} filename
+ * @param {import('../../../compiler/phases/3-transform/client/types.js').SourceLocation[]} locations
+ * @returns {any}
+ */
+export function add_locations(fn, filename, locations) {
+	return (/** @type {any[]} */ ...args) => {
+		const dom = fn(...args);
+
+		const nodes = hydrating
+			? is_array(dom)
+				? dom
+				: [dom]
+			: dom.nodeType === 11
+				? Array.from(dom.childNodes)
+				: [dom];
+
+		assign_locations(nodes, filename, locations);
+
+		return dom;
+	};
+}
+
+/**
+ * @param {Element} element
+ * @param {string} filename
+ * @param {import('../../../compiler/phases/3-transform/client/types.js').SourceLocation} location
+ */
+function assign_location(element, filename, location) {
+	// @ts-expect-error
+	element.__svelte_meta = {
+		loc: { filename, line: location[0], column: location[1] }
+	};
+
+	if (location[2]) {
+		assign_locations(
+			/** @type {import('#client').TemplateNode[]} */ (Array.from(element.childNodes)),
+			filename,
+			location[2]
+		);
+	}
+}
+
+/**
+ * @param {import('#client').TemplateNode[]} nodes
+ * @param {string} filename
+ * @param {import('../../../compiler/phases/3-transform/client/types.js').SourceLocation[]} locations
+ */
+function assign_locations(nodes, filename, locations) {
+	var j = 0;
+	var depth = 0;
+
+	for (var i = 0; i < nodes.length; i += 1) {
+		var node = nodes[i];
+
+		if (hydrating && node.nodeType === 8) {
+			var comment = /** @type {Comment} */ (node);
+			if (comment.data === HYDRATION_START) depth += 1;
+			if (comment.data.startsWith(HYDRATION_END)) depth -= 1;
+		}
+
+		if (depth === 0 && node.nodeType === 1) {
+			assign_location(/** @type {Element} */ (node), filename, locations[j++]);
+		}
+	}
+}

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -1,5 +1,5 @@
 import { namespace_svg } from '../../../../constants.js';
-import { hydrate_anchor, hydrate_nodes, hydrating } from '../hydration.js';
+import { hydrate_anchor, hydrate_nodes, hydrating, set_hydrate_nodes } from '../hydration.js';
 import { empty } from '../operations.js';
 import {
 	block,
@@ -114,6 +114,10 @@ export function element(anchor, get_tag, is_svg, render_fn, get_namespace) {
 						var child_anchor = hydrating
 							? element.firstChild && hydrate_anchor(/** @type {Comment} */ (element.firstChild))
 							: element.appendChild(empty());
+
+						if (hydrating && !element.firstChild) {
+							set_hydrate_nodes([]);
+						}
 
 						// `child_anchor` is undefined if this is a void element, but we still
 						// need to call `render_fn` in order to run actions etc. If the element

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -49,7 +49,7 @@ function swap_block_dom(effect, from, to) {
 export function element(anchor, get_tag, is_svg, render_fn, get_namespace, location) {
 	const parent_effect = /** @type {import('#client').Effect} */ (current_effect);
 
-	const filename = DEV && current_component_context?.function.filename;
+	const filename = DEV && location && current_component_context?.function.filename;
 
 	render_effect(() => {
 		/** @type {string | null} */

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -116,7 +116,9 @@ export function element(anchor, get_tag, is_svg, render_fn, get_namespace) {
 							: element.appendChild(empty());
 
 						if (hydrating && !element.firstChild) {
-							set_hydrate_nodes([]);
+							// if the element is a void element with content, add an empty
+							// node to avoid breaking assumptions elsewhere
+							set_hydrate_nodes([empty()]);
 						}
 
 						// `child_anchor` is undefined if this is a void element, but we still

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -1,5 +1,6 @@
 import { hydrate_anchor, hydrate_nodes, hydrating } from './hydration.js';
 import { get_descriptor } from '../utils.js';
+import { DEV } from 'esm-env';
 
 // We cache the Node and Element prototype methods, so that we can avoid doing
 // expensive prototype chain lookups.
@@ -69,6 +70,11 @@ export function init_operations() {
 	element_prototype.__className = '';
 	// @ts-expect-error
 	element_prototype.__attributes = null;
+
+	if (DEV) {
+		// @ts-expect-error
+		element_prototype.__svelte_meta = null;
+	}
 
 	first_child_get = /** @type {(this: Node) => ChildNode | null} */ (
 		// @ts-ignore

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -1,3 +1,4 @@
+export { add_locations } from './dev/elements.js';
 export { hmr } from './dev/hmr.js';
 export {
 	ADD_OWNER,

--- a/packages/svelte/tests/runtime-runes/samples/svelte-meta-dynamic/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-meta-dynamic/_config.js
@@ -14,14 +14,14 @@ export default test({
 
 		// @ts-expect-error
 		assert.deepEqual(ps[0].__svelte_meta.loc, {
-			filename: '.../samples/svelte-meta/main.svelte',
+			filename: '.../samples/svelte-meta-dynamic/main.svelte',
 			line: 7,
 			column: 0
 		});
 
 		// @ts-expect-error
 		assert.deepEqual(ps[1].__svelte_meta.loc, {
-			filename: '.../samples/svelte-meta/main.svelte',
+			filename: '.../samples/svelte-meta-dynamic/main.svelte',
 			line: 13,
 			column: 0
 		});
@@ -32,7 +32,7 @@ export default test({
 
 		// @ts-expect-error
 		assert.deepEqual(strong.__svelte_meta.loc, {
-			filename: '.../samples/svelte-meta/main.svelte',
+			filename: '.../samples/svelte-meta-dynamic/main.svelte',
 			line: 10,
 			column: 1
 		});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-meta-dynamic/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-meta-dynamic/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let condition = $state(false);
+</script>
+
+<button onclick={() => condition = !condition}>toggle</button>
+
+<svelte:element this={'p'}>before</svelte:element>
+
+{#if condition}
+	<svelte:element this={'strong'}>during</svelte:element>
+{/if}
+
+<svelte:element this={'p'}>after</svelte:element>

--- a/packages/svelte/tests/runtime-runes/samples/svelte-meta/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-meta/_config.js
@@ -1,0 +1,40 @@
+import { flushSync } from '../../../../src/index-client.js';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	html: `<button>toggle</button><p>before</p><p>after</p>`,
+
+	async test({ target, assert }) {
+		const btn = target.querySelector('button');
+		const ps = target.querySelectorAll('p');
+
+		// @ts-expect-error
+		assert.deepEqual(ps[0].__svelte_meta.loc, {
+			filename: '.../samples/svelte-meta/main.svelte',
+			line: 7,
+			column: 0
+		});
+
+		// @ts-expect-error
+		assert.deepEqual(ps[1].__svelte_meta.loc, {
+			filename: '.../samples/svelte-meta/main.svelte',
+			line: 13,
+			column: 0
+		});
+
+		flushSync(() => btn?.click());
+
+		const strong = target.querySelector('strong');
+
+		// @ts-expect-error
+		assert.deepEqual(strong.__svelte_meta.loc, {
+			filename: '.../samples/svelte-meta/main.svelte',
+			line: 10,
+			column: 1
+		});
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-meta/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-meta/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let condition = $state(false);
+</script>
+
+<button onclick={() => condition = !condition}>toggle</button>
+
+<p>before</p>
+
+{#if condition}
+	<strong>during</strong>
+{/if}
+
+<p>after</p>


### PR DESCRIPTION
This is an alternative to #11456. Rather than adding attributes to elements and then removing them, it augments template functions.

It's slightly more code but it feels like a cleaner approach to me since the SSR'd HTML doesn't include a bunch of ugly hashed attributes — in fact we don't need to touch SSR code (compiler or runtime) at all. 

It also works with `<svelte:element>`, unlike the `querySelector`-based approach.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
