### PR TITLE
chore: bump repl version for svelte 4

### DIFF
--- a/sites/svelte.dev/package.json
+++ b/sites/svelte.dev/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@jridgewell/sourcemap-codec": "^1.4.15",
     "@supabase/supabase-js": "^2.39.2",
-    "@sveltejs/repl": "0.6.0",
+    "@sveltejs/repl": "0.6.1",
     "cookie": "^0.6.0",
     "devalue": "^4.3.2",
     "do-not-zip": "^1.0.0",


### PR DESCRIPTION
This is exactly #11646 but for [svelte-4 repl](https://svelte.dev/repl/c5b4138d1b6b4cdc848fecb38b06b0a2?version=4.2.17). 
I made the corresponding PR [HERE](https://github.com/sveltejs/sites/pull/557). Should be merged after v0.6.1 is published.

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
