### PR TITLE
fix: allow runelike writable as prop

### DIFF
--- a/.changeset/chilly-pans-raise.md
+++ b/.changeset/chilly-pans-raise.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow runelike writable as prop

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -285,7 +285,9 @@ export function analyze_component(root, source, options) {
 			!Runes.includes(/** @type {any} */ (name)) ||
 			(declaration !== null &&
 				// const state = $state(0) is valid
-				get_rune(declaration.initial, instance.scope) === null &&
+				(get_rune(declaration.initial, instance.scope) === null ||
+					// rune-line names received as props are valid too (but we have to protect against $props as store)
+					(store_name !== 'props' && get_rune(declaration.initial, instance.scope) === '$props')) &&
 				// allow `import { derived } from 'svelte/store'` in the same file as `const x = $derived(..)` because one is not a subscription to the other
 				!(
 					name === '$derived' &&

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-runelike/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-runelike/_config.js
@@ -1,0 +1,18 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target, ok }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => {
+			button?.click();
+		});
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>1</button>
+		`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-runelike/child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-runelike/child.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { state } = $props();
+</script>
+
+<button onclick={()=> $state++}>{$state}</button>

--- a/packages/svelte/tests/runtime-runes/samples/store-from-props-runelike/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-props-runelike/main.svelte
@@ -1,0 +1,8 @@
+<svelte:options runes />
+<script>
+	import { writable } from "svelte/store";
+	import Child from "./child.svelte";
+	const state = writable(0);
+</script>
+
+<Child {state} />

--- a/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte
+++ b/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { state } = $props();
+	let x = $state();
+</script>
+
+{$state}

--- a/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/warnings.json
+++ b/packages/svelte/tests/validator/samples/store-rune-conflic-from-props/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "store_rune_conflict",
+		"message": "It looks like you're using the `$state` rune, but there is a local binding called `state`. Referencing a local variable with a `$` prefix will create a store subscription. Please rename `state` to avoid the ambiguity",
+		"start": {
+			"line": 3,
+			"column": 9
+		},
+		"end": {
+			"line": 3,
+			"column": 15
+		}
+	}
+]


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11742

I had to guard against `props` being the store name because a situation like this doesn't make sense

```svelte
<script>
    let { props } = $props();
</script>

{$props}
```
because disabling `props` as a rune in favor of a prop being a store would mean you cannot access the writable in the first place (kinda convoluted i know). Should we throw a more descriptive error in that case?

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
