### PR TITLE
fix: make `<select>` `<option value>` behavior consistent

### DIFF
--- a/.changeset/light-hounds-carry.md
+++ b/.changeset/light-hounds-carry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make `<select>` `<option value>` behavior consistent

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -617,7 +617,16 @@ function serialize_element_special_value_attribute(element, node_id, attribute, 
 
 	if (is_reactive) {
 		const id = state.scope.generate(`${node_id.name}_value`);
-		serialize_update_assignment(state, id, undefined, value, update);
+		serialize_update_assignment(
+			state,
+			id,
+			// `<option>` is a special case: The value property reflects to the DOM. If the value is set to undefined,
+			// that means the value should be set to the empty string. To be able to do that when the value is
+			// initially undefined, we need to set a value that is guaranteed to be different.
+			element === 'option' ? b.object([]) : undefined,
+			value,
+			update
+		);
 		return true;
 	} else {
 		state.init.push(update);

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -159,16 +159,7 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 
 	for (var key in prev) {
 		if (!(key in next)) {
-			if (is_option_element && key === 'value') {
-				// Because of the "set falsy option values to the empty string" logic below, which can't
-				// differentiate between a missing value and an explicitly set value of null or undefined,
-				// we need to remove the attribute here and delete the key from the object.
-				element.removeAttribute(key);
-				delete current[key];
-				delete next[key];
-			} else {
-				next[key] = null;
-			}
+			next[key] = null;
 		}
 	}
 
@@ -196,6 +187,12 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 			// the value is set to the text content of the option element, and setting the value
 			// to null or undefined means the value is set to the string "null" or "undefined".
 			// To align with how we handle this case in non-spread-scenarios, this logic is needed.
+			// There's a super-edge-case bug here that is left in in favor of smaller code size:
+			// Because of the "set missing props to null" logic above, we can't differentiate
+			// between a missing value and an explicitly set value of null or undefined. That means
+			// that once set, the value attribute of an <option> element can't be removed. This is
+			// a very rare edge case, and removing the attribute altogether isn't possible either
+			// for the <option value={undefined}> case, so we're not losing any functionality here.
 			// @ts-ignore
 			element.value = element.__value = '';
 			current[key] = value;

--- a/packages/svelte/tests/runtime-runes/samples/select-falsy-value/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/select-falsy-value/_config.js
@@ -1,4 +1,3 @@
-import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 // <option value> is special because falsy values should result in an empty string value attribute
@@ -27,39 +26,6 @@ export default test({
 			<select>
 				<option value="">Default</option>
 			</select>
-
-			<button>update reactive spread</button>
-		`
-		);
-
-		const btn = target.querySelector('button');
-		btn?.click();
-		flushSync();
-
-		assert.htmlEqual(
-			target.innerHTML,
-			`
-			<select>
-				<option value="">Default</option>
-			</select>
-
-			<select>
-				<option value="">Default</option>
-			</select>
-
-			<select>
-				<option value="">Default</option>
-			</select>
-
-			<select>
-				<option value="">Default</option>
-			</select>
-
-			<select>
-				<option>Default</option>
-			</select>
-
-			<button>update reactive spread</button>
 		`
 		);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/select-falsy-value/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/select-falsy-value/_config.js
@@ -1,0 +1,66 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+// <option value> is special because falsy values should result in an empty string value attribute
+export default test({
+	mode: ['client'],
+	test({ assert, target }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<button>update reactive spread</button>
+		`
+		);
+
+		const btn = target.querySelector('button');
+		btn?.click();
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<select>
+				<option value="">Default</option>
+			</select>
+
+			<select>
+				<option>Default</option>
+			</select>
+
+			<button>update reactive spread</button>
+		`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/select-falsy-value/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/select-falsy-value/main.svelte
@@ -1,0 +1,28 @@
+<script>
+	let nonreactive = undefined;
+	let reactive = $state();
+	let nonreactive_spread = { value: undefined };
+	let reactive_spread = $state({ value: undefined });
+</script>
+
+<select>
+	<option value={undefined}>Default</option>
+</select>
+
+<select>
+	<option value={nonreactive}>Default</option>
+</select>
+
+<select>
+	<option value={reactive}>Default</option>
+</select>
+
+<select>
+	<option {...nonreactive_spread}>Default</option>
+</select>
+
+<select>
+	<option {...reactive_spread}>Default</option>
+</select>
+
+<button onclick={() => (reactive_spread = {})}>update reactive spread</button>

--- a/packages/svelte/tests/runtime-runes/samples/select-falsy-value/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/select-falsy-value/main.svelte
@@ -24,5 +24,3 @@
 <select>
 	<option {...reactive_spread}>Default</option>
 </select>
-
-<button onclick={() => (reactive_spread = {})}>update reactive spread</button>


### PR DESCRIPTION
Setting the `value` attribute of an `<option>` element to a falsy value should result in the empty string. This wasn't happening in all situations previously. Fixes #11616

While this fixes the behavior, I'm also somewhat questioning whether or not this should be the way it works. In other situations a falsy value means removing the attribute. In this case it's not. On the other hand for `value` on `input` elements it's the same behavior and it makes sense there, mostly because the value property is not reflected as an attribute - but for option elements it is. So there are arguments both in favor and against this behavior. Either way, it should be consistent, and this makes it consistent with the Svelte 4 behavior (and fixes the spreading inconsistency that was also present in Svelte 4)

Side note: During this I checked what the `value` attribute does for different elements. It's ... really different by element, to say the least:
- progress: no attribute -> indeterminate state, progress bumps around
- meter: no attribute -> value 0
- option: no attribute -> uses text value
- input: no attribute -> no default value
- textare: no attribute -> no default value
- button: no attribute -> empty string value


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
