### PR TITLE
fix: properly delay intro transitions

### DIFF
--- a/.changeset/tricky-ears-shout.md
+++ b/.changeset/tricky-ears-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: properly delay intro transitions

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -266,6 +266,8 @@ export function transition(flags, element, get_fn, get_params) {
  * @returns {import('#client').Animation}
  */
 function animate(element, options, counterpart, t2, callback) {
+	var is_intro = t2 === 1;
+
 	if (is_function(options)) {
 		// In the case of a deferred transition (such as `crossfade`), `option` will be
 		// a function rather than an `AnimationConfig`. We need to call this function
@@ -274,7 +276,7 @@ function animate(element, options, counterpart, t2, callback) {
 		var a;
 
 		queue_micro_task(() => {
-			var o = options({ direction: t2 === 1 ? 'in' : 'out' });
+			var o = options({ direction: is_intro ? 'in' : 'out' });
 			a = animate(element, o, counterpart, t2, callback);
 		});
 
@@ -320,6 +322,16 @@ function animate(element, options, counterpart, t2, callback) {
 		var keyframes = [];
 		var n = Math.ceil(duration / (1000 / 60)); // `n` must be an integer, or we risk missing the `t2` value
 
+		// In case of a delayed intro, apply the initial style for the duration of the delay;
+		// else in case of a fade-in for example the element would be visible until the animation starts
+		if (is_intro && delay > 0) {
+			let m = Math.ceil(delay / (1000 / 60));
+			let keyframe = css_to_keyframe(css(0, 1));
+			for (let i = 0; i <= m; i += 1) {
+				keyframes.push(keyframe);
+			}
+		}
+
 		for (var i = 0; i <= n; i += 1) {
 			var t = t1 + delta * easing(i / n);
 			var styles = css(t, 1 - t);
@@ -327,8 +339,8 @@ function animate(element, options, counterpart, t2, callback) {
 		}
 
 		animation = element.animate(keyframes, {
-			delay,
-			duration,
+			delay: is_intro ? 0 : delay,
+			duration: duration + (is_intro ? delay : 0),
 			easing: 'linear',
 			fill: 'forwards'
 		});

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -327,7 +327,7 @@ function animate(element, options, counterpart, t2, callback) {
 		if (is_intro && delay > 0) {
 			let m = Math.ceil(delay / (1000 / 60));
 			let keyframe = css_to_keyframe(css(0, 1));
-			for (let i = 0; i <= m; i += 1) {
+			for (let i = 0; i < m; i += 1) {
 				keyframes.push(keyframe);
 			}
 		}

--- a/packages/svelte/tests/animation-helpers.js
+++ b/packages/svelte/tests/animation-helpers.js
@@ -172,7 +172,7 @@ function interpolate(a, b, p) {
 
 /**
  * @param {Keyframe[]} keyframes
- * @param {{duration: number}} options
+ * @param {{duration: number, delay: number}} options
  * @returns {globalThis.Animation}
  */
 HTMLElement.prototype.animate = function (keyframes, options) {

--- a/packages/svelte/tests/animation-helpers.js
+++ b/packages/svelte/tests/animation-helpers.js
@@ -35,6 +35,7 @@ class Animation {
 	#target;
 	#keyframes;
 	#duration;
+	#delay;
 
 	#offset = raf.time;
 
@@ -47,12 +48,13 @@ class Animation {
 	/**
 	 * @param {HTMLElement} target
 	 * @param {Keyframe[]} keyframes
-	 * @param {{ duration: number }} options // TODO add delay
+	 * @param {{ duration: number, delay: number }} options
 	 */
-	constructor(target, keyframes, { duration }) {
+	constructor(target, keyframes, { duration, delay }) {
 		this.#target = target;
 		this.#keyframes = keyframes;
 		this.#duration = duration;
+		this.#delay = delay ?? 0;
 
 		// Promise-like semantics, but call callbacks immediately on raf.tick
 		this.finished = {
@@ -73,7 +75,9 @@ class Animation {
 	}
 
 	_update() {
-		this.currentTime = raf.time - this.#offset;
+		this.currentTime = raf.time - this.#offset - this.#delay;
+		if (this.currentTime < 0) return;
+
 		const target_frame = this.currentTime / this.#duration;
 		this.#apply_keyframe(target_frame);
 

--- a/packages/svelte/tests/runtime-runes/samples/transition-delayed/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/transition-delayed/_config.js
@@ -33,16 +33,17 @@ export default test({
 		raf.tick(201);
 		assert.htmlEqual(target.innerHTML, '<button>toggle</button><p style="">delayed fade</p>');
 
+		// TODO this doesn't work because for some reason opacity of the element is always 0
 		// out
-		btn?.click();
-		flushSync();
-		raf.tick(75);
-		assert.htmlEqual(target.innerHTML, '<button>toggle</button><p style="">delayed fade</p>');
+		// btn?.click();
+		// flushSync();
+		// raf.tick(275);
+		// assert.htmlEqual(target.innerHTML, '<button>toggle</button><p style="">delayed fade</p>');
 
-		raf.tick(150);
-		assert.htmlEqual(
-			target.innerHTML,
-			'<button>toggle</button><p style="opacity: 0.5;">delayed fade</p>'
-		);
+		// raf.tick(350);
+		// assert.htmlEqual(
+		// 	target.innerHTML,
+		// 	'<button>toggle</button><p style="opacity: 0.5;">delayed fade</p>'
+		// );
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/transition-delayed/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/transition-delayed/_config.js
@@ -30,20 +30,19 @@ export default test({
 			'<button>toggle</button><p style="opacity: 0.5;">delayed fade</p>'
 		);
 
-		raf.tick(201);
+		raf.tick(200);
 		assert.htmlEqual(target.innerHTML, '<button>toggle</button><p style="">delayed fade</p>');
 
-		// TODO this doesn't work because for some reason opacity of the element is always 0
 		// out
-		// btn?.click();
-		// flushSync();
-		// raf.tick(275);
-		// assert.htmlEqual(target.innerHTML, '<button>toggle</button><p style="">delayed fade</p>');
+		btn?.click();
+		flushSync();
+		raf.tick(275);
+		assert.htmlEqual(target.innerHTML, '<button>toggle</button><p style="">delayed fade</p>');
 
-		// raf.tick(350);
-		// assert.htmlEqual(
-		// 	target.innerHTML,
-		// 	'<button>toggle</button><p style="opacity: 0.5;">delayed fade</p>'
-		// );
+		raf.tick(350);
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="opacity: 0.5;">delayed fade</p>'
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/transition-delayed/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/transition-delayed/_config.js
@@ -1,0 +1,48 @@
+import { flushSync } from '../../../../src/index-client.js';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, raf, target }) {
+		const btn = target.querySelector('button');
+
+		// in
+		btn?.click();
+		flushSync();
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="opacity: 0;">delayed fade</p>'
+		);
+		raf.tick(1);
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="opacity: 0;">delayed fade</p>'
+		);
+
+		raf.tick(99);
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="opacity: 0;">delayed fade</p>'
+		);
+
+		raf.tick(150);
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="opacity: 0.5;">delayed fade</p>'
+		);
+
+		raf.tick(201);
+		assert.htmlEqual(target.innerHTML, '<button>toggle</button><p style="">delayed fade</p>');
+
+		// out
+		btn?.click();
+		flushSync();
+		raf.tick(75);
+		assert.htmlEqual(target.innerHTML, '<button>toggle</button><p style="">delayed fade</p>');
+
+		raf.tick(150);
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="opacity: 0.5;">delayed fade</p>'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/transition-delayed/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/transition-delayed/main.svelte
@@ -1,5 +1,11 @@
 <script>
-	import { fade } from 'svelte/transition';
+	function fade(_) {
+		return {
+			delay: 100,
+			duration: 100,
+			css: (t) => `opacity: ${t}`
+		};
+	}
 
 	let visible = $state(false);
 </script>
@@ -7,6 +13,5 @@
 <button onclick={() => (visible = !visible)}>toggle</button>
 
 {#if visible}
-	<!-- explicit opacity necessary for some reason, else it's calculated as 0 -->
-	<p transition:fade={{ delay: 100, duration: 100 }} style="opacity: 1">delayed fade</p>
+	<p transition:fade>delayed fade</p>
 {/if}

--- a/packages/svelte/tests/runtime-runes/samples/transition-delayed/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/transition-delayed/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { fade } from 'svelte/transition';
+
+	let visible = $state(false);
+</script>
+
+<button onclick={() => (visible = !visible)}>toggle</button>
+
+{#if visible}
+	<p transition:fade={{ delay: 100, duration: 100 }}>delayed fade</p>
+{/if}

--- a/packages/svelte/tests/runtime-runes/samples/transition-delayed/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/transition-delayed/main.svelte
@@ -7,5 +7,6 @@
 <button onclick={() => (visible = !visible)}>toggle</button>
 
 {#if visible}
-	<p transition:fade={{ delay: 100, duration: 100 }}>delayed fade</p>
+	<!-- explicit opacity necessary for some reason, else it's calculated as 0 -->
+	<p transition:fade={{ delay: 100, duration: 100 }} style="opacity: 1">delayed fade</p>
 {/if}


### PR DESCRIPTION
WAAPI applies the styles of a delayed animation only when that animation starts. In the case of fade-in transitions that means the element is visible, then goes invisible and fades in. Fix that by never applying a delay on intro transitions, instead add keyframes of the initial state for the duration of the delay.

Fixes #10876

This works, but the test is failing - I can't figure out how to properly write one. For some reason the `opacity` that the `fade` transition calculates is 0, whereas it should be 1 (and in fact is, when testing this in the playground). Update: got it working by applying the style manually, but feels like a hack and it doesn't work for the outro transition, still no idea why this happens 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
