### PR TITLE
chore: improve $state.frozen performance in prod

### DIFF
--- a/.changeset/silver-sheep-knock.md
+++ b/.changeset/silver-sheep-knock.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+chore: improve $state.frozen performance in prod

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -18,4 +18,5 @@ export const EFFECT_TRANSPARENT = 1 << 15;
 export const LEGACY_DERIVED_PROP = 1 << 16;
 
 export const STATE_SYMBOL = Symbol('$state');
+export const STATE_FROZEN_SYMBOL = Symbol('$state.frozen');
 export const LOADING_ATTR_SYMBOL = Symbol('');

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1,5 +1,11 @@
 import { DEV } from 'esm-env';
-import { define_property, get_descriptors, get_prototype_of, is_frozen, object_freeze } from './utils.js';
+import {
+	define_property,
+	get_descriptors,
+	get_prototype_of,
+	is_frozen,
+	object_freeze
+} from './utils.js';
 import { snapshot } from './proxy.js';
 import { destroy_effect, effect, execute_effect_teardown } from './reactivity/effects.js';
 import {
@@ -18,7 +24,7 @@ import {
 	ROOT_EFFECT,
 	LEGACY_DERIVED_PROP,
 	DISCONNECTED,
-	STATE_FROZEN_SYMBOL,
+	STATE_FROZEN_SYMBOL
 } from './constants.js';
 import { flush_tasks } from './dom/task.js';
 import { add_owner } from './dev/ownership.js';
@@ -1377,4 +1383,3 @@ export function freeze(value) {
 	}
 	return value;
 }
-

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1359,26 +1359,25 @@ if (DEV) {
 }
 
 /**
- * Expects a value that was wrapped with `freeze` and makes it frozen in DEV or adds a symbol in prod.
+ * Expects a value that was wrapped with `freeze` and makes it frozen in DEV.
  * @template T
  * @param {T} value
  * @returns {Readonly<T>}
  */
 export function freeze(value) {
-	if (typeof value === 'object' && value != null && !is_frozen(value)) {
+	if (typeof value === 'object' && value != null && !(STATE_FROZEN_SYMBOL in value)) {
 		// If the object is already proxified, then snapshot the value
-		if (STATE_SYMBOL in value) {
+		if (STATE_SYMBOL in value || is_frozen(value)) {
 			value = snapshot(value);
 		}
-		// Freeze the object in DEV, add the symbol in prod
+		define_property(value, STATE_FROZEN_SYMBOL, {
+			value: true,
+			writable: true,
+			enumerable: false
+		});
+		// Freeze the object in DEV
 		if (DEV) {
 			object_freeze(value);
-		} else {
-			define_property(value, STATE_FROZEN_SYMBOL, {
-				value: true,
-				writable: true,
-				enumerable: false
-			});
 		}
 	}
 	return value;


### PR DESCRIPTION
When we're in prod, let's avoid using `Object.freeze` entirely. Instead we can add a symbol to the object to indicate that it's frozen instead and to avoid proxying it. This should significantly improve runtime performance in certain use-cases.