### PR TITLE
chore: tidy up tests to use flushSync

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/attribute-spread-call-expression/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/attribute-spread-call-expression/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -8,11 +9,13 @@ export default test({
 		<button class="red">red</button>
 	`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [b1, b2, b3, b4] = target.querySelectorAll('button');
 
-		b1?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b1?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -23,8 +26,10 @@ export default test({
 			`
 		);
 
-		b2?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b2?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -35,8 +40,10 @@ export default test({
 			`
 		);
 
-		b3?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b3?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -47,8 +54,10 @@ export default test({
 			`
 		);
 
-		b4?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b4?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`

--- a/packages/svelte/tests/runtime-runes/samples/attribute-spread-hidden/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/attribute-spread-hidden/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -7,7 +8,10 @@ export default test({
 
 		assert.equal(div?.hidden, true);
 
-		await btn?.click();
+		flushSync(() => {
+			btn?.click();
+		});
+
 		assert.equal(div?.hidden, false);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/bind-and-spread/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-and-spread/_config.js
@@ -1,18 +1,25 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button class="foo">0</button><button class="foo">0</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
-		await btn1?.click();
+		flushSync(() => {
+			btn1?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`<button class="foo">1</button><button class="foo">1</button>`
 		);
 
-		await btn2?.click();
+		flushSync(() => {
+			btn2?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`<button class="foo">2</button><button class="foo">2</button>`

--- a/packages/svelte/tests/runtime-runes/samples/derived-cascade/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-cascade/_config.js
@@ -1,11 +1,15 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>00</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>01</button>`);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/derived-write-read-write-read/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-write-read-write-read/_config.js
@@ -1,8 +1,12 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	async test({ assert, target }) {
-		await target.querySelector('button')?.click();
+	test({ assert, target }) {
+		flushSync(() => {
+			target.querySelector('button')?.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, `<button>0</button>`);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/destructure-derived-object/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/destructure-derived-object/_config.js
@@ -1,13 +1,19 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>1 1 1</button>`);
 
-		await btn?.click();
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>2 2 2</button>`);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-element-dynamic-namespace/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-element-dynamic-namespace/_config.js
@@ -1,10 +1,14 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	async test({ assert, target }) {
 		assert.equal(target.querySelector('path')?.namespaceURI, 'http://www.w3.org/2000/svg');
 
-		await target.querySelector('button')?.click();
+		flushSync(() => {
+			target.querySelector('button')?.click();
+		});
+
 		assert.equal(target.querySelector('div')?.namespaceURI, 'http://www.w3.org/1999/xhtml');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-bubble/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-bubble/_config.js
@@ -1,41 +1,52 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>0</button><button>0</button><button>change handler</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [b1, b2, b3] = target.querySelectorAll('button');
 
-		b1?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b1?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			'<button>1</button><button>1</button><button>change handler</button>'
 		);
 
-		b2?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b2?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			'<button>2</button><button>2</button><button>change handler</button>'
 		);
 
-		b3?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b3?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			'<button>2</button><button>2</button><button>change handler</button>'
 		);
 
-		b1?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b1?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			'<button>1</button><button>1</button><button>change handler</button>'
 		);
 
-		b2?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b2?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			'<button>0</button><button>0</button><button>change handler</button>'

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-not-hoistable/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-not-hoistable/_config.js
@@ -1,25 +1,34 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>0</button><button>x0</button><button>y0</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [btn1, btn2, btn3] = target.querySelectorAll('button');
 
