### PR TITLE
fix: ensure spread events are always added

### DIFF
--- a/.changeset/two-brooms-fail.md
+++ b/.changeset/two-brooms-fail.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure spread events are added even when rerunning spread immediately

--- a/packages/svelte/tests/runtime-runes/samples/event-spread-rerun/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-spread-rerun/_config.js
@@ -1,0 +1,15 @@
+import { test, ok } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	async test({ assert, logs, target }) {
+		const input = target.querySelector('input');
+		ok(input);
+
+		input.value = 'foo';
+		await input.dispatchEvent(new Event('input'));
+
+		assert.deepEqual(logs, ['hi']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-spread-rerun/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-spread-rerun/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let rest = $state(undefined);
+</script>
+
+<input {...rest} oninput={() => console.log('hi')}>
+<!-- after input and inside template so that attribute spread reruns immediately -->
+{!rest ? (rest = {}) : false}


### PR DESCRIPTION
In edge cases it may happen that set_attributes is re-run before the effect is executed. In that case the render effect which initiates this re-run will destroy the inner effect and it will never run. But because next and prev may have the same keys, the event would not get added again and it would get lost. We prevent this by using a root effect. The added test case doesn't fail for some reason without this fix, but it does fail when you test it out manually, so I still added it. Found through https://github.com/sveltejs/svelte/issues/10359#issuecomment-2101167524

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
