### PR TITLE
feat: simplify HMR logic

### DIFF
--- a/.changeset/polite-tomatoes-trade.md
+++ b/.changeset/polite-tomatoes-trade.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: simpler HMR logic

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -437,36 +437,15 @@ export function client_component(source, analysis, options) {
 			);
 		}
 
-		body.push(
-			component,
-			b.if(
-				b.id('import.meta.hot'),
-				b.block([
-					b.const(b.id('s'), b.call('$.source', b.id(analysis.name))),
-					b.const(b.id('filename'), b.member(b.id(analysis.name), b.id('filename'))),
-					b.const(b.id('accept'), b.arrow([b.id('module')], b.block(accept_fn_body))),
-					b.stmt(b.assignment('=', b.id(analysis.name), b.call('$.hmr', b.id('s')))),
-					b.stmt(
-						b.assignment('=', b.member(b.id(analysis.name), b.id('filename')), b.id('filename'))
-					),
-					b.if(
-						b.id('import.meta.hot.acceptExports'),
-						b.block([
-							b.stmt(
-								b.call(
-									'import.meta.hot.acceptExports',
-									b.array([b.literal('default')]),
-									b.id('accept')
-								)
-							)
-						]),
-						b.block([b.stmt(b.call('import.meta.hot.accept', b.id('accept')))])
-					)
-				])
-			),
+		const hmr = b.block([
+			b.const(b.id('s'), b.call('$.source', b.id(analysis.name))),
+			b.const(b.id('filename'), b.member(b.id(analysis.name), b.id('filename'))),
+			b.stmt(b.assignment('=', b.id(analysis.name), b.call('$.hmr', b.id('s')))),
+			b.stmt(b.assignment('=', b.member(b.id(analysis.name), b.id('filename')), b.id('filename'))),
+			b.stmt(b.call('import.meta.hot.accept', b.arrow([b.id('module')], b.block(accept_fn_body))))
+		]);
 
-			b.export_default(b.id(analysis.name))
-		);
+		body.push(component, b.if(b.id('import.meta.hot'), hmr), b.export_default(b.id(analysis.name)));
 	} else {
 		body.push(b.export_default(component));
 	}

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
@@ -13,18 +13,12 @@ if (import.meta.hot) {
 	const s = $.source(Hmr);
 	const filename = Hmr.filename;
 
-	const accept = (module) => {
-		$.set(s, module.default);
-	};
-
 	Hmr = $.hmr(s);
 	Hmr.filename = filename;
 
-	if (import.meta.hot.acceptExports) {
-		import.meta.hot.acceptExports(["default"], accept);
-	} else {
-		import.meta.hot.accept(accept);
-	}
+	import.meta.hot.accept((module) => {
+		$.set(s, module.default);
+	});
 }
 
 export default Hmr;


### PR DESCRIPTION
In #11453 we changed the HMR logic from this...

```js
if (import.meta.hot) {
  // ...
  import.meta.hot.accept((module) => {...});
}
```

...to this:

```js
if (import.meta.hot) {
  // ...
  if (import.meta.hot.acceptExports) {
    import.meta.hot.acceptExports(['default'], (module) => {...});
  } else {
    import.meta.hot.accept((module) => {...});
  }
}
```

It turns out that doesn't actually _do_ anything, because Vite transforms `import.meta.hot.accept`:

```diff
if (import.meta.hot) {
  // ...
  if (import.meta.hot.acceptExports) {
    import.meta.hot.acceptExports(['default'], (module) => {...});
  } else {
-   import.meta.hot.accept((module) => {...});
+   import.meta.hot.acceptExports(['default'], (module) => {...});
  }
}
```

It's therefore much simpler to just do what we were doing in the first place.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
