### PR TITLE
fix: allow comments after last selector in css

### DIFF
--- a/.changeset/clever-maps-travel.md
+++ b/.changeset/clever-maps-travel.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow comments after last selector in css

--- a/packages/svelte/src/compiler/phases/1-parse/read/style.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/style.js
@@ -139,6 +139,8 @@ function read_selector_list(parser, inside_pseudo_class = false) {
 
 		const end = parser.index;
 
+		allow_comment_or_whitespace(parser);
+
 		parser.allow_whitespace();
 
 		if (inside_pseudo_class ? parser.match(')') : parser.match('{')) {
@@ -324,7 +326,7 @@ function read_selector(parser, inside_pseudo_class = false) {
 		}
 
 		const index = parser.index;
-		parser.allow_whitespace();
+		allow_comment_or_whitespace(parser);
 
 		if (parser.match(',') || (inside_pseudo_class ? parser.match(')') : parser.match('{'))) {
 			// rewind, so we know whether to continue building the selector list

--- a/packages/svelte/src/compiler/phases/1-parse/read/style.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/style.js
@@ -141,8 +141,6 @@ function read_selector_list(parser, inside_pseudo_class = false) {
 
 		allow_comment_or_whitespace(parser);
 
-		parser.allow_whitespace();
-
 		if (inside_pseudo_class ? parser.match(')') : parser.match('{')) {
 			return {
 				type: 'SelectorList',

--- a/packages/svelte/tests/css/samples/comments-after-last-selector/expected.css
+++ b/packages/svelte/tests/css/samples/comments-after-last-selector/expected.css
@@ -1,0 +1,6 @@
+
+	.foo.svelte-xyz,  /* some comment */
+	.bar.svelte-xyz /* some other comment */
+	{
+		color: red;
+	}

--- a/packages/svelte/tests/css/samples/comments-after-last-selector/input.svelte
+++ b/packages/svelte/tests/css/samples/comments-after-last-selector/input.svelte
@@ -1,0 +1,10 @@
+<div class="foo">foo</div>
+<div class="bar">bar</div>
+
+<style>
+	.foo,  /* some comment */
+	.bar /* some other comment */
+	{
+		color: red;
+	}
+</style>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11721

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
