### PR TITLE
feat: detach inert effects

### DIFF
--- a/.changeset/ten-teachers-travel.md
+++ b/.changeset/ten-teachers-travel.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: detach inert effects

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -1,4 +1,4 @@
-import { is_promise } from '../../../shared/utils.js';
+import { is_promise, noop } from '../../../shared/utils.js';
 import {
 	current_component_context,
 	flush_sync,
@@ -113,5 +113,7 @@ export function await_block(anchor, get_input, pending_fn, then_fn, catch_fn) {
 				then_effect = branch(() => then_fn(anchor, input));
 			}
 		}
+
+		return noop;
 	});
 }

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -114,6 +114,8 @@ export function await_block(anchor, get_input, pending_fn, then_fn, catch_fn) {
 			}
 		}
 
+		// Inert effects are proactively detached from the effect tree. Returning a noop
+		// teardown function is an easy way to ensure that this is not discarded
 		return noop;
 	});
 }

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -153,6 +153,7 @@ export function element(node, get_tag, is_svg, render_fn, get_namespace, locatio
 					}
 				}
 
+				// See below
 				return noop;
 			});
 		}
@@ -163,6 +164,8 @@ export function element(node, get_tag, is_svg, render_fn, get_namespace, locatio
 
 		set_current_each_item(previous_each_item);
 
+		// Inert effects are proactively detached from the effect tree. Returning a noop
+		// teardown function is an easy way to ensure that this is not discarded
 		return noop;
 	});
 }

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -14,6 +14,7 @@ import { current_component_context, current_effect } from '../../runtime.js';
 import { DEV } from 'esm-env';
 import { is_array } from '../../utils.js';
 import { push_template_node } from '../template.js';
