### PR TITLE
fix: correctly validate `<svelte:component>` with `bind:this`

### DIFF
--- a/.changeset/witty-sloths-impress.md
+++ b/.changeset/witty-sloths-impress.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly validate `<svelte:component>` with `bind:this`

--- a/packages/svelte/src/internal/client/dom/elements/bindings/this.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/this.js
@@ -56,4 +56,6 @@ export function bind_this(element_or_component = {}, update, get_value, get_part
 			});
 		};
 	});
+
+	return element_or_component;
 }

--- a/packages/svelte/src/internal/client/validate.js
+++ b/packages/svelte/src/internal/client/validate.js
@@ -12,8 +12,9 @@ function is_void(tag) {
 }
 
 /**
- * @param {() => any} component_fn
- * @returns {any}
+ * @template Component
+ * @param {() => Component} component_fn
+ * @returns {Component}
  */
 export function validate_dynamic_component(component_fn) {
 	try {


### PR DESCRIPTION
We need to return the instance from `bind_this` otherwise `validate_dynamic_component` will get mad. No test because we use the legacy component API in the tests, meaning it doesn't fail in the first place

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
