### PR TITLE
chore: remove binding.mutation

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -137,6 +137,7 @@ export function client_component(analysis, options) {
 		public_state: new Map(),
 		private_state: new Map(),
 		getters: {},
+		setters: {},
 		in_constructor: false,
 
 		// these are set inside the `Fragment` visitor, and cannot be used until then
@@ -624,6 +625,7 @@ export function client_module(analysis, options) {
 		public_state: new Map(),
 		private_state: new Map(),
 		getters: {},
+		setters: {},
 		in_constructor: false
 	};
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
+++ b/packages/svelte/src/compiler/phases/3-transform/client/types.d.ts
@@ -4,7 +4,8 @@ import type {
 	LabeledStatement,
 	Identifier,
 	PrivateIdentifier,
-	Expression
+	Expression,
+	AssignmentExpression
 } from 'estree';
 import type { Namespace, SvelteNode, ValidatedCompileOptions } from '#compiler';
 import type { TransformState } from '../types.js';
@@ -28,6 +29,13 @@ export interface ClientTransformState extends TransformState {
 	 * will be replaced with `node` (e.g. `x` -> `$.get(x)`)
 	 */
 	readonly getters: Record<string, Expression | ((id: Identifier) => Expression)>;
+	/**
+	 * Counterpart to `getters`
+	 */
+	readonly setters: Record<
+		string,
+		(assignment: AssignmentExpression, context: Context) => Expression
+	>;
 }
 
 export interface ComponentClientTransformState extends ClientTransformState {

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -265,8 +265,10 @@ export function build_setter(node, context, fallback, prefix, options) {
 
 	if (!binding) return fallback();
 
-	if (binding.mutation !== null) {
-		return binding.mutation(node, context);
+	if (Object.hasOwn(state.setters, left.name)) {
+		const setter = state.setters[left.name];
+		// @ts-expect-error
+		return setter(node, context);
 	}
 
 	if (binding.kind === 'legacy_reactive_import') {

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -118,7 +118,6 @@ export class Scope {
 			declaration_kind,
 			is_called: false,
 			prop_alias: null,
-			mutation: null,
 			reassigned: false,
 			metadata: null
 		};

--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -307,8 +307,6 @@ export interface Binding {
 	legacy_dependencies: Binding[];
 	/** Legacy props: the `class` in `{ export klass as class}`. $props(): The `class` in { class: klass } = $props() */
 	prop_alias: string | null;
-	/** If this is set, all mutations should use this expression */
-	mutation: ((assignment: AssignmentExpression, context: Context<any, any>) => Expression) | null;
 	/** Additional metadata, varies per binding type */
 	metadata: {
 		/** `true` if is (inside) a rest parameter */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -584,7 +584,6 @@ declare module 'svelte/animate' {
 declare module 'svelte/compiler' {
 	import type { AssignmentExpression, ClassDeclaration, Expression, FunctionDeclaration, Identifier, ImportDeclaration, ArrayExpression, MemberExpression, ObjectExpression, Pattern, Node, VariableDeclarator, ArrowFunctionExpression, VariableDeclaration, FunctionExpression, Program, ChainExpression, SimpleCallExpression } from 'estree';
 	import type { SourceMap } from 'magic-string';
-	import type { Context } from 'zimmerframe';
 	import type { Location } from 'locate-character';
 	/**
 	 * `compile` converts your `.svelte` source code into a JavaScript module that exports a component
@@ -957,8 +956,6 @@ declare module 'svelte/compiler' {
 		legacy_dependencies: Binding[];
 		/** Legacy props: the `class` in `{ export klass as class}`. $props(): The `class` in { class: klass } = $props() */
 		prop_alias: string | null;
-		/** If this is set, all mutations should use this expression */
-		mutation: ((assignment: AssignmentExpression, context: Context<any, any>) => Expression) | null;
 		/** Additional metadata, varies per binding type */
 		metadata: {
 			/** `true` if is (inside) a rest parameter */


### PR DESCRIPTION
Follow-up to #12530. Assigning `binding.mutation` is bad for the same reasons as assigning `binding.expression`. The change in this PR is small, and perhaps even pointless-seeming, but my plan is to use the `setters` mechanism more widely in a way that allows `build_setters` to become less chaotic.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
