### PR TITLE
fix: ensure Svelte action destroy effects are untracked

### DIFF
--- a/.changeset/lazy-bats-turn.md
+++ b/.changeset/lazy-bats-turn.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: unesure Svelte action destroy effects are untracked
+fix: ensure Svelte action destroy effects are untracked

--- a/.changeset/lazy-bats-turn.md
+++ b/.changeset/lazy-bats-turn.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: unesure Svelte action destroy effects are untracked

--- a/packages/svelte/src/internal/client/dom/elements/actions.js
+++ b/packages/svelte/src/internal/client/dom/elements/actions.js
@@ -32,7 +32,7 @@ export function action(dom, action, get_value) {
 		}
 
 		if (payload?.destroy) {
-			return () => /** @type {Function} */ (payload.destroy)();
+			return () => untrack(() => /** @type {Function} */ (payload.destroy)());
 		}
 	});
 }


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11418. An oversight really, we should be untracking the destroy function in actions.