### PR TITLE
fix: inline pointer events now correctly work in Chrome

### DIFF
--- a/.changeset/quiet-cobras-smile.md
+++ b/.changeset/quiet-cobras-smile.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: inline pointer events now correctly work in Chrome

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -2,7 +2,7 @@ import { DEV } from 'esm-env';
 import { hydrating } from '../hydration.js';
 import { get_descriptors, get_prototype_of, map_get, map_set } from '../../utils.js';
 import { AttributeAliases, DelegatedEvents, namespace_svg } from '../../../../constants.js';
-import { delegate } from './events.js';
+import { create_event, delegate } from './events.js';
 import { autofocus } from './misc.js';
 import { effect, effect_root } from '../../reactivity/effects.js';
 import * as w from '../../warnings.js';
@@ -151,9 +151,9 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 				if (!delegated) {
 					// we use `addEventListener` here because these events are not delegated
 					if (!prev) {
-						events.push([key, value, () => element.addEventListener(event_name, value, opts)]);
+						() => (next[key] = create_event(event_name, element, value, opts));
 					} else {
-						element.addEventListener(event_name, value, opts);
+						next[key] = create_event(event_name, element, value, opts);
 					}
 				} else {
 					// @ts-ignore

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -151,7 +151,11 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 				if (!delegated) {
 					// we use `addEventListener` here because these events are not delegated
 					if (!prev) {
-						() => (next[key] = create_event(event_name, element, value, opts));
+						events.push([
+							key,
+							value,
+							() => (next[key] = create_event(event_name, element, value, opts))
+						]);
 					} else {
 						next[key] = create_event(event_name, element, value, opts);
 					}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11691. We have to defer inline pointer event handlers till the DOM has been attached to the document to work around a Chrome bug with `cloneNode`.