### PR TITLE
fix: store a persistent HMR wrapper per component (alternative)

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -418,7 +418,13 @@ export function client_component(source, analysis, options) {
 
 	if (options.hmr) {
 		const accept_fn_body = [
-			b.stmt(b.call('$.set', b.id('s'), b.member(b.id('module.default'), b.id('$.ORIGINAL'), true)))
+			b.stmt(
+				b.call(
+					'$.set',
+					b.id('import.meta.hot.data.source'),
+					b.member(b.id('module.default'), b.id('$.ORIGINAL'), true)
+				)
+			)
 		];
 
 		if (analysis.css.hash) {
@@ -438,13 +444,27 @@ export function client_component(source, analysis, options) {
 		}
 
 		const hmr = b.block([
-			b.const(b.id('s'), b.call('$.source', b.id(analysis.name))),
-			b.const(b.id('filename'), b.member(b.id(analysis.name), b.id('filename'))),
+			b.stmt(
+				b.assignment(
+					'??=',
+					b.id('import.meta.hot.data.source'),
+					b.call('$.source', b.id(analysis.name))
+				)
+			),
+			b.const(b.id('$$filename'), b.member(b.id(analysis.name), b.id('$.FILENAME'), true)),
 			b.const(b.id('$$original'), b.id(analysis.name)),
-			b.stmt(b.assignment('=', b.id(analysis.name), b.call('$.hmr', b.id('s')))),
-			b.stmt(b.assignment('=', b.member(b.id(analysis.name), b.id('filename')), b.id('filename'))),
+			b.stmt(
+				b.assignment('=', b.id(analysis.name), b.call('$.hmr', b.id('import.meta.hot.data.source')))
+			),
+			b.stmt(
+				b.assignment(
+					'=',
+					b.member(b.id(analysis.name), b.id('$.FILENAME'), true),
+					b.id('$$filename')
+				)
+			),
 			// Assign the original component to the wrapper so we can use it on hot reload patching,
-			// else we would call the HMR function two times
+			// else we would create a matryoshka doll of HMR wrappers
 			b.stmt(
 				b.assignment(
 					'=',

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -444,6 +444,7 @@ export function client_component(source, analysis, options) {
 		}
 
 		const hmr = b.block([
+			b.stmt(b.assignment('??=', b.id('import.meta.hot.data'), b.object([]))),
 			b.stmt(
 				b.assignment(
 					'??=',

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
@@ -10,6 +10,7 @@ function Hmr($$anchor) {
 }
 
 if (import.meta.hot) {
+	import.meta.hot.data ??= {};
 	import.meta.hot.data.source ??= $.source(Hmr);
 
 	const $$filename = Hmr[$.FILENAME];

--- a/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/hmr/_expected/client/index.svelte.js
@@ -10,16 +10,17 @@ function Hmr($$anchor) {
 }
 
 if (import.meta.hot) {
-	const s = $.source(Hmr);
-	const filename = Hmr.filename;
+	import.meta.hot.data.source ??= $.source(Hmr);
+
+	const $$filename = Hmr[$.FILENAME];
 	const $$original = Hmr;
 
-	Hmr = $.hmr(s);
-	Hmr.filename = filename;
+	Hmr = $.hmr(import.meta.hot.data.source);
+	Hmr[$.FILENAME] = $$filename;
 	Hmr[$.ORIGINAL] = $$original;
 
 	import.meta.hot.accept((module) => {
-		$.set(s, module.default[$.ORIGINAL]);
+		$.set(import.meta.hot.data.source, module.default[$.ORIGINAL]);
 	});
 }
 


### PR DESCRIPTION
I thought this might be a decent alternative to #12537 that fixes the testing issue — instead of creating our own registry using filenames, let Vite manage it for us — ~~but it seems that `import.meta.hot.data` isn't supported in Vitest????~~ _fixed with `import.meta.hot.data ??= {}`_

I fixed another bug (`Component.filename` instead of `Component[$.FILENAME]`) while I was at it, guess I'll move that into its own PR in the meantime.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
