### PR TITLE
fix: meta element "Description" to "description"

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/[slug]/+page.svelte
+++ b/sites/svelte-5-preview/src/routes/docs/[slug]/+page.svelte
@@ -18,7 +18,7 @@
 
 	<meta name="twitter:title" content="{data.page.title} • Docs • Svelte 5 preview" />
 	<meta name="twitter:description" content="{data.page.title} • Svelte 5 preview documentation" />
-	<meta name="Description" content="{data.page.title} • Svelte 5 preview documentation" />
+	<meta name="description" content="{data.page.title} • Svelte 5 preview documentation" />
 </svelte:head>
 
 <div class="text" id="docs-content" use:copy_code_descendants>

--- a/sites/svelte.dev/src/routes/(authed)/repl/[id]/+page.svelte
+++ b/sites/svelte.dev/src/routes/(authed)/repl/[id]/+page.svelte
@@ -70,7 +70,7 @@
 
 	<meta name="twitter:title" content="{data.gist.name} • REPL • Svelte" />
 	<meta name="twitter:description" content="Cybernetically enhanced web apps" />
-	<meta name="Description" content="Interactive Svelte playground" />
+	<meta name="description" content="Interactive Svelte playground" />
 </svelte:head>
 
 <div class="repl-outer {zen_mode ? 'zen-mode' : ''}">

--- a/sites/svelte.dev/src/routes/(authed)/repl/embed/+page.svelte
+++ b/sites/svelte.dev/src/routes/(authed)/repl/embed/+page.svelte
@@ -10,7 +10,7 @@
 
 	<meta name="twitter:title" content="Svelte REPL" />
 	<meta name="twitter:description" content="Cybernetically enhanced web apps" />
-	<meta name="Description" content="Interactive Svelte playground" />
+	<meta name="description" content="Interactive Svelte playground" />
 </svelte:head>
 
 <div class="repl-outer">

--- a/sites/svelte.dev/src/routes/+page.svelte
+++ b/sites/svelte.dev/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 
 	<meta name="twitter:title" content="Svelte" />
 	<meta name="twitter:description" content="Cybernetically enhanced web apps" />
-	<meta name="Description" content="Cybernetically enhanced web apps" />
+	<meta name="description" content="Cybernetically enhanced web apps" />
 </svelte:head>
 
 <h1 class="visually-hidden">Svelte</h1>

--- a/sites/svelte.dev/src/routes/blog/+page.svelte
+++ b/sites/svelte.dev/src/routes/blog/+page.svelte
@@ -13,7 +13,7 @@
 
 	<meta name="twitter:title" content="Svelte blog" />
 	<meta name="twitter:description" content="Articles about Svelte and UI development" />
-	<meta name="Description" content="Articles about Svelte and UI development" />
+	<meta name="description" content="Articles about Svelte and UI development" />
 </svelte:head>
 
 <h1 class="visually-hidden">Blog</h1>

--- a/sites/svelte.dev/src/routes/blog/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/blog/[slug]/+page.svelte
@@ -14,7 +14,7 @@
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content={data.post.title} />
 	<meta name="twitter:description" content={data.post.description} />
-	<meta name="Description" content={data.post.description} />
+	<meta name="description" content={data.post.description} />
 
 	<meta name="twitter:image" content="https://svelte.dev/blog/{$page.params.slug}/card.png" />
 	<meta name="og:image" content="https://svelte.dev/blog/{$page.params.slug}/card.png" />

--- a/sites/svelte.dev/src/routes/docs/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/docs/[slug]/+page.svelte
@@ -19,7 +19,7 @@
 
 	<meta name="twitter:title" content="{data.page.title} • Docs • Svelte" />
 	<meta name="twitter:description" content="{data.page.title} • Svelte documentation" />
-	<meta name="Description" content="{data.page.title} • Svelte documentation" />
+	<meta name="description" content="{data.page.title} • Svelte documentation" />
 </svelte:head>
 
 <div class="text" id="docs-content" use:copy_code_descendants>

--- a/sites/svelte.dev/src/routes/examples/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/examples/[slug]/+page.svelte
@@ -34,7 +34,7 @@
 
 	<meta name="twitter:title" content="Svelte examples" />
 	<meta name="twitter:description" content="Cybernetically enhanced web apps" />
-	<meta name="Description" content="Interactive example Svelte apps" />
+	<meta name="description" content="Interactive example Svelte apps" />
 </svelte:head>
 
 <h1 class="visually-hidden">Examples</h1>

--- a/sites/svelte.dev/src/routes/tutorial/[slug]/+page.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/+page.svelte
@@ -102,7 +102,7 @@
 
 	<meta name="twitter:title" content="Svelte tutorial" />
 	<meta name="twitter:description" content="{selected.section.title} / {selected.chapter.title}" />
-	<meta name="Description" content="{selected.section.title} / {selected.chapter.title}" />
+	<meta name="description" content="{selected.section.title} / {selected.chapter.title}" />
 </svelte:head>
 
 <svelte:window bind:innerWidth={width} />


### PR DESCRIPTION
Changing `Description` to `description` in order to gain gzip compression and consistency with MDN and web.dev (according to https://html.spec.whatwg.org/dev/semantics.html#the-meta-element it's case sensetive but still it would benefit and simplify to make it same). 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