-		btn1.click();
-		await Promise.resolve();
+		flushSync(() => {
+			btn1.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, '<button>1</button><button>x0</button><button>y0</button>');
 
-		btn1.dispatchEvent(new MouseEvent('mouseenter'));
-		await Promise.resolve();
+		flushSync(() => {
+			btn1.dispatchEvent(new MouseEvent('mouseenter'));
+		});
+
 		assert.htmlEqual(target.innerHTML, '<button>2</button><button>x0</button><button>y0</button>');
 
-		btn2.click();
-		await Promise.resolve();
+		flushSync(() => {
+			btn2.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, '<button>2</button><button>x1</button><button>y0</button>');
 
-		btn3.click();
-		await Promise.resolve();
+		flushSync(() => {
+			btn3.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, '<button>2</button><button>x1</button><button>y1</button>');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-spread/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-spread/_config.js
@@ -1,19 +1,26 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>0</button><button>change handler</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [b1, b2] = target.querySelectorAll('button');
 
-		b1?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b1?.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, '<button>1</button><button>change handler</button>');
 
-		b2?.click();
-		await Promise.resolve();
-		b1?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b2?.click();
+		});
+
+		flushSync(() => {
+			b1?.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, '<button>0</button><button>change handler</button>');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute/_config.js
@@ -1,17 +1,22 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>0</button><button>0</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [b1, b2] = target.querySelectorAll('button');
 
-		b1?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b1?.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, '<button>1</button><button>1</button>');
 
-		b2?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			b2?.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, '<button>2</button><button>2</button>');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-listener-moved-outside-container/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-listener-moved-outside-container/_config.js
@@ -1,20 +1,25 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 // Tests that event delegation still works when the element with the event listener is moved outside the container
 export default test({
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn1 = target.parentElement?.querySelector('button');
 		const btn2 = target.querySelector('button');
 
-		btn1?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			btn1?.click();
+		});
+
 		assert.htmlEqual(
 			target.parentElement?.innerHTML ?? '',
 			'<main><div><button>clicks: 1</button></div></main><button>clicks: 1</button>'
 		);
 
