### PR TITLE
feat: more information when hydration fails

### DIFF
--- a/.changeset/violet-mails-trade.md
+++ b/.changeset/violet-mails-trade.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: more information when hydration fails

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -36,13 +36,9 @@
 
 > Maximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops
 
-## hydration_missing_marker_close
+## hydration_failed
 
-> Missing hydration closing marker
-
-## hydration_missing_marker_open
-
-> Missing hydration opening marker
+> Failed to hydrate the application
 
 ## lifecycle_legacy_only
 

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -6,6 +6,8 @@
 
 > Hydration failed because the initial UI does not match what was rendered on the server
 
+> Hydration failed because the initial UI does not match what was rendered on the server. The error occurred near %location%
+
 ## lifecycle_double_unmount
 
 > Tried to unmount a component that was not mounted

--- a/packages/svelte/scripts/process-messages/index.js
+++ b/packages/svelte/scripts/process-messages/index.js
@@ -163,6 +163,7 @@ function transform(name, dest) {
 					type: 'Literal',
 					value: text
 				};
+				prev_vars = vars;
 				continue;
 			}
 

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -22,6 +22,7 @@ export const TEMPLATE_USE_IMPORT_NODE = 1 << 1;
 export const HYDRATION_START = '[';
 export const HYDRATION_END = ']';
 export const HYDRATION_END_ELSE = `${HYDRATION_END}!`; // used to indicate that an `{:else}...` block was rendered
