### PR TITLE
fix: missing export of imported Invalidator type

### DIFF
--- a/packages/svelte/src/store/public.d.ts
+++ b/packages/svelte/src/store/public.d.ts
@@ -48,6 +48,6 @@ interface Writable<T> extends Readable<T> {
 	update(this: void, updater: Updater<T>): void;
 }
 
-export { Readable, StartStopNotifier, Subscriber, Unsubscriber, Updater, Writable };
+export { Invalidator, Readable, StartStopNotifier, Subscriber, Unsubscriber, Updater, Writable };
 
 export * from './index.js';

--- a/packages/svelte/tests/store/test.ts
+++ b/packages/svelte/tests/store/test.ts
@@ -1,5 +1,13 @@
 import { describe, it, assert } from 'vitest';
-import { readable, writable, derived, get, readonly, type Readable } from 'svelte/store';
+import {
+	readable,
+	writable,
+	derived,
+	get,
+	readonly,
+	type Readable,
+	type Invalidator
+} from 'svelte/store';
 
 describe('writable', () => {
 	it('creates a writable store', () => {
@@ -572,5 +580,15 @@ describe('readonly', () => {
 
 		// @ts-ignore
 		assert.throws(() => readableStore.set(3));
+	});
+});
+
+describe('type Invalidator', () => {
+	it('check it is exported from the store', () => {
+		// dummy test importing Invalidator from store
+		// to check if it is exported
+		// it will fail with tsc if not exported
+		const invalidator: Invalidator<number> = () => {};
+		assert.equal(typeof invalidator, 'function');
 	});
 });

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2298,7 +2298,7 @@ declare module 'svelte/store' {
 	 * */
 	export function get<T>(store: Readable<T>): T;
 
-	export { Subscriber, Unsubscriber, Updater, StartStopNotifier, Readable, Writable };
+	export { Subscriber, Unsubscriber, Updater, StartStopNotifier, Readable, Writable, Invalidator };
 }
 
 declare module 'svelte/transition' {


### PR DESCRIPTION
## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`


fixes https://github.com/sveltejs/svelte/issues/12276

it is a regression made by https://github.com/sveltejs/svelte/pull/12239

it's used by the Readable interface (and imported) but then not exported
https://github.com/sveltejs/svelte/blob/84325bf89b39d1692c302f43ac1fd15f46bf1e71/packages/svelte/src/store/public.d.ts#L27-L34