### PR TITLE
fix: address regressed memory leak

### DIFF
--- a/.changeset/sour-geese-listen.md
+++ b/.changeset/sour-geese-listen.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: address regressed memory leak

--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -4,6 +4,7 @@ import { current_effect, get } from '../../runtime.js';
 import { is_array } from '../../utils.js';
 import { hydrate_nodes, hydrating } from '../hydration.js';
 import { create_fragment_from_html, remove } from '../reconciler.js';
+import { push_template_node } from '../template.js';
 
 /**
  * @param {import('#client').Effect} effect
@@ -37,7 +38,7 @@ export function html(anchor, get_value, svg, mathml) {
 	let value = derived(get_value);
 
 	render_effect(() => {
-		var dom = html_to_dom(anchor, get(value), svg, mathml);
+		var dom = html_to_dom(anchor, parent_effect, get(value), svg, mathml);
 
 		if (dom) {
 			return () => {
@@ -55,12 +56,13 @@ export function html(anchor, get_value, svg, mathml) {
  * inserts it before the target anchor and returns the new nodes.
  * @template V
  * @param {Element | Text | Comment} target
+ * @param {import('#client').Effect | null} effect
  * @param {V} value
  * @param {boolean} svg
  * @param {boolean} mathml
  * @returns {Element | Comment | (Element | Comment | Text)[]}
  */
-function html_to_dom(target, value, svg, mathml) {
+function html_to_dom(target, effect, value, svg, mathml) {
 	if (hydrating) return hydrate_nodes;
 
 	var html = value + '';
@@ -79,6 +81,9 @@ function html_to_dom(target, value, svg, mathml) {
 	if (node.childNodes.length === 1) {
 		var child = /** @type {Text | Element | Comment} */ (node.firstChild);
 		target.before(child);
+		if (effect !== null) {
+			push_template_node(child, effect);
+		}
 		return child;
 	}
 
@@ -90,6 +95,10 @@ function html_to_dom(target, value, svg, mathml) {
 		}
 	} else {
 		target.before(node);
+	}
+
+	if (effect !== null) {
+		push_template_node(nodes, effect);
 	}
 
 	return nodes;

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -4,17 +4,32 @@ import { create_fragment_from_html } from './reconciler.js';
 import { current_effect } from '../runtime.js';
 import { TEMPLATE_FRAGMENT, TEMPLATE_USE_IMPORT_NODE } from '../../../constants.js';
 import { effect } from '../reactivity/effects.js';
+import { is_array } from '../utils.js';
 
 /**
  * @template {import("#client").TemplateNode | import("#client").TemplateNode[]} T
  * @param {T} dom
+ * @param {import("#client").Effect} effect
  */
-function push_template_node(dom) {
-	var effect = /** @type {import('#client').Effect} */ (current_effect);
-
-	if (effect.dom === null) {
+export function push_template_node(
+	dom,
+	effect = /** @type {import('#client').Effect} */ (current_effect)
+) {
+	var current_dom = effect.dom;
+	if (current_dom === null) {
 		effect.dom = dom;
+	} else {
+		if (!is_array(current_dom)) {
+			current_dom = effect.dom = [current_dom];
+		}
+
+		if (is_array(dom)) {
+			current_dom.push(...dom);
+		} else {
+			current_dom.push(dom);
+		}
 	}
+	return dom;
 }
 
 /**
@@ -41,7 +56,15 @@ export function template(content, flags) {
 			if (!is_fragment) node = /** @type {Node} */ (node.firstChild);
 		}
 
-		return use_import_node ? document.importNode(node, true) : node.cloneNode(true);
+		var clone = use_import_node ? document.importNode(node, true) : node.cloneNode(true);
+
+		push_template_node(
+			is_fragment
+				? /** @type {import('#client').TemplateNode[]} */ ([...clone.childNodes])
+				: /** @type {import('#client').TemplateNode} */ (clone)
+		);
+
+		return clone;
 	};
 }
 
@@ -102,7 +125,15 @@ export function ns_template(content, flags, ns = 'svg') {
 			}
 		}
 
-		return node.cloneNode(true);
+		var clone = node.cloneNode(true);
+
+		push_template_node(
+			is_fragment
+				? /** @type {import('#client').TemplateNode[]} */ ([...clone.childNodes])
+				: /** @type {import('#client').TemplateNode} */ (clone)
+		);
+
+		return clone;
 	};
 }
 
@@ -177,7 +208,7 @@ function run_scripts(node) {
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function text(anchor) {
-	if (!hydrating) return empty();
+	if (!hydrating) return push_template_node(empty());
 
 	var node = hydrate_start;
 
@@ -201,6 +232,7 @@ export function comment() {
 	var frag = document.createDocumentFragment();
 	var anchor = empty();
 	frag.append(anchor);
+	push_template_node([anchor]);
 
 	return frag;
 }
@@ -213,13 +245,6 @@ export function comment() {
  */
 export function append(anchor, dom) {
 	if (hydrating) return;
-
-	var effect = /** @type {import('#client').Effect} */ (current_effect);
-
-	effect.dom =
-		dom.nodeType === 11
-			? /** @type {import('#client').TemplateNode[]} */ ([...dom.childNodes])
-			: /** @type {Element | Comment} */ (dom);
 
 	anchor.before(/** @type {Node} */ (dom));
 }

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -245,6 +245,9 @@ export function comment() {
  */
 export function append(anchor, dom) {
 	if (hydrating) return;
+	// We intentionally do not assign the `dom` property of the effect here because it's far too
+	// late. If we try, we will capture additional DOM elements that we cannot control the lifecycle
+	// for and will inevitably cause memory leaks. See https://github.com/sveltejs/svelte/pull/11832
 
 	anchor.before(/** @type {Node} */ (dom));
 }


### PR DESCRIPTION
This PR essentially reverts https://github.com/sveltejs/svelte/pull/11752. As lovely as that PR was, it brought back the memory leak that https://github.com/sveltejs/svelte/pull/11197 aimed to solve. I should have noticed this when I reviewed the PR.

Essentially, the culprit is this https://github.com/sveltejs/svelte/pull/11752#pullrequestreview-2086430319. We cannot do this as it means we will retain references to DOM elements that might have been removed or changed from some other effect within. The memory leak is bad too, as we just end up retaining everything.

We can maybe come up with a nicer cleanup after this, but I want to remove this memory leak first.

If you'd like a repro case, render an each block with a few thousand elements. Then update and remove them all, notice how we retain all the each block elements in the parent effect because they're referenced in its `effect.dom` array.