### PR TITLE
chore: very minor perf improvement when fallback values are used

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1143,7 +1143,7 @@ export function value_or_fallback(value, fallback) {
  * @returns {Promise<V>}
  */
 export function value_or_fallback_async(value, fallback) {
-	return value === undefined ? fallback() : Promise.resolve(value);
+	return value === undefined ? fallback() : value;
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1142,8 +1142,8 @@ export function value_or_fallback(value, fallback) {
  * @param {() => Promise<V>} fallback lazy because could contain side effects
  * @returns {Promise<V>}
  */
-export async function value_or_fallback_async(value, fallback) {
-	return value === undefined ? fallback() : value;
+export function value_or_fallback_async(value, fallback) {
+	return value === undefined ? fallback() : Promise.resolve(value);
 }
 
 /**

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -399,8 +399,8 @@ export function value_or_fallback(value, fallback) {
  * @param {() => Promise<V>} fallback lazy because could contain side effects
  * @returns {Promise<V>}
  */
-export async function value_or_fallback_async(value, fallback) {
-	return value === undefined ? fallback() : value;
+export function value_or_fallback_async(value, fallback) {
+	return value === undefined ? fallback() : Promise.resolve(value);
 }
 
 /**

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -400,7 +400,7 @@ export function value_or_fallback(value, fallback) {
  * @returns {Promise<V>}
  */
 export function value_or_fallback_async(value, fallback) {
-	return value === undefined ? fallback() : Promise.resolve(value);
+	return value === undefined ? fallback() : value;
 }
 
 /**


### PR DESCRIPTION
From this discussion https://github.com/sveltejs/svelte/pull/11842#discussion_r1625062430 it seems best for performance to avoid having unnecessary `async` functions

This is a pretty minimal change, so feel free to close it if it's not worth it. But I noticed while investigating that this was the only place in the codebase where this occurs, so I figured I might as well update it