### PR TITLE
fix: improve reactive Map and Set implementations

### DIFF
--- a/.changeset/eight-jeans-compare.md
+++ b/.changeset/eight-jeans-compare.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: improve reactive Map and Set implementations

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -62,16 +62,6 @@ export function inspect(get_value, inspector = console.log) {
  */
 function deep_snapshot(value, visited = new Map()) {
 	if (typeof value === 'object' && value !== null && !visited.has(value)) {
-		if (DEV) {
-			// When dealing with ReactiveMap or ReactiveSet, return normal versions
-			// so that console.log provides better output versions
-			if (value instanceof Map && value.constructor !== Map) {
-				return new Map(value);
-			}
-			if (value instanceof Set && value.constructor !== Set) {
-				return new Set(value);
-			}
-		}
 		const unstated = snapshot(value);
 
 		if (unstated !== value) {

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -2,7 +2,6 @@ import { DEV } from 'esm-env';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { UNINITIALIZED } from '../constants.js';
-import { map } from './utils.js';
 
 /**
  * @template K
@@ -10,7 +9,7 @@ import { map } from './utils.js';
  * @extends {Map<K, V>}
  */
 export class ReactiveMap extends Map {
-	/** @type {Map<K, import('#client').Source<V>>} */
+	/** @type {Map<K, import('#client').Source<symbol>>} */
 	#sources = new Map();
 	#version = source(0);
 	#size = source(0);
@@ -28,7 +27,8 @@ export class ReactiveMap extends Map {
 			var sources = this.#sources;
 
 			for (var [key, v] of value) {
-				sources.set(key, source(v));
+				sources.set(key, source(Symbol()));
+				super.set(key, v);
 			}
 
 			this.#size.v = sources.size;
@@ -41,18 +41,24 @@ export class ReactiveMap extends Map {
 
 	/** @param {K} key */
 	has(key) {
-		var s = this.#sources.get(key);
+		var sources = this.#sources;
+		var s = sources.get(key);
 
 		if (s === undefined) {
-			// We should always track the version in case
-			// the Set ever gets this value in the future.
-			get(this.#version);
-
-			return false;
+			// If we're working with a non-primitive then we can generate a signal for it
+			if (typeof key !== 'object' || key === null) {
+				s = source(UNINITIALIZED);
+				sources.set(key, s);
+			} else {
+				// We should always track the version in case
+				// the Set ever gets this value in the future.
+				get(this.#version);
+				return false;
+			}
 		}
 
 		get(s);
-		return true;
+		return super.has(key);
 	}
 
 	/**
@@ -62,8 +68,7 @@ export class ReactiveMap extends Map {
 	forEach(callbackfn, this_arg) {
 		get(this.#version);
 
-		var bound_callbackfn = callbackfn.bind(this_arg);
-		this.#sources.forEach((s, key) => bound_callbackfn(s.v, key, this));
+		return super.forEach(callbackfn, this_arg);
 	}
 
 	/** @param {K} key */
@@ -78,7 +83,8 @@ export class ReactiveMap extends Map {
 			return undefined;
 		}
 
-		return get(s);
+		get(s);
+		return super.get(key);
 	}
 
 	/**
@@ -88,32 +94,37 @@ export class ReactiveMap extends Map {
 	set(key, value) {
 		var sources = this.#sources;
 		var s = sources.get(key);
+		var prev_res = super.get(key);
+		var res = super.set(key, value);
 
 		if (s === undefined) {
-			sources.set(key, source(value));
-			set(this.#size, sources.size);
+			sources.set(key, source(Symbol()));
+			set(this.#size, super.size);
 			this.#increment_version();
-		} else {
-			set(s, value);
+		} else if (prev_res !== value) {
+			set(s, Symbol());
 		}
 
-		return this;
+		return res;
 	}
 
 	/** @param {K} key */
 	delete(key) {
 		var sources = this.#sources;
 		var s = sources.get(key);
+		var res = super.delete(key);
 
 		if (s !== undefined) {
-			var removed = sources.delete(key);
-			set(this.#size, sources.size);
-			set(s, /** @type {V} */ (UNINITIALIZED));
+			// Remove non-primitive keys
+			if (typeof key === 'object' && key !== null) {
+				sources.delete(key);
+			}
+			set(this.#size, super.size);
+			set(s, UNINITIALIZED);
 			this.#increment_version();
-			return removed;
 		}
 
-		return false;
+		return res;
 	}
 
 	clear() {
@@ -122,31 +133,28 @@ export class ReactiveMap extends Map {
 		if (sources.size !== 0) {
 			set(this.#size, 0);
 			for (var s of sources.values()) {
-				set(s, /** @type {V} */ (UNINITIALIZED));
+				set(s, UNINITIALIZED);
 			}
 			this.#increment_version();
 		}
 
 		sources.clear();
+		super.clear();
 	}
 
 	keys() {
 		get(this.#version);
-		return this.#sources.keys();
+		return super.keys();
 	}
 
 	values() {
 		get(this.#version);
-		return map(this.#sources.values(), get, 'Map Iterator');
+		return super.values();
 	}
 
 	entries() {
 		get(this.#version);
-		return map(
-			this.#sources.entries(),
-			([key, source]) => /** @type {[K, V]} */ ([key, get(source)]),
-			'Map Iterator'
-		);
+		return super.entries();
 	}
 
 	[Symbol.iterator]() {

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -76,11 +76,13 @@ export class ReactiveMap extends Map {
 		var s = this.#sources.get(key);
 
 		if (s === undefined) {
-			// We should always track the version in case
-			// the Set ever gets this value in the future.
-			get(this.#version);
-
-			return undefined;
+			// Re-use the has code-path to init the signal if needed and also
+			// register to the version if needed.
+			this.has(key);
+			s = this.#sources.get(key);
+			if (s === undefined) {
+				return undefined;
+			}
 		}
 
 		get(s);

--- a/packages/svelte/src/reactivity/map.test.ts
+++ b/packages/svelte/src/reactivity/map.test.ts
@@ -183,3 +183,35 @@ test('map handling of undefined values', () => {
 
 	cleanup();
 });
+
+test('not invoking reactivity when value is not in the map after changes', () => {
+	const map = new ReactiveMap([[1, 1]]);
+
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(map.get(1));
+		});
+
+		render_effect(() => {
+			log.push(map.get(2));
+		});
+
+		flushSync(() => {
+			map.delete(1);
+		});
+
+		flushSync(() => {
+			map.set(1, 1);
+		});
+	});
+
+	assert.deepEqual(log, [1, undefined, undefined, 1]);
+
+	cleanup();
+});
+
+test('Map.instanceOf', () => {
+	assert.equal(new ReactiveMap() instanceof Map, true);
+});

--- a/packages/svelte/src/reactivity/map.test.ts
+++ b/packages/svelte/src/reactivity/map.test.ts
@@ -36,7 +36,7 @@ test('map.values()', () => {
 		map.clear();
 	});
 
-	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, false, []]);
+	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, []]);
 
 	cleanup();
 });

--- a/packages/svelte/src/reactivity/map.test.ts
+++ b/packages/svelte/src/reactivity/map.test.ts
@@ -36,7 +36,7 @@ test('map.values()', () => {
 		map.clear();
 	});
 
-	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, []]);
+	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, false, []]);
 
 	cleanup();
 });
@@ -207,7 +207,7 @@ test('not invoking reactivity when value is not in the map after changes', () =>
 		});
 	});
 
