### PR TITLE
fix: relax constraint for ComponentProps

### DIFF
--- a/.changeset/clean-melons-wash.md
+++ b/.changeset/clean-melons-wash.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: relax constraint for `ComponentProps`

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -198,7 +198,7 @@ export type ComponentEvents<Comp extends SvelteComponent> =
  * </script>
  * ```
  */
-export type ComponentProps<Comp extends SvelteComponent | Component> =
+export type ComponentProps<Comp extends SvelteComponent | Component<any>> =
 	Comp extends SvelteComponent<infer Props>
 		? Props
 		: Comp extends Component<infer Props>

--- a/packages/svelte/tests/types/component.ts
+++ b/packages/svelte/tests/types/component.ts
@@ -231,6 +231,13 @@ functionComponentInstance.foo === 'bar';
 // @ts-expect-error
 functionComponentInstance.foo = 'foo';
 
+const functionComponentProps: ComponentProps<typeof functionComponent> = {
+	binding: true,
+	readonly: 'foo',
+	// @ts-expect-error
+	prop: 1
+};
+
 mount(functionComponent, {
 	target: null as any as Document | Element | ShadowRoot,
 	props: {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -195,7 +195,7 @@ declare module 'svelte' {
 	 * </script>
 	 * ```
 	 */
-	export type ComponentProps<Comp extends SvelteComponent | Component> =
+	export type ComponentProps<Comp extends SvelteComponent | Component<any>> =
 		Comp extends SvelteComponent<infer Props>
 			? Props
 			: Comp extends Component<infer Props>


### PR DESCRIPTION
`Component` with any props should be allowed to pass in

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
