### PR TITLE
fix: ensure `bind:this` works with component with no return value

### DIFF
--- a/.changeset/warm-waves-reply.md
+++ b/.changeset/warm-waves-reply.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure component always returns an object
+fix: ensure `bind:this` works with component with no return value

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -339,9 +339,6 @@ export function client_component(source, analysis, options) {
 				? b.return(b.call('$.pop', b.object(component_returned_object)))
 				: b.stmt(b.call('$.pop'))
 		);
-	} else {
-		// Always return an object, so that `bind:this` on this component will not be falsy
-		component_block.body.push(b.return(b.object(component_returned_object)));
 	}
 
 	if (analysis.uses_rest_props) {

--- a/packages/svelte/src/internal/client/dom/elements/bindings/this.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/this.js
@@ -15,14 +15,14 @@ function is_bound_this(bound_value, element_or_component) {
 }
 
 /**
- * @param {Element} element_or_component
+ * @param {any} element_or_component
  * @param {(value: unknown, ...parts: unknown[]) => void} update
  * @param {(...parts: unknown[]) => unknown} get_value
  * @param {() => unknown[]} [get_parts] Set if the this binding is used inside an each block,
  * 										returns all the parts of the each block context that are used in the expression
  * @returns {void}
  */
-export function bind_this(element_or_component, update, get_value, get_parts) {
+export function bind_this(element_or_component = {}, update, get_value, get_parts) {
 	effect(() => {
 		/** @type {unknown[]} */
 		var old_parts;

--- a/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/client/index.svelte.js
@@ -30,5 +30,4 @@ export default function Bind_component_snippet($$anchor) {
 
 	$.template_effect(() => $.set_text(text, ` value: ${$.get(value) ?? ""}`));
 	$.append($$anchor, fragment_1);
-	return {};
 }

--- a/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-this/_expected/client/index.svelte.js
@@ -3,5 +3,4 @@ import * as $ from "svelte/internal/client";
 
 export default function Bind_this($$anchor) {
 	$.bind_this(Foo($$anchor, { $$legacy: true }), ($$value) => foo = $$value, () => foo);
-	return {};
 }

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -30,5 +30,4 @@ export default function Main($$anchor) {
 	});
 
 	$.append($$anchor, fragment);
-	return {};
 }

--- a/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-string-template/_expected/client/index.svelte.js
@@ -13,5 +13,4 @@ export default function Each_string_template($$anchor) {
 	});
 
 	$.append($$anchor, fragment);
-	return {};
 }

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -22,6 +22,4 @@ export default function Function_prop_no_getter($$anchor) {
 		},
 		$$slots: { default: true }
 	});
-
-	return {};
 }

--- a/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hello-world/_expected/client/index.svelte.js
@@ -7,5 +7,4 @@ export default function Hello_world($$anchor) {
 	var h1 = root();
 
 	$.append($$anchor, h1);
-	return {};
 }

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
@@ -7,7 +7,6 @@ function Hmr($$anchor) {
 	var h1 = root();
 
 	$.append($$anchor, h1);
-	return {};
 }
 
 if (import.meta.hot) {

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -28,7 +28,6 @@ export default function State_proxy_literal($$anchor) {
 	$.bind_value(input, () => $.get(str), ($$value) => $.set(str, $$value));
 	$.bind_value(input_1, () => $.get(tpl), ($$value) => $.set(tpl, $$value));
 	$.append($$anchor, fragment);
-	return {};
 }
 
 $.delegate(["click"]);

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
@@ -8,5 +8,4 @@ export default function Svelte_element($$anchor, $$props) {
 
 	$.element(node, tag, false);
 	$.append($$anchor, fragment);
-	return {};
 }


### PR DESCRIPTION
#12290 increases output size unnecessarily, this is a simpler fix for #12287

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
