### PR TITLE
fix: migrate derivations without semicolons

### DIFF
--- a/.changeset/kind-snakes-drive.md
+++ b/.changeset/kind-snakes-drive.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: migrate derivations without semicolons

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -369,11 +369,15 @@ const instance_script = {
 					/** @type {number} */ (node.body.expression.right.start),
 					'$derived('
 				);
-				state.str.update(
-					/** @type {number} */ (node.body.expression.right.end),
-					/** @type {number} */ (node.end),
-					');'
-				);
+				if (node.body.expression.right.end !== node.end) {
+					state.str.update(
+						/** @type {number} */ (node.body.expression.right.end),
+						/** @type {number} */ (node.end),
+						');'
+					);
+				} else {
+					state.str.appendRight(/** @type {number} */ (node.end), ');');
+				}
 				return;
 			} else {
 				for (const binding of reassigned_bindings) {

--- a/packages/svelte/tests/migrate/samples/derivations-no-colon/input.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations-no-colon/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	let count = 0;
+	$: doubled = count * 2
+	$: ({ quadrupled } = { quadrupled: count * 4 })
+</script>
+
+{count} / {doubled} / {quadrupled}

--- a/packages/svelte/tests/migrate/samples/derivations-no-colon/output.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations-no-colon/output.svelte
@@ -1,0 +1,7 @@
+<script>
+	let count = 0;
+	let doubled = $derived(count * 2);
+	let { quadrupled } = $derived({ quadrupled: count * 4 });
+</script>
+
+{count} / {doubled} / {quadrupled}


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11689 ...i've tried to think of a "general" solution that didn't involve the if but i wasn't able to figure out one because only appending would not work for cases where there's a parentheses and a semicolon since those are "ignored" by the ast and only updating doesn't work when there's no semicolon and no parentheses since then `end` of the expression and `end` of the node are the same. 

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
