### PR TITLE
fix: ensure hydration walks all nodes

### DIFF
--- a/.changeset/giant-jars-applaud.md
+++ b/.changeset/giant-jars-applaud.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure hydration walks all nodes

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -51,11 +51,11 @@ export function empty() {
 }
 
 /**
+ * Don't mark this as side-effect-free, hydration needs to walk all nodes
  * @template {Node} N
  * @param {N} node
  * @returns {Node | null}
  */
-/*#__NO_SIDE_EFFECTS__*/
 export function child(node) {
 	if (!hydrating) {
 		return node.firstChild;
@@ -73,11 +73,11 @@ export function child(node) {
 }
 
 /**
+ * Don't mark this as side-effect-free, hydration needs to walk all nodes
  * @param {DocumentFragment | TemplateNode[]} fragment
  * @param {boolean} is_text
  * @returns {Node | null}
  */
-/*#__NO_SIDE_EFFECTS__*/
 export function first_child(fragment, is_text) {
 	if (!hydrating) {
 		// when not hydrating, `fragment` is a `DocumentFragment` (the result of calling `open_frag`)
@@ -103,12 +103,12 @@ export function first_child(fragment, is_text) {
 }
 
 /**
+ * Don't mark this as side-effect-free, hydration needs to walk all nodes
  * @template {Node} N
  * @param {N} node
  * @param {boolean} is_text
  * @returns {Node | null}
  */
-/*#__NO_SIDE_EFFECTS__*/
 export function sibling(node, is_text = false) {
 	if (!hydrating) {
 		return /** @type {TemplateNode} */ (node.nextSibling);

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -207,7 +207,9 @@ function run_scripts(node) {
 	}
 }
 
-/*#__NO_SIDE_EFFECTS__*/
+/**
+ * Don't mark this as side-effect-free, hydration needs to walk all nodes
+ */
 export function text() {
 	if (!hydrating) {
 		var t = empty();


### PR DESCRIPTION
We've marked several methods used for walking the DOM with a `__NO_SIDE_EFFECTS__` comment. That was good historically, because we didn't need those kept around if its results were unused, but since the hydration changes in #12335 this actually introduces a bug: Because that PR now relies on the hydration nodes being correct due to walking the DOM, tree-shaking unused variables/calls results in the walk being incorrect, leading to bugs

Fixes #12422

No test because we would need to treeshake stuff for it to be testable

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
