### PR TITLE
chore: add warning for invalid render function of createRawSnippet

### DIFF
--- a/.changeset/nervous-dolphins-allow.md
+++ b/.changeset/nervous-dolphins-allow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: add warning for invalid render function of createRawSnippet

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -1,3 +1,7 @@
+## bad_raw_snippet_render
+
+> The `render` function of `createRawSnippet` is expected to return the HTML for a single element. Ensure the HTML generated from `render` is correct.
+
 ## binding_property_non_reactive
 
 > `%binding%` is binding to a non-reactive property

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -1,6 +1,6 @@
 ## bad_raw_snippet_render
 
-> The `render` function of `createRawSnippet` is expected to return the HTML for a single element. Ensure the HTML generated from `render` is correct.
+> The `render` function passed to `createRawSnippet` should return HTML for a single element
 
 ## binding_property_non_reactive
 

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -1,7 +1,3 @@
-## bad_raw_snippet_render
-
-> The `render` function passed to `createRawSnippet` should return HTML for a single element
-
 ## binding_property_non_reactive
 
 > `%binding%` is binding to a non-reactive property
@@ -23,6 +19,10 @@
 > Hydration failed because the initial UI does not match what was rendered on the server
 
 > Hydration failed because the initial UI does not match what was rendered on the server. The error occurred near %location%
+
+## invalid_raw_snippet_render
+
+> The `render` function passed to `createRawSnippet` should return HTML for a single element
 
 ## lifecycle_double_unmount
 

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -11,6 +11,8 @@ import {
 import { hydrate_next, hydrate_node, hydrating } from '../hydration.js';
 import { create_fragment_from_html } from '../reconciler.js';
 import { assign_nodes } from '../template.js';
+import * as w from '../../warnings.js';
+import { DEV } from 'esm-env';
 
 /**
  * @template {(node: TemplateNode, ...args: any[]) => void} SnippetFn
@@ -89,6 +91,9 @@ export function createRawSnippet(fn) {
 				var html = snippet.render().trim();
 				var fragment = create_fragment_from_html(html);
 				element = /** @type {Element} */ (fragment.firstChild);
+				if (DEV && (element.nextSibling !== null || element.nodeType !== 3)) {
+					w.bad_raw_snippet_render();
+				}
 				anchor.before(element);
 			}
 

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -92,7 +92,7 @@ export function createRawSnippet(fn) {
 				var fragment = create_fragment_from_html(html);
 				element = /** @type {Element} */ (fragment.firstChild);
 				if (DEV && (element.nextSibling !== null || element.nodeType !== 3)) {
-					w.bad_raw_snippet_render();
+					w.invalid_raw_snippet_render();
 				}
 				anchor.before(element);
 			}

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -8,12 +8,12 @@ var normal = 'font-weight: normal';
 /**
  * The `render` function passed to `createRawSnippet` should return HTML for a single element
  */
-export function bad_raw_snippet_render() {
+export function invalid_raw_snippet_render() {
 	if (DEV) {
-		console.warn(`%c[svelte] bad_raw_snippet_render\n%cThe \`render\` function passed to \`createRawSnippet\` should return HTML for a single element`, bold, normal);
+		console.warn(`%c[svelte] invalid_raw_snippet_render\n%cThe \`render\` function passed to \`createRawSnippet\` should return HTML for a single element`, bold, normal);
 	} else {
 		// TODO print a link to the documentation
-		console.warn("bad_raw_snippet_render");
+		console.warn("invalid_raw_snippet_render");
 	}
 }
 

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -113,3 +113,15 @@ export function state_proxy_equality_mismatch(operator) {
 		console.warn("state_proxy_equality_mismatch");
 	}
 }
