### PR TITLE
fix: correct start of `{:else if}` and `{:else}`

### DIFF
--- a/.changeset/cold-teachers-turn.md
+++ b/.changeset/cold-teachers-turn.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: correct start of `{:else if}` and `{:else}`

--- a/packages/svelte/src/compiler/legacy.js
+++ b/packages/svelte/src/compiler/legacy.js
@@ -353,11 +353,12 @@ export function convert(source, ast) {
 					};
 				}
 
+				const start = node.elseif ? node.consequent.nodes[0].start : node.start;
 				remove_surrounding_whitespace_nodes(node.consequent.nodes);
 
 				return {
 					type: 'IfBlock',
-					start: node.elseif ? node.consequent.nodes[0].start : node.start,
+					start,
 					end: node.end,
 					expression: node.test,
 					children: node.consequent.nodes.map(

--- a/packages/svelte/src/compiler/legacy.js
+++ b/packages/svelte/src/compiler/legacy.js
@@ -357,7 +357,7 @@ export function convert(source, ast) {
 
 				return {
 					type: 'IfBlock',
-					start: node.start,
+					start: node.elseif ? node.consequent.nodes[0].start : node.start,
 					end: node.end,
 					expression: node.test,
 					children: node.consequent.nodes.map(

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -319,13 +319,13 @@ function open(parser) {
 
 /** @param {import('../index.js').Parser} parser */
 function next(parser) {
-	const next_to_bracket = parser.index - 1;
+	const start = parser.index - 1;
 
 	const block = parser.current(); // TODO type should not be TemplateNode, that's much too broad
 
 	if (block.type === 'IfBlock') {
-		if (!parser.eat('else')) e.expected_token(next_to_bracket, '{:else} or {:else if}');
-		if (parser.eat('if')) e.block_invalid_elseif(next_to_bracket);
+		if (!parser.eat('else')) e.expected_token(start, '{:else} or {:else if}');
+		if (parser.eat('if')) e.block_invalid_elseif(start);
 
 		parser.allow_whitespace();
 
@@ -345,7 +345,7 @@ function next(parser) {
 
 			/** @type {ReturnType<typeof parser.append<import('#compiler').IfBlock>>} */
 			const child = parser.append({
-				start: next_to_bracket - 1,
+				start: start - 1,
 				end: -1,
 				type: 'IfBlock',
 				elseif: true,
@@ -367,7 +367,7 @@ function next(parser) {
 	}
 
 	if (block.type === 'EachBlock') {
-		if (!parser.eat('else')) e.expected_token(next_to_bracket, '{:else}');
+		if (!parser.eat('else')) e.expected_token(start, '{:else}');
 
 		parser.allow_whitespace();
 		parser.eat('}', true);
@@ -383,7 +383,7 @@ function next(parser) {
 	if (block.type === 'AwaitBlock') {
 		if (parser.eat('then')) {
 			if (block.then) {
-				e.block_duplicate_clause(next_to_bracket, '{:then}');
+				e.block_duplicate_clause(start, '{:then}');
 			}
 
 			if (!parser.eat('}')) {
@@ -402,7 +402,7 @@ function next(parser) {
 
 		if (parser.eat('catch')) {
 			if (block.catch) {
-				e.block_duplicate_clause(next_to_bracket, '{:catch}');
+				e.block_duplicate_clause(start, '{:catch}');
 			}
 
 			if (!parser.eat('}')) {
@@ -419,10 +419,10 @@ function next(parser) {
 			return;
 		}
 
-		e.expected_token(next_to_bracket, '{:then ...} or {:catch ...}');
+		e.expected_token(start, '{:then ...} or {:catch ...}');
 	}
 
-	e.block_invalid_continuation_placement(next_to_bracket);
+	e.block_invalid_continuation_placement(start);
 }
 
 /** @param {import('../index.js').Parser} parser */

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -319,13 +319,13 @@ function open(parser) {
 
 /** @param {import('../index.js').Parser} parser */
 function next(parser) {
-	const start = parser.index - 1;
+	const next_to_bracket = parser.index - 1;
 
 	const block = parser.current(); // TODO type should not be TemplateNode, that's much too broad
 
 	if (block.type === 'IfBlock') {
-		if (!parser.eat('else')) e.expected_token(start, '{:else} or {:else if}');
-		if (parser.eat('if')) e.block_invalid_elseif(start);
+		if (!parser.eat('else')) e.expected_token(next_to_bracket, '{:else} or {:else if}');
+		if (parser.eat('if')) e.block_invalid_elseif(next_to_bracket);
 
 		parser.allow_whitespace();
 
@@ -345,7 +345,7 @@ function next(parser) {
 
 			/** @type {ReturnType<typeof parser.append<import('#compiler').IfBlock>>} */
 			const child = parser.append({
-				start: parser.index,
+				start: next_to_bracket - 1,
 				end: -1,
 				type: 'IfBlock',
 				elseif: true,
@@ -367,7 +367,7 @@ function next(parser) {
 	}
 
 	if (block.type === 'EachBlock') {
-		if (!parser.eat('else')) e.expected_token(start, '{:else}');
+		if (!parser.eat('else')) e.expected_token(next_to_bracket, '{:else}');
 
 		parser.allow_whitespace();
 		parser.eat('}', true);
@@ -383,7 +383,7 @@ function next(parser) {
 	if (block.type === 'AwaitBlock') {
 		if (parser.eat('then')) {
 			if (block.then) {
-				e.block_duplicate_clause(start, '{:then}');
+				e.block_duplicate_clause(next_to_bracket, '{:then}');
 			}
 
 			if (!parser.eat('}')) {
@@ -402,7 +402,7 @@ function next(parser) {
 
 		if (parser.eat('catch')) {
 			if (block.catch) {
-				e.block_duplicate_clause(start, '{:catch}');
+				e.block_duplicate_clause(next_to_bracket, '{:catch}');
 			}
 
 			if (!parser.eat('}')) {
@@ -419,10 +419,10 @@ function next(parser) {
 			return;
 		}
 
-		e.expected_token(start, '{:then ...} or {:catch ...}');
+		e.expected_token(next_to_bracket, '{:then ...} or {:catch ...}');
 	}
 
-	e.block_invalid_continuation_placement(start);
+	e.block_invalid_continuation_placement(next_to_bracket);
 }
 
 /** @param {import('../index.js').Parser} parser */

--- a/packages/svelte/tests/parser-legacy/samples/if-block-elseif/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/if-block-elseif/output.json
@@ -82,7 +82,7 @@
 					"children": [
 						{
 							"type": "IfBlock",
-							"start": 58,
+							"start": 42,
 							"end": 89,
 							"expression": {
 								"type": "BinaryExpression",

--- a/packages/svelte/tests/parser-legacy/samples/if-block-elseif/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/if-block-elseif/output.json
@@ -82,7 +82,7 @@
 					"children": [
 						{
 							"type": "IfBlock",
-							"start": 42,
+							"start": 60,
 							"end": 89,
 							"expression": {
 								"type": "BinaryExpression",

--- a/packages/svelte/tests/parser-legacy/samples/if-block-elseif/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/if-block-elseif/output.json
@@ -82,7 +82,7 @@
 					"children": [
 						{
 							"type": "IfBlock",
-							"start": 60,
+							"start": 58,
 							"end": 89,
 							"expression": {
 								"type": "BinaryExpression",

--- a/packages/svelte/tests/parser-modern/samples/if-block-else/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/if-block-else/input.svelte
@@ -1,0 +1,5 @@
+{#if foo}
+	<p>foo</p>
+{:else}
+	<p>not foo</p>
+{/if}

--- a/packages/svelte/tests/parser-modern/samples/if-block-else/output.json
+++ b/packages/svelte/tests/parser-modern/samples/if-block-else/output.json
@@ -1,0 +1,116 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 51,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 0,
+				"end": 51,
+				"test": {
+					"type": "Identifier",
+					"start": 5,
+					"end": 8,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 5
+						},
+						"end": {
+							"line": 1,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 9,
+							"end": 11,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "RegularElement",
+							"start": 11,
+							"end": 21,
+							"name": "p",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 14,
+										"end": 17,
+										"raw": "foo",
+										"data": "foo"
+									}
+								],
+								"transparent": true
+							}
+						},
+						{
+							"type": "Text",
+							"start": 21,
+							"end": 22,
+							"raw": "\n",
+							"data": "\n"
+						}
+					],
+					"transparent": false
+				},
+				"alternate": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 29,
+							"end": 31,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "RegularElement",
+							"start": 31,
+							"end": 45,
+							"name": "p",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 34,
+										"end": 41,
+										"raw": "not foo",
+										"data": "not foo"
+									}
+								],
+								"transparent": true
+							}
+						},
+						{
+							"type": "Text",
+							"start": 45,
+							"end": 46,
+							"raw": "\n",
+							"data": "\n"
+						}
+					],
+					"transparent": false
+				}
+			}
+		],
+		"transparent": false
+	},
+	"options": null
+}

--- a/packages/svelte/tests/parser-modern/samples/if-block-elseif/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/if-block-elseif/input.svelte
@@ -1,0 +1,5 @@
+{#if x > 10}
+	<p>x is greater than 10</p>
+{:else if x < 5}
+	<p>x is less than 5</p>
+{/if}

--- a/packages/svelte/tests/parser-modern/samples/if-block-elseif/output.json
+++ b/packages/svelte/tests/parser-modern/samples/if-block-elseif/output.json
@@ -1,0 +1,211 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 89,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 0,
+				"end": 89,
+				"test": {
+					"type": "BinaryExpression",
+					"start": 5,
+					"end": 11,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 5
+						},
+						"end": {
+							"line": 1,
+							"column": 11
+						}
+					},
+					"left": {
+						"type": "Identifier",
+						"start": 5,
+						"end": 6,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 5
+							},
+							"end": {
+								"line": 1,
+								"column": 6
+							}
+						},
+						"name": "x"
+					},
+					"operator": ">",
+					"right": {
+						"type": "Literal",
+						"start": 9,
+						"end": 11,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 9
+							},
+							"end": {
+								"line": 1,
+								"column": 11
+							}
+						},
+						"value": 10,
+						"raw": "10"
+					}
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 12,
+							"end": 14,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "RegularElement",
+							"start": 14,
+							"end": 41,
+							"name": "p",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 17,
+										"end": 37,
+										"raw": "x is greater than 10",
+										"data": "x is greater than 10"
+									}
+								],
+								"transparent": true
+							}
+						},
+						{
+							"type": "Text",
+							"start": 41,
+							"end": 42,
+							"raw": "\n",
+							"data": "\n"
+						}
+					],
+					"transparent": false
+				},
+				"alternate": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"start": 42,
+							"end": 89,
+							"type": "IfBlock",
+							"elseif": true,
+							"test": {
+								"type": "BinaryExpression",
+								"start": 52,
+								"end": 57,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 10
+									},
+									"end": {
+										"line": 3,
+										"column": 15
+									}
+								},
+								"left": {
+									"type": "Identifier",
+									"start": 52,
+									"end": 53,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 10
+										},
+										"end": {
+											"line": 3,
+											"column": 11
+										}
+									},
+									"name": "x"
+								},
+								"operator": "<",
+								"right": {
+									"type": "Literal",
+									"start": 56,
+									"end": 57,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 14
+										},
+										"end": {
+											"line": 3,
+											"column": 15
+										}
+									},
+									"value": 5,
+									"raw": "5"
+								}
+							},
+							"consequent": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 58,
+										"end": 60,
+										"raw": "\n\t",
+										"data": "\n\t"
+									},
+									{
+										"type": "RegularElement",
+										"start": 60,
+										"end": 83,
+										"name": "p",
+										"attributes": [],
+										"fragment": {
+											"type": "Fragment",
+											"nodes": [
+												{
+													"type": "Text",
+													"start": 63,
+													"end": 79,
+													"raw": "x is less than 5",
+													"data": "x is less than 5"
+												}
+											],
+											"transparent": true
+										}
+									},
+									{
+										"type": "Text",
+										"start": 83,
+										"end": 84,
+										"raw": "\n",
+										"data": "\n"
+									}
+								],
+								"transparent": false
+							},
+							"alternate": null
+						}
+					],
+					"transparent": false
+				}
+			}
+		],
+		"transparent": false
+	},
+	"options": null
+}

