### PR TITLE
fix: add missing hydration mismatch call-site

### DIFF
--- a/.changeset/hip-stingrays-teach.md
+++ b/.changeset/hip-stingrays-teach.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add missing hydration mismatch call-site

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -1,6 +1,12 @@
 /** @import { TemplateNode } from '#client' */
 
-import { HYDRATION_END, HYDRATION_START, HYDRATION_START_ELSE } from '../../../constants.js';
+import {
+	HYDRATION_END,
+	HYDRATION_ERROR,
+	HYDRATION_START,
+	HYDRATION_START_ELSE
+} from '../../../constants.js';
+import * as w from '../warnings.js';
 
 /**
  * Use this variable to guard everything related to hydration code so it can be treeshaken out
@@ -28,6 +34,10 @@ export function set_hydrate_node(node) {
 }
 
 export function hydrate_next() {
+	if (hydrate_node === null) {
+		w.hydration_mismatch();
+		throw HYDRATION_ERROR;
+	}
 	return (hydrate_node = /** @type {TemplateNode} */ (hydrate_node.nextSibling));
 }
 

--- a/playgrounds/demo/index.html
+++ b/playgrounds/demo/index.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 		<noscript>You need to enable JavaScript to run this app.</noscript>
-		<div id="root"><!--ssr-body--></div>
+		<div id="root"><!--[-->Hello<!--]--></div>
 
 		<script type="module">
 			import { mount, hydrate, unmount } from 'svelte';

--- a/playgrounds/demo/index.html
+++ b/playgrounds/demo/index.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 		<noscript>You need to enable JavaScript to run this app.</noscript>
-		<div id="root"><!--[-->Hello<!--]--></div>
+		<div id="root"><!--ssr-body--></div>
 
 		<script type="module">
 			import { mount, hydrate, unmount } from 'svelte';


### PR DESCRIPTION
As pointed out in https://github.com/sveltejs/svelte/issues/12532, we are missing a hydration mismatch call-site.