### PR TITLE
fix: ensure unowned deriveds correctly update

### DIFF
--- a/.changeset/olive-forks-grin.md
+++ b/.changeset/olive-forks-grin.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure unowned deriveds correctly update

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -162,9 +162,9 @@ export function check_dirtiness(reaction) {
 
 	if ((flags & MAYBE_DIRTY) !== 0) {
 		var dependencies = reaction.deps;
+		var is_unowned = (flags & UNOWNED) !== 0;
 
 		if (dependencies !== null) {
-			var is_unowned = (flags & UNOWNED) !== 0;
 			var i;
 
 			if ((flags & DISCONNECTED) !== 0) {
@@ -198,7 +198,10 @@ export function check_dirtiness(reaction) {
 			}
 		}
 
-		set_signal_status(reaction, CLEAN);
+		// Unowned signals should never be marked as clean.
+		if (!is_unowned) {
+			set_signal_status(reaction, CLEAN);
+		}
 	}
 
 	return false;

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -676,4 +676,21 @@ describe('signals', () => {
 			assert.equal(d.deps?.length, 1);
 		};
 	});
+
+	test('unowned deriveds correctly update', () => {
+		return () => {
+			const arr1 = proxy<{ a: number }[]>([]);
+			const arr2 = proxy([]);
+			const combined = derived(() => [...arr1, ...arr2]);
+			const derived_length = derived(() => $.get(combined).length);
+
+			assert.deepEqual($.get(combined), []);
+			assert.equal($.get(derived_length), 0);
+
+			arr1.push({ a: 1 });
+
+			assert.deepEqual($.get(combined), [{ a: 1 }]);
+			assert.equal($.get(derived_length), 1);
+		};
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12708. It turns out that there was a regression in https://github.com/sveltejs/svelte/pull/12272. I knew that we needed this logic for something (see the comments in that PR where I flagged this), and it turns out this was one of those cases that wasn't quite captured in a test.