### PR TITLE
chore: rewrite state_unsafe_mutation message

### DIFF
--- a/.changeset/nasty-glasses-begin.md
+++ b/.changeset/nasty-glasses-begin.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: rewrite state_unsafe_mutation message

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -66,9 +66,7 @@
 
 ## state_unsafe_mutation
 
-> Unsafe mutations during Svelte's render or derived phase are not permitted in runes mode. This can lead to unexpected errors and possibly cause infinite loops.
->
-> If the object is not meant to be reactive, declare it without `$state`
+> Updating state inside a derived is forbidden. If the value should not be reactive, declare it without `$state`
 
 ## svelte_component_invalid_this_value
 

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -279,14 +279,12 @@ export function state_prototype_fixed() {
 }
 
 /**
- * Unsafe mutations during Svelte's render or derived phase are not permitted in runes mode. This can lead to unexpected errors and possibly cause infinite loops.
- * >
- * If the object is not meant to be reactive, declare it without `$state`
+ * Updating state inside a derived is forbidden. If the value should not be reactive, declare it without `$state`
  * @returns {never}
  */
 export function state_unsafe_mutation() {
 	if (DEV) {
-		const error = new Error(`${"state_unsafe_mutation"}\n${"Unsafe mutations during Svelte's render or derived phase are not permitted in runes mode. This can lead to unexpected errors and possibly cause infinite loops.\n>\nIf the object is not meant to be reactive, declare it without `$state`"}`);
+		const error = new Error(`${"state_unsafe_mutation"}\n${"Updating state inside a derived is forbidden. If the value should not be reactive, declare it without `$state`"}`);
 
 		error.name = 'Svelte error';
 		throw error;


### PR DESCRIPTION
The current message is gibberish — the error only happens inside a derived (not render), and 'in runes mode' is redundant if we're talking about deriveds. And the value being updated might be a primitive, not an object

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
