### PR TITLE
feat: sort possible bindings in invalid binding error

### DIFF
--- a/.changeset/witty-bikes-shave.md
+++ b/.changeset/witty-bikes-shave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: sort possible bindings in invalid binding error

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -421,7 +421,8 @@ const validation = {
 									!binding_property.invalid_elements?.includes(parent.name))
 							);
 						})
-						.map(([property_name]) => property_name);
+						.map(([property_name]) => property_name)
+						.sort();
 					e.bind_invalid_name(
 						node,
 						node.name,

--- a/packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/errors.json
+++ b/packages/svelte/tests/validator/samples/document-binding-invalid-dimensions/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "bind_invalid_name",
-		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:document> are focused, activeElement, fullscreenElement, pointerLockElement, visibilityState, this",
+		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:document> are activeElement, focused, fullscreenElement, pointerLockElement, this, visibilityState",
 		"start": {
 			"line": 5,
 			"column": 17

--- a/packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/errors.json
+++ b/packages/svelte/tests/validator/samples/window-binding-invalid-dimensions/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "bind_invalid_name",
-		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:window> are focused, innerWidth, innerHeight, outerWidth, outerHeight, scrollX, scrollY, online, devicePixelRatio, this",
+		"message": "`bind:clientWidth` is not a valid binding. Possible bindings for <svelte:window> are devicePixelRatio, focused, innerHeight, innerWidth, online, outerHeight, outerWidth, scrollX, scrollY, this",
 		"start": {
 			"line": 5,
 			"column": 15


### PR DESCRIPTION
Re: [this comment](https://github.com/sveltejs/svelte/pull/11879#discussion_r1626316314).

Sorts the list of possible bindings in the "`bind:xxx` is not a valid binding" error message to make it easier to read.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] (sort of) It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
