### PR TITLE
docs: Correcting Incorrect Variable Names

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/02-examples/04-old-vs-new.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/02-examples/04-old-vs-new.md
@@ -148,17 +148,17 @@ With runes, we can use `$effect.pre`, which behaves the same as `$effect` but ru
 +	let theme = $state('dark');
 +	let messages = $state([]);
 
-	let div;
+	let viewport;
 
 -	beforeUpdate(() => {
 +	$effect.pre(() => {
 -		if (!updatingMessages) return;
 +		messages;
-		const autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 50;
+		const autoscroll = viewport && viewport.offsetHeight + viewport.scrollTop > viewport.scrollHeight - 50;
 
 		if (autoscroll) {
 			tick().then(() => {
-				div.scrollTo(0, div.scrollHeight);
+				viewport.scrollTo(0, viewport.scrollHeight);
 			});
 		}
 


### PR DESCRIPTION
Here's your translation:

---

I've corrected an incorrect variable name in the docs. Both the previous version and the rune version of the playground are using a correct variable name called `viewport`.

The markup references a `viewport` variable, but in reality, there is no such variable named `viewport`, only a variable named `div`.

**incorrect variable**
```
let div;

...

	<div bind:this={viewport}>
		{#each messages as message}
			<p>{message}</p>
		{/each}
	</div>
```