### PR TITLE
docs(blog): Introducing Runes - mention .svelte.js suffix

### DIFF
--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -151,7 +151,7 @@ export function createCounter() {
 </button>
 ```
 
-> NOTE: Runes can only be used in `.svelte.js` or `.svelte.ts` files.
+> Runes can only be used in `.svelte.js` and `.svelte.ts` files.
 
 Note that we're using a [get property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) in the returned object, so that `counter.count` always refers to the current value rather than the value at the time the function was called.
 

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -74,9 +74,10 @@ Well, no. The reality is that as applications grow in complexity, figuring out w
 
 ## Beyond components
 
-With runes, reactivity extends beyond the boundaries of your `.svelte` files. Suppose we wanted to encapsulate our counter logic in a way that could be reused between components. Today, you would use a [custom store](https://learn.svelte.dev/tutorial/custom-stores) in a `.js` or `.ts` file:
+With runes, reactivity extends beyond the boundaries of your `.svelte` files. Suppose we wanted to encapsulate our counter logic in a way that could be reused between components. Today, you would use a [custom store](https://learn.svelte.dev/tutorial/custom-stores) in a `.svelte.js` or `.svelte.ts` file:
 
 ```js
+/// file: counter.js
 import { writable } from 'svelte/store';
 
 export function createCounter() {
@@ -115,6 +116,7 @@ This works, but it's pretty weird! We've found that the store API can get rather
 With runes, things get much simpler:
 
 ```diff
+/// file: counter.svelte.js
 -import { writable } from 'svelte/store';
 
 export function createCounter() {

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -139,7 +139,8 @@ export function createCounter() {
 ```diff
 <!--- file: App.svelte --->
 <script>
-	import { createCounter } from './counter.svelte.js';
+-	import { createCounter } from './counter.js';
++	import { createCounter } from './counter.svelte.js';
 
 	const counter = createCounter();
 </script>

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -8,6 +8,7 @@ authorURL: /
 In 2019, Svelte 3 turned JavaScript into a [reactive language](/blog/svelte-3-rethinking-reactivity). Svelte is a web UI framework that uses a compiler to turn declarative component code like this...
 
 ```svelte
+<!--- file: App.svelte --->
 <script>
 	let count = 0;
 
@@ -54,6 +55,7 @@ Runes are symbols that influence the Svelte compiler. Whereas Svelte today uses 
 For example, to declare a piece of reactive state, we can use the `$state` rune:
 
 ```diff
+<!--- file: App.svelte --->
 <script>
 -	let count = 0;
 +	let count = $state(0);
@@ -93,7 +95,9 @@ export function createCounter() {
 Because this implements the _store contract_ — the returned value has a `subscribe` method — we can reference the store value by prefixing the store name with `$`:
 
 ```diff
+<!--- file: App.svelte --->
 <script>
+/// file: App.svelte
 +	import { createCounter } from './counter.js';
 +
 +	const counter = createCounter();
@@ -133,6 +137,7 @@ export function createCounter() {
 ```
 
 ```diff
+<!--- file: App.svelte --->
 <script>
 	import { createCounter } from './counter.js';
 

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -150,6 +150,8 @@ export function createCounter() {
 </button>
 ```
 
+> NOTE: Runes can only be used in `.svelte.js` or `.svelte.ts` files.
+
 Note that we're using a [get property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) in the returned object, so that `counter.count` always refers to the current value rather than the value at the time the function was called.
 
 ## Runtime reactivity

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -151,7 +151,7 @@ export function createCounter() {
 </button>
 ```
 
-> Runes can only be used in `.svelte.js`, `.svelte.ts` outside of `.svelte` files.
+> Runes can only be used in `.svelte.js` and `.svelte.ts` outside of `.svelte` files.
 
 Note that we're using a [get property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) in the returned object, so that `counter.count` always refers to the current value rather than the value at the time the function was called.
 

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -139,7 +139,7 @@ export function createCounter() {
 ```diff
 <!--- file: App.svelte --->
 <script>
-	import { createCounter } from './counter.js';
+	import { createCounter } from './counter.svelte.js';
 
 	const counter = createCounter();
 </script>

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -76,7 +76,7 @@ Well, no. The reality is that as applications grow in complexity, figuring out w
 
 ## Beyond components
 
-With runes, reactivity extends beyond the boundaries of your `.svelte` files. Suppose we wanted to encapsulate our counter logic in a way that could be reused between components. Today, you would use a [custom store](https://learn.svelte.dev/tutorial/custom-stores) in a `.svelte.js` or `.svelte.ts` file:
+With runes, reactivity extends beyond the boundaries of your `.svelte` files. Suppose we wanted to encapsulate our counter logic in a way that could be reused between components. Today, you would use a [custom store](https://learn.svelte.dev/tutorial/custom-stores) in a `.js` or `.ts` file:
 
 ```js
 /// file: counter.js

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -151,7 +151,7 @@ export function createCounter() {
 </button>
 ```
 
-> Runes can only be used in `.svelte.js` and `.svelte.ts` outside of `.svelte` files.
+> Outside `.svelte` components, runes can only be used in `.svelte.js` and `.svelte.ts` modules.
 
 Note that we're using a [get property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) in the returned object, so that `counter.count` always refers to the current value rather than the value at the time the function was called.
 

--- a/documentation/blog/2023-09-20-runes.md
+++ b/documentation/blog/2023-09-20-runes.md
@@ -151,7 +151,7 @@ export function createCounter() {
 </button>
 ```
 
-> Runes can only be used in `.svelte.js` and `.svelte.ts` files.
+> Runes can only be used in `.svelte.js`, `.svelte.ts` outside of `.svelte` files.
 
 Note that we're using a [get property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) in the returned object, so that `counter.count` always refers to the current value rather than the value at the time the function was called.
 


### PR DESCRIPTION
It was pointed out in discord that "Introducing Runes" post doesn't specify .svelte.js/ts suffix, hence this fixes that.

Also ad file names to the counter example, so first example shows counter.js, after the diff it shoes counter.svelte.js