### PR TITLE
fix: ensure we clear down each block opening anchors from document

### DIFF
--- a/.changeset/silent-rabbits-join.md
+++ b/.changeset/silent-rabbits-join.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure we clear down each block opening anchors from document

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -280,7 +280,7 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 		item = items.get(key);
 
 		if (item === undefined) {
-			var child_open = push_template_node(empty());
+			var child_open = empty();
 			var child_anchor = current ? current.o : anchor;
 
 			child_anchor.before(child_open);
@@ -407,6 +407,7 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 		for (var i = 0; i < to_destroy.length; i += 1) {
 			var item = to_destroy[i];
 			items.delete(item.k);
+			remove(item.o);
 			link(item.prev, item.next);
 		}
 	});


### PR DESCRIPTION
This was causing a memory leak in the each block because of two reasons:

- `push_template_node` was pushing the anchor to the each block effect, yet we never really do anything with that, so it was just an array that kept growing in size.
- we append the anchor to the document, but we never remove it on the each block entry being removed.

It's a shame we have the opening anchor logic at all, as we never used to have this in the older each block design – we used to get the first/last elements from the child effect's `dom`. This avoided the need to have anchors around each blocks entirely – which reduced the time spent creating and cleaning up each block updates.