### PR TITLE
fix: robustify `bind:scrollX/Y` binding

### DIFF
--- a/.changeset/popular-roses-teach.md
+++ b/.changeset/popular-roses-teach.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: robustify `bind:scrollX/Y` binding


### PR DESCRIPTION
- we were scrolling to the given initial value, which we shouldn't for accessibility reasons (Svelte 4 didn't do it either)
- we need to notify of the value 0 if there's no scroll (https://github.com/sveltejs/svelte/issues/11623#issuecomment-2113495573)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
