### PR TITLE
chore: better bind_property implementation

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2743,7 +2743,7 @@ export const template_visitors = {
 				'$.bind_property',
 				b.literal(node.name),
 				b.literal(property.event),
-				b.literal(property.type ?? 'get'),
+				b.literal(property.bidirectional ? 'set' : 'get'),
 				state.node,
 				getter,
 				setter

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2743,10 +2743,9 @@ export const template_visitors = {
 				'$.bind_property',
 				b.literal(node.name),
 				b.literal(property.event),
-				b.literal(property.bidirectional ? 'set' : 'get'),
 				state.node,
-				getter,
-				setter
+				setter,
+				property.bidirectional && getter
 			);
 		} else {
 			// special cases

--- a/packages/svelte/src/compiler/phases/bindings.js
+++ b/packages/svelte/src/compiler/phases/bindings.js
@@ -2,7 +2,7 @@
  * @typedef BindingProperty
  * @property {string} [event] This is set if the binding corresponds to the property name on the dom element it's bound to
  * 							  and there's an event that notifies of a change to that property
- * @property {string} [type] Set this to `set` if updates are written to the dom property
+ * @property {boolean} [bidirectional] Set this to `true` if updates are written to the dom property
  * @property {boolean} [omit_in_ssr] Set this to true if the binding should not be included in SSR
  * @property {string[]} [valid_elements] If this is set, the binding is only valid on the given elements
  * @property {string[]} [invalid_elements] If this is set, the binding is invalid on the given elements
@@ -166,7 +166,7 @@ export const binding_properties = {
 	// checkbox/radio
 	indeterminate: {
 		event: 'change',
-		type: 'set',
+		bidirectional: true,
 		valid_elements: ['input'],
 		omit_in_ssr: true // no corresponding attribute
 	},
@@ -191,7 +191,7 @@ export const binding_properties = {
 	},
 	open: {
 		event: 'toggle',
-		type: 'set',
+		bidirectional: true,
 		valid_elements: ['details']
 	},
 	value: {

--- a/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
@@ -33,28 +33,25 @@ export function bind_content_editable(property, element, get_value, update) {
 /**
  * @param {string} property
  * @param {string} event_name
- * @param {'get' | 'set'} type
  * @param {Element} element
- * @param {() => unknown} get_value
- * @param {(value: unknown) => void} update
+ * @param {(value: unknown) => void} set
+ * @param {() => unknown} [get]
  * @returns {void}
  */
-export function bind_property(property, event_name, type, element, get_value, update) {
+export function bind_property(property, event_name, element, set, get) {
 	var handler = () => {
 		// @ts-ignore
-		update(element[property]);
+		set(element[property]);
 	};
 
 	element.addEventListener(event_name, handler);
 
-	if (type === 'set') {
+	if (get) {
 		render_effect(() => {
 			// @ts-ignore
-			element[property] = get_value();
+			element[property] = get();
 		});
-	}
-
-	if (type === 'get') {
+	} else {
 		handler();
 	}
 

--- a/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
@@ -40,12 +40,12 @@ export function bind_content_editable(property, element, get_value, update) {
  * @returns {void}
  */
 export function bind_property(property, event_name, type, element, get_value, update) {
-	var target_handler = () => {
+	var handler = () => {
 		// @ts-ignore
 		update(element[property]);
 	};
 
-	element.addEventListener(event_name, target_handler);
+	element.addEventListener(event_name, handler);
 
 	if (type === 'set') {
 		render_effect(() => {
@@ -55,18 +55,17 @@ export function bind_property(property, event_name, type, element, get_value, up
 	}
 
 	if (type === 'get') {
-		// @ts-ignore
-		update(element[property]);
+		handler();
 	}
 
-	render_effect(() => {
-		// @ts-ignore
-		if (element === document.body || element === window || element === document) {
+	// @ts-ignore
+	if (element === document.body || element === window || element === document) {
+		render_effect(() => {
 			return () => {
-				element.removeEventListener(event_name, target_handler);
+				element.removeEventListener(event_name, handler);
 			};
-		}
-	});
+		});
+	}
 }
 
 /**


### PR DESCRIPTION
Noticed our `bind_property` implementation has plenty of room for improvement:

- [x] handler body is repeated
- [x] we create a render effect for all bindings, when we only need one for those on `window`/`document`/`document.body`
- [x] we have a `"get"`/`"set"` type which seems like a pretty strange way to solve the problem of the distinction between readonly and two-way bindings
- [x] we always pass in a `get_value` even for readonly bindings

Given this (contrived) code:

```svelte
<script>
  let w = $state(0);
</script>

<img bind:naturalWidth={w} />
```

Before:

```js
$.bind_property("naturalWidth", "load", "get", img, () => $.get(w), ($$value) => $.set(w, $$value));
```

After:

```js
$.bind_property("naturalWidth", "load", img, ($$value) => $.set(w, $$value));
```

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
