### PR TITLE
docs - Correcting Incorrect Variable Names

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/02-examples/04-old-vs-new.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/02-examples/04-old-vs-new.md
@@ -148,7 +148,7 @@ With runes, we can use `$effect.pre`, which behaves the same as `$effect` but ru
 +	let theme = $state('dark');
 +	let messages = $state([]);
 
-	let div;
+	let viewport;
 
 -	beforeUpdate(() => {
 +	$effect.pre(() => {


### PR DESCRIPTION
Correcting Incorrect Variable Names