### PR TITLE
feat: allow `let props = $props()`, optimize prop read access

### DIFF
--- a/.changeset/six-gorillas-obey.md
+++ b/.changeset/six-gorillas-obey.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: allow `let props = $props()` and optimize prop read access

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -1240,7 +1240,7 @@ export const validation_runes = merge(validation, a11y_validators, {
 				e.rune_invalid_arguments(node, rune);
 			}
 
-			if (node.id.type !== 'ObjectPattern') {
+			if (node.id.type !== 'ObjectPattern' && node.id.type !== 'Identifier') {
 				e.props_invalid_identifier(node);
 			}
 
@@ -1248,17 +1248,19 @@ export const validation_runes = merge(validation, a11y_validators, {
 				e.props_invalid_placement(node);
 			}
 
-			for (const property of node.id.properties) {
-				if (property.type === 'Property') {
-					if (property.computed) {
-						e.props_invalid_pattern(property);
-					}
+			if (node.id.type === 'ObjectPattern') {
+				for (const property of node.id.properties) {
+					if (property.type === 'Property') {
+						if (property.computed) {
+							e.props_invalid_pattern(property);
+						}
 
-					const value =
-						property.value.type === 'AssignmentPattern' ? property.value.left : property.value;
+						const value =
+							property.value.type === 'AssignmentPattern' ? property.value.left : property.value;
 
-					if (value.type !== 'Identifier') {
-						e.props_invalid_pattern(property);
+						if (value.type !== 'Identifier') {
+							e.props_invalid_pattern(property);
+						}
 					}
 				}
 			}

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -78,6 +78,7 @@ const rest_props_handler = {
  * @param {string} [name]
  * @returns {Record<string, unknown>}
  */
+/*#__NO_SIDE_EFFECTS__*/
 export function rest_props(props, exclude, name) {
 	return new Proxy(
 		DEV ? { props, exclude, name, other: {}, to_proxy: [] } : { props, exclude },

--- a/packages/svelte/tests/snapshot/samples/props-identifier/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/props-identifier/_expected/client/index.svelte.js
@@ -1,0 +1,17 @@
+import "svelte/internal/disclose-version";
+import * as $ from "svelte/internal/client";
+
+export default function Props_identifier($$anchor, $$props) {
+	$.push($$props, true);
+
+	let props = $.rest_props($$props, ["$$slots", "$$events", "$$legacy"]);
+
+	$$props.a;
+	props[a];
+	$$props.a.b;
+	$$props.a.b = true;
+	props.a = true;
+	props[a] = true;
+	props;
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/props-identifier/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/props-identifier/_expected/server/index.svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/server";
+
+export default function Props_identifier($$payload, $$props) {
+	$.push();
+
+	let props = $$props;
+
+	props.a;
+	props[a];
+	props.a.b;
+	props.a.b = true;
+	props.a = true;
+	props[a] = true;
+	props;
+	$.pop();
+}

--- a/packages/svelte/tests/snapshot/samples/props-identifier/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/props-identifier/index.svelte
@@ -1,0 +1,10 @@
+<script>
+	let props = $props();
+	props.a;
+	props[a];
+	props.a.b;
+	props.a.b = true;
+	props.a = true;
+	props[a] = true;
+	props;
+</script>

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/02-runes.md
@@ -548,6 +548,12 @@ To get all properties, use rest syntax:
 let { a, b, c, ...everythingElse } = $props();
 ```
 
+You can also use an identifier:
+
+```js
+let props = $props();
+```
+
 If you're using TypeScript, you can declare the prop types:
 
 ```ts


### PR DESCRIPTION
- allow to write `let props = $props()` (helps with some use cases of #9241)
- optimize read access of `props.x` to use `$$props` argument directly; closes #11055

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
