### PR TITLE
chore: simplify internal DOM operations

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/class.js
+++ b/packages/svelte/src/internal/client/dom/elements/class.js
@@ -1,5 +1,4 @@
 import { hydrating } from '../hydration.js';
-import { set_class_name } from '../operations.js';
 
 /**
  * @param {SVGElement} dom
@@ -83,7 +82,7 @@ export function set_class(dom, value) {
 		if (value == null) {
 			dom.removeAttribute('class');
 		} else {
-			set_class_name(dom, next_class_name);
+			dom.className = next_class_name;
 		}
 
 		// @ts-expect-error need to add __className to patched prototype

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -1,5 +1,5 @@
 import { hydrate_nodes, hydrating } from './hydration.js';
-import { clone_node, empty } from './operations.js';
+import { empty } from './operations.js';
 import { create_fragment_from_html } from './reconciler.js';
 import { current_effect } from '../runtime.js';
 import { TEMPLATE_FRAGMENT, TEMPLATE_USE_IMPORT_NODE } from '../../../constants.js';
@@ -55,7 +55,7 @@ export function template(content, flags) {
 			node = create_fragment_from_html(content);
 			if (!is_fragment) node = /** @type {Node} */ (node.firstChild);
 		}
-		var clone = use_import_node ? document.importNode(node, true) : clone_node(node, true);
+		var clone = use_import_node ? document.importNode(node, true) : node.cloneNode(true);
 
 		push_template_node(
 			is_fragment
@@ -122,7 +122,7 @@ export function svg_template(content, flags) {
 			}
 		}
 
-		var clone = clone_node(node, true);
+		var clone = node.cloneNode(true);
 
 		push_template_node(
 			is_fragment
@@ -189,7 +189,7 @@ export function mathml_template(content, flags) {
 			}
 		}
 
-		var clone = clone_node(node, true);
+		var clone = node.cloneNode(true);
 
 		push_template_node(
 			is_fragment

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -324,7 +324,7 @@ export async function append_styles(target, style_sheet_id, styles) {
 		const style = create_element('style');
 		style.id = style_sheet_id;
 		style.textContent = styles;
-		/** @type {Document} */ ((append_styles_to).head || append_styles_to).appendChild(style);
+		/** @type {Document} */ (append_styles_to.head || append_styles_to).appendChild(style);
 	}
 }
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -324,7 +324,8 @@ export async function append_styles(target, style_sheet_id, styles) {
 		const style = create_element('style');
 		style.id = style_sheet_id;
 		style.textContent = styles;
-		/** @type {Document} */ (append_styles_to.head || append_styles_to).appendChild(style);
+		const target = /** @type {Document} */ (append_styles_to).head || append_styles_to;
+		target.appendChild(style);
 	}
 }
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1,11 +1,5 @@
 import { DEV } from 'esm-env';
-import {
-	append_child,
-	clear_text_content,
-	create_element,
-	empty,
-	init_operations
-} from './dom/operations.js';
+import { clear_text_content, create_element, empty, init_operations } from './dom/operations.js';
 import { HYDRATION_ERROR, HYDRATION_START, PassiveDelegatedEvents } from '../../constants.js';
 import { flush_sync, push, pop, current_component_context } from './runtime.js';
 import { effect_root, branch } from './reactivity/effects.js';
@@ -330,7 +324,7 @@ export async function append_styles(target, style_sheet_id, styles) {
 		const style = create_element('style');
 		style.id = style_sheet_id;
 		style.textContent = styles;
-		append_child(/** @type {Document} */ (append_styles_to).head || append_styles_to, style);
+		/** @type {Document} */ ((append_styles_to).head || append_styles_to).appendChild(style);
 	}
 }
 


### PR DESCRIPTION
Since Chrome 125, it appears we no longer need to use the internal prototype methods everywhere to get consistent performance. This simplifies DOM operations a bit.