### PR TITLE
feat: add createRawSnippet API

### DIFF
--- a/.changeset/fresh-zoos-burn.md
+++ b/.changeset/fresh-zoos-burn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add createRawSnippet API

--- a/packages/svelte/src/index-client.js
+++ b/packages/svelte/src/index-client.js
@@ -190,3 +190,5 @@ export {
 	tick,
 	untrack
 } from './internal/client/runtime.js';
+
+export { createRawSnippet } from './internal/client/dom/blocks/snippet.js';

--- a/packages/svelte/src/index-server.js
+++ b/packages/svelte/src/index-server.js
@@ -35,3 +35,5 @@ export function unmount() {
 export async function tick() {}
 
 export { getAllContexts, getContext, hasContext, setContext } from './internal/server/context.js';
+
+export { createRawSnippet } from './internal/server/index.js';

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -13,7 +13,7 @@ import { escape_html } from '../../escaping.js';
 import { DEV } from 'esm-env';
 import { current_component, pop, push } from './context.js';
 import { EMPTY_COMMENT, BLOCK_CLOSE, BLOCK_OPEN } from './hydration.js';
-import { validate_store } from '../shared/validate.js';
+import { add_snippet_symbol, validate_store } from '../shared/validate.js';
 
 // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
 // https://infra.spec.whatwg.org/#noncharacter
@@ -153,6 +153,22 @@ export function head(payload, fn) {
 	head_payload.out += BLOCK_OPEN;
 	fn(head_payload);
 	head_payload.out += BLOCK_CLOSE;
+}
+
+/**
+ * Create a snippet imperatively using mount, hyrdate and render functions.
+ * @param {{
+ * 	 mount: (...params: any[]) => Element,
+ *   hydrate?: (element: Element, ...params: any[]) => void,
+ *   render: (...params: any[]) => string
+ * }} options
+ */
+export function createRawSnippet({ render }) {
+	const snippet_fn = (/** @type {Payload} */ payload, /** @type {any[]} */ ...args) => {
+		payload.out += render(...args);
+	};
+	add_snippet_symbol(snippet_fn);
+	return snippet_fn;
 }
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw-args/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw-args/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true // Render in dev mode to check that the validation error is not thrown
+	},
+	html: `<div><div>0</div></div><button>+</button>`,
+
+	test({ assert, target }) {
+		const [b1] = target.querySelectorAll('button');
+
+		b1?.click();
+		flushSync();
+		assert.htmlEqual(target.innerHTML, `<div><div>1</div></div><button>+</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw-args/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw-args/main.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { createRawSnippet } from 'svelte';
+
+	let count = $state(0);
+
+	const snippet = createRawSnippet({
+		mount(count) {
+			const div = document.createElement('div');
+
+			$effect(() => {
+				div.textContent = count();
+			});
+
+			return div;
+		},
+		hydrate(element, count) {
+
+			$effect(() => {
+				element.textContent = count();
+			});
+
+		},
+		render(count) {
+			return `<div>${count}</div>`;
+		}
+	});
+</script>
+
+<div>
+	{@render snippet(count)}
+</div>
+<button onclick={() => count++}>+</button>

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true // Render in dev mode to check that the validation error is not thrown
+	},
+	html: `<p>hello world</p>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { createRawSnippet } from 'svelte';
+
+	const hello = createRawSnippet({
+		mount() {
+			const p = document.createElement('p')
+			p.textContent = 'hello world';
+			return p;
+		},
+		render() {
+			return '<p>hello world</p>';
+		}
+	});
+</script>
+
+{@render hello()}

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -366,11 +366,19 @@ declare module 'svelte' {
 	/** Anything except a function */
 	type NotFunction<T> = T extends Function ? never : T;
 	/**
+	 * Create a snippet imperatively using mount, hyrdate and render functions.
+	 * */
+	export function createRawSnippet({ mount, hydrate }: {
+		mount: (...params: any[]) => Element;
+		hydrate?: (element: Element, ...params: any[]) => void;
+		render: (...params: any[]) => string;
+	}): (anchor: TemplateNode, ...params: any[]) => void;
+	/**
 	 * Mounts a component to the given target and returns the exports and potentially the props (if compiled with `accessors: true`) of the component.
 	 * Transitions will play during the initial render unless the `intro` option is set to `false`.
 	 *
 	 * */
-	export function mount<Props extends Record<string, any>, Exports extends Record<string, any>>(component: ComponentType<SvelteComponent<Props>> | Component<Props, Exports, any>, options: {} extends Props ? {
+	function mount_1<Props extends Record<string, any>, Exports extends Record<string, any>>(component: ComponentType<SvelteComponent<Props>> | Component<Props, Exports, any>, options: {} extends Props ? {
 		target: Document | Element | ShadowRoot;
 		anchor?: Node;
 		props?: Props;
@@ -389,7 +397,7 @@ declare module 'svelte' {
 	 * Hydrates a component on the given target and returns the exports and potentially the props (if compiled with `accessors: true`) of the component
 	 *
 	 * */
-	export function hydrate<Props extends Record<string, any>, Exports extends Record<string, any>>(component: ComponentType<SvelteComponent<Props>> | Component<Props, Exports, any>, options: {} extends Props ? {
+	function hydrate_1<Props extends Record<string, any>, Exports extends Record<string, any>>(component: ComponentType<SvelteComponent<Props>> | Component<Props, Exports, any>, options: {} extends Props ? {
 		target: Document | Element | ShadowRoot;
 		props?: Props;
 		events?: Record<string, (e: any) => any>;
@@ -450,8 +458,9 @@ declare module 'svelte' {
 	 * https://svelte.dev/docs/svelte#getallcontexts
 	 * */
 	export function getAllContexts<T extends Map<any, any> = Map<any, any>>(): T;
+	type TemplateNode = Text | Element | Comment;
 
-	export {};
+	export { hydrate_1 as hydrate, mount_1 as mount };
 }
 
 declare module 'svelte/action' {


### PR DESCRIPTION
This adds the `createRawSnippet` API, allowing for low-level creation of programmatic snippets outside of Svelte templates. Example as follows:

```svelte
<script>
	import { createRawSnippet } from 'svelte';

	let count = $state(0);

	const snippet = createRawSnippet({
		mount(count) {
			const div = document.createElement('div');

			$effect(() => {
				div.textContent = count();
			});

			return div;
		},
		hydrate(element, count) {
			$effect(() => {
				element.textContent = count();
			});
		},
		render(count) {
			return `<div>${count}</div>`;
		}
	});
</script>

{@render snippet(count)}

<button onclick={() => count++}>+</button>
```

There are three function to a raw snippet:

- mount
- hydrate (optional, used to hydrate from SSR)
- render (used for SSR)

I added a few tests, more to come. Also need to do docs and work out how to build the types locally.