### PR TITLE
fix: robustify migration script

### DIFF
--- a/packages/svelte/.prettierignore
+++ b/packages/svelte/.prettierignore
@@ -18,5 +18,6 @@ tests/**/_output
 tests/**/shards/*.test.js
 tests/hydration/samples/*/_expected.html
 tests/hydration/samples/*/_override.html
+tests/migrate/samples/*/output.svelte
 types
 compiler/index.js

--- a/packages/svelte/.prettierignore
+++ b/packages/svelte/.prettierignore
@@ -18,6 +18,5 @@ tests/**/_output
 tests/**/shards/*.test.js
 tests/hydration/samples/*/_expected.html
 tests/hydration/samples/*/_override.html
-tests/migrate/samples/*/output.svelte
 types
 compiler/index.js

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -556,7 +556,7 @@ function extract_type(declarator, str, path) {
 	if (parent?.type === 'ExportNamedDeclaration' && parent.leadingComments) {
 		const last = parent.leadingComments[parent.leadingComments.length - 1];
 		if (last.type === 'Block') {
-			const match = /@type {([^}]+)}/.exec(last.value);
+			const match = /@type {(.+)}/.exec(last.value);
 			if (match) {
 				str.update(/** @type {any} */ (last).start, /** @type {any} */ (last).end, '');
 				return match[1];

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -708,14 +708,16 @@ function handle_events(node, state) {
 					}
 
 					const needs_curlies = last.expression.body.type !== 'BlockStatement';
-					state.str.prependRight(
-						/** @type {number} */ (pos) + (needs_curlies ? 0 : 1),
-						`${needs_curlies ? '{' : ''}${prepend}${state.indent}`
-					);
-					state.str.appendRight(
-						/** @type {number} */ (last.expression.body.end) - (needs_curlies ? 0 : 1),
-						`\n${needs_curlies ? '}' : ''}`
-					);
+					const end = /** @type {number} */ (last.expression.body.end) - (needs_curlies ? 0 : 1);
+					pos = /** @type {number} */ (pos) + (needs_curlies ? 0 : 1);
+					if (needs_curlies && state.str.original[pos - 1] === '(') {
+						// Prettier does something like on:click={() => (foo = true)}, we need to remove the braces in this case
+						state.str.update(pos - 1, pos, `{${prepend}${state.indent}`);
+						state.str.update(end, end + 1, '\n}');
+					} else {
+						state.str.prependRight(pos, `${needs_curlies ? '{' : ''}${prepend}${state.indent}`);
+						state.str.appendRight(end, `\n${needs_curlies ? '}' : ''}`);
+					}
 				} else {
 					state.str.update(
 						/** @type {number} */ (last.expression.start),

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -63,7 +63,8 @@ export function migrate(source) {
 
 		if (state.props.length > 0 || analysis.uses_rest_props || analysis.uses_props) {
 			const has_many_props = state.props.length > 3;
-			const props_separator = has_many_props ? `\n${indent}${indent}` : ' ';
+			const newline_separator = `\n${indent}${indent}`;
+			const props_separator = has_many_props ? newline_separator : ' ';
 			let props = '';
 			if (analysis.uses_props) {
 				props = `...${state.props_name}`;
@@ -99,11 +100,12 @@ export function migrate(source) {
 					if (analysis.uses_props || analysis.uses_rest_props) {
 						type = `interface ${type_name} { [key: string]: any }`;
 					} else {
-						type = `interface ${type_name} {${props_separator}${state.props
+						type = `interface ${type_name} {${newline_separator}${state.props
 							.map((prop) => {
-								return `${prop.exported}${prop.optional ? '?' : ''}: ${prop.type}`;
+								const comment = prop.comment ? `${prop.comment}${newline_separator}` : '';
+								return `${comment}${prop.exported}${prop.optional ? '?' : ''}: ${prop.type};`;
 							})
-							.join(`,${props_separator}`)}${has_many_props ? `\n${indent}` : ' '}}`;
+							.join(newline_separator)}\n${indent}}`;
 					}
 				} else {
 					if (analysis.uses_props || analysis.uses_rest_props) {
@@ -162,7 +164,7 @@ export function migrate(source) {
  *  str: MagicString;
  *  analysis: import('../phases/types.js').ComponentAnalysis;
  *  indent: string;
- *  props: Array<{ local: string; exported: string; init: string; bindable: boolean; slot_name?: string; optional: boolean; type: string }>;
+ *  props: Array<{ local: string; exported: string; init: string; bindable: boolean; slot_name?: string; optional: boolean; type: string; comment?: string }>;
  *  props_insertion_point: number;
  *  has_props_rune: boolean;
  * 	props_name: string;
@@ -302,8 +304,8 @@ const instance_script = {
 							)
 						: '',
 					optional: !!declarator.init,
-					type: extract_type(declarator, state.str, path),
-					bindable: binding.mutated || binding.reassigned
+					bindable: binding.mutated || binding.reassigned,
+					...extract_type_and_comment(declarator, state.str, path)
 				});
 				state.props_insertion_point = /** @type {number} */ (declarator.end);
 				state.str.update(
@@ -542,25 +544,34 @@ const template = {
  * @param {MagicString} str
  * @param {import('#compiler').SvelteNode[]} path
  */
-function extract_type(declarator, str, path) {
+function extract_type_and_comment(declarator, str, path) {
+	const parent = path.at(-1);
+
+	// Try to find jsdoc above the declaration
+	let comment_node = /** @type {import('estree').Node} */ (parent)?.leadingComments?.at(-1);
+	if (comment_node?.type !== 'Block') comment_node = undefined;
+
+	const comment_start = /** @type {any} */ (comment_node)?.start;
+	const comment_end = /** @type {any} */ (comment_node)?.end;
+	const comment = comment_node && str.original.substring(comment_start, comment_end);
+
+	if (comment_node) {
+		str.update(comment_start, comment_end, '');
+	}
+
 	if (declarator.id.typeAnnotation) {
 		let start = declarator.id.typeAnnotation.start + 1; // skip the colon
 		while (str.original[start] === ' ') {
 			start++;
 		}
-		return str.original.substring(start, declarator.id.typeAnnotation.end);
+		return { type: str.original.substring(start, declarator.id.typeAnnotation.end), comment };
 	}
 
 	// try to find a comment with a type annotation, hinting at jsdoc
-	const parent = path.at(-1);
-	if (parent?.type === 'ExportNamedDeclaration' && parent.leadingComments) {
-		const last = parent.leadingComments[parent.leadingComments.length - 1];
-		if (last.type === 'Block') {
-			const match = /@type {(.+)}/.exec(last.value);
-			if (match) {
-				str.update(/** @type {any} */ (last).start, /** @type {any} */ (last).end, '');
-				return match[1];
-			}
+	if (parent?.type === 'ExportNamedDeclaration' && comment_node) {
+		const match = /@type {(.+)}/.exec(comment_node.value);
+		if (match) {
+			return { type: match[1] };
 		}
 	}
 
@@ -568,11 +579,11 @@ function extract_type(declarator, str, path) {
 	if (declarator.init?.type === 'Literal') {
 		const type = typeof declarator.init.value;
 		if (type === 'string' || type === 'number' || type === 'boolean') {
-			return type;
+			return { type, comment };
 		}
 	}
 
-	return 'any';
+	return { type: 'any', comment };
 }
 
 /**

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -193,6 +193,9 @@ const instance_script = {
 	Identifier(node, { state }) {
 		handle_identifier(node, state);
 	},
+	ImportDeclaration(node, { state }) {
+		state.props_insertion_point = node.end ?? state.props_insertion_point;
+	},
 	ExportNamedDeclaration(node, { state, next }) {
 		if (node.declaration) {
 			next();

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -554,7 +554,8 @@ export function analyze_component(root, source, options) {
 	}
 
 	if (analysis.uses_render_tags && (analysis.uses_slots || analysis.slot_names.size > 0)) {
-		e.slot_snippet_conflict(analysis.slot_names.values().next().value);
+		const pos = analysis.slot_names.values().next().value ?? analysis.source.indexOf('$$slot');
+		e.slot_snippet_conflict(pos);
 	}
 
 	if (analysis.css.ast) {

--- a/packages/svelte/tests/migrate/samples/event-handlers/input.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/input.svelte
@@ -1,5 +1,7 @@
 <button on:click={() => console.log('hi')} on:click>click me</button>
-<button on:click={() => console.log('before')} on:click on:click={() => console.log('after')}>click me</button>
+<button on:click={() => console.log('before')} on:click on:click={() => console.log('after')}
+	>click me</button
+>
 <button on:click on:click={foo}>click me</button>
 <button on:click>click me</button>
 
@@ -9,6 +11,7 @@
 <button on:custom-event-bubble>click me</button>
 
 <button on:click|preventDefault={() => ''}>click me</button>
+<button on:click|preventDefault={() => (searching = true)}>click me</button>
 <button on:click|stopPropagation={() => {}}>click me</button>
 <button on:click|stopImmediatePropagation={() => ''}>click me</button>
 <button on:click|capture={() => ''}>click me</button>

--- a/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
@@ -13,7 +13,9 @@
 
 	onclick?.(event);
 	console.log('after')
-}}>click me</button>
+}}
+	>click me</button
+>
 <button  onclick={(event) => {
 	onclick?.(event);
 
@@ -29,6 +31,10 @@
 <button onclick={(event) => {
 	event.preventDefault();
 	''
+}}>click me</button>
+<button onclick={(event) => {
+	event.preventDefault();
+	searching = true
 }}>click me</button>
 <button onclick={(event) => {
 	event.stopPropagation();

--- a/packages/svelte/tests/migrate/samples/props-export-alias/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-export-alias/output.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	interface Props { class?: string }
+	interface Props {
+		class?: string;
+	}
 
 	let { class: klass = '' }: Props = $props();
 	

--- a/packages/svelte/tests/migrate/samples/props-ts/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/input.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-    export let readonly: number;
-    export let optional = 'foo';
-    export let binding: string;
-    export let bindingOptional: string | undefined = 'bar';
+	/** some comment */
+	export let readonly: number;
+	export let optional = 'foo';
+	export let binding: string;
+	export let bindingOptional: string | undefined = 'bar';
 </script>
 
 {readonly}

--- a/packages/svelte/tests/migrate/samples/props-ts/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/output.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
-    interface Props {
-        readonly: number,
-        optional?: string,
-        binding: string,
-        bindingOptional?: string | undefined
-    }
+	
+	interface Props {
+		/** some comment */
+		readonly: number;
+		optional?: string;
+		binding: string;
+		bindingOptional?: string | undefined;
+	}
 
-    let {
-        readonly,
-        optional = 'foo',
-        binding = $bindable(),
-        bindingOptional = $bindable('bar')
-    }: Props = $props();
+	let {
+		readonly,
+		optional = 'foo',
+		binding = $bindable(),
+		bindingOptional = $bindable('bar')
+	}: Props = $props();
 </script>
 
 {readonly}

--- a/packages/svelte/tests/migrate/samples/props/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props/input.svelte
@@ -1,8 +1,9 @@
 <script>
-    export let readonly;
-    export let optional = 'foo';
-    export let binding;
-    export let bindingOptional = 'bar';
+	/** @type {Record<string, { href: string; title: string; }[]>} */
+	export let readonly;
+	export let optional = 'foo';
+	export let binding;
+	export let bindingOptional = 'bar';
 </script>
 
 {readonly}

--- a/packages/svelte/tests/migrate/samples/props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props/output.svelte
@@ -1,11 +1,12 @@
 <script>
-    /** @type {{readonly: any, optional?: string, binding: any, bindingOptional?: string}} */
-    let {
-        readonly,
-        optional = 'foo',
-        binding = $bindable(),
-        bindingOptional = $bindable('bar')
-    } = $props();
+	
+	/** @type {{readonly: Record<string, { href: string; title: string; }[]>, optional?: string, binding: any, bindingOptional?: string}} */
+	let {
+		readonly,
+		optional = 'foo',
+		binding = $bindable(),
+		bindingOptional = $bindable('bar')
+	} = $props();
 </script>
 
 {readonly}

--- a/packages/svelte/tests/migrate/samples/slots-below-imports/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-below-imports/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Foo from './Foo.svelte';
+</script>
+
+<slot />
+<Foo />

--- a/packages/svelte/tests/migrate/samples/slots-below-imports/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-below-imports/output.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Foo from './Foo.svelte';
+	/** @type {{children?: import('svelte').Snippet}} */
+	let { children } = $props();
+</script>
+
+{@render children?.()}
+<Foo />

--- a/packages/svelte/tests/migrate/samples/slots-multiple/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-multiple/input.svelte
@@ -1,0 +1,5 @@
+<button><slot /></button>
+<button><slot /></button>
+
+<slot name="dashed-name" />
+<slot name="dashed-name" />

--- a/packages/svelte/tests/migrate/samples/slots-multiple/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-multiple/output.svelte
@@ -1,0 +1,10 @@
+<script>
+	/** @type {{children?: import('svelte').Snippet, dashed_name?: import('svelte').Snippet}} */
+	let { children, dashed_name } = $props();
+</script>
+
+<button>{@render children?.()}</button>
+<button>{@render children?.()}</button>
+
+{@render dashed_name?.()}
+{@render dashed_name?.()}

--- a/packages/svelte/tests/migrate/samples/slots/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/input.svelte
@@ -4,4 +4,9 @@
 	<slot name="foo" {foo} />
 {/if}
 
+{#if $$slots.bar}
+	{$$slots}
+	<slot name="bar" />
+{/if}
+
 <slot name="dashed-name" />

--- a/packages/svelte/tests/migrate/samples/slots/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/output.svelte
@@ -1,12 +1,22 @@
 <script>
-	/** @type {{children?: import('svelte').Snippet, foo_1?: import('svelte').Snippet<[any]>, dashed_name?: import('svelte').Snippet}} */
-	let { children, foo_1, dashed_name } = $props();
+	/** @type {{children?: import('svelte').Snippet, foo_1?: import('svelte').Snippet<[any]>, bar?: import('svelte').Snippet, dashed_name?: import('svelte').Snippet}} */
+	let {
+		children,
+		foo_1,
+		bar,
+		dashed_name
+	} = $props();
 </script>
 
 <button>{@render children?.()}</button>
 
 {#if foo}
 	{@render foo_1?.({ foo, })}
+{/if}
+
+{#if bar}
+	{$$slots}
+	{@render bar?.()}
 {/if}
 
 {@render dashed_name?.()}


### PR DESCRIPTION
- handle multiple slots of same kind correctly
- put props below imports
- migrate $$slots, better error position for slot-children-conflict error
- handle event braces+modifier case
- migrate jsdoc type with curly braces correctly
- handle comments above types, fixes #11508

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
