### PR TITLE
fix: don't add scoping modifier to nesting selectors

### DIFF
--- a/.changeset/itchy-beds-kneel.md
+++ b/.changeset/itchy-beds-kneel.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't add scoping modifier to nesting selectors

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -238,7 +238,7 @@ const visitors = {
 					}
 				}
 
-				if (relative_selector.selectors.every((s) => s.type === 'NestingSelector')) {
+				if (relative_selector.selectors.some((s) => s.type === 'NestingSelector')) {
 					continue;
 				}
 

--- a/packages/svelte/tests/css/samples/nested-css/_config.js
+++ b/packages/svelte/tests/css/samples/nested-css/_config.js
@@ -75,29 +75,29 @@ export default test({
 		{
 			code: 'css_unused_selector',
 			end: {
-				character: 634,
+				character: 668,
 				column: 5,
-				line: 66
+				line: 70
 			},
 			message: 'Unused CSS selector "&.b"',
 			start: {
-				character: 631,
+				character: 665,
 				column: 2,
-				line: 66
+				line: 70
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			end: {
-				character: 666,
+				character: 700,
 				column: 9,
-				line: 70
+				line: 74
 			},
 			message: 'Unused CSS selector ".unused"',
 			start: {
-				character: 659,
+				character: 693,
 				column: 2,
-				line: 70
+				line: 74
 			}
 		}
 	]

--- a/packages/svelte/tests/css/samples/nested-css/expected.css
+++ b/packages/svelte/tests/css/samples/nested-css/expected.css
@@ -36,6 +36,10 @@
 			}*/
 		}
 
+		&:hover {
+			color: green;
+		}
+
 		& & {
 			color: green;
 		}

--- a/packages/svelte/tests/css/samples/nested-css/input.svelte
+++ b/packages/svelte/tests/css/samples/nested-css/input.svelte
@@ -50,6 +50,10 @@
 			}
 		}
 
+		&:hover {
+			color: green;
+		}
+
 		& & {
 			color: green;
 		}


### PR DESCRIPTION
fixes #11707 — previously we would add a scoping modifier unless _all_ parts of a relative selector were `&` nesting selectors, but that's incorrect — `&:hover` or `&.foo` doesn't need any additional scoping, because it will have been applied to the parent selector already. This was harmless in the typical case, but caused bugs when the parent selector had a `:global` modifier.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
