### PR TITLE
fix: skip `is_standalone` optimisation for dynamic components

### DIFF
--- a/.changeset/nice-bottles-greet.md
+++ b/.changeset/nice-bottles-greet.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip `is_standalone` optimisation for dynamic components

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -283,6 +283,7 @@ export function clean_nodes(
 			((first.type === 'RenderTag' && !first.metadata.dynamic) ||
 				(first.type === 'Component' &&
 					!state.options.hmr &&
+					!first.metadata.dynamic &&
 					!first.attributes.some(
 						(attribute) => attribute.type === 'Attribute' && attribute.name.startsWith('--')
 					))),

--- a/packages/svelte/tests/runtime-runes/samples/member-expression-component/Row.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/member-expression-component/Row.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { id } = $props();
+</script>
+
+<span>{id}</span>

--- a/packages/svelte/tests/runtime-runes/samples/member-expression-component/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/member-expression-component/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<button>flip</button> <span>0</span><span>1</span><span>2</span>`,
+
+	async test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>flip</button> <span>2</span><span>1</span><span>0</span>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/member-expression-component/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/member-expression-component/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Row from './Row.svelte';
+
+	const items = $state([{ id: 0 }, { id: 1 }, { id: 2 }]);
+
+	const Table = { Row };
+</script>
+
+<button onclick={() => items.reverse()}> flip </button>
+
+{#each items as item (item.id)}
+	<Table.Row id={item.id} />
+{/each}


### PR DESCRIPTION
fixes #12677. `<Foo.Bar>` should be treated as a dynamic component and should not have the `is_standalone` optimisation that allows sole children of blocks to append directly to the current fragment

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
