### PR TITLE
chore: unified expression metadata

### DIFF
--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -135,10 +135,7 @@ function to_public_ast(source, ast, modern) {
 		// remove things that we don't want to treat as public API
 		return zimmerframe_walk(ast, null, {
 			_(node, { next }) {
-				// @ts-ignore
-				delete node.parent;
-				// @ts-ignore
-				delete node.metadata;
+				clean(node);
 				next();
 			}
 		});

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -119,6 +119,19 @@ export function parse(source, { filename, rootDir, modern } = {}) {
  */
 function to_public_ast(source, ast, modern) {
 	if (modern) {
+		const clean = (/** @type {any} */ node) => {
+			delete node.metadata;
+			delete node.parent;
+		};
+
+		ast.options?.attributes.forEach((attribute) => {
+			clean(attribute);
+			clean(attribute.value);
+			if (Array.isArray(attribute.value)) {
+				attribute.value.forEach(clean);
+			}
+		});
+
 		// remove things that we don't want to treat as public API
 		return zimmerframe_walk(ast, null, {
 			_(node, { next }) {

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -507,9 +507,10 @@ function read_attribute(parser) {
 				end: parser.index,
 				expression,
 				parent: null,
-				metadata: {
-					contains_call_expression: false,
-					dynamic: false
+				effect: {
+					is_dynamic: false,
+					has_call_expression: false,
+					bindings: new Set()
 				}
 			};
 
@@ -537,9 +538,10 @@ function read_attribute(parser) {
 					name
 				},
 				parent: null,
-				metadata: {
-					dynamic: false,
-					contains_call_expression: false
+				effect: {
+					has_call_expression: false,
+					is_dynamic: false,
+					bindings: new Set()
 				}
 			};
 

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -163,7 +163,7 @@ export default function element(parser) {
 					fragment: create_fragment(true),
 					parent: null,
 					metadata: {
-						expression: create_expression_metadata()
+						// unpopulated at first, differs between types
 					}
 				});
 

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -9,7 +9,7 @@ import { decode_character_references } from '../utils/html.js';
 import * as e from '../../../errors.js';
 import * as w from '../../../warnings.js';
 import { create_fragment } from '../utils/create.js';
-import { create_attribute } from '../../nodes.js';
+import { create_attribute, create_expression_metadata } from '../../nodes.js';
 import { get_attribute_expression, is_expression_attribute } from '../../../utils/ast.js';
 import { closing_tag_omitted } from '../../../../html-tree-validation.js';
 
@@ -127,7 +127,7 @@ export default function element(parser) {
 
 	const type = meta_tags.has(name)
 		? meta_tags.get(name)
-		: regex_capital_letter.test(name[0]) || name === 'svelte:self' || name === 'svelte:component'
+		: regex_capital_letter.test(name[0])
 			? 'Component'
 			: name === 'title' && parent_is_head(parser.stack)
 				? 'TitleElement'
@@ -140,7 +140,7 @@ export default function element(parser) {
 	const element =
 		type === 'RegularElement'
 			? {
-					type: type,
+					type,
 					start,
 					end: -1,
 					name,
@@ -163,7 +163,7 @@ export default function element(parser) {
 					fragment: create_fragment(true),
 					parent: null,
 					metadata: {
-						svg: false
+						expression: create_expression_metadata()
 					}
 				});
 
@@ -507,10 +507,8 @@ function read_attribute(parser) {
 				end: parser.index,
 				expression,
 				parent: null,
-				effect: {
-					is_dynamic: false,
-					has_call_expression: false,
-					bindings: new Set()
+				metadata: {
+					expression: create_expression_metadata()
 				}
 			};
 
@@ -538,10 +536,8 @@ function read_attribute(parser) {
 					name
 				},
 				parent: null,
-				effect: {
-					has_call_expression: false,
-					is_dynamic: false,
-					bindings: new Set()
+				metadata: {
+					expression: create_expression_metadata()
 				}
 			};
 
@@ -586,7 +582,7 @@ function read_attribute(parser) {
 				value,
 				parent: null,
 				metadata: {
-					dynamic: false
+					expression: create_expression_metadata()
 				}
 			};
 		}
@@ -618,16 +614,9 @@ function read_attribute(parser) {
 			modifiers,
 			expression,
 			metadata: {
-				dynamic: false,
-				contains_call_expression: false
+				expression: create_expression_metadata()
 			}
 		};
-
-		if (directive.type === 'ClassDirective') {
-			directive.metadata = {
-				dynamic: false
-			};
-		}
 
 		if (directive.type === 'TransitionDirective') {
 			const direction = name.slice(0, colon_index);
@@ -791,8 +780,7 @@ function read_sequence(parser, done, location) {
 				expression,
 				parent: null,
 				metadata: {
-					contains_call_expression: false,
-					dynamic: false
+					expression: create_expression_metadata()
 				}
 			};
 

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -7,6 +7,7 @@ import * as e from '../../../errors.js';
 import { create_fragment } from '../utils/create.js';
 import { walk } from 'zimmerframe';
 import { parse_expression_at } from '../acorn.js';
+import { create_expression_metadata } from '../../nodes.js';
 
 const regex_whitespace_with_closing_curly_brace = /^\s*}/;
 
@@ -39,8 +40,7 @@ export default function tag(parser) {
 		end: parser.index,
 		expression,
 		metadata: {
-			contains_call_expression: false,
-			dynamic: false
+			expression: create_expression_metadata()
 		}
 	});
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1540,7 +1540,7 @@ const common_visitors = {
 			node.name.includes('.') ? node.name.slice(0, node.name.indexOf('.')) : node.name
 		);
 
-		node.metadata.expression.has_state = binding !== null && binding.kind !== 'normal';
+		node.metadata.dynamic = binding !== null && binding.kind !== 'normal';
 	},
 	RenderTag(node, context) {
 		context.next({ ...context.state, render_tag: node });

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1264,6 +1264,14 @@ const common_visitors = {
 
 		const binding = context.state.scope.get(node.name);
 
+		if (binding && context.state.expression) {
+			context.state.expression.dependencies.add(binding);
+
+			if (binding.kind !== 'normal') {
+				context.state.expression.has_state = true;
+			}
+		}
+
 		// if no binding, means some global variable
 		if (binding && binding.kind !== 'normal') {
 			if (context.state.expression) {

--- a/packages/svelte/src/compiler/phases/2-analyze/types.d.ts
+++ b/packages/svelte/src/compiler/phases/2-analyze/types.d.ts
@@ -21,7 +21,7 @@ export interface AnalysisState {
 	has_props_rune: boolean;
 	/** Which slots the current parent component has */
 	component_slots: Set<string>;
-	/** The current {expression}, if any */
+	/** Information about the current expression/directive/block value */
 	expression: ExpressionMetadata | null;
 	/** The current {@render ...} tag, if any */
 	render_tag: null | RenderTag;

--- a/packages/svelte/src/compiler/phases/2-analyze/types.d.ts
+++ b/packages/svelte/src/compiler/phases/2-analyze/types.d.ts
@@ -2,6 +2,7 @@ import type { Scope } from '../scope.js';
 import type { ComponentAnalysis, ReactiveStatement } from '../types.js';
 import type {
 	ClassDirective,
+	ExpressionMetadata,
 	ExpressionTag,
 	OnDirective,
 	RenderTag,
@@ -21,7 +22,7 @@ export interface AnalysisState {
 	/** Which slots the current parent component has */
 	component_slots: Set<string>;
 	/** The current {expression}, if any */
-	expression: ExpressionTag | ClassDirective | OnDirective | SpreadAttribute | null;
+	expression: ExpressionMetadata | null;
 	/** The current {@render ...} tag, if any */
 	render_tag: null | RenderTag;
 	private_derived_state: string[];

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -103,13 +103,11 @@ function serialize_style_directives(style_directives, element_id, context, is_at
 			)
 		);
 
-		const has_call = get_attribute_chunks(directive.value).some(
-			(v) => v.type === 'ExpressionTag' && v.metadata.expression.has_call
-		);
+		const { has_state, has_call } = directive.metadata.expression;
 
 		if (!is_attributes_reactive && has_call) {
 			state.init.push(serialize_update(update));
-		} else if (is_attributes_reactive || directive.metadata.expression.has_state || has_call) {
+		} else if (is_attributes_reactive || has_state || has_call) {
 			state.update.push(update);
 		} else {
 			state.init.push(update);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -149,11 +149,12 @@ function serialize_class_directives(class_directives, element_id, context, is_at
 	for (const directive of class_directives) {
 		const value = /** @type {Expression} */ (context.visit(directive.expression));
 		const update = b.stmt(b.call('$.toggle_class', element_id, b.literal(directive.name), value));
-		const has_call = directive.expression.type === 'CallExpression';
+
+		const { has_state, has_call } = directive.metadata.expression;
 
 		if (!is_attributes_reactive && has_call) {
 			state.init.push(serialize_update(update));
-		} else if (is_attributes_reactive || directive.metadata.expression.has_state || has_call) {
+		} else if (is_attributes_reactive || has_state || has_call) {
 			state.update.push(update);
 		} else {
 			state.init.push(update);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -3127,7 +3127,7 @@ export const template_visitors = {
 		}
 	},
 	Component(node, context) {
-		if (node.metadata.expression.has_state) {
+		if (node.metadata.dynamic) {
 			// Handle dynamic references to what seems like static inline components
 			const component = serialize_inline_component(node, '$$component', context, b.id('$$anchor'));
 			context.state.init.push(

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/component.js
@@ -233,7 +233,8 @@ export function serialize_inline_component(node, expression, context) {
 	}
 
 	const dynamic =
-		node.type === 'SvelteComponent' || (node.type === 'Component' && node.metadata.dynamic);
+		node.type === 'SvelteComponent' ||
+		(node.type === 'Component' && node.metadata.expression.has_state);
 
 	if (custom_css_props.length > 0) {
 		context.state.template.push(

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/component.js
@@ -233,8 +233,7 @@ export function serialize_inline_component(node, expression, context) {
 	}
 
 	const dynamic =
-		node.type === 'SvelteComponent' ||
-		(node.type === 'Component' && node.metadata.expression.has_state);
+		node.type === 'SvelteComponent' || (node.type === 'Component' && node.metadata.dynamic);
 
 	if (custom_css_props.length > 0) {
 		context.state.template.push(

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
@@ -12,7 +12,11 @@ import {
 	LoadErrorElements,
 	WhitespaceInsensitiveAttributes
 } from '../../../../constants.js';
-import { create_attribute, is_custom_element_node } from '../../../../nodes.js';
+import {
+	create_attribute,
+	create_expression_metadata,
+	is_custom_element_node
+} from '../../../../nodes.js';
 import { regex_starts_with_newline } from '../../../../patterns.js';
 import * as b from '../../../../../utils/builders.js';
 import {
@@ -142,8 +146,7 @@ export function serialize_element_attributes(node, context) {
 										serialize_attribute_value(value_attribute.value, context)
 									),
 							metadata: {
-								contains_call_expression: false,
-								dynamic: false
+								expression: create_expression_metadata()
 							}
 						}
 					])
@@ -158,8 +161,7 @@ export function serialize_element_attributes(node, context) {
 							parent: attribute,
 							expression: attribute.expression,
 							metadata: {
-								contains_call_expression: false,
-								dynamic: false
+								expression: create_expression_metadata()
 							}
 						}
 					])
@@ -399,7 +401,9 @@ function serialize_class_directives(class_directives, class_attribute) {
 			),
 			b.literal(' ')
 		),
-		metadata: { contains_call_expression: false, dynamic: false }
+		metadata: {
+			expression: create_expression_metadata()
+		}
 	});
 
 	class_attribute.value = chunks;

--- a/packages/svelte/src/compiler/phases/nodes.js
+++ b/packages/svelte/src/compiler/phases/nodes.js
@@ -45,8 +45,19 @@ export function create_attribute(name, start, end, value) {
 		value,
 		parent: null,
 		metadata: {
-			dynamic: false,
+			expression: create_expression_metadata(),
 			delegated: null
 		}
+	};
+}
+
+/**
+ * @returns {Compiler.ExpressionMetadata}
+ */
+export function create_expression_metadata() {
+	return {
+		dependencies: new Set(),
+		has_state: false,
+		has_call: false
 	};
 }

--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -316,6 +316,12 @@ export interface Binding {
 	} | null;
 }
 
+export interface ExpressionMetadata {
+	dependencies: Set<Binding>;
+	has_state: boolean;
+	has_call: boolean;
+}
+
 export * from './template.js';
 export { Css };
 

--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -317,8 +317,11 @@ export interface Binding {
 }
 
 export interface ExpressionMetadata {
+	/** All the bindings that are referenced inside this expression */
 	dependencies: Set<Binding>;
+	/** True if the expression references state directly, or _might_ (via member/call expressions) */
 	has_state: boolean;
+	/** True if the expression involves a call expression (often, it will need to be wrapped in a derived) */
 	has_call: boolean;
 }
 

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -274,7 +274,7 @@ interface BaseElement extends BaseNode {
 export interface Component extends BaseElement {
 	type: 'Component';
 	metadata: {
-		expression: ExpressionMetadata;
+		dynamic: boolean;
 	};
 }
 

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -1,4 +1,4 @@
-import type { Binding, Css, EffectMetadata } from '#compiler';
+import type { Binding, Css, ExpressionMetadata } from '#compiler';
 import type {
 	ArrayExpression,
 	ArrowFunctionExpression,
@@ -110,7 +110,9 @@ export interface Text extends BaseNode {
 export interface ExpressionTag extends BaseNode {
 	type: 'ExpressionTag';
 	expression: Expression;
-	effect: EffectMetadata;
+	metadata: {
+		expression: ExpressionMetadata;
+	};
 }
 
 /** A (possibly reactive) HTML template expression — `{@html ...}` */
@@ -183,7 +185,7 @@ export interface ClassDirective extends BaseNode {
 	/** The 'y' in `class:x={y}`, or the `x` in `class:x` */
 	expression: Expression;
 	metadata: {
-		dynamic: false;
+		expression: ExpressionMetadata;
 	};
 }
 
@@ -205,8 +207,7 @@ export interface OnDirective extends BaseNode {
 	expression: null | Expression;
 	modifiers: string[]; // TODO specify
 	metadata: {
-		contains_call_expression: boolean;
-		dynamic: boolean;
+		expression: ExpressionMetadata;
 	};
 }
 
@@ -226,7 +227,7 @@ export interface StyleDirective extends BaseNode {
 	value: true | ExpressionTag | Array<ExpressionTag | Text>;
 	modifiers: Array<'important'>;
 	metadata: {
-		dynamic: boolean;
+		expression: ExpressionMetadata;
 	};
 }
 
@@ -273,7 +274,7 @@ interface BaseElement extends BaseNode {
 export interface Component extends BaseElement {
 	type: 'Component';
 	metadata: {
-		dynamic: boolean;
+		expression: ExpressionMetadata;
 	};
 }
 
@@ -447,7 +448,7 @@ export interface Attribute extends BaseNode {
 	name: string;
 	value: true | ExpressionTag | Array<Text | ExpressionTag>;
 	metadata: {
-		dynamic: boolean;
+		expression: ExpressionMetadata;
 		/** May be set if this is an event attribute */
 		delegated: null | DelegatedEvent;
 	};
@@ -456,7 +457,9 @@ export interface Attribute extends BaseNode {
 export interface SpreadAttribute extends BaseNode {
 	type: 'SpreadAttribute';
 	expression: Expression;
-	effect: EffectMetadata;
+	metadata: {
+		expression: ExpressionMetadata;
+	};
 }
 
 export type TemplateNode =

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -1,4 +1,4 @@
-import type { Binding, Css } from '#compiler';
+import type { Binding, Css, EffectMetadata } from '#compiler';
 import type {
 	ArrayExpression,
 	ArrowFunctionExpression,
@@ -110,14 +110,7 @@ export interface Text extends BaseNode {
 export interface ExpressionTag extends BaseNode {
 	type: 'ExpressionTag';
 	expression: Expression;
-	metadata: {
-		contains_call_expression: boolean;
-		/**
-		 * Whether or not the expression contains any dynamic references —
-		 * determines whether it will be updated in a render effect or not
-		 */
-		dynamic: boolean;
-	};
+	effect: EffectMetadata;
 }
 
 /** A (possibly reactive) HTML template expression — `{@html ...}` */
@@ -463,10 +456,7 @@ export interface Attribute extends BaseNode {
 export interface SpreadAttribute extends BaseNode {
 	type: 'SpreadAttribute';
 	expression: Expression;
-	metadata: {
-		contains_call_expression: boolean;
-		dynamic: boolean;
-	};
+	effect: EffectMetadata;
 }
 
 export type TemplateNode =

--- a/packages/svelte/tests/parser-modern/samples/options/output.json
+++ b/packages/svelte/tests/parser-modern/samples/options/output.json
@@ -45,7 +45,11 @@
 				],
 				"parent": null,
 				"metadata": {
-					"dynamic": false,
+					"expression": {
+						"dependencies": {},
+						"has_state": false,
+						"has_call": false
+					},
 					"delegated": null
 				}
 			},
@@ -77,13 +81,20 @@
 					},
 					"parent": null,
 					"metadata": {
-						"contains_call_expression": false,
-						"dynamic": false
+						"expression": {
+							"dependencies": {},
+							"has_state": false,
+							"has_call": false
+						}
 					}
 				},
 				"parent": null,
 				"metadata": {
-					"dynamic": false,
+					"expression": {
+						"dependencies": {},
+						"has_state": false,
+						"has_call": false
+					},
 					"delegated": null
 				}
 			}

--- a/packages/svelte/tests/parser-modern/samples/options/output.json
+++ b/packages/svelte/tests/parser-modern/samples/options/output.json
@@ -39,19 +39,9 @@
 						"end": 48,
 						"type": "Text",
 						"raw": "my-custom-element",
-						"data": "my-custom-element",
-						"parent": null
+						"data": "my-custom-element"
 					}
-				],
-				"parent": null,
-				"metadata": {
-					"expression": {
-						"dependencies": {},
-						"has_state": false,
-						"has_call": false
-					},
-					"delegated": null
-				}
+				]
 			},
 			{
 				"type": "Attribute",
@@ -78,24 +68,7 @@
 						},
 						"value": true,
 						"raw": "true"
-					},
-					"parent": null,
-					"metadata": {
-						"expression": {
-							"dependencies": {},
-							"has_state": false,
-							"has_call": false
-						}
 					}
-				},
-				"parent": null,
-				"metadata": {
-					"expression": {
-						"dependencies": {},
-						"has_state": false,
-						"has_call": false
-					},
-					"delegated": null
 				}
 			}
 		],

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -965,6 +965,15 @@ declare module 'svelte/compiler' {
 			inside_rest?: boolean;
 		} | null;
 	}
+
+	interface ExpressionMetadata {
+		/** All the bindings that are referenced inside this expression */
+		dependencies: Set<Binding>;
+		/** True if the expression references state directly, or _might_ (via member/call expressions) */
+		has_state: boolean;
+		/** True if the expression involves a call expression (often, it will need to be wrapped in a derived) */
+		has_call: boolean;
+	}
 	/**
 	 * The preprocess function provides convenient hooks for arbitrarily transforming component source code.
 	 * For example, it can be used to convert a <style lang="sass"> block into vanilla CSS.
@@ -1563,12 +1572,7 @@ declare module 'svelte/compiler' {
 		type: 'ExpressionTag';
 		expression: Expression;
 		metadata: {
-			contains_call_expression: boolean;
-			/**
-			 * Whether or not the expression contains any dynamic references —
-			 * determines whether it will be updated in a render effect or not
-			 */
-			dynamic: boolean;
+			expression: ExpressionMetadata;
 		};
 	}
 
@@ -1642,7 +1646,7 @@ declare module 'svelte/compiler' {
 		/** The 'y' in `class:x={y}`, or the `x` in `class:x` */
 		expression: Expression;
 		metadata: {
-			dynamic: false;
+			expression: ExpressionMetadata;
 		};
 	}
 
@@ -1664,8 +1668,7 @@ declare module 'svelte/compiler' {
 		expression: null | Expression;
 		modifiers: string[]; // TODO specify
 		metadata: {
-			contains_call_expression: boolean;
-			dynamic: boolean;
+			expression: ExpressionMetadata;
 		};
 	}
 
@@ -1685,7 +1688,7 @@ declare module 'svelte/compiler' {
 		value: true | ExpressionTag | Array<ExpressionTag | Text>;
 		modifiers: Array<'important'>;
 		metadata: {
-			dynamic: boolean;
+			expression: ExpressionMetadata;
 		};
 	}
 
@@ -1906,7 +1909,7 @@ declare module 'svelte/compiler' {
 		name: string;
 		value: true | ExpressionTag | Array<Text | ExpressionTag>;
 		metadata: {
-			dynamic: boolean;
+			expression: ExpressionMetadata;
 			/** May be set if this is an event attribute */
 			delegated: null | DelegatedEvent;
 		};
@@ -1916,8 +1919,7 @@ declare module 'svelte/compiler' {
 		type: 'SpreadAttribute';
 		expression: Expression;
 		metadata: {
-			contains_call_expression: boolean;
-			dynamic: boolean;
+			expression: ExpressionMetadata;
 		};
 	}
 


### PR DESCRIPTION
Another step towards the more comprehensive compile-time analysis of each block dependencies that will unblock #12511.

Currently, various nodes need to know whether the expressions they contain are dynamic (i.e. reference state, or _could_ reference state) and/or contain call expressions (which may mean they need to be wrapped in a derived, or a separate effect or whatever). This happens in a slightly ad hoc and messy fashion.

This PR neatens it up, and also adds a `dependencies` set to each expression metadata object, which should soon enable more detailed analysis. The goal is to be able to optimise cases like this...

```svelte
{#each [1, 2, 3] as n}...{/each}
```

...where it's frivolous to wrap the array members in signals.

There is a blocker to doing that currently: we would need to call `context.visit(node.expression, ...)` inside the `EachBlock` visitor. That's not possible, because the analysis-phase visitor merging prevents us from calling `context.visit`. I've been pissed off at this for a long time, and this is the straw that broke the camel's back — it's time to overhaul the analysis phase and have a single visitor per node type. Going to work on that as soon as this is merged.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
