### PR TITLE
chore: make it easier to toggle HMR in playground

### DIFF
--- a/playgrounds/demo/vite.config.js
+++ b/playgrounds/demo/vite.config.js
@@ -2,11 +2,22 @@ import { defineConfig } from 'vite';
 import inspect from 'vite-plugin-inspect';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
+const hmr = true;
+
 export default defineConfig({
 	build: {
 		minify: false
 	},
-	plugins: [inspect(), svelte()],
+
+	plugins: [
+		inspect(),
+		svelte({
+			compilerOptions: {
+				hmr
+			}
+		})
+	],
+
 	optimizeDeps: {
 		// svelte is a local workspace package, optimizing it would require dev server restarts with --force for every change
 		exclude: ['svelte']

--- a/playgrounds/demo/vite.config.js
+++ b/playgrounds/demo/vite.config.js
@@ -2,8 +2,6 @@ import { defineConfig } from 'vite';
 import inspect from 'vite-plugin-inspect';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
-const hmr = true;
-
 export default defineConfig({
 	build: {
 		minify: false
@@ -13,7 +11,7 @@ export default defineConfig({
 		inspect(),
 		svelte({
 			compilerOptions: {
-				hmr
+				hmr: true
 			}
 		})
 	],


### PR DESCRIPTION
small QOL fix — since HMR affects the shape of the effect tree, we sometimes need to enable/disable it, and this makes it more straightforward to do so