### PR TITLE
make invalid `<svelte:element this>` a warning instead of an error

### DIFF
--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -260,13 +260,9 @@
 
 > `<svelte:component>` must have a 'this' attribute
 
-## svelte_element_invalid_this
-
-> Invalid element definition — must be an `{expression}`
-
 ## svelte_element_missing_this
 
-> `<svelte:element>` must have a 'this' attribute
+> `<svelte:element>` must have a 'this' attribute with a value
 
 ## svelte_fragment_invalid_attribute
 

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -37,3 +37,7 @@
 ## slot_element_deprecated
 
 > Using `<slot>` to render parent content is deprecated. Use `{@render ...}` tags instead.
+
+## svelte_element_invalid_this
+
+> `this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -1132,21 +1132,12 @@ export function svelte_component_missing_this(node) {
 }
 
 /**
- * Invalid element definition — must be an `{expression}`
- * @param {null | number | NodeLike} node
- * @returns {never}
- */
-export function svelte_element_invalid_this(node) {
-	e(node, "svelte_element_invalid_this", "Invalid element definition — must be an `{expression}`");
-}
-
-/**
- * `<svelte:element>` must have a 'this' attribute
+ * `<svelte:element>` must have a 'this' attribute with a value
  * @param {null | number | NodeLike} node
  * @returns {never}
  */
 export function svelte_element_missing_this(node) {
-	e(node, "svelte_element_missing_this", "`<svelte:element>` must have a 'this' attribute");
+	e(node, "svelte_element_missing_this", "`<svelte:element>` must have a 'this' attribute with a value");
 }
 
 /**

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -90,7 +90,8 @@ export const codes = [
 	"component_name_lowercase",
 	"element_invalid_self_closing_tag",
 	"event_directive_deprecated",
-	"slot_element_deprecated"
+	"slot_element_deprecated",
+	"svelte_element_invalid_this"
 ];
 
 /**
@@ -712,4 +713,12 @@ export function event_directive_deprecated(node, name) {
  */
 export function slot_element_deprecated(node) {
 	w(node, "slot_element_deprecated", "Using `<slot>` to render parent content is deprecated. Use `{@render ...}` tags instead.");
+}
+
+/**
+ * `this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte
+ * @param {null | NodeLike} node
+ */
+export function svelte_element_invalid_this(node) {
+	w(node, "svelte_element_invalid_this", "`this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte");
 }

--- a/packages/svelte/tests/validator/samples/dynamic-element-invalid-tag/errors.json
+++ b/packages/svelte/tests/validator/samples/dynamic-element-invalid-tag/errors.json
@@ -1,7 +1,7 @@
 [
 	{
-		"code": "svelte_element_invalid_this",
-		"message": "Invalid element definition — must be an `{expression}`",
+		"code": "svelte_element_missing_this",
+		"message": "`<svelte:element>` must have a 'this' attribute with a value",
 		"start": {
 			"line": 2,
 			"column": 17

--- a/packages/svelte/tests/validator/samples/dynamic-element-missing-tag/errors.json
+++ b/packages/svelte/tests/validator/samples/dynamic-element-missing-tag/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "svelte_element_missing_this",
-		"message": "`<svelte:element>` must have a 'this' attribute",
+		"message": "`<svelte:element>` must have a 'this' attribute with a value",
 		"start": {
 			"line": 2,
 			"column": 1

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -241,4 +241,3 @@ In Svelte 4, `<svelte:element this="div">` is valid code. This makes little sens
 ```
 
 Note that whereas Svelte 4 would treat `<svelte:element this="input">` (for example) identically to `<input>` for the purposes of determining which `bind:` directives could be applied, Svelte 5 does not.
-


### PR DESCRIPTION
This is an alternative to #11454. I think it's a very bad idea. Fixes #11398.