### PR TITLE
chore: simplify effect.dom stuff

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -4,7 +4,6 @@ import { current_effect, get } from '../../runtime.js';
 import { is_array } from '../../utils.js';
 import { hydrate_nodes, hydrating } from '../hydration.js';
 import { create_fragment_from_html, remove } from '../reconciler.js';
-import { push_template_node } from '../template.js';
 
 /**
  * @param {import('#client').Effect} effect
@@ -38,7 +37,7 @@ export function html(anchor, get_value, svg, mathml) {
 	let value = derived(get_value);
 
 	render_effect(() => {
-		var dom = html_to_dom(anchor, parent_effect, get(value), svg, mathml);
+		var dom = html_to_dom(anchor, get(value), svg, mathml);
 
 		if (dom) {
 			return () => {
@@ -56,13 +55,12 @@ export function html(anchor, get_value, svg, mathml) {
  * inserts it before the target anchor and returns the new nodes.
  * @template V
  * @param {Element | Text | Comment} target
- * @param {import('#client').Effect | null} effect
  * @param {V} value
  * @param {boolean} svg
  * @param {boolean} mathml
  * @returns {Element | Comment | (Element | Comment | Text)[]}
  */
-function html_to_dom(target, effect, value, svg, mathml) {
+function html_to_dom(target, value, svg, mathml) {
 	if (hydrating) return hydrate_nodes;
 
 	var html = value + '';
@@ -81,9 +79,6 @@ function html_to_dom(target, effect, value, svg, mathml) {
 	if (node.childNodes.length === 1) {
 		var child = /** @type {Text | Element | Comment} */ (node.firstChild);
 		target.before(child);
-		if (effect !== null) {
-			push_template_node(child, effect);
-		}
 		return child;
 	}
 
@@ -95,10 +90,6 @@ function html_to_dom(target, effect, value, svg, mathml) {
 		}
 	} else {
 		target.before(node);
-	}
-
-	if (effect !== null) {
-		push_template_node(nodes, effect);
 	}
 
 	return nodes;


### PR DESCRIPTION
Poking at #11690 some more: I think one of the core ideas there, of assigning `effect.dom` inside `append` when not hydrating (rather than doing it in `push_template_node`) makes a lot of sense. It turns out we're doing stuff that isn't really necessary, and we can make our lives simpler. This also makes the jump from `main` to #11690 slightly smaller

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
