### PR TITLE
chore: tooltip tweaks

### DIFF
--- a/sites/svelte-5-preview/src/lib/CodeMirror.svelte
+++ b/sites/svelte-5-preview/src/lib/CodeMirror.svelte
@@ -295,16 +295,17 @@
 		.cm-tooltip-section {
 			position: relative;
 			padding: 0.5em;
-			/* width: calc(100vw - 10em); */
+			left: -13px;
 			filter: drop-shadow(2px 4px 6px rgba(0, 0, 0, 0.1));
 			background: var(--bg);
 			border-radius: 2px;
+			max-width: 64em;
 		}
 
 		.cm-tooltip-section::before {
 			content: '';
 			position: absolute;
-			left: 20px;
+			left: 10px;
 			width: 8px;
 			height: 8px;
 			transform: rotate(45deg);


### PR DESCRIPTION
follow-up to #11705 — better arrow placement in the case of diagnostics that don't span a range of characters, and a sensible limit on how wide the tooltip can get