### PR TITLE
chore: add pnpm prod command to playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ coverage
 .env.test
 
 # build output
-dist
 .vercel
 
 # OS-specific

--- a/playgrounds/demo/.gitignore
+++ b/playgrounds/demo/.gitignore
@@ -1,4 +1,5 @@
 src/*
-dist/*
+dist/client/*
+dist/server/*
 !src/entry-client.ts
 !src/entry-server.ts

--- a/playgrounds/demo/dist/index.js
+++ b/playgrounds/demo/dist/index.js
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import express from 'express';
+import { head, html } from './server/entry-server.js';
+
+const rendered = fs
+	.readFileSync(path.resolve('./dist/client/index.html'), 'utf-8')
+	.replace(`<!--ssr-html-->`, html)
+	.replace(`<!--ssr-head-->`, head);
+
+express()
+	.use('*', async (req, res) => {
+		if (req.originalUrl !== '/') {
+			res.sendFile(path.resolve('./dist/client' + req.originalUrl));
+			return;
+		}
+
+		res.status(200).set({ 'Content-Type': 'text/html' }).end(rendered);
+	})
+	.listen('3000');
+
+console.log('listening on http://localhost:3000');

--- a/playgrounds/demo/package.json
+++ b/playgrounds/demo/package.json
@@ -7,7 +7,8 @@
     "prepare": "node scripts/create-app-svelte.js",
     "dev": "vite --host",
     "ssr": "node ./server.js",
-    "build": "vite build",
+    "build": "vite build --outDir dist/client && vite build --outDir dist/server --ssr src/entry-server.ts",
+    "prod": "npm run build && node dist",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/playgrounds/demo/vite.config.js
+++ b/playgrounds/demo/vite.config.js
@@ -3,6 +3,9 @@ import inspect from 'vite-plugin-inspect';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
+	build: {
+		minify: false
+	},
 	plugins: [inspect(), svelte()],
 	optimizeDeps: {
 		// svelte is a local workspace package, optimizing it would require dev server restarts with --force for every change


### PR DESCRIPTION
This adds a `pnpm prod` command to `playgrounds/demo`. Running it will build the app (both client and server) in prod mode and launch the server. Minification is disabled to make perf tracing easier.