### PR TITLE
fix: wrap props in deriveds more conservatively in legacy mode

### DIFF
--- a/.changeset/odd-jobs-taste.md
+++ b/.changeset/odd-jobs-taste.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: wrap props in deriveds more conservatively in legacy mode

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1263,8 +1263,9 @@ const common_visitors = {
 	},
 	CallExpression(node, context) {
 		if (
-			context.state.expression?.type === 'ExpressionTag' ||
-			(context.state.expression?.type === 'SpreadAttribute' && !is_known_safe_call(node, context))
+			(context.state.expression?.type === 'ExpressionTag' ||
+				context.state.expression?.type === 'SpreadAttribute') &&
+			!is_known_safe_call(node, context)
 		) {
 			context.state.expression.metadata.contains_call_expression = true;
 		}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -720,9 +720,14 @@ function serialize_inline_component(node, component_name, context) {
 					Array.isArray(attribute.value) &&
 					attribute.value.some((n) => {
 						if (n.type !== 'ExpressionTag') return false;
-						return context.state.analysis.runes
-							? n.metadata.contains_call_expression
-							: n.expression.type !== 'Identifier';
+						if (n.expression.type === 'Identifier' || n.expression.type === 'Literal') return false;
+
+						if (n.expression.type === 'MemberExpression' && context.state.analysis.runes) {
+							// in legacy mode, `foo={bar.baz}` is wrapped in derived to preserve old behaviour.
+							return false;
+						}
+
+						return true;
 					});
 
 				if (should_wrap_in_derived) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -719,11 +719,10 @@ function serialize_inline_component(node, component_name, context) {
 				const should_wrap_in_derived =
 					Array.isArray(attribute.value) &&
 					attribute.value.some((n) => {
-						return (
-							n.type === 'ExpressionTag' &&
-							n.expression.type !== 'Identifier' &&
-							n.expression.type !== 'MemberExpression'
-						);
+						if (n.type !== 'ExpressionTag') return false;
+						return context.state.analysis.runes
+							? n.metadata.contains_call_expression
+							: n.expression.type !== 'Identifier';
 					});
 
 				if (should_wrap_in_derived) {

--- a/packages/svelte/tests/runtime-legacy/samples/component-prop-derived/Child.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-prop-derived/Child.svelte
@@ -1,0 +1,7 @@
+<svelte:options accessors={false} />
+
+<script>
+	export let x;
+
+	$: console.log('x', x);
+</script>

--- a/packages/svelte/tests/runtime-legacy/samples/component-prop-derived/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/component-prop-derived/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, logs, target }) {
+		assert.deepEqual(logs, ['x', 42]);
+
+		const btn = target.querySelector('button');
+		flushSync(() => btn?.click());
+
+		assert.deepEqual(logs, ['x', 42]);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/component-prop-derived/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/component-prop-derived/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Child from './Child.svelte';
+
+	let object = { x: 42 };
+</script>
+
+<button on:click={() => object = { x: 42 }}>update</button>
+
+<Child x={object.x} />


### PR DESCRIPTION
See https://github.com/sveltejs/svelte/pull/11548#issuecomment-2105596919. This fixes #11448 by wrapping props in deriveds in legacy mode, unless they're trivial

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