+import { noop } from '../../../shared/utils.js';
 
 /**
  * @param {import('#client').Effect} effect
@@ -151,6 +152,8 @@ export function element(node, get_tag, is_svg, render_fn, get_namespace, locatio
 						push_template_node(element, parent_effect);
 					}
 				}
+
+				return noop;
 			});
 		}
 
@@ -159,5 +162,7 @@ export function element(node, get_tag, is_svg, render_fn, get_namespace, locatio
 		set_should_intro(true);
 
 		set_current_each_item(previous_each_item);
+
+		return noop;
 	});
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -357,14 +357,7 @@ export function destroy_effect(effect, remove_dom = true) {
 
 	// If the parent doesn't have any children, then skip this work altogether
 	if (parent !== null && (effect.f & BRANCH_EFFECT) !== 0 && parent.first !== null) {
-		var parent = effect.parent;
-		var prev = effect.prev;
-		var next = effect.next;
-
-		if (prev) prev.next = next;
-		if (next) next.prev = prev;
-		if (parent && parent.first === effect) parent.first = next;
-		if (parent && parent.last === effect) parent.last = prev;
+		unlink_effect(effect);
 	}
 
 	// `first` and `child` are nulled out in destroy_effect_children
@@ -377,6 +370,22 @@ export function destroy_effect(effect, remove_dom = true) {
 		effect.parent =
 		effect.fn =
 			null;
+}
+
+/**
+ * Detach an effect from the effect tree, freeing up memory and
+ * reducing the amount of work that happens on subsequent traversals
+ * @param {import('#client').Effect} effect
+ */
+export function unlink_effect(effect) {
+	var parent = effect.parent;
+	var prev = effect.prev;
+	var next = effect.next;
+
+	if (prev) prev.next = next;
+	if (next) next.prev = prev;
+	if (parent && parent.first === effect) parent.first = next;
+	if (parent && parent.last === effect) parent.last = prev;
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -112,7 +112,12 @@ function create_effect(type, fn, sync) {
 
 	// if an effect has no dependencies, no DOM and no teardown function,
 	// don't bother adding it to the effect tree
-	const inert = sync && effect.deps === null && effect.first === null && effect.dom === null;
+	const inert =
+		sync &&
+		effect.deps === null &&
+		effect.first === null &&
+		effect.dom === null &&
+		effect.teardown === null;
 
 	if (!inert && current_reaction !== null && !is_root) {
 		var flags = current_reaction.f;

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -382,10 +382,13 @@ export function unlink_effect(effect) {
 	var prev = effect.prev;
 	var next = effect.next;
 
-	if (prev) prev.next = next;
-	if (next) next.prev = prev;
-	if (parent && parent.first === effect) parent.first = next;
-	if (parent && parent.last === effect) parent.last = prev;
+	if (prev !== null) prev.next = next;
+	if (next !== null) next.prev = prev;
+
+	if (parent !== null) {
+		if (parent.first === effect) parent.first = next;
+		if (parent.last === effect) parent.last = prev;
+	}
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -112,7 +112,7 @@ function create_effect(type, fn, sync) {
 
 	// if an effect has no dependencies, no DOM and no teardown function,
 	// don't bother adding it to the effect tree
-	const inert =
+	var inert =
 		sync &&
 		effect.deps === null &&
 		effect.first === null &&
@@ -357,23 +357,14 @@ export function destroy_effect(effect, remove_dom = true) {
 
 	// If the parent doesn't have any children, then skip this work altogether
 	if (parent !== null && (effect.f & BRANCH_EFFECT) !== 0 && parent.first !== null) {
-		var previous = effect.prev;
+		var parent = effect.parent;
+		var prev = effect.prev;
 		var next = effect.next;
-		if (previous !== null) {
-			if (next !== null) {
-				previous.next = next;
-				next.prev = previous;
-			} else {
-				previous.next = null;
-				parent.last = previous;
-			}
-		} else if (next !== null) {
-			next.prev = null;
-			parent.first = next;
-		} else {
-			parent.first = null;
-			parent.last = null;
-		}
+
+		if (prev) prev.next = next;
+		if (next) next.prev = prev;
+		if (parent && parent.first === effect) parent.first = next;
+		if (parent && parent.last === effect) parent.last = prev;
 	}
 
 	// `first` and `child` are nulled out in destroy_effect_children

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -536,6 +536,27 @@ export function execute_effect(effect) {
 		execute_effect_teardown(effect);
 		var teardown = execute_reaction_fn(effect);
 		effect.teardown = typeof teardown === 'function' ? teardown : null;
+
+		if (
+			(effect.deps === null || effect.deps.length === 0) &&
+			effect.first === null &&
+			effect.dom === null
+		) {
+			if (effect.teardown === null) {
+				// remove this effect from the graph
+				var parent = effect.parent;
+				var prev = effect.prev;
+				var next = effect.next;
+
+				if (prev) prev.next = next;
+				if (next) next.prev = prev;
+				if (parent && parent.first === effect) parent.first = next;
+				if (parent && parent.last === effect) parent.last = prev;
+			} else {
+				// keep the effect in the graph, but free up some memory
+				effect.fn = null;
+			}
+		}
 	} catch (error) {
 		handle_error(/** @type {Error} */ (error), effect, current_component_context);
 	} finally {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -537,11 +537,7 @@ export function execute_effect(effect) {
 		var teardown = execute_reaction_fn(effect);
 		effect.teardown = typeof teardown === 'function' ? teardown : null;
 
-		if (
-			(effect.deps === null || effect.deps.length === 0) &&
-			effect.first === null &&
-			effect.dom === null
-		) {
+		if (effect.deps === null && effect.first === null && effect.dom === null) {
 			if (effect.teardown === null) {
 				// remove this effect from the graph
 				var parent = effect.parent;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -7,7 +7,12 @@ import {
 	object_freeze
 } from './utils.js';
 import { snapshot } from './proxy.js';
-import { destroy_effect, effect, execute_effect_teardown } from './reactivity/effects.js';
+import {
+	destroy_effect,
+	effect,
+	execute_effect_teardown,
+	unlink_effect
+} from './reactivity/effects.js';
 import {
 	EFFECT,
 	RENDER_EFFECT,
@@ -540,14 +545,7 @@ export function execute_effect(effect) {
 		if (effect.deps === null && effect.first === null && effect.dom === null) {
 			if (effect.teardown === null) {
 				// remove this effect from the graph
-				var parent = effect.parent;
-				var prev = effect.prev;
-				var next = effect.next;
-
-				if (prev) prev.next = next;
-				if (next) next.prev = prev;
-				if (parent && parent.first === effect) parent.first = next;
-				if (parent && parent.last === effect) parent.last = prev;
+				unlink_effect(effect);
 			} else {
 				// keep the effect in the graph, but free up some memory
 				effect.fn = null;

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -2,14 +2,13 @@ import { describe, assert, it } from 'vitest';
 import { flushSync } from '../../src/index-client';
 import * as $ from '../../src/internal/client/runtime';
 import {
-	destroy_effect,
 	effect,
 	effect_root,
 	render_effect,
 	user_effect
 } from '../../src/internal/client/reactivity/effects';
 import { source, set } from '../../src/internal/client/reactivity/sources';
-import type { Derived, Effect, Value } from '../../src/internal/client/types';
+import type { Derived, Value } from '../../src/internal/client/types';
 import { proxy } from '../../src/internal/client/proxy';
 import { derived } from '../../src/internal/client/reactivity/deriveds';
 


### PR DESCRIPTION
We create a lot of effects in the course of rendering an application, but many of them don't do any work after the initial execution. In some cases, they shouldn't really be effects in the first place — we're just abusing effects to defer some work until the DOM has been updated, and the actual position in the tree doesn't matter:

https://github.com/sveltejs/svelte/blob/ddb0bc3888ed9a61e89914c6853719f07ad2fc27/packages/svelte/src/internal/client/dom/elements/misc.js#L15-L19

In other cases, they _do_ need to be effects because we don't know whether they'll contain anything dynamic (e.g. an expression like `<p>{location.href}</p>`, or because the position in the tree is important (e.g. `onMount`). But there's no need to keep them around if they're never going to update.

This PR does two things:

- if an immediate effect contains no dependencies, has no children, contains no DOM and returns no teardown function (hereafter: is "inert"), don't add it to the tree in the first place
- for deferred effects, check if the effect is inert after it executes, and detach from the tree if so

I imagined this would be a fairly modest gain, but it's actually quite substantial. For a simple test like this...

```svelte
{#each Array(1e4) as _}
  <p>{Math.floor(100)}</p>
{/each}
```

memory usage in Chrome in prod mode drops 11% from 10MB to 8.9MB.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
