### PR TITLE
chore: remove unnecessary Invalidator type

### DIFF
--- a/packages/svelte/src/store/index.js
+++ b/packages/svelte/src/store/index.js
@@ -1,5 +1,5 @@
 /** @import { Readable, StartStopNotifier, Subscriber, Unsubscriber, Updater, Writable } from './public' */
-/** @import { Invalidator, Stores, StoresValues, SubscribeInvalidateTuple } from './private' */
+/** @import { Stores, SubscribeInvalidateTuple } from './private' */
 import { noop, run_all } from '../internal/shared/utils.js';
 import { safe_not_equal } from '../internal/client/reactivity/equality.js';
 import { subscribe_to_store } from './utils.js';
@@ -74,7 +74,7 @@ export function writable(value, start = noop) {
 
 	/**
 	 * @param {Subscriber<T>} run
-	 * @param {Invalidator} [invalidate]
+	 * @param {() => void} [invalidate]
 	 * @returns {Unsubscriber}
 	 */
 	function subscribe(run, invalidate = noop) {

--- a/packages/svelte/src/store/index.js
+++ b/packages/svelte/src/store/index.js
@@ -1,5 +1,5 @@
 /** @import { Readable, StartStopNotifier, Subscriber, Unsubscriber, Updater, Writable } from './public' */
-/** @import { Stores, SubscribeInvalidateTuple } from './private' */
+/** @import { Stores, StoresValues, SubscribeInvalidateTuple } from './private' */
 import { noop, run_all } from '../internal/shared/utils.js';
 import { safe_not_equal } from '../internal/client/reactivity/equality.js';
 import { subscribe_to_store } from './utils.js';

--- a/packages/svelte/src/store/index.js
+++ b/packages/svelte/src/store/index.js
@@ -74,7 +74,7 @@ export function writable(value, start = noop) {
 
 	/**
 	 * @param {Subscriber<T>} run
-	 * @param {Invalidator<T>} [invalidate]
+	 * @param {Invalidator} [invalidate]
 	 * @returns {Unsubscriber}
 	 */
 	function subscribe(run, invalidate = noop) {

--- a/packages/svelte/src/store/private.d.ts
+++ b/packages/svelte/src/store/private.d.ts
@@ -1,10 +1,7 @@
 import { Readable, Subscriber } from './public.js';
 
-/** Cleanup logic callback. */
-type Invalidator = () => void;
-
 /** Pair of subscriber and invalidator. */
-type SubscribeInvalidateTuple<T> = [Subscriber<T>, Invalidator];
+type SubscribeInvalidateTuple<T> = [Subscriber<T>, () => void];
 
 /** One or more `Readable`s. */
 type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>;
@@ -13,4 +10,4 @@ type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<R
 type StoresValues<T> =
 	T extends Readable<infer U> ? U : { [K in keyof T]: T[K] extends Readable<infer U> ? U : never };
 
-export { Invalidator, SubscribeInvalidateTuple, Stores, StoresValues };
+export { SubscribeInvalidateTuple, Stores, StoresValues };

--- a/packages/svelte/src/store/private.d.ts
+++ b/packages/svelte/src/store/private.d.ts
@@ -1,10 +1,10 @@
 import { Readable, Subscriber } from './public.js';
 
 /** Cleanup logic callback. */
-type Invalidator<T> = (value?: T) => void;
+type Invalidator = () => void;
 
 /** Pair of subscriber and invalidator. */
-type SubscribeInvalidateTuple<T> = [Subscriber<T>, Invalidator<T>];
+type SubscribeInvalidateTuple<T> = [Subscriber<T>, Invalidator];
 
 /** One or more `Readable`s. */
 type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>;

--- a/packages/svelte/src/store/public.d.ts
+++ b/packages/svelte/src/store/public.d.ts
@@ -1,5 +1,3 @@
-import type { Invalidator } from './private.js';
-
 /** Callback to inform of a value updates. */
 type Subscriber<T> = (value: T) => void;
 
@@ -30,7 +28,7 @@ interface Readable<T> {
 	 * @param run subscription callback
 	 * @param invalidate cleanup callback
 	 */
-	subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator): Unsubscriber;
+	subscribe(this: void, run: Subscriber<T>, invalidate?: () => void): Unsubscriber;
 }
 
 /** Writable interface for both updating and subscribing. */

--- a/packages/svelte/src/store/public.d.ts
+++ b/packages/svelte/src/store/public.d.ts
@@ -30,7 +30,7 @@ interface Readable<T> {
 	 * @param run subscription callback
 	 * @param invalidate cleanup callback
 	 */
-	subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
+	subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator): Unsubscriber;
 }
 
 /** Writable interface for both updating and subscribing. */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2075,7 +2075,7 @@ declare module 'svelte/motion' {
 		 * @param run subscription callback
 		 * @param invalidate cleanup callback
 		 */
-		subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
+		subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator): Unsubscriber;
 	}
 	interface SpringOpts {
 		stiffness?: number;
@@ -2097,7 +2097,7 @@ declare module 'svelte/motion' {
 		interpolate?: (a: T, b: T) => (t: number) => T;
 	}
 	/** Cleanup logic callback. */
-	type Invalidator<T> = (value?: T) => void;
+	type Invalidator = () => void;
 	/**
 	 * The spring function in Svelte creates a store whose value is animated, with a motion that simulates the behavior of a spring. This means when the value changes, instead of transitioning at a steady rate, it "bounces" like a spring would, depending on the physics parameters provided. This adds a level of realism to the transitions and can enhance the user experience.
 	 *
@@ -2221,7 +2221,7 @@ declare module 'svelte/store' {
 		 * @param run subscription callback
 		 * @param invalidate cleanup callback
 		 */
-		subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
+		subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator): Unsubscriber;
 	}
 
 	/** Writable interface for both updating and subscribing. */
