### PR TITLE
fix: reset hydrate_node after `hydrate(...)`

### DIFF
--- a/.changeset/four-papayas-turn.md
+++ b/.changeset/four-papayas-turn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: reset hydrate node after `hydrate(...)`

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -119,6 +119,7 @@ export function hydrate(component, options) {
 	options.intro = options.intro ?? false;
 	const target = options.target;
 	const was_hydrating = hydrating;
+	const previous_hydrate_node = hydrate_node;
 
 	try {
 		// Don't flush previous effects to ensure order of outer effects stays consistent
@@ -175,6 +176,7 @@ export function hydrate(component, options) {
 		throw error;
 	} finally {
 		set_hydrating(was_hydrating);
+		set_hydrate_node(previous_hydrate_node);
 		reset_head_anchor();
 	}
 }

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -35,6 +35,7 @@ export interface RuntimeTest<Props extends Record<string, any> = Record<string, 
 	ssrHtml?: string;
 	compileOptions?: Partial<CompileOptions>;
 	props?: Props;
+	server_props?: Props;
 	before_test?: () => void;
 	after_test?: () => void;
 	test?: (args: {
@@ -256,7 +257,9 @@ async function run_test_variant(
 			config.before_test?.();
 			// ssr into target
 			const SsrSvelteComponent = (await import(`${cwd}/_output/server/main.svelte.js`)).default;
-			const { html, head } = render(SsrSvelteComponent, { props: config.props || {} });
+			const { html, head } = render(SsrSvelteComponent, {
+				props: config.server_props ?? config.props ?? {}
+			});
 
 			fs.writeFileSync(`${cwd}/_output/rendered.html`, html);
 			target.innerHTML = html;

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw-component/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw-component/Child.svelte
@@ -1,0 +1,7 @@
+<script>
+	let count = $state(0);
+</script>
+
+<button onclick={() => (count += 1)}>
+	clicks: {count}
+</button>

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw-component/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw-component/_config.js
@@ -1,0 +1,21 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	props: {
+		browser: true
+	},
+
+	server_props: {
+		browser: false
+	},
+
+	html: `<div><button>clicks: 0</button></div>`,
+
+	test({ target, assert }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+		assert.htmlEqual(target.innerHTML, `<div><button>clicks: 1</button></div>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw-component/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw-component/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { createRawSnippet, hydrate } from 'svelte';
+	import { render } from 'svelte/server';
+	import Child from './Child.svelte';
+
+	let { browser } = $props();
+
+	let count = $state(0);
+
+	const hello = createRawSnippet((count) => ({
+		render: () => `
+			<div>${browser ? '' : render(Child).body}</div>
+		`,
+		setup(target) {
+			hydrate(Child, { target })
+		}
+	}));
+</script>
+
+{@render hello()}


### PR DESCRIPTION
While looking into https://github.com/sveltejs/svelte/pull/12425#issuecomment-2241149927 I realised that `hydrate` inside a programmatic snippet currently fails, because we don't reset `hydrate_node`.

This fixes it, and also adds a test showing how to render components in programmatic snippets. (It's fine to call `hydrate` with an empty `target` — it defers immediately to `mount`.)

It did force a couple of realisations:

- `render(Component, {...})` fails in the client — obviously — because it tries to pass the server `$$payload` to the client component function that expects an `$$anchor`. I wonder if `render` should instead return a `{ head: '', body: '' }` object if it's run in the browser? It would be convenient for this use case, though perhaps surprising for others. (In an ideal world each component would include both client and server code, and we'd somehow treeshake away the stuff we weren't using, but it's not really possible AFAICT.)
- it might be convenient to have a `svelte/environment` module with `dev` and `browser` exports, just like we have in SvelteKit (and in future, it could _replace_ `$app/environment`). I tried writing the test with a `typeof window` check, but it turns out `window` is defined in the Vitest environment so it didn't work, and I had to add a mechanism for adding server props to tests instead

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
