### PR TITLE
fix: ensure all effect cleanup functions are untracked

### DIFF
--- a/.changeset/dirty-eyes-itch.md
+++ b/.changeset/dirty-eyes-itch.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure all effect cleanup functions are untracked

--- a/packages/svelte/src/internal/client/dom/elements/actions.js
+++ b/packages/svelte/src/internal/client/dom/elements/actions.js
@@ -32,7 +32,7 @@ export function action(dom, action, get_value) {
 		}
 
 		if (payload?.destroy) {
-			return () => untrack(() => /** @type {Function} */ (payload.destroy)());
+			return () => /** @type {Function} */ (payload.destroy)();
 		}
 	});
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -3,6 +3,7 @@ import {
 	current_component_context,
 	current_effect,
 	current_reaction,
+	current_untracking,
 	destroy_effect_children,
 	dev_current_component_function,
 	execute_effect,
@@ -14,6 +15,7 @@ import {
 	set_is_destroying_effect,
 	set_is_flushing_effect,
 	set_signal_status,
+	set_untracking,
 	untrack
 } from '../runtime.js';
 import {
@@ -295,11 +297,14 @@ export function execute_effect_teardown(effect) {
 	var teardown = effect.teardown;
 	if (teardown !== null) {
 		const previously_destroying_effect = is_destroying_effect;
+		const previous_untracking = current_untracking;
 		set_is_destroying_effect(true);
+		set_untracking(true);
 		try {
 			teardown.call(null);
 		} finally {
 			set_is_destroying_effect(previously_destroying_effect);
+			set_untracking(previous_untracking);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -48,6 +48,11 @@ export function set_is_destroying_effect(value) {
 	is_destroying_effect = value;
 }
 
+/** @param {boolean} value */
+export function set_untracking(value) {
+	current_untracking = value;
+}
+
 // Used for $inspect
 export let is_batching_effect = false;
 let is_inspecting_signal = false;

--- a/packages/svelte/tests/runtime-runes/samples/effect-untrack-teardown/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-untrack-teardown/_config.js
@@ -1,0 +1,4 @@
+import { test } from '../../test';
+
+// nothing to test here — if the teardown function is not untracked, effect will loop
+export default test({});

--- a/packages/svelte/tests/runtime-runes/samples/effect-untrack-teardown/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-untrack-teardown/main.svelte
@@ -1,0 +1,19 @@
+<script>
+	let prop = $state();
+	let key = $state({});
+
+	function action() {
+		prop = {};
+		$effect.pre(() => {
+			return () => {
+				prop;
+			}
+		});
+	}
+
+	$effect(() => key = {});
+</script>
+
+{#key key}
+	<div use:action>test</div>
+{/key}


### PR DESCRIPTION
Better solution than https://github.com/sveltejs/svelte/pull/11562.