### PR TITLE
chore: make versioning more consistent

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -103,8 +103,9 @@ export function update_derived(derived, force_schedule) {
 	set_signal_status(derived, status);
 
 	if (!derived.equals(value)) {
-		derived.version = increment_version();
 		derived.v = value;
+		derived.version = increment_version();
+
 		mark_reactions(derived, DIRTY, force_schedule);
 
 		if (DEV && force_schedule) {


### PR DESCRIPTION
small post-#12047 tweak that makes the code more consistent between `set` and `update_derived`, and removes a now-obsolete comment referencing unowned deriveds

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
