### PR TITLE
fix: whitespace completely removed in each loop

### DIFF
--- a/.changeset/wise-lemons-wave.md
+++ b/.changeset/wise-lemons-wave.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: whitespace completely removed in each loop

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -41,8 +41,12 @@ export function set_should_intro(value) {
  * @returns {void}
  */
 export function set_text(dom, value) {
+	// __nodeValue is ' ' by default...this means that if we are trying to set the value of a node
+	// that has never been updated but is already ' ' that node will never be set and it will remain
+	// an empty text node.
+
 	// @ts-expect-error need to add __value to patched prototype
-	const prev_node_value = dom.__nodeValue;
+	const prev_node_value = dom.nodeValue === dom.__nodeValue ? dom.__nodeValue : dom.nodeValue;
 	const next_node_value = stringify(value);
 	if (hydrating && dom.nodeValue === next_node_value) {
 		// In case of hydration don't reset the nodeValue as it's already correct.

--- a/packages/svelte/tests/runtime-runes/samples/each-whitespace/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-whitespace/_config.js
@@ -1,0 +1,6 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<p>space between</p>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-whitespace/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-whitespace/main.svelte
@@ -1,0 +1,7 @@
+<svelte:options runes />
+
+<p>
+	{#each ['space', ' ', 'between'] as word}
+		{word}
+	{/each}
+</p>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11932

I don't know if this is the best fix but basically the problem is that the empty text node that get passed to `set_text` is never touched if the text to update is `' '`...this is because the `prev_node_value` was `dom.__nodeValue` which by default is `' '`. However the actual text of the text node is `''`. So this is never touched and the result is that every node that has `' '` is basically cancelled.

My fix was to check if `nodeValue` and `__nodeValue` are equals so that if they are not `nodeValue` is given precedence as `prev_node_value`.

Other fixes i've thought of are:

1. add a `__touched` property yo `TextNode` prototype so that we know if the node has ben touched or not. I think messing with the prototype is worst than this.
2. we could literally have a special case for `__nodeValue===' '` since the dissonance between the default value of `__nodeValue` and the "default value" of the empty text node is what's causing the issue.

let me know if you think one of those two solutions is better.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
