### PR TITLE
fix: robust handling of events in spread attributes

### DIFF
--- a/.changeset/cyan-toes-share.md
+++ b/.changeset/cyan-toes-share.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: more robust handling of events in spread attributes


### PR DESCRIPTION
When an event listener is removed right before it would be fired, adding a new listener comes too late for the browser and the event is swallowed. The fix is to tweak the spread attributes function to keep using the same object for updates so that we can wrap the event listener to invoke it like `attributes[key](evt)` instead.
No test because it seems impossible to reproduce in testing environments. This is the reproducible that fails without this fix:
```svelte
<script lang="ts">
	let x = $state({
		onfocus: (e) => {
			console.log('focused');
		},
		onblur: (e) => {
			console.log('blurred');
		}
	});

	let i = 0;
	function handleFocus(node: HTMLButtonElement) {
		function changeFocused() {
			i++;
			x = {
				onfocus: (e) => {
					console.log('focused', i);
				},
				onblur: (e) => {
					console.log('blurred', i);
				}
			};
		}
		node.addEventListener('focus', changeFocused);
		node.addEventListener('blur', changeFocused);

		return {
			destroy() {
				node.removeEventListener('focus', changeFocused);
				node.removeEventListener('blur', changeFocused);
			}
		};
	}
</script>

<button>button 1</button>
<button use:handleFocus {...x}>button 2</button>
```

Fixes #11903

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
