### PR TITLE
chore: add support for HMR env flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.4.0",
-  "engines": {
-    "pnpm": "^9.0.0"
-  },
+
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sveltejs/svelte.git"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.4.0",
-
+  "engines": {
+    "pnpm": "^9.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sveltejs/svelte.git"

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -141,16 +141,13 @@ async function common_setup(cwd: string, runes: boolean | undefined, config: Run
 	const compileOptions: CompileOptions = {
 		generate: 'client',
 		rootDir: cwd,
+		dev: process.env.HMR ? true : undefined,
+		hmr: process.env.HMR ? true : undefined,
 		...config.compileOptions,
 		immutable: config.immutable,
 		accessors: 'accessors' in config ? config.accessors : true,
 		runes
 	};
-
-	if (process.env.HMR && compileOptions.dev !== false) {
-		compileOptions.dev = true;
-		compileOptions.hmr = true;
-	}
 
 	// load_compiled can be used for debugging a test. It means the compiler will not run on the input
 	// so you can manipulate the output manually to see what fixes it, adding console.logs etc.

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -147,7 +147,7 @@ async function common_setup(cwd: string, runes: boolean | undefined, config: Run
 		runes
 	};
 
-	if (process.env.HMR) {
+	if (process.env.HMR && compileOptions.dev !== false) {
 		compileOptions.dev = true;
 		compileOptions.hmr = true;
 	}

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -147,6 +147,11 @@ async function common_setup(cwd: string, runes: boolean | undefined, config: Run
 		runes
 	};
 
+	if (process.env.HMR) {
+		compileOptions.dev = true;
+		compileOptions.hmr = true;
+	}
+
 	// load_compiled can be used for debugging a test. It means the compiler will not run on the input
 	// so you can manipulate the output manually to see what fixes it, adding console.logs etc.
 	if (!config.load_compiled) {


### PR DESCRIPTION
Run this locally:

```bash
HMR=true pnpm run test
```

Interestingly, we have 21 failed tests when doing this.