### PR TITLE
chore: publish package provenance info

### DIFF
--- a/.changeset/fluffy-kings-complain.md
+++ b/.changeset/fluffy-kings-complain.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: publish package provenance info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.repository == 'sveltejs/svelte'
     permissions:
       contents: write # to create release (changesets/action)
+      id-token: write # OpenID Connect token needed for provenance
       pull-requests: write # to create pull request (changesets/action)
     name: Release
     runs-on: ubuntu-latest

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -154,5 +154,8 @@
     "project": [
       "src/**"
     ]
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }


### PR DESCRIPTION
I tested this on SvelteKit already. Now we have a nice little green checkmark next to the version on npm