### PR TITLE
fix: allow global next to `&` for nesting

### DIFF
--- a/.changeset/selfish-panthers-add.md
+++ b/.changeset/selfish-panthers-add.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow global next to `&` for nesting

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -239,6 +239,12 @@ const visitors = {
 				}
 
 				if (relative_selector.selectors.some((s) => s.type === 'NestingSelector')) {
+					// clean every global selector attached to Nesting before bailing out
+					for (const selector of relative_selector.selectors) {
+						if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
+							remove_global_pseudo_class(selector);
+						}
+					}
 					continue;
 				}
 

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -238,13 +238,14 @@ const visitors = {
 					}
 				}
 
-				if (relative_selector.selectors.some((s) => s.type === 'NestingSelector')) {
-					// clean every global selector attached to Nesting before bailing out
-					for (const selector of relative_selector.selectors) {
-						if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
-							remove_global_pseudo_class(selector);
-						}
+				// for any :global() at the middle of compound selector
+				for (const selector of relative_selector.selectors) {
+					if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
+						remove_global_pseudo_class(selector);
 					}
+				}
+
+				if (relative_selector.selectors.some((s) => s.type === 'NestingSelector')) {
 					continue;
 				}
 
@@ -255,13 +256,6 @@ const visitors = {
 				if (context.state.specificity.bumped) modifier = `:where(${modifier})`;
 
 				context.state.specificity.bumped = true;
-
-				// for any :global() at the middle of compound selector
-				for (const selector of relative_selector.selectors) {
-					if (selector.type === 'PseudoClassSelector' && selector.name === 'global') {
-						remove_global_pseudo_class(selector);
-					}
-				}
 
 				let i = relative_selector.selectors.length;
 				while (i--) {

--- a/packages/svelte/tests/css/samples/global-with-nesting/_config.js
+++ b/packages/svelte/tests/css/samples/global-with-nesting/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	warnings: []
+});

--- a/packages/svelte/tests/css/samples/global-with-nesting/expected.css
+++ b/packages/svelte/tests/css/samples/global-with-nesting/expected.css
@@ -1,0 +1,5 @@
+	div.svelte-xyz {
+		&.class{
+			color: red;
+		}
+	}

--- a/packages/svelte/tests/css/samples/global-with-nesting/expected.html
+++ b/packages/svelte/tests/css/samples/global-with-nesting/expected.html
@@ -1,2 +1,6 @@
 <div class="svelte-xyz">
 </div>
+
+<div class="class svelte-xyz">
+	foo
+</div>

--- a/packages/svelte/tests/css/samples/global-with-nesting/expected.html
+++ b/packages/svelte/tests/css/samples/global-with-nesting/expected.html
@@ -1,0 +1,2 @@
+<div class="svelte-xyz">
+</div>

--- a/packages/svelte/tests/css/samples/global-with-nesting/input.svelte
+++ b/packages/svelte/tests/css/samples/global-with-nesting/input.svelte
@@ -8,3 +8,7 @@
 
 <div>
 </div>
+
+<div class="class">
+	foo
+</div>

--- a/packages/svelte/tests/css/samples/global-with-nesting/input.svelte
+++ b/packages/svelte/tests/css/samples/global-with-nesting/input.svelte
@@ -1,0 +1,10 @@
+<style>
+	div {
+		&:global(.class){
+			color: red;
+		}
+	}
+</style>
+
+<div>
+</div>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11782

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
