### PR TITLE
fix: improve derived disconnect/connect heuristics through reactivity graph

### DIFF
--- a/.changeset/friendly-files-remember.md
+++ b/.changeset/friendly-files-remember.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: improve derived disconnect/connect heuristics through reactivity graph

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.2.0",
+  "engines": {
+    "pnpm": "^9.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sveltejs/svelte.git"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.2.0",
-  "engines": {
-    "pnpm": "^9.0.0"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sveltejs/svelte.git"

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -8,7 +8,7 @@ import {
 import { get_descriptor, is_function } from '../utils.js';
 import { mutable_source, set, source } from './sources.js';
 import { derived, derived_safe_equal } from './deriveds.js';
-import { get, is_signals_recorded, untrack, update } from '../runtime.js';
+import { get, increment_version, is_signals_recorded, untrack, update } from '../runtime.js';
 import { safe_equals } from './equality.js';
 import { inspect_fn } from '../dev/inspect.js';
 import * as e from '../errors.js';
@@ -324,7 +324,7 @@ export function prop(props, key, flags, fallback) {
 				set(inner_current_value, value);
 				get(current_value); // force a synchronisation immediately
 				// Increment the value so that unowned/disconnected nodes can validate dirtiness again.
-				current_value.version++;
+				current_value.version = increment_version();
 			}
 
 			return value;

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -14,7 +14,8 @@ import {
 	set_current_untracked_writes,
 	set_last_inspected_signal,
 	set_signal_status,
-	untrack
+	untrack,
+	increment_version
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import { CLEAN, DERIVED, DIRTY, BRANCH_EFFECT } from '../constants.js';
@@ -99,7 +100,7 @@ export function set(signal, value) {
 		signal.v = value;
 
 		// Increment write version so that unowned signals can properly track dirtiness
-		signal.version++;
+		signal.version = increment_version();
 
 		// If the current signal is running for the first time, it won't have any
 		// reactions as we only allocate and assign the reactions after the signal

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -202,7 +202,6 @@ export function check_dirtiness(reaction) {
 	var flags = reaction.f;
 	var is_dirty = (flags & DIRTY) !== 0;
 	var is_unowned = (flags & UNOWNED) !== 0;
-	var is_disconnected = (flags & DISCONNECTED) !== 0;
 
 	// If we are unowned, we still need to ensure that we update our version to that
 	// of our dependencies.
@@ -210,7 +209,9 @@ export function check_dirtiness(reaction) {
 		return true;
 	}
 
-	if ((flags & MAYBE_DIRTY) !== 0 && is_dirty && is_unowned) {
+	var is_disconnected = (flags & DISCONNECTED) !== 0;
+
+	if ((flags & MAYBE_DIRTY) !== 0 || (is_dirty && is_unowned)) {
 		var dependencies = reaction.deps;
 
 		if (dependencies !== null) {
@@ -247,10 +248,8 @@ export function check_dirtiness(reaction) {
 						}
 					}
 				} else if ((reaction.f & DIRTY) !== 0) {
-					{
-						// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
-						return true;
-					}
+					// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
+					return true;
 				} else if (is_disconnected) {
 					// It might be that the derived was was dereferenced from its dependencies but has now come alive again.
 					// In thise case, we need to re-attach it to the graph and mark it dirty if any of its dependencies have

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -237,7 +237,7 @@ export function check_dirtiness(reaction) {
 					}
 					// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
 					// and the version hasn't changed, we still need to check that this reaction
-					// if linked to the dependency source – otherwise future updates will not be caught.
+					// is linked to the dependency source – otherwise future updates will not be caught.
 					if (!current_skip_reaction && !dependency?.reactions?.includes(reaction)) {
 						reactions = dependency.reactions;
 						if (reactions === null) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -454,13 +454,16 @@ function remove_reaction(signal, dependency) {
 			}
 		}
 	}
+	var flags = dependency.f;
 	// If the derived has no reactions, then we can disconnect it from the graph,
 	// allowing it to either reconnect in the future, or be GC'd by the VM.
-	if (reactions_length === 0 && (dependency.f & DERIVED) !== 0) {
-		set_signal_status(dependency, MAYBE_DIRTY);
+	if (reactions_length === 0 && (flags & DERIVED) !== 0) {
+		if ((flags & CLEAN) !== 0) {
+			set_signal_status(dependency, MAYBE_DIRTY);
+		}
 		// If we are working with a derived that is owned by an effect, then mark it as being
 		// disconnected.
-		if ((dependency.f & (UNOWNED | DISCONNECTED)) === 0) {
+		if ((flags & (UNOWNED | DISCONNECTED)) === 0) {
 			dependency.f ^= DISCONNECTED;
 		}
 		remove_reactions(/** @type {import('#client').Derived} **/ (dependency), 0);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -822,6 +822,8 @@ export function get(signal) {
 	if (current_reaction !== null) {
 		var version = signal.version;
 		var current_flags = current_reaction.f;
+		// If the version is higher, ensure we keep our current derived up-to-date to avoid
+		// over-firing.
 		if (
 			(current_flags & DERIVED) !== 0 &&
 			version > /** @type {import('#client').Derived} */ (current_reaction).version

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -249,14 +249,14 @@ export function check_dirtiness(reaction) {
 								return !is_equal;
 							}
 						}
+						// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
+						// and the version hasn't changed, we still need to check that this reaction
+						// if linked to the dependency source – otherwise future updates will not be caught.
 						if (
 							is_unowned &&
 							!current_skip_reaction &&
 							!dependency?.reactions?.includes(reaction)
 						) {
-							// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
-							// and the version hasn't changed, we still need to check that this reaction
-							// if linked to the dependency source – otherwise future updates will not be caught.
 							reactions = dependency.reactions;
 							if (reactions === null) {
 								dependency.reactions = [reaction];

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -202,16 +202,15 @@ export function check_dirtiness(reaction) {
 	var flags = reaction.f;
 	var is_dirty = (flags & DIRTY) !== 0;
 	var is_unowned = (flags & UNOWNED) !== 0;
+	var is_disconnected = (flags & DISCONNECTED) !== 0;
 
-	// If we are unowned, we still need to ensure that we update our version to that
+	// If we are unowned or disconnected, we still need to ensure that we update our version to that
 	// of our dependencies.
-	if (is_dirty && !is_unowned) {
+	if (is_dirty && !is_unowned && !is_disconnected) {
 		return true;
 	}
 
-	var is_disconnected = (flags & DISCONNECTED) !== 0;
-
-	if ((flags & MAYBE_DIRTY) !== 0 || (is_dirty && is_unowned)) {
+	if ((flags & MAYBE_DIRTY) !== 0 || (is_dirty && (is_unowned || is_disconnected))) {
 		var dependencies = reaction.deps;
 
 		if (dependencies !== null) {
@@ -247,9 +246,6 @@ export function check_dirtiness(reaction) {
 							reactions.push(reaction);
 						}
 					}
-				} else if ((reaction.f & DIRTY) !== 0) {
-					// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
-					return true;
 				} else if (is_disconnected) {
 					// It might be that the derived was was dereferenced from its dependencies but has now come alive again.
 					// In thise case, we need to re-attach it to the graph and mark it dirty if any of its dependencies have
@@ -264,6 +260,9 @@ export function check_dirtiness(reaction) {
 					} else if (!reactions.includes(reaction)) {
 						reactions.push(reaction);
 					}
+				} else if ((reaction.f & DIRTY) !== 0) {
+					// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
+					return true;
 				}
 			}
 		}
@@ -827,7 +826,7 @@ export function get(signal) {
 			(current_flags & DERIVED) !== 0 &&
 			version > /** @type {import('#client').Derived} */ (current_reaction).version
 		) {
-			// /** @type {import('#client').Derived} */ (current_reaction).version = version;
+			/** @type {import('#client').Derived} */ (current_reaction).version = version;
 		}
 		if ((current_flags & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 && !current_untracking) {
 			const unowned = (current_flags & UNOWNED) !== 0;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -202,16 +202,14 @@ export function check_dirtiness(reaction) {
 	var flags = reaction.f;
 	var is_dirty = (flags & DIRTY) !== 0;
 	var is_unowned = (flags & UNOWNED) !== 0;
+	var is_disconnected = (flags & DISCONNECTED) !== 0;
+	var is_derived = (flags & DERIVED) !== 0;
 
-	// If we are unowned, we still need to ensure that we update our version to that
-	// of our dependencies.
-	if (is_dirty && !is_unowned) {
+	if (is_dirty && !is_derived) {
 		return true;
 	}
 
-	var is_disconnected = (flags & DISCONNECTED) !== 0;
-
-	if ((flags & MAYBE_DIRTY) !== 0 || (is_dirty && is_unowned)) {
+	if (is_dirty || (flags & MAYBE_DIRTY) !== 0) {
 		var dependencies = reaction.deps;
 
 		if (dependencies !== null) {
@@ -227,32 +225,7 @@ export function check_dirtiness(reaction) {
 				}
 				var version = dependency.version;
 
-				if (is_unowned) {
-					// If we're working with an unowned derived signal, then we need to check
-					// if our dependency write version is higher. If it is then we can assume
-					// that state has changed to a newer version and thus this unowned signal
-					// is also dirty.
-
-					if (version > /** @type {import('#client').Derived} */ (reaction).version) {
-						/** @type {import('#client').Derived} */ (reaction).version = version;
-						return !is_equal;
-					}
-
-					if (!current_skip_reaction && !dependency?.reactions?.includes(reaction)) {
-						// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
-						// and the version hasn't changed, we still need to check that this reaction
-						// if linked to the dependency source – otherwise future updates will not be caught.
-						reactions = dependency.reactions;
-						if (reactions === null) {
-							dependency.reactions = [reaction];
-						} else {
-							reactions.push(reaction);
-						}
-					}
-				} else if ((reaction.f & DIRTY) !== 0) {
-					// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
-					return true;
-				} else if (is_disconnected) {
+				if (is_disconnected) {
 					// It might be that the derived was was dereferenced from its dependencies but has now come alive again.
 					// In thise case, we need to re-attach it to the graph and mark it dirty if any of its dependencies have
 					// changed since.
@@ -265,6 +238,39 @@ export function check_dirtiness(reaction) {
 						dependency.reactions = [reaction];
 					} else if (!reactions.includes(reaction)) {
 						reactions.push(reaction);
+					}
+				} else {
+					if (is_derived) {
+						// Ensure we update the version to match that of our reactions, as we might have other dependencies that
+						// rely on this reaction that become disconnected.
+						if (version > /** @type {import('#client').Derived} */ (reaction).version) {
+							/** @type {import('#client').Derived} */ (reaction).version = version;
+							if (is_unowned) {
+								return !is_equal;
+							}
+						}
+						if (
+							is_unowned &&
+							!current_skip_reaction &&
+							!dependency?.reactions?.includes(reaction)
+						) {
+							// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
+							// and the version hasn't changed, we still need to check that this reaction
+							// if linked to the dependency source – otherwise future updates will not be caught.
+							reactions = dependency.reactions;
+							if (reactions === null) {
+								dependency.reactions = [reaction];
+							} else {
+								reactions.push(reaction);
+							}
+						}
+					}
+					if ((reaction.f & DIRTY) !== 0) {
+						// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
+						if (!is_derived) {
+							return true;
+						}
+						is_dirty = true;
 					}
 				}
 			}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -265,8 +265,8 @@ export function check_dirtiness(reaction) {
 							}
 						}
 					}
-					if ((reaction.f & DIRTY) !== 0) {
-						// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
+					// `signal` might now be dirty, as a result of calling `check_dirtiness` and/or `update_derived`
+					if (!is_dirty && (reaction.f & DIRTY) !== 0) {
 						if (!is_derived) {
 							return true;
 						}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -122,6 +122,9 @@ export function set_last_inspected_signal(signal) {
 /** If `true`, `get`ting the signal should not register it as a dependency */
 export let current_untracking = false;
 
+/** @type {number} */
+let current_version = 0;
+
 // If we are working with a get() chain that has no active container,
 // to prevent memory leaks, we skip adding the reaction.
 export let current_skip_reaction = false;
@@ -153,6 +156,10 @@ export let dev_current_component_function = null;
 /** @param {import('#client').ComponentContext['function']} fn */
 export function set_dev_current_component_function(fn) {
 	dev_current_component_function = fn;
+}
+
+export function increment_version() {
+	return current_version++;
 }
 
 /** @returns {boolean} */

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -451,6 +451,7 @@ describe('signals', () => {
 	test('disconnected and reconnected deriveds work as intended', () => {
 		let a: Derived<unknown>;
 		let state = source(0);
+		let state_b = source(0);
 		let log: any[] = [];
 		let b = derived(() => {
 			log.push('b');
@@ -458,6 +459,7 @@ describe('signals', () => {
 		});
 		let c = derived(() => {
 			log.push('c');
+			$.get(state_b);
 			return $.get(b);
 		});
 		let destroy: () => void;
@@ -480,8 +482,14 @@ describe('signals', () => {
 			assert.deepEqual(log, ['a', 'c', 'b']);
 			log.length = 0;
 			destroy();
+			destroy = effect_root(() => {
+				render_effect(() => {
+					$.get(c);
+					set(state_b, 1);
+				});
+			});
+			destroy();
 			set(state, 1);
-			$.set_signal_status(c, DIRTY);
 			assert.equal($.get(c), 1);
 			assert.deepEqual(log, ['c', 'b']);
 			log.length = 0;

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -232,7 +232,7 @@ describe('signals', () => {
 
 			// Ensure we're not leaking dependencies
 			assert.deepEqual(
-				nested.slice(0, -2).map((s) => s.deps),
+				nested.slice(2, -2).map((s) => s.deps),
 				[null, null]
 			);
 		};
@@ -510,19 +510,17 @@ describe('signals', () => {
 			destroy();
 
 			// Check versioning works as expected
+			const version = b.version;
 			assert.equal($.get(b), 3);
-			assert.equal(b.version, 3);
 			assert.equal($.get(c), 3);
-			assert.equal(c.version, 3);
 			assert.equal($.get(a), 3);
-			assert.equal(a.version, 3);
 			set(state, 4);
 			assert.equal($.get(b), 4);
-			assert.equal(b.version, 4);
+			assert.equal(b.version, version + 1);
 			assert.equal($.get(c), 4);
-			assert.equal(c.version, 4);
+			assert.equal(c.version, version + 1);
 			assert.equal($.get(a), 4);
-			assert.equal(a.version, 4);
+			assert.equal(a.version, version + 1);
 			assert.deepEqual(log, ['a', 'b', 'c', 'a']);
 		};
 	});

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -466,6 +466,7 @@ describe('signals', () => {
 			destroy = effect_root(() => {
 				render_effect(() => {
 					a = derived(() => {
+						log.push('a');
 						return $.get(c);
 					});
 					$.get(a);
@@ -476,7 +477,7 @@ describe('signals', () => {
 		return () => {
 			connect();
 			flushSync();
-			assert.deepEqual(log, ['c', 'b']);
+			assert.deepEqual(log, ['a', 'c', 'b']);
 			log.length = 0;
 			destroy();
 			set(state, 1);
@@ -488,7 +489,33 @@ describe('signals', () => {
 			flushSync();
 			set(state, 2);
 			assert.equal($.get(a), 2);
-			assert.deepEqual(log, ['b', 'c']);
+			assert.deepEqual(log, ['a', 'b', 'c', 'a']);
+			log.length = 0;
+			destroy();
+			set(state, 3);
+			assert.deepEqual(log, []);
+			log.length = 0;
+			connect();
+			flushSync();
+			assert.deepEqual(log, ['a', 'b', 'c']);
+			log.length = 0;
+			destroy();
+
+			// Check versioning works as expected
+			assert.equal($.get(b), 3);
+			assert.equal(b.version, 3);
+			assert.equal($.get(c), 3);
+			assert.equal(c.version, 3);
+			assert.equal($.get(a), 3);
+			assert.equal(a.version, 3);
+			set(state, 4);
+			assert.equal($.get(b), 4);
+			assert.equal(b.version, 4);
+			assert.equal($.get(c), 4);
+			assert.equal(c.version, 4);
+			assert.equal($.get(a), 4);
+			assert.equal(a.version, 4);
+			assert.deepEqual(log, ['a', 'b', 'c', 'a']);
 		};
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/11988. This tweaks the versioning logic and how disconnected deriveds are propagated to ensure that deriveds are not updated when they don't need to be.