### PR TITLE
fix: correctly handle SvelteDate methods with arguments

### DIFF
--- a/.changeset/dirty-pens-look.md
+++ b/.changeset/dirty-pens-look.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly handle SvelteDate methods with arguments

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -39,6 +39,7 @@ export class SvelteDate extends Date {
 						// @ts-ignore
 						return date_proto[method].apply(this, args);
 					}
+
 					var d = this.#deriveds.get(method);
 
 					if (d === undefined) {

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -32,7 +32,9 @@ export class SvelteDate extends Date {
 			if (method.startsWith('get') || method.startsWith('to')) {
 				// @ts-ignore
 				proto[method] = function (...args) {
-					var d = this.#deriveds.get(method);
+					// @ts-ignore
+					var can_cache = args.length === 0;
+					var d = can_cache ? this.#deriveds.get(method) : undefined;
 
 					if (d === undefined) {
 						d = derived(() => {
@@ -41,7 +43,9 @@ export class SvelteDate extends Date {
 							return date_proto[method].apply(this, args);
 						});
 
-						this.#deriveds.set(method, d);
+						if (can_cache) {
+							this.#deriveds.set(method, d);
+						}
 					}
 
 					return get(d);

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -32,7 +32,7 @@ export class SvelteDate extends Date {
 			if (method.startsWith('get') || method.startsWith('to')) {
 				// @ts-ignore
 				proto[method] = function (...args) {
-					// If we have no params, then don't cache or create a derived
+					// don't memoize if there are arguments
 					// @ts-ignore
 					if (args.length > 0) {
 						get(this.#time);

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -32,9 +32,14 @@ export class SvelteDate extends Date {
 			if (method.startsWith('get') || method.startsWith('to')) {
 				// @ts-ignore
 				proto[method] = function (...args) {
+					// If we have no params, then don't cache or create a derived
 					// @ts-ignore
-					var can_cache = args.length === 0;
-					var d = can_cache ? this.#deriveds.get(method) : undefined;
+					if (args.length > 0) {
+						get(this.#time);
+						// @ts-ignore
+						return date_proto[method].apply(this, args);
+					}
+					var d = this.#deriveds.get(method);
 
 					if (d === undefined) {
 						d = derived(() => {
@@ -43,9 +48,7 @@ export class SvelteDate extends Date {
 							return date_proto[method].apply(this, args);
 						});
 
-						if (can_cache) {
-							this.#deriveds.set(method, d);
-						}
+						this.#deriveds.set(method, d);
 					}
 
 					return get(d);

--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -555,7 +555,7 @@ test('Date fine grained tests', () => {
 	cleanup();
 });
 
-test('Datae.toLocaleString', () => {
+test('Date.toLocaleString', () => {
 	const date = new SvelteDate(initial_date);
 
 	const log: any = [];

--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -555,6 +555,30 @@ test('Date fine grained tests', () => {
 	cleanup();
 });
 
+test('Datae.toLocaleString', () => {
+	const date = new SvelteDate(initial_date);
+
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(date.toLocaleString(undefined, { month: 'long', year: 'numeric' }));
+		});
+		render_effect(() => {
+			log.push(date.toLocaleString(undefined, { month: 'long' }));
+		});
+	});
+
+	flushSync();
+
+	assert.deepEqual(log, [
+		initial_date.toLocaleString(undefined, { month: 'long', year: 'numeric' }),
+		initial_date.toLocaleString(undefined, { month: 'long' })
+	]);
+
+	cleanup();
+});
+
 test('Date.instanceOf', () => {
 	assert.equal(new SvelteDate() instanceof Date, true);
 });


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12717. We shouldn't cached deriveds for methods that take params, oops.