### PR TITLE
fix: avoid sending blog post text twice in data payload

### DIFF
--- a/sites/svelte.dev/src/lib/server/docs/index.js
+++ b/sites/svelte.dev/src/lib/server/docs/index.js
@@ -122,8 +122,7 @@ export async function get_sections(markdown) {
 		title: 'Root',
 		slug: 'root',
 		sections: [],
-		breadcrumbs: [''],
-		text: ''
+		breadcrumbs: ['']
 	});
 	let currentNodes = [root];
 
@@ -140,8 +139,7 @@ export async function get_sections(markdown) {
 				title: text,
 				slug,
 				sections: [],
-				breadcrumbs: [...currentNodes[level].breadcrumbs, text],
-				text: ''
+				breadcrumbs: [...currentNodes[level].breadcrumbs, text]
 			};
 
 			// Add the new node to the tree
@@ -152,9 +150,6 @@ export async function get_sections(markdown) {
 			// Prepare for potential children of the new node
 			currentNodes = currentNodes.slice(0, level + 1);
 			currentNodes.push(newNode);
-		} else if (line.trim() !== '') {
-			// Add non-heading line to the text of the current section
-			currentNodes[currentNodes.length - 1].text += line + '\n';
 		}
 	}
 

--- a/sites/svelte.dev/src/lib/server/docs/types.d.ts
+++ b/sites/svelte.dev/src/lib/server/docs/types.d.ts
@@ -6,7 +6,6 @@ export interface Section {
 	// Currently, we are only going with 2 level headings, so this will be undefined. In future, we may want to support 3 levels, in which case this will be a list of sections
 	sections?: Section[];
 	breadcrumbs: string[];
-	text: string;
 }
 
 export type Category = {


### PR DESCRIPTION
`text` is unused inside `Section`. This saves us from sending the content of blog posts twice in the data payload. Ideally we'd have a better way to find these cases than [twitter notifications](https://x.com/JLarky/status/1810839093569540595); opened sveltejs/kit#12458 to track this long-standing TODO.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
