### PR TITLE
fix: always close tags when namespace is foreign

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/RegularElement.js
@@ -95,7 +95,7 @@ export function RegularElement(node, context) {
 		);
 	}
 
-	if (!VoidElements.includes(node.name) && namespace !== 'foreign') {
+	if (!VoidElements.includes(node.name) || namespace === 'foreign') {
 		state.template.push(b.literal(`</${node.name}>`));
 	}
 

--- a/packages/svelte/tests/runtime-legacy/samples/attribute-casing-foreign-namespace/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/attribute-casing-foreign-namespace/_config.js
@@ -1,7 +1,9 @@
 import { test } from '../../test';
 
 export default test({
-	skip: true, // TODO: needs fixing
+	// TODO: needs fixing. Can only be fixed once we also support document.createElementNS-style creation of elements
+	// because the $.template('...') approach has no option to preserve attribute name casing
+	skip: true,
 
 	html: `
 		<page horizontalAlignment="center">


### PR DESCRIPTION
This was a mixup of the if block logic, we should always close tags in foreign namespace. Doesn't really help with unskipping any tests though, because we have no way of preserving attribute names using the `$.template` approach (to my knowledge) - we need the DOM creation abstraction API (`createElement` etc) for that, which will come sometime in 5.x.