### PR TITLE
chore: default remove_dom to false

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -63,15 +63,16 @@ export function derived_safe_equal(fn) {
 }
 
 /**
- * @param {import('#client').Derived} signal
+ * @param {import('#client').Derived} derived
  * @returns {void}
  */
-function destroy_derived_children(signal) {
-	destroy_effect_children(signal);
-	var deriveds = signal.deriveds;
+function destroy_derived_children(derived) {
+	destroy_effect_children(derived);
+	var deriveds = derived.deriveds;
 
 	if (deriveds !== null) {
-		signal.deriveds = null;
+		derived.deriveds = null;
+
 		for (var i = 0; i < deriveds.length; i += 1) {
 			destroy_derived(deriveds[i]);
 		}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -433,18 +433,17 @@ export function remove_reactions(signal, start_index) {
 
 /**
  * @param {import('#client').Reaction} signal
- * @param {boolean} [remove_dom]
+ * @param {boolean} remove_dom
  * @returns {void}
  */
-export function destroy_effect_children(signal, remove_dom = true) {
-	let effect = signal.first;
-	signal.first = null;
-	signal.last = null;
-	var sibling;
+export function destroy_effect_children(signal, remove_dom = false) {
+	var effect = signal.first;
+	signal.first = signal.last = null;
+
 	while (effect !== null) {
-		sibling = effect.next;
+		var next = effect.next;
 		destroy_effect(effect, remove_dom);
-		effect = sibling;
+		effect = next;
 	}
 }
 


### PR DESCRIPTION
A consequence of #12258 is that we only need to remove DOM nodes when a branch or root effect is being destroyed. All other times, there's nothing we need to do.

I suspect we already weren't removing the nodes in question, and so this probably won't actually bring any performance benefits, but it reflects intent more accurately this way.

Made a couple of drive-by style fixes while I was at it.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
