### PR TITLE
fix: validate form inside a form

### DIFF
--- a/.changeset/breezy-waves-camp.md
+++ b/.changeset/breezy-waves-camp.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: validate form inside a form

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -568,6 +568,17 @@ const validation = {
 			}
 		}
 
+		// can't add form to interactive elements because those are also used by the parser
+		// to check for the last auto-closing parent.
+		if (node.name === 'form') {
+			const path = context.path;
+			for (let parent of path) {
+				if (parent.type === 'RegularElement' && parent.name === 'form') {
+					e.node_invalid_placement(node, `<${node.name}>`, parent.name);
+				}
+			}
+		}
+
 		if (interactive_elements.has(node.name)) {
 			const path = context.path;
 			for (let parent of path) {

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -118,7 +118,8 @@ export const interactive_elements = new Set([
 	'iframe',
 	'embed',
 	'select',
-	'textarea'
+	'textarea',
+	'form'
 ]);
 
 export const disallowed_paragraph_contents = [

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -118,8 +118,7 @@ export const interactive_elements = new Set([
 	'iframe',
 	'embed',
 	'select',
-	'textarea',
-	'form'
+	'textarea'
 ]);
 
 export const disallowed_paragraph_contents = [

--- a/packages/svelte/tests/validator/samples/invalid-node-placement-4/errors.json
+++ b/packages/svelte/tests/validator/samples/invalid-node-placement-4/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "node_invalid_placement",
+		"message": "<form> is invalid inside <form>",
+		"start": {
+			"line": 4,
+			"column": 3
+		},
+		"end": {
+			"line": 6,
+			"column": 10
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/invalid-node-placement-4/input.svelte
+++ b/packages/svelte/tests/validator/samples/invalid-node-placement-4/input.svelte
@@ -1,0 +1,9 @@
+<div>
+	<form>
+		<div>
+			<form>
+				<input />
+			</form>
+		</div>
+	</form>
+</div>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11941 (unless we also want to tackle the eventual runtime error here)

initially i added the form to the interactive elements but those are also used by the parser to check for the latest autoclosing parent so i moved the check for the form to it's own check.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
