### PR TITLE
fix: make prop fallback values deeply reactive if needed

### DIFF
--- a/.changeset/strange-roses-brake.md
+++ b/.changeset/strange-roses-brake.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: make prop fallback values deeply reactive if needed

--- a/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
@@ -17,8 +17,8 @@ export default test({
 		assert.htmlEqual(
 			target.innerHTML,
 			`
-				<button>mutate: 0</button>
-				<button>reassign: 0</button>
+				<button>mutate: 1</button>
+				<button>reassign: 1</button>
 			`
 		);
 


### PR DESCRIPTION
If a property is mutated, the assumption is that it is deeply reactive. In those cases, the fallback value should be proxified so that it also is deeply reactive.
fixes #11425

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
