### PR TITLE
docs: Update 01-svelte-components.md to show example markup better

### DIFF
--- a/documentation/docs/02-template-syntax/01-svelte-components.md
+++ b/documentation/docs/02-template-syntax/01-svelte-components.md
@@ -11,7 +11,10 @@ All three sections — script, styles and markup — are optional.
 	// logic goes here
 </script>
 
-<!-- markup (zero or more items) goes here -->
+<!-- any HTML markup (zero or more items) goes here, such as this example markup -->
+<div>
+	<Widget />
+</div>
 
 <style>
 	/* styles go here */


### PR DESCRIPTION
- It is confusing not to see any example markup here.  I completely missed the fact of the markup section because the code comment is grey and I think it's easier to see if we show the 3 sections, instead of 2 with 1 greyed comment.
- We can give the HTML markup example that is used in the next docs section.
