### PR TITLE
chore: speed up exclude_from_object

### DIFF
--- a/.changeset/brown-insects-float.md
+++ b/.changeset/brown-insects-float.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: speed up $.exclude_from_object

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -280,8 +280,10 @@ function _extract_paths(assignments = [], param, expression, update_expression, 
 							if (p.type === 'Property' && p.key.type !== 'PrivateIdentifier') {
 								if (p.key.type === 'Identifier' && !p.computed) {
 									props.push(b.literal(p.key.name));
+								} else if (p.key.type === 'Literal') {
+									props.push(b.literal(String(p.key.value)));
 								} else {
-									props.push(p.key);
+									props.push(b.call('String', p.key));
 								}
 							}
 						}

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -276,6 +276,7 @@ function _extract_paths(assignments = [], param, expression, update_expression, 
 					const rest_expression = (object) => {
 						/** @type {ESTree.Expression[]} */
 						const props = [];
+
 						for (const p of param.properties) {
 							if (p.type === 'Property' && p.key.type !== 'PrivateIdentifier') {
 								if (p.key.type === 'Identifier' && !p.computed) {
@@ -287,6 +288,7 @@ function _extract_paths(assignments = [], param, expression, update_expression, 
 								}
 							}
 						}
+
 						return b.call('$.exclude_from_object', expression(object), b.array(props));
 					};
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -991,12 +991,14 @@ export function update_pre(signal, d = 1) {
  * @returns {Record<string, unknown>}
  */
 export function exclude_from_object(obj, keys) {
-	obj = { ...obj };
-	let key;
-	for (key of keys) {
-		delete obj[key];
+	/** @type {Record<string, unknown>} */
+	let res = {};
+	for (let key in obj) {
+		// Use == because keys could be numbers, and iterating turns them into strings
+		if (keys.find((k) => k == key)) continue;
+		res[key] = obj[key];
 	}
-	return obj;
+	return res;
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -992,13 +992,15 @@ export function update_pre(signal, d = 1) {
  */
 export function exclude_from_object(obj, keys) {
 	/** @type {Record<string, unknown>} */
-	let res = {};
-	for (let key in obj) {
-		// Use == because keys could be numbers, and iterating turns them into strings
-		if (keys.find((k) => k === key)) continue;
-		res[key] = obj[key];
+	var result = {};
+
+	for (var key in obj) {
+		if (!keys.includes(key)) {
+			result[key] = obj[key];
+		}
 	}
-	return res;
+
+	return result;
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -995,7 +995,7 @@ export function exclude_from_object(obj, keys) {
 	let res = {};
 	for (let key in obj) {
 		// Use == because keys could be numbers, and iterating turns them into strings
-		if (keys.find((k) => k == key)) continue;
+		if (keys.find((k) => k === key)) continue;
 		res[key] = obj[key];
 	}
 	return res;

--- a/packages/svelte/tests/runtime-legacy/samples/each-block-destructured-object-literal-rest/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/each-block-destructured-object-literal-rest/_config.js
@@ -9,18 +9,21 @@ export default test({
 					quote: 'q1',
 					'wrong-quote': 'wq1',
 					16: '16',
+					17: '17',
 					class: 'class'
 				},
 				{
 					quote: 'q2',
 					'wrong-quote': 'wq2',
 					16: 'sixteen',
+					17: 'seventeen',
 					class: 'glass'
 				},
 				{
 					quote: 'q3',
 					'wrong-quote': 'wq3',
 					16: 'seize',
+					17: 'dix-sept',
 					class: 'mass'
 				}
 			]
@@ -28,19 +31,19 @@ export default test({
 	},
 
 	html: `
-    <p class="class">Quote: q1, Wrong Quote: wq1, 16: 16</p>
-    <p class="glass">Quote: q2, Wrong Quote: wq2, 16: sixteen</p>
-    <p class="mass">Quote: q3, Wrong Quote: wq3, 16: seize</p>
+    <p class="class">Quote: q1, Wrong Quote: wq1, 16: 16, 17: 17</p>
+    <p class="glass">Quote: q2, Wrong Quote: wq2, 16: sixteen, 17: seventeen</p>
+    <p class="mass">Quote: q3, Wrong Quote: wq3, 16: seize, 17: dix-sept</p>
 	`,
 
 	test({ assert, component, target }) {
 		component.objectsArray = [
-			{ quote: 'new-quote', 'wrong-quote': 'wq4', 16: 'ten+six', role: 'role' }
+			{ quote: 'new-quote', 'wrong-quote': 'wq4', 16: 'ten+six', 17: 'ten+seven', role: 'role' }
 		];
 		assert.htmlEqual(
 			target.innerHTML,
 			`
-			<p role="role">Quote: new-quote, Wrong Quote: wq4, 16: ten+six</p>
+			<p role="role">Quote: new-quote, Wrong Quote: wq4, 16: ten+six, 17: ten+seven</p>
 		`
 		);
 	}

--- a/packages/svelte/tests/runtime-legacy/samples/each-block-destructured-object-literal-rest/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/each-block-destructured-object-literal-rest/main.svelte
@@ -2,6 +2,6 @@
 	export let objectsArray;
 </script>
 
-{#each objectsArray as { "quote": quotedProp, "wrong-quote": wrongQuote, 16: sixteen, ...props } }
-	<p {...props}>Quote: {quotedProp}, Wrong Quote: {wrongQuote}, 16: {sixteen}</p>
+{#each objectsArray as { "quote": quotedProp, "wrong-quote": wrongQuote, 16: sixteen, [10 + 7]: seventeen, ...props }}
+	<p {...props}>Quote: {quotedProp}, Wrong Quote: {wrongQuote}, 16: {sixteen}, 17: {seventeen}</p>
 {/each}


### PR DESCRIPTION
Avoids an unnecessary spread in $.exclude_from_object.

Benchmark (tinybench):
![image](https://github.com/user-attachments/assets/a5c1ddd8-d573-46f6-9267-f2288fdf1195)


## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
