### PR TITLE
docs: fix typo

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/05-imports.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/05-imports.md
@@ -151,7 +151,7 @@ Svelte provides built-in [DOM types](https://github.com/sveltejs/svelte/blob/mas
 </div>
 ```
 
-> You can use `ComponentProps<ImportedComponent>`, if you wish to forward props to forward props to a Svelte component.
+> You can use `ComponentProps<ImportedComponent>`, if you wish to forward props to a Svelte component.
 
 Svelte provides a best-effort of all the HTML DOM types that exist. If an attribute is missing from our [type definitions](https://github.com/sveltejs/svelte/blob/master/packages/svelte/elements.d.ts), you are welcome to open an issue and/or a PR fixing it. For experimental attributes, you can augment the existing types locally by creating a `.d.ts` file:
 


### PR DESCRIPTION
Fixes #11892: A Typo in Svelte 5 Imports documentation.