### PR TITLE
breaking: warn on quotes single-expression attributes in runes mode 

### DIFF
--- a/.changeset/plenty-items-build.md
+++ b/.changeset/plenty-items-build.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: warn on quotes single-expression attributes in runes mode

--- a/.changeset/plenty-items-build.md
+++ b/.changeset/plenty-items-build.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-breaking: warn on quotes single-expression attributes in runes mode
+breaking: warn on quoted single-expression attributes in runes mode

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -16,7 +16,7 @@
 
 ## attribute_quoted
 
-> Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.
+> Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes
 
 ## bind_invalid_each_rest
 

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -14,6 +14,10 @@
 
 > '%wrong%' is not a valid HTML attribute. Did you mean '%right%'?
 
+## attribute_quoted
+
+> Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.
+
 ## bind_invalid_each_rest
 
 > The rest operator (...) will create a new object and binding '%name%' with the original object will not work

--- a/packages/svelte/src/compiler/legacy.js
+++ b/packages/svelte/src/compiler/legacy.js
@@ -411,6 +411,34 @@ export function convert(source, ast) {
 					)
 				};
 			},
+			Attribute(node, { visit, next, path }) {
+				if (node.value !== true && !Array.isArray(node.value)) {
+					path.push(node);
+					const value = /** @type {Legacy.LegacyAttribute['value']} */ ([visit(node.value)]);
+					path.pop();
+
+					return {
+						...node,
+						value
+					};
+				} else {
+					return next();
+				}
+			},
+			StyleDirective(node, { visit, next, path }) {
+				if (node.value !== true && !Array.isArray(node.value)) {
+					path.push(node);
+					const value = /** @type {Legacy.LegacyStyleDirective['value']} */ ([visit(node.value)]);
+					path.pop();
+
+					return {
+						...node,
+						value
+					};
+				} else {
+					return next();
+				}
+			},
 			SpreadAttribute(node) {
 				return { ...node, type: 'Spread' };
 			},

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -532,11 +532,13 @@ const template = {
 				if (attr.name === 'name') {
 					slot_name = /** @type {any} */ (attr.value)[0].data;
 				} else {
+					const attr_value =
+						attr.value === true || Array.isArray(attr.value) ? attr.value : [attr.value];
 					const value =
-						attr.value !== true
+						attr_value !== true
 							? state.str.original.substring(
-									attr.value[0].start,
-									attr.value[attr.value.length - 1].end
+									attr_value[0].start,
+									attr_value[attr_value.length - 1].end
 								)
 							: 'true';
 					slot_props += value === attr.name ? `${value}, ` : `${attr.name}: ${value}, `;

--- a/packages/svelte/src/compiler/phases/1-parse/read/options.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/options.js
@@ -41,8 +41,9 @@ export default function read_options(node) {
 			case 'customElement': {
 				/** @type {SvelteOptions['customElement']} */
 				const ce = { tag: '' };
+				const { value: v } = attribute;
+				const value = v === true || Array.isArray(v) ? v : [v];
 
-				const { value } = attribute;
 				if (value === true) {
 					e.svelte_options_invalid_customelement(attribute);
 				} else if (value[0].type === 'Text') {
@@ -199,7 +200,11 @@ export default function read_options(node) {
  */
 function get_static_value(attribute) {
 	const { value } = attribute;
-	const chunk = value[0];
+
+	if (value === true) return true;
+
+	const chunk = Array.isArray(value) ? value[0] : value;
+
 	if (!chunk) return true;
 	if (value.length > 1) {
 		return null;
@@ -208,6 +213,7 @@ function get_static_value(attribute) {
 	if (chunk.expression.type !== 'Literal') {
 		return null;
 	}
+
 	return chunk.expression.value;
 }
 

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -541,7 +541,7 @@ function read_attribute(parser) {
 				}
 			};
 
-			return create_attribute(name, start, parser.index, [expression]);
+			return create_attribute(name, start, parser.index, expression);
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -9,6 +9,7 @@ import * as e from '../../../errors.js';
 import * as w from '../../../warnings.js';
 import { create_fragment } from '../utils/create.js';
 import { create_attribute } from '../../nodes.js';
+import { get_attribute_expression, is_expression_attribute } from '../../../utils/ast.js';
 
 // eslint-disable-next-line no-useless-escape
 const valid_tag_name = /^\!?[a-zA-Z]{1,}:?[a-zA-Z0-9\-]*/;
@@ -241,15 +242,11 @@ export default function element(parser) {
 		}
 
 		const definition = /** @type {Compiler.Attribute} */ (element.attributes.splice(index, 1)[0]);
-		if (
-			definition.value === true ||
-			definition.value.length !== 1 ||
-			definition.value[0].type === 'Text'
-		) {
+		if (!is_expression_attribute(definition)) {
 			e.svelte_component_invalid_this(definition.start);
 		}
 
-		element.expression = definition.value[0].expression;
+		element.expression = get_attribute_expression(definition);
 	}
 
 	if (element.type === 'SvelteElement') {
@@ -267,15 +264,16 @@ export default function element(parser) {
 			e.svelte_element_missing_this(definition);
 		}
 
-		const chunk = definition.value[0];
-
-		if (definition.value.length !== 1 || chunk.type !== 'ExpressionTag') {
+		if (!is_expression_attribute(definition)) {
 			w.svelte_element_invalid_this(definition);
 
 			// note that this is wrong, in the case of e.g. `this="h{n}"` — it will result in `<h>`.
 			// it would be much better to just error here, but we are preserving the existing buggy
 			// Svelte 4 behaviour out of an overabundance of caution regarding breaking changes.
 			// TODO in 6.0, error
+			const chunk = /** @type {Array<Compiler.ExpressionTag | Compiler.Text>} */ (
+				definition.value
+			)[0];
 			element.tag =
 				chunk.type === 'Text'
 					? {
@@ -287,7 +285,7 @@ export default function element(parser) {
 						}
 					: chunk.expression;
 		} else {
-			element.tag = chunk.expression;
+			element.tag = get_attribute_expression(definition);
 		}
 	}
 
@@ -557,7 +555,7 @@ function read_attribute(parser) {
 	const colon_index = name.indexOf(':');
 	const type = colon_index !== -1 && get_directive_type(name.slice(0, colon_index));
 
-	/** @type {true | Array<Compiler.Text | Compiler.ExpressionTag>} */
+	/** @type {true | Compiler.ExpressionTag | Array<Compiler.Text | Compiler.ExpressionTag>} */
 	let value = true;
 	if (parser.eat('=')) {
 		parser.allow_whitespace();
@@ -589,7 +587,9 @@ function read_attribute(parser) {
 			};
 		}
 
-		const first_value = value === true ? undefined : value[0];
+		const first_value = value === true ? undefined : Array.isArray(value) ? value[0] : value;
+
+		/** @type {import('estree').Expression | null} */
 		let expression = null;
 
 		if (first_value) {
@@ -598,6 +598,8 @@ function read_attribute(parser) {
 			if (attribute_contains_text) {
 				e.directive_invalid_value(/** @type {number} */ (first_value.start));
 			} else {
+				// TODO throw a parser error in a future version here if this `[ExpressionTag]` instead of `ExpressionTag`,
+				// which means stringified value, which isn't allowed for some directives?
 				expression = first_value.expression;
 			}
 		}
@@ -662,6 +664,7 @@ function get_directive_type(name) {
 
 /**
  * @param {Parser} parser
+ * @return {Compiler.ExpressionTag | Array<Compiler.ExpressionTag | Compiler.Text>}
  */
 function read_attribute_value(parser) {
 	const quote_mark = parser.eat("'") ? "'" : parser.eat('"') ? '"' : null;
@@ -678,6 +681,7 @@ function read_attribute_value(parser) {
 		];
 	}
 
+	/** @type {Array<Compiler.ExpressionTag | Compiler.Text>} */
 	let value;
 	try {
 		value = read_sequence(
@@ -708,7 +712,12 @@ function read_attribute_value(parser) {
 	}
 
 	if (quote_mark) parser.index += 1;
-	return value;
+
+	if (quote_mark || value.length > 1 || value[0].type === 'Text') {
+		return value;
+	} else {
+		return value[0];
+	}
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -3,6 +3,7 @@
 import { walk } from 'zimmerframe';
 import { get_possible_values } from './utils.js';
 import { regex_ends_with_whitespace, regex_starts_with_whitespace } from '../../patterns.js';
+import { get_attribute_chunks, is_text_attribute } from '../../../utils/ast.js';
 
 /**
  * @typedef {{
@@ -444,14 +445,11 @@ function attribute_matches(node, name, expected_value, operator, case_insensitiv
 		if (attribute.value === true) return operator === null;
 		if (expected_value === null) return true;
 
-		const chunks = attribute.value;
-		if (chunks.length === 1) {
-			const value = chunks[0];
-			if (value.type === 'Text') {
-				return test_attribute(operator, expected_value, case_insensitive, value.data);
-			}
+		if (is_text_attribute(attribute)) {
+			return test_attribute(operator, expected_value, case_insensitive, attribute.value[0].data);
 		}
 
+		const chunks = get_attribute_chunks(attribute.value);
 		const possible_values = new Set();
 
 		/** @type {string[]} */

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -7,6 +7,7 @@ import {
 import * as e from '../../errors.js';
 import {
 	extract_identifiers,
+	get_attribute_expression,
 	get_parent,
 	is_expression_attribute,
 	is_text_attribute,
@@ -35,7 +36,9 @@ import { a11y_validators } from './a11y.js';
 
 /** @param {import('#compiler').Attribute} attribute */
 function validate_attribute(attribute) {
-	if (attribute.value === true || attribute.value.length === 1) return;
+	if (attribute.value === true || !Array.isArray(attribute.value) || attribute.value.length === 1) {
+		return;
+	}
 
 	const is_quoted = attribute.value.at(-1)?.end !== attribute.end;
 
@@ -72,7 +75,7 @@ function validate_component(node, context) {
 				validate_attribute(attribute);
 
 				if (is_expression_attribute(attribute)) {
-					const expression = attribute.value[0].expression;
+					const expression = get_attribute_expression(attribute);
 					if (expression.type === 'SequenceExpression') {
 						let i = /** @type {number} */ (expression.start);
 						while (--i > 0) {
@@ -125,7 +128,7 @@ function validate_element(node, context) {
 				validate_attribute(attribute);
 
 				if (is_expression) {
-					const expression = attribute.value[0].expression;
+					const expression = get_attribute_expression(attribute);
 					if (expression.type === 'SequenceExpression') {
 						let i = /** @type {number} */ (expression.start);
 						while (--i > 0) {
@@ -146,7 +149,7 @@ function validate_element(node, context) {
 					e.attribute_invalid_event_handler(attribute);
 				}
 
-				const value = attribute.value[0].expression;
+				const value = get_attribute_expression(attribute);
 				if (
 					value.type === 'Identifier' &&
 					value.name === attribute.name &&

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -34,8 +34,23 @@ import { Scope, get_rune } from '../scope.js';
 import { merge } from '../visitors.js';
 import { a11y_validators } from './a11y.js';
 
-/** @param {import('#compiler').Attribute} attribute */
-function validate_attribute(attribute) {
+/**
+ * @param {import('#compiler').Attribute} attribute
+ * @param {import('#compiler').ElementLike} parent
+ */
+function validate_attribute(attribute, parent) {
+	if (
+		Array.isArray(attribute.value) &&
+		attribute.value.length === 1 &&
+		attribute.value[0].type === 'ExpressionTag' &&
+		(parent.type === 'Component' ||
+			parent.type === 'SvelteComponent' ||
+			parent.type === 'SvelteSelf' ||
+			(parent.type === 'RegularElement' && is_custom_element_node(parent)))
+	) {
+		w.attribute_quoted(attribute);
+	}
+
 	if (attribute.value === true || !Array.isArray(attribute.value) || attribute.value.length === 1) {
 		return;
 	}
@@ -72,7 +87,7 @@ function validate_component(node, context) {
 
 		if (attribute.type === 'Attribute') {
 			if (context.state.analysis.runes) {
-				validate_attribute(attribute);
+				validate_attribute(attribute, node);
 
 				if (is_expression_attribute(attribute)) {
 					const expression = get_attribute_expression(attribute);
@@ -125,7 +140,7 @@ function validate_element(node, context) {
 			const is_expression = is_expression_attribute(attribute);
 
 			if (context.state.analysis.runes) {
-				validate_attribute(attribute);
+				validate_attribute(attribute, node);
 
 				if (is_expression) {
 					const expression = get_attribute_expression(attribute);

--- a/packages/svelte/src/compiler/phases/nodes.js
+++ b/packages/svelte/src/compiler/phases/nodes.js
@@ -33,7 +33,7 @@ export function is_custom_element_node(node) {
  * @param {string} name
  * @param {number} start
  * @param {number} end
- * @param {true | Array<Compiler.Text | Compiler.ExpressionTag>} value
+ * @param {Compiler.Attribute['value']} value
  * @returns {Compiler.Attribute}
  */
 export function create_attribute(name, start, end, value) {

--- a/packages/svelte/src/compiler/types/legacy-nodes.d.ts
+++ b/packages/svelte/src/compiler/types/legacy-nodes.d.ts
@@ -1,4 +1,4 @@
-import type { StyleDirective as LegacyStyleDirective, Text, Css } from '#compiler';
+import type { Text, Css, ExpressionTag } from '#compiler';
 import type {
 	ArrayExpression,
 	AssignmentExpression,
@@ -192,6 +192,16 @@ export interface LegacyTransition extends BaseNode {
 	intro: boolean;
 	/** True if this is a `transition:` or `out:` directive */
 	outro: boolean;
+}
+
+/** A `style:` directive */
+export interface LegacyStyleDirective extends BaseNode {
+	type: 'StyleDirective';
+	/** The 'x' in `style:x` */
+	name: string;
+	/** The 'y' in `style:x={y}` */
+	value: true | Array<ExpressionTag | Text>;
+	modifiers: Array<'important'>;
 }
 
 export interface LegacyWindow extends BaseElement {

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -226,7 +226,7 @@ export interface StyleDirective extends BaseNode {
 	/** The 'x' in `style:x` */
 	name: string;
 	/** The 'y' in `style:x={y}` */
-	value: true | Array<ExpressionTag | Text>;
+	value: true | ExpressionTag | Array<ExpressionTag | Text>;
 	modifiers: Array<'important'>;
 	metadata: {
 		dynamic: boolean;
@@ -447,7 +447,7 @@ export type Block = EachBlock | IfBlock | AwaitBlock | KeyBlock | SnippetBlock;
 export interface Attribute extends BaseNode {
 	type: 'Attribute';
 	name: string;
-	value: true | Array<Text | ExpressionTag>;
+	value: true | ExpressionTag | Array<Text | ExpressionTag>;
 	metadata: {
 		dynamic: boolean;
 		/** May be set if this is an event attribute */

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -108,6 +108,7 @@ export const codes = [
 	"attribute_global_event_reference",
 	"attribute_illegal_colon",
 	"attribute_invalid_property_name",
+	"attribute_quoted",
 	"bind_invalid_each_rest",
 	"block_empty",
 	"component_name_lowercase",
@@ -684,6 +685,14 @@ export function attribute_illegal_colon(node) {
  */
 export function attribute_invalid_property_name(node, wrong, right) {
 	w(node, "attribute_invalid_property_name", `'${wrong}' is not a valid HTML attribute. Did you mean '${right}'?`);
+}
+
+/**
+ * Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.
+ * @param {null | NodeLike} node
+ */
+export function attribute_quoted(node) {
+	w(node, "attribute_quoted", "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.");
 }
 
 /**

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -688,11 +688,11 @@ export function attribute_invalid_property_name(node, wrong, right) {
 }
 
 /**
- * Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.
+ * Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes
  * @param {null | NodeLike} node
  */
 export function attribute_quoted(node) {
-	w(node, "attribute_quoted", "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.");
+	w(node, "attribute_quoted", "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes");
 }
 
 /**

--- a/packages/svelte/tests/parser-modern/samples/options/output.json
+++ b/packages/svelte/tests/parser-modern/samples/options/output.json
@@ -54,35 +54,33 @@
 				"start": 50,
 				"end": 62,
 				"name": "runes",
-				"value": [
-					{
-						"type": "ExpressionTag",
-						"start": 56,
-						"end": 62,
-						"expression": {
-							"type": "Literal",
-							"start": 57,
-							"end": 61,
-							"loc": {
-								"start": {
-									"line": 1,
-									"column": 57
-								},
-								"end": {
-									"line": 1,
-									"column": 61
-								}
+				"value": {
+					"type": "ExpressionTag",
+					"start": 56,
+					"end": 62,
+					"expression": {
+						"type": "Literal",
+						"start": 57,
+						"end": 61,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 57
 							},
-							"value": true,
-							"raw": "true"
+							"end": {
+								"line": 1,
+								"column": 61
+							}
 						},
-						"parent": null,
-						"metadata": {
-							"contains_call_expression": false,
-							"dynamic": false
-						}
+						"value": true,
+						"raw": "true"
+					},
+					"parent": null,
+					"metadata": {
+						"contains_call_expression": false,
+						"dynamic": false
 					}
-				],
+				},
 				"parent": null,
 				"metadata": {
 					"dynamic": false,

--- a/packages/svelte/tests/validator/samples/attribute-quoted/input.svelte
+++ b/packages/svelte/tests/validator/samples/attribute-quoted/input.svelte
@@ -1,0 +1,21 @@
+<svelte:options runes />
+
+<!-- don't warn on these -->
+
+<!-- prettier-ignore -->
+<p class="{foo}"></p>
+<!-- prettier-ignore -->
+<svelte:element this={foo} class="{foo}"></svelte:element>
+
+<!-- warn on these -->
+
+<!-- prettier-ignore -->
+<Component class="{foo}" />
+<!-- prettier-ignore -->
+<svelte:component this={foo} class="{foo}" />
+<!-- prettier-ignore -->
+{#if foo}
+	<svelte:self class="{foo}" />
+{/if}
+<!-- prettier-ignore -->
+<custom-element class="{foo}"></custom-element>

--- a/packages/svelte/tests/validator/samples/attribute-quoted/warnings.json
+++ b/packages/svelte/tests/validator/samples/attribute-quoted/warnings.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "attribute_quoted",
-		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.",
+		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes",
 		"start": {
 			"column": 11,
 			"line": 13
@@ -13,7 +13,7 @@
 	},
 	{
 		"code": "attribute_quoted",
-		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.",
+		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes",
 		"start": {
 			"column": 29,
 			"line": 15

--- a/packages/svelte/tests/validator/samples/attribute-quoted/warnings.json
+++ b/packages/svelte/tests/validator/samples/attribute-quoted/warnings.json
@@ -1,0 +1,50 @@
+[
+	{
+		"code": "attribute_quoted",
+		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.",
+		"start": {
+			"column": 11,
+			"line": 13
+		},
+		"end": {
+			"column": 24,
+			"line": 13
+		}
+	},
+	{
+		"code": "attribute_quoted",
+		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.",
+		"start": {
+			"column": 29,
+			"line": 15
+		},
+		"end": {
+			"column": 42,
+			"line": 15
+		}
+	},
+	{
+		"code": "attribute_quoted",
+		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.",
+		"start": {
+			"column": 14,
+			"line": 18
+		},
+		"end": {
+			"column": 27,
+			"line": 18
+		}
+	},
+	{
+		"code": "attribute_quoted",
+		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.",
+		"start": {
+			"column": 16,
+			"line": 21
+		},
+		"end": {
+			"column": 29,
+			"line": 21
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/attribute-quoted/warnings.json
+++ b/packages/svelte/tests/validator/samples/attribute-quoted/warnings.json
@@ -25,7 +25,7 @@
 	},
 	{
 		"code": "attribute_quoted",
-		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.",
+		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes",
 		"start": {
 			"column": 14,
 			"line": 18
@@ -37,7 +37,7 @@
 	},
 	{
 		"code": "attribute_quoted",
-		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes.",
+		"message": "Quoted attributes on components and custom elements will be stringified in a future version of Svelte. If this isn't what you want, remove the quotes",
 		"start": {
 			"column": 16,
 			"line": 21

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1153,6 +1153,16 @@ declare module 'svelte/compiler' {
 		outro: boolean;
 	}
 
+	/** A `style:` directive */
+	interface LegacyStyleDirective extends BaseNode_1 {
+		type: 'StyleDirective';
+		/** The 'x' in `style:x` */
+		name: string;
+		/** The 'y' in `style:x={y}` */
+		value: true | Array<ExpressionTag | Text>;
+		modifiers: Array<'important'>;
+	}
+
 	interface LegacyWindow extends BaseElement_1 {
 		type: 'Window';
 	}
@@ -1171,7 +1181,7 @@ declare module 'svelte/compiler' {
 		| LegacyClass
 		| LegacyLet
 		| LegacyEventHandler
-		| StyleDirective
+		| LegacyStyleDirective
 		| LegacyTransition
 		| LegacyAction;
 
@@ -1634,7 +1644,7 @@ declare module 'svelte/compiler' {
 		/** The 'x' in `style:x` */
 		name: string;
 		/** The 'y' in `style:x={y}` */
-		value: true | Array<ExpressionTag | Text>;
+		value: true | ExpressionTag | Array<ExpressionTag | Text>;
 		modifiers: Array<'important'>;
 		metadata: {
 			dynamic: boolean;
@@ -1855,7 +1865,7 @@ declare module 'svelte/compiler' {
 	interface Attribute extends BaseNode {
 		type: 'Attribute';
 		name: string;
-		value: true | Array<Text | ExpressionTag>;
+		value: true | ExpressionTag | Array<Text | ExpressionTag>;
 		metadata: {
 			dynamic: boolean;
 			/** May be set if this is an event attribute */


### PR DESCRIPTION
In a future version, that will mean things are getting stringified, which is a departure from how things work today, therefore a warning first.
Related to #7925 (but not yet closing that issue; we should only do that once we actually have changed the behavior)

Solved by adjusting the AST so that it's now `{ type: 'Attribute', value: true | ExpressionTag | Array<ExpressionTag | Text>, ... }`

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
