### PR TITLE
fix: throw on invalid attribute expressions

### DIFF
--- a/.changeset/funny-trees-cry.md
+++ b/.changeset/funny-trees-cry.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: throw on invalid attribute expressions

--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -30,6 +30,10 @@
 
 > Event attribute must be a JavaScript expression, not a string
 
+## attribute_invalid_expression
+
+> Invalid attribute expression
+
 ## attribute_invalid_multiple
 
 > 'multiple' attribute must be static if select uses two-way binding

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -601,6 +601,15 @@ export function attribute_invalid_event_handler(node) {
 }
 
 /**
+ * Invalid attribute expression
+ * @param {null | number | NodeLike} node
+ * @returns {never}
+ */
+export function attribute_invalid_expression(node) {
+	e(node, "attribute_invalid_expression", "Invalid attribute expression");
+}
+
+/**
  * 'multiple' attribute must be static if select uses two-way binding
  * @param {null | number | NodeLike} node
  * @returns {never}

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -680,15 +680,6 @@ function read_attribute_value(parser) {
 		];
 	}
 
-	/**
-	 * we need this because if we are not inside a mustache we treat
-	 * the whole thing as a string
-	 * eg.
-	 *
-	 * <input foo=cool{variable} /> it's equal to <input foo="cool{variable}" />
-	 */
-	const mustached = !quote_mark && parser.match('{');
-
 	let value;
 	try {
 		value = read_sequence(
@@ -700,16 +691,6 @@ function read_attribute_value(parser) {
 			},
 			'in attribute value'
 		);
-
-		/**
-		 * if we are in a mustache tag and the value returned is more than one
-		 * expression there's a mismatch in the expression
-		 *
-		 * <input foo={true}} /> or even <input foo={true}something />
-		 */
-		if (mustached && value.length > 1) {
-			e.attribute_invalid_expression(parser.index);
-		}
 	} catch (/** @type {any} */ error) {
 		if (error.code === 'js_parse_error') {
 			// if the attribute value didn't close + self-closing tag

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -8,8 +8,8 @@ import * as e from '../../errors.js';
 import {
 	extract_identifiers,
 	get_parent,
-	is_event_attribute,
 	is_expression_attribute,
+	is_quoted_attribute,
 	is_text_attribute,
 	object,
 	unwrap_optional
@@ -58,6 +58,15 @@ function validate_component(node, context) {
 		}
 
 		if (attribute.type === 'Attribute') {
+			if (
+				context.state.analysis.runes &&
+				!is_quoted_attribute(attribute) &&
+				Array.isArray(attribute.value) &&
+				attribute.value.length > 1
+			) {
+				e.attribute_invalid_expression(attribute);
+			}
+
 			if (context.state.analysis.runes && is_expression_attribute(attribute)) {
 				const expression = attribute.value[0].expression;
 				if (expression.type === 'SequenceExpression') {
@@ -106,6 +115,15 @@ function validate_element(node, context) {
 	for (const attribute of node.attributes) {
 		if (attribute.type === 'Attribute') {
 			const is_expression = is_expression_attribute(attribute);
+
+			if (
+				context.state.analysis.runes &&
+				!is_quoted_attribute(attribute) &&
+				Array.isArray(attribute.value) &&
+				attribute.value.length > 1
+			) {
+				e.attribute_invalid_expression(attribute);
+			}
 
 			if (context.state.analysis.runes && is_expression) {
 				const expression = attribute.value[0].expression;

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -45,6 +45,16 @@ export function is_expression_attribute(attribute) {
 }
 
 /**
+ * Returns true if the attribute is quoted.
+ * @param {import('#compiler').Attribute} attribute
+ * @returns {attribute is import('#compiler').Attribute & { value: [import('#compiler').ExpressionTag] }}
+ */
+export function is_quoted_attribute(attribute) {
+	if (attribute.value === true) return false;
+	return attribute.value.at(-1)?.end !== attribute.end;
+}
+
+/**
  * Returns true if the attribute starts with `on` and contains a single expression node.
  * @param {import('#compiler').Attribute} attribute
  * @returns {attribute is import('#compiler').Attribute & { value: [import('#compiler').ExpressionTag] }}

--- a/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-component/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-component/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'attribute_invalid_expression',
+		message: 'Invalid attribute expression',
+		position: [91, 91]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-component/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-component/_config.js
@@ -4,6 +4,6 @@ export default test({
 	error: {
 		code: 'attribute_invalid_expression',
 		message: 'Invalid attribute expression',
-		position: [91, 91]
+		position: [101, 116]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-component/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-component/main.svelte
@@ -1,3 +1,4 @@
+<svelte:options runes />
 <script>
 	import Component from "./Component.svelte";
 </script>

--- a/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-component/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-component/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Component from "./Component.svelte";
+</script>
+
+<Component onclick={true}} />

--- a/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-element/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-element/_config.js
@@ -4,6 +4,6 @@ export default test({
 	error: {
 		code: 'attribute_invalid_expression',
 		message: 'Invalid attribute expression',
-		position: [46, 46]
+		position: [34, 71]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-element/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-element/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'attribute_invalid_expression',
+		message: 'Invalid attribute expression',
+		position: [46, 46]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-element/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-element/main.svelte
@@ -1,0 +1,5 @@
+<button
+	onclick={() => console.log('hello')}}
+>
+	click
+</button>

--- a/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-element/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/unbalanced-curly-element/main.svelte
@@ -1,3 +1,4 @@
+<svelte:options runes />
 <button
 	onclick={() => console.log('hello')}}
 >


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11734 

Initially i went with: if there's not a quote mark and the value returned is more than a single expression there's a problem. But there's some weird and probably old svelte that you can write that was failing

```svelte
<input foo=text{variable} />
```
that will result in 
```svelte
<input foo="textvalueofvariable" />
```
so i had to check for if we are in a mustache with `parser.match('{')`.

Tests are all passing and it does seem to work so i guess my assumption that mustache tags can only return one expression is correct. If it is a string then the closing tag either is a quote or is the monstrosity up above and we can't really do much about this error imho.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
