### PR TITLE
feat: simpler hydration of CSS custom property wrappers

### DIFF
--- a/.changeset/funny-dragons-double.md
+++ b/.changeset/funny-dragons-double.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: simpler hydration of CSS custom property wrappers

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -896,30 +896,35 @@ function serialize_inline_component(node, component_name, context) {
 					'$.spread_props',
 					...props_and_spreads.map((p) => (Array.isArray(p) ? b.object(p) : p))
 				);
+
 	/** @param {import('estree').Expression} node_id */
-	let fn = (node_id) =>
-		b.call(
+	let fn = (node_id) => {
+		return b.call(
 			context.state.options.dev
 				? b.call('$.validate_component', b.id(component_name))
 				: component_name,
 			node_id,
 			props_expression
 		);
+	};
 
 	if (bind_this !== null) {
 		const prev = fn;
-		fn = (node_id) =>
-			serialize_bind_this(
+
+		fn = (node_id) => {
+			return serialize_bind_this(
 				/** @type {import('estree').Identifier | import('estree').MemberExpression} */ (bind_this),
 				context,
 				prev(node_id)
 			);
+		};
 	}
 
 	if (node.type === 'SvelteComponent') {
 		const prev = fn;
+
 		fn = (node_id) => {
-			let component = b.call(
+			return b.call(
 				'$.component',
 				b.thunk(/** @type {import('estree').Expression} */ (context.visit(node.expression))),
 				b.arrow(
@@ -933,7 +938,6 @@ function serialize_inline_component(node, component_name, context) {
 					])
 				)
 			);
-			return component;
 		};
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -937,6 +937,9 @@ function serialize_inline_component(node, component_name, context) {
 		};
 	}
 
+	// TODO for CSS prop wrappers, push `<div><!></div>` instead
+	context.state.template.push('<!>');
+
 	if (Object.keys(custom_css_props).length > 0) {
 		const prev = fn;
 		fn = (node_id) =>
@@ -2947,8 +2950,6 @@ export const template_visitors = {
 		}
 	},
 	Component(node, context) {
-		context.state.template.push('<!>');
-
 		const binding = context.state.scope.get(
 			node.name.includes('.') ? node.name.slice(0, node.name.indexOf('.')) : node.name
 		);
@@ -2974,13 +2975,10 @@ export const template_visitors = {
 		context.state.init.push(component);
 	},
 	SvelteSelf(node, context) {
-		context.state.template.push('<!>');
 		const component = serialize_inline_component(node, context.state.analysis.name, context);
 		context.state.init.push(component);
 	},
 	SvelteComponent(node, context) {
-		context.state.template.push('<!>');
-
 		let component = serialize_inline_component(node, '$$component', context);
 
 		context.state.init.push(component);

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -1119,7 +1119,9 @@ function serialize_inline_component(node, component_name, context) {
 		statement = b.block([...snippet_declarations, statement]);
 	}
 
-	return statement;
+	context.state.template.push(block_open);
+	context.state.template.push(t_statement(statement));
+	context.state.template.push(block_close);
 }
 
 /**
@@ -1666,29 +1668,17 @@ const template_visitors = {
 		}
 	},
 	Component(node, context) {
-		const state = context.state;
-		state.template.push(block_open);
-		const call = serialize_inline_component(node, node.name, context);
-		state.template.push(t_statement(call));
-		state.template.push(block_close);
+		serialize_inline_component(node, node.name, context);
 	},
 	SvelteSelf(node, context) {
-		const state = context.state;
-		state.template.push(block_open);
-		const call = serialize_inline_component(node, context.state.analysis.name, context);
-		state.template.push(t_statement(call));
-		state.template.push(block_close);
+		serialize_inline_component(node, context.state.analysis.name, context);
 	},
 	SvelteComponent(node, context) {
-		const state = context.state;
-		state.template.push(block_open);
-		const call = serialize_inline_component(
+		serialize_inline_component(
 			node,
 			/** @type {import('estree').Expression} */ (context.visit(node.expression)),
 			context
 		);
-		state.template.push(t_statement(call));
-		state.template.push(block_close);
 	},
 	LetDirective(node, { state }) {
 		if (node.expression && node.expression.type !== 'Identifier') {

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -907,7 +907,6 @@ function serialize_element_spread_attributes(
  * @param {import('#compiler').Component | import('#compiler').SvelteComponent | import('#compiler').SvelteSelf} node
  * @param {string | import('estree').Expression} component_name
  * @param {import('./types').ComponentContext} context
- * @returns {import('estree').Statement}
  */
 function serialize_inline_component(node, component_name, context) {
 	/** @type {Array<import('estree').Property[] | import('estree').Expression>} */

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -1103,6 +1103,10 @@ function serialize_inline_component(node, component_name, context) {
 		)
 	);
 
+	if (snippet_declarations.length > 0) {
+		statement = b.block([...snippet_declarations, statement]);
+	}
+
 	if (custom_css_props.length > 0) {
 		statement = b.stmt(
 			b.call(
@@ -1113,15 +1117,13 @@ function serialize_inline_component(node, component_name, context) {
 				b.thunk(b.block([statement]))
 			)
 		);
-	}
 
-	if (snippet_declarations.length > 0) {
-		statement = b.block([...snippet_declarations, statement]);
+		context.state.template.push(t_statement(statement));
+	} else {
+		context.state.template.push(block_open);
+		context.state.template.push(t_statement(statement));
+		context.state.template.push(block_close);
 	}
-
-	context.state.template.push(block_open);
-	context.state.template.push(t_statement(statement));
-	context.state.template.push(block_close);
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -16,24 +16,19 @@ export function css_props(element, get_styles, component) {
 
 	component(/** @type {Comment} */ (element.lastChild));
 
-	/** @type {Record<string, string>} */
-	let styles = {};
-
 	render_effect(() => {
 		render_effect(() => {
-			const next = get_styles();
+			var styles = get_styles();
 
-			for (const key in styles) {
-				if (!(key in next)) {
+			for (var key in styles) {
+				var value = styles[key];
+
+				if (value) {
+					element.style.setProperty(key, value);
+				} else {
 					element.style.removeProperty(key);
 				}
 			}
-
-			for (const key in next) {
-				element.style.setProperty(key, next[key]);
-			}
-
-			styles = next;
 		});
 
 		return () => {

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -3,11 +3,11 @@ import { render_effect } from '../../reactivity/effects.js';
 
 /**
  * @param {HTMLDivElement | SVGGElement} element
- * @param {() => Record<string, string>} props
+ * @param {() => Record<string, string>} get_styles
  * @param {(anchor: Element | Text | Comment) => any} component
  * @returns {void}
  */
-export function css_props(element, props, component) {
+export function css_props(element, get_styles, component) {
 	if (hydrating) {
 		set_hydrate_nodes(
 			/** @type {import('#client').TemplateNode[]} */ ([...element.childNodes]).slice(0, -1)
@@ -17,23 +17,23 @@ export function css_props(element, props, component) {
 	component(/** @type {Comment} */ (element.lastChild));
 
 	/** @type {Record<string, string>} */
-	let current_props = {};
+	let styles = {};
 
 	render_effect(() => {
 		render_effect(() => {
-			const next_props = props();
+			const next = get_styles();
 
-			for (const key in current_props) {
-				if (!(key in next_props)) {
+			for (const key in styles) {
+				if (!(key in next)) {
 					element.style.removeProperty(key);
 				}
 			}
 
-			for (const key in next_props) {
-				element.style.setProperty(key, next_props[key]);
+			for (const key in next) {
+				element.style.setProperty(key, next[key]);
 			}
 
-			current_props = next_props;
+			styles = next;
 		});
 
 		return () => {

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -4,17 +4,14 @@ import { render_effect } from '../../reactivity/effects.js';
 /**
  * @param {HTMLDivElement | SVGGElement} element
  * @param {() => Record<string, string>} get_styles
- * @param {(anchor: Element | Text | Comment) => any} component
  * @returns {void}
  */
-export function css_props(element, get_styles, component) {
+export function css_props(element, get_styles) {
 	if (hydrating) {
 		set_hydrate_nodes(
 			/** @type {import('#client').TemplateNode[]} */ ([...element.childNodes]).slice(0, -1)
 		);
 	}
-
-	component(/** @type {Comment} */ (element.lastChild));
 
 	render_effect(() => {
 		render_effect(() => {

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -162,15 +162,15 @@ export function attr(name, value, boolean) {
 export function css_props(payload, is_html, props, component) {
 	const styles = style_object_to_string(props);
 	if (is_html) {
-		payload.out += `<div style="display: contents; ${styles}"><!--[-->`;
+		payload.out += `<div style="display: contents; ${styles}">`;
 	} else {
-		payload.out += `<g style="${styles}"><!--[-->`;
+		payload.out += `<g style="${styles}">`;
 	}
 	component();
 	if (is_html) {
-		payload.out += `<!--]--></div>`;
+		payload.out += `<!----></div>`;
 	} else {
-		payload.out += `<!--]--></g>`;
+		payload.out += `<!----></g>`;
 	}
 }
 


### PR DESCRIPTION
As with #11773, we can simplify CSS custom property wrappers around components — we don't need to wrap the wrapper `<div>` in hydration comments or do any `hydrate_nodes` traversal, we can just use the element directly.

We can also put the element in the template, so that we don't need to create it inside the `css_props` helper. This simplifies the implementation and is less work.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
