### PR TITLE
fix: ensure custom element styles append correctly during prod

### DIFF
--- a/.changeset/hip-goats-smoke.md
+++ b/.changeset/hip-goats-smoke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure custom element styles append correctly during prod

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -380,7 +380,9 @@ export function client_component(analysis, options) {
 		state.hoisted.push(b.const('$$css', b.object([b.init('hash', hash), b.init('code', code)])));
 
 		component_block.body.unshift(
-			b.stmt(b.call('$.append_styles', b.id('$$anchor'), b.id('$$css')))
+			b.stmt(
+				b.call('$.append_styles', b.id('$$anchor'), b.id('$$css'), b.literal(options.customElement))
+			)
 		);
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -381,7 +381,7 @@ export function client_component(analysis, options) {
 
 		component_block.body.unshift(
 			b.stmt(
-				b.call('$.append_styles', b.id('$$anchor'), b.id('$$css'), b.literal(options.customElement))
+				b.call('$.append_styles', b.id('$$anchor'), b.id('$$css'), options.customElement && b.true)
 			)
 		);
 	}

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,49 +1,19 @@
-import { DEV } from 'esm-env';
-import { effect } from '../reactivity/effects.js';
-
-var css_counter = new Map();
-
 /**
  * @param {Node} anchor
  * @param {{ hash: string, code: string }} css
  */
 export function append_styles(anchor, css) {
-	const maybe_append_styles = () => {
-		var root = anchor.getRootNode();
+	var root = anchor.getRootNode();
 
-		var target = /** @type {ShadowRoot} */ (root).host
-			? /** @type {ShadowRoot} */ (root)
-			: /** @type {Document} */ (root).head ?? /** @type {Document} */ (root.ownerDocument).head;
+	var target = /** @type {ShadowRoot} */ (root).host
+		? /** @type {ShadowRoot} */ (root)
+		: /** @type {Document} */ (root).head ?? /** @type {Document} */ (root.ownerDocument).head;
 
-		if (!target.querySelector('#' + css.hash)) {
-			const style = document.createElement('style');
-			style.id = css.hash;
-			style.textContent = css.code;
+	if (!target.querySelector('#' + css.hash)) {
+		const style = document.createElement('style');
+		style.id = css.hash;
+		style.textContent = css.code;
 
-			target.appendChild(style);
-		}
-	};
-
-	// Use an effect to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
-	effect(() => {
-		// In dev, always check the DOM, so that styles can be replaced with HMR
-		if (DEV) {
-			maybe_append_styles();
-			return;
-		}
-		// Otherwise, for prod we can use the css object as a key and count the usage to skip the lookup
-		var count = css_counter.get(css) ?? 0;
-
-		css_counter.set(css, count + 1);
-
-		if (count > 0) return;
-
-		maybe_append_styles();
-
-		return () => {
-			var count = css_counter.get(css) - 1;
-			css_counter.set(css, count);
-			if (count === 0) css_counter.delete(css);
-		};
-	});
+		target.appendChild(style);
+	}
 }

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,10 +1,20 @@
+import { DEV } from 'esm-env';
 import { queue_micro_task } from './task.js';
+
+var seen = new Set();
 
 /**
  * @param {Node} anchor
  * @param {{ hash: string, code: string }} css
+ * @param {boolean} is_custom_element
  */
-export function append_styles(anchor, css) {
+export function append_styles(anchor, css, is_custom_element) {
+	// in dev, always check the DOM, so that styles can be replaced with HMR
+	if (!DEV && !is_custom_element) {
+		if (seen.has(css)) return;
+		seen.add(css);
+	}
+
 	// Use `queue_micro_task` to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
 	queue_micro_task(() => {
 		var root = anchor.getRootNode();

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,19 +1,24 @@
+import { queue_micro_task } from './task';
+
 /**
  * @param {Node} anchor
  * @param {{ hash: string, code: string }} css
  */
 export function append_styles(anchor, css) {
-	var root = anchor.getRootNode();
+	// Use `queue_micro_task` to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
+	queue_micro_task(() => {
+		var root = anchor.getRootNode();
 
-	var target = /** @type {ShadowRoot} */ (root).host
-		? /** @type {ShadowRoot} */ (root)
-		: /** @type {Document} */ (root).head ?? /** @type {Document} */ (root.ownerDocument).head;
+		var target = /** @type {ShadowRoot} */ (root).host
+			? /** @type {ShadowRoot} */ (root)
+			: /** @type {Document} */ (root).head ?? /** @type {Document} */ (root.ownerDocument).head;
 
-	if (!target.querySelector('#' + css.hash)) {
-		const style = document.createElement('style');
-		style.id = css.hash;
-		style.textContent = css.code;
+		if (!target.querySelector('#' + css.hash)) {
+			const style = document.createElement('style');
+			style.id = css.hash;
+			style.textContent = css.code;
 
-		target.appendChild(style);
-	}
+			target.appendChild(style);
+		}
+	});
 }

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,21 +1,14 @@
 import { DEV } from 'esm-env';
-import { queue_micro_task } from './task.js';
+import { effect } from '../reactivity/effects.js';
 
-var seen = new Set();
+var css_counter = new Map();
 
 /**
  * @param {Node} anchor
  * @param {{ hash: string, code: string }} css
  */
 export function append_styles(anchor, css) {
-	// in dev, always check the DOM, so that styles can be replaced with HMR
-	if (!DEV) {
-		if (seen.has(css)) return;
-		seen.add(css);
-	}
-
-	// Use `queue_micro_task` to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
-	queue_micro_task(() => {
+	const maybe_append_styles = () => {
 		var root = anchor.getRootNode();
 
 		var target = /** @type {ShadowRoot} */ (root).host
@@ -29,5 +22,28 @@ export function append_styles(anchor, css) {
 
 			target.appendChild(style);
 		}
+	};
+
+	// Use an effect to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
+	effect(() => {
+		// In dev, always check the DOM, so that styles can be replaced with HMR
+		if (DEV) {
+			maybe_append_styles();
+			return;
+		}
+		// Otherwise, for prod we can use the css object as a key and count the usage to skip the lookup
+		var count = css_counter.get(css) ?? 0;
+
+		css_counter.set(css, count + 1);
+
+		if (count > 0) return;
+
+		maybe_append_styles();
+
+		return () => {
+			var count = css_counter.get(css) - 1;
+			css_counter.set(css, count);
+			if (count === 0) css_counter.delete(css);
+		};
 	});
 }

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,4 +1,4 @@
-import { queue_micro_task } from './task';
+import { queue_micro_task } from './task.js';
 
 /**
  * @param {Node} anchor

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -6,9 +6,9 @@ var seen = new Set();
 /**
  * @param {Node} anchor
  * @param {{ hash: string, code: string }} css
- * @param {boolean} is_custom_element
+ * @param {boolean} [is_custom_element]
  */
-export function append_styles(anchor, css, is_custom_element) {
+export function append_styles(anchor, css, is_custom_element = false) {
 	// in dev, always check the DOM, so that styles can be replaced with HMR
 	if (!DEV && !is_custom_element) {
 		if (seen.has(css)) return;


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12776. We always need to do the check for the style, using the key to avoid doing this won't work for cases where the styles are added in their own shadow DOM – as they always need to be added.