### PR TITLE
chore: rename derived_call to derived_by

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -74,7 +74,7 @@ export interface ComponentClientTransformState extends ClientTransformState {
 }
 
 export interface StateField {
-	kind: 'state' | 'frozen_state' | 'derived' | 'derived_call';
+	kind: 'state' | 'frozen_state' | 'derived' | 'derived_by';
 	id: PrivateIdentifier;
 }
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/ClassBody.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/ClassBody.js
@@ -56,7 +56,7 @@ export function ClassBody(node, context) {
 								: rune === '$state.frozen'
 									? 'frozen_state'
 									: rune === '$derived.by'
-										? 'derived_call'
+										? 'derived_by'
 										: 'derived',
 						// @ts-expect-error this is set in the next pass
 						id: is_private ? definition.key : null
@@ -123,7 +123,7 @@ export function ClassBody(node, context) {
 											? b.call('$.freeze', init)
 											: init
 									)
-								: field.kind === 'derived_call'
+								: field.kind === 'derived_by'
 									? b.call('$.derived', init)
 									: b.call('$.derived', b.thunk(init));
 				} else {
@@ -167,7 +167,7 @@ export function ClassBody(node, context) {
 						);
 					}
 
-					if (dev && (field.kind === 'derived' || field.kind === 'derived_call')) {
+					if (dev && (field.kind === 'derived' || field.kind === 'derived_by')) {
 						body.push(
 							b.method(
 								'set',

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/ClassBody.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/ClassBody.js
@@ -39,7 +39,7 @@ export function ClassBody(node, context) {
 				if (rune === '$derived' || rune === '$derived.by') {
 					/** @type {StateField} */
 					const field = {
-						kind: rune === '$derived.by' ? 'derived_call' : 'derived',
+						kind: rune === '$derived.by' ? 'derived_by' : 'derived',
 						// @ts-expect-error this is set in the next pass
 						id: is_private ? definition.key : null
 					};
@@ -86,7 +86,7 @@ export function ClassBody(node, context) {
 					context.visit(definition.value.arguments[0], child_state)
 				);
 				const value =
-					field.kind === 'derived_call' ? b.call('$.once', init) : b.call('$.once', b.thunk(init));
+					field.kind === 'derived_by' ? b.call('$.once', init) : b.call('$.once', b.thunk(init));
 
 				if (is_private) {
 					body.push(b.prop_def(field.id, value));
@@ -98,7 +98,7 @@ export function ClassBody(node, context) {
 					// get foo() { return this.#foo; }
 					body.push(b.method('get', definition.key, [], [b.return(b.call(member))]));
 
-					if (dev && (field.kind === 'derived' || field.kind === 'derived_call')) {
+					if (dev && (field.kind === 'derived' || field.kind === 'derived_by')) {
 						body.push(
 							b.method(
 								'set',


### PR DESCRIPTION
missed this when `$derived.call` became `$derived.by`