-		btn2?.click();
-		await Promise.resolve();
+		flushSync(() => {
+			btn2?.click();
+		});
+
 		assert.htmlEqual(
 			target.parentElement?.innerHTML ?? '',
 			'<main><div><button>clicks: 2</button></div></main><button>clicks: 2</button>'

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-discouraged/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-discouraged/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 /** @type {typeof console.trace} */
@@ -19,9 +20,12 @@ export default test({
 		console.trace = trace;
 	},
 
-	async test({ assert, target, warnings }) {
+	test({ assert, target, warnings }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
 

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-2/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 /** @type {typeof console.warn} */
@@ -26,9 +27,12 @@ export default test({
 		warnings = [];
 	},
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
 

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-3/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 /** @type {typeof console.warn} */
@@ -26,9 +27,12 @@ export default test({
 		warnings = [];
 	},
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>[foo]</button>`);
 

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-4/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 /** @type {typeof console.warn} */
@@ -24,9 +25,13 @@ export default test({
 		warnings = [];
 	},
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
+
 		assert.deepEqual(warnings, []);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-5/_config.js
@@ -1,4 +1,4 @@
-import { tick } from 'svelte';
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -6,15 +6,19 @@ export default test({
 		dev: true
 	},
 
-	async test({ assert, target, warnings }) {
+	test({ assert, target, warnings }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
-		await btn1.click();
-		await tick();
+		flushSync(() => {
+			btn1.click();
+		});
+
 		assert.deepEqual(warnings.length, 0);
 
-		await btn2.click();
-		await tick();
+		flushSync(() => {
+			btn2.click();
+		});
+
 		assert.deepEqual(warnings.length, 1);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-6/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-6/_config.js
@@ -1,4 +1,4 @@
-import { tick } from 'svelte';
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 /** @type {typeof console.warn} */
@@ -28,8 +28,10 @@ export default test({
 	async test({ assert, target }) {
 		const btn = target.querySelector('button');
 
-		await btn?.click();
-		await tick();
+		flushSync(() => {
+			btn?.click();
+		});
+
 		assert.deepEqual(warnings.length, 0);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-7/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner-7/_config.js
@@ -1,4 +1,4 @@
-import { tick } from 'svelte';
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -9,13 +9,15 @@ export default test({
 	async test({ assert, target, warnings }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
-		btn1.click();
-		await tick();
+		flushSync(() => {
+			btn1.click();
+		});
 
 		assert.deepEqual(warnings.length, 0);
 
-		btn2.click();
-		await tick();
+		flushSync(() => {
+			btn2.click();
+		});
 
 		assert.deepEqual(warnings.length, 1);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-inherited-owner/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 /** @type {typeof console.warn} */
@@ -26,9 +27,12 @@ export default test({
 		warnings = [];
 	},
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
 

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 /** @type {typeof console.warn} */
@@ -26,9 +27,12 @@ export default test({
 		warnings = [];
 	},
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
 

--- a/packages/svelte/tests/runtime-runes/samples/props-array-each/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-array-each/_config.js
@@ -1,12 +1,16 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>add</button> <p>1</p><p>1</p><p>1</p>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
 
-		await btn?.click();
+		flushSync(() => {
+			btn?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`<button>add</button> <p>1</p><p>2</p><p>1</p><p>2</p><p>1</p><p>2</p>`

--- a/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -9,7 +10,10 @@ export default test({
 	async test({ assert, target }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
-		await btn1?.click();
+		flushSync(() => {
+			btn1?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -18,7 +22,10 @@ export default test({
 			`
 		);
 
-		await btn2?.click();
+		flushSync(() => {
+			btn2?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`

--- a/packages/svelte/tests/runtime-runes/samples/props-equality/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-equality/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -7,10 +8,13 @@ export default test({
 		<button>a true</button><button>b true</button>
 	`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		let [btn1, _btn2, btn3, _btn4, btn5] = target.querySelectorAll('button');
 
-		await btn1.click();
+		flushSync(() => {
+			btn1.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -21,7 +25,11 @@ export default test({
 		);
 
 		[btn1, _btn2, btn3, _btn4, btn5] = target.querySelectorAll('button');
-		await btn3.click();
+
+		flushSync(() => {
+			btn3.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -32,7 +40,11 @@ export default test({
 		);
 
 		[btn1, _btn2, btn3, _btn4, btn5] = target.querySelectorAll('button');
-		await btn5.click();
+
+		flushSync(() => {
+			btn5.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`

--- a/packages/svelte/tests/runtime-runes/samples/proxy-array/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-array/_config.js
@@ -12,10 +12,13 @@ export default test({
 		<strong>array[1]: 2</strong>
 	`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [add, clear, reverse] = target.querySelectorAll('button');
 
-		await add?.click();
+		flushSync(() => {
+			add?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`

--- a/packages/svelte/tests/runtime-runes/samples/proxy-cyclical/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-cyclical/_config.js
@@ -1,11 +1,15 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>hello!</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>goodbye!</button>`);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/proxy-deep/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-deep/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -6,10 +7,13 @@ export default test({
 		<button>double</button>
 	`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
-		await btn1?.click();
+		flushSync(() => {
+			btn1?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -18,7 +22,10 @@ export default test({
 			`
 		);
 
-		await btn2?.click();
+		flushSync(() => {
+			btn2?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -27,7 +34,10 @@ export default test({
 			`
 		);
 
-		await btn1?.click();
+		flushSync(() => {
+			btn1?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`

--- a/packages/svelte/tests/runtime-runes/samples/proxy-nested/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-nested/_config.js
@@ -1,11 +1,15 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>clicks: 0</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/proxy-prop-bound/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-prop-bound/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -6,9 +7,12 @@ export default test({
 		<p>object.count: 0</p>
 	`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(
 			target.innerHTML,

--- a/packages/svelte/tests/runtime-runes/samples/proxy-shared/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-shared/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -9,7 +10,10 @@ export default test({
 	async test({ assert, target }) {
 		const [btn1, btn2] = target.querySelectorAll('button');
 
-		await btn1?.click();
+		flushSync(() => {
+			btn1?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -18,7 +22,10 @@ export default test({
 			`
 		);
 
-		await btn2?.click();
+		flushSync(() => {
+			btn2?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`

--- a/packages/svelte/tests/runtime-runes/samples/proxy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy/_config.js
@@ -1,11 +1,15 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: `<button>clicks: 0</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
-		await btn?.click();
+
+		flushSync(() => {
+			btn?.click();
+		});
 
 		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/readonly-state-push/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/readonly-state-push/_config.js
@@ -1,10 +1,13 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [b1] = target.querySelectorAll('button');
-		b1.click();
-		await Promise.resolve();
+
+		flushSync(() => {
+			b1.click();
+		});
 
 		assert.htmlEqual(
 			target.innerHTML,

--- a/packages/svelte/tests/runtime-runes/samples/snippet-reactive-args/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-reactive-args/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -7,10 +8,13 @@ export default test({
 		<button>increase count</button>
 	`,
 
-	async test({ assert, target, logs }) {
+	test({ assert, target, logs }) {
 		const [toggle, increment] = target.querySelectorAll('button');
 
-		await increment?.click();
+		flushSync(() => {
+			increment?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -21,7 +25,10 @@ export default test({
 		);
 		assert.deepEqual(logs, []);
 
-		await toggle?.click();
+		flushSync(() => {
+			toggle?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -32,7 +39,10 @@ export default test({
 		);
 		assert.deepEqual(logs, [1]);
 
-		await increment?.click();
+		flushSync(() => {
+			increment?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`
@@ -43,7 +53,10 @@ export default test({
 		);
 		assert.deepEqual(logs, [1]);
 
-		await toggle?.click();
+		flushSync(() => {
+			toggle?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`

--- a/packages/svelte/tests/runtime-runes/samples/state-delete-property/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-delete-property/_config.js
@@ -1,17 +1,24 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	html: '<button>set</button><button>delete</button><p>a,b,c</p><p>{"a":1,"b":2,"c":3}</p>',
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const [btn, bt2] = target.querySelectorAll('button');
 
-		await btn?.click();
+		flushSync(() => {
+			btn?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`<button>set</button><button>delete</button><p>a,b,c</p><p>{"a":1,"b":2,"c":3}</p>`
 		);
 
-		await bt2?.click();
+		flushSync(() => {
+			bt2?.click();
+		});
+
 		assert.htmlEqual(
 			target.innerHTML,
 			`<button>set</button><button>delete</button><p>a,c</p><p>{"a":1,"c":3}</p>`

--- a/packages/svelte/tests/runtime-runes/samples/state-readonly/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-readonly/_config.js
@@ -1,13 +1,17 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	compileOptions: {
 		dev: true
 	},
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
 
-		await btn?.click();
+		flushSync(() => {
+			btn?.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, `<button></button>\n[object Object]`);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/state-reuse/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-reuse/_config.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
@@ -7,10 +8,13 @@ export default test({
 
 	html: `<button>state1.value: a state2.value: a</button>`,
 
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const btn = target.querySelector('button');
 
-		await btn?.click();
+		flushSync(() => {
+			btn?.click();
+		});
+
 		assert.htmlEqual(target.innerHTML, `<button>state1.value: b state2.value: b</button>`);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-hoisting/_config.js
@@ -1,12 +1,16 @@
+import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	compileOptions: {
 		dev: true
 	},
-	async test({ assert, target }) {
+	test({ assert, target }) {
 		const button = target.querySelector('button');
-		await button?.click();
+
+		flushSync(() => {
+			button?.click();
+		});
 
 		assert.htmlEqual(
 			target.innerHTML,


### PR DESCRIPTION
Removes a whole bunch of awaiting in our tests. Instead we use `flushSync` which is far cleaner and also avoids the hacky awaiting of random promises everywhere. This doesn't do all the tests, just ones that make heavy use of click events.