### PR TITLE
chore: improve runtime overhead of creating comment templates

### DIFF
--- a/.changeset/eighty-lizards-notice.md
+++ b/.changeset/eighty-lizards-notice.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+chore: improve runtime overhead of creating comment templates

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -251,7 +251,17 @@ export function text(anchor) {
 	return push_template_node(node);
 }
 
-export const comment = template('<!>', TEMPLATE_FRAGMENT | TEMPLATE_USE_IMPORT_NODE);
+export function comment() {
+	if (hydrating) {
+		return push_template_node(hydrate_nodes);
+	}
+	var frag = document.createDocumentFragment();
+	var anchor = empty();
+	frag.append(anchor);
+	push_template_node([anchor]);
+
+	return frag;
+}
 
 /**
  * Assign the created (or in hydration mode, traversed) dom elements to the current block

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -252,6 +252,7 @@ export function text(anchor) {
 }
 
 export function comment() {
+	// we're not delegating to `template` here for performance reasons
 	if (hydrating) {
 		return push_template_node(hydrate_nodes);
 	}


### PR DESCRIPTION
I think we can go further here and probably remove the need for document fragments entirely, but this has a nice 10% performance uplift on cloning a template with only an anchor in it.