### PR TITLE
fix: don't use console.trace inside dev warnings

### DIFF
--- a/.changeset/six-bears-trade.md
+++ b/.changeset/six-bears-trade.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't use console.trace inside dev warnings

--- a/packages/svelte/scripts/process-messages/templates/shared-warnings.js
+++ b/packages/svelte/scripts/process-messages/templates/shared-warnings.js
@@ -5,13 +5,11 @@ var normal = 'font-weight: normal';
 
 /**
  * MESSAGE
- * @param {boolean} trace
  * @param {string} PARAMETER
  */
-export function CODE(trace, PARAMETER) {
+export function CODE(PARAMETER) {
 	if (DEV) {
 		console.warn(`%c[svelte] ${'CODE'}\n%c${MESSAGE}`, bold, normal);
-		if (trace) console.trace('stack trace');
 	} else {
 		// TODO print a link to the documentation
 		console.warn('CODE');

--- a/packages/svelte/src/internal/client/dev/equality.js
+++ b/packages/svelte/src/internal/client/dev/equality.js
@@ -21,9 +21,6 @@ export function init_array_prototype_warnings() {
 
 			if (test !== -1) {
 				w.state_proxy_equality_mismatch('array.indexOf(...)');
-
-				// eslint-disable-next-line no-console
-				console.trace();
 			}
 		}
 
@@ -38,9 +35,6 @@ export function init_array_prototype_warnings() {
 
 			if (test !== -1) {
 				w.state_proxy_equality_mismatch('array.lastIndexOf(...)');
-
-				// eslint-disable-next-line no-console
-				console.trace();
 			}
 		}
 
@@ -55,9 +49,6 @@ export function init_array_prototype_warnings() {
 
 			if (test) {
 				w.state_proxy_equality_mismatch('array.includes(...)');
-
-				// eslint-disable-next-line no-console
-				console.trace();
 			}
 		}
 
@@ -81,9 +72,6 @@ export function init_array_prototype_warnings() {
 export function strict_equals(a, b, equal = true) {
 	if ((a === b) !== (get_proxied_value(a) === get_proxied_value(b))) {
 		w.state_proxy_equality_mismatch(equal ? '===' : '!==');
-
-		// eslint-disable-next-line no-console
-		console.trace();
 	}
 
 	return (a === b) === equal;
@@ -98,9 +86,6 @@ export function strict_equals(a, b, equal = true) {
 export function equals(a, b, equal = true) {
 	if ((a == b) !== (get_proxied_value(a) == get_proxied_value(b))) {
 		w.state_proxy_equality_mismatch(equal ? '==' : '!=');
-
-		// eslint-disable-next-line no-console
-		console.trace();
 	}
 
 	return (a == b) === equal;

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -241,8 +241,5 @@ export function check_ownership(metadata) {
 		} else {
 			w.ownership_invalid_mutation();
 		}
-
-		// eslint-disable-next-line no-console
-		console.trace();
 	}
 }

--- a/packages/svelte/src/internal/shared/validate.js
+++ b/packages/svelte/src/internal/shared/validate.js
@@ -43,7 +43,7 @@ export function validate_component(component_fn) {
 export function validate_void_dynamic_element(tag_fn) {
 	const tag = tag_fn();
 	if (tag && is_void(tag)) {
-		w.dynamic_void_element_content(false, tag);
+		w.dynamic_void_element_content(tag);
 	}
 }
 

--- a/packages/svelte/src/internal/shared/warnings.js
+++ b/packages/svelte/src/internal/shared/warnings.js
@@ -7,13 +7,11 @@ var normal = 'font-weight: normal';
 
 /**
  * `<svelte:element this="%tag%">` is a void element — it cannot have content
- * @param {boolean} trace
  * @param {string} tag
  */
-export function dynamic_void_element_content(trace, tag) {
+export function dynamic_void_element_content(tag) {
 	if (DEV) {
 		console.warn(`%c[svelte] ${"dynamic_void_element_content"}\n%c${`\`<svelte:element this="${tag}">\` is a void element — it cannot have content`}`, bold, normal);
-		if (trace) console.trace('stack trace');
 	} else {
 		// TODO print a link to the documentation
 		console.warn("dynamic_void_element_content");


### PR DESCRIPTION
While working on the playground console stuff I realised that we're currently doing `console.trace` after printing warnings in dev mode. This is because I'm a Firefox user, and Firefox doesn't include traces in warnings.

Chrome does. Since the vast majority of developers use Chrome for developing, this means unnecessary clutter. We _could_ get fancy and detect which browser we're in but I think it's overkill.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
