### PR TITLE
fix: prevent invalid `:global` usage

### DIFF
--- a/packages/svelte/messages/compile-errors/style.md
+++ b/packages/svelte/messages/compile-errors/style.md
@@ -22,6 +22,10 @@
 
 > A :global {...} block cannot modify an existing selector
 
+## css_global_block_invalid_placement
+
+> A :global {...} block can only appear at the end of a selector sequence (did you mean to use :global(...) instead?)
+
 ## css_global_invalid_placement
 
 > :global(...) can be at the start or end of a selector sequence, but not in the middle

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -471,6 +471,15 @@ export function css_global_block_invalid_modifier(node) {
 }
 
 /**
+ * A :global {...} block can only appear at the end of a selector sequence (did you mean to use :global(...) instead?)
+ * @param {null | number | NodeLike} node
+ * @returns {never}
+ */
+export function css_global_block_invalid_placement(node) {
+	e(node, "css_global_block_invalid_placement", "A :global {...} block can only appear at the end of a selector sequence (did you mean to use :global(...) instead?)");
+}
+
+/**
  * :global(...) can be at the start or end of a selector sequence, but not in the middle
  * @param {null | number | NodeLike} node
  * @returns {never}

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -146,16 +146,20 @@ const validation_visitors = {
 			if (global) {
 				const idx = node.children.indexOf(global);
 
-				// ensure `:global` is only at the end of a selector
 				if (global.selectors[0].args === null && idx !== node.children.length - 1) {
+					// ensure `:global` is only at the end of a selector
 					e.css_global_block_invalid_placement(global.selectors[0]);
 				} else if (
-					// ensure `:global(...)` is not used in the middle of a selector
 					global.selectors[0].args !== null &&
 					idx !== 0 &&
 					idx !== node.children.length - 1
 				) {
-					e.css_global_invalid_placement(global.selectors[0]);
+					// ensure `:global(...)` is not used in the middle of a selector (but multiple `global(...)` in sequence are ok)
+					for (let i = idx + 1; i < node.children.length; i++) {
+						if (!is_global(node.children[i])) {
+							e.css_global_invalid_placement(node.children[i].selectors[0]);
+						}
+					}
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -19,7 +19,7 @@ import { merge } from '../../visitors.js';
 /**
  * True if is `:global(...)` or `:global`
  * @param {Css.RelativeSelector} relative_selector
- * @returns {relative_selector is Css.RelativeSelector & { selectors: [Css.PseudoClassSelector, ...Css.Selector[]] }}
+ * @returns {relative_selector is Css.RelativeSelector & { selectors: [Css.PseudoClassSelector, ...Array<Css.PseudoClassSelector | Css.PseudoElementSelector>] }}
  */
 function is_global(relative_selector) {
 	const first = relative_selector.selectors[0];

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -157,7 +157,7 @@ const validation_visitors = {
 					// ensure `:global(...)` is not used in the middle of a selector (but multiple `global(...)` in sequence are ok)
 					for (let i = idx + 1; i < node.children.length; i++) {
 						if (!is_global(node.children[i])) {
-							e.css_global_invalid_placement(node.children[i].selectors[0]);
+							e.css_global_invalid_placement(global.selectors[0]);
 						}
 					}
 				}

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-invalid-selector/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-invalid-selector/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'css_global_block_invalid_placement',
+		message:
+			'A :global {...} block can only appear at the end of a selector sequence (did you mean to use :global(...) instead?)',
+		position: [50, 57]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/css-global-block-invalid-selector/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/css-global-block-invalid-selector/main.svelte
@@ -1,0 +1,8 @@
+<style>
+	/* ok */
+	.x :global {
+	}
+	/* not ok */
+	:global .x {
+	}
+</style>


### PR DESCRIPTION
Error when it's not at the end of a selector

closes #12437

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
