### PR TITLE
feat: add event modifiers into svelte/event

### DIFF
--- a/.changeset/dull-steaks-warn.md
+++ b/.changeset/dull-steaks-warn.md
@@ -1,0 +1,5 @@
+---
+"svelte-5-preview": patch
+---
+
+feat: add event modifiers into svelte/event

--- a/packages/svelte/src/events/event-modifiers.js
+++ b/packages/svelte/src/events/event-modifiers.js
@@ -1,0 +1,83 @@
+/**
+ * This modifier ensures that the provided callback
+ * function `fn` is invoked exactly once for the given event.
+ *
+ * @param {Function} fn - The function to call once.
+ * @returns {Function} A new function that wraps the original function `fn`.
+ */
+export function once(fn) {
+	return function (event) {
+		if (fn) fn.call(this, event);
+		fn = null;
+	};
+}
+
+/**
+ * Modifies the behavior of an event handler to prevent the default action associated
+ * with the event before executing the provided callback function `fn`.
+ *
+ * @param {Function} fn - The callback function to execute after the default action has been prevented.
+ * @returns {Function} A new function that acts as the modified event handler, calling the provided
+ *                    callback function after preventing the default action of the event.
+ */
+export function preventDefault(fn) {
+	return function (event) {
+		event.preventDefault();
+		fn.call(this, event);
+	};
+}
+
+/**
+ * Modifies the behavior of an event handler to stop the propagation of the event
+ * through the DOM tree before executing the provided callback function `fn`.
+ *
+ * @param {Function} fn - The callback function to execute after the event propagation has been stopped.
+ * @returns {Function} A new function that acts as the modified event handler, calling the provided
+ *                    callback function after stopping the propagation of the event.
+ */
+export function stopPropagation(fn) {
+	return function (event) {
+		event.stopPropagation();
+		fn.call(this, event);
+	};
+}
+
+/**
+ * Modifies the behavior of an event handler to immediately halt further processing
+ * of the current event in both the capturing and bubbling phases, and then executes
+ * the provided callback function `fn`.
+ *
+ * @param {Function} fn - The callback function to execute after immediate propagation has been stopped.
+ * @returns {Function} A new function that acts as the modified event handler, calling the provided
+ *                    callback function after stopping immediate propagation of the event.
+ */
+export function stopImmediatePropagation(fn) {
+	return function (event) {
+		event.stopImmediatePropagation();
+		fn.call(this, event);
+	};
+}
+
+/**
+ * This modifier ensures that the original function (`fn`) is called only if the event's target is the element itself.
+ *
+ * @param {Function} fn The original function to be executed when the event occurs directly on the element.
+ * @returns {Function} A new function that acts as the modified event handler.
+ */
+export function self(fn) {
+	return function (event) {
+		if (event.target === this) fn.call(this, event);
+	};
+}
+
+/**
+ * This modifier function specifically checks if the event is trusted using the `isTrusted` property of the Event interface.
+ *
+ * @param {Function} fn The original function to be executed when a trusted event occurs.
+ * @returns {Function} A new function that acts as the modified event handler.
+ */
+export function trusted(fn) {
+	return function (event) {
+		if (event.isTrusted) fn.call(this, event);
+	};
+}

--- a/packages/svelte/src/events/event-modifiers.js
+++ b/packages/svelte/src/events/event-modifiers.js
@@ -2,12 +2,14 @@
  * This modifier ensures that the provided callback
  * function `fn` is invoked exactly once for the given event.
  *
- * @param {Function} fn - The function to call once.
- * @returns {Function} A new function that wraps the original function `fn`.
+ * @param {import("./public.js").EventHandler}  fn - The function to call once.
+ * @returns {import("./public.js").EventHandler} A new function that wraps the original function `fn`.
  */
 export function once(fn) {
 	return function (event) {
+		// @ts-ignore
 		if (fn) fn.call(this, event);
+		// @ts-expect-error - fn cannot be null, but we need to set it to null
 		fn = null;
 	};
 }
