### PR TITLE
fix: dynamic event delegation for stateful call expressions

### DIFF
--- a/.changeset/brown-moons-sleep.md
+++ b/.changeset/brown-moons-sleep.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: dynamic event delegation for stateful call expressions

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1143,8 +1143,19 @@ function serialize_event_handler(node, { state, visit }) {
 				])
 			);
 
-		if (handler.type === 'Identifier' || handler.type === 'MemberExpression') {
-			const id = object(handler);
+		if (
+			handler.type === 'Identifier' ||
+			handler.type === 'MemberExpression' ||
+			(handler.type === 'CallExpression' &&
+				(handler.callee.type === 'Identifier' || handler.callee.type === 'MemberExpression'))
+		) {
+			const id = object(
+				handler.type === 'CallExpression'
+					? /** @type {import("estree").Identifier | import("estree").MemberExpression} */ (
+							handler.callee
+						)
+					: handler
+			);
 			const binding = id === null ? null : state.scope.get(id.name);
 			if (
 				binding !== null &&

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-hof-delegated-event/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-hof-delegated-event/_config.js
@@ -1,0 +1,24 @@
+import { flushSync } from 'svelte';
+import { test, ok } from '../../test';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, target, logs }) {
+		const [btn1, btn2, btn3] = target.querySelectorAll('button');
+
+		flushSync(() => {
+			btn1.click();
+			btn2.click();
+		});
+
+		assert.deepEqual(logs, ['AA', 'AB']);
+
+		flushSync(() => {
+			btn3.click();
+			btn1.click();
+			btn2.click();
+		});
+
+		assert.deepEqual(logs, ['AA', 'AB', 'BA', 'BB']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-hof-delegated-event/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-hof-delegated-event/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	let hof = $state((name) => () => console.log('A' + name));
+
+	const member = $derived({
+		hof
+	});
+
+	function change() {
+		hof = (name) => () => console.log('B' + name);
+	}
+</script>
+
+<button onclick={hof('A')}>A</button>
+<button onclick={member.hof('B')}>B</button>
+
+<br />
+<button onclick={change}>change</button>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #12520

In theory there could be some weird syntax for `CallExpression` that is not catched by the `callee` be an `Identifier` or a `MemberExpression` but i think the same assumption is also made for normal variables right?

The options could be:

1. always use dynamic function for even delegations in case of `CallExpression`
2. give `CallExpression` is own branch in the if with more thorough checks

Should i do any of the two?

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
