### PR TITLE
chore: add note for state.is using object.is

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -130,6 +130,8 @@ Sometimes you might need to compare two values, one of which is a reactive `$sta
 
 This is handy when you might want to check if the object exists within a deeply reactive object/array.
 
+> `$state.is` uses `Object.is` to check if two values are the same value.
+
 ## `$derived`
 
 Derived state is declared with the `$derived` rune:


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12167 by adding a note to the existing notes about how the rune uses `Object.is` behind-the-scenes.