### PR TITLE
chore: beef up memory leak test for unowned deriveds

### DIFF
--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -273,10 +273,12 @@ describe('signals', () => {
 			flushSync(() => set(count, 0));
 			// Ensure we're not leaking consumers
 			assert.deepEqual(count.reactions?.length, 1);
+			assert.deepEqual(calc.reactions?.length, 1);
 			assert.deepEqual(log, [0, 2, 'limit', 0]);
 			destroy();
 			// Ensure we're not leaking consumers
 			assert.deepEqual(count.reactions, null);
+			assert.deepEqual(calc.reactions, null);
 		};
 	});
 


### PR DESCRIPTION
was just looking at `check_dirtiness` — wanted to take another quick run at #12073 — and this looked like the kind of place I could easily add a regression if I was left to my own devices. This addition makes sure that unowned deriveds don't end up with a memory leak when they are read inside an effect (which takes some gymnastics but is totally possible)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
