### PR TITLE
fix: make animations more robust to quick shuffling

### DIFF
--- a/.changeset/eleven-donuts-sit.md
+++ b/.changeset/eleven-donuts-sit.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make animations more robust to quick shuffling

--- a/packages/svelte/tests/animation-helpers.js
+++ b/packages/svelte/tests/animation-helpers.js
@@ -32,7 +32,6 @@ function tick(time) {
 }
 
 class Animation {
-	#target;
 	#keyframes;
 	#duration;
 	#delay;
@@ -42,6 +41,7 @@ class Animation {
 	#finished = () => {};
 	#cancelled = () => {};
 
+	target;
 	currentTime = 0;
 	startTime = 0;
 
@@ -51,7 +51,7 @@ class Animation {
 	 * @param {{ duration: number, delay: number }} options
 	 */
 	constructor(target, keyframes, { duration, delay }) {
-		this.#target = target;
+		this.target = target;
 		this.#keyframes = keyframes;
 		this.#duration = duration;
 		this.#delay = delay ?? 0;
@@ -111,14 +111,14 @@ class Animation {
 
 		for (let prop in frame) {
 			// @ts-ignore
-			this.#target.style[prop] = frame[prop];
+			this.target.style[prop] = frame[prop];
 		}
 
 		if (this.currentTime >= this.#duration) {
 			this.currentTime = this.#duration;
 			for (let prop in frame) {
 				// @ts-ignore
-				this.#target.style[prop] = null;
+				this.target.style[prop] = null;
 			}
 		}
 	}
@@ -180,4 +180,8 @@ HTMLElement.prototype.animate = function (keyframes, options) {
 	raf.animations.add(animation);
 	// @ts-ignore
 	return animation;
+};
+
+HTMLElement.prototype.getAnimations = function () {
+	return Array.from(raf.animations).filter((animation) => animation.target === this);
 };


### PR DESCRIPTION
Previously, if transitions/animations were playing in quick succession, overlapping each other, it could have disastrous outcomes, leading to elements jumping all over the place. This PR gets that into much better state (not completely fixed, but close) by applying a few fixes:
- destructure style object from `getComputedStyles`, because it's a live object with getters and we're interested in the fixed values at the beginning
- `unfix` for animations didn't reset the transition styles
- don't apply `fix` when we detect already-running animations on the element. That means it's already away from its original position, and doesn't need fixing. Worse, applying an absolute position can lead to the element jumping to the top left if the running animation also applies a transition style - those take precedence over the one we would apply

fixes #10252

No test yet because I don't know how

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
