### PR TITLE
feat: simplify derived object destructuring

### DIFF
--- a/.changeset/wicked-years-drive.md
+++ b/.changeset/wicked-years-drive.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: simplify derived object destructuring

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -172,7 +172,7 @@ export function VariableDeclaration(node, context) {
 					);
 				} else {
 					const bindings = extract_paths(declarator.id);
-					const object_id = context.state.scope.generate('derived_object');
+					const object_id = context.state.scope.generate('$$d');
 
 					declarations.push(
 						b.declarator(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -171,27 +171,13 @@ export function VariableDeclaration(node, context) {
 						)
 					);
 				} else {
-					const bindings = context.state.scope.get_bindings(declarator);
+					const bindings = extract_paths(declarator.id);
 					const object_id = context.state.scope.generate('derived_object');
-					const values_id = context.state.scope.generate('derived_values');
+
 					declarations.push(
 						b.declarator(
 							b.id(object_id),
 							b.call('$.derived', rune === '$derived.by' ? value : b.thunk(value))
-						)
-					);
-					declarations.push(
-						b.declarator(
-							b.id(values_id),
-							b.call(
-								'$.derived',
-								b.thunk(
-									b.block([
-										b.let(declarator.id, b.call('$.get', b.id(object_id))),
-										b.return(b.array(bindings.map((binding) => binding.node)))
-									])
-								)
-							)
 						)
 					);
 					for (let i = 0; i < bindings.length; i++) {
@@ -199,10 +185,7 @@ export function VariableDeclaration(node, context) {
 						declarations.push(
 							b.declarator(
 								binding.node,
-								b.call(
-									'$.derived',
-									b.thunk(b.member(b.call('$.get', b.id(values_id)), b.literal(i), true))
-								)
+								b.call('$.derived', b.thunk(binding.expression(b.call('$.get', b.id(object_id)))))
 							)
 						);
 					}

--- a/packages/svelte/tests/runtime-runes/samples/derived-destructured/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-destructured/_config.js
@@ -1,5 +1,5 @@
 import { test } from '../../test';
 
 export default test({
-	html: `true 1 2 baz`
+	html: `true 1 2 baz 1 2 3`
 });

--- a/packages/svelte/tests/runtime-runes/samples/derived-destructured/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-destructured/main.svelte
@@ -1,6 +1,9 @@
 <script>
   let stuff = $state({ foo: true, bar: [1, 2, {baz: 'baz'}] });
   let { foo, bar: [a, b, { baz }]} = $derived(stuff);
+
+	let stuff2 = $state([1, 2, 3]);
+	let [d, e, f] = $derived(stuff2);
 </script>
 
-{foo} {a} {b} {baz}
+{foo} {a} {b} {baz} {d} {e} {f}


### PR DESCRIPTION
The following $derived
```js
let { foo, bar: [a, b, { baz }]} = $derived(stuff);
```
currently compiles to 
```js
let derived_object = $.derived(() => stuff),
  derived_values = $.derived(() => {
    let { foo, bar: [a, b, { baz }] } = $.get(derived_object);

    return [foo, a, b, baz];
  }),
  foo = $.derived(() => $.get(derived_values)[0]),
  a = $.derived(() => $.get(derived_values)[1]),
  b = $.derived(() => $.get(derived_values)[2]),
  baz = $.derived(() => $.get(derived_values)[3]);
```
By re-using the `extract_paths` function, this PR simplifies the output to
```js
let derived_object = $.derived(() => stuff),
  foo = $.derived(() => $.get(derived_object).foo),
  a = $.derived(() => $.get(derived_object).bar[0]),
  b = $.derived(() => $.get(derived_object).bar[1]),
  baz = $.derived(() => $.get(derived_object).bar[2].baz);
```
which should be more performant because it avoids destructuring twice, and doesn't create as many derived sources.

Also added a test for destructuring an array, which was missing before.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
