### PR TITLE
fix: allow for non optional chain call expression in render

### DIFF
--- a/.changeset/gentle-trees-exercise.md
+++ b/.changeset/gentle-trees-exercise.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow for non optional chain call expression in render

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -587,9 +587,7 @@ function special(parser) {
 
 		if (
 			expression.type !== 'CallExpression' &&
-			(expression.type !== 'ChainExpression' ||
-				expression.expression.type !== 'CallExpression' ||
-				!expression.expression.optional)
+			(expression.type !== 'ChainExpression' || expression.expression.type !== 'CallExpression')
 		) {
 			e.render_tag_invalid_expression(expression);
 		}

--- a/packages/svelte/tests/runtime-runes/samples/snippet-expressions/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-expressions/_config.js
@@ -10,6 +10,10 @@ export default test({
 		<hr>
 		<p>foo</p>
 		<hr>
+		<p>foo</p>
+		<hr>
+		<p>foo</p>
+		<hr>
 		<p>bar</p>
 		<hr>
 		<hr>
@@ -25,6 +29,10 @@ export default test({
 				<p>bar</p>
 				<hr>
 				<p>bar</p>
+				<hr>
+				<p>foo</p>
+				<hr>
+				<p>foo</p>
 				<hr>
 				<p>foo</p>
 				<hr>

--- a/packages/svelte/tests/runtime-runes/samples/snippet-expressions/child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-expressions/child.svelte
@@ -12,6 +12,10 @@
 <hr>
 {@render snippets.foo()}
 <hr>
+{@render snippets?.foo()}
+<hr>
+{@render snippets?.foo?.()}
+<hr>
 {@render snippets.foo?.()}
 <hr>
 {@render (optional ?? snippets.bar)()}


### PR DESCRIPTION
## Svelte 5 rewrite

The issue is not open yet but was highlighted [on discord](https://discord.com/channels/457912077277855764/1153350350158450758/1239482601408954449) : i just removed the optional check, tests and runtime seems to work fine but i would love a bit of insight from @dummdidumm about why he included that check in #10656 

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
