### PR TITLE
fix: store a persistent HMR wrapper per component

### DIFF
--- a/.changeset/hip-ducks-roll.md
+++ b/.changeset/hip-ducks-roll.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: store a persistent HMR wrapper per component

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -417,9 +417,7 @@ export function client_component(source, analysis, options) {
 	);
 
 	if (options.hmr) {
-		const accept_fn_body = [
-			b.stmt(b.call('$.set', b.id('s'), b.member(b.id('module.default'), b.id('$.ORIGINAL'), true)))
-		];
+		const accept_fn_body = [b.stmt(b.call('$$hmr.update', b.id('module.default')))];
 
 		if (analysis.css.hash) {
 			// remove existing `<style>` element, in case CSS changed
@@ -438,20 +436,8 @@ export function client_component(source, analysis, options) {
 		}
 
 		const hmr = b.block([
-			b.const(b.id('s'), b.call('$.source', b.id(analysis.name))),
-			b.const(b.id('filename'), b.member(b.id(analysis.name), b.id('filename'))),
-			b.const(b.id('$$original'), b.id(analysis.name)),
-			b.stmt(b.assignment('=', b.id(analysis.name), b.call('$.hmr', b.id('s')))),
-			b.stmt(b.assignment('=', b.member(b.id(analysis.name), b.id('filename')), b.id('filename'))),
-			// Assign the original component to the wrapper so we can use it on hot reload patching,
-			// else we would call the HMR function two times
-			b.stmt(
-				b.assignment(
-					'=',
-					b.member(b.id(analysis.name), b.id('$.ORIGINAL'), true),
-					b.id('$$original')
-				)
-			),
+			b.const(b.id('$$hmr'), b.call('$.hmr', b.id(analysis.name))),
+			b.stmt(b.assignment('=', b.id(analysis.name), b.id('$$hmr.wrapper'))),
 			b.stmt(b.call('import.meta.hot.accept', b.arrow([b.id('module')], b.block(accept_fn_body))))
 		]);
 

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
@@ -10,16 +10,12 @@ function Hmr($$anchor) {
 }
 
 if (import.meta.hot) {
-	const s = $.source(Hmr);
-	const filename = Hmr.filename;
-	const $$original = Hmr;
+	const $$hmr = $.hmr(Hmr);
 
-	Hmr = $.hmr(s);
-	Hmr.filename = filename;
-	Hmr[$.ORIGINAL] = $$original;
+	Hmr = $$hmr.wrapper;
 
 	import.meta.hot.accept((module) => {
-		$.set(s, module.default[$.ORIGINAL]);
+		$$hmr.update(module.default);
 	});
 }
 


### PR DESCRIPTION
The previous HMR logic created a new wrapper and source per HMR update, which meant things would either get wrapped more and more (prior to #12454) or would not get updated after the first update because the reference to the original would get lost (after #12454).

This fixes that by creating a registry within the HMR wrappers by filename are stored, retrieved and its signals updated. That way nothing gets lost, and nothing gets wrapped more than needed.

Fixes #12506

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
