### PR TITLE
chore: tweak effect docs

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -250,40 +250,34 @@ $effect(() => {
 });
 ```
 
-An effect only reruns when the object it reads changes, not when a property inside it changes. If you want to react to _any_ change inside an object for inspection purposes at dev time, you may want to use [`inspect`](#$inspect).
+An effect only reruns when the object it reads changes, not when a property inside it changes. (If you want to observe changes _inside_ an object at dev time, you can use [`$inspect`](#$inspect).)
 
 ```svelte
 <script>
-	let object = $state({ count: 0 });
-	let derived_object = $derived({
-		doubled: object.count * 2
+	let a = $state({ value: 0 });
+	let b = $derived({ value: a.value * 2 });
+
+	// this will run once, because `a` is never reassigned (only mutated)
+	$effect(() => {
+		a;
 	});
 
+	// this will run whenever `a.value` changes...
 	$effect(() => {
-		// never reruns, because object does not change,
-		// only its property changes
-		object;
-		console.log('object');
+		a.value;
 	});
 
+	// ...and so will this, because `b` is a new object each time
 	$effect(() => {
-		// reruns, because object.count changes
-		object.count;
-		console.log('object.count');
-	});
-
-	$effect(() => {
-		// reruns, because $derived produces a new object on each rerun
-		derived_object;
-		console.log('derived_object');
+		b;
 	});
 </script>
 
-<button onclick={() => object.count++}>
-	{derived_object.doubled}
+<button onclick={() => (a.value += 1)}>
+	{a.value}
 </button>
 
-<p>{object.count} doubled is {derived_object.doubled}</p>
+<p>{a.value} doubled is {b.value}</p>
 ```
 
 You can return a function from `$effect`, which will run immediately before the effect re-runs, and before it is destroyed ([demo](/#H4sIAAAAAAAAE42SzW6DMBCEX2Vl5RDaVCQ9JoDUY--9lUox9lKsGBvZC1GEePcaKPnpqSe86_m0M2t6ViqNnu0_e2Z4jWzP3pqGbRhdmrHwHWrCUHvbOjF2Ei-caijLTU4aCYRtDUEKK0-ccL2NDstNrbRWHoU10t8Eu-121gTVCssSBa3XEaQZ9GMrpziGj0p5OAccCgSHwmEgJZwrNNihg6MyhK7j-gii4uYb_YyGUZ5guQwzPdL7b_U4ZNSOvp9T2B3m1rB5cLx4zMkhtc7AHz7YVCVwEFzrgosTBMuNs52SKDegaPbvWnMH8AhUXaNUIY6-hHCldQhUIcyLCFlfAuHvkCKaYk8iYevGGgy2wyyJnpy9oLwG0sjdNe2yhGhJN32HsUzi2xOapNpl_bSLIYnDeeoVLZE1YI3QSpzSfo7-8J5PKbwOmdf2jC6JZyD7HxpPaMk93aHhF6utVKVCyfbkWhy-hh9Z3o_2nQIAAA==)).

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -254,30 +254,30 @@ An effect only reruns when the object it reads changes, not when a property insi
 
 ```svelte
 <script>
-	let a = $state({ value: 0 });
-	let b = $derived({ value: a.value * 2 });
+	let state = $state({ value: 0 });
+	let derived = $derived({ value: state.value * 2 });
 
-	// this will run once, because `a` is never reassigned (only mutated)
+	// this will run once, because `state` is never reassigned (only mutated)
 	$effect(() => {
-		a;
+		state;
 	});
 
-	// this will run whenever `a.value` changes...
+	// this will run whenever `state.value` changes...
 	$effect(() => {
-		a.value;
+		state.value;
 	});
 
-	// ...and so will this, because `b` is a new object each time
+	// ...and so will this, because `derived` is a new object each time
 	$effect(() => {
-		b;
+		derived;
 	});
 </script>
 
-<button onclick={() => (a.value += 1)}>
-	{a.value}
+<button onclick={() => (state.value += 1)}>
+	{state.value}
 </button>
 
-<p>{a.value} doubled is {b.value}</p>
+<p>{state.value} doubled is {derived.value}</p>
 ```
 
 You can return a function from `$effect`, which will run immediately before the effect re-runs, and before it is destroyed ([demo](/#H4sIAAAAAAAAE42SzW6DMBCEX2Vl5RDaVCQ9JoDUY--9lUox9lKsGBvZC1GEePcaKPnpqSe86_m0M2t6ViqNnu0_e2Z4jWzP3pqGbRhdmrHwHWrCUHvbOjF2Ei-caijLTU4aCYRtDUEKK0-ccL2NDstNrbRWHoU10t8Eu-121gTVCssSBa3XEaQZ9GMrpziGj0p5OAccCgSHwmEgJZwrNNihg6MyhK7j-gii4uYb_YyGUZ5guQwzPdL7b_U4ZNSOvp9T2B3m1rB5cLx4zMkhtc7AHz7YVCVwEFzrgosTBMuNs52SKDegaPbvWnMH8AhUXaNUIY6-hHCldQhUIcyLCFlfAuHvkCKaYk8iYevGGgy2wyyJnpy9oLwG0sjdNe2yhGhJN32HsUzi2xOapNpl_bSLIYnDeeoVLZE1YI3QSpzSfo7-8J5PKbwOmdf2jC6JZyD7HxpPaMk93aHhF6utVKVCyfbkWhy-hh9Z3o_2nQIAAA==)).


### PR DESCRIPTION
Alternative to #10746, so that we can tidy up the PR queue. I still think we're devoting way too much space to `$effect` in these docs, but if we must keep a section on shallow tracking then we can at least whittle it down a bit.

Currently, the comments (which are the important bit) are the least visible part of the section — there's too much visual noise surrounding them (both literally, in that they're inside the `$effect` blocks, and in the sense of being less prominent than the `console.log` calls in terms of syntax highlighting). Moving them out of the blocks, putting them all on a single line, and getting rid of the `console.log` calls helps a lot, I think. I also think that removing the distracting logs makes it clearer that reading a value (even if you don't 'do' anything with it) is what makes something a dependency of an effect.

We should avoid using `snake_case` in snippets like these unless we plan to commit to using it everywhere in docs, which I don't think we're ready to do. When dealing with abstract concepts I think short names like `a` and `b` rather than `object` and `derived_object` tend to work better.