### PR TITLE
feat: remove `$.unwrap` calls from each block indexes

### DIFF
--- a/.changeset/dry-hotels-matter.md
+++ b/.changeset/dry-hotels-matter.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: remove $.unwrap calls from each block indexes

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -79,6 +79,11 @@ export function serialize_get_binding(node, state) {
 		return node;
 	}
 
+	if (Object.hasOwn(state.getters, node.name)) {
+		const getter = state.getters[node.name];
+		return typeof getter === 'function' ? getter(node) : getter;
+	}
+
 	if (binding.node.name === '$$props') {
 		// Special case for $$props which only exists in the old world
 		return b.id('$$sanitized_props');
@@ -86,11 +91,6 @@ export function serialize_get_binding(node, state) {
 
 	if (binding.kind === 'store_sub') {
 		return b.call(node);
-	}
-
-	if (Object.hasOwn(state.getters, node.name)) {
-		const getter = state.getters[node.name];
-		return typeof getter === 'function' ? getter(node) : getter;
 	}
 
 	if (binding.kind === 'prop' || binding.kind === 'bindable_prop') {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2615,10 +2615,8 @@ export const template_visitors = {
 		let key_function = b.id('$.index');
 
 		if (node.key) {
-			key_function = b.arrow(
-				[node.context, index],
-				/** @type {Expression} */ (context.visit(node.key, key_state))
-			);
+			const expression = /** @type {Expression} */ (context.visit(node.key, key_state));
+			key_function = b.arrow([node.context, index], expression);
 		}
 
 		if (node.index && each_node_meta.contains_group_binding) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -2556,7 +2556,9 @@ export const template_visitors = {
 		if (node.index) {
 			child_state.getters[node.index] = (id) => {
 				const index_with_loc = with_loc(index, id);
-				return b.call('$.unwrap', index_with_loc);
+				return (flags & EACH_INDEX_REACTIVE) === 0
+					? index_with_loc
+					: b.call('$.get', index_with_loc);
 			};
 
 			key_state.getters[node.index] = b.id(node.index);


### PR DESCRIPTION
See #12511 and #12530 for more context.

At present, we unnecessarily wrap each block indexes in `unwrap`:

```svelte
{#each things as thing, i}
  <p>{i}: {thing.name}</p>
{/each}
```

```js
$.each(node, 1, () => things, $.index, ($$anchor, thing, i) => {
  var p = root_1();
  var text = $.child(p);

  $.reset(p);
  $.template_effect(() => $.set_text(text, `${$.unwrap(i) ?? ""}: ${$.unwrap(thing).name ?? ""}`));
  $.append($$anchor, p);
});
```

We know that `i` is a number, here; `$.unwrap(i)` is unnecessary. In the case of a keyed block, we can use `$.get(i)`. And in the rare case that a key function references the index, we can always just reference it (and the item) directly.

We shouldn't be using `$.unwrap` _anyway_ because [duck typing doesn't work](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAE1WOQQrCMBBFrzKMG4ViUXcxFjxH00VpJzbQpqGZChJydxutqKv578H_TEBtevIoyoC2HggFXp3DDPnhEvg79UwL-3GemmSkbybjuFBWcU8M3Bl783CBMhnFAbSAA8TsB4__eFqxOisr8--eDRuqm-4zWft3gu3r7PUuppZ0RVhFlLlbiiFPtbh8OYyt0YZaFDzNFKv4BH-wHmDgAAAA) (I guess we _could_ faff around with a private symbol, but let's not) — this PR doesn't kill it off completely but it gets us part of the way there. Will work on that in a follow-up PR.

I didn't include a snapshot test, because when we remove `unwrap` from the codebase it'll no longer be necessary.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
