### PR TITLE
breaking: play transitions on `mount` by default

### DIFF
--- a/.changeset/hip-garlics-tap.md
+++ b/.changeset/hip-garlics-tap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: play transitions on `mount` by default

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -24,8 +24,8 @@ export const root_event_handles = new Set();
 
 /**
  * This is normally true — block effects should run their intro transitions —
- * but is false during hydration and mounting (unless `options.intro` is `true`)
- * and when creating the children of a `<svelte:element>` that just changed tag
+ * but is false during hydration (unless `options.intro` is `true`) and
+ * when creating the children of a `<svelte:element>` that just changed tag
  */
 export let should_intro = true;
 
@@ -66,7 +66,8 @@ export function slot(anchor, slot_fn, slot_props, fallback_fn) {
 }
 
 /**
- * Mounts a component to the given target and returns the exports and potentially the props (if compiled with `accessors: true`) of the component
+ * Mounts a component to the given target and returns the exports and potentially the props (if compiled with `accessors: true`) of the component.
+ * Transitions will play during the initial render unless the `intro` option is set to `false`.
  *
  * @template {Record<string, any>} Props
  * @template {Record<string, any>} Exports
@@ -126,6 +127,7 @@ export function hydrate(component, options) {
 		validate_component(component);
 	}
 
+	options.intro = options.intro ?? false;
 	const target = options.target;
 	const previous_hydrate_nodes = hydrate_nodes;
 
@@ -190,7 +192,7 @@ export function hydrate(component, options) {
  * 	}} options
  * @returns {Exports}
  */
-function _mount(Component, { target, anchor, props = {}, events, context, intro = false }) {
+function _mount(Component, { target, anchor, props = {}, events, context, intro = true }) {
 	init_operations();
 
 	const registered_events = new Set();

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -77,7 +77,7 @@ class Svelte4Component {
 			target: options.target,
 			props,
 			context: options.context,
-			intro: options.intro,
+			intro: options.intro ?? false,
 			recover: options.recover
 		});
 

--- a/packages/svelte/tests/runtime-runes/samples/mount-intro-transition/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/mount-intro-transition/Component.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { fade } from 'svelte/transition';
+</script>
+
+<div in:fade|global={{ duration: 100 }}>DIV</div>

--- a/packages/svelte/tests/runtime-runes/samples/mount-intro-transition/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/mount-intro-transition/_config.js
@@ -1,0 +1,21 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+export default test({
+	async test({ assert, target, raf }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+		const div = target.querySelector('div');
+		ok(div);
+
+		btn1.click();
+		flushSync();
+		assert.htmlEqual(div.innerHTML, `<div style="opacity: 0;">DIV</div>`);
+
+		raf.tick(100);
+		assert.htmlEqual(div.innerHTML, `<div style="">DIV</div>`);
+
+		btn2.click();
+		flushSync();
+		assert.htmlEqual(div.innerHTML, `<div>DIV</div>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/mount-intro-transition/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/mount-intro-transition/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	import { mount, unmount } from 'svelte';
+	import Component from './Component.svelte';
+
+	let el;
+	let instance;
+
+	function intro(animate) {
+		if (instance) unmount(instance);
+
+		instance = mount(Component, {
+			target: el,
+			intro: animate
+		});
+	}
+</script>
+
+<div bind:this={el}></div>
+
+<button onclick={() => intro()}>mount with intro transition</button>
+<button onclick={() => intro(false)}>mount without intro transition</button>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -366,7 +366,8 @@ declare module 'svelte' {
 	/** Anything except a function */
 	type NotFunction<T> = T extends Function ? never : T;
 	/**
-	 * Mounts a component to the given target and returns the exports and potentially the props (if compiled with `accessors: true`) of the component
+	 * Mounts a component to the given target and returns the exports and potentially the props (if compiled with `accessors: true`) of the component.
+	 * Transitions will play during the initial render unless the `intro` option is set to `false`.
 	 *
 	 * */
 	export function mount<Props extends Record<string, any>, Exports extends Record<string, any>>(component: ComponentType<SvelteComponent<Props>> | Component<Props, Exports, any>, options: {} extends Props ? {

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -281,3 +281,7 @@ In Svelte 4, `<svelte:element this="div">` is valid code. This makes little sens
 ```
 
 Note that whereas Svelte 4 would treat `<svelte:element this="input">` (for example) identically to `<input>` for the purposes of determining which `bind:` directives could be applied, Svelte 5 does not.
+
+### `mount` plays transitions by default
+
+The `mount` function used to render a component tree plays transitions by default unless the `intro` option is set to `false`. This is different from legacy class components which, when manually instantiated, didn't play transitions by default.


### PR DESCRIPTION
closes #11280

During testing this I noticed two things:
- in the added test, without `|global` the intro transition does not play within the component. Is that expected, because it's not inside any block (like an if block)?
- HMR prevents playing the intro transition for some reason. We can investigate that separately if we don't want to hold up this PR

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
