### PR TITLE
fix: add css hash to custom element rendered with `svelte:element`

### DIFF
--- a/.changeset/chilly-carpets-switch.md
+++ b/.changeset/chilly-carpets-switch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add css hash to custom element rendered with `svelte:element`

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -470,10 +470,8 @@ function build_element_spread_attributes(
 			attribute.type === 'SpreadAttribute' && attribute.metadata.expression.has_call;
 	}
 
-	const lowercase_attributes =
-		element.metadata.svg || element.metadata.mathml || is_custom_element_node(element)
-			? b.false
-			: b.true;
+	const preserve_attribute_case =
+		element.metadata.svg || element.metadata.mathml || is_custom_element_node(element);
 	const id = context.state.scope.generate('attributes');
 
 	const update = b.stmt(
@@ -485,8 +483,8 @@ function build_element_spread_attributes(
 				element_id,
 				b.id(id),
 				b.object(values),
-				lowercase_attributes,
 				context.state.analysis.css.hash !== '' && b.literal(context.state.analysis.css.hash),
+				preserve_attribute_case && b.true,
 				is_ignored(element, 'hydration_attribute_changed') && b.true
 			)
 		)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -486,7 +486,7 @@ function build_element_spread_attributes(
 				b.id(id),
 				b.object(values),
 				lowercase_attributes,
-				b.literal(context.state.analysis.css.hash),
+				context.state.analysis.css.hash !== '' && b.literal(context.state.analysis.css.hash),
 				is_ignored(element, 'hydration_attribute_changed') && b.true
 			)
 		)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
@@ -200,7 +200,7 @@ function build_dynamic_element_attributes(attributes, context, element_id) {
 					element_id,
 					b.id(id),
 					b.object(values),
-					b.literal(context.state.analysis.css.hash)
+					context.state.analysis.css.hash !== '' && b.literal(context.state.analysis.css.hash)
 				)
 			)
 		);
@@ -221,7 +221,7 @@ function build_dynamic_element_attributes(attributes, context, element_id) {
 				element_id,
 				b.literal(null),
 				b.object(values),
-				b.literal(context.state.analysis.css.hash)
+				context.state.analysis.css.hash !== '' && b.literal(context.state.analysis.css.hash)
 			)
 		)
 	);

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -148,7 +148,7 @@ export function set_custom_element_data(node, prop, value) {
  * @param {Record<string, any> | undefined} prev
  * @param {Record<string, any>} next New attributes - this function mutates this object
  * @param {boolean} lowercase_attributes
- * @param {string} css_hash
+ * @param {string} [css_hash]
  * @param {boolean} [skip_warning]
  * @returns {Record<string, any>}
  */
@@ -162,7 +162,7 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 		}
 	}
 
