### PR TITLE
Svelte5 (Types/Doc) import Component as Type

### DIFF
--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -113,7 +113,7 @@ export class SvelteComponent<
  * you export a component called `MyComponent`. For Svelte+TypeScript users,
  * you want to provide typings. Therefore you create a `index.d.ts`:
  * ```ts
- * import { Component } from "svelte";
+ * import type { Component } from "svelte";
  * export declare const MyComponent: Component<{ foo: string }> {}
  * ```
  * Typing this makes it possible for IDEs like VS Code with the Svelte extension

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -113,7 +113,7 @@ export class SvelteComponent<
  * you export a component called `MyComponent`. For Svelte+TypeScript users,
  * you want to provide typings. Therefore you create a `index.d.ts`:
  * ```ts
- * import type { Component } from "svelte";
+ * import type { Component } from 'svelte';
  * export declare const MyComponent: Component<{ foo: string }> {}
  * ```
  * Typing this makes it possible for IDEs like VS Code with the Svelte extension

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -110,7 +110,7 @@ declare module 'svelte' {
 	 * you export a component called `MyComponent`. For Svelte+TypeScript users,
 	 * you want to provide typings. Therefore you create a `index.d.ts`:
 	 * ```ts
-	 * import { Component } from "svelte";
+	 * import type { Component } from "svelte";
 	 * export declare const MyComponent: Component<{ foo: string }> {}
 	 * ```
 	 * Typing this makes it possible for IDEs like VS Code with the Svelte extension

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -110,7 +110,7 @@ declare module 'svelte' {
 	 * you export a component called `MyComponent`. For Svelte+TypeScript users,
 	 * you want to provide typings. Therefore you create a `index.d.ts`:
 	 * ```ts
-	 * import type { Component } from "svelte";
+	 * import type { Component } from 'svelte';
 	 * export declare const MyComponent: Component<{ foo: string }> {}
 	 * ```
 	 * Typing this makes it possible for IDEs like VS Code with the Svelte extension


### PR DESCRIPTION
interfaces can only be used as a Type, that way it should be imported as type