@@ -16,13 +18,17 @@ export function once(fn) {
  * Modifies the behavior of an event handler to prevent the default action associated
  * with the event before executing the provided callback function `fn`.
  *
- * @param {Function} fn - The callback function to execute after the default action has been prevented.
- * @returns {Function} A new function that acts as the modified event handler, calling the provided
- *                    callback function after preventing the default action of the event.
+ * @param {import("./public.js").EventHandler} fn - The callback function to execute after
+ * 																									the default action has been prevented.
+ * @returns {import("./public.js").EventHandler} A new function that acts as the modified event handler,
+ * 																							calling the provided callback function after preventing the
+ *																								default action of the event.
  */
 export function preventDefault(fn) {
 	return function (event) {
 		event.preventDefault();
+
+		// @ts-ignore
 		fn.call(this, event);
 	};
 }
@@ -31,13 +37,15 @@ export function preventDefault(fn) {
  * Modifies the behavior of an event handler to stop the propagation of the event
  * through the DOM tree before executing the provided callback function `fn`.
  *
- * @param {Function} fn - The callback function to execute after the event propagation has been stopped.
- * @returns {Function} A new function that acts as the modified event handler, calling the provided
- *                    callback function after stopping the propagation of the event.
+ * @param {import("./public.js").EventHandler} fn - The callback function to execute after
+ *                                                  the event propagation has been stopped.
+ * @returns {import("./public.js").EventHandler} A new function that acts as the modified event handler, calling the 																							provided callback function after stopping the propagation of the event.
  */
 export function stopPropagation(fn) {
 	return function (event) {
 		event.stopPropagation();
+
+		// @ts-ignore
 		fn.call(this, event);
 	};
 }
@@ -47,13 +55,17 @@ export function stopPropagation(fn) {
  * of the current event in both the capturing and bubbling phases, and then executes
  * the provided callback function `fn`.
  *
- * @param {Function} fn - The callback function to execute after immediate propagation has been stopped.
- * @returns {Function} A new function that acts as the modified event handler, calling the provided
- *                    callback function after stopping immediate propagation of the event.
+ * @param {import("./public.js").EventHandler} fn - The callback function to execute after
+ *                                                  immediate propagation has been stopped.
+ * @returns {import("./public.js").EventHandler} A new function that acts as the modified event handler, calling
+ * 																							the provided callback function after stopping immediate
+ *																							propagation of the event.
  */
 export function stopImmediatePropagation(fn) {
 	return function (event) {
 		event.stopImmediatePropagation();
+
+		// @ts-ignore
 		fn.call(this, event);
 	};
 }
@@ -61,11 +73,13 @@ export function stopImmediatePropagation(fn) {
 /**
  * This modifier ensures that the original function (`fn`) is called only if the event's target is the element itself.
  *
- * @param {Function} fn The original function to be executed when the event occurs directly on the element.
- * @returns {Function} A new function that acts as the modified event handler.
+ * @param {import("./public.js").EventHandler} fn The original function to be executed when
+ *                                                the event occurs directly on the element.
+ * @returns {import("./public.js").EventHandler} A new function that acts as the modified event handler.
  */
 export function self(fn) {
 	return function (event) {
+		// @ts-ignore
 		if (event.target === this) fn.call(this, event);
 	};
 }
@@ -73,11 +87,13 @@ export function self(fn) {
 /**
  * This modifier function specifically checks if the event is trusted using the `isTrusted` property of the Event interface.
  *
- * @param {Function} fn The original function to be executed when a trusted event occurs.
- * @returns {Function} A new function that acts as the modified event handler.
+ * @param {import("./public.js").EventHandler} fn The original function to be executed
+ *                                                when a trusted event occurs.
+ * @returns {import("./public.js").EventHandler} A new function that acts as the modified event handler.
  */
 export function trusted(fn) {
 	return function (event) {
+		// @ts-ignore
 		if (event.isTrusted) fn.call(this, event);
 	};
 }

--- a/packages/svelte/src/events/index.js
+++ b/packages/svelte/src/events/index.js
@@ -1,1 +1,2 @@
 export { on } from '../internal/client/dom/elements/events.js';
+export * from './event-modifiers.js';

--- a/packages/svelte/src/events/public.d.ts
+++ b/packages/svelte/src/events/public.d.ts
@@ -1,0 +1,3 @@
+export type EventHandler = (event: Event) => unknown;
+
+export * from './index.js';

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/04-event-handlers.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/04-event-handlers.md
@@ -123,23 +123,11 @@ In Svelte 4, you can add event modifiers to handlers:
 
 Modifiers are specific to `on:` and as such do not work with modern event handlers. Adding things like `event.preventDefault()` inside the handler itself is preferable, since all the logic lives in one place rather than being split between handler and modifiers.
 
-Since event handlers are just functions, you can create your own wrappers as necessary:
+Since event handlers are just functions, you can import wrappers from svelte/events, or create own:
 
 ```svelte
 <script>
-	function once(fn) {
-		return function (event) {
-			if (fn) fn.call(this, event);
-			fn = null;
-		};
-	}
-
-	function preventDefault(fn) {
-		return function (event) {
-			event.preventDefault();
-			fn.call(this, event);
-		};
-	}
+	import { once, preventDefault } from 'svelte/events';
 </script>
 
 <button onclick={once(preventDefault(handler))}>...</button>


### PR DESCRIPTION
## Svelte 5 rewrite

Svelte 5 documentation says that such event modifiers as: trusted, once, self, stopImmediatePropagation, stopPropagation and preventDefault should be implemented independently. This is inconvenient, so I suggest implementing these modifiers in svelte/events.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

