### PR TITLE
chore: add comments to `update_reaction` and `get`

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -2,7 +2,7 @@ import { DEV } from 'esm-env';
 import {
 	current_component_context,
 	current_reaction,
-	current_dependencies,
+	new_deps,
 	current_effect,
 	current_untracked_writes,
 	get,
@@ -109,7 +109,7 @@ export function set(source, value) {
 			(current_effect.f & CLEAN) !== 0 &&
 			(current_effect.f & BRANCH_EFFECT) === 0
 		) {
-			if (current_dependencies !== null && current_dependencies.includes(source)) {
+			if (new_deps !== null && new_deps.includes(source)) {
 				set_signal_status(current_effect, DIRTY);
 				schedule_effect(current_effect);
 			} else {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -317,7 +317,7 @@ export function update_reaction(reaction) {
 
 	try {
 		var result = /** @type {Function} */ (0, reaction.fn)();
-		var deps = /** @type {import('#client').Value<unknown>[]} **/ (reaction.deps);
+		var deps = reaction.deps;
 
 		if (new_deps !== null) {
 			var dependency;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -769,18 +769,12 @@ export function get(signal) {
 
 	// Register the dependency on the current reaction signal.
 	if (current_reaction !== null) {
-		var unowned = (current_reaction.f & UNOWNED) !== 0;
 		var deps = current_reaction.deps;
 
 		// If the signal is accessing the same dependencies in the same
 		// order as it did last time, increment `skipped_deps`
 		// rather than updating `new_deps`, which creates GC cost
-		if (
-			new_deps === null &&
-			deps !== null &&
-			deps[skipped_deps] === signal &&
-			!(unowned && current_effect !== null)
-		) {
+		if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
 			skipped_deps++;
 		}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -757,7 +757,8 @@ export async function tick() {
  * @returns {V}
  */
 export function get(signal) {
-	const flags = signal.f;
+	var flags = signal.f;
+
 	if ((flags & DESTROYED) !== 0) {
 		return signal.v;
 	}
@@ -768,8 +769,8 @@ export function get(signal) {
 
 	// Register the dependency on the current reaction signal.
 	if (current_reaction !== null) {
-		const unowned = (current_reaction.f & UNOWNED) !== 0;
-		const deps = current_reaction.deps;
+		var unowned = (current_reaction.f & UNOWNED) !== 0;
+		var deps = current_reaction.deps;
 
 		// If the signal is accessing the same dependencies in the same
 		// order as it did last time, increment `skipped_deps`

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -324,8 +324,6 @@ export function update_reaction(reaction) {
 			var i;
 
 			if (deps !== null) {
-				var deps_length = deps.length;
-
 				/** All dependencies of the reaction, including those tracked on the previous run */
 				var array = skipped_deps === 0 ? new_deps : deps.slice(0, skipped_deps).concat(new_deps);
 
@@ -333,7 +331,7 @@ export function update_reaction(reaction) {
 				// TODO: evaluate if we should always just use a Set or not here?
 				var set = array.length > 16 ? new Set(array) : null;
 
-				for (i = skipped_deps; i < deps_length; i++) {
+				for (i = skipped_deps; i < deps.length; i++) {
 					dependency = deps[i];
 
 					if (set !== null ? !set.has(dependency) : !array.includes(dependency)) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -331,6 +331,7 @@ export function update_reaction(reaction) {
 				// TODO: evaluate if we should always just use a Set or not here?
 				var set = array.length > 16 ? new Set(array) : null;
 
+				// Remove dependencies that should no longer be tracked
 				for (i = skipped_deps; i < deps.length; i++) {
 					dependency = deps[i];
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -347,7 +347,7 @@ export function update_reaction(reaction) {
 					deps[skipped_deps + i] = new_deps[i];
 				}
 			} else {
-				reaction.deps = /** @type {import('#client').Value<V>[]} **/ (deps = new_deps);
+				reaction.deps = deps = new_deps;
 			}
 
 			if (!current_skip_reaction) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -331,7 +331,7 @@ export function update_reaction(reaction) {
 
 				// If we have more than 16 elements in the array then use a Set for faster performance
 				// TODO: evaluate if we should always just use a Set or not here?
-				var set = array.length > 16 && deps_length - skipped_deps > 1 ? new Set(array) : null;
+				var set = array.length > 16 ? new Set(array) : null;
 
 				for (i = skipped_deps; i < deps_length; i++) {
 					dependency = deps[i];


### PR DESCRIPTION
More adventures in grokking the codebase. This adds a bunch of explanatory comments, renames some variables...

- `current_dependencies` becomes `new_deps`. We don't adhere to the `current_` convention consistently, and `new_deps` does a better job of communicating what they are. While I normally prefer full words, `dependencies` is very long and it often causes Prettier to split stuff onto multiple lines, exacerbating the wall-of-text effect
- `current_dependencies_index` becomes `skipped_deps`, which again does a slightly nicer job (IMHO) if articulating what it's for

...and makes some very small logic tweaks:

- the `!(unowned && current_effect !== null)` check in `get` doesn't appear to do anything useful. At the very least, nothing breaks if we remove it. I suspect it was deopting us from the `skipped_deps` mechanism unnecessarily, possibly as a hangover from an earlier implementation
- ~~we simplify some of the `if` stuff inside `if (new_deps !== null)`~~ this broke stuff somehow, reverted. trying to unrevert
- we simplify the logic around when to create a set. I couldn't understand what the previous logic was doing, but if the goal is to make lookups faster then it seems that the only relevant criterion is the length of the array itself

`pnpm bench:compare` gave this PR the edge over `main`, but they're essentially indistinguishable

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
