### PR TITLE
feat: function called as tagged template literal is reactively called

### DIFF
--- a/.changeset/serious-owls-think.md
+++ b/.changeset/serious-owls-think.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: function called as tagged template literal is reactively called

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -23,6 +23,7 @@ import { Attribute } from './visitors/Attribute.js';
 import { AwaitBlock } from './visitors/AwaitBlock.js';
 import { BindDirective } from './visitors/BindDirective.js';
 import { CallExpression } from './visitors/CallExpression.js';
+import { TaggedTemplateExpression } from './visitors/TaggedTemplateExpression.js';
 import { ClassBody } from './visitors/ClassBody.js';
 import { ClassDeclaration } from './visitors/ClassDeclaration.js';
 import { ClassDirective } from './visitors/ClassDirective.js';
@@ -164,7 +165,8 @@ const visitors = {
 	Text,
 	TitleElement,
 	UpdateExpression,
-	VariableDeclarator
+	VariableDeclarator,
+	TaggedTemplateExpression
 };
 
 /**

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -23,7 +23,6 @@ import { Attribute } from './visitors/Attribute.js';
 import { AwaitBlock } from './visitors/AwaitBlock.js';
 import { BindDirective } from './visitors/BindDirective.js';
 import { CallExpression } from './visitors/CallExpression.js';
-import { TaggedTemplateExpression } from './visitors/TaggedTemplateExpression.js';
 import { ClassBody } from './visitors/ClassBody.js';
 import { ClassDeclaration } from './visitors/ClassDeclaration.js';
 import { ClassDirective } from './visitors/ClassDirective.js';
@@ -59,6 +58,7 @@ import { SvelteElement } from './visitors/SvelteElement.js';
 import { SvelteFragment } from './visitors/SvelteFragment.js';
 import { SvelteHead } from './visitors/SvelteHead.js';
 import { SvelteSelf } from './visitors/SvelteSelf.js';
+import { TaggedTemplateExpression } from './visitors/TaggedTemplateExpression.js';
 import { Text } from './visitors/Text.js';
 import { TitleElement } from './visitors/TitleElement.js';
 import { UpdateExpression } from './visitors/UpdateExpression.js';
@@ -162,11 +162,11 @@ const visitors = {
 	SvelteFragment,
 	SvelteComponent,
 	SvelteSelf,
+	TaggedTemplateExpression,
 	Text,
 	TitleElement,
 	UpdateExpression,
-	VariableDeclarator,
-	TaggedTemplateExpression
+	VariableDeclarator
 };
 
 /**

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -150,7 +150,7 @@ export function CallExpression(node, context) {
 			break;
 	}
 
-	if (context.state.expression && !is_known_safe_call(node, context)) {
+	if (context.state.expression && !is_known_safe_call(node.callee, context)) {
 		context.state.expression.has_call = true;
 		context.state.expression.has_state = true;
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -4,7 +4,7 @@
 import { get_rune } from '../../scope.js';
 import * as e from '../../../errors.js';
 import { get_parent, unwrap_optional } from '../../../utils/ast.js';
-import { is_safe_identifier } from './shared/utils.js';
+import { is_known_safe_call, is_safe_identifier } from './shared/utils.js';
 
 /**
  * @param {CallExpression} node
@@ -181,29 +181,4 @@ export function CallExpression(node, context) {
 	} else {
 		context.next();
 	}
-}
-
-/**
- * @param {CallExpression} node
- * @param {Context} context
- * @returns {boolean}
- */
-function is_known_safe_call(node, context) {
-	const callee = node.callee;
-
-	// String / Number / BigInt / Boolean casting calls
-	if (callee.type === 'Identifier') {
-		const name = callee.name;
-		const binding = context.state.scope.get(name);
-		if (
-			binding === null &&
-			(name === 'BigInt' || name === 'String' || name === 'Number' || name === 'Boolean')
-		) {
-			return true;
-		}
-	}
-
-	// TODO add more cases
-
-	return false;
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/TaggedTemplateExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/TaggedTemplateExpression.js
@@ -7,7 +7,7 @@ import { is_known_safe_call } from './shared/utils.js';
  * @param {Context} context
  */
 export function TaggedTemplateExpression(node, context) {
-	if (context.state.expression && !is_known_safe_call(node, context)) {
+	if (context.state.expression && !is_known_safe_call(node.tag, context)) {
 		context.state.expression.has_call = true;
 		context.state.expression.has_state = true;
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/TaggedTemplateExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/TaggedTemplateExpression.js
@@ -1,0 +1,23 @@
+/** @import { TaggedTemplateExpression, VariableDeclarator } from 'estree' */
+/** @import { Context } from '../types' */
+import { is_known_safe_call } from './shared/utils.js';
+
+/**
+ * @param {TaggedTemplateExpression} node
+ * @param {Context} context
+ */
+export function TaggedTemplateExpression(node, context) {
+	if (context.state.expression && !is_known_safe_call(node, context)) {
+		context.state.expression.has_call = true;
+		context.state.expression.has_state = true;
+	}
+
+	if (node.tag.type === 'Identifier') {
+		const binding = context.state.scope.get(node.tag.name);
+
+		if (binding !== null) {
+			binding.is_called = true;
+		}
+	}
+	context.next();
+}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
@@ -1,4 +1,4 @@
-/** @import { AssignmentExpression, Expression, Pattern, PrivateIdentifier, Super, UpdateExpression, VariableDeclarator } from 'estree' */
+/** @import { AssignmentExpression, CallExpression, Expression, Pattern, PrivateIdentifier, Super, TaggedTemplateExpression, UpdateExpression, VariableDeclarator } from 'estree' */
 /** @import { Fragment } from '#compiler' */
 /** @import { AnalysisState, Context } from '../../types' */
 /** @import { Scope } from '../../../scope' */
@@ -164,4 +164,29 @@ export function is_safe_identifier(expression, scope) {
 		binding.kind !== 'bindable_prop' &&
 		binding.kind !== 'rest_prop'
 	);
+}
+
+/**
+ * @param {TaggedTemplateExpression | CallExpression} node
+ * @param {Context} context
+ * @returns {boolean}
+ */
+export function is_known_safe_call(node, context) {
+	const callee = node.type === 'TaggedTemplateExpression' ? node.tag : node.callee;
+
+	// String / Number / BigInt / Boolean casting calls
+	if (callee.type === 'Identifier') {
+		const name = callee.name;
+		const binding = context.state.scope.get(name);
+		if (
+			binding === null &&
+			(name === 'BigInt' || name === 'String' || name === 'Number' || name === 'Boolean')
+		) {
+			return true;
+		}
+	}
+
+	// TODO add more cases
+
+	return false;
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
@@ -167,13 +167,11 @@ export function is_safe_identifier(expression, scope) {
 }
 
 /**
- * @param {TaggedTemplateExpression | CallExpression} node
+ * @param {Expression | Super} callee
  * @param {Context} context
  * @returns {boolean}
  */
-export function is_known_safe_call(node, context) {
-	const callee = node.type === 'TaggedTemplateExpression' ? node.tag : node.callee;
-
+export function is_known_safe_call(callee, context) {
 	// String / Number / BigInt / Boolean casting calls
 	if (callee.type === 'Identifier') {
 		const name = callee.name;

--- a/packages/svelte/tests/runtime-runes/samples/tagged-template-literal-reactive/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/tagged-template-literal-reactive/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, target, ok }) {
+		const button = target.querySelector('button');
+
+		assert.htmlEqual(target.innerHTML, `0 <button></button>`);
+
+		flushSync(() => {
+			button?.click();
+		});
+
+		assert.htmlEqual(target.innerHTML, `1 <button></button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/tagged-template-literal-reactive/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/tagged-template-literal-reactive/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	let count = $state(0);
+	function showCount() {
+		return count;
+	}
+</script>
+
+{showCount``} <button onclick={() => count++}></button>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #12687

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
