### PR TITLE
feat: warn on possible implicit snippet shadowing

### DIFF
--- a/.changeset/honest-steaks-grow.md
+++ b/.changeset/honest-steaks-grow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: warn on possible implicit snippet shadowing

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -38,6 +38,10 @@
 
 > Using `on:%name%` to listen to the %name% event is deprecated. Use the event attribute `on%name%` instead
 
+## implicit_children_possible_shadowing
+
+> if `%name%` is using `{@render}` the attribute `children` will shadow the implicit snippet
+
 ## slot_element_deprecated
 
 > Using `<slot>` to render parent content is deprecated. Use `{@render ...}` tags instead

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -107,6 +107,10 @@ function validate_component(node, context) {
 			if (attribute.name === 'slot') {
 				validate_slot_attribute(context, attribute, true);
 			}
+
+			if (attribute.name === 'children' && node.fragment.nodes.length > 0) {
+				w.implicit_children_possible_shadowing(node, node.name);
+			}
 		}
 	}
 

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -114,6 +114,7 @@ export const codes = [
 	"component_name_lowercase",
 	"element_invalid_self_closing_tag",
 	"event_directive_deprecated",
+	"implicit_children_possible_shadowing",
 	"slot_element_deprecated",
 	"svelte_element_invalid_this"
 ];
@@ -737,6 +738,15 @@ export function element_invalid_self_closing_tag(node, name) {
  */
 export function event_directive_deprecated(node, name) {
 	w(node, "event_directive_deprecated", `Using \`on:${name}\` to listen to the ${name} event is deprecated. Use the event attribute \`on${name}\` instead`);
+}
+
+/**
+ * if `%name%` is using `{@render}` the attribute `children` will shadow the implicit snippet
+ * @param {null | NodeLike} node
+ * @param {string} name
+ */
+export function implicit_children_possible_shadowing(node, name) {
+	w(node, "implicit_children_possible_shadowing", `if \`${name}\` is using \`{@render}\` the attribute \`children\` will shadow the implicit snippet`);
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/implicit-children-possible-shadowing/input.svelte
+++ b/packages/svelte/tests/validator/samples/implicit-children-possible-shadowing/input.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Component from './Component.svelte';
+	import Legacy from './Legacy.svelte';
+</script>
+
+<Component children="foo">Children</Component>
+
+<Component children="foo" />
+
+<Component children="foo"></Component>
+
+<!-- svelte-ignore implicit_children_possible_shadowing -->
+<Legacy children="foo">Legacy</Legacy>

--- a/packages/svelte/tests/validator/samples/implicit-children-possible-shadowing/warnings.json
+++ b/packages/svelte/tests/validator/samples/implicit-children-possible-shadowing/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "implicit_children_possible_shadowing",
+		"end": {
+			"column": 46,
+			"line": 6
+		},
+		"message": "if `Component` is using `{@render}` the attribute `children` will shadow the implicit snippet",
+		"start": {
+			"column": 0,
+			"line": 6
+		}
+	}
+]


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #12550 

I don't know if we actually want this but it could be a bit of an extra incentive to write components that don't rely on `children` props so that you will not have problems to switch to svelte 5. We can't actually error because the component could be a Legacy component which should continue working if you pass `children` and a `slot` but a warning could be a good middleground.

I'm also not really sure about the warning sentence but could not come up with a better one.

It wasn't a lot of work so feel free to close if you think it's not what we want. 😄 

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
