### PR TITLE
fix: robustify initial scroll value detection when scroll is smooth

### DIFF
--- a/.changeset/tough-tomatoes-explain.md
+++ b/.changeset/tough-tomatoes-explain.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: robustify initial scroll value detection when scroll is smooth

--- a/packages/svelte/src/internal/client/dom/elements/bindings/window.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/window.js
@@ -49,14 +49,8 @@ export function bind_window_scroll(type, get_value, update) {
 		}
 	});
 
-	// Browsers fire the scroll event only if the scroll position is not 0.
-	// This effect is (almost) guaranteed to run after the scroll event would've fired.
-	effect(() => {
-		var value = window[is_scrolling_x ? 'scrollX' : 'scrollY'];
-		if (value === 0) {
-			yield_updates(() => update(value));
-		}
-	});
+	// Browsers don't fire the scroll event for the initial scroll position when scroll style isn't set to smooth
+	effect(target_handler);
 
 	render_effect(() => {
 		return () => {


### PR DESCRIPTION
- the previous assumption was wrong: browser don't fire a scroll event initially when the scroll isn't smooth
- the previous logic wasn't using the "is scrolling now" logic which meant the render effect fired immediately after, causing smooth scrolling to start too late to be overridden

adjusted the comment and reused the scroll handler function to guard against the race condition
fixes #11623

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
