### PR TITLE
chore: remove unused `create_element` helper

### DIFF
--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -142,9 +142,3 @@ export function sibling(node, is_text = false) {
 export function clear_text_content(node) {
 	node.textContent = '';
 }
-
-/** @param {string} name */
-/*#__NO_SIDE_EFFECTS__*/
-export function create_element(name) {
-	return document.createElement(name);
-}

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -1,12 +1,11 @@
 import { DEV } from 'esm-env';
-import { clear_text_content, create_element, empty, init_operations } from './dom/operations.js';
+import { clear_text_content, empty, init_operations } from './dom/operations.js';
 import { HYDRATION_ERROR, HYDRATION_START, PassiveDelegatedEvents } from '../../constants.js';
-import { flush_sync, push, pop, current_component_context, current_effect } from './runtime.js';
+import { flush_sync, push, pop, current_component_context } from './runtime.js';
 import { effect_root, branch } from './reactivity/effects.js';
 import {
 	hydrate_anchor,
 	hydrate_nodes,
-	hydrating,
 	set_hydrate_nodes,
 	set_hydrating
 } from './dom/hydration.js';
@@ -304,7 +303,7 @@ export async function append_styles(target, style_sheet_id, styles) {
 	await Promise.resolve();
 	const append_styles_to = get_root_for_style(target);
 	if (!append_styles_to.getElementById(style_sheet_id)) {
-		const style = create_element('style');
+		const style = document.createElement('style');
 		style.id = style_sheet_id;
 		style.textContent = styles;
 		const target = /** @type {Document} */ (append_styles_to).head || append_styles_to;


### PR DESCRIPTION
there's no point in having a helper that's only used once — adds bundle size and runtime overhead for no reason

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
