### PR TITLE
fix: allow classes to be reassigned

### DIFF
--- a/.changeset/gentle-wasps-pull.md
+++ b/.changeset/gentle-wasps-pull.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow classes to be reassigned

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -476,7 +476,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 		SwitchStatement: create_block_scope,
 
 		ClassDeclaration(node, { state, next }) {
-			if (node.id) state.scope.declare(node.id, 'normal', 'const', node);
+			if (node.id) state.scope.declare(node.id, 'normal', 'let', node);
 			next();
 		},
 


### PR DESCRIPTION
Ran into this while upgrading a site to Svelte 5. There were other issues besides this one — for some reason files inside SvelteKit were being passed by `vite-plugin-svelte` to Svelte, incorrectly, which meant [this line](https://github.com/sveltejs/kit/blob/966cabd88828cda5598498814f86106ad59b39fa/packages/kit/src/runtime/control.js#L80) triggered the bug — but this is as good a place to start as any.

No test because it doesn't really seem worth it, doesn't seem like something we'll regress on

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
