### PR TITLE
fix: make more types from `svelte/compiler` public

### DIFF
--- a/.changeset/curly-cooks-cheer.md
+++ b/.changeset/curly-cooks-cheer.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make more types from `svelte/compiler` public

--- a/packages/svelte/scripts/generate-types.js
+++ b/packages/svelte/scripts/generate-types.js
@@ -25,7 +25,7 @@ await createBundle({
 		[pkg.name]: `${dir}/src/index.d.ts`,
 		[`${pkg.name}/action`]: `${dir}/src/action/public.d.ts`,
 		[`${pkg.name}/animate`]: `${dir}/src/animate/public.d.ts`,
-		[`${pkg.name}/compiler`]: `${dir}/src/compiler/index.js`,
+		[`${pkg.name}/compiler`]: `${dir}/src/compiler/public.d.ts`,
 		[`${pkg.name}/easing`]: `${dir}/src/easing/index.js`,
 		[`${pkg.name}/legacy`]: `${dir}/src/legacy/legacy-client.js`,
 		[`${pkg.name}/motion`]: `${dir}/src/motion/public.d.ts`,

--- a/packages/svelte/src/compiler/preprocess/public.d.ts
+++ b/packages/svelte/src/compiler/preprocess/public.d.ts
@@ -69,7 +69,7 @@ export interface PreprocessorGroup {
 }
 
 /**
- * Utility type to extract the type of a preprocessor from a preprocessor group
+ * @description Utility type to extract the type of a preprocessor from a preprocessor group
  * @deprecated Create this utility type yourself instead
  */
 export interface SveltePreprocessor<

--- a/packages/svelte/src/compiler/public.d.ts
+++ b/packages/svelte/src/compiler/public.d.ts
@@ -1,5 +1,8 @@
-export type { Preprocessor, PreprocessorGroup } from './preprocess/public';
-
-export type { CompileOptions } from './types/index';
-
 export * from './index.js';
+export type {
+	MarkupPreprocessor,
+	Preprocessor,
+	PreprocessorGroup,
+	Processed
+} from './preprocess/public';
+export type { CompileOptions, ModuleCompileOptions } from './types/index';

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -606,6 +606,75 @@ declare module 'svelte/compiler' {
 	 * @deprecated Replace this with `import { walk } from 'estree-walker'`
 	 * */
 	function walk(): never;
+	/**
+	 * The result of a preprocessor run. If the preprocessor does not return a result, it is assumed that the code is unchanged.
+	 */
+	interface Processed {
+		/**
+		 * The new code
+		 */
+		code: string;
+		/**
+		 * A source map mapping back to the original code
+		 */
+		map?: string | object; // we are opaque with the type here to avoid dependency on the remapping module for our public types.
+		/**
+		 * A list of additional files to watch for changes
+		 */
+		dependencies?: string[];
+		/**
+		 * Only for script/style preprocessors: The updated attributes to set on the tag. If undefined, attributes stay unchanged.
+		 */
+		attributes?: Record<string, string | boolean>;
+		toString?: () => string;
+	}
+
+	/**
+	 * A markup preprocessor that takes a string of code and returns a processed version.
+	 */
+	type MarkupPreprocessor = (options: {
+		/**
+		 * The whole Svelte file content
+		 */
+		content: string;
+		/**
+		 * The filename of the Svelte file
+		 */
+		filename?: string;
+	}) => Processed | void | Promise<Processed | void>;
+
+	/**
+	 * A script/style preprocessor that takes a string of code and returns a processed version.
+	 */
+	type Preprocessor = (options: {
+		/**
+		 * The script/style tag content
+		 */
+		content: string;
+		/**
+		 * The attributes on the script/style tag
+		 */
+		attributes: Record<string, string | boolean>;
+		/**
+		 * The whole Svelte file content
+		 */
+		markup: string;
+		/**
+		 * The filename of the Svelte file
+		 */
+		filename?: string;
+	}) => Processed | void | Promise<Processed | void>;
+
+	/**
+	 * A preprocessor group is a set of preprocessors that are applied to a Svelte file.
+	 */
+	interface PreprocessorGroup {
+		/** Name of the preprocessor. Will be a required option in the next major version */
+		name?: string;
+		markup?: MarkupPreprocessor;
+		style?: Preprocessor;
+		script?: Preprocessor;
+	}
 	/** The return value of `compile` from `svelte/compiler` */
 	interface CompileResult {
 		/** The compiled JavaScript */
@@ -1823,77 +1892,8 @@ declare module 'svelte/compiler' {
 		content: Program;
 		attributes: Attribute[];
 	}
-	/**
-	 * The result of a preprocessor run. If the preprocessor does not return a result, it is assumed that the code is unchanged.
-	 */
-	interface Processed {
-		/**
-		 * The new code
-		 */
-		code: string;
-		/**
-		 * A source map mapping back to the original code
-		 */
-		map?: string | object; // we are opaque with the type here to avoid dependency on the remapping module for our public types.
-		/**
-		 * A list of additional files to watch for changes
-		 */
-		dependencies?: string[];
-		/**
-		 * Only for script/style preprocessors: The updated attributes to set on the tag. If undefined, attributes stay unchanged.
-		 */
-		attributes?: Record<string, string | boolean>;
-		toString?: () => string;
-	}
 
-	/**
-	 * A markup preprocessor that takes a string of code and returns a processed version.
-	 */
-	type MarkupPreprocessor = (options: {
-		/**
-		 * The whole Svelte file content
-		 */
-		content: string;
-		/**
-		 * The filename of the Svelte file
-		 */
-		filename?: string;
-	}) => Processed | void | Promise<Processed | void>;
-
-	/**
-	 * A script/style preprocessor that takes a string of code and returns a processed version.
-	 */
-	type Preprocessor = (options: {
-		/**
-		 * The script/style tag content
-		 */
-		content: string;
-		/**
-		 * The attributes on the script/style tag
-		 */
-		attributes: Record<string, string | boolean>;
-		/**
-		 * The whole Svelte file content
-		 */
-		markup: string;
-		/**
-		 * The filename of the Svelte file
-		 */
-		filename?: string;
-	}) => Processed | void | Promise<Processed | void>;
-
-	/**
-	 * A preprocessor group is a set of preprocessors that are applied to a Svelte file.
-	 */
-	interface PreprocessorGroup {
-		/** Name of the preprocessor. Will be a required option in the next major version */
-		name?: string;
-		markup?: MarkupPreprocessor;
-		style?: Preprocessor;
-		script?: Preprocessor;
-	}
-
-	export { compile, compileModule, parse, walk, preprocess, CompileError, VERSION, migrate };
+	export { MarkupPreprocessor, Preprocessor, PreprocessorGroup, Processed, CompileOptions, ModuleCompileOptions, compile, compileModule, parse, walk, preprocess, CompileError, VERSION, migrate };
 }
 
 declare module 'svelte/easing' {
@@ -2510,7 +2510,7 @@ declare module 'svelte/types/compiler/preprocess' {
 	}
 
 	/**
-	 * Utility type to extract the type of a preprocessor from a preprocessor group
+	 * @description Utility type to extract the type of a preprocessor from a preprocessor group
 	 * @deprecated Create this utility type yourself instead
 	 */
 	interface SveltePreprocessor_1<


### PR DESCRIPTION
The types generation script used the wrong entry point, as a consequence not all types that should've been exposed where actually made public

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