+export const HYDRATION_ERROR = {};
 
 export const UNINITIALIZED = Symbol();
 

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -1,5 +1,6 @@
-import { HYDRATION_END, HYDRATION_START } from '../../../constants.js';
-import * as e from '../errors.js';
+import { DEV } from 'esm-env';
+import { HYDRATION_END, HYDRATION_START, HYDRATION_ERROR } from '../../../constants.js';
+import * as w from '../warnings.js';
 
 /**
  * Use this variable to guard everything related to hydration code so it can be treeshaken out
@@ -67,5 +68,16 @@ export function hydrate_anchor(node) {
 		nodes.push(current);
 	}
 
-	e.hydration_missing_marker_close();
+	let location;
+
+	if (DEV) {
+		// @ts-expect-error
+		const loc = node.parentNode?.__svelte_meta?.loc;
+		if (loc) {
+			location = `${loc.file}:${loc.line}:${loc.column}`;
+		}
+	}
+
+	w.hydration_mismatch(location);
+	throw HYDRATION_ERROR;
 }

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -161,38 +161,6 @@ export function effect_update_depth_exceeded() {
 }
 
 /**
- * Missing hydration closing marker
- * @returns {never}
- */
-export function hydration_missing_marker_close() {
-	if (DEV) {
-		const error = new Error(`${"hydration_missing_marker_close"}\n${"Missing hydration closing marker"}`);
-
-		error.name = 'Svelte error';
-		throw error;
-	} else {
-		// TODO print a link to the documentation
-		throw new Error("hydration_missing_marker_close");
-	}
-}
-
-/**
- * Missing hydration opening marker
- * @returns {never}
- */
-export function hydration_missing_marker_open() {
-	if (DEV) {
-		const error = new Error(`${"hydration_missing_marker_open"}\n${"Missing hydration opening marker"}`);
-
-		error.name = 'Svelte error';
-		throw error;
-	} else {
-		// TODO print a link to the documentation
-		throw new Error("hydration_missing_marker_open");
-	}
-}
-
-/**
  * `%name%(...)` cannot be used in runes mode
  * @param {string} name
  * @returns {never}
@@ -307,5 +275,21 @@ export function svelte_component_invalid_this_value() {
 	} else {
 		// TODO print a link to the documentation
 		throw new Error("svelte_component_invalid_this_value");
+	}
+}
+
+/**
+ * Failed to hydrate the application
+ * @returns {never}
+ */
+export function hydration_failed() {
+	if (DEV) {
+		const error = new Error(`${"hydration_failed"}\n${"Failed to hydrate the application"}`);
+
+		error.name = 'Svelte error';
+		throw error;
+	} else {
+		// TODO print a link to the documentation
+		throw new Error("hydration_failed");
 	}
 }

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -161,6 +161,22 @@ export function effect_update_depth_exceeded() {
 }
 
 /**
+ * Failed to hydrate the application
+ * @returns {never}
+ */
+export function hydration_failed() {
+	if (DEV) {
+		const error = new Error(`${"hydration_failed"}\n${"Failed to hydrate the application"}`);
+
+		error.name = 'Svelte error';
+		throw error;
+	} else {
+		// TODO print a link to the documentation
+		throw new Error("hydration_failed");
+	}
+}
+
+/**
  * `%name%(...)` cannot be used in runes mode
  * @param {string} name
  * @returns {never}
@@ -275,21 +291,5 @@ export function svelte_component_invalid_this_value() {
 	} else {
 		// TODO print a link to the documentation
 		throw new Error("svelte_component_invalid_this_value");
-	}
-}
-
-/**
- * Failed to hydrate the application
- * @returns {never}
- */
-export function hydration_failed() {
-	if (DEV) {
-		const error = new Error(`${"hydration_failed"}\n${"Failed to hydrate the application"}`);
-
-		error.name = 'Svelte error';
-		throw error;
-	} else {
-		// TODO print a link to the documentation
-		throw new Error("hydration_failed");
 	}
 }

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -26,7 +26,7 @@ export function hydration_attribute_changed(attribute, html, value) {
  */
 export function hydration_mismatch(location) {
 	if (DEV) {
-		console.warn(`%c[svelte] ${"hydration_mismatch"}\n%c${`Hydration failed because the initial UI does not match what was rendered on the server. The error occurred near ${location}`}`, bold, normal);
+		console.warn(`%c[svelte] ${"hydration_mismatch"}\n%c${location ? `Hydration failed because the initial UI does not match what was rendered on the server. The error occurred near ${location}` : "Hydration failed because the initial UI does not match what was rendered on the server"}`, bold, normal);
 	} else {
 		// TODO print a link to the documentation
 		console.warn("hydration_mismatch");
@@ -67,7 +67,7 @@ export function ownership_invalid_binding(parent, child, owner) {
  */
 export function ownership_invalid_mutation(component, owner) {
 	if (DEV) {
-		console.warn(`%c[svelte] ${"ownership_invalid_mutation"}\n%c${`${component} mutated a value owned by ${owner}. This is strongly discouraged. Consider passing values to child components with \`bind:\`, or use a callback instead`}`, bold, normal);
+		console.warn(`%c[svelte] ${"ownership_invalid_mutation"}\n%c${component ? `${component} mutated a value owned by ${owner}. This is strongly discouraged. Consider passing values to child components with \`bind:\`, or use a callback instead` : "Mutating a value outside the component that created it is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead"}`, bold, normal);
 	} else {
 		// TODO print a link to the documentation
 		console.warn("ownership_invalid_mutation");

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -21,11 +21,12 @@ export function hydration_attribute_changed(attribute, html, value) {
 }
 
 /**
- * Hydration failed because the initial UI does not match what was rendered on the server
+ * Hydration failed because the initial UI does not match what was rendered on the server. The error occurred near %location%
+ * @param {string | undefined | null} [location]
  */
-export function hydration_mismatch() {
+export function hydration_mismatch(location) {
 	if (DEV) {
-		console.warn(`%c[svelte] ${"hydration_mismatch"}\n%c${"Hydration failed because the initial UI does not match what was rendered on the server"}`, bold, normal);
+		console.warn(`%c[svelte] ${"hydration_mismatch"}\n%c${`Hydration failed because the initial UI does not match what was rendered on the server. The error occurred near ${location}`}`, bold, normal);
 	} else {
 		// TODO print a link to the documentation
 		console.warn("hydration_mismatch");


### PR DESCRIPTION
In the case of an invalid child element, we already get information about the parent and the child, but in other cases where a mismatch could occur you're pretty much on your own.

This adds a bit more context to `hydration_mismatch` warnings — 'The error occurred near ...'

<img width="1067" alt="image" src="https://github.com/sveltejs/svelte/assets/1162160/685e6798-dd13-41d4-b6ca-d8dbcaad5a42">

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
