### PR TITLE
fix: Abort outro when intro starts

### DIFF
--- a/.changeset/bright-needles-pretend.md
+++ b/.changeset/bright-needles-pretend.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: abort outro when intro starts

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -190,6 +190,9 @@ export function transition(flags, element, get_fn, get_params) {
 		in() {
 			element.inert = inert;
 
+			// abort the outro to prevent overlap with the intro
+			outro?.abort();
+
 			if (is_intro) {
 				dispatch_event(element, 'introstart');
 				intro = animate(element, get_options(), outro, 1, () => {
@@ -197,7 +200,6 @@ export function transition(flags, element, get_fn, get_params) {
 					intro = current_options = undefined;
 				});
 			} else {
-				outro?.abort();
 				reset?.();
 			}
 		},

--- a/packages/svelte/tests/runtime-legacy/samples/transition-abort/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-abort/_config.js
@@ -12,24 +12,48 @@ export default test({
 	async test({ assert, component, target, raf }) {
 		component.visible = false;
 
-		// abort halfway through the outro transition
-		raf.tick(50);
+		raf.tick(25);
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<div style="opacity: 0.75;">a</div>
+			<div style="opacity: 0.75;">a</div>
+		`
+		);
 
+		// abort 1/4 through the outro transition
 		await component.$set({
 			visible: true,
 			array: ['a', 'b', 'c']
 		});
 
+		raf.tick(50);
+		assert.htmlEqual(
+			target.innerHTML,
+			// because outro is aborted it will be finished earlier with the intro than the new items
+			`
+			<div style="">a</div>
+			<div style="opacity: 0.25;">b</div>
+			<div style="opacity: 0.25;">c</div>
+
+			<div style="">a</div>
+			<div style="opacity: 0.25;">b</div>
+			<div style="opacity: 0.25;">c</div>
+		`
+		);
+
+		// intros of new items almost finished, aborted outro shouldn't overlap re-intro
+		raf.tick(75);
 		assert.htmlEqual(
 			target.innerHTML,
 			`
-			<div>a</div>
-			<div>b</div>
-			<div>c</div>
+			<div style="">a</div>
+			<div style="opacity: 0.5;">b</div>
+			<div style="opacity: 0.5;">c</div>
 
-			<div>a</div>
-			<div>b</div>
-			<div>c</div>
+			<div style="">a</div>
+			<div style="opacity: 0.5;">b</div>
+			<div style="opacity: 0.5;">c</div>
 		`
 		);
 	}

--- a/packages/svelte/tests/runtime-legacy/samples/transition-abort/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-abort/main.svelte
@@ -2,20 +2,22 @@
 	export let array = ['a'];
 	export let visible = true;
 
-	function slide(_, params) {
-		return params;
+	function slide(_) {
+		return {
+			duration: 100,
+			css: (t) => `opacity: ${t}`
+		};
 	}
 </script>
 
 {#if visible}
 	{#each array as item}
-		<div transition:slide={{duration:100}}>{item}</div>
+		<div transition:slide|global>{item}</div>
 	{/each}
 {/if}
 
-{#if !visible}
-{:else}
+{#if !visible}{:else}
 	{#each array as item}
-		<div transition:slide={{duration:100}}>{item}</div>
+		<div transition:slide|global>{item}</div>
 	{/each}
 {/if}


### PR DESCRIPTION
Fixes #12319.

Currently, if an intro animation starts before an outro is finished, the outro overlaps the intro and leaves the element in an unwanted state (see the PR for a video). I think the outro should always be cancelled if an intro starts.

## Reproduction

Write this into `playgrounds/demo/src/main.svelte`...

```svelte
<!-- file: playgrounds/demo/src/main.svelte -->

<script lang="ts">
  import { fly } from 'svelte/transition';

  let state = $state(0);
</script>

<button onclick={() => state++}>{state}</button>

{#if state % 2 === 0}
  <h2 transition:fly={{ duration: 1000, x: 100 }}>Hello World!</h2>
{/if}
```

then...

```sh
cd playgrounds/demo
pnpm dev
```

---

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
