### PR TITLE
chore: add `@description` tags

### DIFF
--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -170,6 +170,7 @@ export class SvelteComponentTyped<
 /**
  * @deprecated The new `Component` type does not have a dedicated Events type. Use `ComponentProps` instead.
  *
+ * @description
  * Convenience type to get the events the given component expects. Example:
  * ```html
  * <script lang="ts">
@@ -208,6 +209,7 @@ export type ComponentProps<Comp extends SvelteComponent | Component<any>> =
 /**
  * @deprecated This type is obsolete when working with the new `Component` type.
  *
+ * @description
  * Convenience type to get the type of a Svelte component. Useful for example in combination with
  * dynamic components using `<svelte:component>`.
  *

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -167,6 +167,7 @@ declare module 'svelte' {
 	/**
 	 * @deprecated The new `Component` type does not have a dedicated Events type. Use `ComponentProps` instead.
 	 *
+	 * @description
 	 * Convenience type to get the events the given component expects. Example:
 	 * ```html
 	 * <script lang="ts">
@@ -205,6 +206,7 @@ declare module 'svelte' {
 	/**
 	 * @deprecated This type is obsolete when working with the new `Component` type.
 	 *
+	 * @description
 	 * Convenience type to get the type of a Svelte component. Useful for example in combination with
 	 * dynamic components using `<svelte:component>`.
 	 *


### PR DESCRIPTION
add them so that the TypeScript parser doesn't put the following content under the `@deprecated` tag, which messes with the JSON-type-generation script.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
