### PR TITLE
chore: tidy up dynamic event handler generated code

### DIFF
--- a/.changeset/calm-cameras-hide.md
+++ b/.changeset/calm-cameras-hide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: tidy up dynamic event handler generated code

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1139,16 +1139,20 @@ function serialize_event_handler(node, { state, visit }) {
 		handler = node.expression;
 
 		// Event handlers can be dynamic (source/store/prop/conditional etc)
-		const dynamic_handler = () => {
-			return b.arrow(
+		const dynamic_handler = () =>
+			b.function(
+				null,
 				[b.rest(b.id('$$args'))],
-				b.call(
-					b.member(/** @type {Expression} */ (visit(handler)), b.id('apply'), false, true),
-					b.this,
-					b.id('$$args')
-				)
+				b.block([
+					b.return(
+						b.call(
+							b.member(/** @type {Expression} */ (visit(handler)), b.id('apply'), false, true),
+							b.this,
+							b.id('$$args')
+						)
+					)
+				])
 			);
-		};
 
 		if (handler.type === 'Identifier' || handler.type === 'MemberExpression') {
 			const id = object(handler);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1139,17 +1139,16 @@ function serialize_event_handler(node, { state, visit }) {
 		handler = node.expression;
 
 		// Event handlers can be dynamic (source/store/prop/conditional etc)
-		const dynamic_handler = () =>
-			b.function(
-				null,
+		const dynamic_handler = () => {
+			return b.arrow(
 				[b.rest(b.id('$$args'))],
-				b.block([
-					b.const('$$callback', /** @type {Expression} */ (visit(handler))),
-					b.return(
-						b.call(b.member(b.id('$$callback'), b.id('apply'), false, true), b.this, b.id('$$args'))
-					)
-				])
+				b.call(
+					b.member(/** @type {Expression} */ (visit(handler)), b.id('apply'), false, true),
+					b.this,
+					b.id('$$args')
+				)
 			);
+		};
 
 		if (handler.type === 'Identifier' || handler.type === 'MemberExpression') {
 			const id = object(handler);


### PR DESCRIPTION
Small tweak post-#12549 — we can make dynamic event handlers a bit more compact:

```diff
button.__click = function (...$$args) {
- const $$callback = a || b;
-
- return $$callback?.apply(this, $$args);
+ return (a || b)?.apply(this, $$args);
};
```

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
