### PR TITLE
fix: better support for lazy img elements

### DIFF
--- a/.changeset/rare-mirrors-act.md
+++ b/.changeset/rare-mirrors-act.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: better support for lazy img elements

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1896,15 +1896,11 @@ export const template_visitors = {
 			// Therefore we need to use importNode instead, which doesn't have this caveat.
 			is_custom_element ||
 			// If we have an <img loading="lazy"> occurance, we need to use importNode for FF
-			// otherwise, the image won't be lazy.
+			// otherwise, the image won't be lazy. If we detect an attribute for "loading" then
+			// just fallback to using importNode.
 			(node.name === 'img' &&
 				node.attributes.some(
-					(attribute) =>
-						attribute.type === 'Attribute' &&
-						attribute.name === 'loading' &&
-						Array.isArray(attribute.value) &&
-						attribute.value[0].type === 'Text' &&
-						attribute.value[0].data === 'lazy'
+					(attribute) => attribute.type === 'Attribute' && attribute.name === 'loading'
 				))
 		) {
 			metadata.context.template_needs_import_node = true;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1889,11 +1889,24 @@ export const template_visitors = {
 		let is_content_editable = false;
 		let has_content_editable_binding = false;
 
-		if (is_custom_element) {
+		if (
 			// cloneNode is faster, but it does not instantiate the underlying class of the
 			// custom element until the template is connected to the dom, which would
 			// cause problems when setting properties on the custom element.
 			// Therefore we need to use importNode instead, which doesn't have this caveat.
+			is_custom_element ||
+			// If we have an <img loading="lazy"> occurance, we need to use importNode for FF
+			// otherwise, the image won't be lazy.
+			(node.name === 'img' &&
+				node.attributes.some(
+					(attribute) =>
+						attribute.type === 'Attribute' &&
+						attribute.name === 'loading' &&
+						Array.isArray(attribute.value) &&
+						attribute.value[0].type === 'Text' &&
+						attribute.value[0].data === 'lazy'
+				))
+		) {
 			metadata.context.template_needs_import_node = true;
 		}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1897,10 +1897,13 @@ export const template_visitors = {
 			is_custom_element ||
 			// If we have an <img loading="lazy"> occurance, we need to use importNode for FF
 			// otherwise, the image won't be lazy. If we detect an attribute for "loading" then
-			// just fallback to using importNode.
+			// just fallback to using importNode. Also if we have a spread attribute on the img,
+			// then it might contain this property, so we also need to fallback there too.
 			(node.name === 'img' &&
 				node.attributes.some(
-					(attribute) => attribute.type === 'Attribute' && attribute.name === 'loading'
+					(attribute) =>
+						attribute.type === 'SpreadAttribute' ||
+						(attribute.type === 'Attribute' && attribute.name === 'loading')
 				))
 		) {
 			metadata.context.template_needs_import_node = true;

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -251,7 +251,7 @@ export function text(anchor) {
 	return push_template_node(node);
 }
 
-export const comment = template('<!>', TEMPLATE_FRAGMENT);
+export const comment = template('<!>', TEMPLATE_FRAGMENT | TEMPLATE_USE_IMPORT_NODE);
 
 /**
  * Assign the created (or in hydration mode, traversed) dom elements to the current block


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11497.

This was a tricky one. We already have a heuristic to use `importNode` in the codebase, so retrofitting it to support `loading="lazy"` was relatively trivial.

However that didn't fix the problem. In fact, lazy images weren't working in Chrome for me either (I added a `onload` event to the images to test this behaviour).

The reason was because our `comment` template was being cloned, even though it's just a comment node. I presume this is because we're inserting the elements that were from `importNode` into an element from `cloneNode`. Either way, this PR seems to remedy the problem.

Unfortunately, none of this is testable with JSDOM and I battled with Playwright, but to no avail.