### PR TITLE
chore: allow `<svelte:element>` effects to be pruned

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -10,10 +10,9 @@ import {
 } from '../../reactivity/effects.js';
 import { set_should_intro } from '../../render.js';
 import { current_each_item, set_current_each_item } from './each.js';
-import { current_component_context, current_effect } from '../../runtime.js';
+import { current_component_context } from '../../runtime.js';
 import { DEV } from 'esm-env';
 import { assign_nodes } from '../template.js';
-import { noop } from '../../../shared/utils.js';
 import { EFFECT_TRANSPARENT } from '../../constants.js';
 
 /**
@@ -121,9 +120,6 @@ export function element(node, get_tag, is_svg, render_fn, get_namespace, locatio
 				}
 
 				anchor.before(element);
-
-				// See below
-				return noop;
 			});
 		}
 
@@ -132,9 +128,5 @@ export function element(node, get_tag, is_svg, render_fn, get_namespace, locatio
 		set_should_intro(true);
 
 		set_current_each_item(previous_each_item);
-
-		// Inert effects are proactively detached from the effect tree. Returning a noop
-		// teardown function is an easy way to ensure that this is not discarded
-		return noop;
 	}, EFFECT_TRANSPARENT);
 }


### PR DESCRIPTION
'Inert' effects (those with no dependencies, or DOM, or teardown functions) do not get added to the effect tree, since there's no reason to keep them alive.

In two cases — `{#await ...}` and `<svelte:element>` effects — we return a noop function to prevent the effects from being pruned. In the case of `await` blocks this is necessary because a branch might not be created during the block's first run. In the case of `<svelte:element>` it's not — I think it was only there because we were previously updating the DOM manually rather than using the simpler `assign_nodes` mechanism, which organically prevents the effect being pruned.

In fact there's an edge case where we _want_ the effect to be pruned — the case where `this` is non-reactive and falsy...

```svelte
<svelte:element this={null} />
```

...and that's what happens with this PR.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
