### PR TITLE
fix: ensure custom elements do not sync flush on mount

### DIFF
--- a/.changeset/cool-turtles-travel.md
+++ b/.changeset/cool-turtles-travel.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure Svelte4Components do not sync flush
+fix: ensure custom elements do not sync flush on mount

--- a/.changeset/cool-turtles-travel.md
+++ b/.changeset/cool-turtles-travel.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure Svelte4Components do not sync flush

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -110,7 +110,6 @@ class Svelte4Component {
 			recover: options.recover
 		});
 
-
 		this.#events = props.$$events;
 
 		for (const key of Object.keys(this.#instance)) {

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -2,7 +2,7 @@
 import { mutable_source, set } from '../internal/client/reactivity/sources.js';
 import { user_pre_effect } from '../internal/client/reactivity/effects.js';
 import { hydrate, mount, unmount } from '../internal/client/render.js';
-import { flush_sync, get } from '../internal/client/runtime.js';
+import { get } from '../internal/client/runtime.js';
 import { define_property } from '../internal/shared/utils.js';
 
 /**
@@ -110,7 +110,6 @@ class Svelte4Component {
 			recover: options.recover
 		});
 
-		flush_sync();
 
 		this.#events = props.$$events;
 

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -2,7 +2,7 @@
 import { mutable_source, set } from '../internal/client/reactivity/sources.js';
 import { user_pre_effect } from '../internal/client/reactivity/effects.js';
 import { hydrate, mount, unmount } from '../internal/client/render.js';
-import { get } from '../internal/client/runtime.js';
+import { flush_sync, get } from '../internal/client/runtime.js';
 import { define_property } from '../internal/shared/utils.js';
 
 /**
@@ -109,6 +109,11 @@ class Svelte4Component {
 			intro: options.intro ?? false,
 			recover: options.recover
 		});
+
+		// We don't flush_sync for custom element wrappers
+		if (!options?.props?.$$host) {
+			flush_sync();
+		}
 
 		this.#events = props.$$events;
 

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/_config.js
@@ -5,21 +5,15 @@ export default test({
 	async test({ assert, target }) {
 		let changed = false;
 
-		target.innerHTML = '<div id="root"><child-element></child-element></div>';
-		const root = target.querySelector('#root');
+		target.innerHTML = '<child-element></child-element>';
 
-		// Let the custom-elements load
-		await tick();
-
-		// Add `change` listener
-		root.addEventListener('change', () => {
+		target.addEventListener('change', () => {
 			changed = true;
 		});
 
-		// Let $effect flush
-		await tick();
+		await tick(); // wait for element to upgrade
+		await tick(); // wait for effect
 
-		// the `change` event should have been captured
 		assert.equal(changed, true);
 	}
 });

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/_config.js
@@ -7,11 +7,12 @@ export default test({
 
 		target.innerHTML = '<child-element></child-element>';
 
+		await tick(); // wait for element to upgrade
+
 		target.addEventListener('change', () => {
 			changed = true;
 		});
 
-		await tick(); // wait for element to upgrade
 		await tick(); // wait for effect
 
 		assert.equal(changed, true);

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/_config.js
@@ -1,0 +1,25 @@
+import { test } from '../../assert';
+const tick = () => Promise.resolve();
+
+export default test({
+	async test({ assert, target }) {
+		let changed = false;
+
+		target.innerHTML = '<div id="root"><child-element></child-element></div>';
+		const root = target.querySelector('#root');
+
+		// Let the custom-elements load
+		await tick();
+
+		// Add `change` listener
+		root.addEventListener('change', () => {
+			changed = true;
+		});
+
+		// Let $effect flush
+		await tick();
+
+		// the `change` event should have been captured
+		assert.equal(changed, true);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/main.svelte
@@ -1,0 +1,8 @@
+<svelte:options customElement="child-element" />
+
+<script>
+  $effect(() => {
+    $host().dispatchEvent(new CustomEvent('change', { bubbles: true }));
+  })
+</script>
+

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/effect-sequence/main.svelte
@@ -1,8 +1,7 @@
 <svelte:options customElement="child-element" />
 
 <script>
-  $effect(() => {
-    $host().dispatchEvent(new CustomEvent('change', { bubbles: true }));
-  })
+	$effect(() => {
+		$host().dispatchEvent(new CustomEvent('change', { bubbles: true }));
+	});
 </script>
-

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/escaped-css/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/escaped-css/_config.js
@@ -5,6 +5,7 @@ export default test({
 	async test({ assert, target }) {
 		target.innerHTML = '<custom-element></custom-element>';
 		await tick();
+		await tick();
 		/** @type {any} */
 		const ce = target.querySelector('custom-element');
 		const icon = ce.shadowRoot.querySelector('.icon');


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12772.

We currently have an inconsistency around using `$effect` together with custom elements. If you put in an `$effect` inside a custom element, then we flush the effects sync before moving on the handling the next custom element. This is problematic when you have things like event handlers or other sequence/propagation sensitive things around as normally effects happen after we write we've handled the DOM, not incrementally as we're handling the DOM.

This is compounded if someone were to have `$effect.pre` in one custom element that is a parent of a child that has an `$effect`, the child `$effect` would run before the parent `$effect.pre` which makes for glitchy behaviour when creating interactions that depend on the correct ordering.

To fix this, we remove the problematic `flush_sync` from `Svelte4Component`. If people want to force their custom elements to work sync, they can always manually `flush_sync` themselves, however that's rarely needed.