### PR TITLE
fix: tweak element_invalid_self_closing_tag to exclude namespace

### DIFF
--- a/.changeset/quick-pumpkins-study.md
+++ b/.changeset/quick-pumpkins-study.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: tweak element_invalid_self_closing_tag to exclude namespace

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -636,11 +636,14 @@ const validation = {
 			}
 		}
 
+		// Strip off any namespace from the beginning of the node name.
+		const node_name = node.name.replace(/[a-zA-Z-]*:/g, '');
+
 		if (
 			context.state.analysis.source[node.end - 2] === '/' &&
 			context.state.options.namespace !== 'foreign' &&
-			!VoidElements.includes(node.name) &&
-			!SVGElements.includes(node.name)
+			!VoidElements.includes(node_name) &&
+			!SVGElements.includes(node_name)
 		) {
 			w.element_invalid_self_closing_tag(node, node.name);
 		}

--- a/packages/svelte/tests/validator/samples/invalid-self-closing-tag/input.svelte
+++ b/packages/svelte/tests/validator/samples/invalid-self-closing-tag/input.svelte
@@ -1,6 +1,8 @@
 <!-- valid -->
 <link />
 <svg><g /></svg>
+<enhanced:img />
+
 
 <!-- invalid -->
 <div />

--- a/packages/svelte/tests/validator/samples/invalid-self-closing-tag/warnings.json
+++ b/packages/svelte/tests/validator/samples/invalid-self-closing-tag/warnings.json
@@ -3,11 +3,11 @@
 		"code": "element_invalid_self_closing_tag",
 		"message": "Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`",
 		"start": {
-			"line": 6,
+			"line": 8,
 			"column": 0
 		},
 		"end": {
-			"line": 6,
+			"line": 8,
 			"column": 7
 		}
 	},
@@ -15,11 +15,11 @@
 		"code": "element_invalid_self_closing_tag",
 		"message": "Self-closing HTML tags for non-void elements are ambiguous — use `<my-thing ...></my-thing>` rather than `<my-thing ... />`",
 		"start": {
-			"line": 7,
+			"line": 9,
 			"column": 0
 		},
 		"end": {
-			"line": 7,
+			"line": 9,
 			"column": 12
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12546