### PR TITLE
fix: check for invalid bindings on window and document

### DIFF
--- a/.changeset/plenty-elephants-fry.md
+++ b/.changeset/plenty-elephants-fry.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: check for invalid bindings on window and document

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -397,9 +397,9 @@ const validation = {
 					const valid_bindings = Object.entries(binding_properties)
 						.filter(([_, binding_property]) => {
 							return (
-								binding_property.valid_elements?.includes(node.name) ||
+								binding_property.valid_elements?.includes(parent.name) ||
 								(!binding_property.valid_elements &&
-									!binding_property.invalid_elements?.includes(node.name))
+									!binding_property.invalid_elements?.includes(parent.name))
 							);
 						})
 						.map(([property_name]) => property_name);

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -393,6 +393,23 @@ const validation = {
 					);
 				}
 
+				if (property.invalid_elements && property.invalid_elements.includes(parent.name)) {
+					const valid_bindings = Object.entries(binding_properties)
+						.filter(([_, binding_property]) => {
+							return (
+								binding_property.valid_elements?.includes(node.name) ||
+								(!binding_property.valid_elements &&
+									!binding_property.invalid_elements?.includes(node.name))
+							);
+						})
+						.map(([property_name]) => property_name);
+					e.bind_invalid_name(
+						node,
+						node.name,
+						`Possible bindings for <${parent.name}> are ${valid_bindings.join(', ')}`
+					);
+				}
+
 				if (parent.name === 'input' && node.name !== 'this') {
 					const type = /** @type {import('#compiler').Attribute | undefined} */ (
 						parent.attributes.find((a) => a.type === 'Attribute' && a.name === 'type')

--- a/packages/svelte/src/compiler/phases/bindings.js
+++ b/packages/svelte/src/compiler/phases/bindings.js
@@ -5,6 +5,7 @@
  * @property {string} [type] Set this to `set` if updates are written to the dom property
  * @property {boolean} [omit_in_ssr] Set this to true if the binding should not be included in SSR
  * @property {string[]} [valid_elements] If this is set, the binding is only valid on the given elements
+ * @property {string[]} [invalid_elements] If this is set, the binding is invalid on the given elements
  */
 
 /**
@@ -131,28 +132,36 @@ export const binding_properties = {
 	},
 	// dimensions
 	clientWidth: {
-		omit_in_ssr: true
+		omit_in_ssr: true,
+		invalid_elements: ['svelte:window', 'svelte:document']
 	},
 	clientHeight: {
-		omit_in_ssr: true
+		omit_in_ssr: true,
+		invalid_elements: ['svelte:window', 'svelte:document']
 	},
 	offsetWidth: {
-		omit_in_ssr: true
+		omit_in_ssr: true,
+		invalid_elements: ['svelte:window', 'svelte:document']
 	},
 	offsetHeight: {
-		omit_in_ssr: true
+		omit_in_ssr: true,
+		invalid_elements: ['svelte:window', 'svelte:document']
 	},
 	contentRect: {
-		omit_in_ssr: true
+		omit_in_ssr: true,
+		invalid_elements: ['svelte:window', 'svelte:document']
 	},
 	contentBoxSize: {
-		omit_in_ssr: true
+		omit_in_ssr: true,
+		invalid_elements: ['svelte:window', 'svelte:document']
 	},
 	borderBoxSize: {
-		omit_in_ssr: true
+		omit_in_ssr: true,
+		invalid_elements: ['svelte:window', 'svelte:document']
 	},
 	devicePixelContentBoxSize: {
-		omit_in_ssr: true
+		omit_in_ssr: true,
+		invalid_elements: ['svelte:window', 'svelte:document']
 	},
 	// checkbox/radio
 	indeterminate: {

--- a/packages/svelte/src/compiler/phases/bindings.js
+++ b/packages/svelte/src/compiler/phases/bindings.js
@@ -180,9 +180,15 @@ export const binding_properties = {
 	this: {
 		omit_in_ssr: true
 	},
-	innerText: {},
-	innerHTML: {},
-	textContent: {},
+	innerText: {
+		invalid_elements: ['svelte:window', 'svelte:document']
+	},
+	innerHTML: {
+		invalid_elements: ['svelte:window', 'svelte:document']
+	},
+	textContent: {
+		invalid_elements: ['svelte:window', 'svelte:document']
+	},
 	open: {
 		event: 'toggle',
 		type: 'set',

--- a/packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/errors.json
+++ b/packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "bind_invalid_name",
-		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:document> are focused, clientWidth, clientHeight, offsetWidth, offsetHeight, contentRect, contentBoxSize, borderBoxSize, devicePixelContentBoxSize, this, innerText, innerHTML, textContent",
+		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:document> are focused, fullscreenElement, visibilityState, this",
 		"start": {
 			"line": 5,
 			"column": 17

--- a/packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/errors.json
+++ b/packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "bind_invalid_name",
+		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:document> are focused, clientWidth, clientHeight, offsetWidth, offsetHeight, contentRect, contentBoxSize, borderBoxSize, devicePixelContentBoxSize, this, innerText, innerHTML, textContent",
+		"start": {
+			"line": 5,
+			"column": 17
+		},
+		"end": {
+			"line": 5,
+			"column": 39
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/input.svelte
+++ b/packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/input.svelte
@@ -1,0 +1,5 @@
+<script>
+    let foo;
+</script>
+
+<svelte:document bind:clientWidth={foo} />

--- a/packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/errors.json
+++ b/packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "bind_invalid_name",
+		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:window> are focused, clientWidth, clientHeight, offsetWidth, offsetHeight, contentRect, contentBoxSize, borderBoxSize, devicePixelContentBoxSize, this, innerText, innerHTML, textContent",
+		"start": {
+			"line": 5,
+			"column": 15
+		},
+		"end": {
+			"line": 5,
+			"column": 37
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/errors.json
+++ b/packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "bind_invalid_name",
-		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:window> are focused, clientWidth, clientHeight, offsetWidth, offsetHeight, contentRect, contentBoxSize, borderBoxSize, devicePixelContentBoxSize, this, innerText, innerHTML, textContent",
+		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:window> are focused, innerWidth, innerHeight, outerWidth, outerHeight, scrollX, scrollY, online, devicePixelRatio, this",
 		"start": {
 			"line": 5,
 			"column": 15

--- a/packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/input.svelte
+++ b/packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/input.svelte
@@ -1,0 +1,5 @@
+<script>
+    let foo;
+</script>
+
+<svelte:window bind:clientWidth={foo} />


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11673

Technically we could write a test for each invalid binding but i don't know if it's necessary, willing to add them if it's deemed necessary.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