-	if (css_hash !== '') {
+	if (css_hash !== undefined) {
 		next.class = next.class ? next.class + ' ' + css_hash : css_hash;
 	}
 
@@ -305,7 +305,7 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
  * @param {Record<string, any>} next The new attributes - this function mutates this object
  * @param {string} [css_hash]
  */
-export function set_dynamic_element_attributes(node, prev, next, css_hash = '') {
+export function set_dynamic_element_attributes(node, prev, next, css_hash) {
 	if (node.tagName.includes('-')) {
 		for (var key in prev) {
 			if (!(key in next)) {
@@ -313,7 +313,7 @@ export function set_dynamic_element_attributes(node, prev, next, css_hash = '') 
 			}
 		}
 
-		if (css_hash !== '') {
+		if (css_hash !== undefined) {
 			next.class = next.class ? next.class + ' ' + css_hash : css_hash;
 		}
 

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -129,8 +129,9 @@ export function set_xlink_attribute(dom, attribute, value) {
  * @param {any} node
  * @param {string} prop
  * @param {any} value
+ * @param {string} [css_hash]
  */
-export function set_custom_element_data(node, prop, value) {
+export function set_custom_element_data(node, prop, value, css_hash) {
 	if (prop in node) {
 		var curr_val = node[prop];
 		var next_val = typeof curr_val === 'boolean' && value === '' ? true : value;
@@ -138,6 +139,10 @@ export function set_custom_element_data(node, prop, value) {
 			node[prop] = next_val;
 		}
 	} else {
+		if (css_hash && css_hash.length !== 0 && prop === 'class') {
+			if (value) value += ' ';
+			value += css_hash;
+		}
 		set_attribute(node, prop, value);
 	}
 }
@@ -320,7 +325,7 @@ export function set_dynamic_element_attributes(node, prev, next, css_hash) {
 		}
 
 		for (key in next) {
-			set_custom_element_data(node, key, next[key]);
+			set_custom_element_data(node, key, next[key], css_hash);
 		}
 
 		return next;

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -129,9 +129,8 @@ export function set_xlink_attribute(dom, attribute, value) {
  * @param {any} node
  * @param {string} prop
  * @param {any} value
- * @param {string} [css_hash]
  */
-export function set_custom_element_data(node, prop, value, css_hash) {
+export function set_custom_element_data(node, prop, value) {
 	if (prop in node) {
 		var curr_val = node[prop];
 		var next_val = typeof curr_val === 'boolean' && value === '' ? true : value;
@@ -139,10 +138,6 @@ export function set_custom_element_data(node, prop, value, css_hash) {
 			node[prop] = next_val;
 		}
 	} else {
-		if (css_hash && css_hash.length !== 0 && prop === 'class') {
-			if (value) value += ' ';
-			value += css_hash;
-		}
 		set_attribute(node, prop, value);
 	}
 }
@@ -158,7 +153,6 @@ export function set_custom_element_data(node, prop, value, css_hash) {
  * @returns {Record<string, any>}
  */
 export function set_attributes(element, prev, next, lowercase_attributes, css_hash, skip_warning) {
-	var has_hash = css_hash.length !== 0;
 	var current = prev || {};
 	var is_option_element = element.tagName === 'OPTION';
 
@@ -168,8 +162,8 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 		}
 	}
 
-	if (has_hash && !next.class) {
-		next.class = '';
+	if (css_hash !== '') {
+		next.class = next.class ? next.class + ' ' + css_hash : css_hash;
 	}
 
 	var setters = setters_cache.get(element.nodeName);
@@ -284,11 +278,6 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 					element[name] = value;
 				}
 			} else if (typeof value !== 'function') {
-				if (has_hash && name === 'class') {
-					if (value) value += ' ';
-					value += css_hash;
-				}
-
 				set_attribute(element, name, value);
 			}
 		}
@@ -314,9 +303,9 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
  * @param {Element} node
  * @param {Record<string, any> | undefined} prev
  * @param {Record<string, any>} next The new attributes - this function mutates this object
- * @param {string} css_hash
+ * @param {string} [css_hash]
  */
-export function set_dynamic_element_attributes(node, prev, next, css_hash) {
+export function set_dynamic_element_attributes(node, prev, next, css_hash = '') {
 	if (node.tagName.includes('-')) {
 		for (var key in prev) {
 			if (!(key in next)) {
@@ -324,8 +313,12 @@ export function set_dynamic_element_attributes(node, prev, next, css_hash) {
 			}
 		}
 
+		if (css_hash !== '') {
+			next.class = next.class ? next.class + ' ' + css_hash : css_hash;
+		}
+
 		for (key in next) {
-			set_custom_element_data(node, key, next[key], css_hash);
+			set_custom_element_data(node, key, next[key]);
 		}
 
 		return next;

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -147,12 +147,19 @@ export function set_custom_element_data(node, prop, value) {
  * @param {Element & ElementCSSInlineStyle} element
  * @param {Record<string, any> | undefined} prev
  * @param {Record<string, any>} next New attributes - this function mutates this object
- * @param {boolean} lowercase_attributes
  * @param {string} [css_hash]
+ * @param {boolean} preserve_attribute_case
  * @param {boolean} [skip_warning]
  * @returns {Record<string, any>}
  */
-export function set_attributes(element, prev, next, lowercase_attributes, css_hash, skip_warning) {
+export function set_attributes(
+	element,
+	prev,
+	next,
+	css_hash,
+	preserve_attribute_case = false,
+	skip_warning
+) {
 	var current = prev || {};
 	var is_option_element = element.tagName === 'OPTION';
 
@@ -266,7 +273,7 @@ export function set_attributes(element, prev, next, lowercase_attributes, css_ha
 			element.value = element[key] = element.__value = value;
 		} else {
 			var name = key;
-			if (lowercase_attributes) {
+			if (!preserve_attribute_case) {
 				name = normalize_attribute(name);
 			}
 
@@ -328,8 +335,8 @@ export function set_dynamic_element_attributes(node, prev, next, css_hash) {
 		/** @type {Element & ElementCSSInlineStyle} */ (node),
 		prev,
 		next,
-		node.namespaceURI !== NAMESPACE_SVG,
-		css_hash
+		css_hash,
+		node.namespaceURI !== NAMESPACE_SVG
 	);
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-custom-element-css-hash/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-custom-element-css-hash/_config.js
@@ -1,0 +1,14 @@
+import { ok, test } from '../../test';
+
+export default test({
+	html: `<custom-element class="red svelte-p153w3"></custom-element><custom-element class="red svelte-p153w3"></custom-element>`,
+
+	async test({ assert, target }) {
+		const [el, el2] = target.querySelectorAll('custom-element');
+		ok(el);
+		ok(el2);
+
+		assert.deepEqual(el.className, 'red svelte-p153w3');
+		assert.deepEqual(el2.className, 'red svelte-p153w3');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-custom-element-css-hash/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-custom-element-css-hash/main.svelte
@@ -1,0 +1,8 @@
+<svelte:element this={'custom-element'} class="red"></svelte:element>
+<custom-element class="red"></custom-element>
+
+<style>
+	.red {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #12714

I initially did this change and then searched for where `set_custom_element_data` was used. I added the `css_hash` there too but then realized that for a normal custom element (rendered without the use of `svelte:element` it was already adding the class.

I did a bit of digging and found out that the css hash is added during the analysis phase which seemed a bit odd to me but seems part of a bigger system in place which i was a bit scared to touch). So for the moment i've made the `css_hash` argument optional and i'm checking for it's presence before adding the class but if you think a major refactor to always pass the `css_hash` during the transform phase instead of the analysis phase is needed i can work on this a bit more.

I've added the normal custom element to the test to avoid falling, in the future, in the trap of adding the custom css hash twice.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
