### PR TITLE
fix: use svg methods for updating svg attributes too

### DIFF
--- a/.changeset/green-snails-tickle.md
+++ b/.changeset/green-snails-tickle.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: use svg methods for updating svg attributes too

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -472,7 +472,7 @@ function serialize_dynamic_element_attributes(attributes, context, element_id) {
 function serialize_element_attribute_update_assignment(element, node_id, attribute, context) {
 	const state = context.state;
 	const name = get_attribute_name(element, attribute, context);
-	const is_svg = context.state.metadata.namespace === 'svg';
+	const is_svg = context.state.metadata.namespace === 'svg' || element.name === 'svg';
 	const is_mathml = context.state.metadata.namespace === 'mathml';
 	let [contains_call_expression, value] = serialize_attribute_value(attribute.value, context);
 

--- a/packages/svelte/tests/runtime-runes/samples/svg-element-attribute-serialize/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svg-element-attribute-serialize/_config.js
@@ -1,0 +1,18 @@
+import { flushSync } from '../../../../src/index-client';
+import { test, ok } from '../../test';
+
+export default test({
+	mode: ['client'],
+	test({ assert, target }) {
+		const svg = target.querySelector('svg');
+		const button = target.querySelector('button');
+		ok(svg);
+		ok(button);
+
+		assert.equal(svg.getAttribute('class'), '0');
+		flushSync(() => {
+			button.click();
+		});
+		assert.equal(svg.getAttribute('class'), '1');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svg-element-attribute-serialize/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svg-element-attribute-serialize/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	let count = $state(0);
+</script>
+
+<svg class={count}>
+</svg>
+
+<button onclick={()=>count++}></button>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11746 

we were using the svg methods for every child of svg but not for svg itself

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
