### PR TITLE
chore: make store initialization logic simpler

### DIFF
--- a/.changeset/fair-beers-help.md
+++ b/.changeset/fair-beers-help.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: make store initialization logic simpler

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -24,7 +24,6 @@ import {
 	UNOWNED,
 	MAYBE_DIRTY
 } from '../constants.js';
-import { UNINITIALIZED } from '../../../constants.js';
 import * as e from '../errors.js';
 
 let inspect_effects = new Set();
@@ -84,14 +83,7 @@ export function mutate(source, value) {
  * @returns {V}
  */
 export function set(source, value) {
-	var initialized = source.v !== UNINITIALIZED;
-
-	if (
-		initialized &&
-		current_reaction !== null &&
-		is_runes() &&
-		(current_reaction.f & DERIVED) !== 0
-	) {
+	if (current_reaction !== null && is_runes() && (current_reaction.f & DERIVED) !== 0) {
 		e.state_unsafe_mutation();
 	}
 
@@ -112,7 +104,6 @@ export function set(source, value) {
 		// We additionally want to skip this logic when initialising store sources
 		if (
 			is_runes() &&
-			initialized &&
 			current_effect !== null &&
 			(current_effect.f & CLEAN) !== 0 &&
 			(current_effect.f & BRANCH_EFFECT) === 0

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -2,7 +2,6 @@
 /** @import { Store } from '#shared' */
 import { subscribe_to_store } from '../../../store/utils.js';
 import { noop } from '../../shared/utils.js';
-import { UNINITIALIZED } from '../../../constants.js';
 import { get } from '../runtime.js';
 import { teardown } from './effects.js';
 import { mutable_source, set } from './sources.js';
@@ -20,7 +19,7 @@ import { mutable_source, set } from './sources.js';
 export function store_get(store, store_name, stores) {
 	const entry = (stores[store_name] ??= {
 		store: null,
-		source: mutable_source(UNINITIALIZED),
+		source: mutable_source(undefined),
 		unsubscribe: noop
 	});
 
@@ -32,9 +31,12 @@ export function store_get(store, store_name, stores) {
 			set(entry.source, undefined);
 			entry.unsubscribe = noop;
 		} else {
+			var initial = true;
+
 			entry.unsubscribe = subscribe_to_store(store, (v) => {
-				if (entry.source.v === UNINITIALIZED) {
+				if (initial) {
 					entry.source.v = v;
+					initial = false;
 				} else {
 					set(entry.source, v);
 				}

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -32,7 +32,13 @@ export function store_get(store, store_name, stores) {
 			set(entry.source, undefined);
 			entry.unsubscribe = noop;
 		} else {
-			entry.unsubscribe = subscribe_to_store(store, (v) => set(entry.source, v));
+			entry.unsubscribe = subscribe_to_store(store, (v) => {
+				if (entry.source.v === UNINITIALIZED) {
+					entry.source.v = v;
+				} else {
+					set(entry.source, v);
+				}
+			});
 		}
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -35,6 +35,8 @@ export function store_get(store, store_name, stores) {
 
 			entry.unsubscribe = subscribe_to_store(store, (v) => {
 				if (initial) {
+					// if the first time the store value is read is inside a derived,
+					// we will hit the `state_unsafe_mutation` error if we `set` the value
 					entry.source.v = v;
 					initial = false;
 				} else {


### PR DESCRIPTION
At the moment we have to explicitly check whether stores are initialized on every `set`, just to handle the edge case that we're setting up a store subscription. Much simpler to just to `store.v = blah` instead of `set(store, blah)` in that case, and it quarantines the complexity better

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
