### PR TITLE
fix: ensure $state.snapshot correctly clones Date objects

### DIFF
--- a/.changeset/dirty-pianos-eat.md
+++ b/.changeset/dirty-pianos-eat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure $state.snapshot correctly clones Date objects

--- a/packages/svelte/src/internal/shared/clone.js
+++ b/packages/svelte/src/internal/shared/clone.js
@@ -79,6 +79,10 @@ function clone(value, cloned, path, paths) {
 			return copy;
 		}
 
+		if (value instanceof Date) {
+			return /** @type {Snapshot<T>} */ (structuredClone(value));
+		}
+
 		if (typeof (/** @type {T & { toJSON?: any } } */ (value).toJSON) === 'function') {
 			return clone(
 				/** @type {T & { toJSON(): any } } */ (value).toJSON(),

--- a/packages/svelte/tests/runtime-runes/samples/state-snapshot-date/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-snapshot-date/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `true\ntrue\ntrue\ntrue`
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-snapshot-date/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-snapshot-date/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	let test = $state({
+		a: new Date()
+	});
+	let test2 = $state.snapshot(test);
+
+	let test3 = {
+		a: new Date()
+	}
+	let test4 = structuredClone(test3);
+</script>
+
+{test.a instanceof Date}
+{test2.a instanceof Date}
+{test3.a instanceof Date}
+{test4.a instanceof Date}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12561