### PR TITLE
feat: more efficient code generation when referencing globals

### DIFF
--- a/.changeset/red-kings-draw.md
+++ b/.changeset/red-kings-draw.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: more efficient code generation when referencing globals

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -4,7 +4,7 @@
 import { get_rune } from '../../scope.js';
 import * as e from '../../../errors.js';
 import { get_parent, unwrap_optional } from '../../../utils/ast.js';
-import { is_known_safe_call, is_safe_identifier } from './shared/utils.js';
+import { is_pure, is_safe_identifier } from './shared/utils.js';
 
 /**
  * @param {CallExpression} node
@@ -150,7 +150,7 @@ export function CallExpression(node, context) {
 			break;
 	}
 
-	if (context.state.expression && !is_known_safe_call(node.callee, context)) {
+	if (context.state.expression && !is_pure(node.callee, context)) {
 		context.state.expression.has_call = true;
 		context.state.expression.has_state = true;
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/MemberExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/MemberExpression.js
@@ -1,7 +1,7 @@
 /** @import { MemberExpression } from 'estree' */
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
-import { is_safe_identifier } from './shared/utils.js';
+import { is_pure, is_safe_identifier } from './shared/utils.js';
 
 /**
  * @param {MemberExpression} node
@@ -15,7 +15,7 @@ export function MemberExpression(node, context) {
 		}
 	}
 
-	if (context.state.expression) {
+	if (context.state.expression && !is_pure(node, context)) {
 		context.state.expression.has_state = true;
 	}
 

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/TaggedTemplateExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/TaggedTemplateExpression.js
@@ -1,13 +1,13 @@
 /** @import { TaggedTemplateExpression, VariableDeclarator } from 'estree' */
 /** @import { Context } from '../types' */
-import { is_known_safe_call } from './shared/utils.js';
+import { is_pure } from './shared/utils.js';
 
 /**
  * @param {TaggedTemplateExpression} node
  * @param {Context} context
  */
 export function TaggedTemplateExpression(node, context) {
-	if (context.state.expression && !is_known_safe_call(node.tag, context)) {
+	if (context.state.expression && !is_pure(node.tag, context)) {
 		context.state.expression.has_call = true;
 		context.state.expression.has_state = true;
 	}

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking/main.svelte
@@ -1,5 +1,5 @@
 <script>
-	import {untrack} from 'svelte';
+	import { untrack } from 'svelte';
 
 	const foo = $effect.tracking();
 	let bar = $state(false);
@@ -10,5 +10,5 @@
 
 <p>{foo}</p>
 <p>{bar}</p>
-<p>{$effect.tracking()}</p>
-<p>{untrack(() => $effect.tracking())}</p>
+<p>{(bar, $effect.tracking())}</p>
+<p>{untrack(() => (bar, $effect.tracking()))}</p>

--- a/packages/svelte/tests/snapshot/samples/purity/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/purity/_expected/client/index.svelte.js
@@ -1,0 +1,32 @@
+import "svelte/internal/disclose-version";
+import * as $ from "svelte/internal/client";
+
+var root = $.template(`<p> </p> <p> </p> <!>`, 1);
+
+export default function Purity($$anchor) {
+	let min = 0;
+	let max = 100;
+	let number = 50;
+	let value = 'hello';
+	var fragment = root();
+	var p = $.first_child(fragment);
+	var text = $.child(p);
+
+	text.nodeValue = Math.max(min, Math.min(max, number));
+	$.reset(p);
+
+	var p_1 = $.sibling($.sibling(p, true));
+	var text_1 = $.child(p_1);
+
+	text_1.nodeValue = location.href;
+	$.reset(p_1);
+
+	var node = $.sibling($.sibling(p_1, true));
+
+	Child(node, {
+		prop: encodeURIComponent(value),
+		$$legacy: true
+	});
+
+	$.append($$anchor, fragment);
+}

--- a/packages/svelte/tests/snapshot/samples/purity/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/purity/_expected/server/index.svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/server";
+
+export default function Purity($$payload) {
+	let min = 0;
+	let max = 100;
+	let number = 50;
+	let value = 'hello';
+
+	$$payload.out += `<p>${$.escape(Math.max(min, Math.min(max, number)))}</p> <p>${$.escape(location.href)}</p> `;
+	Child($$payload, { prop: encodeURIComponent(value) });
+	$$payload.out += `<!---->`;
+}

--- a/packages/svelte/tests/snapshot/samples/purity/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/purity/index.svelte
@@ -1,0 +1,12 @@
+<script>
+	let min = 0;
+	let max = 100;
+	let number = 50;
+
+	let value = 'hello';
+</script>
+
+<p>{Math.max(min, Math.min(max, number))}</p>
+<p>{location.href}</p>
+
+<Child prop={encodeURIComponent(value)} />


### PR DESCRIPTION
Noticed this while reviewing #12692 — there's some low-hanging fruit here. When referencing built-ins in templates...

```js
<p>{location.href}</p>
<p>{btoa('hello world')}</p>
```

...we currently create effects (or deriveds, in the case of component props):

```js
$.template_effect(() => $.set_text(text_1, btoa('hello world')));
$.template_effect(() => $.set_text(text, location.href));
```

If we make the perfectly reasonable assumption that globals don't reference Svelte state, we can do this instead:

```js
text.nodeValue = location.href;
text_1.nodeValue = btoa('hello world');
```

This assumption would break if someone did something stupid...

```js
globalThis.foo = () => somestate;
```

...but if people do that they will have their Svelte license revoked.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
