### PR TITLE
fix: ensure `$effect.root` is ignored on the server

### DIFF
--- a/.changeset/wicked-emus-drive.md
+++ b/.changeset/wicked-emus-drive.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure `$effect.root` is ignored on the server

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -412,11 +412,8 @@ const global_visitors = {
 		}
 
 		if (rune === '$effect.root') {
-			const args = /** @type {import('estree').Expression[]} */ (
-				node.arguments.map((arg) => context.visit(arg))
-			);
-			// Just call the function directly
-			return b.call(args[0]);
+			// ignore $effect.root() calls, just return a noop which mimics the cleanup function
+			return b.arrow([], b.block([]));
 		}
 
 		if (rune === '$state.snapshot') {

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -61,7 +61,7 @@ export interface RuntimeTest<Props extends Record<string, any> = Record<string, 
 		warnings: any[];
 		hydrate: Function;
 	}) => void | Promise<void>;
-	test_ssr?: (args: { assert: Assert }) => void | Promise<void>;
+	test_ssr?: (args: { logs: any[]; assert: Assert }) => void | Promise<void>;
 	accessors?: boolean;
 	immutable?: boolean;
 	intro?: boolean;
@@ -285,6 +285,7 @@ async function run_test_variant(
 
 			if (config.test_ssr) {
 				await config.test_ssr({
+					logs,
 					// @ts-expect-error
 					assert: {
 						...assert,

--- a/packages/svelte/tests/runtime-runes/samples/effect-root-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root-4/_config.js
@@ -1,0 +1,18 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: '<button>cleanup</button>',
+
+	async test({ assert, target, logs }) {
+		const btn = target.querySelector('button');
+
+		btn?.click();
+		flushSync();
+
+		assert.deepEqual(logs, ['effect1', 'effect2']);
+	},
+	test_ssr({ assert, logs }) {
+		assert.deepEqual(logs, []);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-root-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root-4/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	$effect.root(() => {
+		console.log('effect1');
+	});
+	const cleanup = $effect.root(() => {
+		console.log('effect2');
+	});
+</script>
+
+<button onclick={cleanup}>cleanup</button>

--- a/packages/svelte/tests/runtime-runes/samples/effect-root/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-root/_config.js
@@ -24,5 +24,8 @@ export default test({
 		});
 
 		assert.deepEqual(logs, [0, 1, 'cleanup 1', 'cleanup 2']);
+	},
+	test_ssr({ assert, logs }) {
+		assert.deepEqual(logs, []);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-store-no-hoisting/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-store-no-hoisting/main.svelte
@@ -5,8 +5,7 @@
 
 	function setStore() {
 		store = writable(0, () => {
-			console.log('start');
-			return () => console.log('stop');
+			return () => {};
 		});
 	}
 </script>


### PR DESCRIPTION
Alternate PR to #12331 - choose one.

Ignore the contents of the effect root, just return a noop where necessary

fixes #12322

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