-	assert.deepEqual(log, [1, undefined, undefined, 1]);
+	assert.deepEqual(log, [1, undefined, undefined, undefined, 1, undefined]);
 
 	cleanup();
 });

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -27,14 +27,10 @@ export class ReactiveSet extends Set {
 		if (DEV) new Set(value);
 
 		if (value) {
-			var sources = this.#sources;
-
 			for (var element of value) {
-				sources.set(element, source(true));
 				super.add(element);
 			}
-
-			this.#size.v = sources.size;
+			this.#size.v = super.size;
 		}
 
 		if (!inited) this.#init();
@@ -77,9 +73,9 @@ export class ReactiveSet extends Set {
 		var s = sources.get(value);
 
 		if (s === undefined) {
-			// If we're working with a non-primitive then we can generate a signal for it
-			if (typeof value !== 'object' || value === null) {
-				s = source(false);
+			var ret = super.has(value);
+			if (ret) {
+				s = source(true);
 				sources.set(value, s);
 			} else {
 				// We should always track the version in case
@@ -129,15 +125,14 @@ export class ReactiveSet extends Set {
 	clear() {
 		var sources = this.#sources;
 
-		if (sources.size !== 0) {
+		if (super.size !== 0) {
 			set(this.#size, 0);
 			for (var s of sources.values()) {
 				set(s, false);
 			}
 			this.#increment_version();
+			sources.clear();
 		}
-
-		sources.clear();
 		super.clear();
 	}
 

--- a/packages/svelte/src/reactivity/set.test.ts
+++ b/packages/svelte/src/reactivity/set.test.ts
@@ -30,7 +30,7 @@ test('set.values()', () => {
 		set.clear();
 	});
 
-	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, false, []]);
+	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, []]);
 
 	cleanup();
 });

--- a/packages/svelte/src/reactivity/set.test.ts
+++ b/packages/svelte/src/reactivity/set.test.ts
@@ -30,7 +30,7 @@ test('set.values()', () => {
 		set.clear();
 	});
 
-	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, []]);
+	assert.deepEqual(log, [5, true, [1, 2, 3, 4, 5], 4, false, [1, 2, 4, 5], 0, false, []]);
 
 	cleanup();
 });
@@ -143,8 +143,12 @@ test('not invoking reactivity when value is not in the set after changes', () =>
 		false,
 		'has 2',
 		false,
+		'has 3',
+		false,
 		'has 2',
-		true
+		true,
+		'has 3',
+		false
 	]);
 
 	cleanup();

--- a/packages/svelte/src/reactivity/set.test.ts
+++ b/packages/svelte/src/reactivity/set.test.ts
@@ -106,3 +106,50 @@ test('set.forEach()', () => {
 
 	cleanup();
 });
+
+test('not invoking reactivity when value is not in the set after changes', () => {
+	const set = new ReactiveSet([1, 2]);
+
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push('has 1', set.has(1));
+		});
+
+		render_effect(() => {
+			log.push('has 2', set.has(2));
+		});
+
+		render_effect(() => {
+			log.push('has 3', set.has(3));
+		});
+	});
+
+	flushSync(() => {
+		set.delete(2);
+	});
+
+	flushSync(() => {
+		set.add(2);
+	});
+
+	assert.deepEqual(log, [
+		'has 1',
+		true,
+		'has 2',
+		true,
+		'has 3',
+		false,
+		'has 2',
+		false,
+		'has 2',
+		true
+	]);
+
+	cleanup();
+});
+
+test('Set.instanceOf', () => {
+	assert.equal(new ReactiveSet() instanceof Set, true);
+});


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/11727.

This PR aims to tackle issues around our reactive Map/Set implementations. Notably:

- We now store the values on the backing Map/Set, allowing for much better introspection in console/dev tools
- We no longer store the values inside the source signals, instead we use Symbols and booleans only as markers