### PR TITLE
fix: ensure correct node boundaries during hydration

### DIFF
--- a/.changeset/strong-pugs-hammer.md
+++ b/.changeset/strong-pugs-hammer.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure correct node boundaries during hydration

--- a/packages/svelte/src/internal/client/dev/hmr.js
+++ b/packages/svelte/src/internal/client/dev/hmr.js
@@ -1,6 +1,7 @@
 /** @import { Source, Effect } from '#client' */
 import { FILENAME, HMR } from '../../../constants.js';
 import { EFFECT_TRANSPARENT } from '../constants.js';
+import { hydrate_node, hydrating } from '../dom/hydration.js';
 import { block, branch, destroy_effect } from '../reactivity/effects.js';
 import { source } from '../reactivity/sources.js';
 import { set_should_intro } from '../render.js';
@@ -50,6 +51,12 @@ export function hmr(original, get_source) {
 				if (ran) set_should_intro(true);
 			});
 		}, EFFECT_TRANSPARENT);
+
+		if (hydrating) {
+			// The anchor is last because everything is prepended before it,
+			// and so we only come across it after hydrating the inner contents
+			anchor = /** @type {Comment} */ (hydrate_node);
+		}
 
 		ran = true;
 

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -35,7 +35,11 @@ export function template(content, flags) {
 
 	return () => {
 		if (hydrating) {
-			assign_nodes(hydrate_node, null);
+			assign_nodes(
+				// Within if/each/etc blocks, we're walking past the initial anchor, and need to revert that here
+				has_start ? hydrate_node : /** @type {TemplateNode} */ (hydrate_node.previousSibling),
+				null
+			);
 			return hydrate_node;
 		}
 
@@ -107,7 +111,11 @@ export function ns_template(content, flags, ns = 'svg') {
 
 	return () => {
 		if (hydrating) {
-			assign_nodes(hydrate_node, null);
+			assign_nodes(
+				// Within if/each/etc blocks, we're walking past the initial anchor, and need to revert that here
+				has_start ? hydrate_node : /** @type {TemplateNode} */ (hydrate_node.previousSibling),
+				null
+			);
 			return hydrate_node;
 		}
 
@@ -232,7 +240,8 @@ export function text() {
 export function comment() {
 	// we're not delegating to `template` here for performance reasons
 	if (hydrating) {
-		assign_nodes(hydrate_node, null);
+		// During hydration we already walked past the comment, so go back once
+		assign_nodes(/** @type {TemplateNode} */ (hydrate_node.previousSibling), null);
 		return hydrate_node;
 	}
 


### PR DESCRIPTION
- in certain situations, we need to go back once during hydration to properly capture the start node
- we need to adjust the anchor for HMR; we only come across it after hydrating the inner contents

fixes #12417

no test yet because I'm in a rush; and it would be good to test this out manually a bit

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
