### PR TITLE
chore: tweak reactivity

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -6,7 +6,7 @@ import {
 	set_signal_status,
 	mark_reactions,
 	current_skip_reaction,
-	execute_reaction_fn,
+	update_reaction,
 	destroy_effect_children,
 	increment_version
 } from '../runtime.js';
@@ -86,7 +86,7 @@ export function update_derived(derived) {
 	var previous_updating_derived = updating_derived;
 	updating_derived = true;
 	destroy_derived_children(derived);
-	var value = execute_reaction_fn(derived);
+	var value = update_reaction(derived);
 	updating_derived = previous_updating_derived;
 
 	var status =

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -5,7 +5,7 @@ import {
 	current_reaction,
 	destroy_effect_children,
 	dev_current_component_function,
-	execute_effect,
+	update_effect,
 	get,
 	is_destroying_effect,
 	is_flushing_effect,
@@ -106,7 +106,7 @@ function create_effect(type, fn, sync, push = true) {
 
 		try {
 			set_is_flushing_effect(true);
-			execute_effect(effect);
+			update_effect(effect);
 			effect.f |= EFFECT_RAN;
 		} finally {
 			set_is_flushing_effect(previously_flushing_effect);
@@ -267,7 +267,7 @@ export function legacy_pre_effect_reset() {
 			var effect = token.effect;
 
 			if (check_dirtiness(effect)) {
-				execute_effect(effect);
+				update_effect(effect);
 			}
 
 			token.ran = false;
@@ -495,7 +495,7 @@ function resume_children(effect, local) {
 	// If a dependency of this effect changed while it was paused,
 	// apply the change now
 	if (check_dirtiness(effect)) {
-		execute_effect(effect);
+		update_effect(effect);
 	}
 
 	var child = effect.first;

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -13,7 +13,7 @@ import {
 	set_signal_status,
 	untrack,
 	increment_version,
-	execute_effect,
+	update_effect,
 	inspect_effects
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
@@ -123,7 +123,7 @@ export function set(source, value) {
 
 		if (DEV) {
 			for (const effect of inspect_effects) {
-				execute_effect(effect);
+				update_effect(effect);
 			}
 
 			inspect_effects.clear();

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -313,6 +313,7 @@ export function update_reaction(reaction) {
 		var dependencies = /** @type {import('#client').Value<unknown>[]} **/ (reaction.deps);
 
 		if (current_dependencies !== null) {
+			var dependency;
 			var i;
 
 			if (dependencies !== null) {
@@ -330,7 +331,7 @@ export function update_reaction(reaction) {
 					array.length > 16 && deps_length - current_dependencies_index > 1 ? new Set(array) : null;
 
 				for (i = current_dependencies_index; i < deps_length; i++) {
-					var dependency = dependencies[i];
+					dependency = dependencies[i];
 
 					if (set !== null ? !set.has(dependency) : !array.includes(dependency)) {
 						remove_reaction(reaction, dependency);
@@ -351,7 +352,7 @@ export function update_reaction(reaction) {
 
 			if (!current_skip_reaction) {
 				for (i = current_dependencies_index; i < dependencies.length; i++) {
-					var dependency = dependencies[i];
+					dependency = dependencies[i];
 					var reactions = dependency.reactions;
 
 					if (reactions === null) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -296,11 +296,11 @@ function handle_error(error, effect, component_context) {
  * @returns {V}
  */
 export function update_reaction(reaction) {
-	const previous_dependencies = current_dependencies;
-	const previous_dependencies_index = current_dependencies_index;
-	const previous_untracked_writes = current_untracked_writes;
-	const previous_reaction = current_reaction;
-	const previous_skip_reaction = current_skip_reaction;
+	var previous_dependencies = current_dependencies;
+	var previous_dependencies_index = current_dependencies_index;
+	var previous_untracked_writes = current_untracked_writes;
+	var previous_reaction = current_reaction;
+	var previous_skip_reaction = current_skip_reaction;
 
 	current_dependencies = /** @type {null | import('#client').Value[]} */ (null);
 	current_dependencies_index = 0;
@@ -309,31 +309,30 @@ export function update_reaction(reaction) {
 	current_skip_reaction = !is_flushing_effect && (reaction.f & UNOWNED) !== 0;
 
 	try {
-		let res = /** @type {Function} */ (0, reaction.fn)();
-		let dependencies = /** @type {import('#client').Value<unknown>[]} **/ (reaction.deps);
+		var result = /** @type {Function} */ (0, reaction.fn)();
+		var dependencies = /** @type {import('#client').Value<unknown>[]} **/ (reaction.deps);
+
 		if (current_dependencies !== null) {
-			let i;
+			var i;
+
 			if (dependencies !== null) {
-				const deps_length = dependencies.length;
-				// Include any dependencies up until the current_dependencies_index.
-				const full_current_dependencies =
+				var deps_length = dependencies.length;
+
+				/** All dependencies of the reaction, including those tracked on the previous run */
+				var array =
 					current_dependencies_index === 0
 						? current_dependencies
 						: dependencies.slice(0, current_dependencies_index).concat(current_dependencies);
-				const current_dep_length = full_current_dependencies.length;
+
 				// If we have more than 16 elements in the array then use a Set for faster performance
 				// TODO: evaluate if we should always just use a Set or not here?
-				const full_current_dependencies_set =
-					current_dep_length > 16 && deps_length - current_dependencies_index > 1
-						? new Set(full_current_dependencies)
-						: null;
+				var set =
+					array.length > 16 && deps_length - current_dependencies_index > 1 ? new Set(array) : null;
+
 				for (i = current_dependencies_index; i < deps_length; i++) {
-					const dependency = dependencies[i];
-					if (
-						full_current_dependencies_set !== null
-							? !full_current_dependencies_set.has(dependency)
-							: !full_current_dependencies.includes(dependency)
-					) {
+					var dependency = dependencies[i];
+
+					if (set !== null ? !set.has(dependency) : !array.includes(dependency)) {
 						remove_reaction(reaction, dependency);
 					}
 				}
@@ -352,8 +351,8 @@ export function update_reaction(reaction) {
 
 			if (!current_skip_reaction) {
 				for (i = current_dependencies_index; i < dependencies.length; i++) {
-					const dependency = dependencies[i];
-					const reactions = dependency.reactions;
+					var dependency = dependencies[i];
+					var reactions = dependency.reactions;
 
 					if (reactions === null) {
 						dependency.reactions = [reaction];
@@ -369,7 +368,8 @@ export function update_reaction(reaction) {
 			remove_reactions(reaction, current_dependencies_index);
 			dependencies.length = current_dependencies_index;
 		}
-		return res;
+
+		return result;
 	} finally {
 		current_dependencies = previous_dependencies;
 		current_dependencies_index = previous_dependencies_index;


### PR DESCRIPTION
I'm circling around `check_dirtiness` and `mark_reactions`, trying to understand some of the nuances therein. I'm pretty confident that we shouldn't be calling `mark_reactions` inside `update_derived`, for example.

For now I'm just making a few cosmetic tweaks to make the code slightly easier to follow:

- `execute_effect` and `execute_reaction_fn` are now `update_effect` and `update_reaction`, to match `update_derived`
- inside `check_dirtiness`, we check the `DIRTY` flag and early return before checking the (rarer) `is_unowned` and `is_disconnected` cases
- inside `mark_derived`, we don't need to check `maybe_dirty && unowned`, because by the time we get to that check there's no way an unowned derived could be anything _but_ maybe dirty (if we're dirty we've already continued, if we're clean we don't reach that part of the condition). As such we can simplify the condition
- use `var` over `let` or `const` where possible

I also added a few newlines to separate paragraphs of code. We have a tendency to write walls of text, and it makes logic harder to follow because paragraphs all run into each other.

Ran `pnpm bench:compare` and it was basically identical, with a slight edge to this PR (likely because of the simpler condition in `mark_reactions` and the re-ordering of cases in `check_dirtiness`).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
