### PR TITLE
chore: dedupe safe_not_equal in svelte/store

### DIFF
--- a/packages/svelte/src/store/index.js
+++ b/packages/svelte/src/store/index.js
@@ -1,4 +1,5 @@
 import { noop, run_all } from '../internal/shared/utils.js';
+import { safe_not_equal } from '../internal/client/reactivity/equality.js';
 import { subscribe_to_store } from './utils.js';
 
 /**
@@ -19,15 +20,6 @@ export function readable(value, start) {
 	return {
 		subscribe: writable(value, start).subscribe
 	};
-}
-
-/**
- * @param {any} a
- * @param {any} b
- * @returns {boolean}
- */
-export function safe_not_equal(a, b) {
-	return a != a ? b == b : a !== b || (a && typeof a === 'object') || typeof a === 'function';
 }
 
 /**


### PR DESCRIPTION
While looking at a bundled app that used stores, I noticed I had both `safe_not_equal` and `safe_not_equal$1` - each having _almost_ identical implementations. I don't think there's any reason for stores to need their own copy. This switches them over to using the same copy as is used elsewhere.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
