### PR TITLE
fix: prevent numerous transition/animation memory leaks

### DIFF
--- a/.changeset/silly-masks-exist.md
+++ b/.changeset/silly-masks-exist.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent numerous transition/animation memory leaks

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -448,12 +448,7 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 
 	return {
 		abort: () => {
-			if (animation) {
-				animation.cancel();
-				// Force cleanup on properties that can retain memory
-				animation.effect = null;
-				animation.timeline = null;
-			}
+			animation?.cancel();
 			task?.abort();
 			on_abort?.();
 		},

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -326,8 +326,10 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 		// once DOM has been updated...
 		/** @type {Animation} */
 		var a;
+		var aborted = false;
 
 		queue_micro_task(() => {
+			if (aborted) return;
 			var o = options({ direction: is_intro ? 'in' : 'out' });
 			a = animate(element, o, counterpart, t2, on_finish, on_abort);
 		});
@@ -335,7 +337,10 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 		// ...but we want to do so without using `async`/`await` everywhere, so
 		// we return a facade that allows everything to remain synchronous
 		return {
-			abort: () => a?.abort(),
+			abort: () => {
+				aborted = true;
+				a?.abort();
+			},
 			deactivate: () => a.deactivate(),
 			reset: () => a.reset(),
 			t: (now) => a.t(now)

--- a/playgrounds/demo/index.html
+++ b/playgrounds/demo/index.html
@@ -20,9 +20,6 @@
 			const component = render(App, {
 				target: document.getElementById('root')
 			});
-
-			// @ts-ignore
-			window.unmount = () => unmount(component);
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
Whilst digging into https://github.com/sveltejs/svelte/issues/12719, I discovered several memory leaks where we retain DOM elements longer than we should. We also frustratingly retain the animation even after the DOM element has been detached and the animation is cancelled – but this seems to happen on the MDN site too, so maybe WAAPI has issues on Chromium?

I can't say for sure if this solves all the issues, but it definitely solves a whole load for me and memory usage now doesn't grow at a large rate when toggling the DOM elements in and out in the example. 

[Test case](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAE42Qy07DMBBFf2XkgtqKqKYs0zgSe9ixwyzSZBJZccaRM6mIjP8dpaUPCRYsfe1zPXOCqI3FQaTvQVDRoUjFc9-LRPDUz4fhgJZRJGJwoy_nJBtKb3rONWk2Xe88wyt2zk8vWLRQe9fBciOv0eZUsdxpmhGLDKUbidGDgruBC8bV43qnKZPXZsr2I7MjcFRaU7YqrNagclid0QcF23XM31zTWMzk6XWuKSxMfem_hydQSsE2zj-HRYvT-e6YaM5uRpfHlYJscYqagjR11CQS0bnK1AYrkbIfMSYXUVf2H77AFtQoLXjQ4tZdgLqoEOKPuRMv2Rc0GDaOlr_MVOYAhtIZ-2qs2xc2Z_zkTFbmkP818Uf8BtwvzYTmAQAA)

- Go to the dev tools memory tab, record a snapshot
- Toggle the animation on and off
- Take another snapshot
- Toggle the animation on and off one last time
- Take a third snapshot

If you compare the 2nd and 3rd snapshots, we have no retained DOM elements leaking.