### PR TITLE
chore: rename serialize_ prefix to build_

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -5,7 +5,7 @@
 import { walk } from 'zimmerframe';
 import * as b from '../../../utils/builders.js';
 import { set_scope } from '../../scope.js';
-import { serialize_get_binding } from './utils.js';
+import { build_getter } from './utils.js';
 import { render_stylesheet } from '../css/index.js';
 import { dev, filename } from '../../../state.js';
 import { AnimateDirective } from './visitors/AnimateDirective.js';
@@ -198,7 +198,7 @@ export function client_component(analysis, options) {
 			}
 
 			// We're creating an arrow function that gets the store value which minifies better for two or more references
-			const store_reference = serialize_get_binding(b.id(name.slice(1)), instance_state);
+			const store_reference = build_getter(b.id(name.slice(1)), instance_state);
 			const store_get = b.call('$.store_get', store_reference, b.literal(name), b.id('$$stores'));
 			store_setup.push(
 				b.const(
@@ -240,7 +240,7 @@ export function client_component(analysis, options) {
 	/** @type {Array<ESTree.Property | ESTree.SpreadElement>} */
 	const component_returned_object = analysis.exports.flatMap(({ name, alias }) => {
 		const binding = instance_state.scope.get(name);
-		const expression = serialize_get_binding(b.id(name), instance_state);
+		const expression = build_getter(b.id(name), instance_state);
 		const getter = b.get(alias ?? name, [b.return(expression)]);
 
 		if (expression.type === 'Identifier') {
@@ -365,7 +365,7 @@ export function client_component(analysis, options) {
 						'$.bind_prop',
 						b.id('$$props'),
 						b.literal(alias ?? name),
-						serialize_get_binding(b.id(name), instance_state)
+						build_getter(b.id(name), instance_state)
 					)
 				)
 			);

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -32,7 +32,7 @@ export function get_assignment_value(node, { state, visit }) {
 			: // turn something like x += 1 into x = x + 1
 				b.binary(
 					/** @type {BinaryOperator} */ (operator.slice(0, -1)),
-					serialize_get_binding(node.left, state),
+					build_getter(node.left, state),
 					/** @type {Expression} */ (visit(node.right))
 				);
 	} else if (
@@ -72,7 +72,7 @@ export function is_state_source(binding, state) {
  * @param {ClientTransformState} state
  * @returns {Expression}
  */
-export function serialize_get_binding(node, state) {
+export function build_getter(node, state) {
 	const binding = state.scope.get(node.name);
 
 	if (binding === null || node === binding.node) {
@@ -130,7 +130,7 @@ export function serialize_get_binding(node, state) {
  * @param {{skip_proxy_and_freeze?: boolean}} [options]
  * @returns {Expression}
  */
-export function serialize_set_binding(node, context, fallback, prefix, options) {
+export function build_setter(node, context, fallback, prefix, options) {
 	const { state, visit } = context;
 
 	const assignee = node.left;
@@ -154,9 +154,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 			const value = path.expression?.(b.id(tmp_id));
 			const assignment = b.assignment('=', path.node, value);
 			original_assignments.push(assignment);
-			assignments.push(
-				serialize_set_binding(assignment, context, () => assignment, prefix, options)
-			);
+			assignments.push(build_setter(assignment, context, () => assignment, prefix, options));
 		}
 
 		if (assignments.every((assignment, i) => assignment === original_assignments[i])) {
@@ -213,7 +211,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 							assignment.right =
 								private_state.kind === 'frozen_state'
 									? b.call('$.freeze', value)
-									: serialize_proxy_reassignment(value, private_state.id);
+									: build_proxy_reassignment(value, private_state.id);
 							return assignment;
 						}
 					}
@@ -226,7 +224,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 							should_proxy_or_freeze(value, context.state.scope)
 							? private_state.kind === 'frozen_state'
 								? b.call('$.freeze', value)
-								: serialize_proxy_reassignment(value, private_state.id)
+								: build_proxy_reassignment(value, private_state.id)
 							: value
 					);
 				}
@@ -250,7 +248,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 					assignment.right =
 						public_state.kind === 'frozen_state'
 							? b.call('$.freeze', value)
-							: serialize_proxy_reassignment(value, public_state.id);
+							: build_proxy_reassignment(value, public_state.id);
 					return assignment;
 				}
 			}
@@ -324,7 +322,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 			if ((binding.kind === 'prop' || binding.kind === 'bindable_prop') && !is_initial_proxy) {
 				return b.call(left, value);
 			} else if (is_store) {
-				return b.call('$.store_set', serialize_get_binding(b.id(left_name), state), value);
+				return b.call('$.store_set', build_getter(b.id(left_name), state), value);
 			} else {
 				let call;
 				if (binding.kind === 'state') {
@@ -334,7 +332,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 						context.state.analysis.runes &&
 							!options?.skip_proxy_and_freeze &&
 							should_proxy_or_freeze(value, context.state.scope)
-							? serialize_proxy_reassignment(value, left_name)
+							? build_proxy_reassignment(value, left_name)
 							: value
 					);
 				} else if (binding.kind === 'frozen_state') {
@@ -357,7 +355,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 							!options?.skip_proxy_and_freeze &&
 							should_proxy_or_freeze(value, context.state.scope) &&
 							binding.kind === 'bindable_prop'
-							? serialize_proxy_reassignment(value, left_name)
+							? build_proxy_reassignment(value, left_name)
 							: value
 					);
 				} else {
@@ -401,7 +399,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 				return maybe_skip_ownership_validation(
 					b.call(
 						'$.store_mutate',
-						serialize_get_binding(b.id(left_name), state),
+						build_getter(b.id(left_name), state),
 						b.assignment(node.operator, /** @type {Pattern}} */ (visit_node(node.left)), value),
 						b.call('$.untrack', b.id('$' + left_name))
 					)
@@ -453,7 +451,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
 	};
 
 	if (value.type === 'BinaryExpression' && /** @type {any} */ (value.operator) === '??') {
-		return b.logical('??', serialize_get_binding(b.id(left_name), state), serialize());
+		return b.logical('??', build_getter(b.id(left_name), state), serialize());
 	}
 
 	return serialize();
@@ -463,7 +461,7 @@ export function serialize_set_binding(node, context, fallback, prefix, options) 
  * @param {Expression} value
  * @param {PrivateIdentifier | string} proxy_reference
  */
-export function serialize_proxy_reassignment(value, proxy_reference) {
+export function build_proxy_reassignment(value, proxy_reference) {
 	return dev
 		? b.call(
 				'$.proxy',
@@ -549,7 +547,7 @@ function get_hoistable_params(node, context) {
  * @param {ComponentContext} context
  * @returns {Pattern[]}
  */
-export function serialize_hoistable_params(node, context) {
+export function build_hoistable_params(node, context) {
 	const hoistable_params = get_hoistable_params(node, context);
 	node.metadata.hoistable_params = hoistable_params;
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
@@ -1,11 +1,11 @@
 /** @import { AssignmentExpression } from 'estree' */
 /** @import { Context } from '../types' */
-import { serialize_set_binding } from '../utils.js';
+import { build_setter } from '../utils.js';
 
 /**
  * @param {AssignmentExpression} node
  * @param {Context} context
  */
 export function AssignmentExpression(node, context) {
-	return serialize_set_binding(node, context, context.next);
+	return build_setter(node, context, context.next);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/Attribute.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/Attribute.js
@@ -1,7 +1,7 @@
 /** @import { Attribute } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
 import { is_event_attribute } from '../../../../utils/ast.js';
-import { serialize_event_attribute } from './shared/element.js';
+import { build_event_attribute } from './shared/element.js';
 
 /**
  * @param {Attribute} node
@@ -9,6 +9,6 @@ import { serialize_event_attribute } from './shared/element.js';
  */
 export function Attribute(node, context) {
 	if (is_event_attribute(node)) {
-		serialize_event_attribute(node, context);
+		build_event_attribute(node, context);
 	}
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
@@ -5,9 +5,9 @@ import { dev, is_ignored } from '../../../../state.js';
 import { is_text_attribute } from '../../../../utils/ast.js';
 import * as b from '../../../../utils/builders.js';
 import { binding_properties } from '../../../bindings.js';
-import { serialize_set_binding } from '../utils.js';
-import { serialize_attribute_value } from './shared/element.js';
-import { serialize_bind_this, serialize_validate_binding } from './shared/utils.js';
+import { build_setter } from '../utils.js';
+import { build_attribute_value } from './shared/element.js';
+import { build_bind_this, build_validate_binding } from './shared/utils.js';
 
 /**
  * @param {BindDirective} node
@@ -31,7 +31,7 @@ export function BindDirective(node, context) {
 		!is_ignored(node, 'binding_property_non_reactive')
 	) {
 		context.state.init.push(
-			serialize_validate_binding(
+			build_validate_binding(
 				context.state,
 				node,
 				/**@type {MemberExpression} */ (context.visit(expression))
@@ -43,7 +43,7 @@ export function BindDirective(node, context) {
 	const assignment = b.assignment('=', expression, b.id('$$value'));
 	const setter = b.arrow(
 		[b.id('$$value')],
-		serialize_set_binding(
+		build_setter(
 			assignment,
 			context,
 			() => /** @type {Expression} */ (context.visit(assignment)),
@@ -161,7 +161,7 @@ export function BindDirective(node, context) {
 				break;
 
 			case 'this':
-				call = serialize_bind_this(expression, context.state.node, context);
+				call = build_bind_this(expression, context.state.node, context);
 				break;
 
 			case 'textContent':
@@ -212,7 +212,7 @@ export function BindDirective(node, context) {
 					if (value !== undefined) {
 						group_getter = b.thunk(
 							b.block([
-								b.stmt(serialize_attribute_value(value, context)[1]),
+								b.stmt(build_attribute_value(value, context)[1]),
 								b.return(/** @type {Expression} */ (context.visit(expression)))
 							])
 						);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/ClassBody.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/ClassBody.js
@@ -5,7 +5,7 @@ import { dev, is_ignored } from '../../../../state.js';
 import * as b from '../../../../utils/builders.js';
 import { regex_invalid_identifier_chars } from '../../../patterns.js';
 import { get_rune } from '../../../scope.js';
-import { serialize_proxy_reassignment, should_proxy_or_freeze } from '../utils.js';
+import { build_proxy_reassignment, should_proxy_or_freeze } from '../utils.js';
 
 /**
  * @param {ClassBody} node
@@ -149,7 +149,7 @@ export function ClassBody(node, context) {
 								'set',
 								definition.key,
 								[value],
-								[b.stmt(b.call('$.set', member, serialize_proxy_reassignment(value, field.id)))]
+								[b.stmt(b.call('$.set', member, build_proxy_reassignment(value, field.id)))]
 							)
 						);
 					}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/Component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/Component.js
@@ -2,7 +2,7 @@
 /** @import { Component } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
 import * as b from '../../../../utils/builders.js';
-import { serialize_component } from './shared/component.js';
+import { build_component } from './shared/component.js';
 
 /**
  * @param {Component} node
@@ -11,7 +11,7 @@ import { serialize_component } from './shared/component.js';
 export function Component(node, context) {
 	if (node.metadata.dynamic) {
 		// Handle dynamic references to what seems like static inline components
-		const component = serialize_component(node, '$$component', context, b.id('$$anchor'));
+		const component = build_component(node, '$$component', context, b.id('$$anchor'));
 		context.state.init.push(
 			b.stmt(
 				b.call(
@@ -27,6 +27,6 @@ export function Component(node, context) {
 		return;
 	}
 
-	const component = serialize_component(node, node.name, context);
+	const component = build_component(node, node.name, context);
 	context.state.init.push(component);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/Fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/Fragment.js
@@ -7,7 +7,7 @@ import { dev } from '../../../../state.js';
 import * as b from '../../../../utils/builders.js';
 import { clean_nodes, infer_namespace } from '../../utils.js';
 import { process_children } from './shared/fragment.js';
-import { serialize_render_stmt } from './shared/utils.js';
+import { build_render_statement } from './shared/utils.js';
 
 /**
  * @param {Fragment} node
@@ -97,7 +97,7 @@ export function Fragment(node, context) {
 				'$.add_locations',
 				call,
 				b.member(b.id(context.state.analysis.name), b.id('$.FILENAME'), true),
-				serialize_locations(state.locations)
+				build_locations(state.locations)
 			);
 		}
 
@@ -184,7 +184,7 @@ export function Fragment(node, context) {
 	}
 
 	if (state.update.length > 0) {
-		body.push(serialize_render_stmt(state.update));
+		body.push(build_render_statement(state.update));
 	}
 
 	body.push(...state.after_update);
@@ -221,13 +221,13 @@ function get_template_function(namespace, state) {
 /**
  * @param {SourceLocation[]} locations
  */
-function serialize_locations(locations) {
+function build_locations(locations) {
 	return b.array(
 		locations.map((loc) => {
 			const expression = b.array([b.literal(loc[0]), b.literal(loc[1])]);
 
 			if (loc.length === 3) {
-				expression.elements.push(serialize_locations(loc[2]));
+				expression.elements.push(build_locations(loc[2]));
 			}
 
 			return expression;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/FunctionDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/FunctionDeclaration.js
@@ -1,6 +1,6 @@
 /** @import { FunctionDeclaration } from 'estree' */
 /** @import { ComponentContext } from '../types' */
-import { serialize_hoistable_params } from '../utils.js';
+import { build_hoistable_params } from '../utils.js';
 import * as b from '../../../../utils/builders.js';
 
 /**
@@ -13,7 +13,7 @@ export function FunctionDeclaration(node, context) {
 	const state = { ...context.state, in_constructor: false };
 
 	if (metadata?.hoistable === true) {
-		const params = serialize_hoistable_params(node, context);
+		const params = build_hoistable_params(node, context);
 
 		context.state.hoisted.push(
 			/** @type {FunctionDeclaration} */ ({

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/Identifier.js
@@ -2,7 +2,7 @@
 /** @import { Context } from '../types' */
 import is_reference from 'is-reference';
 import * as b from '../../../../utils/builders.js';
-import { serialize_get_binding } from '../utils.js';
+import { build_getter } from '../utils.js';
 
 /**
  * @param {Identifier} node
@@ -36,6 +36,6 @@ export function Identifier(node, context) {
 			}
 		}
 
-		return serialize_get_binding(node, context.state);
+		return build_getter(node, context.state);
 	}
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/LabeledStatement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/LabeledStatement.js
@@ -2,7 +2,7 @@
 /** @import { ReactiveStatement } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
 import * as b from '../../../../utils/builders.js';
-import { serialize_get_binding } from '../utils.js';
+import { build_getter } from '../utils.js';
 
 /**
  * @param {LabeledStatement} node
@@ -37,7 +37,7 @@ export function LabeledStatement(node, context) {
 		if (binding.kind === 'normal') continue;
 
 		const name = binding.node.name;
-		let serialized = serialize_get_binding(b.id(name), context.state);
+		let serialized = build_getter(b.id(name), context.state);
 
 		// If the binding is a prop, we need to deep read it because it could be fine-grained $state
 		// from a runes-component, where mutations don't trigger an update on the prop as a whole.

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/OnDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/OnDirective.js
@@ -1,11 +1,11 @@
 /** @import { OnDirective } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
-import { serialize_event } from './shared/element.js';
+import { build_event } from './shared/element.js';
 
 /**
  * @param {OnDirective} node
  * @param {ComponentContext} context
  */
 export function OnDirective(node, context) {
-	serialize_event(node, node.metadata.expression, context);
+	build_event(node, node.metadata.expression, context);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SlotElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SlotElement.js
@@ -2,7 +2,7 @@
 /** @import { SlotElement } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
 import * as b from '../../../../utils/builders.js';
-import { serialize_attribute_value } from './shared/element.js';
+import { build_attribute_value } from './shared/element.js';
 
 /**
  * @param {SlotElement} node
@@ -30,7 +30,7 @@ export function SlotElement(node, context) {
 		if (attribute.type === 'SpreadAttribute') {
 			spreads.push(b.thunk(/** @type {Expression} */ (context.visit(attribute))));
 		} else if (attribute.type === 'Attribute') {
-			const [, value] = serialize_attribute_value(attribute.value, context);
+			const [, value] = build_attribute_value(attribute.value, context);
 			if (attribute.name === 'name') {
 				name = value;
 				is_default = false;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteComponent.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteComponent.js
@@ -1,12 +1,12 @@
 /** @import { SvelteComponent } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
-import { serialize_component } from './shared/component.js';
+import { build_component } from './shared/component.js';
 
 /**
  * @param {SvelteComponent} node
  * @param {ComponentContext} context
  */
 export function SvelteComponent(node, context) {
-	const component = serialize_component(node, '$$component', context);
+	const component = build_component(node, '$$component', context);
 	context.state.init.push(component);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteSelf.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteSelf.js
@@ -1,12 +1,12 @@
 /** @import { SvelteSelf } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
-import { serialize_component } from './shared/component.js';
+import { build_component } from './shared/component.js';
 
 /**
  * @param {SvelteSelf} node
  * @param {ComponentContext} context
  */
 export function SvelteSelf(node, context) {
-	const component = serialize_component(node, context.state.analysis.name, context);
+	const component = build_component(node, context.state.analysis.name, context);
 	context.state.init.push(component);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/TitleElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/TitleElement.js
@@ -1,7 +1,7 @@
 /** @import { TitleElement, Text } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
 import * as b from '../../../../utils/builders.js';
-import { serialize_template_literal } from './shared/utils.js';
+import { build_template_literal } from './shared/utils.js';
 
 /**
  * @param {TitleElement} node
@@ -27,7 +27,7 @@ export function TitleElement(node, context) {
 				b.assignment(
 					'=',
 					b.member(b.id('$.document'), b.id('title')),
-					serialize_template_literal(
+					build_template_literal(
 						/** @type {any} */ (node.fragment.nodes),
 						context.visit,
 						context.state

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/UpdateExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/UpdateExpression.js
@@ -2,7 +2,7 @@
 /** @import { Context } from '../types' */
 import { is_ignored } from '../../../../state.js';
 import * as b from '../../../../utils/builders.js';
-import { serialize_get_binding, serialize_set_binding } from '../utils.js';
+import { build_getter, build_setter } from '../utils.js';
 
 /**
  * @param {UpdateExpression} node
@@ -34,7 +34,7 @@ export function UpdateExpression(node, context) {
 
 			if (is_store) {
 				fn += '_store';
-				args.push(serialize_get_binding(b.id(name), context.state), b.call('$' + name));
+				args.push(build_getter(b.id(name), context.state), b.call('$' + name));
 			} else {
 				if (binding.kind === 'prop' || binding.kind === 'bindable_prop') fn += '_prop';
 				args.push(b.id(name));
@@ -84,12 +84,7 @@ export function UpdateExpression(node, context) {
 		b.literal(1)
 	);
 
-	const serialized_assignment = serialize_set_binding(
-		assignment,
-		context,
-		() => assignment,
-		node.prefix
-	);
+	const serialized_assignment = build_setter(assignment, context, () => assignment, node.prefix);
 
 	const value = /** @type {Expression} */ (context.visit(argument));
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
@@ -2,7 +2,7 @@
 /** @import { ExpressionTag, SvelteNode, Text } from '#compiler' */
 /** @import { ComponentClientTransformState, ComponentContext } from '../../types' */
 import * as b from '../../../../../utils/builders.js';
-import { serialize_template_literal, serialize_update } from './utils.js';
+import { build_template_literal, build_update } from './utils.js';
 
 /**
  * Processes an array of template nodes, joining sibling text/expression nodes
@@ -44,7 +44,7 @@ export function process_children(nodes, expression, is_element, { visit, state }
 			);
 
 			if (node.metadata.expression.has_call && !within_bound_contenteditable) {
-				state.init.push(serialize_update(update));
+				state.init.push(build_update(update));
 			} else if (node.metadata.expression.has_state && !within_bound_contenteditable) {
 				state.update.push(update);
 			} else {
@@ -66,12 +66,12 @@ export function process_children(nodes, expression, is_element, { visit, state }
 
 			state.template.push(' ');
 
-			const [has_call, value] = serialize_template_literal(sequence, visit, state);
+			const [has_call, value] = build_template_literal(sequence, visit, state);
 
 			const update = b.stmt(b.call('$.set_text', text_id, value));
 
 			if (has_call && !within_bound_contenteditable) {
-				state.init.push(serialize_update(update));
+				state.init.push(build_update(update));
 			} else if (
 				sequence.some(
 					(node) => node.type === 'ExpressionTag' && node.metadata.expression.has_state

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/function.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/function.js
@@ -1,6 +1,6 @@
 /** @import { ArrowFunctionExpression, FunctionExpression, Node } from 'estree' */
 /** @import { ComponentContext } from '../../types' */
-import { serialize_hoistable_params } from '../../utils.js';
+import { build_hoistable_params } from '../../utils.js';
 
 /**
  * @param {ArrowFunctionExpression | FunctionExpression} node
@@ -21,7 +21,7 @@ export const visit_function = (node, context) => {
 	}
 
 	if (metadata?.hoistable === true) {
-		const params = serialize_hoistable_params(node, context);
+		const params = build_hoistable_params(node, context);
 
 		return /** @type {FunctionExpression} */ ({
 			...node,

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -16,7 +16,7 @@ import { locator } from '../../../../../state.js';
  * @param {ComponentClientTransformState} state
  * @returns {[boolean, TemplateLiteral]}
  */
-export function serialize_template_literal(values, visit, state) {
+export function build_template_literal(values, visit, state) {
 	/** @type {TemplateElement[]} */
 	const quasis = [];
 
@@ -76,7 +76,7 @@ export function serialize_template_literal(values, visit, state) {
 /**
  * @param {Statement} statement
  */
-export function serialize_update(statement) {
+export function build_update(statement) {
 	const body =
 		statement.type === 'ExpressionStatement' ? statement.expression : b.block([statement]);
 
@@ -86,9 +86,9 @@ export function serialize_update(statement) {
 /**
  * @param {Statement[]} update
  */
-export function serialize_render_stmt(update) {
+export function build_render_statement(update) {
 	return update.length === 1
-		? serialize_update(update[0])
+		? build_update(update[0])
 		: b.stmt(b.call('$.template_effect', b.thunk(b.block(update))));
 }
 
@@ -120,7 +120,7 @@ export function parse_directive_name(name) {
  * @param {Expression} value
  * @param {ExpressionStatement} update
  */
-export function serialize_update_assignment(state, id, init, value, update) {
+export function build_update_assignment(state, id, init, value, update) {
 	state.init.push(b.var(id, init));
 	state.update.push(
 		b.if(b.binary('!==', b.id(id), b.assignment('=', b.id(id), value)), b.block([update]))
@@ -133,7 +133,7 @@ export function serialize_update_assignment(state, id, init, value, update) {
  * @param {null | ExpressionMetadata} metadata
  * @param {ComponentContext} context
  */
-export function serialize_event_handler(node, metadata, { state, visit }) {
+export function build_event_handler(node, metadata, { state, visit }) {
 	/** @type {Expression} */
 	let handler;
 
@@ -242,7 +242,7 @@ export function serialize_event_handler(node, metadata, { state, visit }) {
  * @param {Expression} value
  * @param {import('zimmerframe').Context<SvelteNode, ComponentClientTransformState>} context
  */
-export function serialize_bind_this(expression, value, { state, visit }) {
+export function build_bind_this(expression, value, { state, visit }) {
 	/** @type {Identifier[]} */
 	const ids = [];
 
@@ -308,7 +308,7 @@ export function serialize_bind_this(expression, value, { state, visit }) {
  * @param {BindDirective} binding
  * @param {MemberExpression} expression
  */
-export function serialize_validate_binding(state, binding, expression) {
+export function build_validate_binding(state, binding, expression) {
 	const string = state.analysis.source.slice(binding.start, binding.end);
 
 	const get_object = b.thunk(/** @type {Expression} */ (expression.object));

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -3,7 +3,7 @@
 /** @import { Context, ServerTransformState } from '../types.js' */
 import * as b from '../../../../utils/builders.js';
 import { extract_paths } from '../../../../utils/ast.js';
-import { serialize_get_binding } from './shared/utils.js';
+import { build_getter } from './shared/utils.js';
 
 /**
  * @param {AssignmentExpression} node
@@ -27,7 +27,7 @@ export function AssignmentExpression(node, context) {
 		const assignments = extract_paths(node.left).map((path) => {
 			const value = path.expression?.(rhs);
 
-			let assignment = serialize_assignment('=', path.node, value, context);
+			let assignment = build_assignment('=', path.node, value, context);
 			if (assignment !== null) changed = true;
 
 			return assignment ?? b.assignment('=', path.node, value);
@@ -53,7 +53,7 @@ export function AssignmentExpression(node, context) {
 		return sequence;
 	}
 
-	return serialize_assignment(node.operator, node.left, node.right, context) || context.next();
+	return build_assignment(node.operator, node.left, node.right, context) || context.next();
 }
 
 /**
@@ -64,7 +64,7 @@ export function AssignmentExpression(node, context) {
  * @param {import('zimmerframe').Context<SvelteNode, ServerTransformState>} context
  * @returns {Expression | null}
  */
-function serialize_assignment(operator, left, right, context) {
+function build_assignment(operator, left, right, context) {
 	let object = left;
 
 	while (object.type === 'MemberExpression') {
@@ -89,7 +89,7 @@ function serialize_assignment(operator, left, right, context) {
 			// turn `x += 1` into `x = x + 1`
 			value = b.binary(
 				/** @type {BinaryOperator} */ (operator.slice(0, -1)),
-				serialize_get_binding(left, context.state),
+				build_getter(left, context.state),
 				value
 			);
 		}

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/Component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/Component.js
@@ -1,12 +1,12 @@
 /** @import { Component } from '#compiler' */
 /** @import { ComponentContext } from '../types.js' */
 import * as b from '../../../../utils/builders.js';
-import { serialize_inline_component } from './shared/component.js';
+import { build_inline_component } from './shared/component.js';
 
 /**
  * @param {Component} node
  * @param {ComponentContext} context
  */
 export function Component(node, context) {
-	serialize_inline_component(node, b.id(node.name), context);
+	build_inline_component(node, b.id(node.name), context);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/Fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/Fragment.js
@@ -2,7 +2,7 @@
 /** @import { ComponentContext, ComponentServerTransformState } from '../types.js' */
 import { clean_nodes, infer_namespace } from '../../utils.js';
 import * as b from '../../../../utils/builders.js';
-import { empty_comment, process_children, serialize_template } from './shared/utils.js';
+import { empty_comment, process_children, build_template } from './shared/utils.js';
 
 /**
  * @param {Fragment} node
@@ -42,5 +42,5 @@ export function Fragment(node, context) {
 
 	process_children(trimmed, { ...context, state });
 
-	return b.block([...state.init, ...serialize_template(state.template)]);
+	return b.block([...state.init, ...build_template(state.template)]);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/Identifier.js
@@ -2,7 +2,7 @@
 /** @import { Context } from '../types.js' */
 import is_reference from 'is-reference';
 import * as b from '../../../../utils/builders.js';
-import { serialize_get_binding } from './shared/utils.js';
+import { build_getter } from './shared/utils.js';
 
 /**
  * @param {Identifier} node
@@ -14,6 +14,6 @@ export function Identifier(node, context) {
 			return b.id('$$sanitized_props');
 		}
 
-		return serialize_get_binding(node, context.state);
+		return build_getter(node, context.state);
 	}
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/RegularElement.js
@@ -6,8 +6,8 @@ import { is_void } from '../../../../../utils.js';
 import { dev, locator } from '../../../../state.js';
 import * as b from '../../../../utils/builders.js';
 import { clean_nodes, determine_namespace_for_children } from '../../utils.js';
-import { serialize_element_attributes } from './shared/element.js';
-import { process_children, serialize_template } from './shared/utils.js';
+import { build_element_attributes } from './shared/element.js';
+import { process_children, build_template } from './shared/utils.js';
 
 /**
  * @param {RegularElement} node
@@ -26,7 +26,7 @@ export function RegularElement(node, context) {
 	};
 
 	context.state.template.push(b.literal(`<${node.name}`));
-	const body = serialize_element_attributes(node, { ...context, state });
+	const body = build_element_attributes(node, { ...context, state });
 	context.state.template.push(b.literal('>'));
 
 	if ((node.name === 'script' || node.name === 'style') && node.fragment.nodes.length === 1) {
@@ -89,8 +89,8 @@ export function RegularElement(node, context) {
 		state.template.push(
 			b.if(
 				id,
-				b.block(serialize_template([id])),
-				b.block([...inner_state.init, ...serialize_template(inner_state.template)])
+				b.block(build_template([id])),
+				b.block([...inner_state.init, ...build_template(inner_state.template)])
 			)
 		);
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/SlotElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/SlotElement.js
@@ -2,7 +2,7 @@
 /** @import { SlotElement } from '#compiler' */
 /** @import { ComponentContext } from '../types.js' */
 import * as b from '../../../../utils/builders.js';
-import { empty_comment, serialize_attribute_value } from './shared/utils.js';
+import { empty_comment, build_attribute_value } from './shared/utils.js';
 
 /**
  * @param {SlotElement} node
@@ -22,7 +22,7 @@ export function SlotElement(node, context) {
 		if (attribute.type === 'SpreadAttribute') {
 			spreads.push(/** @type {Expression} */ (context.visit(attribute)));
 		} else if (attribute.type === 'Attribute') {
-			const value = serialize_attribute_value(attribute.value, context, false, true);
+			const value = build_attribute_value(attribute.value, context, false, true);
 
 			if (attribute.name === 'name') {
 				expression = b.member(b.member_id('$$props.$$slots'), value, true, true);

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/SvelteComponent.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/SvelteComponent.js
@@ -1,16 +1,12 @@
 /** @import { Expression } from 'estree' */
 /** @import { SvelteComponent } from '#compiler' */
 /** @import { ComponentContext } from '../types.js' */
-import { serialize_inline_component } from './shared/component.js';
+import { build_inline_component } from './shared/component.js';
 
 /**
  * @param {SvelteComponent} node
  * @param {ComponentContext} context
  */
 export function SvelteComponent(node, context) {
-	serialize_inline_component(
-		node,
-		/** @type {Expression} */ (context.visit(node.expression)),
-		context
-	);
+	build_inline_component(node, /** @type {Expression} */ (context.visit(node.expression)), context);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/SvelteElement.js
@@ -4,8 +4,8 @@
 import { dev } from '../../../../state.js';
 import * as b from '../../../../utils/builders.js';
 import { determine_namespace_for_children } from '../../utils.js';
-import { serialize_element_attributes } from './shared/element.js';
-import { serialize_template } from './shared/utils.js';
+import { build_element_attributes } from './shared/element.js';
+import { build_template } from './shared/utils.js';
 
 /**
  * @param {SvelteElement} node
@@ -33,13 +33,13 @@ export function SvelteElement(node, context) {
 		init: []
 	};
 
-	serialize_element_attributes(node, { ...context, state });
+	build_element_attributes(node, { ...context, state });
 
 	if (dev) {
 		context.state.template.push(b.stmt(b.call('$.push_element', tag, b.id('$$payload'))));
 	}
 
-	const attributes = b.block([...state.init, ...serialize_template(state.template)]);
+	const attributes = b.block([...state.init, ...build_template(state.template)]);
 	const children = /** @type {BlockStatement} */ (context.visit(node.fragment, state));
 
 	context.state.template.push(

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/SvelteSelf.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/SvelteSelf.js
@@ -1,12 +1,12 @@
 /** @import { SvelteSelf } from '#compiler' */
 /** @import { ComponentContext } from '../types.js' */
 import * as b from '../../../../utils/builders.js';
-import { serialize_inline_component } from './shared/component.js';
+import { build_inline_component } from './shared/component.js';
 
 /**
  * @param {SvelteSelf} node
  * @param {ComponentContext} context
  */
 export function SvelteSelf(node, context) {
-	serialize_inline_component(node, b.id(context.state.analysis.name), context);
+	build_inline_component(node, b.id(context.state.analysis.name), context);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/TitleElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/TitleElement.js
@@ -1,7 +1,7 @@
 /** @import { TitleElement } from '#compiler' */
 /** @import { ComponentContext } from '../types.js' */
 import * as b from '../../../../utils/builders.js';
-import { process_children, serialize_template } from './shared/utils.js';
+import { process_children, build_template } from './shared/utils.js';
 
 /**
  * @param {TitleElement} node
@@ -13,5 +13,5 @@ export function TitleElement(node, context) {
 	process_children(node.fragment.nodes, { ...context, state: { ...context.state, template } });
 	template.push(b.literal('</title>'));
 
-	context.state.init.push(...serialize_template(template, b.id('$$payload.title'), '='));
+	context.state.init.push(...build_template(template, b.id('$$payload.title'), '='));
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/component.js
@@ -1,7 +1,7 @@
 /** @import { BlockStatement, Expression, Pattern, Property, Statement } from 'estree' */
 /** @import { Attribute, Component, LetDirective, SvelteComponent, SvelteSelf, TemplateNode, Text } from '#compiler' */
 /** @import { ComponentContext } from '../../types.js' */
-import { empty_comment, serialize_attribute_value } from './utils.js';
+import { empty_comment, build_attribute_value } from './utils.js';
 import * as b from '../../../../../utils/builders.js';
 import { is_element_node } from '../../../../nodes.js';
 
@@ -10,7 +10,7 @@ import { is_element_node } from '../../../../nodes.js';
  * @param {Expression} expression
  * @param {ComponentContext} context
  */
-export function serialize_inline_component(node, expression, context) {
+export function build_inline_component(node, expression, context) {
 	/** @type {Array<Property[] | Expression>} */
 	const props_and_spreads = [];
 
@@ -59,7 +59,7 @@ export function serialize_inline_component(node, expression, context) {
 			props_and_spreads.push(/** @type {Expression} */ (context.visit(attribute)));
 		} else if (attribute.type === 'Attribute') {
 			if (attribute.name.startsWith('--')) {
-				const value = serialize_attribute_value(attribute.value, context, false, true);
+				const value = build_attribute_value(attribute.value, context, false, true);
 				custom_css_props.push(b.init(attribute.name, value));
 				continue;
 			}
@@ -68,7 +68,7 @@ export function serialize_inline_component(node, expression, context) {
 				has_children_prop = true;
 			}
 
-			const value = serialize_attribute_value(attribute.value, context, false, true);
+			const value = build_attribute_value(attribute.value, context, false, true);
 			push_prop(b.prop('init', b.key(attribute.name), value));
 		} else if (attribute.type === 'BindDirective' && attribute.name !== 'this') {
 			// TODO this needs to turn the whole thing into a while loop because the binding could be mutated eagerly in the child

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
@@ -94,7 +94,7 @@ function is_statement(node) {
  * @param {AssignmentOperator} operator
  * @returns {Statement[]}
  */
-export function serialize_template(template, out = b.id('$$payload.out'), operator = '+=') {
+export function build_template(template, out = b.id('$$payload.out'), operator = '+=') {
 	/** @type {TemplateElement[]} */
 	let quasis = [];
 
@@ -152,7 +152,7 @@ export function serialize_template(template, out = b.id('$$payload.out'), operat
  * @param {boolean} is_component
  * @returns {Expression}
  */
-export function serialize_attribute_value(
+export function build_attribute_value(
 	value,
 	context,
 	trim_whitespace = false,
@@ -207,7 +207,7 @@ export function serialize_attribute_value(
  * @param {ServerTransformState} state
  * @returns {Expression}
  */
-export function serialize_get_binding(node, state) {
+export function build_getter(node, state) {
 	const binding = state.scope.get(node.name);
 
 	if (binding === null || node === binding.node) {
@@ -221,7 +221,7 @@ export function serialize_get_binding(node, state) {
 			'$.store_get',
 			b.assignment('??=', b.id('$$store_subs'), b.object([])),
 			b.literal(node.name),
-			serialize_get_binding(store_id, state)
+			build_getter(store_id, state)
 		);
 	}
 


### PR DESCRIPTION
I'm taking advantage of the fact that Dominic and Simon are on holiday to fix various minor things that have been bugging me for a while, without needing to worry about merge conflicts and whatnot.

We use the word 'serialize' in a really weird way — it means 'convert into a byte stream', but all the `serialize_foo` functions return ESTree nodes. It's also a long, awkward word to type, and it's four syllables (try saying `serialize_custom_element_attribute_update_assignment` ten times fast).

There's already a perfectly good (one-syllable!) word that describes the process of creating ESTree nodes, and we use it throughout the codebase courtesy of [this module](https://github.com/sveltejs/svelte/blob/79ef6451518852665c0b9e482b60e44fae4e811b/packages/svelte/src/compiler/utils/builders.js).

It's Time To Build.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
