### PR TITLE
fix: make media bindings more robust

### DIFF
--- a/.changeset/popular-feet-rule.md
+++ b/.changeset/popular-feet-rule.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make media bindings more robust

--- a/packages/svelte/tests/runtime-browser/assert.js
+++ b/packages/svelte/tests/runtime-browser/assert.js
@@ -44,6 +44,7 @@ export function equal(a, b, message) {
 /**
  * @param {any} condition
  * @param {string} [message]
+ * @returns {asserts condition}
  */
 export function ok(condition, message) {
 	if (!condition) throw new Error(message || `Expected ${condition} to be truthy`);

--- a/packages/svelte/tests/runtime-browser/samples/bind-muted/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/bind-muted/_config.js
@@ -1,0 +1,29 @@
+import { test, ok } from '../../assert';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, target }) {
+		const audio = target.querySelector('audio');
+		const button = target.querySelector('button');
+		ok(audio);
+
+		assert.equal(audio.muted, false);
+
+		audio.muted = true;
+		audio.dispatchEvent(new CustomEvent('volumechange'));
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.muted, true, 'event');
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.muted, false, 'click 1');
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.muted, true, 'click 2');
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.muted, false, 'click 3');
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/bind-muted/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/bind-muted/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let muted = $state(false);
+</script>
+
+<audio bind:muted></audio>
+<button onclick={() => (muted = !muted)}>toggle</button>

--- a/packages/svelte/tests/runtime-browser/samples/bind-playbackrate/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/bind-playbackrate/_config.js
@@ -1,0 +1,29 @@
+import { test, ok } from '../../assert';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, target }) {
+		const audio = target.querySelector('audio');
+		const button = target.querySelector('button');
+		ok(audio);
+
+		assert.equal(audio.playbackRate, 0.5);
+
+		audio.playbackRate = 1.0;
+		audio.dispatchEvent(new CustomEvent('ratechange'));
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.playbackRate, 1.0);
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.playbackRate, 2);
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.playbackRate, 3);
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.playbackRate, 4);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/bind-playbackrate/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/bind-playbackrate/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let playbackRate = $state(0.5);
+</script>
+
+<audio bind:playbackRate></audio>
+<button onclick={() => (playbackRate += 1)}>increment</button>

--- a/packages/svelte/tests/runtime-browser/samples/bind-volume/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/bind-volume/_config.js
@@ -1,0 +1,29 @@
+import { test, ok } from '../../assert';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, target }) {
+		const audio = target.querySelector('audio');
+		const button = target.querySelector('button');
+		ok(audio);
+
+		assert.equal(audio.volume, 0.1);
+
+		audio.volume = 0.2;
+		audio.dispatchEvent(new CustomEvent('volumechange'));
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.volume, 0.2);
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.volume, 0.2 + 0.1); // JavaScript can't add floating point numbers correctly
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.volume, 0.2 + 0.1 + 0.1);
+
+		button?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(audio.volume, 0.2 + 0.1 + 0.1 + 0.1);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/bind-volume/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/bind-volume/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let volume = $state(0.1);
+</script>
+
+<audio bind:volume></audio>
+<button onclick={() => (volume += 0.1)}>increment</button>


### PR DESCRIPTION
The media bindings where fragile because the "prevent rerun if update in progress"-logic was flawed: It didn't (re)set the `updating` flag correctly, because it assumed an event and a render effect would always directly follow each other, with one always being first - but that's not true.
It's much more robust to instead compare the value with what's currently present in the DOM. For the very fast-firing current-time-binding a variable is used to not invoke the DOM getter as much, for the others this is not necessary.
Lastly, the playback-rate-binding contained another bug where the listener was setup inside the effect - turns out we can rework the whole binding a bit now that render effects fire synchronously on first run.

Noticed these bugs while working on the Svelte site, and tested these fixes there.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
