### PR TITLE
chore: only call `mark_reactions` when updating a source

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -4,7 +4,6 @@ import {
 	current_effect,
 	remove_reactions,
 	set_signal_status,
-	mark_reactions,
 	current_skip_reaction,
 	update_reaction,
 	destroy_effect_children,
@@ -100,7 +99,6 @@ export function update_derived(derived) {
 	if (!derived.equals(value)) {
 		derived.v = value;
 		derived.version = increment_version();
-		mark_reactions(derived, DIRTY, false);
 	}
 }
 

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -38,7 +38,7 @@ export function derived(fn) {
 	};
 
 	if (current_reaction !== null && (current_reaction.f & DERIVED) !== 0) {
-		var current_derived = /** @type {import('#client').Derived<V>} */ (current_reaction);
+		var current_derived = /** @type {import('#client').Derived} */ (current_reaction);
 		if (current_derived.deriveds === null) {
 			current_derived.deriveds = [signal];
 		} else {

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -94,7 +94,8 @@ function create_effect(type, fn, sync, push = true) {
 		parent: is_root ? null : current_effect,
 		prev: null,
 		teardown: null,
-		transitions: null
+		transitions: null,
+		version: 0
 	};
 
 	if (DEV) {

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -156,15 +156,15 @@ function mark_reactions(signal, status) {
 		var reaction = reactions[i];
 		var flags = reaction.f;
 
+		// Skip any effects that are already dirty
+		if ((flags & DIRTY) !== 0) continue;
+
+		// In legacy mode, skip the current effect to prevent infinite loops
+		if (!runes && reaction === current_effect) continue;
+
+		// Inspect effects need to run immediately, so that the stack trace makes sense
 		if (DEV && (flags & INSPECT_EFFECT) !== 0) {
 			inspect_effects.add(reaction);
-			continue;
-		}
-
-		// We skip any effects that are already dirty. Additionally, we also
-		// skip if the reaction is the same as the current effect (except if we're not in runes or we
-		// are in force schedule mode).
-		if ((flags & DIRTY) !== 0 || (!runes && reaction === current_effect)) {
 			continue;
 		}
 

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -12,8 +12,7 @@ import {
 	set_signal_status,
 	untrack,
 	increment_version,
-	update_effect,
-	inspect_effects
+	update_effect
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import {
@@ -27,6 +26,8 @@ import {
 } from '../constants.js';
 import { UNINITIALIZED } from '../../../constants.js';
 import * as e from '../errors.js';
+
+let inspect_effects = new Set();
 
 /**
  * @template V

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -3,6 +3,8 @@ import type { ComponentContext, Dom, Equals, TemplateNode, TransitionManager } f
 export interface Signal {
 	/** Flags bitmask */
 	f: number;
+	/** Write version */
+	version: number;
 }
 
 export interface Value<V = unknown> extends Signal {
@@ -12,8 +14,6 @@ export interface Value<V = unknown> extends Signal {
 	equals: Equals;
 	/** The latest value for this signal */
 	v: V;
-	/** Write version */
-	version: number;
 }
 
 export interface Reaction extends Signal {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -156,17 +156,14 @@ export function check_dirtiness(reaction) {
 	var flags = reaction.f;
 	var is_dirty = (flags & DIRTY) !== 0;
 
-	if (is_dirty) {
-		return true;
-	}
-
-	var is_effect = (flags & EFFECT) !== 0;
-	var is_unowned = (flags & UNOWNED) !== 0;
+	if (is_dirty) return true;
 
 	if ((flags & MAYBE_DIRTY) !== 0) {
 		var dependencies = reaction.deps;
 
 		if (dependencies !== null) {
+			var is_effect = (flags & EFFECT) !== 0;
+			var is_unowned = (flags & UNOWNED) !== 0;
 			var length = dependencies.length;
 
 			for (var i = 0; i < length; i++) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -164,9 +164,8 @@ export function check_dirtiness(reaction) {
 
 		if (dependencies !== null) {
 			var is_unowned = (flags & UNOWNED) !== 0;
-			var length = dependencies.length;
 
-			for (var i = 0; i < length; i++) {
+			for (var i = 0; i < dependencies.length; i++) {
 				var dependency = dependencies[i];
 
 				if (check_dirtiness(/** @type {import('#client').Derived} */ (dependency))) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -187,10 +187,6 @@ export function check_dirtiness(reaction) {
 				}
 
 				if (is_unowned) {
-					// If we're working with an unowned derived signal, then we need to check
-					// if our dependency write version is higher. If it is then we can assume
-					// that state has changed to a newer version and thus this unowned signal
-					// is also dirty.
 					if (is_dirty) {
 						return true;
 					}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -170,7 +170,7 @@ export function check_dirtiness(reaction) {
 				var dependency = dependencies[i];
 
 				if (check_dirtiness(/** @type {import('#client').Derived} */ (dependency))) {
-					update_derived(/** @type {import('#client').Derived} **/ (dependency));
+					update_derived(/** @type {import('#client').Derived} */ (dependency));
 				}
 
 				if (dependency.version > reaction.version) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -184,8 +184,7 @@ export function check_dirtiness(reaction) {
 				}
 
 				if (is_unowned) {
-					// TODO is there a more efficient place to do this work?
-
+					// TODO is there a more logical place to do this work?
 					if (!current_skip_reaction && !dependency?.reactions?.includes(reaction)) {
 						// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
 						// and the version hasn't changed, we still need to check that this reaction
@@ -196,11 +195,7 @@ export function check_dirtiness(reaction) {
 			}
 		}
 
-		// Unowned signals are always maybe dirty
-		// TODO nothing happens if we remove the `if`, do we still need it?
-		// if (!is_unowned) {
 		set_signal_status(reaction, CLEAN);
-		// }
 	}
 
 	return is_dirty;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -773,7 +773,7 @@ export function get(signal) {
 
 		if ((flags & DISCONNECTED) !== 0) {
 			// reconnect to the graph
-			var deps = derived.deps;
+			deps = derived.deps;
 
 			if (deps !== null) {
 				for (var i = 0; i < deps.length; i++) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -179,18 +179,13 @@ export function check_dirtiness(reaction) {
 				}
 
 				if (dependency.version > reaction.version) {
+					// we don't need to update the status of these signals
+					if (is_effect || is_unowned) return true;
+
 					is_dirty = true;
 				}
 
-				if (is_effect && is_dirty) {
-					return true;
-				}
-
 				if (is_unowned) {
-					if (is_dirty) {
-						return true;
-					}
-
 					if (!current_skip_reaction && !dependency?.reactions?.includes(reaction)) {
 						// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
 						// and the version hasn't changed, we still need to check that this reaction
@@ -211,10 +206,12 @@ export function check_dirtiness(reaction) {
 			}
 		}
 
-		// Unowned signals are always maybe dirty, as we instead check their dependency versions.
+		// Unowned signals are always maybe dirty
+		// TODO nothing happens if we remove the `if`, do we still need it?
 		if (!is_unowned) {
 			set_signal_status(reaction, CLEAN);
 		}
+
 		if (is_disconnected) {
 			reaction.f ^= DISCONNECTED;
 		}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -184,6 +184,8 @@ export function check_dirtiness(reaction) {
 				}
 
 				if (is_unowned) {
+					// TODO is there a more efficient place to do this work?
+
 					if (!current_skip_reaction && !dependency?.reactions?.includes(reaction)) {
 						// If we are working with an unowned signal as part of an effect (due to !current_skip_reaction)
 						// and the version hasn't changed, we still need to check that this reaction
@@ -196,9 +198,9 @@ export function check_dirtiness(reaction) {
 
 		// Unowned signals are always maybe dirty
 		// TODO nothing happens if we remove the `if`, do we still need it?
-		if (!is_unowned) {
-			set_signal_status(reaction, CLEAN);
-		}
+		// if (!is_unowned) {
+		set_signal_status(reaction, CLEAN);
+		// }
 	}
 
 	return is_dirty;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -62,8 +62,6 @@ export function set_is_destroying_effect(value) {
 	is_destroying_effect = value;
 }
 
-export let inspect_effects = new Set();
-
 // Handle effect queues
 
 /** @type {import('#client').Effect[]} */

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -154,30 +154,27 @@ export function is_runes() {
  */
 export function check_dirtiness(reaction) {
 	var flags = reaction.f;
-	var is_dirty = (flags & DIRTY) !== 0;
 
-	if (is_dirty) return true;
+	if ((flags & DIRTY) !== 0) {
+		return true;
+	}
 
 	if ((flags & MAYBE_DIRTY) !== 0) {
 		var dependencies = reaction.deps;
 
 		if (dependencies !== null) {
-			var is_effect = (flags & EFFECT) !== 0;
 			var is_unowned = (flags & UNOWNED) !== 0;
 			var length = dependencies.length;
 
 			for (var i = 0; i < length; i++) {
 				var dependency = dependencies[i];
 
-				if (!is_dirty && check_dirtiness(/** @type {import('#client').Derived} */ (dependency))) {
+				if (check_dirtiness(/** @type {import('#client').Derived} */ (dependency))) {
 					update_derived(/** @type {import('#client').Derived} **/ (dependency));
 				}
 
 				if (dependency.version > reaction.version) {
-					// we don't need to update the status of these signals
-					if (is_effect || is_unowned) return true;
-
-					is_dirty = true;
+					return true;
 				}
 
 				if (is_unowned) {
@@ -195,7 +192,7 @@ export function check_dirtiness(reaction) {
 		set_signal_status(reaction, CLEAN);
 	}
 
-	return is_dirty;
+	return false;
 }
 
 /**


### PR DESCRIPTION
This implements something I've been wanting to get at for a while. Currently, we call `mark_reactions` in two places — when updating a source, and when updating a derived. The latter doesn't really make sense — we should only mark reactions when sources update.

This fixes that, and allows us to simplify things a bit — there's no more `force_schedule`. It also allows us to move `mark_reactions` (and `inspect_effects`) out of the neverending module that is `runtime.js` and into `sources.js`.

It works by using version tracking as the universal mechanism for knowing if a reaction is dirty. We can use `current_version` for effects, rather than `increment_version()`, so this doesn't increase the (infinitesimal) danger of an overflow. (I thought I'd be able to use the same trick for deriveds, but it doesn't work for some reason — will continue investigating.)

~~Performance-wise it's basically neutral, except for `kairo_mux_unowned` which is slower. I'm not exactly sure why but my hunch is that it's somehow related to the fact that we're pushing reactions further down — it feels weird that we do that there in addition to doing it inside `update_reaction`. Feels off, will look into it.~~ With the most recent commits, this is significantly faster than `main`. I'm still a bit confused by the `is_unowned` stuff inside `check_dirtiness`, but we can worry about that another time.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
