### PR TITLE
fix: ensure `$effect.root` is handled correctly on the server

### DIFF
--- a/.changeset/wicked-emus-drive.md
+++ b/.changeset/wicked-emus-drive.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure `$effect.root` is handled correctly on the server

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -415,8 +415,7 @@ const global_visitors = {
 			const args = /** @type {import('estree').Expression[]} */ (
 				node.arguments.map((arg) => context.visit(arg))
 			);
-			// Just call the function directly
-			return b.call(args[0]);
+			return b.call('$.effect_root', args[0]);
 		}
 
 		if (rune === '$state.snapshot') {
@@ -651,7 +650,8 @@ const javascript_visitors_runes = {
 			if (
 				callee.type === 'MemberExpression' &&
 				callee.object.type === 'Identifier' &&
-				callee.object.name === '$effect'
+				callee.object.name === '$effect' &&
+				(callee.property.type !== 'Identifier' || callee.property.name !== 'root')
 			) {
 				return b.empty;
 			}

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -291,6 +291,23 @@ export function merge_styles(attribute, styles) {
 	return merged;
 }
 
+let is_nested_effect_root = false;
+
+/**
+ * @param {any} fn
+ */
+export function effect_root(fn) {
+	let is_nested = is_nested_effect_root;
+	is_nested_effect_root = true;
+
+	const cleanup = fn() ?? noop;
+
+	is_nested_effect_root = is_nested;
+	if (!is_nested) on_destroy.push(cleanup);
+
+	return cleanup;
+}
+
 /**
  * @template V
  * @param {Record<string, [any, any, any]>} store_values

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -61,7 +61,7 @@ export interface RuntimeTest<Props extends Record<string, any> = Record<string, 
 		warnings: any[];
 		hydrate: Function;
 	}) => void | Promise<void>;
-	test_ssr?: (args: { assert: Assert }) => void | Promise<void>;
+	test_ssr?: (args: { logs: any[]; assert: Assert }) => void | Promise<void>;
 	accessors?: boolean;
 	immutable?: boolean;
 	intro?: boolean;
@@ -285,6 +285,7 @@ async function run_test_variant(
 
 			if (config.test_ssr) {
 				await config.test_ssr({
+					logs,
 					// @ts-expect-error
 					assert: {
 						...assert,

--- a/packages/svelte/tests/runtime-runes/samples/effect-root-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root-4/_config.js
@@ -1,0 +1,18 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: '<button>cleanup</button>',
+
+	async test({ assert, target, logs }) {
+		const btn = target.querySelector('button');
+
+		btn?.click();
+		flushSync();
+
+		assert.deepEqual(logs, ['effect1', 'effect2']);
+	},
+	test_ssr({ assert, logs }) {
+		assert.deepEqual(logs, ['effect1', 'effect2']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-root-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root-4/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	$effect.root(() => {
+		console.log('effect1');
+	});
+	const cleanup = $effect.root(() => {
+		console.log('effect2');
+	});
+</script>
+
+<button onclick={cleanup}>cleanup</button>

--- a/packages/svelte/tests/runtime-runes/samples/effect-root/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root/_config.js
@@ -24,5 +24,8 @@ export default test({
 		});
 
 		assert.deepEqual(logs, [0, 1, 'cleanup 1', 'cleanup 2']);
+	},
+	test_ssr({ assert, logs }) {
+		assert.deepEqual(logs, ['cleanup 1', 'cleanup 2']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-store-no-hoisting/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-store-no-hoisting/main.svelte
@@ -5,8 +5,7 @@
 
 	function setStore() {
 		store = writable(0, () => {
-			console.log('start');
-			return () => console.log('stop');
+			return () => {};
 		});
 	}
 </script>


### PR DESCRIPTION
Alternate PR to #12332 - choose one

- should return a callback function, always (which means it may need a fallback noop function)
- should invoke the cleanup function on component destroy in SSR for effect root directly connected to a component

fixes #12322

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
