### PR TITLE
fix: more efficient spread attributes in SSR output

### DIFF
--- a/.changeset/quiet-berries-explode.md
+++ b/.changeset/quiet-berries-explode.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: more efficient spread attributes in SSR output

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -24,7 +24,13 @@ import {
 import { create_attribute, is_custom_element_node, is_element_node } from '../../nodes.js';
 import { binding_properties } from '../../bindings.js';
 import { regex_starts_with_newline, regex_whitespaces_strict } from '../../patterns.js';
-import { DOMBooleanAttributes, HYDRATION_END, HYDRATION_START } from '../../../../constants.js';
+import {
+	DOMBooleanAttributes,
+	ELEMENT_IS_NAMESPACED,
+	ELEMENT_PRESERVE_ATTRIBUTE_CASE,
+	HYDRATION_END,
+	HYDRATION_START
+} from '../../../../constants.js';
 import { escape_html } from '../../../../escaping.js';
 import { sanitize_template_string } from '../../../utils/sanitize_template_string.js';
 import { BLOCK_CLOSE, BLOCK_CLOSE_ELSE } from '../../../../internal/server/hydration.js';
@@ -889,39 +895,29 @@ function serialize_element_spread_attributes(
 	class_directives,
 	context
 ) {
-	const lowercase_attributes =
-		element.metadata.svg ||
-		element.metadata.mathml ||
-		(element.type === 'RegularElement' && is_custom_element_node(element))
-			? b.false
-			: b.true;
+	let classes;
+	let styles;
+	let flags = 0;
 
-	const is_html = element.metadata.svg || element.metadata.mathml ? b.false : b.true;
+	if (class_directives.length > 0 || context.state.analysis.css.hash) {
+		const properties = class_directives.map((directive) =>
+			b.init(
+				directive.name,
+				directive.expression.type === 'Identifier' && directive.expression.name === directive.name
+					? b.id(directive.name)
+					: /** @type {import('estree').Expression} */ (context.visit(directive.expression))
+			)
+		);
 
-	/** @type {import('estree').Expression[]} */
-	const args = [
-		b.object(
-			attributes.map((attribute) => {
-				if (attribute.type === 'Attribute') {
-					const name = get_attribute_name(element, attribute, context);
-					const value = serialize_attribute_value(
-						attribute.value,
-						context,
-						WhitespaceInsensitiveAttributes.includes(name)
-					);
-					return b.prop('init', b.key(name), value);
-				}
+		if (context.state.analysis.css.hash) {
+			properties.unshift(b.init(context.state.analysis.css.hash, b.literal(true)));
+		}
 
-				return b.spread(/** @type {import('estree').Expression} */ (context.visit(attribute)));
-			})
-		),
-		lowercase_attributes,
-		is_html,
-		b.literal(context.state.analysis.css.hash)
-	];
+		classes = b.object(properties);
+	}
 
-	if (style_directives.length > 0 || class_directives.length > 0) {
-		const styles = style_directives.map((directive) =>
+	if (style_directives.length > 0) {
+		const properties = style_directives.map((directive) =>
 			b.init(
 				directive.name,
 				directive.value === true
@@ -929,25 +925,33 @@ function serialize_element_spread_attributes(
 					: serialize_attribute_value(directive.value, context, true)
 			)
 		);
-		const expressions = class_directives.map((directive) =>
-			b.conditional(directive.expression, b.literal(directive.name), b.literal(''))
-		);
-		const classes = expressions.length
-			? b.call(
-					b.member(
-						b.call(b.member(b.array(expressions), b.id('filter')), b.id('Boolean')),
-						b.id('join')
-					),
-					b.literal(' ')
-				)
-			: b.literal('');
-		args.push(
-			b.object([
-				b.init('styles', styles.length === 0 ? b.literal(null) : b.object(styles)),
-				b.init('classes', classes)
-			])
-		);
+
+		styles = b.object(properties);
 	}
+
+	if (element.metadata.svg || element.metadata.mathml) {
+		flags |= ELEMENT_IS_NAMESPACED | ELEMENT_PRESERVE_ATTRIBUTE_CASE;
+	} else if (is_custom_element_node(element)) {
+		flags |= ELEMENT_PRESERVE_ATTRIBUTE_CASE;
+	}
+
+	const object = b.object(
+		attributes.map((attribute) => {
+			if (attribute.type === 'Attribute') {
+				const name = get_attribute_name(element, attribute, context);
+				const value = serialize_attribute_value(
+					attribute.value,
+					context,
+					WhitespaceInsensitiveAttributes.includes(name)
+				);
+				return b.prop('init', b.key(name), value);
+			}
+
+			return b.spread(/** @type {import('estree').Expression} */ (context.visit(attribute)));
+		})
+	);
+
+	const args = [object, classes, styles, flags ? b.literal(flags) : undefined];
 	context.state.template.push(t_expression(b.call('$.spread_attributes', ...args)));
 }
 

--- a/packages/svelte/src/compiler/phases/nodes.js
+++ b/packages/svelte/src/compiler/phases/nodes.js
@@ -21,11 +21,11 @@ export function is_element_node(node) {
 }
 
 /**
- * @param {import('#compiler').RegularElement} node
+ * @param {import('#compiler').RegularElement | import('#compiler').SvelteElement} node
  * @returns {boolean}
  */
 export function is_custom_element_node(node) {
-	return node.name.includes('-');
+	return node.type === 'RegularElement' && node.name.includes('-');
 }
 
 /**

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -24,6 +24,9 @@ export const HYDRATION_END = ']';
 export const HYDRATION_END_ELSE = `${HYDRATION_END}!`; // used to indicate that an `{:else}...` block was rendered
 export const HYDRATION_ERROR = {};
 
+export const ELEMENT_IS_NAMESPACED = 1;
+export const ELEMENT_PRESERVE_ATTRIBUTE_CASE = 1 << 1;
+
 export const UNINITIALIZED = Symbol();
 
 /** List of elements that require raw contents and should not have SSR comments put in them */


### PR DESCRIPTION
Spread attributes are needlessly laborious in SSR output. Before:

```js
import * as $ from "svelte/internal/server";

export default function App($$payload, $$props) {
	$.push();

	$$payload.out += `<div${$.spread_attributes(
		[
			{ "a": 1 },
			{ "b": 2 },
			{ "c": 3 },
			obj
		],
		true,
		true,
		""
	)}></div>`;

	$.pop();
}
```

After:

```js
import * as $ from "svelte/internal/server";

export default function App($$payload, $$props) {
	$.push();
	$$payload.out += `<div${$.spread_attributes({ a: 1, b: 2, c: 3, ...obj })}></div>`;
	$.pop();
}
```

No test because there's no user-observable difference.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
