### PR TITLE
feat: warn for lowercase `object.component` rendering

### DIFF
--- a/.changeset/nine-cobras-stare.md
+++ b/.changeset/nine-cobras-stare.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: warn for lowercase `object.component` rendering

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -38,6 +38,10 @@
 
 > Using `on:%name%` to listen to the %name% event is deprecated. Use the event attribute `on%name%` instead
 
+## lowercase_component_rendering
+
+> Are you trying to render `%component%`? Component names should be uppercase.
+
 ## node_invalid_placement_ssr
 
 > %thing% is invalid inside `<%parent%>`. When rendering this component on the server, the resulting HTML will be modified by the browser, likely resulting in a `hydration_mismatch` warning

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/RegularElement.js
@@ -78,6 +78,16 @@ export function RegularElement(node, context) {
 	}
 
 	const binding = context.state.scope.get(node.name);
+
+	if (context.state.analysis.runes && node.name.includes('.')) {
+		const [maybe_object] = node.name.split('.');
+		const object_binding = context.state.scope.get(maybe_object);
+
+		if (object_binding) {
+			w.lowercase_component_rendering(node, node.name);
+		}
+	}
+
 	if (
 		binding !== null &&
 		binding.declaration_kind === 'import' &&

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -115,6 +115,7 @@ export const codes = [
 	"component_name_lowercase",
 	"element_invalid_self_closing_tag",
 	"event_directive_deprecated",
+	"lowercase_component_rendering",
 	"node_invalid_placement_ssr",
 	"slot_element_deprecated",
 	"svelte_element_invalid_this"
@@ -747,6 +748,15 @@ export function element_invalid_self_closing_tag(node, name) {
  */
 export function event_directive_deprecated(node, name) {
 	w(node, "event_directive_deprecated", `Using \`on:${name}\` to listen to the ${name} event is deprecated. Use the event attribute \`on${name}\` instead`);
+}
+
+/**
+ * Are you trying to render `%component%`? Component names should be uppercase.
+ * @param {null | NodeLike} node
+ * @param {string} component
+ */
+export function lowercase_component_rendering(node, component) {
+	w(node, "lowercase_component_rendering", `Are you trying to render \`${component}\`? Component names should be uppercase.`);
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/lowercase-component-rendering/input.svelte
+++ b/packages/svelte/tests/validator/samples/lowercase-component-rendering/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	const component = $state({});
+</script>
+
+<component.component></component.component>
+
+<weird.element></weird.element>

--- a/packages/svelte/tests/validator/samples/lowercase-component-rendering/warnings.json
+++ b/packages/svelte/tests/validator/samples/lowercase-component-rendering/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "lowercase_component_rendering",
+		"message": "Are you trying to render `component.component`? Component names should be uppercase.",
+		"start": {
+			"line": 5,
+			"column": 0
+		},
+		"end": {
+			"line": 5,
+			"column": 43
+		}
+	}
+]


### PR DESCRIPTION
## Svelte 5 rewrite

As discussed in #12694 i've reverted the warn for lowercase `object.component` in that pr and i'm opening this one to continue discussing what we should do.

The options are:

1. warn like this pr is doing
2. consider `object.component` a component and not a `RegularElement`...this could be technically problematic for Svelte Native so we are waiting for a word from @halfnelson on it (you can follow the discussion starting from [here](https://github.com/sveltejs/svelte/pull/12694#issuecomment-2265371452)

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
