### PR TITLE
fix: handle duplicate signal dependencies gracefully

### DIFF
--- a/.changeset/witty-phones-retire.md
+++ b/.changeset/witty-phones-retire.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: handle duplicate signal dependencies gracefully

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -419,10 +419,15 @@ function remove_reaction(signal, dependency) {
 export function remove_reactions(signal, start_index) {
 	const dependencies = signal.deps;
 	if (dependencies !== null) {
-		const active_dependencies = start_index === 0 ? null : dependencies.slice(0, start_index);
+		var active_dependencies = start_index === 0 ? null : dependencies.slice(0, start_index);
+		var visited = new Set();
 		let i;
 		for (i = start_index; i < dependencies.length; i++) {
 			const dependency = dependencies[i];
+			if (visited.has(dependency)) {
+				continue;
+			}
+			visited.add(dependency);
 			// Avoid removing a reaction if we know that it is active (start_index will not be 0)
 			if (active_dependencies === null || !active_dependencies.includes(dependency)) {
 				remove_reaction(signal, dependency);
@@ -774,10 +779,7 @@ export function get(signal) {
 		) {
 			if (current_dependencies === null) {
 				current_dependencies = [signal];
-			} else if (
-				current_dependencies[current_dependencies.length - 1] !== signal &&
-				!current_dependencies.includes(signal)
-			) {
+			} else if (current_dependencies[current_dependencies.length - 1] !== signal) {
 				current_dependencies.push(signal);
 			}
 		}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -417,21 +417,21 @@ function remove_reaction(signal, dependency) {
  * @returns {void}
  */
 export function remove_reactions(signal, start_index) {
-	const dependencies = signal.deps;
-	if (dependencies !== null) {
-		var active_dependencies = start_index === 0 ? null : dependencies.slice(0, start_index);
-		var visited = new Set();
-		let i;
-		for (i = start_index; i < dependencies.length; i++) {
-			const dependency = dependencies[i];
-			if (visited.has(dependency)) {
-				continue;
-			}
-			visited.add(dependency);
-			// Avoid removing a reaction if we know that it is active (start_index will not be 0)
-			if (active_dependencies === null || !active_dependencies.includes(dependency)) {
-				remove_reaction(signal, dependency);
-			}
+	var dependencies = signal.deps;
+	if (dependencies === null) return;
+
+	var active_dependencies = start_index === 0 ? null : dependencies.slice(0, start_index);
+	var seen = new Set();
+
+	for (var i = start_index; i < dependencies.length; i++) {
+		var dependency = dependencies[i];
+
+		if (seen.has(dependency)) continue;
+		seen.add(dependency);
+
+		// Avoid removing a reaction if we know that it is active (start_index will not be 0)
+		if (active_dependencies === null || !active_dependencies.includes(dependency)) {
+			remove_reaction(signal, dependency);
 		}
 	}
 }

--- a/packages/svelte/tests/runtime-runes/samples/derived-dependencies-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-dependencies-2/_config.js
@@ -5,34 +5,33 @@ export default test({
 	async test({ assert, target }) {
 		let [btn1, btn2] = target.querySelectorAll('button');
 
-		btn1?.click();
-		flushSync();
-		await Promise.resolve();
-
-		assert.htmlEqual(target.innerHTML, `<button>hide</button><button>show</button`);
-
-		btn2?.click();
-		await Promise.resolve();
-		await Promise.resolve();
-
+		flushSync(() => btn1?.click());
 		assert.htmlEqual(
 			target.innerHTML,
-			`<h1>John Doe</h1><p>Body</p><div>123</div><button>hide</button><button>show</button>`
+			`
+				<button>toggle a</button>
+				<button>toggle b</button>
+				false/true/true
+			`
 		);
 
-		btn1?.click();
-		flushSync();
-		await Promise.resolve();
-
-		assert.htmlEqual(target.innerHTML, `<button>hide</button><button>show</button`);
-
-		btn2?.click();
-		await Promise.resolve();
-		await Promise.resolve();
-
+		flushSync(() => btn2?.click());
 		assert.htmlEqual(
 			target.innerHTML,
-			`<h1>John Doe</h1><p>Body</p><div>123</div><button>hide</button><button>show</button>`
+			`
+				<button>toggle a</button>
+				<button>toggle b</button>
+			`
+		);
+
+		flushSync(() => btn2?.click());
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>toggle a</button>
+				<button>toggle b</button>
+				false/true/true
+			`
 		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/derived-dependencies-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-dependencies-2/_config.js
@@ -1,0 +1,38 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		let [btn1, btn2] = target.querySelectorAll('button');
+
+		btn1?.click();
+		flushSync();
+		await Promise.resolve();
+
+		assert.htmlEqual(target.innerHTML, `<button>hide</button><button>show</button`);
+
+		btn2?.click();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`<h1>John Doe</h1><p>Body</p><div>123</div><button>hide</button><button>show</button>`
+		);
+
+		btn1?.click();
+		flushSync();
+		await Promise.resolve();
+
+		assert.htmlEqual(target.innerHTML, `<button>hide</button><button>show</button`);
+
+		btn2?.click();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`<h1>John Doe</h1><p>Body</p><div>123</div><button>hide</button><button>show</button>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-dependencies-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-dependencies-2/main.svelte
@@ -1,0 +1,49 @@
+<script>
+	import { writable } from "svelte/store";
+
+	const store = writable({
+		url: {
+			pathname: '123'
+		}
+	})
+	const page = {
+		subscribe(fn) {
+			return store.subscribe(fn);
+		}
+	}
+
+	let data = $state({
+		event: {
+			author: 'John Doe',
+			body: 'Body',
+			foo: '123'
+		},
+	});
+
+	const { event } = $derived(data);
+</script>
+
+{#if event}
+	<h1>{event.author}</h1>
+	<p>{event.body}</p>
+	<div>{$page.url.pathname}</div>
+{/if}
+
+<button onclick={() => {
+	data = {}
+	store.update(v => ({...v}));
+}}>hide</button>
+
+<button onclick={() => {
+	data = {
+		event: {
+			author: 'John Doe',
+			body: 'Body',
+			foo: '123'
+		},
+	}
+	queueMicrotask(() => {
+		store.update(v => ({...v}));
+	})
+}}>show</button>
+

--- a/packages/svelte/tests/runtime-runes/samples/derived-dependencies-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-dependencies-2/main.svelte
@@ -1,49 +1,13 @@
 <script>
-	import { writable } from "svelte/store";
+	let a = $state(true);
+	let b = $state({ c: true });
 
-	const store = writable({
-		url: {
-			pathname: '123'
-		}
-	})
-	const page = {
-		subscribe(fn) {
-			return store.subscribe(fn);
-		}
-	}
-
-	let data = $state({
-		event: {
-			author: 'John Doe',
-			body: 'Body',
-			foo: '123'
-		},
-	});
-
-	const { event } = $derived(data);
+	const x = $derived(b);
 </script>
 
-{#if event}
-	<h1>{event.author}</h1>
-	<p>{event.body}</p>
-	<div>{$page.url.pathname}</div>
+<button onclick={() => (a = !a)}>toggle a</button>
+<button onclick={() => (b = b ? null : { c: true })}>toggle b</button>
+
+{#if x}
+	{a}/{x.c}/{x.c}
 {/if}
-
-<button onclick={() => {
-	data = {}
-	store.update(v => ({...v}));
-}}>hide</button>
-
-<button onclick={() => {
-	data = {
-		event: {
-			author: 'John Doe',
-			body: 'Body',
-			foo: '123'
-		},
-	}
-	queueMicrotask(() => {
-		store.update(v => ({...v}));
-	})
-}}>show</button>
-


### PR DESCRIPTION
Follow up to https://github.com/sveltejs/svelte/pull/12245. Fixes https://github.com/sveltejs/svelte/issues/12230. This also permits duplicate dependencies and instead we avoid processing duplicates in `remove_reactions`. This means far less work is done on the fast normal path, and instead we just do a bit more work when removing signals.

This PR faster in almost all the benchmarks than `main` for me, and the ones it is not it's off by a small fraction which shows that the codepath likely isn't being hit.