### PR TITLE
fix: handle `is` attribute on elements with spread

### DIFF
--- a/.changeset/large-waves-join.md
+++ b/.changeset/large-waves-join.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: handle `is` attribute on elements with spread

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -279,6 +279,15 @@ function serialize_element_spread_attributes(
 			const [, value] = serialize_attribute_value(attribute.value, context);
 
 			if (
+				name === 'is' &&
+				value.type === 'Literal' &&
+				context.state.metadata.namespace === 'html'
+			) {
+				context.state.template.push(` is="${escape_html(value.value, true)}"`);
+				continue;
+			}
+
+			if (
 				is_event_attribute(attribute) &&
 				(attribute.value[0].expression.type === 'ArrowFunctionExpression' ||
 					attribute.value[0].expression.type === 'FunctionExpression')

--- a/packages/svelte/tests/runtime-runes/samples/element-is-attribute/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/element-is-attribute/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	test({ assert, target, logs }) {
+		const [b1, b2] = target.querySelectorAll('button');
+
+		b1.click();
+		flushSync();
+		assert.deepEqual(logs, ['works']);
+
+		b2.click();
+		flushSync();
+		assert.deepEqual(logs, ['works', 'works']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/element-is-attribute/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/element-is-attribute/main.svelte
@@ -1,0 +1,18 @@
+<script lang="ts" context="module">
+	if (!customElements.get('x-button')) {
+		class XButton extends HTMLButtonElement {
+			connectedCallback() {
+				this.addEventListener('click', () => console.log('works'));
+			}
+		}
+
+		customElements.define('x-button', XButton, { extends: 'button' });
+	}
+</script>
+
+<script lang="ts">
+	let { ...props } = $props();
+</script>
+
+<button is="x-button">click me</button>
+<button {...props} is="x-button">click me</button>


### PR DESCRIPTION
The `is` attribute is special and always needs to be part of the static template string, or else it wouldn't be taken into account on initialization
fixes #12052

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
