### PR TITLE
fix: make props optional during SSR

### DIFF
--- a/.changeset/itchy-pianos-marry.md
+++ b/.changeset/itchy-pianos-marry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make props optional during SSR

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -113,7 +113,7 @@ export function render(component, options = {}) {
 	}
 
 	// @ts-expect-error
-	component(payload, options.props, {}, {});
+	component(payload, options.props ?? {}, {}, {});
 
 	if (options.context) {
 		pop();


### PR DESCRIPTION
Props are typed as optional, but if you don't specify them with `render(...)` and the component has props, things crash. No test because it would require fiddling about with how our tests work

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
