### PR TITLE
breaking: remove deep reactivity from non-bindable props

### DIFF
--- a/.changeset/heavy-feet-attend.md
+++ b/.changeset/heavy-feet-attend.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: remove deep reactivity from non-bindable props

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -336,7 +336,8 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 						left,
 						context.state.analysis.runes &&
 							!options?.skip_proxy_and_freeze &&
-							should_proxy_or_freeze(value, context.state.scope)
+							should_proxy_or_freeze(value, context.state.scope) &&
+							binding.kind === 'bindable_prop'
 							? serialize_proxy_reassignment(value, left_name, state)
 							: value
 					);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -276,7 +276,7 @@ export const javascript_visitors_runes = {
 								/** @type {import('estree').Expression} */ (visit(binding.initial));
 							// We're adding proxy here on demand and not within the prop runtime function so that
 							// people not using proxied state anywhere in their code don't have to pay the additional bundle size cost
-							if (initial && binding.mutated && should_proxy_or_freeze(initial, state.scope)) {
+							if (initial && binding.kind === 'bindable_prop' && should_proxy_or_freeze(initial, state.scope)) {
 								initial = b.call('$.proxy', initial);
 							}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/javascript-runes.js
@@ -276,7 +276,11 @@ export const javascript_visitors_runes = {
 								/** @type {import('estree').Expression} */ (visit(binding.initial));
 							// We're adding proxy here on demand and not within the prop runtime function so that
 							// people not using proxied state anywhere in their code don't have to pay the additional bundle size cost
-							if (initial && binding.kind === 'bindable_prop' && should_proxy_or_freeze(initial, state.scope)) {
+							if (
+								initial &&
+								binding.kind === 'bindable_prop' &&
+								should_proxy_or_freeze(initial, state.scope)
+							) {
 								initial = b.call('$.proxy', initial);
 							}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -776,7 +776,6 @@ function serialize_inline_component(node, component_name, context, anchor = cont
 				push_prop(b.init(attribute.name, value));
 			}
 		} else if (attribute.type === 'BindDirective') {
-			debugger
 			if (attribute.name === 'this') {
 				bind_this = attribute.expression;
 			} else {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -776,6 +776,7 @@ function serialize_inline_component(node, component_name, context, anchor = cont
 				push_prop(b.init(attribute.name, value));
 			}
 		} else if (attribute.type === 'BindDirective') {
+			debugger
 			if (attribute.name === 'this') {
 				bind_this = attribute.expression;
 			} else {

--- a/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
@@ -63,8 +63,8 @@ export default test({
 			`
 				<button>mutate: 3</button>
 				<button>reassign: 3</button>
-				<button>mutate: 1</button>
-				<button>reassign: 1</button>
+				<button>mutate: 0</button>
+				<button>reassign: 0</button>
 			`
 		);
 
@@ -91,8 +91,8 @@ export default test({
 			`
 				<button>mutate: 3</button>
 				<button>reassign: 3</button>
-				<button>mutate: 3</button>
-				<button>reassign: 3</button>
+				<button>mutate: 2</button>
+				<button>reassign: 2</button>
 			`
 		);
 	}


### PR DESCRIPTION
This reverts parts of https://github.com/sveltejs/svelte/pull/11804. Specifically, if we have a prop is not defined as `$bindable`, then we don't proxy the fallback value, nor do we proxy any mutations to that prop. We now specifically only make props that have been marked as `$bindable` deeply reactive.