### PR TITLE
fix: skip deriveds for props with known safe calls

### DIFF
--- a/.changeset/popular-apes-bathe.md
+++ b/.changeset/popular-apes-bathe.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip deriveds for props with known safe calls

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1042,6 +1042,9 @@ function is_known_safe_call(node, context) {
 			return true;
 		}
 	}
+
+	// TODO add more cases
+
 	return false;
 }
 
@@ -1262,11 +1265,12 @@ const common_visitors = {
 		}
 	},
 	CallExpression(node, context) {
+		const { expression } = context.state;
 		if (
-			context.state.expression?.type === 'ExpressionTag' ||
-			(context.state.expression?.type === 'SpreadAttribute' && !is_known_safe_call(node, context))
+			(expression?.type === 'ExpressionTag' || expression?.type === 'SpreadAttribute') &&
+			!is_known_safe_call(node, context)
 		) {
-			context.state.expression.metadata.contains_call_expression = true;
+			expression.metadata.contains_call_expression = true;
 		}
 
 		const callee = node.callee;


### PR DESCRIPTION
Very small thing but I noticed while working on #11571 and #11574 that we treat certain function calls as 'safe' for the purposes of determining whether to wrap props in deriveds, but we only use that information for spread attributes, because we put the parentheses in the wrong place.

No test because it's finicky and extremely minor

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
