### PR TITLE
fix: better `render` type

### DIFF
--- a/.changeset/funny-cooks-clean.md
+++ b/.changeset/funny-cooks-clean.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: better `render` type

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -96,8 +96,10 @@ export function element(payload, tag, attributes_fn, children_fn) {
 export let on_destroy = [];
 
 /**
- * @param {typeof import('svelte').SvelteComponent} component
- * @param {{ props: Record<string, any>; context?: Map<any, any> }} options
+ * @template {Record<string, any>} TProps
+ *
+ * @param {import('svelte').Component<TProps> | import('svelte').ComponentType<import('svelte').SvelteComponent<TProps>>} component
+ * @param {{ props: Omit<TProps, '$$slots' | '$$events'>; context?: Map<any, any> }} options
  * @returns {import('#server').RenderOutput}
  */
 export function render(component, options) {

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -96,10 +96,11 @@ export function element(payload, tag, attributes_fn, children_fn) {
 export let on_destroy = [];
 
 /**
- * @template {Record<string, any>} TProps
- *
- * @param {import('svelte').Component<TProps> | import('svelte').ComponentType<import('svelte').SvelteComponent<TProps>>} component
- * @param {{ props: Omit<TProps, '$$slots' | '$$events'>; context?: Map<any, any> }} options
+ * Only available on the server and when compiling with the `server` option.
+ * Takes a component and returns an object with `body` and `head` properties on it, which you can use to populate the HTML when server-rendering your app.
+ * @template {Record<string, any>} Props
+ * @param {import('svelte').Component<Props> | import('svelte').ComponentType<import('svelte').SvelteComponent<Props>>} component
+ * @param {{ props: Omit<Props, '$$slots' | '$$events'>; context?: Map<any, any> }} options
  * @returns {import('#server').RenderOutput}
  */
 export function render(component, options) {

--- a/packages/svelte/tests/types/component.ts
+++ b/packages/svelte/tests/types/component.ts
@@ -8,6 +8,7 @@ import {
 	hydrate,
 	type Component
 } from 'svelte';
+import { render } from 'svelte/server';
 
 SvelteComponent.element === HTMLElement;
 
@@ -148,6 +149,14 @@ hydrate(NewComponent, {
 	recover: false
 });
 
+render(NewComponent, {
+	props: {
+		prop: 'foo',
+		// @ts-expect-error
+		x: ''
+	}
+});
+
 // --------------------------------------------------------------------------- interop
 
 const AsLegacyComponent = asClassComponent(newComponent);
@@ -254,5 +263,14 @@ hydrate(functionComponent, {
 	// @ts-expect-error missing prop
 	props: {
 		binding: true
+	}
+});
+
+render(functionComponent, {
+	props: {
+		binding: true,
+		readonly: 'foo',
+		// @ts-expect-error
+		x: ''
 	}
 });

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2108,9 +2108,9 @@ declare module 'svelte/reactivity' {
 }
 
 declare module 'svelte/server' {
-	export function render(component: typeof import('svelte').SvelteComponent, options: {
-		props: Record<string, any>;
-		context?: Map<any, any>;
+	export function render<TProps extends Record<string, any>>(component: import("svelte").Component<TProps, any, string> | import("svelte").ComponentType<import("svelte").SvelteComponent<TProps, any, any>>, options: {
+		props: Omit<TProps, "$$slots" | "$$events">;
+		context?: Map<any, any> | undefined;
 	}): RenderOutput;
 	interface RenderOutput {
 		/** HTML that goes into the `<head>` */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2108,8 +2108,12 @@ declare module 'svelte/reactivity' {
 }
 
 declare module 'svelte/server' {
-	export function render<TProps extends Record<string, any>>(component: import("svelte").Component<TProps, any, string> | import("svelte").ComponentType<import("svelte").SvelteComponent<TProps, any, any>>, options: {
-		props: Omit<TProps, "$$slots" | "$$events">;
+	/**
+	 * Only available on the server and when compiling with the `server` option.
+	 * Takes a component and returns an object with `body` and `head` properties on it, which you can use to populate the HTML when server-rendering your app.
+	 * */
+	export function render<Props extends Record<string, any>>(component: import("svelte").Component<Props, any, string> | import("svelte").ComponentType<import("svelte").SvelteComponent<Props, any, any>>, options: {
+		props: Omit<Props, "$$slots" | "$$events">;
 		context?: Map<any, any> | undefined;
 	}): RenderOutput;
 	interface RenderOutput {


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #11996 

For the moment i've excluded `$$slots` and `$$events` from the Props in the second argument but we can add them back in.

Also for the moment i've allowed the user to pass a ComponentType<SvelteComponent> while still inferring the props...this is the case if the user is using some old svelte 4 library with old `.d.ts`. Again if this is not desirable we can change that.

No test because it's just at the type level.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
