### PR TITLE
fix: detect mutations within assignments expressions (alternative approach)

### DIFF
--- a/.changeset/thirty-dogs-whisper.md
+++ b/.changeset/thirty-dogs-whisper.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: detect mutations within assignment expressions

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -769,8 +769,7 @@ const legacy_scope_tweaker = {
 			}
 
 			if (
-				binding !== null &&
-				binding.kind === 'normal' &&
+				binding?.kind === 'normal' &&
 				((binding.scope === state.instance_scope && binding.declaration_kind !== 'function') ||
 					binding.declaration_kind === 'import')
 			) {
@@ -795,23 +794,24 @@ const legacy_scope_tweaker = {
 					parent.left === binding.node
 				) {
 					binding.kind = 'derived';
-				} else {
-					let idx = -1;
-					let ancestor = path.at(idx);
-					while (ancestor) {
-						if (ancestor.type === 'EachBlock') {
-							// Ensures that the array is reactive when only its entries are mutated
-							// TODO: this doesn't seem correct. We should be checking at the points where
-							// the identifier (the each expression) is used in a way that makes it reactive.
-							// This just forces the collection identifier to always be reactive even if it's
-							// not.
-							if (ancestor.expression === (idx === -1 ? node : path.at(idx + 1))) {
-								binding.kind = 'state';
-								break;
+				}
+			} else if (binding?.kind === 'each' && binding.mutated) {
+				// Ensure that the array is marked as reactive even when only its entries are mutated
+				let idx = -1;
+				let ancestor = path.at(idx);
+				while (ancestor) {
+					if (
+						ancestor.type === 'EachBlock' &&
+						state.analysis.template.scopes.get(ancestor)?.declarations.get(node.name) === binding
+					) {
+						for (const reference of ancestor.metadata.references) {
+							if (reference.kind === 'normal') {
+								reference.kind = 'state';
 							}
 						}
-						ancestor = path.at(--idx);
+						break;
 					}
+					ancestor = path.at(--idx);
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -804,9 +804,9 @@ const legacy_scope_tweaker = {
 						ancestor.type === 'EachBlock' &&
 						state.analysis.template.scopes.get(ancestor)?.declarations.get(node.name) === binding
 					) {
-						for (const reference of ancestor.metadata.references) {
-							if (reference.kind === 'normal') {
-								reference.kind = 'state';
+						for (const binding of ancestor.metadata.references) {
+							if (binding.kind === 'normal') {
+								binding.kind = 'state';
 							}
 						}
 						break;

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -797,9 +797,9 @@ const legacy_scope_tweaker = {
 				}
 			} else if (binding?.kind === 'each' && binding.mutated) {
 				// Ensure that the array is marked as reactive even when only its entries are mutated
-				let idx = -1;
-				let ancestor = path.at(idx);
-				while (ancestor) {
+				let i = path.length;
+				while (i--) {
+					const ancestor = path[i];
 					if (
 						ancestor.type === 'EachBlock' &&
 						state.analysis.template.scopes.get(ancestor)?.declarations.get(node.name) === binding
@@ -811,7 +811,6 @@ const legacy_scope_tweaker = {
 						}
 						break;
 					}
-					ancestor = path.at(--idx);
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -2024,7 +2024,8 @@ export function server_component(analysis, options) {
 
 		if (
 			node.body.type === 'ExpressionStatement' &&
-			node.body.expression.type === 'AssignmentExpression'
+			node.body.expression.type === 'AssignmentExpression' &&
+			node.body.expression.left.type !== 'MemberExpression'
 		) {
 			for (const id of extract_identifiers(node.body.expression.left)) {
 				const binding = analysis.instance.scope.get(id.name);

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -2024,8 +2024,7 @@ export function server_component(analysis, options) {
 
 		if (
 			node.body.type === 'ExpressionStatement' &&
-			node.body.expression.type === 'AssignmentExpression' &&
-			node.body.expression.left.type !== 'MemberExpression'
+			node.body.expression.type === 'AssignmentExpression'
 		) {
 			for (const id of extract_identifiers(node.body.expression.left)) {
 				const binding = analysis.instance.scope.get(id.name);

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -361,7 +361,8 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 
 			if (
 				node.body.type === 'ExpressionStatement' &&
-				node.body.expression.type === 'AssignmentExpression'
+				node.body.expression.type === 'AssignmentExpression' &&
+				node.body.expression.left.type !== 'MemberExpression'
 			) {
 				for (const id of extract_identifiers(node.body.expression.left)) {
 					if (!id.name.startsWith('$')) {

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -713,7 +713,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			const binding = scope.get(/** @type {import('estree').Identifier} */ (object).name);
 			if (binding) binding.mutated = true;
 		} else {
-			extract_identifiers(node).forEach((identifier) => {
+			extract_identifiers(node, [], true).forEach((identifier) => {
 				const binding = scope.get(identifier.name);
 				if (binding && identifier !== binding.node) {
 					binding.mutated = true;

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -54,32 +54,29 @@ export function is_event_attribute(attribute) {
 }
 
 /**
- * Extracts all identifiers from a pattern. By default only those which can be newly declared as part of an assignment expression are included.
+ * Extracts all identifiers from a pattern.
  * @param {ESTree.Pattern} param
  * @param {ESTree.Identifier[]} [nodes]
- * @param {boolean} [include_member_expressions] If `true`, will also include member expressions which can be important in a case like `[a, b] = [c, d]`
  * @returns {ESTree.Identifier[]}
  */
-export function extract_identifiers(param, nodes = [], include_member_expressions = false) {
+export function extract_identifiers(param, nodes = []) {
 	switch (param.type) {
 		case 'Identifier':
 			nodes.push(param);
 			break;
 
 		case 'MemberExpression':
-			if (include_member_expressions) {
-				// Only the `a` from `[a.b[c].d]` is of interest to us here
-				const id = object(param);
-				if (id) nodes.push(id);
-			}
+			// Only the `a` from `[a.b[c].d]` is of interest to us here
+			const id = object(param);
+			if (id) nodes.push(id);
 			break;
 
 		case 'ObjectPattern':
 			for (const prop of param.properties) {
 				if (prop.type === 'RestElement') {
-					extract_identifiers(prop.argument, nodes, include_member_expressions);
+					extract_identifiers(prop.argument, nodes);
 				} else {
-					extract_identifiers(prop.value, nodes, include_member_expressions);
+					extract_identifiers(prop.value, nodes);
 				}
 			}
 
@@ -87,17 +84,17 @@ export function extract_identifiers(param, nodes = [], include_member_expression
 
 		case 'ArrayPattern':
 			for (const element of param.elements) {
-				if (element) extract_identifiers(element, nodes, include_member_expressions);
+				if (element) extract_identifiers(element, nodes);
 			}
 
 			break;
 
 		case 'RestElement':
-			extract_identifiers(param.argument, nodes, include_member_expressions);
+			extract_identifiers(param.argument, nodes);
 			break;
 
 		case 'AssignmentPattern':
-			extract_identifiers(param.left, nodes, include_member_expressions);
+			extract_identifiers(param.left, nodes);
 			break;
 	}
 

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -66,6 +66,8 @@ export function unwrap_pattern(pattern, nodes = []) {
 			break;
 
 		case 'MemberExpression':
+			// member expressions can be part of an assignment pattern, but not a binding pattern
+			// see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#binding_and_assignment
 			nodes.push(pattern);
 			break;
 

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -54,51 +54,58 @@ export function is_event_attribute(attribute) {
 }
 
 /**
- * Extracts all identifiers from a pattern.
- * @param {ESTree.Pattern} param
- * @param {ESTree.Identifier[]} [nodes]
- * @returns {ESTree.Identifier[]}
+ * Extracts all identifiers and member expressions from a pattern.
+ * @param {ESTree.Pattern} pattern
+ * @param {Array<ESTree.Identifier | ESTree.MemberExpression>} [nodes]
+ * @returns {Array<ESTree.Identifier | ESTree.MemberExpression>}
  */
-export function extract_identifiers(param, nodes = []) {
-	switch (param.type) {
+export function unwrap_pattern(pattern, nodes = []) {
+	switch (pattern.type) {
 		case 'Identifier':
-			nodes.push(param);
+			nodes.push(pattern);
 			break;
 
 		case 'MemberExpression':
-			// Only the `a` from `[a.b[c].d]` is of interest to us here
-			const id = object(param);
-			if (id) nodes.push(id);
+			nodes.push(pattern);
 			break;
 
 		case 'ObjectPattern':
-			for (const prop of param.properties) {
+			for (const prop of pattern.properties) {
 				if (prop.type === 'RestElement') {
-					extract_identifiers(prop.argument, nodes);
+					unwrap_pattern(prop.argument, nodes);
 				} else {
-					extract_identifiers(prop.value, nodes);
+					unwrap_pattern(prop.value, nodes);
 				}
 			}
 
 			break;
 
 		case 'ArrayPattern':
-			for (const element of param.elements) {
-				if (element) extract_identifiers(element, nodes);
+			for (const element of pattern.elements) {
+				if (element) unwrap_pattern(element, nodes);
 			}
 
 			break;
 
 		case 'RestElement':
-			extract_identifiers(param.argument, nodes);
+			unwrap_pattern(pattern.argument, nodes);
 			break;
 
 		case 'AssignmentPattern':
-			extract_identifiers(param.left, nodes);
+			unwrap_pattern(pattern.left, nodes);
 			break;
 	}
 
 	return nodes;
+}
+
+/**
+ * Extracts all identifiers from a pattern.
+ * @param {ESTree.Pattern} pattern
+ * @returns {ESTree.Identifier[]}
+ */
+export function extract_identifiers(pattern) {
+	return unwrap_pattern(pattern, []).filter((node) => node.type === 'Identifier');
 }
 
 /**

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -67,11 +67,10 @@ export function extract_identifiers(param, nodes = [], include_member_expression
 			break;
 
 		case 'MemberExpression':
-			if (
-				include_member_expressions &&
-				(param.object.type === 'Identifier' || param.object.type === 'MemberExpression')
-			) {
-				extract_identifiers(param.object, nodes, include_member_expressions);
+			if (include_member_expressions) {
+				// Only the `a` from `[a.b[c].d]` is of interest to us here
+				const id = object(param);
+				if (id) nodes.push(id);
 			}
 			break;
 

--- a/packages/svelte/tests/migrate/samples/each-block-const/input.svelte
+++ b/packages/svelte/tests/migrate/samples/each-block-const/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { foo } = x();
+</script>
+
+{#each foo as f}{/each}

--- a/packages/svelte/tests/migrate/samples/each-block-const/output.svelte
+++ b/packages/svelte/tests/migrate/samples/each-block-const/output.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { foo } = x();
+</script>
+
+{#each foo as f}{/each}


### PR DESCRIPTION
Alternative to #12411.

We use the `extract_identifiers` utility to find the identifiers in patterns, like these:

```js
let a = ...; // ['a']
let { b, c: d } = ...; // ['b', 'd']
```

Patterns also occur in e.g. function declarations and assignment expressions. But there are two kinds of pattern — binding patterns and assignment patterns — and they're subtly different. Binding patterns can ultimately only contain identifiers (the things being declared), while assignment patterns can contain any lvalue (i.e. `Identifier` or `MemberExpression` in ESTree terminology).

The drawback of #12411 is that it lumps identifiers and member expressions together. This _works_, but it has a cost — it means that the bindings referenced in an assignment pattern are always marked as reassigned (rather than merely mutated) even if they're member expressions. This means that the compiler sees something like this...

```js
function swap() {
  [array[1], array[0]] = [array[0], array[1]];
}
```

...and marks `array` as being reassigned, which means that we have to create a source for it:

```diff
-let array = $.proxy([1, 2]);
+let array = $.source($.proxy([1, 2]));
```

It's better if we can differentiate between these things. That's what this PR does: it expands the pattern unwrapping logic to include member expression nodes, and updates the `AssignmentExpression` logic to use it. The existing `extract_identifiers` function is kept with the same API, by calling `unwrap_pattern` under the hood but filtering out non-identifier nodes.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
