### PR TITLE
fix: warn on implicit children snipett shadowing a prop

### DIFF
--- a/.changeset/empty-worms-leave.md
+++ b/.changeset/empty-worms-leave.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: warn on implicit children snipett shadowing a prop

--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -240,9 +240,13 @@
 
 > snippets do not support rest parameters; use an array instead
 
+## snippet_shadowing_children_prop
+
+> The component content is implicitly passed as a `children` snippet which conflicts with the `children` prop set as an attribute.
+
 ## snippet_shadowing_prop
 
-> This snippet is shadowing the prop `%prop%` with the same name
+> This snippet is conflicting with the prop `%prop%` with the same name
 
 ## style_directive_invalid_modifier
 

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -1077,6 +1077,15 @@ export function snippet_invalid_rest_parameter(node) {
 }
 
 /**
+ * The component content is implicitly passed as a `children` snippet which conflicts with the `children` prop set as an attribute.
+ * @param {null | number | NodeLike} node
+ * @returns {never}
+ */
+export function snippet_shadowing_children_prop(node) {
+	e(node, "snippet_shadowing_children_prop", "The component content is implicitly passed as a `children` snippet which conflicts with the `children` prop set as an attribute.");
+}
+
+/**
  * This snippet is conflicting with the prop `%prop%` with the same name
  * @param {null | number | NodeLike} node
  * @param {string} prop
@@ -1384,13 +1393,4 @@ export function unexpected_reserved_word(node, word) {
  */
 export function void_element_invalid_content(node) {
 	e(node, "void_element_invalid_content", "Void elements cannot have children or closing tags");
-}
-
-/**
- * The component content is implicitly passed as a `children` snippet which conflicts with the `children` prop set as an attribute.
- * @param {null | number | NodeLike} node
- * @returns {never}
- */
-export function snippet_shadowing_children_prop(node) {
-	e(node, "snippet_shadowing_children_prop", "The component content is implicitly passed as a `children` snippet which conflicts with the `children` prop set as an attribute.");
 }

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -1077,13 +1077,13 @@ export function snippet_invalid_rest_parameter(node) {
 }
 
 /**
- * This snippet is shadowing the prop `%prop%` with the same name
+ * This snippet is conflicting with the prop `%prop%` with the same name
  * @param {null | number | NodeLike} node
  * @param {string} prop
  * @returns {never}
  */
 export function snippet_shadowing_prop(node, prop) {
-	e(node, "snippet_shadowing_prop", `This snippet is shadowing the prop \`${prop}\` with the same name`);
+	e(node, "snippet_shadowing_prop", `This snippet is conflicting with the prop \`${prop}\` with the same name`);
 }
 
 /**
@@ -1384,4 +1384,13 @@ export function unexpected_reserved_word(node, word) {
  */
 export function void_element_invalid_content(node) {
 	e(node, "void_element_invalid_content", "Void elements cannot have children or closing tags");
+}
+
+/**
+ * The component content is implicitly passed as a `children` snippet which conflicts with the `children` prop set as an attribute.
+ * @param {null | number | NodeLike} node
+ * @returns {never}
+ */
+export function snippet_shadowing_children_prop(node) {
+	e(node, "snippet_shadowing_children_prop", "The component content is implicitly passed as a `children` snippet which conflicts with the `children` prop set as an attribute.");
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -48,7 +48,7 @@ function validate_component(node, context) {
 				attribute.name === 'children'
 		)
 	) {
-		e.snippet_shadowing_prop(node, 'children');
+		e.snippet_shadowing_children_prop(node);
 	}
 	for (const attribute of node.attributes) {
 		if (

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -39,6 +39,17 @@ import { a11y_validators } from './a11y.js';
  * @param {import('zimmerframe').Context<import('#compiler').SvelteNode, import('./types.js').AnalysisState>} context
  */
 function validate_component(node, context) {
+	const has_implicit_children = node.fragment.nodes.length > 0;
+	if (
+		has_implicit_children &&
+		node.attributes.some(
+			(attribute) =>
+				(attribute.type === 'Attribute' || attribute.type === 'BindDirective') &&
+				attribute.name === 'children'
+		)
+	) {
+		e.snippet_shadowing_prop(node, 'children');
+	}
 	for (const attribute of node.attributes) {
 		if (
 			attribute.type !== 'Attribute' &&

--- a/packages/svelte/tests/validator/samples/snippet-shadowing-prop-implicit-children/errors.json
+++ b/packages/svelte/tests/validator/samples/snippet-shadowing-prop-implicit-children/errors.json
@@ -1,7 +1,7 @@
 [
 	{
-		"code": "snippet_shadowing_prop",
-		"message": "This snippet is shadowing the prop `children` with the same name",
+		"code": "snippet_shadowing_children_prop",
+		"message": "The component content is implicitly passed as a `children` snippet which conflicts with the `children` prop set as an attribute.",
 		"start": {
 			"column": 0,
 			"line": 5

--- a/packages/svelte/tests/validator/samples/snippet-shadowing-prop-implicit-children/errors.json
+++ b/packages/svelte/tests/validator/samples/snippet-shadowing-prop-implicit-children/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "snippet_shadowing_prop",
+		"message": "This snippet is shadowing the prop `children` with the same name",
+		"start": {
+			"column": 0,
+			"line": 5
+		},
+		"end": {
+			"column": 12,
+			"line": 7
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/snippet-shadowing-prop-implicit-children/input.svelte
+++ b/packages/svelte/tests/validator/samples/snippet-shadowing-prop-implicit-children/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Component from "./Component.svelte";
+</script>
+
+<Component children="">
+	title
+</Component>

--- a/packages/svelte/tests/validator/samples/snippet-shadowing-prop/errors.json
+++ b/packages/svelte/tests/validator/samples/snippet-shadowing-prop/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "snippet_shadowing_prop",
-		"message": "This snippet is shadowing the prop `title` with the same name",
+		"message": "This snippet is conflicting with the prop `title` with the same name",
 		"start": {
 			"column": 1,
 			"line": 6


### PR DESCRIPTION
## Svelte 5 rewrite

As pointed out by https://github.com/sveltejs/svelte/issues/11603#issuecomment-2112128158 we can add an error also for implicit children snippet.

I've thrown the same error on the whole component but let me know if a new error is more appropriate.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
