### PR TITLE
fix: detect mutations within assignments expressions

### DIFF
--- a/.changeset/thirty-dogs-whisper.md
+++ b/.changeset/thirty-dogs-whisper.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: detect mutations within assignment expressions

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -769,8 +769,7 @@ const legacy_scope_tweaker = {
 			}
 
 			if (
-				binding !== null &&
-				binding.kind === 'normal' &&
+				binding?.kind === 'normal' &&
 				((binding.scope === state.instance_scope && binding.declaration_kind !== 'function') ||
 					binding.declaration_kind === 'import')
 			) {
@@ -795,23 +794,24 @@ const legacy_scope_tweaker = {
 					parent.left === binding.node
 				) {
 					binding.kind = 'derived';
-				} else {
-					let idx = -1;
-					let ancestor = path.at(idx);
-					while (ancestor) {
-						if (ancestor.type === 'EachBlock') {
-							// Ensures that the array is reactive when only its entries are mutated
-							// TODO: this doesn't seem correct. We should be checking at the points where
-							// the identifier (the each expression) is used in a way that makes it reactive.
-							// This just forces the collection identifier to always be reactive even if it's
-							// not.
-							if (ancestor.expression === (idx === -1 ? node : path.at(idx + 1))) {
-								binding.kind = 'state';
-								break;
+				}
+			} else if (binding?.kind === 'each' && binding.mutated) {
+				// Ensure that the array is marked as reactive even when only its entries are mutated
+				let idx = -1;
+				let ancestor = path.at(idx);
+				while (ancestor) {
+					if (
+						ancestor.type === 'EachBlock' &&
+						state.analysis.template.scopes.get(ancestor)?.declarations.get(node.name) === binding
+					) {
+						for (const reference of ancestor.metadata.references) {
+							if (reference.kind === 'normal') {
+								reference.kind = 'state';
 							}
 						}
-						ancestor = path.at(--idx);
+						break;
 					}
+					ancestor = path.at(--idx);
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -797,9 +797,9 @@ const legacy_scope_tweaker = {
 				}
 			} else if (binding?.kind === 'each' && binding.mutated) {
 				// Ensure that the array is marked as reactive even when only its entries are mutated
-				let idx = -1;
-				let ancestor = path.at(idx);
-				while (ancestor) {
+				let i = path.length;
+				while (i--) {
+					const ancestor = path[i];
 					if (
 						ancestor.type === 'EachBlock' &&
 						state.analysis.template.scopes.get(ancestor)?.declarations.get(node.name) === binding
@@ -811,7 +811,6 @@ const legacy_scope_tweaker = {
 						}
 						break;
 					}
-					ancestor = path.at(--idx);
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -713,7 +713,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			const binding = scope.get(/** @type {import('estree').Identifier} */ (object).name);
 			if (binding) binding.mutated = true;
 		} else {
-			extract_identifiers(node).forEach((identifier) => {
+			extract_identifiers(node, [], true).forEach((identifier) => {
 				const binding = scope.get(identifier.name);
 				if (binding && identifier !== binding.node) {
 					binding.mutated = true;

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -67,11 +67,10 @@ export function extract_identifiers(param, nodes = [], include_member_expression
 			break;
 
 		case 'MemberExpression':
-			if (
-				include_member_expressions &&
-				(param.object.type === 'Identifier' || param.object.type === 'MemberExpression')
-			) {
-				extract_identifiers(param.object, nodes, include_member_expressions);
+			if (include_member_expressions) {
+				// Only the `a` from `[a.b[c].d]` is of interest to us here
+				const id = object(param);
+				if (id) nodes.push(id);
 			}
 			break;
 

--- a/packages/svelte/tests/migrate/samples/each-block-const/input.svelte
+++ b/packages/svelte/tests/migrate/samples/each-block-const/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { foo } = x();
+</script>
+
+{#each foo as f}{/each}

--- a/packages/svelte/tests/migrate/samples/each-block-const/output.svelte
+++ b/packages/svelte/tests/migrate/samples/each-block-const/output.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { foo } = x();
+</script>
+
+{#each foo as f}{/each}


### PR DESCRIPTION
This enhances our "variable was mutated" detection to also recognize that `foo` in `[foo[1]] = [..]` was mutated. This allows us to be more granular about detecting mutations to each expressions in legacy mode, which fixes #12169

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
