### PR TITLE
fix: bail-out of hydrating head if no anchor is found

### DIFF
--- a/.changeset/neat-boxes-chew.md
+++ b/.changeset/neat-boxes-chew.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: bail-out of hydrating head if no anchor is found

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
@@ -36,17 +36,18 @@ export function head(render_fn) {
 		}
 
 		while (
-			head_anchor.nodeType !== 8 ||
-			/** @type {Comment} */ (head_anchor).data !== HYDRATION_START
+			head_anchor !== null &&
+			(head_anchor.nodeType !== 8 || /** @type {Comment} */ (head_anchor).data !== HYDRATION_START)
 		) {
 			head_anchor = /** @type {TemplateNode} */ (head_anchor.nextSibling);
-			// If we don't encounter the hydration end, then skip hydration for head element
-			if (head_anchor === null) {
-				set_hydrating(false);
-			}
 		}
 
-		head_anchor = set_hydrate_node(/** @type {TemplateNode} */ (head_anchor.nextSibling));
+		// If we don't encounter the hydration end, then skip hydration for head element
+		if (head_anchor === null) {
+			set_hydrating(false);
+		} else {
+			head_anchor = set_hydrate_node(/** @type {TemplateNode} */ (head_anchor.nextSibling));
+		}
 	}
 
 	if (!hydrating) {

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
@@ -42,7 +42,8 @@ export function head(render_fn) {
 			head_anchor = /** @type {TemplateNode} */ (head_anchor.nextSibling);
 		}
 
-		// If we don't encounter the hydration end, then skip hydration for head element
+		// If we can't find an opening hydration marker, skip hydration (this can happen
+		// if a framework rendered body but not head content)
 		if (head_anchor === null) {
 			set_hydrating(false);
 		} else {

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
@@ -1,5 +1,5 @@
 /** @import { TemplateNode } from '#client' */
-import { hydrate_node, hydrating, set_hydrate_node } from '../hydration.js';
+import { hydrate_node, hydrating, set_hydrate_node, set_hydrating } from '../hydration.js';
 import { empty } from '../operations.js';
 import { block } from '../../reactivity/effects.js';
 import { HEAD_EFFECT } from '../../constants.js';
@@ -40,10 +40,16 @@ export function head(render_fn) {
 			/** @type {Comment} */ (head_anchor).data !== HYDRATION_START
 		) {
 			head_anchor = /** @type {TemplateNode} */ (head_anchor.nextSibling);
+			// If we don't encounter the hydration end, then skip hydration for head element
+			if (head_anchor === null) {
+				set_hydrating(false);
+			}
 		}
 
 		head_anchor = set_hydrate_node(/** @type {TemplateNode} */ (head_anchor.nextSibling));
-	} else {
+	}
+
+	if (!hydrating) {
 		anchor = document.head.appendChild(empty());
 	}
 
@@ -51,6 +57,7 @@ export function head(render_fn) {
 		block(() => render_fn(anchor), HEAD_EFFECT);
 	} finally {
 		if (was_hydrating) {
+			set_hydrating(true);
 			head_anchor = hydrate_node; // so that next head block starts from the correct node
 			set_hydrate_node(/** @type {TemplateNode} */ (previous_hydrate_node));
 		}

--- a/packages/svelte/tests/hydration/samples/head-missing/_config.js
+++ b/packages/svelte/tests/hydration/samples/head-missing/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	test(assert, target, snapshot, component, window) {
+		assert.equal(window.document.querySelectorAll('meta').length, 2);
+	}
+});

--- a/packages/svelte/tests/hydration/samples/head-missing/_expected_head.html
+++ b/packages/svelte/tests/hydration/samples/head-missing/_expected_head.html
@@ -1,0 +1,1 @@
+<meta name="description" content="some description"> <meta name="keywords" content="some keywords">

--- a/packages/svelte/tests/hydration/samples/head-missing/main.svelte
+++ b/packages/svelte/tests/hydration/samples/head-missing/main.svelte
@@ -1,0 +1,6 @@
+<svelte:head>
+	<meta name="description" content="some description" />
+	<meta name="keywords" content="some keywords" />
+</svelte:head>
+
+<div>Just a dummy page.</div>

--- a/packages/svelte/tests/hydration/test.ts
+++ b/packages/svelte/tests/hydration/test.ts
@@ -53,13 +53,14 @@ const { test, run } = suite<HydrationTest>(async (config, cwd) => {
 	});
 
 	const override = read(`${cwd}/_override.html`);
+	const override_head = read(`${cwd}/_override_head.html`);
 
 	fs.writeFileSync(`${cwd}/_output/body.html`, rendered.html + '\n');
 	target.innerHTML = override ?? rendered.html;
 
 	if (rendered.head) {
 		fs.writeFileSync(`${cwd}/_output/head.html`, rendered.head + '\n');
-		head.innerHTML = rendered.head;
+		head.innerHTML = override_head ?? rendered.head;
 	}
 
 	config.before_test?.();


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12531.

If we encounter a head block that doesn't have any hydration markers, then we can skip the hydration for the head block and just render like it is client-side only.