### PR TITLE
fix: adjust heuristics for effect_update_depth_exceeded

### DIFF
--- a/.changeset/famous-kiwis-thank.md
+++ b/.changeset/famous-kiwis-thank.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: adjust heuristics for effect_update_depth_exceeded

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -529,7 +529,6 @@ function flush_queued_effects(effects) {
 	var length = effects.length;
 	if (length === 0) return;
 
-	infinite_loop_guard();
 	for (var i = 0; i < length; i++) {
 		var effect = effects[i];
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -677,6 +677,7 @@ function process_effects(effect, filter_flags, shallow, collected_effects) {
  * @returns {void}
  */
 function flush_nested_effects(effect, filter_flags, shallow = false) {
+	infinite_loop_guard();
 	/** @type {import('#client').Effect[]} */
 	var collected_effects = [];
 


### PR DESCRIPTION
When we refactored how flushing works, the `effect_update_depth_exceeded` logic was probably not in the right place – as having too many root effects will mean that it easily goes past the limit – indicating lots of work rather than an infinite loop. This PR moves it to the correct location.