### PR TITLE
fix: remove passive from OnDirective events

### DIFF
--- a/.changeset/modern-peaches-cheer.md
+++ b/.changeset/modern-peaches-cheer.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: remove passive from OnDirective events
+fix: remove implicit passive behavior from OnDirective events

--- a/.changeset/modern-peaches-cheer.md
+++ b/.changeset/modern-peaches-cheer.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove passive from OnDirective events

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/template.js
@@ -1298,7 +1298,11 @@ function serialize_event(node, metadata, context) {
 			args.push(b.literal(true));
 		} else if (node.modifiers.includes('nonpassive')) {
 			args.push(b.literal(false));
-		} else if (PassiveEvents.includes(node.name)) {
+		} else if (
+			PassiveEvents.includes(node.name) &&
+			/** @type {OnDirective} */ (node).type !== 'OnDirective'
+		) {
+			// For on:something events we don't apply passive behaviour to match Svelte 4.
 			args.push(b.literal(true));
 		}
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12639. For `OnDirective` we shouldn't apply `passive` as this is a breaking change from Svelte 4.