### PR TITLE
chore: support `modernAst` flag on repl

### DIFF
--- a/sites/svelte-5-preview/src/lib/Output/CompilerOptions.svelte
+++ b/sites/svelte-5-preview/src/lib/Output/CompilerOptions.svelte
@@ -23,6 +23,12 @@
 		<Checkbox bind:checked={$compile_options.dev} />
 		<span class="boolean">{$compile_options.dev}</span>,
 	</label>
+
+	<label class="option">
+		<span class="key">modernAst:</span>
+		<Checkbox bind:checked={$compile_options.modernAst} />
+		<span class="boolean">{$compile_options.modernAst}</span>,
+	</label>
 	});
 </div>
 

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -77,7 +77,8 @@
 	/** @type {import('svelte/compiler').CompileOptions} */
 	const DEFAULT_COMPILE_OPTIONS = {
 		generate: 'client',
-		dev: false
+		dev: false,
+		modernAst: true
 	};
 
 	/** @type {Map<string, import('@codemirror/state').EditorState>} */

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -70,7 +70,7 @@ function compile({ id, source, options, return_ast }) {
 
 			const { js, css, warnings, metadata } = compiled;
 
-			const ast = return_ast ? svelte.parse(source, { modern: true }) : undefined;
+			const ast = return_ast ? svelte.parse(source, { modern: options.modernAst }) : undefined;
 
 			return {
 				id,


### PR DESCRIPTION
I added `modernAst` option  for REPL.
Sometimes I need to use this now, so this is convenient at least for me.

<img width="413" alt="image" src="https://github.com/sveltejs/svelte/assets/19153718/d9c7456c-9975-4ff6-b680-b2f00cb0fcbd">

Simple demo:

https://github.com/sveltejs/svelte/assets/19153718/5e687042-8f87-4b4c-898a-5bfccd50873f


## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
