### PR TITLE
chore: add warning when using non-reactive objects as bindable props

### DIFF
--- a/.changeset/silent-eagles-roll.md
+++ b/.changeset/silent-eagles-roll.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: add warning when using non-reactive objects as bindable props

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -1,3 +1,7 @@
+## bindable_prop_not_reactive
+
+> The `%name%` prop was passed an object that isn't reactive yet was marked as bindable. The object should be either made reactive using `$state` or should contain properties that have a `set` accessor.
+
 ## hydration_attribute_changed
 
 > The `%attribute%` attribute on `%html%` changed its value between server and client renders. The client value, `%value%`, will be ignored in favour of the server value

--- a/packages/svelte/src/internal/client/validate.js
+++ b/packages/svelte/src/internal/client/validate.js
@@ -120,6 +120,8 @@ export function validate_prop_bindings($$props, bindable, exports, component) {
 				e.bind_not_bindable(key, component[FILENAME], name);
 			}
 		}
+		if (key === '$$slots' || key === '$$events' || key === '$$legacy') return;
+
 		var value = $$props[key];
 		if (typeof value === 'object' && value !== null && !is_possiblly_reactive_object(value)) {
 			w.bindable_prop_not_reactive(key);

--- a/packages/svelte/src/internal/client/validate.js
+++ b/packages/svelte/src/internal/client/validate.js
@@ -84,18 +84,19 @@ function is_possiblly_reactive_object(value) {
 		return true;
 	}
 	const prototype = get_prototype_of(value);
-	if (prototype === array_prototype || prototype === object_prototype) {
-		const descriptors = get_descriptors(value);
-		for (let key in descriptors) {
-			var prop_value = value[key];
-			if (
-				descriptors[key].set ||
-				(typeof prop_value === 'object' &&
-					prop_value !== null &&
-					is_possiblly_reactive_object(prop_value))
-			)
-				return true;
-		}
+	if (prototype !== array_prototype && prototype === object_prototype) {
+		return true;
+	}
+	const descriptors = get_descriptors(value);
+	for (let key in descriptors) {
+		var prop_value = value[key];
+		if (
+			descriptors[key].set ||
+			(typeof prop_value === 'object' &&
+				prop_value !== null &&
+				is_possiblly_reactive_object(prop_value))
+		)
+			return true;
 	}
 	return false;
 }

--- a/packages/svelte/src/internal/client/validate.js
+++ b/packages/svelte/src/internal/client/validate.js
@@ -84,7 +84,7 @@ function is_possiblly_reactive_object(value) {
 		return true;
 	}
 	const prototype = get_prototype_of(value);
-	if (prototype !== array_prototype && prototype === object_prototype) {
+	if (prototype !== array_prototype && prototype !== object_prototype) {
 		return true;
 	}
 	const descriptors = get_descriptors(value);

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -6,6 +6,19 @@ var bold = 'font-weight: bold';
 var normal = 'font-weight: normal';
 
 /**
+ * The `%name%` prop was passed an object that isn't reactive yet was marked as bindable. The object should be either made reactive using `$state` or should contain properties that have a `set` accessor.
+ * @param {string} name
+ */
+export function bindable_prop_not_reactive(name) {
+	if (DEV) {
+		console.warn(`%c[svelte] bindable_prop_not_reactive\n%cThe \`${name}\` prop was passed an object that isn't reactive yet was marked as bindable. The object should be either made reactive using \`$state\` or should contain properties that have a \`set\` accessor.`, bold, normal);
+	} else {
+		// TODO print a link to the documentation
+		console.warn("bindable_prop_not_reactive");
+	}
+}
+
+/**
  * The `%attribute%` attribute on `%html%` changed its value between server and client renders. The client value, `%value%`, will be ignored in favour of the server value
  * @param {string} attribute
  * @param {string} html

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/Component.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { object = $bindable() } = $props();
+</script>
+
+<button onclick={() => object.count += 1}>
+	clicks: {object.count}
+</button>

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<button>clicks: 0</button>`,
+
+	compileOptions: {
+		dev: true
+	},
+
+	warnings: [
+		"The `object` prop was passed an object that isn't reactive yet was marked as bindable. The object should be either made reactive using `$state` or should contain properties that have a `set` accessor."
+	]
+});

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Component from './Component.svelte';
+</script>
+
+<Component object={{ count: 0 }} />


### PR DESCRIPTION
When we encounter a `$bindable()` prop, we now validate that when an object is passed through, it potentially could be reactive. This avoids issues where someone might have passed through a non-reactive object without any setters, expecting reactivity to work deeply.