### PR TITLE
fix: reevaluate namespace in slots

### DIFF
--- a/.changeset/shiny-months-tease.md
+++ b/.changeset/shiny-months-tease.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: reevaluate namespace in slots

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -176,7 +176,8 @@ export function infer_namespace(namespace, parent, nodes) {
 			parent.type === 'Component' ||
 			parent.type === 'SvelteComponent' ||
 			parent.type === 'SvelteFragment' ||
-			parent.type === 'SnippetBlock'
+			parent.type === 'SnippetBlock' ||
+			parent.type === 'SlotElement'
 		) {
 			const new_namespace = check_nodes_for_namespace(nodes, 'keep');
 			if (new_namespace !== 'keep' && new_namespace !== 'maybe_html') {

--- a/packages/svelte/tests/runtime-legacy/samples/slot-svg/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/slot-svg/_config.js
@@ -1,0 +1,9 @@
+import { ok, test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const circle = target.querySelector('circle');
+		ok(circle);
+		assert.equal(circle.namespaceURI, 'http://www.w3.org/2000/svg');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/slot-svg/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/slot-svg/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Points from './points.svelte';
+</script>
+
+<svg>
+	<Points />
+</svg>

--- a/packages/svelte/tests/runtime-legacy/samples/slot-svg/points.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/slot-svg/points.svelte
@@ -1,0 +1,3 @@
+<slot>
+	<circle cx={10} cy={10} r={5} />
+</slot>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11847

This is the simple fix for the issue but i think there's a more fondamental issue that we either have to fix or list as a breaking from svelte 4. As soon as there's an html element in the component the whole component namespace goes to html.

[Svelte 5 repl](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAE32OzQrCMBCEXyXsuTR68FLTgPgYxoOmaQ3kjyQtlpB3lyaiB8HT7gzzMZNglEoE6C4JzE0L6ODkHDQQV7eJsAgVBTQQ7Oz55pDAvXSRMsOi1M76iM4PqQY0eqsRgxYX2VaSwZEZgr-MIWGZCkwqhmkJLBOFBrQd5CjFAF30s8jNZ1TJ_p3FpedKIP7s036XEV_r9X065Fpyn2O0hhL8fn77rvkFYyQsGRABAAA=)

[Svelte 4 repl](https://svelte.dev/repl/ecea4c28063546eba7f4fc2058ac1a29?version=4.2.17)

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
