### PR TITLE
fix: ensure rest props access on hoisted event handlers works

### DIFF
--- a/.changeset/loud-insects-arrive.md
+++ b/.changeset/loud-insects-arrive.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure rest props access on hoisted event handlers works

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -547,6 +547,11 @@ function get_hoistable_params(node, context) {
 			} else {
 				// create a copy to remove start/end tags which would mess up source maps
 				push_unique(b.id(binding.node.name));
+				// rest props are often accessed through the $$props object for optimization reasons,
+				// but we can't know if the delegated event handler will use it, so we need to add both as params
+				if (binding.kind === 'rest_prop' && context.state.analysis.runes) {
+					push_unique(b.id('$$props'));
+				}
 			}
 		}
 	}

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-rest-prop/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-rest-prop/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	test({ assert, target, logs }) {
+		const btn = target.querySelector('button');
+
+		btn?.click();
+		flushSync();
+
+		assert.deepEqual(logs, ['worked']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-rest-prop/child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-rest-prop/child.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { label, ...rest } = $props();
+</script>
+
+<button onclick={() => rest?.onclick()}>{label}</button>

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-rest-prop/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-rest-prop/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Child from './child.svelte';
+</script>
+
+<Child label="click me" onclick={() => console.log('worked')} />


### PR DESCRIPTION
If an even handler is hoisted and said event handler access rest props, we can't be sure whether or not it will access it via `$$props` (optimized) or via `rest()` - therefore we add both as params in this edge case

fixes #12279

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
