### PR TITLE
fix: ensure element size bindings don't unsubscribe multiple times

### DIFF
--- a/.changeset/gorgeous-hats-wonder.md
+++ b/.changeset/gorgeous-hats-wonder.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure element size bindings don't unsubscribe multiple times from the resize observer

--- a/packages/svelte/src/internal/client/dom/elements/bindings/size.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/size.js
@@ -1,4 +1,5 @@
 import { effect, teardown } from '../../../reactivity/effects.js';
+import { untrack } from '../../../runtime.js';
 
 /**
  * Resize observer singleton.
@@ -100,7 +101,8 @@ export function bind_element_size(element, type, update) {
 	var unsub = resize_observer_border_box.observe(element, () => update(element[type]));
 
 	effect(() => {
-		update(element[type]);
+		// The update could contain reads which should be ignored
+		untrack(() => update(element[type]));
 		return unsub;
 	});
 }


### PR DESCRIPTION
The `update` function could cause a read, which would end up being tracked in the effect, and said effect would then run multiple times when it should only run once

fixes #11934
fixes #12028

No test because not sure how to reproduce this through tests

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
