### PR TITLE
fix: throw compilation error for malformed snippets

### DIFF
--- a/.changeset/polite-ways-serve.md
+++ b/.changeset/polite-ways-serve.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: throw compilation error for malformed snippets

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -279,8 +279,14 @@ function open(parser) {
 		while (!parser.match(')') || parentheses !== 1) {
 			if (parser.match('(')) parentheses++;
 			if (parser.match(')')) parentheses--;
-			params += parser.read(/^./);
+
+			var next_char = parser.read(/^./);
+			if (next_char == null) break; // end of template
+			params += next_char;
 		}
+
+		parser.eat(')', true);
+		parser.eat('}', true);
 
 		let function_expression = /** @type {import('estree').ArrowFunctionExpression} */ (
 			parse_expression_at(
@@ -289,8 +295,6 @@ function open(parser) {
 				0
 			)
 		);
-
-		parser.index += 2;
 
 		/** @type {ReturnType<typeof parser.append<import('#compiler').SnippetBlock>>} */
 		const block = parser.append({

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -280,7 +280,7 @@ function open(parser) {
 			if (parser.match('(')) parentheses++;
 			if (parser.match(')')) parentheses--;
 
-			var next_char = parser.read(/^./);
+			var next_char = parser.read(/^(.|[\r\n])/);
 			if (next_char == null) break; // end of template
 			params += next_char;
 		}

--- a/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'expected_token',
+		message: 'Expected token )',
+		position: [31, 31]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte
@@ -1,0 +1,1 @@
+{#snippet children(hi{/snippet}

--- a/packages/svelte/tests/compiler-errors/samples/malformed-snippet/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/malformed-snippet/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'expected_token',
+		message: 'Expected token }',
+		position: [20, 20]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/malformed-snippet/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/malformed-snippet/main.svelte
@@ -1,0 +1,1 @@
+{#snippet children()hi{/snippet}


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #12143 
Closes #12146
Closes #12136 

I've added both tests because in the second case the compiler was actually ending in an infinite loop. Not likely to be a regression but better be safe imho.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
