### PR TITLE
feat: improve type arguments for Snippet and $bindable

### DIFF
--- a/.changeset/tricky-laws-bathe.md
+++ b/.changeset/tricky-laws-bathe.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: improve type arguments for Snippet and $bindable

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -306,7 +306,7 @@ declare function $props(): any;
  *
  * https://svelte-5-preview.vercel.app/docs/runes#$bindable
  */
-declare function $bindable<T>(t?: T): T;
+declare function $bindable<T>(fallback?: T): T;
 
 /**
  * Inspects one or more values whenever they, or the properties they contain, change. Example:

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -259,20 +259,24 @@ declare const SnippetReturn: unique symbol;
 /**
  * The type of a `#snippet` block. You can use it to (for example) express that your component expects a snippet of a certain type:
  * ```ts
- * let { banner }: { banner: Snippet<{ text: string }> } = $props();
+ * let { banner }: { banner: Snippet<[{ text: string }]> } = $props();
  * ```
  * You can only call a snippet through the `{@render ...}` tag.
+ *
+ * https://svelte-5-preview.vercel.app/docs/snippets
+ *
+ * @template Arguments Parameters that the snippet expects (if any) as a tuple. The default type is no parameters.
  */
-export type Snippet<T extends unknown[] = []> =
+export type Snippet<Arguments extends unknown[] = []> =
 	// this conditional allows tuples but not arrays. Arrays would indicate a
 	// rest parameter type, which is not supported. If rest parameters are added
 	// in the future, the condition can be removed.
-	number extends T['length']
+	number extends Arguments['length']
 		? never
 		: {
 				(
 					this: void,
-					...args: T
+					...args: Arguments
 				): typeof SnippetReturn & {
 					_: 'functions passed to {@render ...} tags must use the `Snippet` type imported from "svelte"';
 				};

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -265,18 +265,18 @@ declare const SnippetReturn: unique symbol;
  *
  * https://svelte-5-preview.vercel.app/docs/snippets
  *
- * @template Arguments Parameters that the snippet expects (if any) as a tuple. The default type is no parameters.
+ * @template Parameters the parameters that the snippet expects (if any) as a tuple.
  */
-export type Snippet<Arguments extends unknown[] = []> =
+export type Snippet<Parameters extends unknown[] = []> =
 	// this conditional allows tuples but not arrays. Arrays would indicate a
 	// rest parameter type, which is not supported. If rest parameters are added
 	// in the future, the condition can be removed.
-	number extends Arguments['length']
+	number extends Parameters['length']
 		? never
 		: {
 				(
 					this: void,
-					...args: Arguments
+					...args: Parameters
 				): typeof SnippetReturn & {
 					_: 'functions passed to {@render ...} tags must use the `Snippet` type imported from "svelte"';
 				};

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -262,18 +262,18 @@ declare module 'svelte' {
 	 *
 	 * https://svelte-5-preview.vercel.app/docs/snippets
 	 *
-	 * @template Arguments Parameters that the snippet expects (if any) as a tuple. The default type is no parameters.
+	 * @template Parameters the parameters that the snippet expects (if any) as a tuple.
 	 */
-	type Snippet<Arguments extends unknown[] = []> =
+	type Snippet<Parameters extends unknown[] = []> =
 		// this conditional allows tuples but not arrays. Arrays would indicate a
 		// rest parameter type, which is not supported. If rest parameters are added
 		// in the future, the condition can be removed.
-		number extends Arguments['length']
+		number extends Parameters['length']
 			? never
 			: {
 					(
 						this: void,
-						...args: Arguments
+						...args: Parameters
 					): typeof SnippetReturn & {
 						_: 'functions passed to {@render ...} tags must use the `Snippet` type imported from "svelte"';
 					};

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -256,20 +256,24 @@ declare module 'svelte' {
 	/**
 	 * The type of a `#snippet` block. You can use it to (for example) express that your component expects a snippet of a certain type:
 	 * ```ts
-	 * let { banner }: { banner: Snippet<{ text: string }> } = $props();
+	 * let { banner }: { banner: Snippet<[{ text: string }]> } = $props();
 	 * ```
 	 * You can only call a snippet through the `{@render ...}` tag.
+	 *
+	 * https://svelte-5-preview.vercel.app/docs/snippets
+	 *
+	 * @template Arguments Parameters that the snippet expects (if any) as a tuple. The default type is no parameters.
 	 */
-	type Snippet<T extends unknown[] = []> =
+	type Snippet<Arguments extends unknown[] = []> =
 		// this conditional allows tuples but not arrays. Arrays would indicate a
 		// rest parameter type, which is not supported. If rest parameters are added
 		// in the future, the condition can be removed.
-		number extends T['length']
+		number extends Arguments['length']
 			? never
 			: {
 					(
 						this: void,
-						...args: T
+						...args: Arguments
 					): typeof SnippetReturn & {
 						_: 'functions passed to {@render ...} tags must use the `Snippet` type imported from "svelte"';
 					};
@@ -3009,7 +3013,7 @@ declare function $props(): any;
  *
  * https://svelte-5-preview.vercel.app/docs/runes#$bindable
  */
-declare function $bindable<T>(t?: T): T;
+declare function $bindable<T>(fallback?: T): T;
 
 /**
  * Inspects one or more values whenever they, or the properties they contain, change. Example:


### PR DESCRIPTION
When looking at the type for Snippet (for example, using Go to Type Definition in VSCode) it's difficult to tell what generics to pass. I replaced the vauge `T` name with `Arguments` and added some JSDoc. I also fixed the sample code for Snippet to use a tuple.

Additional small change in the same vein: rename `t` in `$bindable` to `fallback` in the types

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
