### PR TITLE
fix: keep default values of props a proxy after reassignment

### DIFF
--- a/.changeset/empty-horses-tell.md
+++ b/.changeset/empty-horses-tell.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: keep default values of props a proxy after reassignment

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -292,15 +292,15 @@ export function serialize_set_binding(node, context, fallback, options) {
 
 	const serialize = () => {
 		if (left === node.left) {
-			const initial_bindable_proxy =
-				binding.initial &&
+			const is_initial_proxy =
+				binding.initial !== null &&
 				should_proxy_or_freeze(
 					/**@type {import("estree").Expression}*/ (binding.initial),
 					context.state.scope
 				);
 			if (
 				(binding.kind === 'prop' || binding.kind === 'bindable_prop') &&
-				!initial_bindable_proxy
+				!is_initial_proxy
 			) {
 				return b.call(left, value);
 			} else if (is_store) {
@@ -329,7 +329,7 @@ export function serialize_set_binding(node, context, fallback, options) {
 					);
 				} else if (
 					(binding.kind === 'prop' || binding.kind === 'bindable_prop') &&
-					initial_bindable_proxy
+					is_initial_proxy
 				) {
 					call = b.call(
 						left,

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -298,10 +298,7 @@ export function serialize_set_binding(node, context, fallback, options) {
 					/**@type {import("estree").Expression}*/ (binding.initial),
 					context.state.scope
 				);
-			if (
-				(binding.kind === 'prop' || binding.kind === 'bindable_prop') &&
-				!is_initial_proxy
-			) {
+			if ((binding.kind === 'prop' || binding.kind === 'bindable_prop') && !is_initial_proxy) {
 				return b.call(left, value);
 			} else if (is_store) {
 				return b.call('$.store_set', serialize_get_binding(b.id(left_name), state), value);

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -300,8 +300,8 @@ export function serialize_set_binding(node, context, fallback, options) {
 				binding.initial.type !== 'EachBlock' &&
 				should_proxy_or_freeze(binding.initial, context.state.scope);
 			if (
-				binding.kind === 'prop' ||
-				(binding.kind === 'bindable_prop' && !initial_bindable_proxy)
+				(binding.kind === 'prop' || binding.kind === 'bindable_prop') &&
+				!initial_bindable_proxy
 			) {
 				return b.call(left, value);
 			} else if (is_store) {
@@ -328,7 +328,10 @@ export function serialize_set_binding(node, context, fallback, options) {
 							? b.call('$.freeze', value)
 							: value
 					);
-				} else if (initial_bindable_proxy) {
+				} else if (
+					(binding.kind === 'prop' || binding.kind === 'bindable_prop') &&
+					initial_bindable_proxy
+				) {
 					call = b.call(
 						left,
 						context.state.analysis.runes &&

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -294,11 +294,10 @@ export function serialize_set_binding(node, context, fallback, options) {
 		if (left === node.left) {
 			const initial_bindable_proxy =
 				binding.initial &&
-				binding.initial.type !== 'ClassDeclaration' &&
-				binding.initial.type !== 'FunctionDeclaration' &&
-				binding.initial.type !== 'ImportDeclaration' &&
-				binding.initial.type !== 'EachBlock' &&
-				should_proxy_or_freeze(binding.initial, context.state.scope);
+				should_proxy_or_freeze(
+					/**@type {import("estree").Expression}*/ (binding.initial),
+					context.state.scope
+				);
 			if (
 				(binding.kind === 'prop' || binding.kind === 'bindable_prop') &&
 				!initial_bindable_proxy

--- a/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/Counter.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/Counter.svelte
@@ -1,12 +1,20 @@
 <script>
-	/** @type {{ object?: { count: number }}} */
-	let { object = $bindable({ count: 0 }) } = $props();
+	/** @type {{ object?: { count: number }, non_bindable?: { count: number }}} */
+	let { object = $bindable({ count: 0 }), non_bindable = { count: 0 } } = $props();
 </script>
 
-<button onclick={() => object.count += 1}>
+<button onclick={() => (object.count += 1)}>
 	mutate: {object.count}
 </button>
 
-<button onclick={() => object = { count: object.count + 1 } }>
+<button onclick={() => (object = { count: object.count + 1 })}>
 	reassign: {object.count}
+</button>
+
+<button onclick={() => (non_bindable.count += 1)}>
+	mutate: {non_bindable.count}
+</button>
+
+<button onclick={() => (non_bindable = { count: non_bindable.count + 1 })}>
+	reassign: {non_bindable.count}
 </button>

--- a/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
@@ -5,10 +5,12 @@ export default test({
 	html: `
 		<button>mutate: 0</button>
 		<button>reassign: 0</button>
+		<button>mutate: 0</button>
+		<button>reassign: 0</button>
 	`,
 
 	async test({ assert, target }) {
-		const [btn1, btn2] = target.querySelectorAll('button');
+		const [btn1, btn2, btn3, btn4] = target.querySelectorAll('button');
 
 		flushSync(() => {
 			btn1?.click();
@@ -19,6 +21,8 @@ export default test({
 			`
 				<button>mutate: 1</button>
 				<button>reassign: 1</button>
+				<button>mutate: 0</button>
+				<button>reassign: 0</button>
 			`
 		);
 
@@ -31,6 +35,8 @@ export default test({
 			`
 				<button>mutate: 2</button>
 				<button>reassign: 2</button>
+				<button>mutate: 0</button>
+				<button>reassign: 0</button>
 			`
 		);
 
@@ -41,6 +47,50 @@ export default test({
 		assert.htmlEqual(
 			target.innerHTML,
 			`
+				<button>mutate: 3</button>
+				<button>reassign: 3</button>
+				<button>mutate: 0</button>
+				<button>reassign: 0</button>
+			`
+		);
+
+		flushSync(() => {
+			btn3?.click();
+		});
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>mutate: 3</button>
+				<button>reassign: 3</button>
+				<button>mutate: 1</button>
+				<button>reassign: 1</button>
+			`
+		);
+
+		flushSync(() => {
+			btn4?.click();
+		});
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>mutate: 3</button>
+				<button>reassign: 3</button>
+				<button>mutate: 2</button>
+				<button>reassign: 2</button>
+			`
+		);
+
+		flushSync(() => {
+			btn3?.click();
+		});
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>mutate: 3</button>
+				<button>reassign: 3</button>
 				<button>mutate: 3</button>
 				<button>reassign: 3</button>
 			`

--- a/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
@@ -33,5 +33,17 @@ export default test({
 				<button>reassign: 2</button>
 			`
 		);
+
+		flushSync(() => {
+			btn1?.click();
+		});
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>mutate: 3</button>
+				<button>reassign: 3</button>
+			`
+		);
 	}
 });


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11859

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
