### PR TITLE
chore: use event objects to know when to flush

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -13,14 +13,15 @@ import { yield_event_updates } from '../../../runtime.js';
  * @returns {void}
  */
 export function bind_value(input, get_value, update) {
-	listen_to_event_and_reset_event(input, 'input', () => {
+	listen_to_event_and_reset_event(input, 'input', (evt) => {
 		if (DEV && input.type === 'checkbox') {
 			// TODO should this happen in prod too?
 			e.bind_invalid_checkbox_value();
 		}
 
-		yield_event_updates(() =>
-			update(is_numberlike_input(input) ? to_number(input.value) : input.value)
+		yield_event_updates(
+			() => update(is_numberlike_input(input) ? to_number(input.value) : input.value),
+			evt
 		);
 	});
 
@@ -79,7 +80,7 @@ export function bind_group(inputs, group_index, input, get_value, update) {
 	listen_to_event_and_reset_event(
 		input,
 		'change',
-		() => {
+		(evt) => {
 			// @ts-ignore
 			var value = input.__value;
 
@@ -87,7 +88,7 @@ export function bind_group(inputs, group_index, input, get_value, update) {
 				value = get_binding_group_value(binding_group, value, input.checked);
 			}
 
-			yield_event_updates(() => update(value));
+			yield_event_updates(() => update(value), evt);
 		},
 		// TODO better default value handling
 		() => yield_event_updates(() => update(is_checkbox ? [] : null))
@@ -129,9 +130,9 @@ export function bind_group(inputs, group_index, input, get_value, update) {
  * @returns {void}
  */
 export function bind_checked(input, get_value, update) {
-	listen_to_event_and_reset_event(input, 'change', () => {
+	listen_to_event_and_reset_event(input, 'change', (evt) => {
 		var value = input.checked;
-		yield_event_updates(() => update(value));
+		yield_event_updates(() => update(value), evt);
 	});
 
 	if (get_value() == undefined) {
@@ -189,8 +190,8 @@ function to_number(value) {
  * @param {(value: FileList | null) => void} update
  */
 export function bind_files(input, get_value, update) {
-	listen_to_event_and_reset_event(input, 'change', () => {
-		yield_event_updates(() => update(input.files));
+	listen_to_event_and_reset_event(input, 'change', (evt) => {
+		yield_event_updates(() => update(input.files), evt);
 	});
 	render_effect(() => {
 		input.files = get_value();

--- a/packages/svelte/src/internal/client/dom/elements/bindings/select.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/select.js
@@ -78,7 +78,7 @@ export function init_select(select, get_value) {
 export function bind_select_value(select, get_value, update) {
 	var mounting = true;
 
-	listen_to_event_and_reset_event(select, 'change', () => {
+	listen_to_event_and_reset_event(select, 'change', (evt) => {
 		/** @type {unknown} */
 		var value;
 
@@ -90,7 +90,7 @@ export function bind_select_value(select, get_value, update) {
 			value = selected_option && get_option_value(selected_option);
 		}
 
-		yield_event_updates(() => update(value));
+		yield_event_updates(() => update(value), evt);
 	});
 
 	// Needs to be an effect, not a render_effect, so that in case of each loops the logic runs after the each block has updated

--- a/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
@@ -6,7 +6,7 @@ import { add_form_reset_listener } from '../misc.js';
  * then listens to the given events until the render effect context is destroyed
  * @param {Element | Window} target
  * @param {Array<string>} events
- * @param {() => void} handler
+ * @param {(evt?: Event) => void} handler
  * @param {any} call_handler_immediately
  */
 export function listen(target, events, handler, call_handler_immediately = true) {
@@ -32,7 +32,7 @@ export function listen(target, events, handler, call_handler_immediately = true)
  * to notify all bindings when the form is reset
  * @param {HTMLElement} element
  * @param {string} event
- * @param {() => void} handler
+ * @param {(evt?: Event) => void} handler
  * @param {() => void} [on_reset]
  */
 export function listen_to_event_and_reset_event(element, event, handler, on_reset = handler) {

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -48,7 +48,7 @@ export function create_event(event_name, dom, handler, options) {
 			handle_event_propagation(dom, event);
 		}
 		if (!event.cancelBubble) {
-			return yield_event_updates(() => handler.call(this, event), event.isTrusted);
+			return yield_event_updates(() => handler.call(this, event), event);
 		}
 	}
 
@@ -204,7 +204,7 @@ export function handle_event_propagation(handler_element, event) {
 	}
 
 	try {
-		yield_event_updates(() => next(/** @type {Element} */ (current_target)), event.isTrusted);
+		yield_event_updates(() => next(/** @type {Element} */ (current_target)), event);
 	} finally {
 		// @ts-expect-error is used above
 		event.__root = handler_element;

--- a/packages/svelte/tests/runtime-runes/samples/deferred-events-consistency-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/deferred-events-consistency-2/_config.js
@@ -1,12 +1,14 @@
-import { flushSync } from 'svelte';
+import { tick } from 'svelte';
 import { test } from '../../test';
 
 export default test({
 	async test({ assert, target, logs }) {
 		const [b1] = target.querySelectorAll('button');
 		b1.click();
-		flushSync();
+		await tick();
 
+		// TODO this test needs to be moved to runtime-browser, because jsdom seems to synchronously dispatch the submit event
+		// after the click event, which is not the case in a real browser.
 		assert.deepEqual(logs, ['http://localhost:3000/new%20url']);
 	}
 });


### PR DESCRIPTION
Instead of using "is_trusted" as a gateway to know when to flush, we instead
- never flush when the microtask before the yield is still pending because we can put the other tasks in the same queue still
- always flush when the yield is pending after the microtask and a different event comes in

There's one test failing but that seems like a JSDOM bug, see comment on the test.

We shouldn't merge this until we're clear on what direction we want to go in with regards to the question in https://github.com/sveltejs/svelte/pull/11810#discussion_r1618484206 

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
