### PR TITLE
fix: `array.lastIndexOf` without second argument

### DIFF
--- a/.changeset/clever-stingrays-shout.md
+++ b/.changeset/clever-stingrays-shout.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: `array.lastIndexOf` without second argument

--- a/.changeset/clever-stingrays-shout.md
+++ b/.changeset/clever-stingrays-shout.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: `array.lastIndexOf` without second argument
+fix: support `array.lastIndexOf` without second argument

--- a/packages/svelte/src/internal/client/dev/equality.js
+++ b/packages/svelte/src/internal/client/dev/equality.js
@@ -28,10 +28,18 @@ export function init_array_prototype_warnings() {
 	};
 
 	array_prototype.lastIndexOf = function (item, from_index) {
-		const index = lastIndexOf.call(this, item, from_index);
+		// we need to specify this.length - 1 because it's probably using something like
+		// `arguments` inside so passing undefined is different from not passing anything
+		const index = lastIndexOf.call(this, item, from_index ?? this.length - 1);
 
 		if (index === -1) {
-			const test = lastIndexOf.call(get_proxied_value(this), get_proxied_value(item), from_index);
+			// we need to specify this.length - 1 because it's probably using something like
+			// `arguments` inside so passing undefined is different from not passing anything
+			const test = lastIndexOf.call(
+				get_proxied_value(this),
+				get_proxied_value(item),
+				from_index ?? this.length - 1
+			);
 
 			if (test !== -1) {
 				w.state_proxy_equality_mismatch('array.lastIndexOf(...)');

--- a/packages/svelte/tests/runtime-runes/samples/array-lastindexof/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/array-lastindexof/_config.js
@@ -1,0 +1,9 @@
+import { ok, test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, logs }) {
+		assert.equal(logs[0], logs[1]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/array-lastindexof/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/array-lastindexof/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	const arr = [0, 1, 2];
+	console.log(arr.lastIndexOf(2));
+	console.log(arr.lastIndexOf(2, arr.length - 1));
+</script>


### PR DESCRIPTION
## Svelte 5 rewrite

Close #11756 

I think lastIndexOf is using `arguments` internally so passing `undefined` is different from not passing it (you can test that in the console)

<img width="320" alt="image" src="https://github.com/sveltejs/svelte/assets/26281609/e3ef6679-c00f-493d-9f26-9472be9f1e61">

I've resorted to pass `item.length` but another possibly more correct solution could be to do 

```ts
const args = [this, item];
if(from_index){
    args.push(from_index);
}
```
and then spread those as arguments but it seemed unnecessary.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
