### PR TITLE
fix: allow multiple optional parameters with defaults

### DIFF
--- a/.changeset/ten-geese-share.md
+++ b/.changeset/ten-geese-share.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow multiple optional parameters with defaults

--- a/.changeset/ten-geese-share.md
+++ b/.changeset/ten-geese-share.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: allow multiple optional parameters with defaults
+fix: allow multiple optional parameters with defaults in snippets

--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -1,6 +1,7 @@
 import * as acorn from 'acorn';
 import { walk } from 'zimmerframe';
 import { tsPlugin } from 'acorn-typescript';
+import { locator } from '../../state.js';
 
 const ParserWithTS = acorn.Parser.extend(tsPlugin({ allowSatisfies: true }));
 
@@ -126,6 +127,16 @@ function amend(source, node) {
 			delete node.loc.start.index;
 			// @ts-expect-error
 			delete node.loc.end.index;
+
+			if (typeof node.loc?.end === 'number') {
+				const loc = locator(node.loc.end);
+				if (loc) {
+					node.loc.end = {
+						line: loc.line,
+						column: loc.column
+					};
+				}
+			}
 
 			if (/** @type {any} */ (node).typeAnnotation && node.end === undefined) {
 				// i think there might be a bug in acorn-typescript that prevents

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -281,7 +281,14 @@ function open(parser) {
 			parser.allow_whitespace();
 			if (parser.eat('=')) {
 				parser.allow_whitespace();
-				const right = read_expression(parser);
+				let right = read_expression(parser);
+				// multiple assignment expression will be confused by the parser for a sequence expression
+				// so if the returned value is a sequence expression we use the first expression as the
+				// right and we reset the parser.index
+				if (right.type === 'SequenceExpression') {
+					right = right.expressions[0];
+					parser.index = right.end ?? parser.index;
+				}
 				pattern = {
 					type: 'AssignmentPattern',
 					left: pattern,

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -281,18 +281,24 @@ function open(parser) {
 			parser.allow_whitespace();
 			if (parser.eat('=')) {
 				parser.allow_whitespace();
+
+				let index = parser.index;
 				let right = read_expression(parser);
+
+				parser.allow_whitespace();
+
 				// multiple assignment expression will be confused by the parser for a sequence expression
 				// so if the returned value is a sequence expression we use the first expression as the
 				// right and we reset the parser.index
-				if (right.type === 'SequenceExpression') {
+				if (right.type === 'SequenceExpression' && parser.template[index] !== '(') {
 					right = right.expressions[0];
-					parser.index = right.end ?? parser.index;
+					parser.index = /** @type {number} */ (right.end);
 				}
+
 				pattern = {
 					type: 'AssignmentPattern',
 					left: pattern,
-					right: right,
+					right,
 					start: pattern.start,
 					end: right.end
 				};

--- a/packages/svelte/tests/parser-modern/samples/snippets/output.json
+++ b/packages/svelte/tests/parser-modern/samples/snippets/output.json
@@ -32,8 +32,7 @@
 						"loc": {
 							"start": {
 								"line": 3,
-								"column": 14,
-								"character": 43
+								"column": 14
 							},
 							"end": {
 								"line": 3,
@@ -41,11 +40,21 @@
 								"character": 54
 							}
 						},
-						"end": 54,
+						"end": 46,
 						"typeAnnotation": {
 							"type": "TSTypeAnnotation",
 							"start": 46,
 							"end": 54,
+							"loc": {
+								"start": {
+									"line": 3,
+									"column": 17
+								},
+								"end": {
+									"line": 3,
+									"column": 25
+								}
+							},
 							"typeAnnotation": {
 								"type": "TSStringKeyword",
 								"start": 48,

--- a/packages/svelte/tests/parser-modern/samples/snippets/output.json
+++ b/packages/svelte/tests/parser-modern/samples/snippets/output.json
@@ -36,8 +36,7 @@
 							},
 							"end": {
 								"line": 3,
-								"column": 25,
-								"character": 54
+								"column": 25
 							}
 						},
 						"end": 46,

--- a/packages/svelte/tests/parser-modern/samples/typescript-in-event-handler/output.json
+++ b/packages/svelte/tests/parser-modern/samples/typescript-in-event-handler/output.json
@@ -54,7 +54,10 @@
 											"line": 6,
 											"column": 12
 										},
-										"end": 87
+										"end": {
+											"line": 6,
+											"column": 25
+										}
 									},
 									"name": "e",
 									"typeAnnotation": {

--- a/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/_config.js
@@ -1,0 +1,7 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: '012',
+	ssrHtml: '012'
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/_config.js
@@ -1,4 +1,3 @@
-import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({

--- a/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/_config.js
@@ -2,6 +2,5 @@ import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	html: '012',
-	ssrHtml: '012'
+	html: '013'
 });

--- a/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/_config.js
@@ -1,5 +1,5 @@
 import { test } from '../../test';
 
 export default test({
-	html: '013'
+	html: '013/023'
 });

--- a/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/main.svelte
@@ -1,0 +1,5 @@
+{#snippet snip(a, b = 1, c=2)}
+{a}{b}{c}
+{/snippet}
+
+{@render snip(0)}

--- a/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/main.svelte
@@ -1,5 +1,9 @@
-{#snippet snip(a, b = 1, c = (2, 3))}
-	{a}{b}{c}
+{#snippet one(a, b = 1, c = (2, 3))}
+  {a}{b}{c}
 {/snippet}
 
-{@render snip(0)}
+{#snippet two(a, b = (1, 2), c = 3)}
+  {a}{b}{c}
+{/snippet}
+
+{@render one(0)}/{@render two(0)}

--- a/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-optional-arguments-defaults/main.svelte
@@ -1,5 +1,5 @@
-{#snippet snip(a, b = 1, c=2)}
-{a}{b}{c}
+{#snippet snip(a, b = 1, c = (2, 3))}
+	{a}{b}{c}
 {/snippet}
 
 {@render snip(0)}


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #12067 i was not totally confident this was an ok fix but i've seen that a similar trick is used in `read_type_annotation` too so i guess it can be good? Feel free to close if it's not the right fix.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
