### PR TITLE
chore: better store subscriptions

### DIFF
--- a/.changeset/thirty-flies-push.md
+++ b/.changeset/thirty-flies-push.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: tidy up store logic

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -154,17 +154,12 @@ export function client_component(source, analysis, options) {
 		}
 		if (binding.kind === 'store_sub') {
 			if (store_setup.length === 0) {
-				store_setup.push(b.const('$$subscriptions', b.call('$.create_stores')));
+				store_setup.push(b.const('$$stores', b.call('$.setup_stores')));
 			}
 
 			// We're creating an arrow function that gets the store value which minifies better for two or more references
 			const store_reference = serialize_get_binding(b.id(name.slice(1)), instance_state);
-			const store_get = b.call(
-				'$.store_get',
-				store_reference,
-				b.literal(name),
-				b.id('$$subscriptions')
-			);
+			const store_get = b.call('$.store_get', store_reference, b.literal(name), b.id('$$stores'));
 			store_setup.push(
 				b.const(
 					binding.node,

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -154,11 +154,9 @@ export function client_component(source, analysis, options) {
 		}
 		if (binding.kind === 'store_sub') {
 			if (store_setup.length === 0) {
-				store_setup.push(
-					b.const('$$subscriptions', b.object([])),
-					b.stmt(b.call('$.unsubscribe_on_destroy', b.id('$$subscriptions')))
-				);
+				store_setup.push(b.const('$$subscriptions', b.call('$.create_stores')));
 			}
+
 			// We're creating an arrow function that gets the store value which minifies better for two or more references
 			const store_reference = serialize_get_binding(b.id(name.slice(1)), instance_state);
 			const store_get = b.call(

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -345,7 +345,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 				}
 
 				if (state.scope.get(`$${left.name}`)?.kind === 'store_sub') {
-					return b.call('$.store_unsub', call, b.literal(`$${left.name}`), b.id('$$subscriptions'));
+					return b.call('$.store_unsub', call, b.literal(`$${left.name}`), b.id('$$stores'));
 				} else {
 					return call;
 				}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2438,7 +2438,7 @@ export const template_visitors = {
 					b.thunk(b.sequence(indirect_dependencies))
 				);
 				const invalidate_store = store_to_invalidate
-					? b.call('$.invalidate_store', b.id('$$subscriptions'), b.literal(store_to_invalidate))
+					? b.call('$.invalidate_store', b.id('$$stores'), b.literal(store_to_invalidate))
 					: undefined;
 
 				const sequence = [];

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -109,12 +109,12 @@ export {
 	update_prop
 } from './reactivity/props.js';
 export {
+	create_stores,
 	invalidate_store,
 	mutate_store,
 	store_get,
 	store_set,
 	store_unsub,
-	unsubscribe_on_destroy,
 	update_pre_store,
 	update_store
 } from './reactivity/store.js';

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -109,7 +109,7 @@ export {
 	update_prop
 } from './reactivity/props.js';
 export {
-	create_stores,
+	setup_stores,
 	invalidate_store,
 	mutate_store,
 	store_get,

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -109,9 +109,9 @@ export {
 	update_prop
 } from './reactivity/props.js';
 export {
-	setup_stores,
 	invalidate_store,
 	mutate_store,
+	setup_stores,
 	store_get,
 	store_set,
 	store_unsub,

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -104,16 +104,20 @@ export function invalidate_store(stores, store_name) {
 
 /**
  * Unsubscribes from all auto-subscribed stores on destroy
- * @param {StoreReferencesContainer} stores
+ * @returns {StoreReferencesContainer}
  */
-export function unsubscribe_on_destroy(stores) {
+export function create_stores() {
+	/** @type {StoreReferencesContainer} */
+	const stores = {};
+
 	teardown(() => {
-		let store_name;
-		for (store_name in stores) {
+		for (var store_name in stores) {
 			const ref = stores[store_name];
 			ref.unsubscribe();
 		}
 	});
+
+	return stores;
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -1,4 +1,4 @@
-/** @import { StoreReferencesContainer, Source } from '#client' */
+/** @import { StoreReferencesContainer } from '#client' */
 /** @import { Store } from '#shared' */
 import { subscribe_to_store } from '../../../store/utils.js';
 import { noop } from '../../shared/utils.js';
@@ -27,7 +27,13 @@ export function store_get(store, store_name, stores) {
 	if (entry.store !== store) {
 		entry.unsubscribe();
 		entry.store = store ?? null;
-		entry.unsubscribe = connect_store_to_signal(store, entry.source);
+
+		if (store == null) {
+			set(entry.source, undefined);
+			entry.unsubscribe = noop;
+		} else {
+			entry.unsubscribe = subscribe_to_store(store, (v) => set(entry.source, v));
+		}
 	}
 
 	return get(entry.source);
@@ -52,20 +58,6 @@ export function store_unsub(store, store_name, stores) {
 	}
 
 	return store;
-}
-
-/**
- * @template V
- * @param {Store<V> | null | undefined} store
- * @param {Source<V>} source
- */
-function connect_store_to_signal(store, source) {
-	if (store == null) {
-		set(source, undefined);
-		return noop;
-	}
-
-	return subscribe_to_store(store, (v) => set(source, v));
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -25,7 +25,6 @@ export function store_get(store, store_name, stores) {
 	if (is_new) {
 		entry = {
 			store: null,
-			last_value: null,
 			value: mutable_source(UNINITIALIZED),
 			unsubscribe: noop
 		};
@@ -38,10 +37,7 @@ export function store_get(store, store_name, stores) {
 		entry.unsubscribe = connect_store_to_signal(store, entry.value);
 	}
 
-	const value = get(entry.value);
-	// This could happen if the store was cleaned up because the component was destroyed and there's a leak on the user side.
-	// In that case we don't want to fail with a cryptic Symbol error, but rather return the last value we got.
-	return value === UNINITIALIZED ? entry.last_value : value;
+	return get(entry.value);
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -20,17 +20,17 @@ import { mutable_source, set } from './sources.js';
 export function store_get(store, store_name, stores) {
 	const entry = (stores[store_name] ??= {
 		store: null,
-		value: mutable_source(UNINITIALIZED),
+		source: mutable_source(UNINITIALIZED),
 		unsubscribe: noop
 	});
 
 	if (entry.store !== store) {
 		entry.unsubscribe();
 		entry.store = store ?? null;
-		entry.unsubscribe = connect_store_to_signal(store, entry.value);
+		entry.unsubscribe = connect_store_to_signal(store, entry.source);
 	}
 
-	return get(entry.value);
+	return get(entry.source);
 }
 
 /**
@@ -85,9 +85,9 @@ export function store_set(store, value) {
  * @param {string} store_name
  */
 export function invalidate_store(stores, store_name) {
-	const store = stores[store_name];
-	if (store.store) {
-		store_set(store.store, store.value.v);
+	var entry = stores[store_name];
+	if (entry.store !== null) {
+		store_set(entry.store, entry.source.v);
 	}
 }
 
@@ -95,7 +95,7 @@ export function invalidate_store(stores, store_name) {
  * Unsubscribes from all auto-subscribed stores on destroy
  * @returns {StoreReferencesContainer}
  */
-export function create_stores() {
+export function setup_stores() {
 	/** @type {StoreReferencesContainer} */
 	const stores = {};
 

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -18,20 +18,13 @@ import { mutable_source, set } from './sources.js';
  * @returns {V}
  */
 export function store_get(store, store_name, stores) {
-	/** @type {StoreReferencesContainer[''] | undefined} */
-	let entry = stores[store_name];
-	const is_new = entry === undefined;
+	const entry = (stores[store_name] ??= {
+		store: null,
+		value: mutable_source(UNINITIALIZED),
+		unsubscribe: noop
+	});
 
-	if (is_new) {
-		entry = {
-			store: null,
-			value: mutable_source(UNINITIALIZED),
-			unsubscribe: noop
-		};
-		stores[store_name] = entry;
-	}
-
-	if (is_new || entry.store !== store) {
+	if (entry.store !== store) {
 		entry.unsubscribe();
 		entry.store = store ?? null;
 		entry.unsubscribe = connect_store_to_signal(store, entry.value);

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -3,8 +3,8 @@
 import { subscribe_to_store } from '../../../store/utils.js';
 import { noop } from '../../shared/utils.js';
 import { UNINITIALIZED } from '../../../constants.js';
-import { get, untrack } from '../runtime.js';
-import { effect } from './effects.js';
+import { get } from '../runtime.js';
+import { teardown } from './effects.js';
 import { mutable_source, set } from './sources.js';
 
 /**
@@ -107,7 +107,7 @@ export function invalidate_store(stores, store_name) {
  * @param {StoreReferencesContainer} stores
  */
 export function unsubscribe_on_destroy(stores) {
-	on_destroy(() => {
+	teardown(() => {
 		let store_name;
 		for (store_name in stores) {
 			const ref = stores[store_name];
@@ -149,13 +149,4 @@ export function update_pre_store(store, store_value, d = 1) {
 	const value = store_value + d;
 	store.set(value);
 	return value;
-}
-
-/**
- * Schedules a callback to run immediately before the component is unmounted.
- * @param {() => any} fn
- * @returns {void}
- */
-function on_destroy(fn) {
-	effect(() => () => untrack(fn));
 }

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -149,7 +149,7 @@ export type StoreReferencesContainer = Record<
 	{
 		store: Store<any> | null;
 		unsubscribe: Function;
-		value: Source<any>;
+		source: Source<any>;
 	}
 >;
 

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -148,7 +148,6 @@ export type StoreReferencesContainer = Record<
 	string,
 	{
 		store: Store<any> | null;
-		last_value: any;
 		unsubscribe: Function;
 		value: Source<any>;
 	}


### PR DESCRIPTION
Noticed a few opportunities for improvement with our store logic, figured I'd quickly address them even though it's low priority. First, the compiler output is improved. Before:

```js
const $$subscriptions = {};

$.unsubscribe_on_destroy($$subscriptions);

const $count = () => $.store_get(count, "$count", $$subscriptions);
let count = writable(0);
```

After (we can create the subscriptions and setup the teardown in a single step):

```js
const $$stores = $.setup_stores();
const $count = () => $.store_get(count, "$count", $$stores);
let count = writable(0);
```

The runtime also gets a bit smaller. We can use the existing `teardown` function which is more efficient than creating a new `on_destroy` function, and we can simplify `store_get` — `last_value` was never written to, so whatever that logic was attempting to do, it wasn't doing it.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
