### PR TITLE
chore: delegate input event

### DIFF
--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -40,7 +40,7 @@ export const DelegatedEvents = [
 	'contextmenu',
 	'focusin',
 	'focusout',
-	// 'input', This conflicts with bind:input
+	'input',
 	'keydown',
 	'keyup',
 	'mousedown',

--- a/packages/svelte/tests/runtime-runes/samples/event-spread-rerun/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-spread-rerun/_config.js
@@ -1,14 +1,16 @@
+import { flushSync } from 'svelte';
 import { test, ok } from '../../test';
 
 export default test({
 	mode: ['client'],
 
-	async test({ assert, logs, target }) {
+	test({ assert, logs, target }) {
 		const input = target.querySelector('input');
 		ok(input);
 
 		input.value = 'foo';
-		await input.dispatchEvent(new Event('input'));
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		flushSync();
 
 		assert.deepEqual(logs, ['hi']);
 	}


### PR DESCRIPTION
We didn't delegate the input event back when we were also delegating `on:x` events, because it messes up the event/bindings/actions order. Since we're only doing that for `onx` event attributes now that reason is obsolete and we can start delegating it.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
