### PR TITLE
docs: fix svelte 5 discord channel name & release estimation

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/02-examples/06-more-examples.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/02-examples/06-more-examples.md
@@ -4,4 +4,4 @@ title: More examples
 
 Check out [component-party.dev](https://component-party.dev/?f=svelte4,svelte5) to see side-by-side comparisons of some common patterns.
 
-We'll add more examples over time, but if there's something in particular you'd like to see then hop over to the `#svelte-5-alpha` channel of the [Svelte Discord](https://svelte.dev/chat).
+We'll add more examples over time, but if there's something in particular you'd like to see then hop over to the `#svelte-5-rc` channel of the [Svelte Discord](https://svelte.dev/chat).

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/01-faq.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/01-faq.md
@@ -116,7 +116,7 @@ npm i --save-dev prettier-plugin-svelte prettier
 
 ### When is it coming out?
 
-When it's done. The goal is sometime in early 2024.
+When it's done. The goal is sometime in late 2024.
 
 ### Should I prepare my code for Svelte 5?
 

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/01-faq.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/01-faq.md
@@ -116,7 +116,7 @@ npm i --save-dev prettier-plugin-svelte prettier
 
 ### When is it coming out?
 
-When it's done. The goal is sometime in late 2024.
+When it's done. The goal is sometime in 2024.
 
 ### Should I prepare my code for Svelte 5?
 
@@ -154,7 +154,7 @@ We appreciate your enthusiasm! We welcome issues on the [sveltejs/svelte](https:
 
 ### How can I share feedback or cool examples of what this enables?
 
-You can use the `#svelte-5-rc` channel on the [Discord server](https://svelte.dev/chat) or the tag `#svelte-5-rc` on social media.
+You can use the `#svelte-5-rc` channel on the [Discord server](https://svelte.dev/chat) or the tag `#svelte-5` on social media.
 
 ### My question wasn't answered. What gives?
 

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/01-faq.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/01-faq.md
@@ -154,8 +154,8 @@ We appreciate your enthusiasm! We welcome issues on the [sveltejs/svelte](https:
 
 ### How can I share feedback or cool examples of what this enables?
 
-You can use the `#svelte-5-alpha` channel on the [Discord server](https://svelte.dev/chat) or the tag `#svelte-5-alpha` on social media.
+You can use the `#svelte-5-rc` channel on the [Discord server](https://svelte.dev/chat) or the tag `#svelte-5-rc` on social media.
 
 ### My question wasn't answered. What gives?
 
-It must not have been asked frequently enough. To fix that, stop by the `#svelte-5-alpha` channel of the [Discord server](https://svelte.dev/chat).
+It must not have been asked frequently enough. To fix that, stop by the `#svelte-5-rc` channel of the [Discord server](https://svelte.dev/chat).


### PR DESCRIPTION
## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`


Fixes the Svelte 5 channel name which was change a while back and the release estimate