### PR TITLE
fix: adjust heuristics for effect_update_depth_exceeded

### DIFF
--- a/.changeset/famous-kiwis-thank.md
+++ b/.changeset/famous-kiwis-thank.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: adjust heuristics for effect_update_depth_exceeded

--- a/.changeset/grumpy-avocados-fetch.md
+++ b/.changeset/grumpy-avocados-fetch.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: further adjust heuristics for effect_update_depth_exceeded

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -529,7 +529,6 @@ function flush_queued_effects(effects) {
 	var length = effects.length;
 	if (length === 0) return;
 
-	infinite_loop_guard();
 	for (var i = 0; i < length; i++) {
 		var effect = effects[i];
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -677,6 +677,7 @@ function process_effects(effect, filter_flags, shallow, collected_effects) {
  * @returns {void}
  */
 function flush_nested_effects(effect, filter_flags, shallow = false) {
+	infinite_loop_guard();
 	/** @type {import('#client').Effect[]} */
 	var collected_effects = [];
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -515,6 +515,7 @@ function infinite_loop_guard() {
  * @returns {void}
  */
 function flush_queued_root_effects(root_effects) {
+	infinite_loop_guard();
 	for (var i = 0; i < root_effects.length; i++) {
 		var signal = root_effects[i];
 		flush_nested_effects(signal, RENDER_EFFECT | EFFECT);
@@ -676,7 +677,6 @@ function process_effects(effect, filter_flags, shallow, collected_effects) {
  * @returns {void}
  */
 function flush_nested_effects(effect, filter_flags, shallow = false) {
-	infinite_loop_guard();
 	/** @type {import('#client').Effect[]} */
 	var collected_effects = [];
 
@@ -701,6 +701,7 @@ function flush_nested_effects(effect, filter_flags, shallow = false) {
  * @returns {void}
  */
 export function flush_local_render_effects(effect) {
+	infinite_loop_guard();
 	// We are entering a new flush sequence, so ensure counter is reset.
 	flush_count = 0;
 	flush_nested_effects(effect, RENDER_EFFECT, true);


### PR DESCRIPTION
Follow up to https://github.com/sveltejs/svelte/pull/11557. The call-sites were not quite right in that PR, this adjusts them accordingly.