### PR TITLE
fix: always set draggable through `setAttribute` to avoid weird behavior

### DIFF
--- a/.changeset/wild-poems-design.md
+++ b/.changeset/wild-poems-design.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: always set draggable through `setAttribute` to avoid weird behavior

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -341,9 +341,10 @@ export function set_dynamic_element_attributes(node, prev, next, css_hash) {
  * because updating them through the property setter doesn't work reliably.
  * In the example of `width`/`height`, the problem is that the setter only
  * accepts numeric values, but the attribute can also be set to a string like `50%`.
- * If this list becomes too big, rethink this approach.
+ * If this list becomes too big, rethink this approach. In case of draggable trying to
+ * set `element.draggable='false'` will actually set draggable to `true`
  */
-var always_set_through_set_attribute = ['width', 'height'];
+var always_set_through_set_attribute = ['width', 'height', 'draggable'];
 
 /** @type {Map<string, string[]>} */
 var setters_cache = new Map();

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -341,8 +341,8 @@ export function set_dynamic_element_attributes(node, prev, next, css_hash) {
  * because updating them through the property setter doesn't work reliably.
  * In the example of `width`/`height`, the problem is that the setter only
  * accepts numeric values, but the attribute can also be set to a string like `50%`.
- * If this list becomes too big, rethink this approach. In case of draggable trying to
- * set `element.draggable='false'` will actually set draggable to `true`
+ * In case of draggable trying to set `element.draggable='false'` will actually set
+ * draggable to `true`. If this list becomes too big, rethink this approach.
  */
 var always_set_through_set_attribute = ['width', 'height', 'draggable'];
 

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/_config.js
@@ -1,0 +1,13 @@
+import { ok, test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	html: `<div draggable="false"></div>`,
+
+	async test({ assert, target, logs }) {
+		const div = target.querySelector('div');
+		ok(div);
+
+		assert.deepEqual(div.getAttribute('draggable'), 'false');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/_config.js
@@ -2,12 +2,15 @@ import { ok, test } from '../../test';
 import { flushSync } from 'svelte';
 
 export default test({
-	html: `<div draggable="false"></div>`,
+	html: `<div draggable="false"></div><div draggable="false"></div>`,
 
 	async test({ assert, target, logs }) {
-		const div = target.querySelector('div');
+		const [div, div2] = target.querySelectorAll('div');
 		ok(div);
 
 		assert.deepEqual(div.getAttribute('draggable'), 'false');
+		assert.deepEqual(div.draggable, false);
+		assert.deepEqual(div2.getAttribute('draggable'), 'false');
+		assert.deepEqual(div2.draggable, false);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/_config.js
@@ -7,6 +7,7 @@ export default test({
 	async test({ assert, target, logs }) {
 		const [div, div2] = target.querySelectorAll('div');
 		ok(div);
+		ok(div2);
 
 		assert.deepEqual(div.getAttribute('draggable'), 'false');
 		assert.deepEqual(div.draggable, false);

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/main.svelte
@@ -1,1 +1,7 @@
+<script>
+	let attrs = $state({ draggable: 'false' });
+</script>
+
 <svelte:element this={'div'} draggable="false"></svelte:element>
+
+<div {...attrs}></div>

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-draggable/main.svelte
@@ -1,0 +1,1 @@
+<svelte:element this={'div'} draggable="false"></svelte:element>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #12643

Very weird behaviour from the draggable setter...if you set `element.draggable="false"` it will actually set draggable to `true` (the boolean).

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