@@ -2239,7 +2239,7 @@ declare module 'svelte/store' {
 		update(this: void, updater: Updater<T>): void;
 	}
 	/** Cleanup logic callback. */
-	type Invalidator<T> = (value?: T) => void;
+	type Invalidator = () => void;
 
 	/** One or more `Readable`s. */
 	type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>;

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2075,7 +2075,7 @@ declare module 'svelte/motion' {
 		 * @param run subscription callback
 		 * @param invalidate cleanup callback
 		 */
-		subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator): Unsubscriber;
+		subscribe(this: void, run: Subscriber<T>, invalidate?: () => void): Unsubscriber;
 	}
 	interface SpringOpts {
 		stiffness?: number;
@@ -2096,8 +2096,6 @@ declare module 'svelte/motion' {
 		easing?: (t: number) => number;
 		interpolate?: (a: T, b: T) => (t: number) => T;
 	}
-	/** Cleanup logic callback. */
-	type Invalidator = () => void;
 	/**
 	 * The spring function in Svelte creates a store whose value is animated, with a motion that simulates the behavior of a spring. This means when the value changes, instead of transitioning at a steady rate, it "bounces" like a spring would, depending on the physics parameters provided. This adds a level of realism to the transitions and can enhance the user experience.
 	 *
@@ -2221,7 +2219,7 @@ declare module 'svelte/store' {
 		 * @param run subscription callback
 		 * @param invalidate cleanup callback
 		 */
-		subscribe(this: void, run: Subscriber<T>, invalidate?: Invalidator): Unsubscriber;
+		subscribe(this: void, run: Subscriber<T>, invalidate?: () => void): Unsubscriber;
 	}
 
 	/** Writable interface for both updating and subscribing. */
@@ -2238,15 +2236,6 @@ declare module 'svelte/store' {
 		 */
 		update(this: void, updater: Updater<T>): void;
 	}
-	/** Cleanup logic callback. */
-	type Invalidator = () => void;
-
-	/** One or more `Readable`s. */
-	type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>;
-
-	/** One or more values from `Readable` stores. */
-	type StoresValues<T> =
-		T extends Readable<infer U> ? U : { [K in keyof T]: T[K] extends Readable<infer U> ? U : never };
 	/**
 	 * Creates a `Readable` store that allows reading by subscription.
 	 *
@@ -2288,6 +2277,12 @@ declare module 'svelte/store' {
 	 * https://svelte.dev/docs/svelte-store#get
 	 * */
 	export function get<T>(store: Readable<T>): T;
+	/** One or more `Readable`s. */
+	type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>;
+
+	/** One or more values from `Readable` stores. */
+	type StoresValues<T> =
+		T extends Readable<infer U> ? U : { [K in keyof T]: T[K] extends Readable<infer U> ? U : never };
 
 	export { Subscriber, Unsubscriber, Updater, StartStopNotifier, Readable, Writable };
 }


### PR DESCRIPTION
Via #12311 I noticed this is wrong — it doesn't take an argument, and by extension shouldn't take a type argument

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
