### PR TITLE
fix(repl): attach click listener above svelte event delegator (#12127)

### DIFF
--- a/sites/svelte-5-preview/src/lib/Output/srcdoc/index.html
+++ b/sites/svelte-5-preview/src/lib/Output/srcdoc/index.html
@@ -86,7 +86,8 @@
 						}
 
 						if (action === 'catch_clicks') {
-							document.body.addEventListener('click', (event) => {
+							// attached to document to not interfere with svelte's event delegators that are attached to the app root (document.body)
+							document.addEventListener('click', (event) => {
 								if (event.which !== 1) return;
 								if (event.metaKey || event.ctrlKey || event.shiftKey) return;
 								if (event.defaultPrevented) return;


### PR DESCRIPTION
## broken `e.preventDefault()` calls in click event handlers in REPL

I opened #12127 yesterday, because calling `e.preventDefault()` in a click handler attached with `onclick` in svelte 5's REPL would do nothing to prevent the click. (see: [broken REPL](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAEy3K0QqDIBiG4VuR_2hB1LlUMNhdzB24_CSZqehvbET3PmI7fB_enazzKCTvOwW9giRdU6KW-JPOKBs8g1oqseb5lOFHMiZ2MRSRa0AR_aTCoMWSYUdFC3OSfY-3XpNHN8dVkYhh9m5-jfsFjRgnsaNLGRsC32B19XxpjmNSQXFZYvVGPCH-A4wKQ68nammNxlkHQ5JzxfE4vv7W9DPCAAAA))

## Cause

The reason `e.preventDefault()` fails to take effect in the REPL is because a combination of svelte 5's event delegation and a global click handler attached to the body of the iframe of the REPL.

since links clicked by the user in the REPL should open in the iframe, but instead in a new tab, a global click handler is attached to the REPL's iframe body.
While this click handler contains logic to return early if `preventDefault` was called on the click event, svelte 5's event delegation introduces a race condition that breaks this logic.
While event handlers execute **in order of attachment** on each element they bubble to, this used to be no issue in svelte 4, since event handlers were directly attached to elements. 
This means, they were handled on the element, before bubbling up to the body, where they would "lose" to the previously attached global link click event handler
Svelte 5 introduced event delegation, where for performance reasons only a single event listener is used per event type. This event listener is attached to the App root, which in case of the REPL coincides with the iframe's `body` element, hence running into the problem of another click handler being executed before them (the REPL's global click handler)

## Solution

The simplest solution is to eliminate the race condition by simply moving the repl's click handler one level up in the dom. (to the document)
That way, the event delegator listeners attached by svelte to the body no longer are preceded by the global event listeners and everything works as intended.
I could not think of any disadvantages from having the `open link in new tab` listener attached to the document instead of the body, but perhaps I am missing something?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
