### PR TITLE
fix: export add snippet symbol func

### DIFF
--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -158,6 +158,7 @@ export {
 } from './dom/operations.js';
 export { noop } from '../shared/utils.js';
 export {
+	add_snippet_symbol,
 	validate_component,
 	validate_dynamic_element_tag,
 	validate_snippet,


### PR DESCRIPTION
Hello!

Astro uses `add_snippet_symbol` func: https://github.com/withastro/astro/blob/main/packages/integrations/svelte/client-v5.js#L2

When I use the latest version of Svelte 5 with Astro I get an error:

```
12:19:22 [ERROR] [UnhandledRejection] Astro detected an unhandled rejection. Here's the stack trace:
Error: Build failed with 1 error:
node_modules/.pnpm/@astrojs+svelte@5.5.0_astro@4.10.2_@types+node@20.10.0_lightningcss@1.25.1_terser@5.31.1_type_45aq3zregi4esy5helmin3cl6q/node_modules/@astrojs/svelte/client-v5.js:2:9: ERROR: No matching export in "node_modules/.pnpm/svelte@5.0.0-next.153/node_modules/svelte/src/internal/client/index.js" for import "add_snippet_symbol"
    at failureErrorWithLog (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/esbuild@0.20.2/node_modules/esbuild/lib/main.js:1651:15)
    at /Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/esbuild@0.20.2/node_modules/esbuild/lib/main.js:1059:25
    at /Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/esbuild@0.20.2/node_modules/esbuild/lib/main.js:1527:9
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This export was removed in this PR: https://github.com/sveltejs/svelte/commit/4365562228870aaa5c7d85cfd27d03d929a5f295

Please bring back the export of this feature so that you can use Svelte 5 with Astro.

Issue in Astro: https://github.com/withastro/astro/issues/11149