### PR TITLE
chore: simplify assignments in server code

### DIFF
--- a/.changeset/violet-otters-carry.md
+++ b/.changeset/violet-otters-carry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly update stores when reassigning with operator other than `=`

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -382,7 +382,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 				}
 
 				return b.call(
-					'$.mutate_store',
+					'$.store_mutate',
 					serialize_get_binding(b.id(left_name), state),
 					b.assignment(node.operator, /** @type {Pattern}} */ (visit_node(node.left)), value),
 					b.call('$.untrack', b.id('$' + left_name))

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -22,19 +22,18 @@ export function AssignmentExpression(node, context) {
 		const should_cache = value.type !== 'Identifier';
 		const rhs = should_cache ? b.id('$$value') : value;
 
-		let unchanged = 0;
+		let changed = false;
 
 		const assignments = extract_paths(node.left).map((path) => {
 			const value = path.expression?.(rhs);
-			const assignment = b.assignment('=', path.node, value);
 
-			return serialize_assignment('=', path.node, value, context, () => {
-				unchanged += 1;
-				return assignment;
-			});
+			let assignment = serialize_assignment('=', path.node, value, context);
+			if (assignment !== null) changed = true;
+
+			return assignment ?? b.assignment('=', path.node, value);
 		});
 
-		if (unchanged === assignments.length) {
+		if (!changed) {
 			// No change to output -> nothing to transform -> we can keep the original assignment
 			return context.next();
 		}
@@ -54,7 +53,7 @@ export function AssignmentExpression(node, context) {
 		return sequence;
 	}
 
-	return serialize_assignment(node.operator, node.left, node.right, context, context.next);
+	return serialize_assignment(node.operator, node.left, node.right, context) || context.next();
 }
 
 /**
@@ -62,10 +61,9 @@ export function AssignmentExpression(node, context) {
  * @param {Pattern} left
  * @param {Expression} right
  * @param {import('zimmerframe').Context<SvelteNode, ServerTransformState>} context
- * @param {() => any} fallback
- * @returns {Expression}
+ * @returns {Expression | null}
  */
-function serialize_assignment(operator, left, right, context, fallback) {
+function serialize_assignment(operator, left, right, context) {
 	let object = left;
 
 	while (object.type === 'MemberExpression') {
@@ -74,25 +72,26 @@ function serialize_assignment(operator, left, right, context, fallback) {
 	}
 
 	if (object.type !== 'Identifier' || !is_store_name(object.name)) {
-		return fallback();
+		return null;
 	}
 
 	const name = object.name.slice(1);
 
 	if (!context.state.scope.get(name)) {
-		return fallback();
+		return null;
 	}
 
 	if (object === left) {
-		const value =
-			operator === '='
-				? /** @type {Expression} */ (context.visit(right))
-				: // turn something like x += 1 into x = x + 1
-					b.binary(
-						/** @type {BinaryOperator} */ (operator.slice(0, -1)),
-						serialize_get_binding(left, context.state),
-						/** @type {Expression} */ (context.visit(right))
-					);
+		let value = /** @type {Expression} */ (context.visit(right));
+
+		if (operator !== '=') {
+			// turn `x += 1` into `x = x + 1`
+			value = b.binary(
+				/** @type {BinaryOperator} */ (operator.slice(0, -1)),
+				serialize_get_binding(left, context.state),
+				value
+			);
+		}
 
 		return b.call('$.store_set', b.id(name), value);
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -1,11 +1,137 @@
-/** @import { AssignmentExpression } from 'estree' */
-/** @import { Context } from '../types.js' */
-import { serialize_set_binding } from './shared/utils.js';
+/** @import { AssignmentExpression, BinaryOperator, Expression, Node, Pattern } from 'estree' */
+/** @import { SvelteNode } from '#compiler' */
+/** @import { Context, ServerTransformState } from '../types.js' */
+import { extract_paths } from '../../../../utils/ast.js';
+import * as b from '../../../../utils/builders.js';
+import { serialize_get_binding } from './shared/utils.js';
 
 /**
  * @param {AssignmentExpression} node
  * @param {Context} context
  */
 export function AssignmentExpression(node, context) {
-	return serialize_set_binding(node, context, context.next);
+	const parent = /** @type {Node} */ (context.path.at(-1));
+	const is_standalone = parent.type.endsWith('Statement');
+	return serialize_assignment(node, context, is_standalone, context.next);
+}
+
+/**
+ * @param {AssignmentExpression} node
+ * @param {import('zimmerframe').Context<SvelteNode, ServerTransformState>} context
+ * @param {boolean} is_standalone
+ * @param {() => any} fallback
+ * @returns {Expression}
+ */
+function serialize_assignment(node, context, is_standalone, fallback) {
+	if (
+		node.left.type === 'ArrayPattern' ||
+		node.left.type === 'ObjectPattern' ||
+		node.left.type === 'RestElement'
+	) {
+		const value = /** @type {Expression} */ (context.visit(node.right));
+
+		const should_cache = value.type !== 'Identifier';
+		const rhs = should_cache ? b.id('$$value') : value;
+
+		/** @type {Expression[]} */
+		const assignments = [];
+		let should_transform = false;
+
+		for (const path of extract_paths(node.left)) {
+			const assignment = b.assignment('=', path.node, path.expression?.(rhs));
+			let changed = true;
+
+			assignments.push(
+				serialize_assignment(assignment, context, false, () => {
+					changed = false;
+					return assignment;
+				})
+			);
+
+			should_transform ||= changed;
+		}
+
+		if (!should_transform) {
+			// No change to output -> nothing to transform -> we can keep the original assignment
+			return fallback();
+		}
+
+		const sequence = b.sequence(assignments);
+
+		if (!is_standalone) {
+			// this is part of an expression, we need the sequence to end with the value
+			sequence.expressions.push(rhs);
+		}
+
+		if (should_cache) {
+			return b.call(b.arrow([rhs], sequence), value);
+		}
+
+		return sequence;
+	}
+
+	if (node.left.type !== 'Identifier' && node.left.type !== 'MemberExpression') {
+		throw new Error(`Unexpected assignment type ${node.left.type}`);
+	}
+
+	let left = node.left;
+
+	while (left.type === 'MemberExpression') {
+		// @ts-expect-error
+		left = left.object;
+	}
+
+	if (left.type !== 'Identifier' || !is_store_name(left.name)) {
+		return fallback();
+	}
+
+	const name = left.name.slice(1);
+
+	if (!context.state.scope.get(name)) {
+		// TODO error if it's a computed (or rest prop)? or does that already happen elsewhere?
+		return fallback();
+	}
+
+	if (left === node.left) {
+		return b.call('$.store_set', b.id(name), /** @type {Expression} */ (context.visit(node.right)));
+	}
+
+	return b.call(
+		'$.mutate_store',
+		b.assignment('??=', b.id('$$store_subs'), b.object([])),
+		b.literal(left.name),
+		b.id(name),
+		b.assignment(
+			node.operator,
+			/** @type {Pattern} */ (context.visit(node.left)),
+			get_assignment_value(node, context)
+		)
+	);
+}
+
+/**
+ * @param {AssignmentExpression} node
+ * @param {Pick<import('zimmerframe').Context<SvelteNode, ServerTransformState>, 'visit' | 'state'>} context
+ */
+function get_assignment_value(node, { state, visit }) {
+	if (node.left.type === 'Identifier') {
+		const operator = node.operator;
+		return operator === '='
+			? /** @type {Expression} */ (visit(node.right))
+			: // turn something like x += 1 into x = x + 1
+				b.binary(
+					/** @type {BinaryOperator} */ (operator.slice(0, -1)),
+					serialize_get_binding(node.left, state),
+					/** @type {Expression} */ (visit(node.right))
+				);
+	}
+
+	return /** @type {Expression} */ (visit(node.right));
+}
+
+/**
+ * @param {string} name
+ */
+function is_store_name(name) {
+	return name[0] === '$' && /[A-Za-z_]/.test(name[1]);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -77,7 +77,6 @@ function serialize_assignment(node, context, fallback) {
 	const name = left.name.slice(1);
 
 	if (!context.state.scope.get(name)) {
-		// TODO error if it's a computed (or rest prop)? or does that already happen elsewhere?
 		return fallback();
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -57,6 +57,7 @@ export function AssignmentExpression(node, context) {
 }
 
 /**
+ * Only returns an expression if this is not a `$store` assignment, as others can be kept as-is
  * @param {AssignmentOperator} operator
  * @param {Pattern} left
  * @param {Expression} right

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -1,8 +1,8 @@
 /** @import { AssignmentExpression, BinaryOperator, Expression, Node, Pattern } from 'estree' */
 /** @import { SvelteNode } from '#compiler' */
 /** @import { Context, ServerTransformState } from '../types.js' */
-import { extract_paths } from '../../../../utils/ast.js';
 import * as b from '../../../../utils/builders.js';
+import { extract_paths } from '../../../../utils/ast.js';
 import { serialize_get_binding } from './shared/utils.js';
 
 /**
@@ -12,6 +12,7 @@ import { serialize_get_binding } from './shared/utils.js';
 export function AssignmentExpression(node, context) {
 	const parent = /** @type {Node} */ (context.path.at(-1));
 	const is_standalone = parent.type.endsWith('Statement');
+
 	return serialize_assignment(node, context, is_standalone, context.next);
 }
 
@@ -61,10 +62,6 @@ function serialize_assignment(node, context, is_standalone, fallback) {
 		}
 
 		return sequence;
-	}
-
-	if (node.left.type !== 'Identifier' && node.left.type !== 'MemberExpression') {
-		throw new Error(`Unexpected assignment type ${node.left.type}`);
 	}
 
 	let left = node.left;

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -97,7 +97,7 @@ function serialize_assignment(operator, left, right, context) {
 	}
 
 	return b.call(
-		'$.mutate_store',
+		'$.store_mutate',
 		b.assignment('??=', b.id('$$store_subs'), b.object([])),
 		b.literal(object.name),
 		b.id(name),

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
@@ -296,24 +296,26 @@ export function serialize_set_binding(node, context, fallback) {
 		return fallback();
 	}
 
-	const is_store = is_store_name(left.name);
-	const left_name = is_store ? left.name.slice(1) : left.name;
-	const binding = state.scope.get(left_name);
+	if (!is_store_name(left.name)) {
+		return fallback();
+	}
 
-	if (!binding || !is_store) {
+	const name = left.name.slice(1);
+
+	if (!state.scope.get(name)) {
 		// TODO error if it's a computed (or rest prop)? or does that already happen elsewhere?
 		return fallback();
 	}
 
 	if (left === node.left) {
-		return b.call('$.store_set', b.id(left_name), /** @type {Expression} */ (visit(node.right)));
+		return b.call('$.store_set', b.id(name), /** @type {Expression} */ (visit(node.right)));
 	}
 
 	return b.call(
 		'$.mutate_store',
 		b.assignment('??=', b.id('$$store_subs'), b.object([])),
 		b.literal(left.name),
-		b.id(left_name),
+		b.id(name),
 		b.assignment(
 			node.operator,
 			/** @type {Pattern} */ (visit(node.left)),

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
@@ -1,7 +1,7 @@
-/** @import {  AssignmentExpression, AssignmentOperator, BinaryOperator, Expression, Identifier, Node, Pattern, Statement, TemplateElement } from 'estree' */
+/** @import {  AssignmentOperator, Expression, Identifier, Node, Statement, TemplateElement } from 'estree' */
 /** @import { Attribute, Comment, ExpressionTag, SvelteNode, Text } from '#compiler' */
 /** @import { ComponentContext, ServerTransformState } from '../../types.js' */
-import { extract_paths } from '../../../../../utils/ast.js';
+
 import { escape_html } from '../../../../../../escaping.js';
 import {
 	BLOCK_CLOSE,
@@ -231,117 +231,4 @@ export function serialize_get_binding(node, state) {
 	}
 
 	return node;
-}
-
-/**
- * @param {AssignmentExpression} node
- * @param {import('zimmerframe').Context<SvelteNode, ServerTransformState>} context
- * @param {() => any} fallback
- * @returns {Expression}
- */
-export function serialize_set_binding(node, context, fallback) {
-	if (
-		node.left.type === 'ArrayPattern' ||
-		node.left.type === 'ObjectPattern' ||
-		node.left.type === 'RestElement'
-	) {
-		const value = /** @type {Expression} */ (context.visit(node.right));
-
-		const should_cache = value.type !== 'Identifier';
-		const rhs = should_cache ? b.id('$$value') : value;
-
-		/** @type {Expression[]} */
-		const assignments = [];
-		let should_transform = false;
-
-		for (const path of extract_paths(node.left)) {
-			const assignment = b.assignment('=', path.node, path.expression?.(rhs));
-			let changed = true;
-
-			assignments.push(
-				serialize_set_binding(assignment, context, () => {
-					changed = false;
-					return assignment;
-				})
-			);
-
-			should_transform ||= changed;
-		}
-
-		if (!should_transform) {
-			// No change to output -> nothing to transform -> we can keep the original assignment
-			return fallback();
-		}
-
-		if (should_cache) {
-			return b.call(b.arrow([rhs], b.sequence([...assignments, rhs])), value);
-		} else {
-			return b.call(b.thunk(b.sequence([...assignments, rhs])));
-		}
-	}
-
-	if (node.left.type !== 'Identifier' && node.left.type !== 'MemberExpression') {
-		throw new Error(`Unexpected assignment type ${node.left.type}`);
-	}
-
-	let left = node.left;
-
-	while (left.type === 'MemberExpression') {
-		// @ts-expect-error
-		left = left.object;
-	}
-
-	if (left.type !== 'Identifier' || !is_store_name(left.name)) {
-		return fallback();
-	}
-
-	const name = left.name.slice(1);
-
-	if (!context.state.scope.get(name)) {
-		// TODO error if it's a computed (or rest prop)? or does that already happen elsewhere?
-		return fallback();
-	}
-
-	if (left === node.left) {
-		return b.call('$.store_set', b.id(name), /** @type {Expression} */ (context.visit(node.right)));
-	}
-
-	return b.call(
-		'$.mutate_store',
-		b.assignment('??=', b.id('$$store_subs'), b.object([])),
-		b.literal(left.name),
-		b.id(name),
-		b.assignment(
-			node.operator,
-			/** @type {Pattern} */ (context.visit(node.left)),
-			get_assignment_value(node, context)
-		)
-	);
-}
-
-/**
- * @param {AssignmentExpression} node
- * @param {Pick<import('zimmerframe').Context<SvelteNode, ServerTransformState>, 'visit' | 'state'>} context
- */
-function get_assignment_value(node, { state, visit }) {
-	if (node.left.type === 'Identifier') {
-		const operator = node.operator;
-		return operator === '='
-			? /** @type {Expression} */ (visit(node.right))
-			: // turn something like x += 1 into x = x + 1
-				b.binary(
-					/** @type {BinaryOperator} */ (operator.slice(0, -1)),
-					serialize_get_binding(node.left, state),
-					/** @type {Expression} */ (visit(node.right))
-				);
-	}
-
-	return /** @type {Expression} */ (visit(node.right));
-}
-
-/**
- * @param {string} name
- */
-function is_store_name(name) {
-	return name[0] === '$' && /[A-Za-z_]/.test(name[1]);
 }

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -116,7 +116,7 @@ export {
 } from './reactivity/props.js';
 export {
 	invalidate_store,
-	mutate_store,
+	store_mutate,
 	setup_stores,
 	store_get,
 	store_set,

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -119,7 +119,7 @@ export function setup_stores() {
  * @param {V} new_value  the new store value
  * @template V
  */
-export function mutate_store(store, expression, new_value) {
+export function store_mutate(store, expression, new_value) {
 	store.set(new_value);
 	return expression;
 }

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -362,7 +362,7 @@ export function store_set(store, value) {
  * @param {Store<V>} store
  * @param {any} expression
  */
-export function mutate_store(store_values, store_name, store, expression) {
+export function store_mutate(store_values, store_name, store, expression) {
 	store_set(store, store_get(store_values, store_name, store));
 	return expression;
 }

--- a/packages/svelte/tests/runtime-runes/samples/store-assignments/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-assignments/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: '<p>3</p>'
+});

--- a/packages/svelte/tests/runtime-runes/samples/store-assignments/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-assignments/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	const count = writable(0);
+
+	$count += 1;
+	$count += 1;
+	$count += 1;
+</script>
+
+<p>{$count}</p>


### PR DESCRIPTION
Another thing I found during the recent refactor — the server version of `serialize_set_binding` contains some useless code. This tidies it up, colocates it with `AssignmentExpression` (the only visitor that uses it), and as a bonus improves the code generation along the lines suggested by #11921. Given this input...

```js
[$a, $b] = values;
```

...we generate this:

```diff
-(() => {
-  const tmp = values;
-
-  (
-    $.store_set(a, tmp[0]),
-    $.store_set(b, tmp[1])
-  );
-
-  return tmp;
-})();
+(
+  $.store_set(a, values[0]),
+  $.store_set(b, values[1])
+);
```

It'd be good to do the same for client-side code, and we can probably reuse some code. I didn't want to get carried away though.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
