### PR TITLE
fix: increment derived versions when updating

### DIFF
--- a/.changeset/brave-pigs-obey.md
+++ b/.changeset/brave-pigs-obey.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: increment derived versions when updating

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -8,7 +8,8 @@ import {
 	mark_reactions,
 	current_skip_reaction,
 	execute_reaction_fn,
-	destroy_effect_children
+	destroy_effect_children,
+	increment_version
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 
@@ -104,6 +105,7 @@ export function update_derived(derived, force_schedule) {
 	var is_equal = derived.equals(value);
 
 	if (!is_equal) {
+		derived.version = increment_version();
 		derived.v = value;
 		mark_reactions(derived, DIRTY, force_schedule);
 

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -8,7 +8,7 @@ import {
 import { get_descriptor, is_function } from '../utils.js';
 import { mutable_source, set, source } from './sources.js';
 import { derived, derived_safe_equal } from './deriveds.js';
-import { get, increment_version, is_signals_recorded, untrack, update } from '../runtime.js';
+import { get, is_signals_recorded, untrack, update } from '../runtime.js';
 import { safe_equals } from './equality.js';
 import { inspect_fn } from '../dev/inspect.js';
 import * as e from '../errors.js';
@@ -323,8 +323,6 @@ export function prop(props, key, flags, fallback) {
 				from_child = true;
 				set(inner_current_value, value);
 				get(current_value); // force a synchronisation immediately
-				// Increment the value so that unowned/disconnected nodes can validate dirtiness again.
-				current_value.version = increment_version();
 			}
 
 			return value;

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -8,7 +8,7 @@ import {
 import { get_descriptor, is_function } from '../utils.js';
 import { mutable_source, set, source } from './sources.js';
 import { derived, derived_safe_equal } from './deriveds.js';
-import { get, is_signals_recorded, untrack, update } from '../runtime.js';
+import { get, increment_version, is_signals_recorded, untrack, update } from '../runtime.js';
 import { safe_equals } from './equality.js';
 import { inspect_fn } from '../dev/inspect.js';
 import * as e from '../errors.js';
@@ -324,7 +324,7 @@ export function prop(props, key, flags, fallback) {
 				set(inner_current_value, value);
 				get(current_value); // force a synchronisation immediately
 				// Increment the value so that unowned/disconnected nodes can validate dirtiness again.
-				current_value.version++;
+				current_value.version = increment_version();
 			}
 
 			return value;

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -14,7 +14,8 @@ import {
 	set_current_untracked_writes,
 	set_last_inspected_signal,
 	set_signal_status,
-	untrack
+	untrack,
+	increment_version
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import { CLEAN, DERIVED, DIRTY, BRANCH_EFFECT } from '../constants.js';
@@ -99,7 +100,7 @@ export function set(signal, value) {
 		signal.v = value;
 
 		// Increment write version so that unowned signals can properly track dirtiness
-		signal.version++;
+		signal.version = increment_version();
 
 		// If the current signal is running for the first time, it won't have any
 		// reactions as we only allocate and assign the reactions after the signal

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -241,7 +241,6 @@ export function check_dirtiness(reaction) {
 					// is also dirty.
 
 					if (version > /** @type {import('#client').Derived} */ (reaction).version) {
-						/** @type {import('#client').Derived} */ (reaction).version = increment_version();
 						return !is_equal;
 					}
 
@@ -264,7 +263,6 @@ export function check_dirtiness(reaction) {
 					// In thise case, we need to re-attach it to the graph and mark it dirty if any of its dependencies have
 					// changed since.
 					if (version > /** @type {import('#client').Derived} */ (reaction).version) {
-						/** @type {import('#client').Derived} */ (reaction).version = increment_version();
 						is_dirty = true;
 					}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -122,6 +122,9 @@ export function set_last_inspected_signal(signal) {
 /** If `true`, `get`ting the signal should not register it as a dependency */
 export let current_untracking = false;
 
+/** @type {number} */
+let current_version = 0;
+
 // If we are working with a get() chain that has no active container,
 // to prevent memory leaks, we skip adding the reaction.
 export let current_skip_reaction = false;
@@ -153,6 +156,10 @@ export let dev_current_component_function = null;
 /** @param {import('#client').ComponentContext['function']} fn */
 export function set_dev_current_component_function(fn) {
 	dev_current_component_function = fn;
+}
+
+export function increment_version() {
+	return current_version++;
 }
 
 /** @returns {boolean} */
@@ -234,7 +241,7 @@ export function check_dirtiness(reaction) {
 					// is also dirty.
 
 					if (version > /** @type {import('#client').Derived} */ (reaction).version) {
-						/** @type {import('#client').Derived} */ (reaction).version = version;
+						/** @type {import('#client').Derived} */ (reaction).version = increment_version();
 						return !is_equal;
 					}
 
@@ -257,9 +264,10 @@ export function check_dirtiness(reaction) {
 					// In thise case, we need to re-attach it to the graph and mark it dirty if any of its dependencies have
 					// changed since.
 					if (version > /** @type {import('#client').Derived} */ (reaction).version) {
-						/** @type {import('#client').Derived} */ (reaction).version = version;
+						/** @type {import('#client').Derived} */ (reaction).version = increment_version();
 						is_dirty = true;
 					}
+
 					reactions = dependency.reactions;
 					if (reactions === null) {
 						dependency.reactions = [reaction];

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -447,7 +447,7 @@ describe('signals', () => {
 		};
 	});
 
-	test('deriveds update upon reconnection', () => {
+	test('deriveds update upon reconnection #1', () => {
 		let a = source(false);
 		let b = source(false);
 
@@ -486,6 +486,55 @@ describe('signals', () => {
 
 			flushSync(() => set(b, true));
 			assert.deepEqual(last, { a: false, b: true, c: false, d: false });
+		};
+	});
+
+	test('deriveds update upon reconnection #2', () => {
+		let a = source(false);
+		let b = source(false);
+		let c = source(false);
+
+		let d = derived(() => $.get(a) || $.get(b));
+
+		let branch = '';
+
+		render_effect(() => {
+			if ($.get(c) && !$.get(d)) {
+				branch = 'if';
+			} else {
+				branch = 'else';
+			}
+		});
+
+		return () => {
+			assert.deepEqual(branch, 'else');
+
+			flushSync(() => set(c, true));
+			assert.deepEqual(branch, 'if');
+
+			flushSync(() => set(a, true));
+			assert.deepEqual(branch, 'else');
+
+			set(a, false);
+			set(b, false);
+			set(c, false);
+			flushSync();
+			assert.deepEqual(branch, 'else');
+
+			flushSync(() => set(c, true));
+			assert.deepEqual(branch, 'if');
+
+			flushSync(() => set(b, true));
+			assert.deepEqual(branch, 'else');
+
+			set(a, false);
+			set(b, false);
+			set(c, false);
+			flushSync();
+			assert.deepEqual(branch, 'else');
+
+			flushSync(() => set(c, true));
+			assert.deepEqual(branch, 'if');
 		};
 	});
 });

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -479,6 +479,13 @@ describe('signals', () => {
 			flushSync(() => set(a, true));
 			flushSync(() => set(b, true));
 			assert.deepEqual(last, { a: true, b: true, c: true, d: true });
+
+			flushSync(() => set(a, false));
+			flushSync(() => set(b, false));
+			assert.deepEqual(last, { a: false, b: false, c: false, d: null });
+
+			flushSync(() => set(b, true));
+			assert.deepEqual(last, { a: false, b: true, c: false, d: false });
 		};
 	});
 });


### PR DESCRIPTION
This is an alternative to #12016 that I think is slightly simpler. AFAICT all we need to do is ensure that if a derived `a` depends on another derived `b`, and `a` is reconnecting to the dependency graph, that if `b` was updated more recently than `a`, `a` also updates.

Fixes #11988
Fixes #12044

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
