### PR TITLE
fix: avoid stack overflows from derived recursion

### DIFF
--- a/.changeset/thick-chefs-change.md
+++ b/.changeset/thick-chefs-change.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid stack overflows from derived recursion

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive-2/_config.js
@@ -10,11 +10,17 @@ export default test({
 		b1?.click();
 		flushSync();
 
-		assert.htmlEqual(target.innerHTML, `<p>Is odd</p><button>clicks: 1</button><button>disable</button>`);
+		assert.htmlEqual(
+			target.innerHTML,
+			`<p>Is odd</p><button>clicks: 1</button><button>disable</button>`
+		);
 
 		b2?.click();
 		flushSync();
 
-		assert.htmlEqual(target.innerHTML, `<p>Is odd</p><button>clicks: 1</button><button>disable</button>`);
+		assert.htmlEqual(
+			target.innerHTML,
+			`<p>Is odd</p><button>clicks: 1</button><button>disable</button>`
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive-2/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<p>Is even</p><button>clicks: 0</button><button>disable</button>`,
+
+	test({ assert, target }) {
+		const [b1, b2] = target.querySelectorAll('button');
+
+		b1?.click();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<p>Is odd</p><button>clicks: 1</button><button>disable</button>`);
+
+		b2?.click();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<p>Is odd</p><button>clicks: 1</button><button>disable</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive-2/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	let count = $state(0);
+	let disabled = $state(false);
+
+	let even = $derived.by(() => {
+		if (disabled) return definitely_even;
+
+		return count % 2 === 0;
+	});
+
+
+	let definitely_even = $derived(even);
+
+	function increment() {
+		count += 1;
+	}
+</script>
+
+<p>Is {even ? 'even' : 'odd'}</p>
+
+<button onclick={increment}>clicks: {count}</button>
+<button onclick={() => disabled = true}>disable</button>

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive/_config.js
@@ -10,11 +10,17 @@ export default test({
 		b1?.click();
 		flushSync();
 
-		assert.htmlEqual(target.innerHTML, `<p>Is odd</p><button>clicks: 1</button><button>disable</button>`);
+		assert.htmlEqual(
+			target.innerHTML,
+			`<p>Is odd</p><button>clicks: 1</button><button>disable</button>`
+		);
 
 		b2?.click();
 		flushSync();
 
-		assert.htmlEqual(target.innerHTML, `<p>Is odd</p><button>clicks: 1</button><button>disable</button>`);
+		assert.htmlEqual(
+			target.innerHTML,
+			`<p>Is odd</p><button>clicks: 1</button><button>disable</button>`
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<p>Is even</p><button>clicks: 0</button><button>disable</button>`,
+
+	test({ assert, target }) {
+		const [b1, b2] = target.querySelectorAll('button');
+
+		b1?.click();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<p>Is odd</p><button>clicks: 1</button><button>disable</button>`);
+
+		b2?.click();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<p>Is odd</p><button>clicks: 1</button><button>disable</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-fn-recursive/main.svelte
@@ -1,0 +1,19 @@
+<script>
+	let count = $state(0);
+	let disabled = $state(false);
+
+	let even = $derived.by(() => {
+		if (disabled) return even;
+
+		return count % 2 === 0;
+	})
+
+	function increment() {
+		count += 1;
+	}
+</script>
+
+<p>Is {even ? 'even' : 'odd'}</p>
+
+<button onclick={increment}>clicks: {count}</button>
+<button onclick={() => disabled = true}>disable</button>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12723. We can actually track updating deriveds and prevent stack overflows internally.