### PR TITLE
chore: bring back prettierignore root config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,47 @@
 # Temporarily ignore this file to avoid merge conflicts.
 # see: https://github.com/sveltejs/svelte/pull/9609
 documentation/docs/05-misc/03-typescript.md
+
+# The following are all duplicated with prettierignore configs in the packages,
+# which is necessary because of https://github.com/prettier/prettier-vscode/issues/3424
+packages/**/dist/*.js
+packages/**/build/*.js
+packages/**/npm/**/*
+packages/**/config/*.js
+packages/svelte/messages/**/*.md
+packages/svelte/src/compiler/errors.js
+packages/svelte/src/compiler/warnings.js
+packages/svelte/src/internal/client/errors.js
+packages/svelte/src/internal/client/warnings.js
+packages/svelte/src/internal/shared/errors.js
+packages/svelte/src/internal/shared/warnings.js
+packages/svelte/src/internal/server/errors.js
+packages/svelte/tests/migrate/samples/*/output.svelte
+packages/svelte/tests/**/_expected*
+packages/svelte/tests/**/_actual*
+packages/svelte/tests/**/expected*
+packages/svelte/tests/**/_output
+packages/svelte/tests/**/shards/*.test.js
+packages/svelte/tests/hydration/samples/*/_expected.html
+packages/svelte/tests/hydration/samples/*/_override.html
+packages/svelte/types
+packages/svelte/compiler/index.js
+playgrounds/sandbox/input/**.svelte
+playgrounds/sandbox/output
+
+sites/svelte.dev/static/svelte-app.json
+sites/svelte.dev/scripts/svelte-app/
+sites/svelte.dev/src/routes/_components/Supporters/contributors.jpg
+sites/svelte.dev/src/routes/_components/Supporters/contributors.js
+sites/svelte.dev/src/routes/_components/Supporters/donors.jpg
+sites/svelte.dev/src/routes/_components/Supporters/donors.js
+sites/svelte.dev/src/lib/generated
+
+**/node_modules
+**/.svelte-kit
+**/.vercel
+.github/CODEOWNERS
+.prettierignore
+.changeset
+pnpm-lock.yaml
+pnpm-workspace.yaml


### PR DESCRIPTION
It was wrongfully cut down in #11508 - sadly we need to duplicate the config because of a prettier VS Code bug which does not pick up the nearest prettier config. This change results in the proper files getting ignored when touching them with the editor
