### PR TITLE
fix: tune hydrate mismatch logic to catch more cases

### DIFF
--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -133,6 +133,7 @@ export function hydrate(component, options) {
 		const instance = _mount(component, { ...options, anchor });
 
 		if (
+			hydrate_node === null ||
 			hydrate_node.nodeType !== 8 ||
 			/** @type {Comment} */ (hydrate_node).data !== HYDRATION_END
 		) {


### PR DESCRIPTION
As per https://github.com/sveltejs/svelte/issues/12532#issuecomment-2251342685 we're missing a `null` check.