### PR TITLE
chore: simplify SSR

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript.js
@@ -3,18 +3,6 @@ import { function_visitor, serialize_hoistable_params } from '../utils.js';
 
 /** @type {import('../types.js').ComponentVisitors} */
 export const javascript_visitors = {
-	Program(node, { visit }) {
-		return /** @type {import('estree').Program} */ ({
-			...node,
-			body: node.body.map((node) => /** @type {import('estree').Node} */ (visit(node)))
-		});
-	},
-	BlockStatement(node, { visit }) {
-		return /** @type {import('estree').BlockStatement} */ ({
-			...node,
-			body: node.body.map((node) => /** @type {import('estree').Node} */ (visit(node)))
-		});
-	},
 	FunctionExpression: function_visitor,
 	ArrowFunctionExpression: function_visitor,
 	FunctionDeclaration(node, context) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1446,10 +1446,6 @@ function serialize_attribute_value(attribute_value, context) {
 		return [contains_call_expression, b.literal(true)];
 	}
 
-	if (attribute_value.length === 0) {
-		return [contains_call_expression, b.literal('')]; // is this even possible?
-	}
-
 	if (attribute_value.length === 1) {
 		const value = attribute_value[0];
 		if (value.type === 'Text') {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1435,33 +1435,29 @@ function get_node_id(expression, state, name) {
 }
 
 /**
- * @param {true | Array<import('#compiler').Text | import('#compiler').ExpressionTag>} attribute_value
+ * @param {true | Array<import('#compiler').Text | import('#compiler').ExpressionTag>} value
  * @param {import('../types').ComponentContext} context
- * @returns {[boolean, import('estree').Expression]}
+ * @returns {[contains_call_expression: boolean, import('estree').Expression]}
  */
-function serialize_attribute_value(attribute_value, context) {
-	let contains_call_expression = false;
-
-	if (attribute_value === true) {
-		return [contains_call_expression, b.literal(true)];
+function serialize_attribute_value(value, context) {
+	if (value === true) {
+		return [false, b.literal(true)];
 	}
 
-	if (attribute_value.length === 1) {
-		const value = attribute_value[0];
-		if (value.type === 'Text') {
-			return [contains_call_expression, b.literal(value.data)];
-		} else {
-			if (value.type === 'ExpressionTag') {
-				contains_call_expression = value.metadata.contains_call_expression;
-			}
-			return [
-				contains_call_expression,
-				/** @type {import('estree').Expression} */ (context.visit(value.expression))
-			];
+	if (value.length === 1) {
+		const chunk = value[0];
+
+		if (chunk.type === 'Text') {
+			return [false, b.literal(chunk.data)];
 		}
+
+		return [
+			chunk.metadata.contains_call_expression,
+			/** @type {import('estree').Expression} */ (context.visit(chunk.expression))
+		];
 	}
 
-	return serialize_template_literal(attribute_value, context.visit, context.state);
+	return serialize_template_literal(value, context.visit, context.state);
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -694,34 +694,29 @@ const javascript_visitors_runes = {
 
 /**
  *
- * @param {true | Array<import('#compiler').Text | import('#compiler').ExpressionTag>} attribute_value
+ * @param {true | Array<import('#compiler').Text | import('#compiler').ExpressionTag>} value
  * @param {import('./types').ComponentContext} context
  * @param {boolean} trim_whitespace
  * @param {boolean} is_component
  * @returns {import('estree').Expression}
  */
-function serialize_attribute_value(
-	attribute_value,
-	context,
-	trim_whitespace = false,
-	is_component = false
-) {
-	if (attribute_value === true) {
+function serialize_attribute_value(value, context, trim_whitespace = false, is_component = false) {
+	if (value === true) {
 		return b.true;
 	}
 
-	if (attribute_value.length === 1) {
-		const value = attribute_value[0];
-		if (value.type === 'Text') {
-			let data = value.data;
-			if (trim_whitespace) {
-				data = data.replace(regex_whitespaces_strict, ' ').trim();
-			}
+	if (value.length === 1) {
+		const chunk = value[0];
+
+		if (chunk.type === 'Text') {
+			const data = trim_whitespace
+				? chunk.data.replace(regex_whitespaces_strict, ' ').trim()
+				: chunk.data;
 
 			return b.literal(is_component ? data : escape_html(data, true));
-		} else {
-			return /** @type {import('estree').Expression} */ (context.visit(value.expression));
 		}
+
+		return /** @type {import('estree').Expression} */ (context.visit(chunk.expression));
 	}
 
 	let quasi = b.quasi('', false);
@@ -730,8 +725,9 @@ function serialize_attribute_value(
 	/** @type {import('estree').Expression[]} */
 	const expressions = [];
 
-	for (let i = 0; i < attribute_value.length; i++) {
-		const node = attribute_value[i];
+	for (let i = 0; i < value.length; i++) {
+		const node = value[i];
+
 		if (node.type === 'Text') {
 			quasi.value.raw += trim_whitespace
 				? node.data.replace(regex_whitespaces_strict, ' ')
@@ -744,7 +740,7 @@ function serialize_attribute_value(
 				)
 			);
 
-			quasi = b.quasi('', i + 1 === attribute_value.length);
+			quasi = b.quasi('', i + 1 === value.length);
 			quasis.push(quasi);
 		}
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -39,14 +39,12 @@ import {
 } from '../../../../internal/server/hydration.js';
 import { filename, locator } from '../../../state.js';
 
-export const block_open = t_string(BLOCK_OPEN);
-export const block_close = t_string(BLOCK_CLOSE);
-export const block_anchor = t_string(BLOCK_ANCHOR);
+export const block_open = string(BLOCK_OPEN);
+export const block_close = string(BLOCK_CLOSE);
+export const block_anchor = string(BLOCK_ANCHOR);
 
-/**
- * @param {string} value
- */
-function t_string(value) {
+/** @param {string} value */
+function string(value) {
 	return b.literal(sanitize_template_string(value));
 }
 
@@ -147,15 +145,15 @@ function process_children(nodes, parent, { visit, state }) {
 					parent.type === 'RegularElement' &&
 					(parent.name === 'script' || parent.name === 'style')
 				) {
-					state.template.push(t_string(node.data));
+					state.template.push(string(node.data));
 				} else {
-					state.template.push(t_string(escape_html(node.data)));
+					state.template.push(string(escape_html(node.data)));
 				}
 				return;
 			}
 
 			if (node.type === 'Comment') {
-				state.template.push(t_string(`<!--${escape_html(node.data)}-->`));
+				state.template.push(string(`<!--${escape_html(node.data)}-->`));
 				return;
 			}
 
@@ -165,7 +163,7 @@ function process_children(nodes, parent, { visit, state }) {
 			}
 
 			if (node.expression.type === 'Literal') {
-				state.template.push(t_string(escape_html(node.expression.value + '')));
+				state.template.push(string(escape_html(node.expression.value + '')));
 			} else {
 				state.template.push(
 					b.call('$.escape', /** @type {import('estree').Expression} */ (visit(node.expression)))
@@ -1343,9 +1341,9 @@ const template_visitors = {
 		throw new Error('Node should have been handled elsewhere');
 	},
 	RegularElement(node, context) {
-		context.state.template.push(t_string(`<${node.name}`));
+		context.state.template.push(string(`<${node.name}`));
 		const body = serialize_element_attributes(node, context);
-		context.state.template.push(t_string('>'));
+		context.state.template.push(string('>'));
 
 		const namespace = determine_namespace_for_children(node, context.state.metadata.namespace);
 
@@ -1416,7 +1414,7 @@ const template_visitors = {
 		}
 
 		if (!VoidElements.includes(node.name) && namespace !== 'foreign') {
-			state.template.push(t_string(`</${node.name}>`));
+			state.template.push(string(`</${node.name}>`));
 		}
 
 		if (state.options.dev) {
@@ -1677,7 +1675,7 @@ const template_visitors = {
 
 		// Use `=` so that later title changes override earlier ones
 		state.init.push(b.stmt(b.assignment('=', b.id('$$payload.title'), b.literal('<title>'))));
-		inner_state.template.push(t_string('</title>'));
+		inner_state.template.push(string('</title>'));
 		// title is guaranteed to contain only text/expression tag children
 		state.init.push(...serialize_template(inner_state.template, b.id('title')));
 	},
@@ -1952,7 +1950,7 @@ function serialize_element_attributes(node, context) {
 				).value;
 				if (name !== 'class' || literal_value) {
 					context.state.template.push(
-						t_string(
+						string(
 							` ${attribute.name}${
 								DOMBooleanAttributes.includes(name) && literal_value === true
 									? ''
@@ -1980,7 +1978,7 @@ function serialize_element_attributes(node, context) {
 
 	if (events_to_capture.size !== 0) {
 		for (const event of events_to_capture) {
-			context.state.template.push(t_string(` ${event}="this.__e=event"`));
+			context.state.template.push(string(` ${event}="this.__e=event"`));
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -116,10 +116,9 @@ function serialize_template(template, out = b.id('out')) {
  * Processes an array of template nodes, joining sibling text/expression nodes and
  * recursing into child nodes.
  * @param {Array<import('#compiler').SvelteNode>} nodes
- * @param {import('#compiler').SvelteNode} parent
  * @param {import('./types').ComponentContext} context
  */
-function process_children(nodes, parent, { visit, state }) {
+function process_children(nodes, { visit, state }) {
 	/** @typedef {Array<import('#compiler').Text | import('#compiler').Comment | import('#compiler').ExpressionTag>} Sequence */
 
 	/** @type {Sequence} */
@@ -1180,7 +1179,7 @@ const template_visitors = {
 			context.visit(node, state);
 		}
 
-		process_children(trimmed, parent, { ...context, state });
+		process_children(trimmed, { ...context, state });
 
 		return b.block([...state.init, ...serialize_template(state.template)]);
 	},
@@ -1302,7 +1301,7 @@ const template_visitors = {
 		}
 
 		if (body === null) {
-			process_children(trimmed, node, { ...context, state });
+			process_children(trimmed, { ...context, state });
 		} else {
 			let id = body;
 
@@ -1314,7 +1313,7 @@ const template_visitors = {
 			// if this is a `<textarea>` value or a contenteditable binding, we only add
 			// the body if the attribute/binding is falsy
 			const inner_state = { ...state, template: [], init: [] };
-			process_children(trimmed, node, { ...context, state: inner_state });
+			process_children(trimmed, { ...context, state: inner_state });
 
 			// Use the body expression as the body if it's truthy, otherwise use the inner template
 			state.template.push(
@@ -1574,10 +1573,7 @@ const template_visitors = {
 			template: []
 		};
 
-		process_children(node.fragment.nodes, node, {
-			...context,
-			state: inner_state
-		});
+		process_children(node.fragment.nodes, { ...context, state: inner_state });
 
 		// Use `=` so that later title changes override earlier ones
 		state.init.push(b.stmt(b.assignment('=', b.id('$$payload.title'), b.literal('<title>'))));

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -407,22 +407,6 @@ const global_visitors = {
 };
 
 /** @type {import('./types').Visitors} */
-const javascript_visitors = {
-	Program(node, { visit }) {
-		return /** @type {import('estree').Program} */ ({
-			...node,
-			body: node.body.map((node) => /** @type {import('estree').Node} */ (visit(node)))
-		});
-	},
-	BlockStatement(node, { visit }) {
-		return /** @type {import('estree').BlockStatement} */ ({
-			...node,
-			body: node.body.map((node) => /** @type {import('estree').Node} */ (visit(node)))
-		});
-	}
-};
-
-/** @type {import('./types').Visitors} */
 const javascript_visitors_runes = {
 	ClassBody(node, { state, visit }) {
 		/** @type {Map<string, import('../../3-transform/client/types.js').StateField>} */
@@ -1979,7 +1963,6 @@ export function server_component(analysis, options) {
 			{
 				...set_scope(analysis.module.scopes),
 				...global_visitors,
-				...javascript_visitors,
 				...(analysis.runes ? javascript_visitors_runes : javascript_visitors_legacy)
 			}
 		)
@@ -1993,7 +1976,6 @@ export function server_component(analysis, options) {
 			{
 				...set_scope(analysis.instance.scopes),
 				...global_visitors,
-				...javascript_visitors,
 				...(analysis.runes ? javascript_visitors_runes : javascript_visitors_legacy),
 				ImportDeclaration(node) {
 					state.hoisted.push(node);
@@ -2265,7 +2247,7 @@ export function server_module(analysis, options) {
 		scope: analysis.module.scope,
 		scopes: analysis.module.scopes,
 		// this is an anomaly — it can only be used in components, but it needs
-		// to be present for `javascript_visitors` and so is included in module
+		// to be present for `javascript_visitors_legacy` and so is included in module
 		// transform state as well as component transform state
 		legacy_reactive_statements: new Map(),
 		private_derived: new Map()
@@ -2275,7 +2257,6 @@ export function server_module(analysis, options) {
 		walk(/** @type {import('#compiler').SvelteNode} */ (analysis.module.ast), state, {
 			...set_scope(analysis.module.scopes),
 			...global_visitors,
-			...javascript_visitors,
 			...javascript_visitors_runes
 		})
 	);

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -152,16 +152,14 @@ function process_children(nodes, parent, { visit, state }) {
 			return;
 		}
 
-		/** @type {import('estree').TemplateElement[]} */
-		const quasis = [];
+		const quasis = [b.quasi('', false)];
 
 		/** @type {import('estree').Expression[]} */
 		const expressions = [];
 
-		quasis.push(b.quasi('', false));
-
 		for (let i = 0; i < sequence.length; i++) {
 			const node = sequence[i];
+
 			if (node.type === 'Text' || node.type === 'Comment') {
 				let last = /** @type {import('estree').TemplateElement} */ (quasis.at(-1));
 				last.value.raw += sanitize_template_string(

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -147,20 +147,11 @@ function process_children(nodes, parent, { visit, state }) {
 				} else {
 					state.template.push(string(escape_html(node.data)));
 				}
-				return;
-			}
-
-			if (node.type === 'Comment') {
+			} else if (node.type === 'Comment') {
 				state.template.push(string(`<!--${escape_html(node.data)}-->`));
-				return;
-			}
-
-			if (node.type === 'Anchor') {
+			} else if (node.type === 'Anchor') {
 				state.template.push(node.id);
-				return;
-			}
-
-			if (node.expression.type === 'Literal') {
+			} else if (node.expression.type === 'Literal') {
 				state.template.push(string(escape_html(node.expression.value + '')));
 			} else {
 				state.template.push(
@@ -2044,20 +2035,16 @@ function serialize_style_directives(style_directives, style_attribute, context) 
 		return b.init(directive.name, value);
 	});
 
-	if (style_attribute === null) {
-		context.state.template.push(b.call('$.add_styles', b.object(styles)));
-	} else {
-		context.state.template.push(
-			b.call(
-				'$.add_styles',
-				b.call(
+	const arg =
+		style_attribute === null
+			? b.object(styles)
+			: b.call(
 					'$.merge_styles',
 					serialize_attribute_value(style_attribute.value, context, true),
 					b.object(styles)
-				)
-			)
-		);
-	}
+				);
+
+	context.state.template.push(b.call('$.add_styles', arg));
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -204,9 +204,7 @@ function process_children(nodes, parent, { visit, state }) {
 				sequence = [];
 			}
 
-			visit(node, {
-				...state
-			});
+			visit(node, { ...state });
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -367,15 +367,11 @@ function serialize_set_binding(node, context, fallback) {
 /**
  * @param {import('#compiler').RegularElement | import('#compiler').SvelteElement} element
  * @param {import('#compiler').Attribute} attribute
- * @param {{ state: { metadata: { namespace: import('#compiler').Namespace }}}} context
+ * @param {{ state: { namespace: import('#compiler').Namespace }}} context
  */
 function get_attribute_name(element, attribute, context) {
 	let name = attribute.name;
-	if (
-		!element.metadata.svg &&
-		!element.metadata.mathml &&
-		context.state.metadata.namespace !== 'foreign'
-	) {
+	if (!element.metadata.svg && !element.metadata.mathml && context.state.namespace !== 'foreign') {
 		name = name.toLowerCase();
 		// don't lookup boolean aliases here, the server runtime function does only
 		// check for the lowercase variants of boolean attributes
@@ -1048,7 +1044,7 @@ function serialize_inline_component(node, component_name, context) {
 			b.call(
 				'$.css_props',
 				b.id('$$payload'),
-				b.literal(context.state.metadata.namespace === 'svg' ? false : true),
+				b.literal(context.state.namespace === 'svg' ? false : true),
 				b.object(custom_css_props),
 				b.thunk(b.block([statement]))
 			)
@@ -1173,7 +1169,7 @@ const javascript_visitors_legacy = {
 const template_visitors = {
 	Fragment(node, context) {
 		const parent = context.path.at(-1) ?? node;
-		const namespace = infer_namespace(context.state.metadata.namespace, parent, node.nodes);
+		const namespace = infer_namespace(context.state.namespace, parent, node.nodes);
 
 		const { hoisted, trimmed } = clean_nodes(
 			parent,
@@ -1194,9 +1190,7 @@ const template_visitors = {
 			...context.state,
 			init: [],
 			template: [],
-			metadata: {
-				namespace
-			}
+			namespace
 		};
 
 		for (const node of hoisted) {
@@ -1288,12 +1282,12 @@ const template_visitors = {
 			return;
 		}
 
-		const namespace = determine_namespace_for_children(node, context.state.metadata.namespace);
+		const namespace = determine_namespace_for_children(node, context.state.namespace);
 
 		/** @type {import('./types').ComponentServerTransformState} */
 		const state = {
 			...context.state,
-			metadata: { ...context.state.metadata, namespace },
+			namespace,
 			preserve_whitespace:
 				context.state.preserve_whitespace ||
 				((node.name === 'pre' || node.name === 'textarea') && namespace !== 'foreign')
@@ -1381,10 +1375,7 @@ const template_visitors = {
 
 		const state = {
 			...context.state,
-			metadata: {
-				...context.state.metadata,
-				namespace: determine_namespace_for_children(node, context.state.metadata.namespace)
-			},
+			namespace: determine_namespace_for_children(node, context.state.namespace),
 			template: [],
 			init: []
 		};
@@ -2014,9 +2005,7 @@ export function server_component(analysis, options) {
 		// these are set inside the `Fragment` visitor, and cannot be used until then
 		init: /** @type {any} */ (null),
 		template: /** @type {any} */ (null),
-		metadata: {
-			namespace: options.namespace
-		},
+		namespace: options.namespace,
 		preserve_whitespace: options.preserveWhitespace,
 		private_derived: new Map()
 	};

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -124,22 +124,14 @@ function process_children(nodes, parent, { visit, state }) {
 
 	/** @type {Sequence} */
 	let sequence = [];
-	let did_flush = false;
 
-	/**
-	 * @param {Sequence} sequence
-	 * @param {boolean} final
-	 */
-	function flush_sequence(sequence, final) {
-		const is_single_flush = !did_flush && final;
-		did_flush = true;
-
+	/** @param {Sequence} sequence */
+	function flush_sequence(sequence) {
 		if (sequence.length === 1) {
 			const node = sequence[0];
 
 			if (node.type === 'Text') {
 				if (
-					is_single_flush &&
 					parent.type === 'RegularElement' &&
 					(parent.name === 'script' || parent.name === 'style')
 				) {
@@ -208,7 +200,7 @@ function process_children(nodes, parent, { visit, state }) {
 			sequence.push(node);
 		} else {
 			if (sequence.length > 0) {
-				flush_sequence(sequence, false);
+				flush_sequence(sequence);
 				sequence = [];
 			}
 
@@ -219,7 +211,7 @@ function process_children(nodes, parent, { visit, state }) {
 	}
 
 	if (sequence.length > 0) {
-		flush_sequence(sequence, true);
+		flush_sequence(sequence);
 	}
 }
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -152,7 +152,8 @@ function process_children(nodes, parent, { visit, state }) {
 			return;
 		}
 
-		const quasis = [b.quasi('', false)];
+		let quasi = b.quasi('', false);
+		const quasis = [quasi];
 
 		/** @type {import('estree').Expression[]} */
 		const expressions = [];
@@ -161,20 +162,20 @@ function process_children(nodes, parent, { visit, state }) {
 			const node = sequence[i];
 
 			if (node.type === 'Text' || node.type === 'Comment') {
-				let last = /** @type {import('estree').TemplateElement} */ (quasis.at(-1));
-				last.value.raw += sanitize_template_string(
+				quasi.value.raw += sanitize_template_string(
 					node.type === 'Comment' ? `<!--${node.data}-->` : escape_html(node.data)
 				);
 			} else if (node.type === 'ExpressionTag' && node.expression.type === 'Literal') {
-				let last = /** @type {import('estree').TemplateElement} */ (quasis.at(-1));
 				if (node.expression.value != null) {
-					last.value.raw += sanitize_template_string(escape_html(node.expression.value + ''));
+					quasi.value.raw += sanitize_template_string(escape_html(node.expression.value + ''));
 				}
 			} else {
 				expressions.push(
 					b.call('$.escape', /** @type {import('estree').Expression} */ (visit(node.expression)))
 				);
-				quasis.push(b.quasi('', i + 1 === sequence.length));
+
+				quasi = b.quasi('', i + 1 === sequence.length);
+				quasis.push(quasi);
 			}
 		}
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -115,12 +115,12 @@ function serialize_template(template, out = b.id('out')) {
 /**
  * Processes an array of template nodes, joining sibling text/expression nodes and
  * recursing into child nodes.
- * @param {Array<import('#compiler').SvelteNode | import('./types').Anchor>} nodes
+ * @param {Array<import('#compiler').SvelteNode>} nodes
  * @param {import('#compiler').SvelteNode} parent
  * @param {import('./types').ComponentContext} context
  */
 function process_children(nodes, parent, { visit, state }) {
-	/** @typedef {Array<import('#compiler').Text | import('#compiler').Comment | import('#compiler').ExpressionTag | import('./types').Anchor>} Sequence */
+	/** @typedef {Array<import('#compiler').Text | import('#compiler').Comment | import('#compiler').ExpressionTag>} Sequence */
 
 	/** @type {Sequence} */
 	let sequence = [];
@@ -141,8 +141,6 @@ function process_children(nodes, parent, { visit, state }) {
 				}
 			} else if (node.type === 'Comment') {
 				state.template.push(string(`<!--${escape_html(node.data)}-->`));
-			} else if (node.type === 'Anchor') {
-				state.template.push(node.id);
 			} else if (node.expression.type === 'Literal') {
 				state.template.push(string(escape_html(node.expression.value + '')));
 			} else {
@@ -174,9 +172,6 @@ function process_children(nodes, parent, { visit, state }) {
 				if (node.expression.value != null) {
 					last.value.raw += sanitize_template_string(escape_html(node.expression.value + ''));
 				}
-			} else if (node.type === 'Anchor') {
-				expressions.push(node.id);
-				quasis.push(b.quasi('', i + 1 === sequence.length));
 			} else {
 				expressions.push(
 					b.call('$.escape', /** @type {import('estree').Expression} */ (visit(node.expression)))
@@ -191,12 +186,7 @@ function process_children(nodes, parent, { visit, state }) {
 	for (let i = 0; i < nodes.length; i += 1) {
 		const node = nodes[i];
 
-		if (
-			node.type === 'Text' ||
-			node.type === 'Comment' ||
-			node.type === 'ExpressionTag' ||
-			node.type === 'Anchor'
-		) {
+		if (node.type === 'Text' || node.type === 'Comment' || node.type === 'ExpressionTag') {
 			sequence.push(node);
 		} else {
 			if (sequence.length > 0) {

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -1181,10 +1181,6 @@ const template_visitors = {
 			context.state.options.preserveComments
 		);
 
-		if (hoisted.length === 0 && trimmed.length === 0) {
-			return b.block([]);
-		}
-
 		/** @type {import('./types').ComponentServerTransformState} */
 		const state = {
 			...context.state,
@@ -1199,14 +1195,7 @@ const template_visitors = {
 
 		process_children(trimmed, parent, { ...context, state });
 
-		/** @type {import('estree').Statement[]} */
-		const body = [...state.init];
-
-		if (state.template.length > 0) {
-			body.push(...serialize_template(state.template));
-		}
-
-		return b.block(body);
+		return b.block([...state.init, ...serialize_template(state.template)]);
 	},
 	HtmlTag(node, context) {
 		const expression = /** @type {import('estree').Expression} */ (context.visit(node.expression));

--- a/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
@@ -20,9 +20,7 @@ export interface ComponentServerTransformState extends ServerTransformState {
 
 	/** The SSR template  */
 	readonly template: Array<Statement | Expression>;
-	readonly metadata: {
-		namespace: Namespace;
-	};
+	readonly namespace: Namespace;
 	readonly preserve_whitespace: boolean;
 }
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
@@ -10,18 +10,6 @@ import type { TransformState } from '../types.js';
 import type { ComponentAnalysis } from '../../types.js';
 import type { StateField } from '../client/types.js';
 
-export type TemplateExpression = {
-	type: 'expression';
-	value: Expression;
-};
-
-export type TemplateStatement = {
-	type: 'statement';
-	value: Statement;
-};
-
-export type Template = TemplateExpression | TemplateStatement;
-
 export interface Anchor {
 	type: 'Anchor';
 	id: Identifier;

--- a/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
@@ -13,7 +13,6 @@ import type { StateField } from '../client/types.js';
 export type TemplateExpression = {
 	type: 'expression';
 	value: Expression;
-	needs_escaping: boolean;
 };
 
 export type TemplateString = {

--- a/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
@@ -1,19 +1,8 @@
-import type {
-	Expression,
-	Identifier,
-	Statement,
-	ModuleDeclaration,
-	LabeledStatement
-} from 'estree';
+import type { Expression, Statement, ModuleDeclaration, LabeledStatement } from 'estree';
 import type { SvelteNode, Namespace, ValidatedCompileOptions } from '#compiler';
 import type { TransformState } from '../types.js';
 import type { ComponentAnalysis } from '../../types.js';
 import type { StateField } from '../client/types.js';
-
-export interface Anchor {
-	type: 'Anchor';
-	id: Identifier;
-}
 
 export interface ServerTransformState extends TransformState {
 	/** The $: calls, which will be ordered in the end */

--- a/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
@@ -15,17 +15,12 @@ export type TemplateExpression = {
 	value: Expression;
 };
 
-export type TemplateString = {
-	type: 'string';
-	value: string;
-};
-
 export type TemplateStatement = {
 	type: 'statement';
 	value: Statement;
 };
 
-export type Template = TemplateExpression | TemplateString | TemplateStatement;
+export type Template = TemplateExpression | TemplateStatement;
 
 export interface Anchor {
 	type: 'Anchor';

--- a/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/server/types.d.ts
@@ -42,7 +42,7 @@ export interface ComponentServerTransformState extends ServerTransformState {
 	readonly hoisted: Array<Statement | ModuleDeclaration>;
 
 	/** The SSR template  */
-	readonly template: Template[];
+	readonly template: Array<Statement | Expression>;
 	readonly metadata: {
 		namespace: Namespace;
 	};

--- a/packages/svelte/tests/runtime-legacy/samples/escaped-expression/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/escaped-expression/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<p>&lt;marquee&gt;hello&lt;/marquee&gt;</p>`
+});

--- a/packages/svelte/tests/runtime-legacy/samples/escaped-expression/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/escaped-expression/main.svelte
@@ -1,0 +1,1 @@
+<p>{'<marquee>hello</marquee>'}</p>


### PR DESCRIPTION
This simplifies SSR a bit — instead of having `t_string` and `t_expression` and `t_statement`, we just use ESTree nodes directly. One less wrapper object to deal with, one less type to understand, and it makes a lot of code more compact.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