--- a/packages/svelte/tests/parser-modern/samples/if-block/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/if-block/input.svelte
@@ -1,0 +1,1 @@
+{#if foo}bar{/if}

--- a/packages/svelte/tests/parser-modern/samples/if-block/output.json
+++ b/packages/svelte/tests/parser-modern/samples/if-block/output.json
@@ -1,0 +1,50 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 17,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 0,
+				"end": 17,
+				"test": {
+					"type": "Identifier",
+					"start": 5,
+					"end": 8,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 5
+						},
+						"end": {
+							"line": 1,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 9,
+							"end": 12,
+							"raw": "bar",
+							"data": "bar"
+						}
+					],
+					"transparent": false
+				},
+				"alternate": null
+			}
+		],
+		"transparent": false
+	},
+	"options": null
+}


### PR DESCRIPTION
## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Currently, the AST node for `{:else if}` and `{:else}` has its start pointing to the start of the body. However, it should point to the start of the block. 

<img width="933" alt="image" src="https://github.com/sveltejs/svelte/assets/19153718/d58eb78d-4a9c-4643-90d2-aa611508fcd8">

https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAE2WQu27DMAxFf4VQl7h1amd1HkDHDl2KbnUHQaYTAhJlSFSQwvC_FzKcPtJBD-rcyytpVD1ZjKp5HxVrh6pRT8OgSiWfQy7iGa2gKlX0KZh8sosm0CCHllvpExshz3BEedXceffMsnLEJTh9KWDMIgBHDHt40XJ6NEg2C4rtgvTlinrrfVhl38ICSgr8G87bMAetCriHrIZ17l_Aw7xsoareTpj7kksOKAJejE2RzgiaO5AMia-QeIE5cspTHsZzFDA-scD-7-PWm7qETT3fkXfVz2fweEf94jlAPfca53LKQceAWjCAnDRD3fLYoI0I35bdf4vFGG_0t5IMKuqnllWpnO-oJ-xUIyHh9DF9AVb2PN_dAQAA

With the PR, AST will be like this.

<img width="843" alt="image" src="https://github.com/sveltejs/svelte/assets/19153718/0b149050-594f-4553-b631-634dfaa6c9bb">


