### PR TITLE
fix: process-messages script does not work when hidden file is auto-created

### DIFF
--- a/packages/svelte/scripts/process-messages/index.js
+++ b/packages/svelte/scripts/process-messages/index.js
@@ -9,6 +9,8 @@ const messages = {};
 const seen = new Set();
 
 for (const category of fs.readdirSync('messages')) {
+	if (category.startsWith('.')) continue;
+	
 	messages[category] = {};
 
 	for (const file of fs.readdirSync(`messages/${category}`)) {


### PR DESCRIPTION
e.g. if .DS_Store on macos is created in `/packages/svelte/messages/`

Fixes  #11856