### PR TITLE
chore: simplify dependency tracking

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -120,7 +120,7 @@ export function update_derived(derived, force_schedule) {
  */
 export function destroy_derived(signal) {
 	destroy_derived_children(signal);
-	remove_reactions(signal, 0);
+	remove_reactions(signal);
 	set_signal_status(signal, DESTROYED);
 
 	// TODO we need to ensure we remove the derived from any parent derives

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -336,7 +336,7 @@ export function destroy_effect(effect, remove_dom = true) {
 	}
 
 	destroy_effect_children(effect, remove_dom);
-	remove_reactions(effect, 0);
+	remove_reactions(effect);
 	set_signal_status(effect, DESTROYED);
 
 	if (effect.transitions) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -426,27 +426,22 @@ function remove_reaction(signal, dependency) {
 		if ((dependency.f & (UNOWNED | DISCONNECTED)) === 0) {
 			dependency.f ^= DISCONNECTED;
 		}
-		remove_reactions(/** @type {import('#client').Derived} **/ (dependency), 0);
+		remove_reactions(/** @type {import('#client').Derived} **/ (dependency));
 	}
 }
 
 /**
  * @param {import('#client').Reaction} signal
- * @param {number} start_index
  * @returns {void}
  */
-export function remove_reactions(signal, start_index) {
+export function remove_reactions(signal) {
 	const dependencies = signal.deps;
-	if (dependencies !== null) {
-		const active_dependencies = start_index === 0 ? null : dependencies.slice(0, start_index);
-		let i;
-		for (i = start_index; i < dependencies.length; i++) {
-			const dependency = dependencies[i];
-			// Avoid removing a reaction if we know that it is active (start_index will not be 0)
-			if (active_dependencies === null || !active_dependencies.includes(dependency)) {
-				remove_reaction(signal, dependency);
-			}
-		}
+	if (dependencies === null) return;
+
+	for (var i = 0; i < dependencies.length; i++) {
+		const dependency = dependencies[i];
+		// Avoid removing a reaction if we know that it is active (start_index will not be 0)
+		remove_reaction(signal, dependency);
 	}
 }
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -402,11 +402,13 @@ export function execute_reaction_fn(reaction) {
  * @returns {void}
  */
 function remove_reaction(signal, dependency) {
-	const reactions = dependency.reactions;
-	let reactions_length = 0;
+	var reactions = dependency.reactions;
+	var reactions_length = 0;
+
 	if (reactions !== null) {
 		reactions_length = reactions.length - 1;
-		const index = reactions.indexOf(signal);
+		var index = reactions.indexOf(signal);
+
 		if (index !== -1) {
 			if (reactions_length === 0) {
 				dependency.reactions = null;
@@ -417,6 +419,7 @@ function remove_reaction(signal, dependency) {
 			}
 		}
 	}
+
 	// If the derived has no reactions, then we can disconnect it from the graph,
 	// allowing it to either reconnect in the future, or be GC'd by the VM.
 	if (reactions_length === 0 && (dependency.f & DERIVED) !== 0) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -93,7 +93,7 @@ export function set_current_effect(effect) {
 
 /** @type {null | import('#client').Value[]} */
 export let current_dependencies = null;
-let current_dependencies_index = 0;
+
 /**
  * Tracks writes that the effect it's executed in doesn't listen to yet,
  * so that the dependency can be added to the effect later on if it then reads it
@@ -334,88 +334,61 @@ function handle_error(error, effect, component_context) {
 
 /**
  * @template V
- * @param {import('#client').Reaction} signal
+ * @param {import('#client').Reaction} reaction
  * @returns {V}
  */
-export function execute_reaction_fn(signal) {
+export function execute_reaction_fn(reaction) {
 	const previous_dependencies = current_dependencies;
-	const previous_dependencies_index = current_dependencies_index;
 	const previous_untracked_writes = current_untracked_writes;
 	const previous_reaction = current_reaction;
 	const previous_skip_reaction = current_skip_reaction;
 
 	current_dependencies = /** @type {null | import('#client').Value[]} */ (null);
-	current_dependencies_index = 0;
 	current_untracked_writes = null;
-	current_reaction = (signal.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? signal : null;
-	current_skip_reaction = !is_flushing_effect && (signal.f & UNOWNED) !== 0;
+	current_reaction = (reaction.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? reaction : null;
+	current_skip_reaction = !is_flushing_effect && (reaction.f & UNOWNED) !== 0;
 
 	try {
-		let res = /** @type {Function} */ (0, signal.fn)();
-		let dependencies = /** @type {import('#client').Value<unknown>[]} **/ (signal.deps);
-		if (current_dependencies !== null) {
-			let i;
-			if (dependencies !== null) {
-				const deps_length = dependencies.length;
-				// Include any dependencies up until the current_dependencies_index.
-				const full_current_dependencies =
-					current_dependencies_index === 0
-						? current_dependencies
-						: dependencies.slice(0, current_dependencies_index).concat(current_dependencies);
-				const current_dep_length = full_current_dependencies.length;
-				// If we have more than 16 elements in the array then use a Set for faster performance
-				// TODO: evaluate if we should always just use a Set or not here?
-				const full_current_dependencies_set =
-					current_dep_length > 16 && deps_length - current_dependencies_index > 1
-						? new Set(full_current_dependencies)
-						: null;
-				for (i = current_dependencies_index; i < deps_length; i++) {
-					const dependency = dependencies[i];
-					if (
-						full_current_dependencies_set !== null
-							? !full_current_dependencies_set.has(dependency)
-							: !full_current_dependencies.includes(dependency)
-					) {
-						remove_reaction(signal, dependency);
-					}
-				}
-			}
+		let result = /** @type {Function} */ (0, reaction.fn)();
 
-			if (dependencies !== null && current_dependencies_index > 0) {
-				dependencies.length = current_dependencies_index + current_dependencies.length;
-				for (i = 0; i < current_dependencies.length; i++) {
-					dependencies[current_dependencies_index + i] = current_dependencies[i];
-				}
-			} else {
-				signal.deps = /** @type {import('#client').Value<V>[]} **/ (
-					dependencies = current_dependencies
-				);
-			}
+		let old_deps = reaction.deps;
+		var start = 0;
+		var i;
+		var dependency;
 
-			if (!current_skip_reaction) {
-				for (i = current_dependencies_index; i < dependencies.length; i++) {
-					const dependency = dependencies[i];
-					const reactions = dependency.reactions;
+		// very often, dependencies stay the same between runs — optimise for that case
+		// by skipping the first n identical dependencies
+		if (current_dependencies !== null && old_deps !== null) {
+			var min = Math.min(current_dependencies.length, old_deps.length);
 
-					if (reactions === null) {
-						dependency.reactions = [signal];
-					} else if (reactions[reactions.length - 1] !== signal) {
-						// TODO: should this be:
-						//
-						// } else if (!reactions.includes(signal)) {
-						//
-						reactions.push(signal);
-					}
-				}
+			for (; start < min; start += 1) {
+				if (current_dependencies[start] !== old_deps[start]) break;
 			}
-		} else if (dependencies !== null && current_dependencies_index < dependencies.length) {
-			remove_reactions(signal, current_dependencies_index);
-			dependencies.length = current_dependencies_index;
 		}
-		return res;
+
+		if (old_deps !== null) {
+			for (i = start; i < old_deps.length; i += 1) {
+				dependency = old_deps[i];
+				if (current_dependencies === null || !current_dependencies.includes(dependency)) {
+					remove_reaction(reaction, dependency);
+				}
+			}
+		}
+
+		if (current_dependencies !== null && !current_skip_reaction) {
+			for (i = start; i < current_dependencies.length; i += 1) {
+				dependency = current_dependencies[i];
+				if (old_deps === null || !old_deps.includes(dependency)) {
+					(dependency.reactions ??= []).push(reaction);
+				}
+			}
+		}
+
+		reaction.deps = current_dependencies;
+
+		return result;
 	} finally {
 		current_dependencies = previous_dependencies;
-		current_dependencies_index = previous_dependencies_index;
 		current_untracked_writes = previous_untracked_writes;
 		current_reaction = previous_reaction;
 		current_skip_reaction = previous_skip_reaction;
@@ -810,26 +783,10 @@ export function get(signal) {
 
 	// Register the dependency on the current reaction signal.
 	if (current_reaction !== null) {
-		const unowned = (current_reaction.f & UNOWNED) !== 0;
-		const dependencies = current_reaction.deps;
-		if (
-			current_dependencies === null &&
-			dependencies !== null &&
-			dependencies[current_dependencies_index] === signal &&
-			!(unowned && current_effect !== null)
-		) {
-			current_dependencies_index++;
-		} else if (
-			dependencies === null ||
-			current_dependencies_index === 0 ||
-			dependencies[current_dependencies_index - 1] !== signal
-		) {
-			if (current_dependencies === null) {
-				current_dependencies = [signal];
-			} else if (current_dependencies[current_dependencies.length - 1] !== signal) {
-				current_dependencies.push(signal);
-			}
+		if (!current_dependencies?.includes(signal)) {
+			(current_dependencies ??= []).push(signal);
 		}
+
 		if (
 			current_untracked_writes !== null &&
 			current_effect !== null &&


### PR DESCRIPTION
Trying to salvage parts of #12073, since the memory leak thing is proving finicky.

We have some slightly elaborate dependency tracking logic in the codebase. It's not explained anywhere but I _think_ the purpose of `current_dependencies_index` is to optimise the common case where a reaction (i.e. derived/effect) has the same dependencies, and gets them in the same order, on each run. When that happens, it doesn't make sense to unravel the dependency graph just to put it back together in the exact same shape.

But I don't think we need `current_dependencies_index` to do that. We can just push to a dependency array, and compare the new array with the old array at the end of the process.

The old code also has some logic for using sets when the dependency array is very large. I'm very sceptical that it's worthwhile but am open to persuasion.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
