### PR TITLE
chore: use unbound event listeners

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -44,7 +44,7 @@ export function create_event(event_name, dom, handler, options) {
 	function target_handler(/** @type {Event} */ event) {
 		if (!options.capture) {
 			// Only call in the bubble phase, else delegated events would be called before the capturing events
-			handle_event_propagation(dom, event);
+			handle_event_propagation.call(dom, event);
 		}
 		if (!event.cancelBubble) {
 			return handler.call(this, event);
@@ -143,11 +143,12 @@ export function delegate(events) {
 }
 
 /**
- * @param {EventTarget} handler_element
+ * @this {EventTarget}
  * @param {Event} event
  * @returns {void}
  */
-export function handle_event_propagation(handler_element, event) {
+export function handle_event_propagation(event) {
+	var handler_element = this;
 	var owner_document = /** @type {Node} */ (handler_element).ownerDocument;
 	var event_name = event.type;
 	var path = event.composedPath?.() || [];


### PR DESCRIPTION
We don't need to use bound event listeners, because `this` is the value of the element the handler was bound to.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
