### PR TITLE
fix: ensure bound input content is resumed on hydration

### DIFF
--- a/.changeset/flat-feet-visit.md
+++ b/.changeset/flat-feet-visit.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure bound input content is resumed on hydration

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -4,6 +4,7 @@ import { listen_to_event_and_reset_event } from './shared.js';
 import * as e from '../../../errors.js';
 import { get_proxied_value, is } from '../../../proxy.js';
 import { queue_micro_task } from '../../task.js';
+import { hydrating } from '../../hydration.js';
 
 /**
  * @param {HTMLInputElement} input
@@ -26,7 +27,11 @@ export function bind_value(input, get_value, update) {
 			// TODO should this happen in prod too?
 			e.bind_invalid_checkbox_value();
 		}
-
+		// If we are hydrating and the value has since changed, then use the update value
+		// from the input instead.
+		if (hydrating && input.defaultValue !== input.value) {
+			update(input.value);
+		}
 		var value = get_value();
 
 		// @ts-ignore

--- a/playgrounds/demo/src/entry-client.ts
+++ b/playgrounds/demo/src/entry-client.ts
@@ -4,8 +4,11 @@ import App from './App.svelte';
 const root = document.getElementById('root')!;
 const render = root.firstChild?.nextSibling ? hydrate : mount;
 
-const component = render(App, {
-	target: document.getElementById('root')!
-});
-// @ts-ignore
-window.unmount = () => unmount(component);
+setTimeout(() => {
+	const component = render(App, {
+		target: document.getElementById('root')!
+	});
+	// @ts-ignore
+	window.unmount = () => unmount(component);
+}, 1000)
+

--- a/playgrounds/demo/src/entry-client.ts
+++ b/playgrounds/demo/src/entry-client.ts
@@ -4,11 +4,8 @@ import App from './App.svelte';
 const root = document.getElementById('root')!;
 const render = root.firstChild?.nextSibling ? hydrate : mount;
 
-setTimeout(() => {
-	const component = render(App, {
-		target: document.getElementById('root')!
-	});
-	// @ts-ignore
-	window.unmount = () => unmount(component);
-}, 1000)
-
+const component = render(App, {
+	target: document.getElementById('root')!
+});
+// @ts-ignore
+window.unmount = () => unmount(component);


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/1755.

Before:

https://github.com/sveltejs/svelte/assets/1519870/f80bf421-e5c6-483e-afd2-0988a7de5bd9

After:

https://github.com/sveltejs/svelte/assets/1519870/2bcc7856-014f-48cc-9f0d-cc1a960809eb

