### PR TITLE
fix: counterpart transition not cancelled (#11528)

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -350,6 +350,7 @@ function animate(element, options, counterpart, t2, callback) {
 				callback?.();
 
 				if (t2 === 1) {
+					counterpart?.abort();
 					animation.cancel();
 				}
 			})


### PR DESCRIPTION
# Fix: Counterpart transition not cancelled

**Fixes:** #11528 

On transitions that have both directions, elements may get stuck on the "out" state, if the updating condition gets updated while the `out` transition is still running.  

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
