### PR TITLE
chore: always return hydrate_start from template functions

### DIFF
--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -1,4 +1,4 @@
-import { hydrate_anchor, hydrating } from './hydration.js';
+import { hydrate_anchor, hydrate_start, hydrating } from './hydration.js';
 import { DEV } from 'esm-env';
 import { init_array_prototype_warnings } from '../dev/equality.js';
 import { current_effect } from '../runtime.js';
@@ -96,24 +96,21 @@ export function first_child(fragment, is_text) {
 		return /** @type {DocumentFragment} */ (fragment).firstChild;
 	}
 
-	// when we _are_ hydrating, `fragment` is an array of nodes
-	var first_node = /** @type {import('#client').TemplateNode[]} */ (fragment)[0];
-
 	// if an {expression} is empty during SSR, there might be no
 	// text node to hydrate — we must therefore create one
-	if (is_text && first_node?.nodeType !== 3) {
+	if (is_text && hydrate_start?.nodeType !== 3) {
 		var text = empty();
 		var dom = /** @type {import('#client').TemplateNode[]} */ (
 			/** @type {import('#client').Effect} */ (current_effect).dom
 		);
 
 		dom.unshift(text);
-		first_node?.before(text);
+		hydrate_start?.before(text);
 
 		return text;
 	}
 
-	return hydrate_anchor(first_node);
+	return hydrate_anchor(hydrate_start);
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -8,7 +8,6 @@ import { effect } from '../reactivity/effects.js';
 /**
  * @template {import("#client").TemplateNode | import("#client").TemplateNode[]} T
  * @param {T} dom
- * @returns {T}
  */
 function push_template_node(dom) {
 	var effect = /** @type {import('#client').Effect} */ (current_effect);
@@ -16,8 +15,6 @@ function push_template_node(dom) {
 	if (effect.dom === null) {
 		effect.dom = dom;
 	}
-
-	return dom;
 }
 
 /**
@@ -35,7 +32,8 @@ export function template(content, flags) {
 
 	return () => {
 		if (hydrating) {
-			return push_template_node(is_fragment ? hydrate_nodes : hydrate_start);
+			push_template_node(is_fragment ? hydrate_nodes : hydrate_start);
+			return hydrate_start;
 		}
 
 		if (!node) {
@@ -87,7 +85,8 @@ export function ns_template(content, flags, ns = 'svg') {
 
 	return () => {
 		if (hydrating) {
-			return push_template_node(is_fragment ? hydrate_nodes : hydrate_start);
+			push_template_node(is_fragment ? hydrate_nodes : hydrate_start);
+			return hydrate_start;
 		}
 
 		if (!node) {
@@ -188,14 +187,17 @@ export function text(anchor) {
 		anchor.before((node = empty()));
 	}
 
-	return push_template_node(node);
+	push_template_node(node);
+	return node;
 }
 
 export function comment() {
 	// we're not delegating to `template` here for performance reasons
 	if (hydrating) {
-		return push_template_node(hydrate_nodes);
+		push_template_node(hydrate_nodes);
+		return hydrate_start;
 	}
+
 	var frag = document.createDocumentFragment();
 	var anchor = empty();
 	frag.append(anchor);


### PR DESCRIPTION
Another incidental part of #11690. We never use the return value from template functions in hydration mode if it's a fragment, because we always refer to `hydrate_start` instead. This makes that clearer. No performance impact

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
