### PR TITLE
fix: allow trailing comments on functions

### DIFF
--- a/.changeset/few-mails-play.md
+++ b/.changeset/few-mails-play.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow trailing comments on functions

--- a/packages/svelte/src/compiler/phases/1-parse/read/expression.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/expression.js
@@ -18,7 +18,12 @@ export default function read_expression(parser) {
 
 		let index = /** @type {number} */ (node.end);
 		if (node.trailingComments !== undefined && node.trailingComments.length > 0) {
-			index = node.trailingComments.at(-1).end;
+			// in simple expressions like {true/*this is literal*/} trailing comments are not included
+			// in the node end so we need them added to the index to keep the parser in check.
+			// but for arrow functions trailing comments are actually already included in the end
+			// and doesn't include whitespace in the end so if we set the parse index to that we
+			// will loose chars that we already read.
+			index = Math.max(node.trailingComments.at(-1).end, index);
 		}
 
 		while (num_parens > 0) {

--- a/packages/svelte/tests/parser-legacy/samples/trailing-comments-on-functions/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/trailing-comments-on-functions/input.svelte
@@ -1,0 +1,5 @@
+<button
+	onclick={() => {
+		/* some comment */
+	}}
+></button>

--- a/packages/svelte/tests/parser-legacy/samples/trailing-comments-on-functions/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/trailing-comments-on-functions/output.json
@@ -1,0 +1,75 @@
+{
+	"html": {
+		"type": "Fragment",
+		"start": 0,
+		"end": 61,
+		"children": [
+			{
+				"type": "Element",
+				"start": 0,
+				"end": 61,
+				"name": "button",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 9,
+						"end": 50,
+						"name": "onclick",
+						"value": [
+							{
+								"type": "MustacheTag",
+								"start": 17,
+								"end": 50,
+								"expression": {
+									"type": "ArrowFunctionExpression",
+									"start": 18,
+									"end": 49,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 10
+										},
+										"end": {
+											"line": 4,
+											"column": 2
+										}
+									},
+									"id": null,
+									"expression": false,
+									"generator": false,
+									"async": false,
+									"params": [],
+									"body": {
+										"type": "BlockStatement",
+										"start": 24,
+										"end": 49,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 16
+											},
+											"end": {
+												"line": 4,
+												"column": 2
+											}
+										},
+										"body": []
+									},
+									"trailingComments": [
+										{
+											"type": "Block",
+											"value": " some comment ",
+											"start": 28,
+											"end": 46
+										}
+									]
+								}
+							}
+						]
+					}
+				],
+				"children": []
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #12466

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
