### PR TITLE
fix: only create `document.title` effect if value is dynamic

### DIFF
--- a/.changeset/strange-pears-perform.md
+++ b/.changeset/strange-pears-perform.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only create `document.title` effect if value is dynamic

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
@@ -209,10 +209,11 @@ export function BindDirective(node, context) {
 							)
 						)?.value
 					);
+
 					if (value !== undefined) {
 						group_getter = b.thunk(
 							b.block([
-								b.stmt(build_attribute_value(value, context)[1]),
+								b.stmt(build_attribute_value(value, context).value),
 								b.return(/** @type {Expression} */ (context.visit(expression)))
 							])
 						);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -230,7 +230,7 @@ export function RegularElement(node, context) {
 			) {
 				const name = get_attribute_name(node, attribute, context);
 				const literal_value = /** @type {Literal} */ (
-					build_attribute_value(attribute.value, context)[1]
+					build_attribute_value(attribute.value, context).value
 				).value;
 				if (name !== 'class' || literal_value) {
 					// TODO namespace=foreign probably doesn't want to do template stuff at all and instead use programmatic methods
@@ -440,7 +440,7 @@ function build_element_spread_attributes(
 		if (attribute.type === 'Attribute') {
 			const name = get_attribute_name(element, attribute, context);
 			// TODO: handle has_call
-			const [, value] = build_attribute_value(attribute.value, context);
+			const { value } = build_attribute_value(attribute.value, context);
 
 			if (
 				name === 'is' &&
@@ -554,7 +554,7 @@ function build_element_attribute_update_assignment(element, node_id, attribute, 
 	const name = get_attribute_name(element, attribute, context);
 	const is_svg = context.state.metadata.namespace === 'svg' || element.name === 'svg';
 	const is_mathml = context.state.metadata.namespace === 'mathml';
-	let [has_call, value] = build_attribute_value(attribute.value, context);
+	let { has_call, value } = build_attribute_value(attribute.value, context);
 
 	// The foreign namespace doesn't have any special handling, everything goes through the attr function
 	if (context.state.metadata.namespace === 'foreign') {
@@ -636,7 +636,7 @@ function build_element_attribute_update_assignment(element, node_id, attribute, 
 function build_custom_element_attribute_update_assignment(node_id, attribute, context) {
 	const state = context.state;
 	const name = attribute.name; // don't lowercase, as we set the element's property, which might be case sensitive
-	let [has_call, value] = build_attribute_value(attribute.value, context);
+	let { has_call, value } = build_attribute_value(attribute.value, context);
 
 	const update = b.stmt(b.call('$.set_custom_element_data', node_id, b.literal(name), value));
 
@@ -665,7 +665,7 @@ function build_custom_element_attribute_update_assignment(node_id, attribute, co
  */
 function build_element_special_value_attribute(element, node_id, attribute, context) {
 	const state = context.state;
-	const [, value] = build_attribute_value(attribute.value, context);
+	const { value } = build_attribute_value(attribute.value, context);
 
 	const inner_assignment = b.assignment(
 		'=',

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -229,17 +229,16 @@ export function RegularElement(node, context) {
 				(attribute.value === true || is_text_attribute(attribute))
 			) {
 				const name = get_attribute_name(node, attribute, context);
-				const literal_value = /** @type {Literal} */ (
-					build_attribute_value(attribute.value, context).value
-				).value;
-				if (name !== 'class' || literal_value) {
+				const value = is_text_attribute(attribute) ? attribute.value[0].data : true;
+
+				if (name !== 'class' || value) {
 					// TODO namespace=foreign probably doesn't want to do template stuff at all and instead use programmatic methods
 					// to create the elements it needs.
 					context.state.template.push(
 						` ${attribute.name}${
-							is_boolean_attribute(name) && literal_value === true
+							is_boolean_attribute(name) && value === true
 								? ''
-								: `="${literal_value === true ? '' : escape_html(literal_value, true)}"`
+								: `="${value === true ? '' : escape_html(value, true)}"`
 						}`
 					);
 					continue;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -675,7 +675,7 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 			value
 		)
 	);
-	const is_reactive = attribute.metadata.expression.has_state;
+
 	const is_select_with_value =
 		// attribute.metadata.dynamic would give false negatives because even if the value does not change,
 		// the inner options could still change, so we need to always treat it as reactive
@@ -698,7 +698,7 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 		state.init.push(b.stmt(b.call('$.init_select', node_id, b.thunk(value))));
 	}
 
-	if (is_reactive) {
+	if (attribute.metadata.expression.has_state) {
 		const id = state.scope.generate(`${node_id.name}_value`);
 		build_update_assignment(
 			state,

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SlotElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SlotElement.js
@@ -30,7 +30,8 @@ export function SlotElement(node, context) {
 		if (attribute.type === 'SpreadAttribute') {
 			spreads.push(b.thunk(/** @type {Expression} */ (context.visit(attribute))));
 		} else if (attribute.type === 'Attribute') {
-			const [, value] = build_attribute_value(attribute.value, context);
+			const { value } = build_attribute_value(attribute.value, context);
+
 			if (attribute.name === 'name') {
 				name = value;
 				is_default = false;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
@@ -126,7 +126,7 @@ export function SvelteElement(node, context) {
 				get_tag,
 				node.metadata.svg || node.metadata.mathml ? b.true : b.false,
 				inner.length > 0 && b.arrow([element_id, b.id('$$anchor')], b.block(inner)),
-				dynamic_namespace && b.thunk(build_attribute_value(dynamic_namespace, context)[1]),
+				dynamic_namespace && b.thunk(build_attribute_value(dynamic_namespace, context).value),
 				location && b.array([b.literal(location.line), b.literal(location.column)])
 			)
 		)
@@ -161,7 +161,7 @@ function build_dynamic_element_attributes(attributes, context, element_id) {
 
 	for (const attribute of attributes) {
 		if (attribute.type === 'Attribute') {
-			const [, value] = build_attribute_value(attribute.value, context);
+			const { value } = build_attribute_value(attribute.value, context);
 
 			if (
 				is_event_attribute(attribute) &&

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/TitleElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/TitleElement.js
@@ -8,15 +8,11 @@ import { build_template_literal } from './shared/utils.js';
  * @param {ComponentContext} context
  */
 export function TitleElement(node, context) {
-	let has_state = node.fragment.nodes.some(
-		(node) => node.type === 'ExpressionTag' && node.metadata.expression.has_state
-	);
-
-	const value = build_template_literal(
+	const { has_state, value } = build_template_literal(
 		/** @type {any} */ (node.fragment.nodes),
 		context.visit,
 		context.state
-	)[1];
+	);
 
 	const statement = b.stmt(b.assignment('=', b.member(b.id('$.document'), b.id('title')), value));
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -93,7 +93,7 @@ export function build_component(node, component_name, context, anchor = context.
 		} else if (attribute.type === 'Attribute') {
 			if (attribute.name.startsWith('--')) {
 				custom_css_props.push(
-					b.init(attribute.name, build_attribute_value(attribute.value, context)[1])
+					b.init(attribute.name, build_attribute_value(attribute.value, context).value)
 				);
 				continue;
 			}
@@ -106,7 +106,7 @@ export function build_component(node, component_name, context, anchor = context.
 				has_children_prop = true;
 			}
 
-			const [, value] = build_attribute_value(attribute.value, context);
+			const { value } = build_attribute_value(attribute.value, context);
 
 			if (attribute.metadata.expression.has_state) {
 				let arg = value;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
@@ -112,7 +112,10 @@ export function build_attribute_value(value, context) {
 		];
 	}
 
-	return build_template_literal(value, context.visit, context.state);
+	const { has_call, value: v } = build_template_literal(value, context.visit, context.state);
+
+	// TODO return the same signature
+	return [has_call, v];
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
@@ -33,7 +33,7 @@ export function build_style_directives(
 		let value =
 			directive.value === true
 				? build_getter({ name: directive.name, type: 'Identifier' }, context.state)
-				: build_attribute_value(directive.value, context)[1];
+				: build_attribute_value(directive.value, context).value;
 
 		const update = b.stmt(
 			b.call(
@@ -92,30 +92,27 @@ export function build_class_directives(
 /**
  * @param {Attribute['value']} value
  * @param {ComponentContext} context
- * @returns {[has_call: boolean, Expression]}
  */
 export function build_attribute_value(value, context) {
 	if (value === true) {
-		return [false, b.literal(true)];
+		return { has_state: false, has_call: false, value: b.literal(true) };
 	}
 
 	if (!Array.isArray(value) || value.length === 1) {
 		const chunk = Array.isArray(value) ? value[0] : value;
 
 		if (chunk.type === 'Text') {
-			return [false, b.literal(chunk.data)];
+			return { has_state: false, has_call: false, value: b.literal(chunk.data) };
 		}
 
-		return [
-			chunk.metadata.expression.has_call,
-			/** @type {Expression} */ (context.visit(chunk.expression))
-		];
+		return {
+			has_state: chunk.metadata.expression.has_call,
+			has_call: chunk.metadata.expression.has_call,
+			value: /** @type {Expression} */ (context.visit(chunk.expression))
+		};
 	}
 
-	const { has_call, value: v } = build_template_literal(value, context.visit, context.state);
-
-	// TODO return the same signature
-	return [has_call, v];
+	return build_template_literal(value, context.visit, context.state);
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
@@ -66,18 +66,13 @@ export function process_children(nodes, expression, is_element, { visit, state }
 
 			state.template.push(' ');
 
-			const { has_call, value } = build_template_literal(sequence, visit, state);
+			const { has_state, has_call, value } = build_template_literal(sequence, visit, state);
 
 			const update = b.stmt(b.call('$.set_text', text_id, value));
 
 			if (has_call && !within_bound_contenteditable) {
 				state.init.push(build_update(update));
-			} else if (
-				sequence.some(
-					(node) => node.type === 'ExpressionTag' && node.metadata.expression.has_state
-				) &&
-				!within_bound_contenteditable
-			) {
+			} else if (has_state && !within_bound_contenteditable) {
 				state.update.push(update);
 			} else {
 				state.init.push(b.stmt(b.assignment('=', b.member(text_id, b.id('nodeValue')), value)));

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
@@ -66,7 +66,7 @@ export function process_children(nodes, expression, is_element, { visit, state }
 
 			state.template.push(' ');
 
-			const [has_call, value] = build_template_literal(sequence, visit, state);
+			const { has_call, value } = build_template_literal(sequence, visit, state);
 
 			const update = b.stmt(b.call('$.set_text', text_id, value));
 


### PR DESCRIPTION
```diff
$.head(($$anchor) => {
- $.template_effect(() => $.document.title = `${title ?? ""}`);
+ $.document.title = `${title ?? ""}`;
});
```

To enable this, I fixed the weird `build_template_literal` signature, which has been on my TODO list for a while. It now returns `has_state` along with `has_call` and `value`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
