### PR TITLE
chore: move `slot` function into its own module

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/slot.js
+++ b/packages/svelte/src/internal/client/dom/blocks/slot.js
@@ -1,0 +1,15 @@
+/**
+ * @param {Comment} anchor
+ * @param {void | ((anchor: Comment, slot_props: Record<string, unknown>) => void)} slot_fn
+ * @param {Record<string, unknown>} slot_props
+ * @param {null | ((anchor: Comment) => void)} fallback_fn
+ */
+export function slot(anchor, slot_fn, slot_props, fallback_fn) {
+	if (slot_fn === undefined) {
+		if (fallback_fn !== null) {
+			fallback_fn(anchor);
+		}
+	} else {
+		slot_fn(anchor, slot_props);
+	}
+}

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -15,6 +15,7 @@ export { key_block as key } from './dom/blocks/key.js';
 export { css_props } from './dom/blocks/css-props.js';
 export { index, each } from './dom/blocks/each.js';
 export { html } from './dom/blocks/html.js';
+export { slot } from './dom/blocks/slot.js';
 export { snippet, wrap_snippet } from './dom/blocks/snippet.js';
 export { component } from './dom/blocks/svelte-component.js';
 export { element } from './dom/blocks/svelte-element.js';
@@ -118,7 +119,7 @@ export {
 	update_pre_store,
 	update_store
 } from './reactivity/store.js';
-export { append_styles, sanitize_slots, set_text, slot } from './render.js';
+export { append_styles, sanitize_slots, set_text } from './render.js';
 export {
 	get,
 	invalidate_inner_signals,

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -50,22 +50,6 @@ export function set_text(text, value) {
 }
 
 /**
- * @param {Comment} anchor
- * @param {void | ((anchor: Comment, slot_props: Record<string, unknown>) => void)} slot_fn
- * @param {Record<string, unknown>} slot_props
- * @param {null | ((anchor: Comment) => void)} fallback_fn
- */
-export function slot(anchor, slot_fn, slot_props, fallback_fn) {
-	if (slot_fn === undefined) {
-		if (fallback_fn !== null) {
-			fallback_fn(anchor);
-		}
-	} else {
-		slot_fn(anchor, slot_props);
-	}
-}
-
-/**
  * Mounts a component to the given target and returns the exports and potentially the props (if compiled with `accessors: true`) of the component.
  * Transitions will play during the initial render unless the `intro` option is set to `false`.
  *


### PR DESCRIPTION
`slot` is roughly equivalent to `snippet`, and belongs in its own module rather than in `render.js`. merging once green for the sake of #12335