### PR TITLE
chore: tweak Map/Set for better inspect output

### DIFF
--- a/.changeset/eleven-hounds-pump.md
+++ b/.changeset/eleven-hounds-pump.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+chore: clear `Map`/`Set` before triggering `$inspect` callbacks

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -122,9 +122,11 @@ export class ReactiveMap extends Map {
 	}
 
 	clear() {
-		var sources = this.#sources;
+		var size = super.size;
+		super.clear();
 
-		if (super.size !== 0) {
+		if (size !== 0) {
+			var sources = this.#sources;
 			set(this.#size, 0);
 			for (var s of sources.values()) {
 				set(s, -1);
@@ -132,7 +134,6 @@ export class ReactiveMap extends Map {
 			increment(this.#version);
 			sources.clear();
 		}
-		super.clear();
 	}
 
 	#read_all() {

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -122,19 +122,18 @@ export class ReactiveMap extends Map {
 	}
 
 	clear() {
-		var size = super.size;
+		if (super.size === 0) {
+			return;
+		}
 		// Clear first, so we get nice console.log outputs with $inspect
 		super.clear();
-
-		if (size !== 0) {
-			var sources = this.#sources;
-			set(this.#size, 0);
-			for (var s of sources.values()) {
-				set(s, -1);
-			}
-			increment(this.#version);
-			sources.clear();
+		var sources = this.#sources;
+		set(this.#size, 0);
+		for (var s of sources.values()) {
+			set(s, -1);
 		}
+		increment(this.#version);
+		sources.clear();
 	}
 
 	#read_all() {

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -123,6 +123,7 @@ export class ReactiveMap extends Map {
 
 	clear() {
 		var size = super.size;
+		// Clear first, so we get nice console.log outputs with $inspect
 		super.clear();
 
 		if (size !== 0) {

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -117,21 +117,20 @@ export class ReactiveSet extends Set {
 	}
 
 	clear() {
-		var size = super.size;
+		if (super.size === 0) {
+			return;
+		}
 		// Clear first, so we get nice console.log outputs with $inspect
 		super.clear();
+		var sources = this.#sources;
 
-		if (size !== 0) {
-			var sources = this.#sources;
-
-			for (var s of sources.values()) {
-				set(s, false);
-			}
-
-			sources.clear();
-			set(this.#size, 0);
-			increment(this.#version);
+		for (var s of sources.values()) {
+			set(s, false);
 		}
+
+		sources.clear();
+		set(this.#size, 0);
+		increment(this.#version);
 	}
 
 	keys() {

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -122,10 +122,8 @@ export class ReactiveSet extends Set {
 
 		if (size !== 0) {
 			var sources = this.#sources;
-			var values = sources.values();
-			sources.clear();
 
-			for (var s of values) {
+			for (var s of sources.values()) {
 				set(s, false);
 			}
 

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -119,6 +119,7 @@ export class ReactiveSet extends Set {
 	clear() {
 		var size = super.size;
 		super.clear();
+
 		if (size !== 0) {
 			var sources = this.#sources;
 			var values = sources.values();

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -117,10 +117,14 @@ export class ReactiveSet extends Set {
 	}
 
 	clear() {
-		if (super.size !== 0) {
+		var size = super.size;
+		super.clear();
+		if (size !== 0) {
 			var sources = this.#sources;
+			var values = sources.values();
+			sources.clear();
 
-			for (var s of sources.values()) {
+			for (var s of values) {
 				set(s, false);
 			}
 
@@ -128,8 +132,6 @@ export class ReactiveSet extends Set {
 			set(this.#size, 0);
 			increment(this.#version);
 		}
-
-		super.clear();
 	}
 
 	keys() {

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -118,6 +118,7 @@ export class ReactiveSet extends Set {
 
 	clear() {
 		var size = super.size;
+		// Clear first, so we get nice console.log outputs with $inspect
 		super.clear();
 
 		if (size !== 0) {


### PR DESCRIPTION
This isn't really a bug fix, but just a nice change to make the console debugged output of the `Map` and `Set` show as having no entries when used with `$inspect`.  The trick is to first clear the object before we do the reactive work.