### PR TITLE
fix: add `unused-export-let` to legacy lint replacements

### DIFF
--- a/.changeset/tidy-deers-hope.md
+++ b/.changeset/tidy-deers-hope.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add `unused-export-let` to legacy lint replacements

--- a/packages/svelte/src/compiler/utils/extract_svelte_ignore.js
+++ b/packages/svelte/src/compiler/utils/extract_svelte_ignore.js
@@ -12,7 +12,8 @@ const replacements = {
 	'invalid-html-attribute': 'attribute_invalid_property_name',
 	'a11y-structure': 'a11y_figcaption_parent',
 	'illegal-attribute-character': 'attribute_illegal_colon',
-	'invalid-rest-eachblock-binding': 'bind_invalid_each_rest'
+	'invalid-rest-eachblock-binding': 'bind_invalid_each_rest',
+	'unused-export-let': 'export_let_unused'
 };
 
 /**


### PR DESCRIPTION
Closes #11890.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
