### PR TITLE
chore: expose css option in playground

### DIFF
--- a/sites/svelte-5-preview/src/lib/Output/CompilerOptions.svelte
+++ b/sites/svelte-5-preview/src/lib/Output/CompilerOptions.svelte
@@ -18,6 +18,16 @@
 		<label for="server"><span class="string">"server"</span>,</label>
 	</div>
 
+	<div class="option">
+		<span class="key">css:</span>
+
+		<input id="injected" type="radio" bind:group={$compile_options.css} value="injected" />
+		<label for="injected"><span class="string">"injected"</span></label>
+
+		<input id="external" type="radio" bind:group={$compile_options.css} value="external" />
+		<label for="external"><span class="string">"external"</span>,</label>
+	</div>
+
 	<label class="option">
 		<span class="key">dev:</span>
 		<Checkbox bind:checked={$compile_options.dev} />

--- a/sites/svelte-5-preview/src/lib/Repl.svelte
+++ b/sites/svelte-5-preview/src/lib/Repl.svelte
@@ -77,7 +77,8 @@
 	/** @type {import('svelte/compiler').CompileOptions} */
 	const DEFAULT_COMPILE_OPTIONS = {
 		generate: 'client',
-		dev: false
+		dev: false,
+		css: 'external'
 	};
 
 	/** @type {Map<string, import('@codemirror/state').EditorState>} */

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -62,9 +62,7 @@ function compile({ id, source, options, return_ast }) {
 
 		if (options.filename.endsWith('.svelte')) {
 			const compiled = svelte.compile(source, {
-				filename: options.filename,
-				generate: options.generate,
-				dev: options.dev,
+				...options,
 				discloseVersion: false // less visual noise in the output tab
 			});
 


### PR DESCRIPTION
This allows us to see the effect of toggling `css` between `'injected'` and `'external'`. See #12294