### PR TITLE
skip pending block for already-resolved promises on mount

### DIFF
--- a/.changeset/gentle-eagles-walk.md
+++ b/.changeset/gentle-eagles-walk.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: wait a microtask for await blocks to reduce UI churn

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -77,9 +77,10 @@ export function await_block(anchor, get_input, pending_fn, then_fn, catch_fn) {
 		if (input === (input = get_input())) return;
 
 		if (is_promise(input)) {
+			let was_hydrating = hydrating;
+
 			if (hydrating && pending_fn) {
 				pending_effect = branch(() => pending_fn(anchor));
-				return;
 			}
 
 			var promise = /** @type {Promise<any>} */ (input);
@@ -111,7 +112,7 @@ export function await_block(anchor, get_input, pending_fn, then_fn, catch_fn) {
 				// if the promise was already resolved, avoid thrash
 				if (settled) return;
 
-				if (pending_fn) {
+				if (pending_fn && !was_hydrating) {
 					if (pending_effect && (pending_effect.f & INERT) === 0) {
 						destroy_effect(pending_effect);
 					}

--- a/packages/svelte/tests/runtime-runes/samples/await-resolve/Pending.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-resolve/Pending.svelte
@@ -1,0 +1,7 @@
+<script>
+	$effect(() => {
+		console.log('mounting Pending.svelte');
+	});
+</script>
+
+<p>pending</p>

--- a/packages/svelte/tests/runtime-runes/samples/await-resolve/Then.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-resolve/Then.svelte
@@ -1,0 +1,9 @@
+<script>
+	let { value } = $props();
+
+	$effect(() => {
+		console.log('mounting Then.svelte');
+	});
+</script>
+
+<p>then {value}</p>

--- a/packages/svelte/tests/runtime-runes/samples/await-resolve/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-resolve/_config.js
@@ -1,0 +1,30 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [b1, b2] = target.querySelectorAll('button');
+		b1.click();
+		await Promise.resolve();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<p>then a</p><button>Show Promise A</button><button>Show Promise B</button>`
+		);
+		b2.click();
+		await Promise.resolve();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>Show Promise A</button><button>Show Promise B</button>`
+		);
+		await Promise.resolve();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<p>then b</p><button>Show Promise A</button><button>Show Promise B</button>`
+		);
+
+		assert.deepEqual(logs, [
+			'mounting Pending.svelte',
+			'mounting Then.svelte',
+			'mounting Then.svelte'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/await-resolve/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-resolve/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	import Pending from "./Pending.svelte"
+	import Then from './Then.svelte';
+
+	const promise_a = Promise.resolve('a')
+	const promise_b = Promise.resolve('b')
+
+	let current_promise = $state(promise_a);
+</script>
+
+{#await current_promise}
+	<Pending />
+{:then value}
+	<Then {value} />
+{/await}
+
+<button onclick={()=>{current_promise = promise_a}}>Show Promise A</button>
+<button onclick={()=>{current_promise = promise_b}}>Show Promise B</button>


### PR DESCRIPTION
#11989 got me thinking — aside from the question of keeping `then`/`catch` blocks mounted rather than recreating them each time (as though they contained `{#key ...}` blocks), why do we create pending blocks at all on mount, if the promise is already resolved?

This PR suggests an approach to that ~~(though it appears to have picked up some unrelated changes due to a sloppy merge, oops)~~. More intended to spark discussion than anything — it's draft for two reasons:

- a whole bunch of tests fail, because they expect pending blocks to be rendered initially
- it doesn't address the 'keep then/catch blocks mounted' thing

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
