### PR TITLE
chore: perf tweaks for actions/styles/classes

### DIFF
--- a/.changeset/sharp-fishes-serve.md
+++ b/.changeset/sharp-fishes-serve.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: perf tweaks for actions/styles/classes

--- a/packages/svelte/src/internal/client/dom/elements/actions.js
+++ b/packages/svelte/src/internal/client/dom/elements/actions.js
@@ -1,5 +1,6 @@
 /** @import { ActionPayload } from '#client' */
 import { effect, render_effect } from '../../reactivity/effects.js';
+import { safe_not_equal } from '../../reactivity/equality.js';
 import { deep_read_state, untrack } from '../../runtime.js';
 
 /**
@@ -15,6 +16,8 @@ export function action(dom, action, get_value) {
 
 		if (get_value && payload?.update) {
 			var inited = false;
+			/** @type {P} */
+			var prev = /** @type {any} */ ({}); // initialize with something so it's never equal on first run
 
 			render_effect(() => {
 				var value = get_value();
@@ -24,7 +27,8 @@ export function action(dom, action, get_value) {
 				// together with actions and mutation, it wouldn't notice the change without a deep read.
 				deep_read_state(value);
 
-				if (inited) {
+				if (inited && safe_not_equal(prev, value)) {
+					prev = value;
 					/** @type {Function} */ (payload.update)(value);
 				}
 			});

--- a/packages/svelte/src/internal/client/dom/elements/class.js
+++ b/packages/svelte/src/internal/client/dom/elements/class.js
@@ -107,8 +107,10 @@ function to_class(value) {
  */
 export function toggle_class(dom, class_name, value) {
 	if (value) {
+		if (dom.classList.contains(class_name)) return;
 		dom.classList.add(class_name);
 	} else {
+		if (!dom.classList.contains(class_name)) return;
 		dom.classList.remove(class_name);
 	}
 }

--- a/packages/svelte/src/internal/client/dom/elements/style.js
+++ b/packages/svelte/src/internal/client/dom/elements/style.js
@@ -3,15 +3,23 @@
  * @param {string} key
  * @param {string} value
  * @param {boolean} [important]
+ * @param {boolean} [force_check] Should be `true` if we can't rely on our cached value, because for example there's also a `style` attribute
  */
-export function set_style(dom, key, value, important) {
-	const style = dom.style;
-	const prev_value = style.getPropertyValue(key);
+export function set_style(dom, key, value, important, force_check) {
+	// @ts-expect-error
+	var attributes = (dom.__attributes ??= {});
+	var style = dom.style;
+	var style_key = 'style-' + key;
+
+	if (attributes[style_key] === value && (!force_check || style.getPropertyValue(key) === value)) {
+		return;
+	}
+
+	attributes[style_key] = value;
+
 	if (value == null) {
-		if (prev_value !== '') {
-			style.removeProperty(key);
-		}
-	} else if (prev_value !== value) {
+		style.removeProperty(key);
+	} else {
 		style.setProperty(key, value, important ? 'important' : '');
 	}
 }


### PR DESCRIPTION
- check if we really need to add/remove the class (calling `includes` first is cheaper than always setting/removing it)
- check if we really need to update a style (calling `getPropertyValue/setProperty` is expensive)
- check if we should call the action's update function (this is not only a perf tweak but also a correctness fix)

closes #12652

@peterkogo could you check if these tweaks increase perf for you? From a quick local test it did for me

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
