### PR TITLE
fix: coherent infinite loop guard

### DIFF
--- a/.changeset/slimy-hairs-impress.md
+++ b/.changeset/slimy-hairs-impress.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: coherent infinite loop guard

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -573,7 +573,7 @@ function flush_queued_effects(effects) {
 function process_deferred() {
 	is_micro_task_queued = false;
 	is_yield_task_queued = false;
-	if (flush_count > 101) {
+	if (flush_count > 1001) {
 		return;
 	}
 	const previous_queued_root_effects = current_queued_root_effects;


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11813 

Very simple fix in theory but in #10949 one of the two checks for the excessive depth was updated to be `1000` from `100` while the other was left to `101`. I think this is preventing the error to show up in the situation described in the issue.

I didn't write a test for this because i can't seem to think of a way of doing it sorry.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
