### PR TITLE
chore: refactor HTML validation

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/utils/html.js
+++ b/packages/svelte/src/compiler/phases/1-parse/utils/html.js
@@ -1,4 +1,4 @@
-import { interactive_elements } from '../../../../constants.js';
+import { disallowed_children } from '../../../utils/html.js';
 import entities from './entities.js';
 
 const windows_1252 = [
@@ -120,34 +120,6 @@ function validate_code(code) {
 	return NUL;
 }
 
-// based on http://developers.whatwg.org/syntax.html#syntax-tag-omission
-
-/** @type {Record<string, Set<string>>} */
-const disallowed_contents = {
-	li: new Set(['li']),
-	dt: new Set(['dt', 'dd']),
-	dd: new Set(['dt', 'dd']),
-	p: new Set(
-		'address article aside blockquote div dl fieldset footer form h1 h2 h3 h4 h5 h6 header hgroup hr main menu nav ol p pre section table ul'.split(
-			' '
-		)
-	),
-	rt: new Set(['rt', 'rp']),
-	rp: new Set(['rt', 'rp']),
-	optgroup: new Set(['optgroup']),
-	option: new Set(['option', 'optgroup']),
-	thead: new Set(['tbody', 'tfoot']),
-	tbody: new Set(['tbody', 'tfoot']),
-	tfoot: new Set(['tbody']),
-	tr: new Set(['tr', 'tbody']),
-	td: new Set(['td', 'th', 'tr']),
-	th: new Set(['td', 'th', 'tr'])
-};
-
-for (const interactive_element of interactive_elements) {
-	disallowed_contents[interactive_element] = interactive_elements;
-}
-
 // can this be a child of the parent element, or does it implicitly
 // close it, like `<li>one<li>two`?
 
@@ -156,8 +128,8 @@ for (const interactive_element of interactive_elements) {
  * @param {string} [next]
  */
 export function closing_tag_omitted(current, next) {
-	if (disallowed_contents[current]) {
-		if (!next || disallowed_contents[current].has(next)) {
+	if (disallowed_children[current]) {
+		if (!next || disallowed_children[current].includes(next)) {
 			return true;
 		}
 	}

--- a/packages/svelte/src/compiler/utils/html.js
+++ b/packages/svelte/src/compiler/utils/html.js
@@ -1,0 +1,61 @@
+const interactive_elements = ['a', 'button', 'iframe', 'embed', 'select', 'textarea'];
+
+/** @type {Record<string, string[]>} */
+export const disallowed_children = {
+	dd: ['dd', 'dt'],
+	dt: ['dd', 'dt'],
+	form: ['form'],
+	li: ['li'],
+	optgroup: ['optgroup'],
+	option: ['option', 'optgroup'],
+	p: [
+		'address',
+		'article',
+		'aside',
+		'blockquote',
+		'div',
+		'dl',
+		'fieldset',
+		'footer',
+		'form',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'header',
+		'hgroup',
+		'hr',
+		'main',
+		'menu',
+		'nav',
+		'ol',
+		'p',
+		'pre',
+		'section',
+		'table',
+		'ul'
+	],
+	rp: ['rp', 'rt'],
+	rt: ['rp', 'rt'],
+	tbody: ['tbody', 'tfoot'],
+	td: ['td', 'th', 'tr'],
+	th: ['td', 'th', 'tr'],
+	tfoot: ['tbody'],
+	thead: ['tbody', 'tfoot'],
+	tr: ['tr', 'tbody']
+};
+
+for (const interactive_element of interactive_elements) {
+	disallowed_children[interactive_element] = [...interactive_elements];
+}
+
+/** @type {Record<string, string[]>} */
+export const disallowed_parents = {};
+
+for (const parent in disallowed_children) {
+	for (const child of disallowed_children[parent]) {
+		(disallowed_parents[child] ??= []).push(parent);
+	}
+}

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -112,47 +112,6 @@ export const DOMBooleanAttributes = [
 export const namespace_svg = 'http://www.w3.org/2000/svg';
 export const namespace_mathml = 'http://www.w3.org/1998/Math/MathML';
 
-// while `input` is also an interactive element, it is never moved by the browser, so we don't need to check for it
-export const interactive_elements = new Set([
-	'a',
-	'button',
-	'iframe',
-	'embed',
-	'select',
-	'textarea'
-]);
-
-export const disallowed_paragraph_contents = [
-	'address',
-	'article',
-	'aside',
-	'blockquote',
-	'details',
-	'div',
-	'dl',
-	'fieldset',
-	'figcapture',
-	'figure',
-	'footer',
-	'form',
-	'h1',
-	'h2',
-	'h3',
-	'h4',
-	'h5',
-	'h6',
-	'header',
-	'hr',
-	'menu',
-	'nav',
-	'ol',
-	'pre',
-	'section',
-	'table',
-	'ul',
-	'p'
-];
-
 // https://html.spec.whatwg.org/multipage/syntax.html#generate-implied-end-tags
 const implied_end_tags = ['dd', 'dt', 'li', 'option', 'optgroup', 'p', 'rp', 'rt'];
 

--- a/packages/svelte/src/internal/server/dev.js
+++ b/packages/svelte/src/internal/server/dev.js
@@ -1,8 +1,5 @@
-import {
-	disallowed_paragraph_contents,
-	interactive_elements,
-	is_tag_valid_with_parent
-} from '../../constants.js';
+import { disallowed_parents } from '../../compiler/utils/html.js';
+import { is_tag_valid_with_parent } from '../../constants.js';
 import { current_component } from './context.js';
 
 /**
@@ -63,21 +60,12 @@ export function push_element(payload, tag, line, column) {
 		print_error(payload, parent, child);
 	}
 
-	if (interactive_elements.has(tag)) {
-		let element = parent;
-		while (element !== null) {
-			if (interactive_elements.has(element.tag)) {
-				print_error(payload, element, child);
-				break;
-			}
-			element = element.parent;
-		}
-	}
+	if (tag in disallowed_parents) {
+		const parents = disallowed_parents[tag];
 
-	if (disallowed_paragraph_contents.includes(tag)) {
 		let element = parent;
 		while (element !== null) {
-			if (element.tag === 'p') {
+			if (parents.includes(element.tag)) {
 				print_error(payload, element, child);
 				break;
 			}


### PR DESCRIPTION
Follow-up to #11947. Right now our HTML validation (for checking which elements are allowed inside which other elements) isn't great — we have special handling for `<p>` (why?) and interactive elements, and #11947 added some logic for preventing `<form><form></form></form>` that doesn't prevent `<form><Form></Form></form>`.

This PR is a naive attempt to fix it by having a single place to define disallowed children/parents that can be used in multiple places (parsing, validation, SSR) rather than having a bunch of special-case logic. Unfortunately it doesn't quite work, because it prevents children from having certain _descendant_ elements, when the required logic is a bit more subtle. For example one test fails because an `<li>` has a valid descendant (not child) `<li>`. Examples of nuances that aren't captured by our current validation or this PR:

- `<ul>` and `<ol>` can only contain `<li>`, `<script>` or `<template>` — we don't have the concept of an allowlist of direct children
- `<li>` must be a direct child of `<ul>` or `<ol>` or `<menu>` — we don't have the concept of an allowlist of direct parents
- `<table>` can contain `<tr>` directly — the intermediate `<tbody>` is automatically created if absent. we only insist on it because we're not sophisticated enough to handle the resulting hydration complexities
- some errors (`<p>` inside `<p>`) result in broken DOM, others (`<h1>` inside `<dd>`) are invalid but do not result in broken DOM

I also wonder if an error is appropriate. In one app I converted to Svelte 5, I hit an error immediately because a `<button>` contained another `<button>` — this is incorrect, but the app had been working just fine. For people who aren't using SSR, this case is a potential accessibility pitfall but it won't result in a hydration mismatch, and so maybe a warning is actually more appropriate?

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
