### PR TITLE
fix: properly update store values

### DIFF
--- a/.changeset/silver-mice-double.md
+++ b/.changeset/silver-mice-double.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: properly update store values

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -28,7 +28,7 @@ export function store_get(store, store_name, stores) {
 		entry.store = store ?? null;
 
 		if (store == null) {
-			set(entry.source, undefined);
+			entry.source.v = undefined; // see synchronous callback comment below
 			entry.unsubscribe = noop;
 		} else {
 			var is_synchronous_callback = true;

--- a/packages/svelte/tests/runtime-runes/samples/store-no-mutation-validation/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-no-mutation-validation/main.svelte
@@ -9,10 +9,12 @@
 			return () => {};
 		}
 	};
+	let store3 = undefined;
 
 	// store signal is updated during reading this, which normally errors, but shouldn't for stores
 	let name = $derived($store1);
 	let hello = $derived($store2);
+	let undefined_value = $derived($store3);
 </script>
 
-<h1>{hello} {name}</h1>
+<h1>{hello} {name} {undefined_value}</h1>


### PR DESCRIPTION
We need to extend the "don't use `set` on first run" logic to the falsy branch aswell

Fixes #12558

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
