### PR TITLE
Add documentation for svelte/elements

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/05-imports.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/05-imports.md
@@ -107,3 +107,46 @@ const result = render(App, {
 	props: { some: 'property' }
 });
 ```
+
+## `svelte/element`
+
+Svelte provides built-in [DOM types](https://github.com/sveltejs/svelte/blob/master/packages/svelte/elements.d.ts). A common use case for DOM types is forwarding props to an HTML element. To properly type your props and get full intellisense, your props interface should extend the attributes type for your HTML element:
+
+```svelte
+<script lang="ts">
+	import { HTMLAttributes } from 'svelte/elements';
+
+	interface Props extends HTMLAttributes<HTMLDivElement> {
+		name: string;
+	}
+
+	let { name, ...rest }: Props = $props();
+</script>
+
+<div {...rest}>
+	Hi, {name}!
+</div>
+```
+
+> You can use `ComponentProps<ImportedComponent>`, if you wish to forward props to forward props to a Svelte component.
+
+Svelte provides a best-effort of all the HTML DOM types that exist. If an attribute is missing from our [type definitions](https://github.com/sveltejs/svelte/blob/master/packages/svelte/elements.d.ts), you are welcome to open an issue and/or a PR fixing it. For experimental attributes, you can augment the existing type locally by creating a `.d.ts` file:
+
+```ts
+import { HTMLButtonAttributes } from 'svelte/elements';
+
+declare module 'svelte/elements' {
+	export interface SvelteHTMLElements {
+		'custom-button': HTMLButtonAttributes;
+	}
+
+	// allows for more granular control over what element to add the typings to
+	export interface HTMLButtonAttributes {
+		veryexperimentalattribute?: string;
+	}
+}
+
+export {}; // ensure this is not an ambient module, else types will be overridden instead of augmented
+```
+
+The `.d.ts` file must be included in your `tsconfig.json` file. If you are using the standard `"include": ["src/**/*"]`, this just means the file should be placed in the `src` directory.

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/05-imports.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/05-imports.md
@@ -108,7 +108,7 @@ const result = render(App, {
 });
 ```
 
-## `svelte/element`
+## `svelte/elements`
 
 Svelte provides built-in [DOM types](https://github.com/sveltejs/svelte/blob/master/packages/svelte/elements.d.ts). A common use case for DOM types is forwarding props to an HTML element. To properly type your props and get full intellisense, your props interface should extend the attributes type for your HTML element:
 
@@ -117,20 +117,20 @@ Svelte provides built-in [DOM types](https://github.com/sveltejs/svelte/blob/mas
 	import { HTMLAttributes } from 'svelte/elements';
 
 	interface Props extends HTMLAttributes<HTMLDivElement> {
-		name: string;
+		username: string;
 	}
 
-	let { name, ...rest }: Props = $props();
+	let { username, ...rest }: Props = $props();
 </script>
 
 <div {...rest}>
-	Hi, {name}!
+	Hi, {username}!
 </div>
 ```
 
 > You can use `ComponentProps<ImportedComponent>`, if you wish to forward props to forward props to a Svelte component.
 
-Svelte provides a best-effort of all the HTML DOM types that exist. If an attribute is missing from our [type definitions](https://github.com/sveltejs/svelte/blob/master/packages/svelte/elements.d.ts), you are welcome to open an issue and/or a PR fixing it. For experimental attributes, you can augment the existing type locally by creating a `.d.ts` file:
+Svelte provides a best-effort of all the HTML DOM types that exist. If an attribute is missing from our [type definitions](https://github.com/sveltejs/svelte/blob/master/packages/svelte/elements.d.ts), you are welcome to open an issue and/or a PR fixing it. For experimental attributes, you can augment the existing types locally by creating a `.d.ts` file:
 
 ```ts
 import { HTMLButtonAttributes } from 'svelte/elements';


### PR DESCRIPTION
Fixes #11451.

Add documentation for `svelte/elements` package with example. Added in Svelte 5 docs as it's not really possible to use (except with double-typing all props and using `$$Props` in Svelte 4 - see issue discussion.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
