### PR TITLE
chore: simpler untracking

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -46,6 +46,10 @@ export function validate_effect(rune) {
 		e.effect_orphan(rune);
 	}
 
+	if (current_reaction !== null && (current_reaction.f & UNOWNED) !== 0) {
+		e.effect_in_unowned_derived();
+	}
+
 	if (is_destroying_effect) {
 		e.effect_in_teardown(rune);
 	}
@@ -124,17 +128,8 @@ function create_effect(type, fn, sync) {
 		}
 
 		// if we're in a derived, add the effect there too...
-		if (current_reaction !== null) {
-			var flags = current_reaction.f;
-
-			if ((flags & DERIVED) !== 0) {
-				// ...unless it's unowned
-				if ((flags & UNOWNED) !== 0) {
-					e.effect_in_unowned_derived();
-				}
-
-				push_effect(effect, current_reaction);
-			}
+		if (current_reaction !== null && (current_reaction.f & DERIVED) !== 0) {
+			push_effect(effect, current_reaction);
 		}
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -127,7 +127,7 @@ function create_effect(type, fn, sync) {
 			push_effect(effect, current_effect);
 		}
 
-		// if we're in a derived, add the effect there too...
+		// if we're in a derived, add the effect there too
 		if (current_reaction !== null && (current_reaction.f & DERIVED) !== 0) {
 			push_effect(effect, current_reaction);
 		}

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -119,7 +119,6 @@ function create_effect(type, fn, sync) {
 		effect.teardown === null;
 
 	if (!inert && !is_root) {
-		// TODO we only need this `if` check because of a contrived test case in signals.ts — we should rewrite the test
 		if (current_effect !== null) {
 			push_effect(effect, current_effect);
 		}

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -151,15 +151,7 @@ export function effect_tracking() {
 		return false;
 	}
 
-	if ((current_reaction.f & DERIVED) !== 0) {
-		return (current_reaction.f & UNOWNED) === 0;
-	}
-
-	if (current_effect) {
-		return (current_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0;
-	}
-
-	return false;
+	return (current_reaction.f & UNOWNED) === 0;
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -3,7 +3,6 @@ import {
 	current_component_context,
 	current_effect,
 	current_reaction,
-	current_untracking,
 	destroy_effect_children,
 	dev_current_component_function,
 	execute_effect,
@@ -12,10 +11,10 @@ import {
 	is_flushing_effect,
 	remove_reactions,
 	schedule_effect,
+	set_current_reaction,
 	set_is_destroying_effect,
 	set_is_flushing_effect,
 	set_signal_status,
-	set_untracking,
 	untrack
 } from '../runtime.js';
 import {
@@ -119,20 +118,25 @@ function create_effect(type, fn, sync) {
 		effect.dom === null &&
 		effect.teardown === null;
 
-	if (!inert && current_reaction !== null && !is_root) {
-		var flags = current_reaction.f;
-		if ((flags & DERIVED) !== 0) {
-			if ((flags & UNOWNED) !== 0) {
-				e.effect_in_unowned_derived();
-			}
-			// If we are inside a derived, then we also need to attach the
-			// effect to the parent effect too.
-			if (current_effect !== null) {
-				push_effect(effect, current_effect);
-			}
+	if (!inert && !is_root) {
+		// TODO we only need this `if` check because of a contrived test case in signals.ts — we should rewrite the test
+		if (current_effect !== null) {
+			push_effect(effect, current_effect);
 		}
 
-		push_effect(effect, current_reaction);
+		// if we're in a derived, add the effect there too...
+		if (current_reaction !== null) {
+			var flags = current_reaction.f;
+
+			if ((flags & DERIVED) !== 0) {
+				// ...unless it's unowned
+				if ((flags & UNOWNED) !== 0) {
+					e.effect_in_unowned_derived();
+				}
+
+				push_effect(effect, current_reaction);
+			}
+		}
 	}
 
 	return effect;
@@ -143,10 +147,11 @@ function create_effect(type, fn, sync) {
  * @returns {boolean}
  */
 export function effect_tracking() {
-	if (current_untracking) {
+	if (current_reaction === null) {
 		return false;
 	}
-	if (current_reaction && (current_reaction.f & DERIVED) !== 0) {
+
+	if ((current_reaction.f & DERIVED) !== 0) {
 		return (current_reaction.f & UNOWNED) === 0;
 	}
 
@@ -320,14 +325,14 @@ export function execute_effect_teardown(effect) {
 	var teardown = effect.teardown;
 	if (teardown !== null) {
 		const previously_destroying_effect = is_destroying_effect;
-		const previous_untracking = current_untracking;
+		const previous_reaction = current_reaction;
 		set_is_destroying_effect(true);
-		set_untracking(true);
+		set_current_reaction(null);
 		try {
 			teardown.call(null);
 		} finally {
 			set_is_destroying_effect(previously_destroying_effect);
-			set_untracking(previous_untracking);
+			set_current_reaction(previous_reaction);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -5,7 +5,6 @@ import {
 	current_dependencies,
 	current_effect,
 	current_untracked_writes,
-	current_untracking,
 	get,
 	is_batching_effect,
 	is_runes,
@@ -86,7 +85,6 @@ export function set(signal, value) {
 	var initialized = signal.v !== UNINITIALIZED;
 
 	if (
-		!current_untracking &&
 		initialized &&
 		current_reaction !== null &&
 		is_runes() &&

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -349,7 +349,7 @@ export function execute_reaction_fn(signal) {
 	current_dependencies = /** @type {null | import('#client').Value[]} */ (null);
 	current_dependencies_index = 0;
 	current_untracked_writes = null;
-	current_reaction = signal;
+	current_reaction = (signal.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? signal : null;
 	current_skip_reaction = !is_flushing_effect && (signal.f & UNOWNED) !== 0;
 
 	try {
@@ -811,7 +811,7 @@ export function get(signal) {
 	}
 
 	// Register the dependency on the current reaction signal.
-	if (current_reaction !== null && (current_reaction.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
+	if (current_reaction !== null) {
 		const unowned = (current_reaction.f & UNOWNED) !== 0;
 		const dependencies = current_reaction.deps;
 		if (


### PR DESCRIPTION
We don't need `current_untracking`, we can just set `current_reaction` to `null`. Similarly, there's no need to set `current_reaction` to the current effect if it's a root or branch effect — better to have the logic there than in every `get` call.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
