### PR TITLE
GitHub Contributors Visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The source code for https://svelte.dev lives in the [sites](https://github.com/s
 
 Probably not, but it's possible. If you can't seem to access any `.dev` sites, check out [this SuperUser question and answer](https://superuser.com/q/1413402).
 
+## Contributors 
+<img src="https://markupgo.com/github/sveltejs/svelte/contributors?count=0&circleSize=24&circleRadius=24&center=true" />
+
 ## License
 
 [MIT](LICENSE.md)


### PR DESCRIPTION
## Hello from MarkupGo!

We’re thrilled to introduce a new feature that lets you create a beautiful image showcasing your GitHub contributors. It’s a great way to recognize the amazing people who help make **svelte** awesome!

### Here's how it looks:

<img src="https://markupgo.com/github/sveltejs/svelte/contributors?count=0&circleSize=24&circleRadius=24&center=true" />

### On the Repo page:

![image](https://github.com/user-attachments/assets/f8b9f9ff-f3c3-48fd-af51-939ec0497c77)

### How to configure it:

1. Visit the [GitHub Contributors page on MarkupGo](https://markupgo.com/github?username=sveltejs&repo=svelte&count=0&circleSize=24&circleRadius=24&center=true).
2. Customize the settings to your liking.
3. Click “See Preview” to generate your image.
4. Copy the URL and add it to your README.md file.

![image](https://github.com/user-attachments/assets/583576f9-437b-4fe7-92da-4c453c8928d4)


* The image will automatically update as new contributors join your project after caching expires (every 24 hours).