### PR TITLE
chore: finish up const tag work

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -839,8 +839,7 @@ function serialize_inline_component(node, component_name, context) {
 			}
 		}
 
-		children[slot_name] = children[slot_name] || [];
-		children[slot_name].push(child);
+		(children[slot_name] ||= []).push(child);
 	}
 
 	// Serialize each slot

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -1382,7 +1382,10 @@ const template_visitors = {
 			node.fragment.nodes,
 			inner_context.path,
 			metadata.namespace,
-			context.state,
+			{
+				...context.state,
+				scope: /** @type {import('../../scope').Scope} */ (context.state.scopes.get(node.fragment))
+			},
 			state.preserve_whitespace,
 			state.options.preserveComments
 		);

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -40,7 +40,6 @@ function sort_const_tags(nodes, state) {
 	 * }} Tag
 	 */
 
-	const const_tags = [];
 	const other = [];
 
 	/** @type {Map<import('#compiler').Binding, Tag>} */
@@ -77,26 +76,22 @@ function sort_const_tags(nodes, state) {
 					}
 				}
 			});
-
-			const_tags.push(tag);
 		} else {
 			other.push(node);
 		}
 	}
 
-	if (const_tags.length === 0) {
+	if (tags.size === 0) {
 		return nodes;
 	}
 
 	/** @type {Array<[import('#compiler').Binding, import('#compiler').Binding]>} */
 	const edges = [];
 
-	for (const tag of const_tags) {
-		for (const id of tag.ids) {
-			for (const dep of tag.deps) {
-				if (tags.has(dep)) {
-					edges.push([id, dep]);
-				}
+	for (const [id, tag] of tags) {
+		for (const dep of tag.deps) {
+			if (tags.has(dep)) {
+				edges.push([id, dep]);
 			}
 		}
 	}
@@ -124,7 +119,7 @@ function sort_const_tags(nodes, state) {
 		sorted.push(tag.node);
 	}
 
-	for (const tag of const_tags) {
+	for (const tag of tags.values()) {
 		add(tag);
 	}
 


### PR DESCRIPTION
small follow-up to #11908. In the process of making a small simplification (removing `const_tags`, and just using the declaration map) I found another latent bug in our scope handling, relating to elements in SSR. this fixes it

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
