### PR TITLE
fix: remove event listeners on hydration error

### DIFF
--- a/.changeset/small-chefs-sing.md
+++ b/.changeset/small-chefs-sing.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove event listeners on hydration error

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -1,4 +1,5 @@
 import { teardown } from '../../reactivity/effects.js';
+import { push_init_error_handler } from '../../render.js';
 import { define_property, is_array } from '../../utils.js';
 import { hydrating } from '../hydration.js';
 import { queue_micro_task } from '../task.js';
@@ -8,9 +9,6 @@ export const all_registered_events = new Set();
 
 /** @type {Set<(events: Array<string>) => void>} */
 export const root_event_handles = new Set();
-
-/** @type {Array<() => void>} */
-export const event_handles_to_remove_on_error = [];
 
 /**
  * SSR adds onload and onerror attributes to catch those events before the hydration.
@@ -134,11 +132,7 @@ export function event(event_name, dom, handler, capture, passive) {
 			dom.removeEventListener(event_name, target_handler, options);
 		});
 
-		if (hydrating) {
-			event_handles_to_remove_on_error.push(() =>
-				dom.removeEventListener(event_name, target_handler, options)
-			);
-		}
+		push_init_error_handler(() => dom.removeEventListener(event_name, target_handler, options));
 	}
 }
 

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -1,8 +1,16 @@
 import { teardown } from '../../reactivity/effects.js';
-import { all_registered_events, root_event_handles } from '../../render.js';
 import { define_property, is_array } from '../../utils.js';
 import { hydrating } from '../hydration.js';
 import { queue_micro_task } from '../task.js';
+
+/** @type {Set<string>} */
+export const all_registered_events = new Set();
+
+/** @type {Set<(events: Array<string>) => void>} */
+export const root_event_handles = new Set();
+
+/** @type {Array<() => void>} */
+export const event_handles_to_remove_on_error = [];
 
 /**
  * SSR adds onload and onerror attributes to catch those events before the hydration.
@@ -125,6 +133,12 @@ export function event(event_name, dom, handler, capture, passive) {
 		teardown(() => {
 			dom.removeEventListener(event_name, target_handler, options);
 		});
+
+		if (hydrating) {
+			event_handles_to_remove_on_error.push(() =>
+				dom.removeEventListener(event_name, target_handler, options)
+			);
+		}
 	}
 }
 

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -104,7 +104,10 @@ export function runtime_suite(runes: boolean) {
 				if (config.skip_mode?.includes('hydrate')) return true;
 			}
 
-			if (variant === 'dom' && config.skip_mode?.includes('client')) {
+			if (
+				variant === 'dom' &&
+				(config.skip_mode?.includes('client') || (config.mode && !config.mode.includes('client')))
+			) {
 				return 'no-test';
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/event-global-hydration-error-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-global-hydration-error-cleanup/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: '<p><p>invalid</p></p>',
+	mode: ['hydrate'],
+	recover: true,
+	test({ assert, target, logs }) {
+		target.click();
+		flushSync();
+		assert.deepEqual(logs, ['body', 'document', 'window']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-global-hydration-error-cleanup/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-global-hydration-error-cleanup/main.svelte
@@ -1,0 +1,5 @@
+<svelte:window onclick={() => console.log('window')} />
+<svelte:document onclick={() => console.log('document')} />
+<svelte:body onclick={() => console.log('body')} />
+
+<p>{@html '<p>invalid</p>'}</p>

--- a/packages/svelte/tests/runtime-runes/samples/event-global-mount-error-cleanup/Inner.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-global-mount-error-cleanup/Inner.svelte
@@ -1,0 +1,3 @@
+<script>
+	throw new Error('boom');
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/event-global-mount-error-cleanup/Outer.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-global-mount-error-cleanup/Outer.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Inner from './Inner.svelte';
+</script>
+
+<svelte:window onclick={() => console.log('window')} />
+<svelte:document onclick={() => console.log('document')} />
+<svelte:body onclick={() => console.log('body')} />
+
+<Inner />

--- a/packages/svelte/tests/runtime-runes/samples/event-global-mount-error-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-global-mount-error-cleanup/_config.js
@@ -1,0 +1,11 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	test({ assert, target, logs }) {
+		target.click();
+		flushSync();
+		assert.deepEqual(logs, []);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-global-mount-error-cleanup/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-global-mount-error-cleanup/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { mount, onMount } from 'svelte';
+	import Outer from './Outer.svelte';
+
+	let el;
+
+	onMount(() => {
+		try {
+			mount(Outer, { target: el });
+		} catch {}
+	});
+</script>
+
+<div bind:this={el}></div>


### PR DESCRIPTION
fixes #12360

While fixing this I realized this can happen for `mount` aswell. I really don't like all the additional code that is needed for this. Now I'm wondering if there's a better approach - for example, should teardown listeners be able to somehow run on error? Or is that a lost cause because we're in a broken state anyway?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
