### PR TITLE
chore: optimise effects

### DIFF
--- a/.changeset/blue-waves-sneeze.md
+++ b/.changeset/blue-waves-sneeze.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+chore: optimise effects

--- a/packages/svelte/src/internal/client/dom/legacy/lifecycle.js
+++ b/packages/svelte/src/internal/client/dom/legacy/lifecycle.js
@@ -1,14 +1,6 @@
-import { CLEAN } from '../../constants.js';
 import { run, run_all } from '../../../shared/utils.js';
 import { user_pre_effect, user_effect } from '../../reactivity/effects.js';
-import {
-	current_component_context,
-	current_effect,
-	deep_read_state,
-	flush_local_render_effects,
-	get,
-	untrack
-} from '../../runtime.js';
+import { current_component_context, deep_read_state, get, untrack } from '../../runtime.js';
 
 /**
  * Legacy-mode only: Call `onMount` callbacks and set up `beforeUpdate`/`afterUpdate` effects
@@ -26,13 +18,6 @@ export function init() {
 		user_pre_effect(() => {
 			observe_all(context);
 			run_all(callbacks.b);
-			// beforeUpdate might change state that affects rendering, ensure the render effects following from it
-			// are batched up with the current run. Avoids for example child components rerunning when they're
-			// now hidden because beforeUpdate did set an if block to false.
-			const parent = current_effect?.parent;
-			if (parent != null && (parent.f & CLEAN) === 0) {
-				flush_local_render_effects(parent);
-			}
 		});
 	}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -655,9 +655,9 @@ function process_effects(effect, recursive, collected_effects) {
 		// We might be dealing with many effects here, far more than can be spread into
 		// an array push call (callstack overflow). So let's deal with each effect in a loop.
 		for (var i = 0; i < effects.length; i++) {
-			var effect = effects[i];
-			collected_effects.push(effect);
-			process_effects(effect, true, collected_effects);
+			child = effects[i];
+			collected_effects.push(child);
+			process_effects(child, true, collected_effects);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -652,12 +652,13 @@ function process_effects(effect, filter_flags, recursive, collected_effects) {
 		current_effect = sibling;
 	}
 
-	if (recursive && effects.length > 0) {
+	if (recursive) {
 		// We might be dealing with many effects here, far more than can be spread into
 		// an array push call (callstack overflow). So let's deal with each effect in a loop.
 		for (var i = 0; i < effects.length; i++) {
-			collected_effects.push(effects[i]);
-			process_effects(effects[i], filter_flags, true, collected_effects);
+			var effect = effects[i];
+			collected_effects.push(effect);
+			process_effects(effect, filter_flags, true, collected_effects);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -516,8 +516,27 @@ function infinite_loop_guard() {
  */
 function flush_queued_root_effects(root_effects) {
 	infinite_loop_guard();
-	for (var i = 0; i < root_effects.length; i++) {
-		flush_nested_effects(root_effects[i]);
+
+	var previously_flushing_effect = is_flushing_effect;
+	is_flushing_effect = true;
+
+	try {
+		for (var i = 0; i < root_effects.length; i++) {
+			var effect = root_effects[i];
+
+			// When working with custom elements, the root effects might not have a root
+			if (effect.first === null && (effect.f & BRANCH_EFFECT) === 0) {
+				flush_queued_effects([effect]);
+			} else {
+				/** @type {import('#client').Effect[]} */
+				var collected_effects = [];
+
+				process_effects(effect, collected_effects);
+				flush_queued_effects(collected_effects);
+			}
+		}
+	} finally {
+		is_flushing_effect = previously_flushing_effect;
 	}
 }
 
@@ -586,11 +605,10 @@ export function schedule_effect(signal) {
  * effects to be flushed.
  *
  * @param {import('#client').Effect} effect
- * @param {boolean} recursive
  * @param {import('#client').Effect[]} collected_effects
  * @returns {void}
  */
-function process_effects(effect, recursive, collected_effects) {
+function process_effects(effect, collected_effects) {
 	var current_effect = effect.first;
 	var effects = [];
 
@@ -614,13 +632,14 @@ function process_effects(effect, recursive, collected_effects) {
 					// Child might have been mutated since running the effect
 					child = current_effect.first;
 				}
-				if (recursive && child !== null) {
+
+				if (child !== null) {
 					current_effect = child;
 					continue;
 				}
 			} else if ((flags & EFFECT) !== 0) {
 				if (is_branch || is_clean) {
-					if (recursive && child !== null) {
+					if (child !== null) {
 						current_effect = child;
 						continue;
 					}
@@ -650,56 +669,13 @@ function process_effects(effect, recursive, collected_effects) {
 		current_effect = sibling;
 	}
 
-	if (recursive) {
-		// We might be dealing with many effects here, far more than can be spread into
-		// an array push call (callstack overflow). So let's deal with each effect in a loop.
-		for (var i = 0; i < effects.length; i++) {
-			child = effects[i];
-			collected_effects.push(child);
-			process_effects(child, true, collected_effects);
-		}
+	// We might be dealing with many effects here, far more than can be spread into
+	// an array push call (callstack overflow). So let's deal with each effect in a loop.
+	for (var i = 0; i < effects.length; i++) {
+		child = effects[i];
+		collected_effects.push(child);
+		process_effects(child, collected_effects);
 	}
-}
-
-/**
- *
- * This function recursively collects effects in topological order from the starting effect passed in.
- * Effects will be collected when they match the filtered bitwise flag passed in only. The collected
- * array will be populated with all the effects.
- *
- * @param {import('#client').Effect} effect
- * @param {boolean} [recursive]
- * @returns {void}
- */
-function flush_nested_effects(effect, recursive = true) {
-	var previously_flushing_effect = is_flushing_effect;
-	is_flushing_effect = true;
-
-	try {
-		// When working with custom elements, the root effects might not have a root
-		if (effect.first === null && (effect.f & BRANCH_EFFECT) === 0) {
-			flush_queued_effects([effect]);
-		} else {
-			/** @type {import('#client').Effect[]} */
-			var collected_effects = [];
-
-			process_effects(effect, recursive, collected_effects);
-			flush_queued_effects(collected_effects);
-		}
-	} finally {
-		is_flushing_effect = previously_flushing_effect;
-	}
-}
-
-/**
- * @param {import('#client').Effect} effect
- * @returns {void}
- */
-export function flush_local_render_effects(effect) {
-	infinite_loop_guard();
-	// We are entering a new flush sequence, so ensure counter is reset.
-	flush_count = 0;
-	flush_nested_effects(effect, false);
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -675,9 +675,6 @@ function process_effects(effect, filter_flags, recursive, collected_effects) {
  * @returns {void}
  */
 function flush_nested_effects(effect, filter_flags, recursive = true) {
-	/** @type {import('#client').Effect[]} */
-	var collected_effects = [];
-
 	var previously_flushing_effect = is_flushing_effect;
 	is_flushing_effect = true;
 
@@ -686,6 +683,9 @@ function flush_nested_effects(effect, filter_flags, recursive = true) {
 		if (effect.first === null && (effect.f & BRANCH_EFFECT) === 0) {
 			flush_queued_effects([effect]);
 		} else {
+			/** @type {import('#client').Effect[]} */
+			var collected_effects = [];
+
 			process_effects(effect, filter_flags, recursive, collected_effects);
 			flush_queued_effects(collected_effects);
 		}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -518,7 +518,7 @@ function flush_queued_root_effects(root_effects) {
 	infinite_loop_guard();
 	for (var i = 0; i < root_effects.length; i++) {
 		var signal = root_effects[i];
-		flush_nested_effects(signal, RENDER_EFFECT | EFFECT);
+		flush_nested_effects(signal);
 	}
 }
 
@@ -587,12 +587,11 @@ export function schedule_effect(signal) {
  * effects to be flushed.
  *
  * @param {import('#client').Effect} effect
- * @param {number} filter_flags
  * @param {boolean} recursive
  * @param {import('#client').Effect[]} collected_effects
  * @returns {void}
  */
-function process_effects(effect, filter_flags, recursive, collected_effects) {
+function process_effects(effect, recursive, collected_effects) {
 	var current_effect = effect.first;
 	var effects = [];
 
@@ -658,7 +657,7 @@ function process_effects(effect, filter_flags, recursive, collected_effects) {
 		for (var i = 0; i < effects.length; i++) {
 			var effect = effects[i];
 			collected_effects.push(effect);
-			process_effects(effect, filter_flags, true, collected_effects);
+			process_effects(effect, true, collected_effects);
 		}
 	}
 }
@@ -670,11 +669,10 @@ function process_effects(effect, filter_flags, recursive, collected_effects) {
  * array will be populated with all the effects.
  *
  * @param {import('#client').Effect} effect
- * @param {number} filter_flags
  * @param {boolean} [recursive]
  * @returns {void}
  */
-function flush_nested_effects(effect, filter_flags, recursive = true) {
+function flush_nested_effects(effect, recursive = true) {
 	var previously_flushing_effect = is_flushing_effect;
 	is_flushing_effect = true;
 
@@ -686,7 +684,7 @@ function flush_nested_effects(effect, filter_flags, recursive = true) {
 			/** @type {import('#client').Effect[]} */
 			var collected_effects = [];
 
-			process_effects(effect, filter_flags, recursive, collected_effects);
+			process_effects(effect, recursive, collected_effects);
 			flush_queued_effects(collected_effects);
 		}
 	} finally {
@@ -702,7 +700,7 @@ export function flush_local_render_effects(effect) {
 	infinite_loop_guard();
 	// We are entering a new flush sequence, so ensure counter is reset.
 	flush_count = 0;
-	flush_nested_effects(effect, RENDER_EFFECT, false);
+	flush_nested_effects(effect, false);
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -517,8 +517,7 @@ function infinite_loop_guard() {
 function flush_queued_root_effects(root_effects) {
 	infinite_loop_guard();
 	for (var i = 0; i < root_effects.length; i++) {
-		var signal = root_effects[i];
-		flush_nested_effects(signal);
+		flush_nested_effects(root_effects[i]);
 	}
 }
 


### PR DESCRIPTION
Noticed this while reviewing recently merged PRs. @dummdidumm realised in https://github.com/sveltejs/svelte/pull/11560/files#r1597502682 that we're doing unnecessary work in a loop.

It turns out we can go further — we don't need the `filter_flags & EFFECT` stuff at all, because `effects` only contains effects with that flag. And since the only time we _don't_ want to process effects recursively is inside `flush_local_render_effects` (when `EFFECT` effects are excluded), these two conditions are in fact synonymous:

```js
if ((filter_flags & EFFECT) !== 0) {...}
if (!shallow) {...}
```

And `shallow` is only used negatively, so rather than doing `!shallow` everywhere we should save ourselves the unnecessary instruction by doing `recursive` instead.

The resulting code is somewhat clearer in my eyes.