### PR TITLE
fix: better support for onwheel events in chrome

### DIFF
--- a/.changeset/metal-pans-trade.md
+++ b/.changeset/metal-pans-trade.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: better support for onwheel events in chrome

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -55,8 +55,8 @@ export function create_event(event_name, dom, handler, options) {
 	// Chrome has a bug where pointer events don't work when attached to a DOM element that has been cloned
 	// with cloneNode() and the DOM element is disconnected from the document. To ensure the event works, we
 	// defer the attachment till after it's been appended to the document. TODO: remove this once Chrome fixes
-	// this bug.
-	if (event_name.startsWith('pointer')) {
+	// this bug. The same applies to wheel events.
+	if (event_name.startsWith('pointer') || event_name === 'wheel') {
 		queue_micro_task(() => {
 			dom.addEventListener(event_name, target_handler, options);
 		});


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11805. Seems related to the regressions in Chrome 125 (for pointer events).