### PR TITLE
fix: improved checked/value handling

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -39,6 +39,32 @@ export function remove_input_attr_defaults(dom) {
 
 /**
  * @param {Element} element
+ * @param {any} value
+ */
+export function set_value(element, value) {
+	// @ts-expect-error
+	var attributes = (element.__attributes ??= {});
+
+	if (attributes.value === (attributes.value = value)) return;
+	// @ts-expect-error
+	element.value = value;
+}
+
+/**
+ * @param {Element} element
+ * @param {boolean} value
+ */
+export function set_checked(element, value) {
+	// @ts-expect-error
+	var attributes = (element.__attributes ??= {});
+
+	if (attributes.value === (attributes.value = value)) return;
+	// @ts-expect-error
+	element.value = value;
+}
+
+/**
+ * @param {Element} element
  * @param {string} attribute
  * @param {string | null} value
  */

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -52,15 +52,15 @@ export function set_value(element, value) {
 
 /**
  * @param {Element} element
- * @param {boolean} value
+ * @param {boolean} checked
  */
-export function set_checked(element, value) {
+export function set_checked(element, checked) {
 	// @ts-expect-error
 	var attributes = (element.__attributes ??= {});
 
-	if (attributes.value === (attributes.value = value)) return;
+	if (attributes.checked === (attributes.checked = checked)) return;
 	// @ts-expect-error
-	element.value = value;
+	element.checked = checked;
 }
 
 /**

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -27,7 +27,9 @@ export {
 	set_custom_element_data,
 	set_dynamic_element_attributes,
 	set_xlink_attribute,
-	handle_lazy_img
+	handle_lazy_img,
+	set_value,
+	set_checked
 } from './dom/elements/attributes.js';
 export { set_class, set_svg_class, set_mathml_class, toggle_class } from './dom/elements/class.js';
 export { event, delegate, replay_events } from './dom/elements/events.js';


### PR DESCRIPTION
Follow up to https://github.com/sveltejs/svelte/pull/11720.

This is an alternative take that means we don't need to break out another template effect. Instead we can use the fact we have internal attribute caches for the `value` and `checked` values and if the value matches, we can skip doing work.