### PR TITLE
feat: warn on obvious legacy component instantiation

### DIFF
--- a/packages/svelte/messages/compile-warnings/script.md
+++ b/packages/svelte/messages/compile-warnings/script.md
@@ -6,6 +6,10 @@
 
 > Component has unused export property '%name%'. If it is for external reference only, please consider using `export const %name%`
 
+## legacy_component_creation
+
+> Svelte 5 components are no longer classes. Instantiate them using `mount` or `hydrate` (imported from 'svelte') instead.
+
 ## non_reactive_update
 
 > `%name%` is updated, but is not declared with `$state(...)`. Changing its value will not correctly trigger updates

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -363,17 +363,24 @@ function validate_block_not_empty(node, context) {
  */
 const validation = {
 	ExpressionStatement(node, { state }) {
-		if (node.expression.type === 'NewExpression' && node.expression.callee.type === 'Identifier') {
+		if (
+			node.expression.type === 'NewExpression' &&
+			node.expression.callee.type === 'Identifier' &&
+			node.expression.arguments.length === 1
+		) {
 			const binding = state.scope.get(node.expression.callee.name);
-			if (
-				binding?.kind === 'normal' &&
-				binding.declaration_kind === 'import' &&
+			if (binding?.kind === 'normal' && binding.declaration_kind === 'import') {
+				const declaration = /** @type {ImportDeclaration} */ (binding.initial);
+
 				// Theoretically someone could import a class from a `.svelte.js` module, but that's too rare to worry about
-				/** @type {string} */ (
-					/** @type {ImportDeclaration} */ (binding.initial).source.value
-				)?.endsWith('.svelte')
-			) {
-				w.legacy_component_creation(node.expression);
+				if (
+					/** @type {string} */ (declaration.source.value)?.endsWith('.svelte') &&
+					declaration.specifiers.find(
+						(s) => s.local.name === binding.node.name && s.type === 'ImportDefaultSpecifier'
+					)
+				) {
+					w.legacy_component_creation(node.expression);
+				}
 			}
 		}
 	},

--- a/packages/svelte/src/compiler/phases/2-analyze/validation.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/validation.js
@@ -366,7 +366,11 @@ const validation = {
 		if (
 			node.expression.type === 'NewExpression' &&
 			node.expression.callee.type === 'Identifier' &&
-			node.expression.arguments.length === 1
+			node.expression.arguments.length === 1 &&
+			node.expression.arguments[0].type === 'ObjectExpression' &&
+			node.expression.arguments[0].properties.some(
+				(p) => p.type === 'Property' && p.key.type === 'Identifier' && p.key.name === 'target'
+			)
 		) {
 			const binding = state.scope.get(node.expression.callee.name);
 			if (binding?.kind === 'normal' && binding.declaration_kind === 'import') {

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -96,6 +96,7 @@ export const codes = [
 	"options_renamed_ssr_dom",
 	"derived_iife",
 	"export_let_unused",
+	"legacy_component_creation",
 	"non_reactive_update",
 	"perf_avoid_inline_class",
 	"perf_avoid_nested_class",
@@ -584,6 +585,14 @@ export function derived_iife(node) {
  */
 export function export_let_unused(node, name) {
 	w(node, "export_let_unused", `Component has unused export property '${name}'. If it is for external reference only, please consider using \`export const ${name}\``);
+}
+
+/**
+ * Svelte 5 components are no longer classes. Instantiate them using `mount` or `hydrate` (imported from 'svelte') instead.
+ * @param {null | NodeLike} node
+ */
+export function legacy_component_creation(node) {
+	w(node, "legacy_component_creation", "Svelte 5 components are no longer classes. Instantiate them using `mount` or `hydrate` (imported from 'svelte') instead.");
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte
+++ b/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte
@@ -1,10 +1,11 @@
 <script>
-	import Foo from './Somewhere.svelte';
-	import Bar from './somewhereelse';
+	import Foo, { Bar } from './Somewhere.svelte';
+	import Baz from './somewhereelse';
 
-	let Baz;
+	let Buzz;
 
-	new Foo();
+	new Foo({});
 	new Bar();
 	new Baz();
+	new Buzz();
 </script>

--- a/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte
+++ b/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte
@@ -4,7 +4,9 @@
 
 	let Buzz;
 
-	new Foo({});
+	new Foo({ target: null });
+	new Foo({}); // also a false negative to be really sure we don't get false positives
+	new Foo();
 	new Bar();
 	new Baz();
 	new Buzz();

--- a/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte
+++ b/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Foo from './Somewhere.svelte';
+	import Bar from './somewhereelse';
+
+	let Baz;
+
+	new Foo();
+	new Bar();
+	new Baz();
+</script>

--- a/packages/svelte/tests/validator/samples/component-legacy-instantiation/warnings.json
+++ b/packages/svelte/tests/validator/samples/component-legacy-instantiation/warnings.json
@@ -2,7 +2,7 @@
 	{
 		"code": "legacy_component_creation",
 		"end": {
-			"column": 10,
+			"column": 12,
 			"line": 7
 		},
 		"message": "Svelte 5 components are no longer classes. Instantiate them using `mount` or `hydrate` (imported from 'svelte') instead.",

--- a/packages/svelte/tests/validator/samples/component-legacy-instantiation/warnings.json
+++ b/packages/svelte/tests/validator/samples/component-legacy-instantiation/warnings.json
@@ -1,13 +1,13 @@
 [
 	{
 		"code": "legacy_component_creation",
-		"end": {
-			"column": 12,
-			"line": 7
-		},
 		"message": "Svelte 5 components are no longer classes. Instantiate them using `mount` or `hydrate` (imported from 'svelte') instead.",
 		"start": {
 			"column": 1,
+			"line": 7
+		},
+		"end": {
+			"column": 26,
 			"line": 7
 		}
 	}

--- a/packages/svelte/tests/validator/samples/component-legacy-instantiation/warnings.json
+++ b/packages/svelte/tests/validator/samples/component-legacy-instantiation/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "legacy_component_creation",
+		"end": {
+			"column": 10,
+			"line": 7
+		},
+		"message": "Svelte 5 components are no longer classes. Instantiate them using `mount` or `hydrate` (imported from 'svelte') instead.",
+		"start": {
+			"column": 1,
+			"line": 7
+		}
+	}
+]


### PR DESCRIPTION
Adds a compiler warning that warns about legacy component instantiation (i.e. using `new Component(..)`). This won't catch all cases, but the most obvious ones which probably make up ~80%

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
