### PR TITLE
fix: parse ongotpointercapture and onlostpointercapture events correctly

### DIFF
--- a/.changeset/sleepy-cats-eat.md
+++ b/.changeset/sleepy-cats-eat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: parse ongotpointercapture and onlostpointercapture events correctly

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -18,7 +18,12 @@ import { validation_legacy, validation_runes, validation_runes_js } from './vali
 import check_graph_for_cycles from './utils/check_graph_for_cycles.js';
 import { regex_starts_with_newline } from '../patterns.js';
 import { create_attribute, is_element_node } from '../nodes.js';
-import { DelegatedEvents, namespace_mathml, namespace_svg } from '../../../constants.js';
+import {
+	DelegatedEvents,
+	is_capture_event,
+	namespace_mathml,
+	namespace_svg
+} from '../../../constants.js';
 import { should_proxy_or_freeze } from '../3-transform/client/utils.js';
 import { analyze_css } from './css/css-analyze.js';
 import { prune } from './css/css-prune.js';
@@ -1508,21 +1513,11 @@ function determine_element_spread(node) {
  * @param {string} event_name
  */
 function get_attribute_event_name(event_name) {
-	if (is_capture_event(event_name)) {
+	if (is_capture_event(event_name, 'include-on')) {
 		event_name = event_name.slice(0, -7);
 	}
 	event_name = event_name.slice(2);
 	return event_name;
-}
-
-/**
- * @param {string} name
- * @returns boolean
- */
-function is_capture_event(name) {
-	return (
-		name.endsWith('capture') && name !== 'ongotpointercapture' && name !== 'onlostpointercapture'
-	);
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -32,6 +32,7 @@ import {
 	EACH_IS_STRICT_EQUALS,
 	EACH_ITEM_REACTIVE,
 	EACH_KEYED,
+	is_capture_event,
 	TEMPLATE_FRAGMENT,
 	TEMPLATE_USE_IMPORT_NODE,
 	TRANSITION_GLOBAL,
@@ -1410,11 +1411,7 @@ function serialize_event_attribute(node, context) {
 	const modifiers = [];
 
 	let event_name = node.name.slice(2);
-	if (
-		event_name.endsWith('capture') &&
-		event_name !== 'ongotpointercapture' &&
-		event_name !== 'onlostpointercapture'
-	) {
+	if (is_capture_event(event_name)) {
 		event_name = event_name.slice(0, -7);
 		modifiers.push('capture');
 	}

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -279,3 +279,16 @@ export function is_tag_valid_with_parent(tag, parent_tag) {
 
 	return true;
 }
+
+/**
+ * @param {string} name
+ * @param {"include-on" | "exclude-on"} [mode] - wether if name starts with `on` or `on` is excluded at this point
+ */
+export function is_capture_event(name, mode = 'exclude-on') {
+	if (!name.endsWith('capture')) {
+		return false;
+	}
+	return mode == 'exclude-on'
+		? name !== 'gotpointercapture' && name !== 'lostpointercapture'
+		: name !== 'ongotpointercapture' && name !== 'onlostpointercapture';
+}

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -1,7 +1,12 @@
 import { DEV } from 'esm-env';
 import { hydrating } from '../hydration.js';
 import { get_descriptors, get_prototype_of, map_get, map_set } from '../../utils.js';
-import { AttributeAliases, DelegatedEvents, namespace_svg } from '../../../../constants.js';
+import {
+	AttributeAliases,
+	DelegatedEvents,
+	is_capture_event,
+	namespace_svg
+} from '../../../../constants.js';
 import { create_event, delegate } from './events.js';
 import { add_form_reset_listener, autofocus } from './misc.js';
 import { effect, effect_root } from '../../reactivity/effects.js';
@@ -172,11 +177,7 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 			let event_name = key.slice(2);
 			var delegated = DelegatedEvents.includes(event_name);
 
-			if (
-				event_name.endsWith('capture') &&
-				event_name !== 'ongotpointercapture' &&
-				event_name !== 'onlostpointercapture'
-			) {
+			if (is_capture_event(event_name)) {
 				event_name = event_name.slice(0, -7);
 				opts.capture = true;
 			}

--- a/packages/svelte/tests/runtime-browser/samples/browser-events-ending-with-capture/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/browser-events-ending-with-capture/_config.js
@@ -1,0 +1,16 @@
+import { tick } from 'svelte';
+import { test } from '../../assert';
+
+export default test({
+	async test({ assert, window }) {
+		const div = window.document.querySelector('div');
+
+		div.dispatchEvent(new PointerEvent('gotpointercapture'));
+		div.dispatchEvent(new PointerEvent('lostpointercapture'));
+
+		await tick();
+
+		assert.equal(div?.dataset.lostCaptured, 'true');
+		assert.equal(div?.dataset.gotCaptured, 'true');
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/browser-events-ending-with-capture/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/browser-events-ending-with-capture/_config.js
@@ -5,8 +5,8 @@ export default test({
 	async test({ assert, window }) {
 		const div = window.document.querySelector('div');
 
-		div.dispatchEvent(new PointerEvent('gotpointercapture'));
-		div.dispatchEvent(new PointerEvent('lostpointercapture'));
+		div?.dispatchEvent(new PointerEvent('gotpointercapture'));
+		div?.dispatchEvent(new PointerEvent('lostpointercapture'));
 
 		await tick();
 

--- a/packages/svelte/tests/runtime-browser/samples/browser-events-ending-with-capture/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/browser-events-ending-with-capture/main.svelte
@@ -1,0 +1,13 @@
+<script>
+</script>
+
+<div
+  ongotpointercapture={(e) => {
+    e.target.dataset.gotCaptured = "true";
+  }}
+  onlostpointercapture={(e) => {
+	e.target.dataset.lostCaptured = "true";
+  }}
+>
+</div>
+


### PR DESCRIPTION
There are some instances in the code where we remove the `on` prefix from the event names but still compare them against `ongotpointercapture` and `onlostpointercapture` with the on prefix.

Fixes #11789.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
