### PR TITLE
chore: improve npm search rank for `svelte` package

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -97,6 +97,7 @@
   },
   "homepage": "https://svelte.dev",
   "keywords": [
+    "svelte",
     "UI",
     "framework",
     "templates",


### PR DESCRIPTION
https://github.com/sveltejs/svelte/assets/33713262/c6a69481-4ca8-4396-ad0d-ab00f2638a62

On npmjs.com, this package is not the first result when searching for "svelte". Instead, the first result is svelte-portal.

It seems that this is caused by svelte-portal having the term "svelte" in its list of [keywords](https://github.com/romkor/svelte-portal/blob/bddbc7c6d95c84b073b05319646ee25cdec3e5a5/package.json#L28). Perhaps npm assigns a lower weight to `package_json.name` than `package_json.keywords[n]` when it comes to search ranking? Or maybe this is due to having the term "svelte" both in the package name *and* the keyword list. Either way, we've been out-svelted.

Anyways, this package should come first.