+
+/**
+ * The `render` function of `createRawSnippet` is expected to return the HTML for a single element. Ensure the HTML generated from `render` is correct.
+ */
+export function bad_raw_snippet_render() {
+	if (DEV) {
+		console.warn(`%c[svelte] bad_raw_snippet_render\n%cThe \`render\` function of \`createRawSnippet\` is expected to return the HTML for a single element. Ensure the HTML generated from \`render\` is correct.`, bold, normal);
+	} else {
+		// TODO print a link to the documentation
+		console.warn("bad_raw_snippet_render");
+	}
+}

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -6,11 +6,11 @@ var bold = 'font-weight: bold';
 var normal = 'font-weight: normal';
 
 /**
- * The `render` function of `createRawSnippet` is expected to return the HTML for a single element. Ensure the HTML generated from `render` is correct.
+ * The `render` function passed to `createRawSnippet` should return HTML for a single element
  */
 export function bad_raw_snippet_render() {
 	if (DEV) {
-		console.warn(`%c[svelte] bad_raw_snippet_render\n%cThe \`render\` function of \`createRawSnippet\` is expected to return the HTML for a single element. Ensure the HTML generated from \`render\` is correct.`, bold, normal);
+		console.warn(`%c[svelte] bad_raw_snippet_render\n%cThe \`render\` function passed to \`createRawSnippet\` should return HTML for a single element`, bold, normal);
 	} else {
 		// TODO print a link to the documentation
 		console.warn("bad_raw_snippet_render");

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -6,18 +6,6 @@ var bold = 'font-weight: bold';
 var normal = 'font-weight: normal';
 
 /**
- * The `render` function passed to `createRawSnippet` should return HTML for a single element
- */
-export function invalid_raw_snippet_render() {
-	if (DEV) {
-		console.warn(`%c[svelte] invalid_raw_snippet_render\n%cThe \`render\` function passed to \`createRawSnippet\` should return HTML for a single element`, bold, normal);
-	} else {
-		// TODO print a link to the documentation
-		console.warn("invalid_raw_snippet_render");
-	}
-}
-
-/**
  * `%binding%` (%location%) is binding to a non-reactive property
  * @param {string} binding
  * @param {string | undefined | null} [location]
@@ -69,6 +57,18 @@ export function hydration_mismatch(location) {
 	} else {
 		// TODO print a link to the documentation
 		console.warn("hydration_mismatch");
+	}
+}
+
+/**
+ * The `render` function passed to `createRawSnippet` should return HTML for a single element
+ */
+export function invalid_raw_snippet_render() {
+	if (DEV) {
+		console.warn(`%c[svelte] invalid_raw_snippet_render\n%cThe \`render\` function passed to \`createRawSnippet\` should return HTML for a single element`, bold, normal);
+	} else {
+		// TODO print a link to the documentation
+		console.warn("invalid_raw_snippet_render");
 	}
 }
 

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -6,6 +6,18 @@ var bold = 'font-weight: bold';
 var normal = 'font-weight: normal';
 
 /**
+ * The `render` function of `createRawSnippet` is expected to return the HTML for a single element. Ensure the HTML generated from `render` is correct.
+ */
+export function bad_raw_snippet_render() {
+	if (DEV) {
+		console.warn(`%c[svelte] bad_raw_snippet_render\n%cThe \`render\` function of \`createRawSnippet\` is expected to return the HTML for a single element. Ensure the HTML generated from \`render\` is correct.`, bold, normal);
+	} else {
+		// TODO print a link to the documentation
+		console.warn("bad_raw_snippet_render");
+	}
+}
+
+/**
  * `%binding%` (%location%) is binding to a non-reactive property
  * @param {string} binding
  * @param {string | undefined | null} [location]
@@ -111,17 +123,5 @@ export function state_proxy_equality_mismatch(operator) {
 	} else {
 		// TODO print a link to the documentation
 		console.warn("state_proxy_equality_mismatch");
-	}
-}
-
-/**
- * The `render` function of `createRawSnippet` is expected to return the HTML for a single element. Ensure the HTML generated from `render` is correct.
- */
-export function bad_raw_snippet_render() {
-	if (DEV) {
-		console.warn(`%c[svelte] bad_raw_snippet_render\n%cThe \`render\` function of \`createRawSnippet\` is expected to return the HTML for a single element. Ensure the HTML generated from \`render\` is correct.`, bold, normal);
-	} else {
-		// TODO print a link to the documentation
-		console.warn("bad_raw_snippet_render");
 	}
 }

--- a/packages/svelte/tests/runtime-runes/samples/create-raw-snippet-invalid-render/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/create-raw-snippet-invalid-render/_config.js
@@ -8,6 +8,6 @@ export default test({
 	skip_mode: ['hydrate'],
 
 	warnings: [
-		'The `render` function of `createRawSnippet` is expected to return the HTML for a single element. Ensure the HTML generated from `render` is correct.'
+		'The `render` function passed to `createRawSnippet` should return HTML for a single element'
 	]
 });

--- a/packages/svelte/tests/runtime-runes/samples/create-raw-snippet-invalid-render/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/create-raw-snippet-invalid-render/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	skip_mode: ['hydrate'],
+
+	warnings: [
+		'The `render` function of `createRawSnippet` is expected to return the HTML for a single element. Ensure the HTML generated from `render` is correct.'
+	]
+});

--- a/packages/svelte/tests/runtime-runes/samples/create-raw-snippet-invalid-render/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/create-raw-snippet-invalid-render/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { createRawSnippet } from 'svelte';
+
+	const snippet = createRawSnippet(() => ({
+		render: () => `
+			<!-- --><div>123</div>
+		`,
+		setup(target) {
+
+		}
+	}));
+</script>
+
+{@render snippet()}

--- a/packages/svelte/tests/runtime-runes/samples/create-raw-snippet-invalid-render/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/create-raw-snippet-invalid-render/main.svelte
@@ -4,10 +4,7 @@
 	const snippet = createRawSnippet(() => ({
 		render: () => `
 			<!-- --><div>123</div>
-		`,
-		setup(target) {
-
-		}
+		`
 	}));
 </script>
 


### PR DESCRIPTION
Adds a warning for `createRawSnippet` for when the `render` function generates HTML that isn't a single element.