### PR TITLE
chore: use CustomEvent constructor instead of deprecated createEvent method

### DIFF
--- a/.changeset/yellow-trees-juggle.md
+++ b/.changeset/yellow-trees-juggle.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: use `new CustomEvent` instead of deprecated `initCustomEvent`

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -10,25 +10,12 @@ import { TRANSITION_GLOBAL, TRANSITION_IN, TRANSITION_OUT } from '../../../../co
 import { BLOCK_EFFECT, EFFECT_RAN, EFFECT_TRANSPARENT } from '../../constants.js';
 
 /**
- * @template T
- * @param {string} type
- * @param {T} [detail]
- * @param {any}params_0
- * @returns {Event}
- */
-function custom_event(type, detail, { bubbles = false, cancelable = false } = {}) {
-	const e = document.createEvent('CustomEvent');
-	e.initCustomEvent(type, bubbles, cancelable, detail);
-	return e;
-}
-
-/**
  * @param {Element} dom
  * @param {'introstart' | 'introend' | 'outrostart' | 'outroend'} type
  * @returns {void}
  */
 function dispatch_event(dom, type) {
-	dom.dispatchEvent(custom_event(type));
+	dom.dispatchEvent(new CustomEvent(type));
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -10,12 +10,12 @@ import { TRANSITION_GLOBAL, TRANSITION_IN, TRANSITION_OUT } from '../../../../co
 import { BLOCK_EFFECT, EFFECT_RAN, EFFECT_TRANSPARENT } from '../../constants.js';
 
 /**
- * @param {Element} dom
+ * @param {Element} element
  * @param {'introstart' | 'introend' | 'outrostart' | 'outroend'} type
  * @returns {void}
  */
-function dispatch_event(dom, type) {
-	dom.dispatchEvent(new CustomEvent(type));
+function dispatch_event(element, type) {
+	element.dispatchEvent(new CustomEvent(type));
 }
 
 /**


### PR DESCRIPTION
Same as this PR #8775 but for transitions.js, where the change wasn't made.
#7178
#8474

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
