### PR TITLE
fix: reflect SvelteURLSearchParams changes to SvelteURL 

### DIFF
--- a/.changeset/angry-birds-fly.md
+++ b/.changeset/angry-birds-fly.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: reflect SvelteURLSearchParams changes to SvelteURL

--- a/packages/svelte/src/reactivity/index-client.js
+++ b/packages/svelte/src/reactivity/index-client.js
@@ -1,7 +1,8 @@
 export { SvelteDate } from './date.js';
 export { SvelteSet } from './set.js';
 export { SvelteMap } from './map.js';
-export { SvelteURL, SvelteURLSearchParams } from './url.js';
+export { SvelteURL } from './url.js';
+export { SvelteURLSearchParams } from './url-search-params.js';
 
 /** @deprecated Use `SvelteDate` instead */
 export function Date() {

--- a/packages/svelte/src/reactivity/url-search-params.js
+++ b/packages/svelte/src/reactivity/url-search-params.js
@@ -13,14 +13,19 @@ export class SvelteURLSearchParams extends URLSearchParams {
 
 	#update_url() {
 		if (!this.#url || this.#updating) return;
+		this.#updating = true;
+
 		const search = this.toString();
 		this.#url.search = search && `?${search}`;
+
+		this.#updating = false;
 	}
 
 	/**
 	 * @param {URLSearchParams} params
 	 */
 	[REPLACE](params) {
+		if (this.#updating) return;
 		this.#updating = true;
 
 		for (const key of [...super.keys()]) {
@@ -32,7 +37,6 @@ export class SvelteURLSearchParams extends URLSearchParams {
 		}
 
 		increment(this.#version);
-
 		this.#updating = false;
 	}
 

--- a/packages/svelte/src/reactivity/url-search-params.js
+++ b/packages/svelte/src/reactivity/url-search-params.js
@@ -1,0 +1,126 @@
+import { source } from '../internal/client/reactivity/sources.js';
+import { get } from '../internal/client/runtime.js';
+import { increment } from './utils.js';
+
+export const REPLACE = Symbol();
+
+export class SvelteURLSearchParams extends URLSearchParams {
+	#version = source(0);
+
+	/**
+	 * @param {URLSearchParams} params
+	 */
+	[REPLACE](params) {
+		for (const key of [...super.keys()]) {
+			super.delete(key);
+		}
+
+		for (const [key, value] of params) {
+			super.append(key, value);
+		}
+
+		increment(this.#version);
+	}
+
+	/**
+	 * @param {string} name
+	 * @param {string} value
+	 * @returns {void}
+	 */
+	append(name, value) {
+		increment(this.#version);
+		return super.append(name, value);
+	}
+
+	/**
+	 * @param {string} name
+	 * @param {string=} value
+	 * @returns {void}
+	 */
+	delete(name, value) {
+		var has_value = super.has(name, value);
+		var res = super.delete(name, value);
+		if (has_value) {
+			increment(this.#version);
+		}
+		return res;
+	}
+
+	/**
+	 * @param {string} name
+	 * @returns {string|null}
+	 */
+	get(name) {
+		get(this.#version);
+		return super.get(name);
+	}
+
+	/**
+	 * @param {string} name
+	 * @returns {string[]}
+	 */
+	getAll(name) {
+		get(this.#version);
+		return super.getAll(name);
+	}
+
+	/**
+	 * @param {string} name
+	 * @param {string=} value
+	 * @returns {boolean}
+	 */
+	has(name, value) {
+		get(this.#version);
+		return super.has(name, value);
+	}
+
+	keys() {
+		get(this.#version);
+		return super.keys();
+	}
+
+	/**
+	 * @param {string} name
+	 * @param {string} value
+	 * @returns {void}
+	 */
+	set(name, value) {
+		var value_before_change = super.getAll(name).join('');
+		super.set(name, value);
+		// can't use has(name, value), because for something like https://svelte.dev?foo=1&bar=2&foo=3
+		// if you set `foo` to 1, then foo=3 gets deleted whilst `has("foo", "1")` returns true
+		if (value_before_change !== super.getAll(name).join('')) {
+			increment(this.#version);
+		}
+	}
+
+	sort() {
+		var res = super.sort();
+		increment(this.#version);
+		return res;
+	}
+
+	toString() {
+		get(this.#version);
+		return super.toString();
+	}
+
+	values() {
+		get(this.#version);
+		return super.values();
+	}
+
+	entries() {
+		get(this.#version);
+		return super.entries();
+	}
+
+	[Symbol.iterator]() {
+		return this.entries();
+	}
+
+	get size() {
+		get(this.#version);
+		return super.size;
+	}
+}

--- a/packages/svelte/src/reactivity/url-search-params.js
+++ b/packages/svelte/src/reactivity/url-search-params.js
@@ -34,8 +34,8 @@ export class SvelteURLSearchParams extends URLSearchParams {
 	 */
 	append(name, value) {
 		var res = super.append(name, value);
-		increment(this.#version);
 		this[onChange]?.('append', name, value);
+		increment(this.#version);
 		return res;
 	}
 
@@ -48,8 +48,8 @@ export class SvelteURLSearchParams extends URLSearchParams {
 		var has_value = super.has(name, value);
 		var res = super.delete(name, value);
 		if (has_value) {
-			increment(this.#version);
 			this[onChange]?.('delete', name, value);
+			increment(this.#version);
 		}
 		return res;
 	}
@@ -98,15 +98,15 @@ export class SvelteURLSearchParams extends URLSearchParams {
 		// can't use has(name, value), because for something like https://svelte.dev?foo=1&bar=2&foo=3
 		// if you set `foo` to 1, then foo=3 gets deleted whilst `has("foo", "1")` returns true
 		if (value_before_change !== super.getAll(name).join('')) {
-			increment(this.#version);
 			this[onChange]?.('set', name, value);
+			increment(this.#version);
 		}
 	}
 
 	sort() {
 		var res = super.sort();
-		increment(this.#version);
 		this[onChange]?.('sort');
+		increment(this.#version);
 		return res;
 	}
 

--- a/packages/svelte/src/reactivity/url-search-params.test.ts
+++ b/packages/svelte/src/reactivity/url-search-params.test.ts
@@ -3,6 +3,30 @@ import { flushSync } from '../index-client.js';
 import { assert, test } from 'vitest';
 import { SvelteURLSearchParams } from './url-search-params';
 
+test('new URLSearchParams', () => {
+	const params = new SvelteURLSearchParams('a=b');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.toString());
+		});
+	});
+
+	flushSync(() => {
+		params.set('a', 'c');
+	});
+
+	flushSync(() => {
+		// nothing should happen here
+		params.set('a', 'c');
+	});
+
+	assert.deepEqual(log, ['a=b', 'a=c']);
+
+	cleanup();
+});
+
 test('URLSearchParams.set', () => {
 	const params = new SvelteURLSearchParams();
 	const log: any = [];

--- a/packages/svelte/src/reactivity/url-search-params.test.ts
+++ b/packages/svelte/src/reactivity/url-search-params.test.ts
@@ -203,6 +203,6 @@ test('URLSearchParams.toString', () => {
 	cleanup();
 });
 
-test('URLSearchParams.instanceOf', () => {
-	assert.equal(new SvelteURLSearchParams() instanceof URLSearchParams, true);
+test('SvelteURLSearchParams instanceof URLSearchParams', () => {
+	assert.ok(new SvelteURLSearchParams() instanceof URLSearchParams);
 });

--- a/packages/svelte/src/reactivity/url-search-params.test.ts
+++ b/packages/svelte/src/reactivity/url-search-params.test.ts
@@ -1,0 +1,184 @@
+import { render_effect, effect_root } from '../internal/client/reactivity/effects.js';
+import { flushSync } from '../index-client.js';
+import { assert, test } from 'vitest';
+import { SvelteURLSearchParams } from './url-search-params';
+
+test('URLSearchParams.set', () => {
+	const params = new SvelteURLSearchParams();
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.toString());
+		});
+	});
+
+	flushSync(() => {
+		params.set('a', 'b');
+	});
+
+	flushSync(() => {
+		params.set('a', 'c');
+	});
+
+	flushSync(() => {
+		// nothing should happen here
+		params.set('a', 'c');
+	});
+
+	assert.deepEqual(log, ['', 'a=b', 'a=c']);
+
+	cleanup();
+});
+
+test('URLSearchParams.append', () => {
+	const params = new SvelteURLSearchParams();
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.toString());
+		});
+	});
+
+	flushSync(() => {
+		params.append('a', 'b');
+	});
+
+	flushSync(() => {
+		// nothing should happen here
+		params.set('a', 'b');
+	});
+
+	flushSync(() => {
+		params.append('a', 'c');
+	});
+
+	assert.deepEqual(log, ['', 'a=b', 'a=b&a=c']);
+
+	cleanup();
+});
+
+test('URLSearchParams.delete', () => {
+	const params = new SvelteURLSearchParams('a=b&c=d');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.toString());
+		});
+	});
+
+	flushSync(() => {
+		params.delete('a');
+	});
+
+	flushSync(() => {
+		// nothing should happen here
+		params.delete('a');
+	});
+
+	flushSync(() => {
+		params.set('a', 'b');
+	});
+
+	assert.deepEqual(log, ['a=b&c=d', 'c=d', 'c=d&a=b']);
+
+	cleanup();
+});
+
+test('URLSearchParams.get', () => {
+	const params = new SvelteURLSearchParams('a=b&c=d');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.get('a'));
+		});
+		render_effect(() => {
+			log.push(params.get('c'));
+		});
+		render_effect(() => {
+			log.push(params.get('e'));
+		});
+	});
+
+	flushSync(() => {
+		params.set('a', 'b');
+	});
+
+	flushSync(() => {
+		params.set('a', 'new-b');
+	});
+
+	flushSync(() => {
+		params.delete('a');
+	});
+
+	assert.deepEqual(log, ['b', 'd', null, 'new-b', 'd', null, null, 'd', null]);
+
+	cleanup();
+});
+
+test('URLSearchParams.getAll', () => {
+	const params = new SvelteURLSearchParams('a=b&c=d');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.getAll('a'));
+		});
+		render_effect(() => {
+			log.push(params.getAll('q'));
+		});
+	});
+
+	flushSync(() => {
+		params.append('a', 'b1');
+	});
+
+	flushSync(() => {
+		params.append('q', 'z');
+	});
+
+	assert.deepEqual(log, [
+		// initial
+		['b'],
+		[],
+		// first flush
+		['b', 'b1'],
+		[],
+		// second flush
+		['b', 'b1'],
+		['z']
+	]);
+
+	cleanup();
+});
+
+test('URLSearchParams.toString', () => {
+	const params = new SvelteURLSearchParams();
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.toString());
+		});
+	});
+
+	flushSync(() => {
+		params.set('a', 'b');
+	});
+
+	flushSync(() => {
+		params.append('a', 'c');
+	});
+
+	assert.deepEqual(log, ['', 'a=b', 'a=b&a=c']);
+
+	cleanup();
+});
+
+test('URLSearchParams.instanceOf', () => {
+	assert.equal(new SvelteURLSearchParams() instanceof URLSearchParams, true);
+});

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -1,6 +1,6 @@
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
-import { REPLACE, SvelteURLSearchParams } from './url-search-params.js';
+import { onChange, REPLACE, SvelteURLSearchParams } from './url-search-params.js';
 
 export class SvelteURL extends URL {
 	#protocol = source(super.protocol);
@@ -20,6 +20,11 @@ export class SvelteURL extends URL {
 		url = new URL(url, base);
 		super(url);
 		this.#searchParams[REPLACE](url.searchParams);
+		this.#searchParams[onChange] = (command, ...args) => {
+			// by doing this, we sync SvelteSearchParams with internal implementation of URL.searchParams
+			// @ts-ignore
+			super.searchParams[command](...args);
+		};
 	}
 
 	get hash() {

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -28,7 +28,7 @@ export class SvelteURL extends URL {
 				return;
 			}
 			// by doing this, we sync SvelteSearchParams with internal implementation of URL.searchParams
-			// @ts-ignore
+			// @ts-expect-error
 			super.searchParams[command](...args);
 		};
 	}

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -72,7 +72,7 @@ export class SvelteURL extends URL {
 		get(this.#port);
 		get(this.#pathname);
 		get(this.#hash);
-		this.#searchParams.toString();
+		get(this.#search);
 		return super.href;
 	}
 
@@ -85,6 +85,7 @@ export class SvelteURL extends URL {
 		set(this.#port, super.port);
 		set(this.#pathname, super.pathname);
 		set(this.#hash, super.hash);
+		set(this.#search, super.search);
 		this.#searchParams[REPLACE](super.searchParams);
 	}
 

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -1,8 +1,6 @@
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
-import { increment } from './utils.js';
-
-const REPLACE = Symbol();
+import { REPLACE, SvelteURLSearchParams } from './url-search-params.js';
 
 export class SvelteURL extends URL {
 	#protocol = source(super.protocol);
@@ -150,116 +148,5 @@ export class SvelteURL extends URL {
 
 	toJSON() {
 		return this.href;
-	}
-}
-
-export class SvelteURLSearchParams extends URLSearchParams {
-	#version = source(0);
-
-	/**
-	 * @param {URLSearchParams} params
-	 */
-	[REPLACE](params) {
-		for (const key of [...super.keys()]) {
-			super.delete(key);
-		}
-
-		for (const [key, value] of params) {
-			super.append(key, value);
-		}
-
-		increment(this.#version);
-	}
-
-	/**
-	 * @param {string} name
-	 * @param {string} value
-	 * @returns {void}
-	 */
-	append(name, value) {
-		increment(this.#version);
-		return super.append(name, value);
-	}
-
-	/**
-	 * @param {string} name
-	 * @param {string=} value
-	 * @returns {void}
-	 */
-	delete(name, value) {
-		increment(this.#version);
-		return super.delete(name, value);
-	}
-
-	/**
-	 * @param {string} name
-	 * @returns {string|null}
-	 */
-	get(name) {
-		get(this.#version);
-		return super.get(name);
-	}
-
-	/**
-	 * @param {string} name
-	 * @returns {string[]}
-	 */
-	getAll(name) {
-		get(this.#version);
-		return super.getAll(name);
-	}
-
-	/**
-	 * @param {string} name
-	 * @param {string=} value
-	 * @returns {boolean}
-	 */
-	has(name, value) {
-		get(this.#version);
-		return super.has(name, value);
-	}
-
-	keys() {
-		get(this.#version);
-		return super.keys();
-	}
-
-	/**
-	 * @param {string} name
-	 * @param {string} value
-	 * @returns {void}
-	 */
-	set(name, value) {
-		increment(this.#version);
-		return super.set(name, value);
-	}
-
-	sort() {
-		increment(this.#version);
-		return super.sort();
-	}
-
-	toString() {
-		get(this.#version);
-		return super.toString();
-	}
-
-	values() {
-		get(this.#version);
-		return super.values();
-	}
-
-	entries() {
-		get(this.#version);
-		return super.entries();
-	}
-
-	[Symbol.iterator]() {
-		return this.entries();
-	}
-
-	get size() {
-		get(this.#version);
-		return super.size;
 	}
 }

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -21,6 +21,9 @@ export class SvelteURL extends URL {
 		super(url);
 		this.#searchParams[REPLACE](url.searchParams);
 		this.#searchParams[onChange] = (command, ...args) => {
+			if (this.search !== super.search) {
+				super.search = this.search;
+			}
 			if (this.#searchParams.toString() === super.searchParams.toString()) {
 				return;
 			}

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -21,6 +21,9 @@ export class SvelteURL extends URL {
 		super(url);
 		this.#searchParams[REPLACE](url.searchParams);
 		this.#searchParams[onChange] = (command, ...args) => {
+			if (this.#searchParams.toString() === super.searchParams.toString()) {
+				return;
+			}
 			// by doing this, we sync SvelteSearchParams with internal implementation of URL.searchParams
 			// @ts-ignore
 			super.searchParams[command](...args);

--- a/packages/svelte/src/reactivity/url.test.ts
+++ b/packages/svelte/src/reactivity/url.test.ts
@@ -115,6 +115,6 @@ test('url.searchParams', () => {
 	cleanup();
 });
 
-test('URL.instanceOf', () => {
-	assert.equal(new SvelteURL('https://svelte.dev') instanceof URL, true);
+test('SvelteURL instanceof URL', () => {
+	assert.ok(new SvelteURL('https://svelte.dev') instanceof URL);
 });

--- a/packages/svelte/src/reactivity/url.test.ts
+++ b/packages/svelte/src/reactivity/url.test.ts
@@ -1,6 +1,6 @@
 import { render_effect, effect_root } from '../internal/client/reactivity/effects.js';
 import { flushSync } from '../index-client.js';
-import { SvelteURL, SvelteURLSearchParams } from './url.js';
+import { SvelteURL } from './url.js';
 import { assert, test } from 'vitest';
 
 test('url.hash', () => {
@@ -73,29 +73,6 @@ test('url.searchParams', () => {
 		'foo: null',
 		'q: true'
 	]);
-
-	cleanup();
-});
-
-test('URLSearchParams', () => {
-	const params = new SvelteURLSearchParams();
-	const log: any = [];
-
-	const cleanup = effect_root(() => {
-		render_effect(() => {
-			log.push(params.toString());
-		});
-	});
-
-	flushSync(() => {
-		params.set('a', 'b');
-	});
-
-	flushSync(() => {
-		params.append('a', 'c');
-	});
-
-	assert.deepEqual(log, ['', 'a=b', 'a=b&a=c']);
 
 	cleanup();
 });

--- a/packages/svelte/src/reactivity/url.test.ts
+++ b/packages/svelte/src/reactivity/url.test.ts
@@ -4,7 +4,7 @@ import { SvelteURL } from './url.js';
 import { assert, test } from 'vitest';
 
 test('url.hash', () => {
-	const url = new SvelteURL('http://google.com');
+	const url = new SvelteURL('https://svelte.dev');
 	const log: any = [];
 
 	const cleanup = effect_root(() => {
@@ -18,7 +18,7 @@ test('url.hash', () => {
 	});
 
 	flushSync(() => {
-		url.href = 'http://google.com/a/b/c#def';
+		url.href = 'https://svelte.dev/a/b/c#def';
 	});
 
 	flushSync(() => {
@@ -27,6 +27,44 @@ test('url.hash', () => {
 	});
 
 	assert.deepEqual(log, ['', '#abc', '#def']);
+
+	cleanup();
+});
+
+test('url.href', () => {
+	const url = new SvelteURL('https://svelte.dev?foo=bar&t=123');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(url.href);
+		});
+	});
+
+	flushSync(() => {
+		url.search = '?q=kit&foo=baz';
+	});
+
+	flushSync(() => {
+		// changes from searchParams should be synced to URL instance as well
+		url.searchParams.append('foo', 'qux');
+	});
+
+	flushSync(() => {
+		url.searchParams.delete('foo');
+	});
+
+	flushSync(() => {
+		url.searchParams.set('love', 'svelte5');
+	});
+
+	assert.deepEqual(log, [
+		'https://svelte.dev/?foo=bar&t=123',
+		'https://svelte.dev/?q=kit&foo=baz',
+		'https://svelte.dev/?q=kit&foo=baz&foo=qux',
+		'https://svelte.dev/?q=kit',
+		'https://svelte.dev/?q=kit&love=svelte5'
+	]);
 
 	cleanup();
 });
@@ -75,4 +113,8 @@ test('url.searchParams', () => {
 	]);
 
 	cleanup();
+});
+
+test('URL.instanceOf', () => {
+	assert.equal(new SvelteURL('https://svelte.dev') instanceof URL, true);
 });

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2157,12 +2157,15 @@ declare module 'svelte/reactivity' {
 		get searchParams(): SvelteURLSearchParams;
 		#private;
 	}
+	const REPLACE: unique symbol;
+	const onChange: unique symbol;
 	export class SvelteURLSearchParams extends URLSearchParams {
+		
+		[onChange]: ((command: "set" | "append" | "delete" | "sort", ...args: any[]) => void) | null;
 		
 		[REPLACE](params: URLSearchParams): void;
 		#private;
 	}
-	const REPLACE: unique symbol;
 
 	export { Date_1 as Date, Set_1 as Set, Map_1 as Map, URL_1 as URL, URLSearchParams_1 as URLSearchParams };
 }

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2158,10 +2158,7 @@ declare module 'svelte/reactivity' {
 		#private;
 	}
 	const REPLACE: unique symbol;
-	const onChange: unique symbol;
 	export class SvelteURLSearchParams extends URLSearchParams {
-		
-		[onChange]: ((command: "set" | "append" | "delete" | "sort", ...args: any[]) => void) | null;
 		
 		[REPLACE](params: URLSearchParams): void;
 		#private;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -30,9 +30,9 @@ export default defineConfig({
 		dir: '.',
 		reporters: ['dot'],
 		include: [
-			'packages/svelte/**/*.test.ts',
-			'packages/svelte/tests/*/test.ts',
-			'packages/svelte/tests/runtime-browser/test-ssr.ts'
+			'packages/svelte/**/*.test.ts'
+			// 'packages/svelte/tests/*/test.ts',
+			// 'packages/svelte/tests/runtime-browser/test-ssr.ts'
 		],
 		exclude: [...configDefaults.exclude, '**/samples/**'],
 		coverage: {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -30,9 +30,9 @@ export default defineConfig({
 		dir: '.',
 		reporters: ['dot'],
 		include: [
-			'packages/svelte/**/*.test.ts'
-			// 'packages/svelte/tests/*/test.ts',
-			// 'packages/svelte/tests/runtime-browser/test-ssr.ts'
+			'packages/svelte/**/*.test.ts',
+			'packages/svelte/tests/*/test.ts',
+			'packages/svelte/tests/runtime-browser/test-ssr.ts'
 		],
 		exclude: [...configDefaults.exclude, '**/samples/**'],
 		coverage: {


### PR DESCRIPTION
Currently any change to SvelteURL.searchParams is not reflected on SvelteURL directly. This PR separates url-search-params and url into different files (just like other classes) and adds more tests (also reduces the number of redundant updates). 

fixes URL part of #11727 (meaning [this](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAACpWPQU-EMBCF_8pkDsImSN2DFwSMdw_GjSfrAWGQxtI27cBmQ_jvhmV1oyYm3mbee1_ezISt0hQwe57QVD1hhnfOYYJ8cMsSRtJMmGCwg68XJQ-1V45LaSSr3lnPMMHuGHt6vIcZWm97iFZQeKpqVqPiQ3QjzcJoYhi8hgIM7c9gHHXMLmRCrGTa0Cg8OS060tpe7q3Xze1IPihriuv06oKL7XYbbW6kycX5JpM3aiw7T20G0-B1uoxzLhb1ZLLdsVfm7RT4XOPN95irfNWHUyhQ5evu4Sh9xaTJXwdma8CaWqv6vZjiDRQlTMujP7E0EMcSmQJLTEDigYLEjTTzXFZNA4sBbGFlYK3Pxdrw_7bKOTJNLLG19nff0YTW2r8aMcHeNqpV1GDGfqD5Zf4AxGqmljECAAA=) where changes to search params is not reflected on url)

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
