### PR TITLE
docs: Fix a typo and spelling in Svelte 5 breaking changes doc

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -99,7 +99,7 @@ In Svelte 4, rendering a component to a string also returned the CSS of all comp
 
 ### Component typing changes
 
-The change from classes towards functions is also reflected in the typings: `SvelteComponent`, the base class from Svelte 4, is deprecated in favor of the new `Component` type which defines the function shape of a Svelte component. To manually define a component shape in a `d.ts` file:
+The change from classes towards functions is also reflected in the typings: `SvelteComponent`, the base class from Svelte 4, is deprecated in favour of the new `Component` type which defines the function shape of a Svelte component. To manually define a component shape in a `d.ts` file:
 
 ```ts
 import type { Component } from 'svelte';

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -18,7 +18,7 @@ import App from './App.svelte'
 export default app;
 ```
 
-`mount` and `hydrate` have the exact same API. The difference is that `hydrate` will pick up the Svelte's server-rendered HTML inside its target and hydrate it. Both return an object with the exports of the component and potentially property accessors (if compiled with `accesors: true`). They do not come with the `$on`, `$set` and `$destroy` methods you may know from the class component API. These are its replacements:
+`mount` and `hydrate` have the exact same API. The difference is that `hydrate` will pick up the Svelte's server-rendered HTML inside its target and hydrate it. Both return an object with the exports of the component and potentially property accessors (if compiled with `accessors: true`). They do not come with the `$on`, `$set` and `$destroy` methods you may know from the class component API. These are its replacements:
 
 For `$on`, instead of listening to events, pass them via the `events` property on the options argument.
 


### PR DESCRIPTION
Found a typo on the Svelte 5 Preview site — [Breaking changes](https://svelte-5-preview.vercel.app/docs/breaking-changes):

> Both return an object with the exports of the component and potentially property accessors (if compiled with `accesors: true`). 

This PR adds a missing “s” in `accesors: true`.

Also, it’s not a typo but there is an inconsistent spelling:

> The change from classes towards functions is also reflected in the typings: `SvelteComponent`, the base class from Svelte 4, is deprecated in favor of the new `Component` type which defines the function shape of a Svelte component. 

I believe Svelte docs are consistently written in British English (for example, the [Runes](https://svelte-5-preview.vercel.app/docs/runes) page says “initialisation”, not “initialization”), and the [Event handlers](https://svelte-5-preview.vercel.app/docs/event-handlers) page does say “favour”. So I’ve added a “u” to “favor”.