### PR TITLE
fix: only emit binding_property_non_reactive warning in runes mode

### DIFF
--- a/.changeset/two-keys-watch.md
+++ b/.changeset/two-keys-watch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only emit binding_property_non_reactive warning in runes mode

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -780,7 +780,11 @@ function serialize_inline_component(node, component_name, context, anchor = cont
 		} else if (attribute.type === 'BindDirective') {
 			const expression = /** @type {Expression} */ (context.visit(attribute.expression));
 
-			if (expression.type === 'MemberExpression' && context.state.options.dev) {
+			if (
+				expression.type === 'MemberExpression' &&
+				context.state.options.dev &&
+				context.state.analysis.runes
+			) {
 				context.state.init.push(serialize_validate_binding(context.state, attribute, expression));
 			}
 
@@ -2826,7 +2830,11 @@ export const template_visitors = {
 		const { state, path, visit } = context;
 		const expression = node.expression;
 
-		if (expression.type === 'MemberExpression' && context.state.options.dev) {
+		if (
+			expression.type === 'MemberExpression' &&
+			context.state.options.dev &&
+			context.state.analysis.runes
+		) {
 			context.state.init.push(
 				serialize_validate_binding(
 					context.state,

--- a/packages/svelte/tests/runtime-legacy/samples/binding-member-expression-no-warning/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-member-expression-no-warning/_config.js
@@ -1,0 +1,23 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, window }) {
+		assert.htmlEqual(target.innerHTML, `<input><p>hello</p>`);
+
+		const input = target.querySelector('input');
+		ok(input);
+
+		input.value = 'goodbye';
+		input.dispatchEvent(new window.Event('input'));
+
+		flushSync();
+		assert.htmlEqual(target.innerHTML, `<input><p>goodbye</p>`);
+	},
+
+	warnings: []
+});

--- a/packages/svelte/tests/runtime-legacy/samples/binding-member-expression-no-warning/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-member-expression-no-warning/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let object = { value: 'hello' };
+</script>
+
+<input bind:value={object.value} />
+<p>{object.value}</p>


### PR DESCRIPTION
oops, my bad

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
