### PR TITLE
chore: typecheck scripts

### DIFF
--- a/packages/svelte/scripts/check-treeshakeability.js
+++ b/packages/svelte/scripts/check-treeshakeability.js
@@ -5,6 +5,9 @@ import virtual from '@rollup/plugin-virtual';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { compile } from 'svelte/compiler';
 
+/**
+ * @param {string} entry
+ */
 async function bundle_code(entry) {
 	const bundle = await rollup({
 		input: '__entry__',

--- a/packages/svelte/scripts/process-messages/index.js
+++ b/packages/svelte/scripts/process-messages/index.js
@@ -238,33 +238,31 @@ function transform(name, dest) {
 			Block(node, context) {
 				if (!node.value.includes('PARAMETER')) return;
 
-				const value = node.value
+				const value = /** @type {string} */ (node.value)
 					.split('\n')
-					.map(
-						/** @param {string} line */ (line) => {
-							if (line === ' * MESSAGE') {
-								return messages[messages.length - 1]
-									.split('\n')
-									.map((line) => ` * ${line}`)
-									.join('\n');
-							}
-
-							if (line.includes('PARAMETER')) {
-								return vars
-									.map((name, i) => {
-										const optional = i >= group[0].vars.length;
-
-										return optional
-											? ` * @param {string | undefined | null} [${name}]`
-											: ` * @param {string} ${name}`;
-									})
-									.join('\n');
-							}
-
-							return line;
+					.map((line) => {
+						if (line === ' * MESSAGE') {
+							return messages[messages.length - 1]
+								.split('\n')
+								.map((line) => ` * ${line}`)
+								.join('\n');
 						}
-					)
-					.filter(/** @param {string} x */ (x) => x !== '')
+
+						if (line.includes('PARAMETER')) {
+							return vars
+								.map((name, i) => {
+									const optional = i >= group[0].vars.length;
+
+									return optional
+										? ` * @param {string | undefined | null} [${name}]`
+										: ` * @param {string} ${name}`;
+								})
+								.join('\n');
+						}
+
+						return line;
+					})
+					.filter((x) => x !== '')
 					.join('\n');
 
 				if (value !== node.value) {

--- a/packages/svelte/scripts/process-messages/index.js
+++ b/packages/svelte/scripts/process-messages/index.js
@@ -54,11 +54,23 @@ for (const category of fs.readdirSync('messages')) {
 	}
 }
 
+/**
+ * @param {string} name
+ * @param {string} dest
+ */
 function transform(name, dest) {
 	const source = fs
 		.readFileSync(new URL(`./templates/${name}.js`, import.meta.url), 'utf-8')
 		.replace(/\r\n/g, '\n');
 
+	/**
+	 * @type {Array<{
+	 * 	type: string;
+	 * 	value: string;
+	 * 	start: number;
+	 * 	end: number
+	 * }>}
+	 */
 	const comments = [];
 
 	let ast = acorn.parse(source, {
@@ -135,6 +147,7 @@ function transform(name, dest) {
 
 	for (const code in category) {
 		const { messages } = category[code];
+		/** @type {string[]} */
 		const vars = [];
 
 		const group = messages.map((text, i) => {
@@ -227,29 +240,31 @@ function transform(name, dest) {
 
 				const value = node.value
 					.split('\n')
-					.map((line) => {
-						if (line === ' * MESSAGE') {
-							return messages[messages.length - 1]
-								.split('\n')
-								.map((line) => ` * ${line}`)
-								.join('\n');
+					.map(
+						/** @param {string} line */ (line) => {
+							if (line === ' * MESSAGE') {
+								return messages[messages.length - 1]
+									.split('\n')
+									.map((line) => ` * ${line}`)
+									.join('\n');
+							}
+
+							if (line.includes('PARAMETER')) {
+								return vars
+									.map((name, i) => {
+										const optional = i >= group[0].vars.length;
+
+										return optional
+											? ` * @param {string | undefined | null} [${name}]`
+											: ` * @param {string} ${name}`;
+									})
+									.join('\n');
+							}
+
+							return line;
 						}
-
-						if (line.includes('PARAMETER')) {
-							return vars
-								.map((name, i) => {
-									const optional = i >= group[0].vars.length;
-
-									return optional
-										? ` * @param {string | undefined | null} [${name}]`
-										: ` * @param {string} ${name}`;
-								})
-								.join('\n');
-						}
-
-						return line;
-					})
-					.filter((x) => x !== '')
+					)
+					.filter(/** @param {string} x */ (x) => x !== '')
 					.join('\n');
 
 				if (value !== node.value) {

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -31,10 +31,12 @@
 		}
 	},
 	"include": [
-		"./src",
+		"./*.js",
+		"./scripts/",
+		"./src/",
 		"./tests/*/test.ts",
 		"./tests/runtime-browser/test-ssr.ts",
 		"./tests/*/samples/*/_config.js"
 	],
-	"exclude": ["./src/compiler/optimizer"]
+	"exclude": ["./scripts/process-messages/templates/", "./src/compiler/optimizer/"]
 }


### PR DESCRIPTION
Helps align eslint and tsc to cover the same sets of files. Some eslint rules require that the file be covered by tsc. But either way, this is probably still a good thing to do