### PR TITLE
fix: address derived memory leak on disconnection from reactive graph

### DIFF
--- a/.changeset/afraid-worms-drum.md
+++ b/.changeset/afraid-worms-drum.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: address derived memory leak on disconnection from reactive graph

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "private": true,
   "type": "module",
   "license": "MIT",
-  "engines": {
-    "pnpm": "^9.0.0"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sveltejs/svelte.git"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "type": "module",
   "license": "MIT",
+  "engines": {
+    "pnpm": "^9.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sveltejs/svelte.git"

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -5,16 +5,17 @@ export const BLOCK_EFFECT = 1 << 4;
 export const BRANCH_EFFECT = 1 << 5;
 export const ROOT_EFFECT = 1 << 6;
 export const UNOWNED = 1 << 7;
-export const CLEAN = 1 << 8;
-export const DIRTY = 1 << 9;
-export const MAYBE_DIRTY = 1 << 10;
-export const INERT = 1 << 11;
-export const DESTROYED = 1 << 12;
-export const EFFECT_RAN = 1 << 13;
+export const DISCONNECTED = 1 << 8;
+export const CLEAN = 1 << 9;
+export const DIRTY = 1 << 10;
+export const MAYBE_DIRTY = 1 << 11;
+export const INERT = 1 << 12;
+export const DESTROYED = 1 << 13;
+export const EFFECT_RAN = 1 << 14;
 /** 'Transparent' effects do not create a transition boundary */
-export const EFFECT_TRANSPARENT = 1 << 14;
+export const EFFECT_TRANSPARENT = 1 << 15;
 /** Svelte 4 legacy mode props need to be handled with deriveds and be recognized elsewhere, hence the dedicated flag */
-export const LEGACY_DERIVED_PROP = 1 << 15;
+export const LEGACY_DERIVED_PROP = 1 << 16;
 
 export const STATE_SYMBOL = Symbol('$state');
 export const LOADING_ATTR_SYMBOL = Symbol('');

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -323,6 +323,7 @@ export function prop(props, key, flags, fallback) {
 				from_child = true;
 				set(inner_current_value, value);
 				get(current_value); // force a synchronisation immediately
+				// Increment the value so that unowned/disconnected nodes can validate dirtiness again.
 				current_value.version++;
 			}
 

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -323,6 +323,7 @@ export function prop(props, key, flags, fallback) {
 				from_child = true;
 				set(inner_current_value, value);
 				get(current_value); // force a synchronisation immediately
+				current_value.version++;
 			}
 
 			return value;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -248,12 +248,10 @@ export function check_dirtiness(reaction) {
 						is_dirty = true;
 					}
 					reactions = dependency.reactions;
-					if (reactions === null || !reactions.includes(reaction)) {
-						if (reactions === null) {
-							dependency.reactions = [reaction];
-						} else {
-							reactions.push(reaction);
-						}
+					if (reactions === null) {
+						dependency.reactions = [reaction];
+					} else if (!reactions.includes(reaction)) {
+						reactions.push(reaction);
 					}
 				}
 			}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -439,9 +439,9 @@ function remove_reaction(signal, dependency) {
 			}
 		}
 	}
-	debugger;
+	// If the derived has no reactions, then we can disconnect it from the graph,
+	// allowing it to either reconnect in the future, or be GC'd by the VM.
 	if (reactions_length === 0 && (dependency.f & DERIVED) !== 0) {
-		// If the signal is unowned then we need to make sure to change it to maybe dirty.
 		set_signal_status(dependency, MAYBE_DIRTY);
 		remove_reactions(/** @type {import('#client').Derived} **/ (dependency), 0);
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -239,7 +239,7 @@ export function check_dirtiness(reaction) {
 				} else if ((reaction.f & DIRTY) !== 0) {
 					// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
 					return true;
-				} else {
+				} else if ((reaction.f & DERIVED) !== 0) {
 					// It might be that the derived was was dereferenced from its dependencies but has now come alive again.
 					// In thise case, we need to re-attach it to the graph and mark it dirty if any of its dependencies have
 					// changed since.

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -198,7 +198,8 @@ export function check_dirtiness(reaction) {
 	if (is_dirty && !is_unowned) {
 		return true;
 	}
-	var is_disconnected = (reaction.f & DISCONNECTED) !== 0;
+
+	var is_disconnected = (flags & DISCONNECTED) !== 0;
 
 	if ((flags & MAYBE_DIRTY) !== 0 || (is_dirty && is_unowned)) {
 		var dependencies = reaction.deps;


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11817.

It turns out that we weren't fully handling the disconnection of derived signals from the reactivity graph – resulting in cases where they could leak memory because they were not being removed from their dependency reactions array. However, removing ourselves from this array meant that any future changes might mean we need to reconnect the derived to the graph again – so we have to do some additional bookkeeping to make this work. Thankfully, we already have versioning because of unowned deriveds, we can use the versions to understand if the owned derived signal is dirty after being connected to the reactivity graph again – something we couldn't do in early permutations of the signal architecture – and likely why we hadn't addressed this in the same sense. 