### PR TITLE
fix: prevent whitespaces merging across component boundaries

### DIFF
--- a/.changeset/perfect-hats-dance.md
+++ b/.changeset/perfect-hats-dance.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent whitespaces merging across component boundaries

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -288,7 +288,11 @@ export function clean_nodes(
 					))),
 		/** if a component or snippet starts with text, we need to add an anchor comment so that its text node doesn't get fused with its surroundings */
 		is_text_first:
-			(parent.type === 'Fragment' || parent.type === 'SnippetBlock') &&
+			(parent.type === 'Fragment' ||
+				parent.type === 'SnippetBlock' ||
+				parent.type === 'SvelteComponent' ||
+				parent.type === 'Component' ||
+				parent.type === 'SvelteSelf') &&
 			first &&
 			(first?.type === 'Text' || first?.type === 'ExpressionTag')
 	};

--- a/packages/svelte/tests/runtime-runes/samples/component-dont-fuse-whitespace/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/component-dont-fuse-whitespace/Child.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { children } = $props();
+</script>
+
+<p>text before the render tag {@render children()}</p>

--- a/packages/svelte/tests/runtime-runes/samples/component-dont-fuse-whitespace/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/component-dont-fuse-whitespace/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<p>text before the render tag dont fuse this text with the one from the child</p>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/component-dont-fuse-whitespace/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/component-dont-fuse-whitespace/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Child from './Child.svelte';
+	let text = $state('dont fuse this text with the one from the child');
+</script>
+
+<Child>{text}</Child>

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/client/index.svelte.js
@@ -15,6 +15,8 @@ export default function Function_prop_no_getter($$anchor) {
 		onmouseup,
 		onmouseenter: () => $.set(count, $.proxy(plusOne($.get(count)))),
 		children: ($$anchor, $$slotProps) => {
+			$.next();
+
 			var text = $.text();
 
 			$.template_effect(() => $.set_text(text, `clicks: ${$.get(count) ?? ""}`));

--- a/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/function-prop-no-getter/_expected/server/index.svelte.js
@@ -14,7 +14,7 @@ export default function Function_prop_no_getter($$payload) {
 		onmouseup,
 		onmouseenter: () => count = plusOne(count),
 		children: ($$payload, $$slotProps) => {
-			$$payload.out += `clicks: ${$.escape(count)}`;
+			$$payload.out += `<!---->clicks: ${$.escape(count)}`;
 		},
 		$$slots: { default: true }
 	});


### PR DESCRIPTION
The logic that was there didn't take components into account. The underlying problem is that the parent isn't properly set to `Fragment` in all cases because of nested `visit` calls we do in some places.

Fixes #12447

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
