### PR TITLE
chore: relax types of (svelte/events).on

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -35,15 +35,14 @@ export function replay_events(dom) {
  * @param {string} event_name
  * @param {Element} dom
  * @param {EventListener} handler
- * @param {AddEventListenerOptions | boolean} options
+ * @param {AddEventListenerOptions} options
  */
 export function create_event(event_name, dom, handler, options) {
-	const capture = typeof options === 'boolean' ? options : options.capture;
 	/**
 	 * @this {EventTarget}
 	 */
 	function target_handler(/** @type {Event} */ event) {
-		if (!capture) {
+		if (!options.capture) {
 			// Only call in the bubble phase, else delegated events would be called before the capturing events
 			handle_event_propagation(dom, event);
 		}
@@ -80,7 +79,11 @@ export function create_event(event_name, dom, handler, options) {
  * @returns {() => void}
  */
 export function on(element, type, handler, options = {}) {
-	var target_handler = create_event(type, element, handler, options);
+	const resolved_options = typeof options === 'boolean'
+		? { capture: options }
+		: options;
+
+	var target_handler = create_event(type, element, handler, resolved_options);
 
 	return () => {
 		element.removeEventListener(type, target_handler, options);

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -71,10 +71,12 @@ export function create_event(event_name, dom, handler, options) {
  * rather than `addEventListener` will preserve the correct order relative to handlers added declaratively
  * (with attributes like `onclick`), which use event delegation for performance reasons
  *
+ * @template {keyof ElementEventMap} K
  * @param {Element} element
- * @param {string} type
- * @param {EventListener} handler
+ * @param {K} type
+ * @param {(this: Element, ev: ElementEventMap[K]) => any} handler
  * @param {AddEventListenerOptions} [options]
+ * @returns {() => void}
  */
 export function on(element, type, handler, options = {}) {
 	var target_handler = create_event(type, element, handler, options);

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -35,14 +35,15 @@ export function replay_events(dom) {
  * @param {string} event_name
  * @param {Element} dom
  * @param {EventListener} handler
- * @param {AddEventListenerOptions} options
+ * @param {AddEventListenerOptions | boolean} options
  */
 export function create_event(event_name, dom, handler, options) {
+	const capture = typeof options === 'boolean' ? options : options.capture;
 	/**
 	 * @this {EventTarget}
 	 */
 	function target_handler(/** @type {Event} */ event) {
-		if (!options.capture) {
+		if (!capture) {
 			// Only call in the bubble phase, else delegated events would be called before the capturing events
 			handle_event_propagation(dom, event);
 		}
@@ -75,7 +76,7 @@ export function create_event(event_name, dom, handler, options) {
  * @param {Element} element
  * @param {K} type
  * @param {(this: Element, ev: ElementEventMap[K]) => any} handler
- * @param {AddEventListenerOptions} [options]
+ * @param {AddEventListenerOptions | boolean} [options]
  * @returns {() => void}
  */
 export function on(element, type, handler, options = {}) {

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -71,10 +71,13 @@ export function create_event(event_name, dom, handler, options) {
  * rather than `addEventListener` will preserve the correct order relative to handlers added declaratively
  * (with attributes like `onclick`), which use event delegation for performance reasons
  *
- * @template {keyof ElementEventMap} K
- * @param {Element} element
- * @param {K} type
- * @param {(this: Element, ev: ElementEventMap[K]) => any} handler
+ * @template {EventTarget} El
+ * @template {import('#client').AddEventListenerParams<El['addEventListener']>} P
+ * @template {P['type']} T
+ * @template {P['event']} E
+ * @param {El} element
+ * @param {T} type
+ * @param {(this: El, ev: E) => void} handler
  * @param {AddEventListenerOptions | boolean} [options]
  * @returns {() => void}
  */
@@ -83,7 +86,7 @@ export function on(element, type, handler, options = {}) {
 		? { capture: options }
 		: options;
 
-	var target_handler = create_event(type, element, handler, resolved_options);
+	var target_handler = create_event(type, /** @type {any} */(element), /** @type {EventListener} */(handler), resolved_options);
 
 	return () => {
 		element.removeEventListener(type, target_handler, options);

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -78,15 +78,11 @@ export function create_event(event_name, dom, handler, options) {
  * @param {El} element
  * @param {T} type
  * @param {(this: El, ev: E) => void} handler
- * @param {AddEventListenerOptions | boolean} [options]
+ * @param {AddEventListenerOptions} [options]
  * @returns {() => void}
  */
 export function on(element, type, handler, options = {}) {
-	const resolved_options = typeof options === 'boolean'
-		? { capture: options }
-		: options;
-
-	var target_handler = create_event(type, /** @type {any} */(element), /** @type {EventListener} */(handler), resolved_options);
+	var target_handler = create_event(type, /** @type {any} */(element), /** @type {EventListener} */(handler), options);
 
 	return () => {
 		element.removeEventListener(type, target_handler, options);

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -5,6 +5,20 @@ import type { Effect, Source, Value } from './reactivity/types.js';
 type EventCallback = (event: Event) => boolean;
 export type EventCallbackMap = Record<string, EventCallback | EventCallback[]>;
 
+/**
+ * utility for typing the `on` function in svelte/events.
+ * Essentially this mirror `.addEventListener` type from upstream typescript to
+ * allow extracting the applicable event types from the more-specific function signature
+ */
+export type AddEventListenerParams<AddEventListenerFn> = AddEventListenerFn extends {
+	(type: infer EventType, listener: (this: infer EventTarget, ev: infer Event) => void, options?: boolean | AddEventListenerOptions): void;
+	(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+} ? {
+	target: EventTarget;
+	type: EventType;
+	event: Event;
+} : never;
+
 // For all the core internal objects, we use single-character property strings.
 // This not only reduces code-size and parsing, but it also improves the performance
 // when the JS VM JITs the code.


### PR DESCRIPTION
will help with #12027. Additionally, this PR relaxes type of the `options` parameter passed to `on` (and `create_event`) to allow boolean, to better match [addEventListener API](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener), reducing friction for folks migrating to Svelte 5.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
