### PR TITLE
chore: simpler fallback values

### DIFF
--- a/.changeset/witty-frogs-cheat.md
+++ b/.changeset/witty-frogs-cheat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: simpler fallback values

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
@@ -96,9 +96,7 @@ export function VariableDeclaration(node, context) {
 						const name = /** @type {Identifier} */ (path.node).name;
 						const binding = /** @type {Binding} */ (context.state.scope.get(name));
 						const prop = b.member(b.id('$$props'), b.literal(binding.prop_alias ?? name), true);
-						declarations.push(
-							b.declarator(path.node, b.call('$.value_or_fallback', prop, b.thunk(value)))
-						);
+						declarations.push(b.declarator(path.node, b.call('$.fallback', prop, b.thunk(value))));
 					}
 					continue;
 				}
@@ -115,8 +113,8 @@ export function VariableDeclaration(node, context) {
 				if (declarator.init) {
 					const default_value = /** @type {Expression} */ (context.visit(declarator.init));
 					init = is_expression_async(default_value)
-						? b.await(b.call('$.value_or_fallback', prop, b.thunk(default_value, true)))
-						: b.call('$.value_or_fallback', prop, b.thunk(default_value));
+						? b.await(b.call('$.fallback', prop, b.thunk(default_value, true)))
+						: b.call('$.fallback', prop, b.thunk(default_value));
 				}
 
 				declarations.push(b.declarator(declarator.id, init));

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
@@ -2,7 +2,7 @@
 /** @import { Binding } from '#compiler' */
 /** @import { Context } from '../types.js' */
 /** @import { Scope } from '../../../scope.js' */
-import { extract_paths, is_expression_async } from '../../../../utils/ast.js';
+import { build_fallback, extract_paths, is_expression_async } from '../../../../utils/ast.js';
 import * as b from '../../../../utils/builders.js';
 import { get_rune } from '../../../scope.js';
 import { walk } from 'zimmerframe';
@@ -112,9 +112,7 @@ export function VariableDeclaration(node, context) {
 				let init = prop;
 				if (declarator.init) {
 					const default_value = /** @type {Expression} */ (context.visit(declarator.init));
-					init = is_expression_async(default_value)
-						? b.await(b.call('$.fallback', prop, b.thunk(default_value, true)))
-						: b.call('$.fallback', prop, b.thunk(default_value));
+					init = build_fallback(prop, default_value);
 				}
 
 				declarations.push(b.declarator(declarator.id, init));

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
@@ -2,7 +2,7 @@
 /** @import { Binding } from '#compiler' */
 /** @import { Context } from '../types.js' */
 /** @import { Scope } from '../../../scope.js' */
-import { build_fallback, extract_paths, is_expression_async } from '../../../../utils/ast.js';
+import { build_fallback, extract_paths } from '../../../../utils/ast.js';
 import * as b from '../../../../utils/builders.js';
 import { get_rune } from '../../../scope.js';
 import { walk } from 'zimmerframe';

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
@@ -96,7 +96,7 @@ export function VariableDeclaration(node, context) {
 						const name = /** @type {Identifier} */ (path.node).name;
 						const binding = /** @type {Binding} */ (context.state.scope.get(name));
 						const prop = b.member(b.id('$$props'), b.literal(binding.prop_alias ?? name), true);
-						declarations.push(b.declarator(path.node, b.call('$.fallback', prop, b.thunk(value))));
+						declarations.push(b.declarator(path.node, build_fallback(prop, value)));
 					}
 					continue;
 				}

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
@@ -115,7 +115,7 @@ export function VariableDeclaration(node, context) {
 				if (declarator.init) {
 					const default_value = /** @type {Expression} */ (context.visit(declarator.init));
 					init = is_expression_async(default_value)
-						? b.await(b.call('$.value_or_fallback_async', prop, b.thunk(default_value, true)))
+						? b.await(b.call('$.value_or_fallback', prop, b.thunk(default_value, true)))
 						: b.call('$.value_or_fallback', prop, b.thunk(default_value));
 				}
 

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -368,10 +368,7 @@ function _extract_paths(assignments = [], param, expression, update_expression, 
 
 		case 'AssignmentPattern': {
 			/** @type {DestructuredAssignment['expression']} */
-			const fallback_expression = (object) =>
-				is_expression_async(param.right)
-					? b.await(b.call('$.fallback', expression(object), b.thunk(param.right, true)))
-					: b.call('$.fallback', expression(object), b.thunk(param.right));
+			const fallback_expression = (object) => build_fallback(expression(object), param.right);
 
 			if (param.left.type === 'Identifier') {
 				assignments.push({
@@ -546,4 +543,15 @@ export function is_expression_async(expression) {
 		default:
 			return false;
 	}
+}
+
+/**
+ *
+ * @param {ESTree.Expression} expression
+ * @param {ESTree.Expression} fallback
+ */
+export function build_fallback(expression, fallback) {
+	return is_expression_async(fallback)
+		? b.await(b.call('$.fallback', expression, b.thunk(fallback, true)))
+		: b.call('$.fallback', expression, b.thunk(fallback));
 }

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -551,7 +551,15 @@ export function is_expression_async(expression) {
  * @param {ESTree.Expression} fallback
  */
 export function build_fallback(expression, fallback) {
+	if (is_simple_expression(fallback)) {
+		return b.call('$.fallback', expression, fallback);
+	}
+
+	if (fallback.type === 'AwaitExpression' && is_simple_expression(fallback.argument)) {
+		return b.await(b.call('$.fallback', expression, fallback.argument));
+	}
+
 	return is_expression_async(fallback)
-		? b.await(b.call('$.fallback', expression, b.thunk(fallback, true)))
-		: b.call('$.fallback', expression, b.thunk(fallback));
+		? b.await(b.call('$.fallback', expression, b.thunk(fallback, true), b.true))
+		: b.call('$.fallback', expression, b.thunk(fallback), b.true);
 }

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -370,8 +370,8 @@ function _extract_paths(assignments = [], param, expression, update_expression, 
 			/** @type {DestructuredAssignment['expression']} */
 			const fallback_expression = (object) =>
 				is_expression_async(param.right)
-					? b.await(b.call('$.value_or_fallback', expression(object), b.thunk(param.right, true)))
-					: b.call('$.value_or_fallback', expression(object), b.thunk(param.right));
+					? b.await(b.call('$.fallback', expression(object), b.thunk(param.right, true)))
+					: b.call('$.fallback', expression(object), b.thunk(param.right));
 
 			if (param.left.type === 'Identifier') {
 				assignments.push({

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -370,9 +370,7 @@ function _extract_paths(assignments = [], param, expression, update_expression, 
 			/** @type {DestructuredAssignment['expression']} */
 			const fallback_expression = (object) =>
 				is_expression_async(param.right)
-					? b.await(
-							b.call('$.value_or_fallback_async', expression(object), b.thunk(param.right, true))
-						)
+					? b.await(b.call('$.value_or_fallback', expression(object), b.thunk(param.right, true)))
 					: b.call('$.value_or_fallback', expression(object), b.thunk(param.right));
 
 			if (param.left.type === 'Identifier') {

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -134,8 +134,6 @@ export {
 	untrack,
 	update,
 	update_pre,
-	value_or_fallback,
-	value_or_fallback_async,
 	exclude_from_object,
 	pop,
 	push,
@@ -164,7 +162,7 @@ export {
 	$document as document
 } from './dom/operations.js';
 export { snapshot } from '../shared/clone.js';
-export { noop } from '../shared/utils.js';
+export { noop, value_or_fallback, value_or_fallback_async } from '../shared/utils.js';
 export {
 	invalid_default_snippet,
 	validate_dynamic_element_tag,

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -162,7 +162,7 @@ export {
 	$document as document
 } from './dom/operations.js';
 export { snapshot } from '../shared/clone.js';
-export { noop, value_or_fallback, value_or_fallback_async } from '../shared/utils.js';
+export { noop, value_or_fallback } from '../shared/utils.js';
 export {
 	invalid_default_snippet,
 	validate_dynamic_element_tag,

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -162,7 +162,7 @@ export {
 	$document as document
 } from './dom/operations.js';
 export { snapshot } from '../shared/clone.js';
-export { noop, value_or_fallback } from '../shared/utils.js';
+export { noop, fallback } from '../shared/utils.js';
 export {
 	invalid_default_snippet,
 	validate_dynamic_element_tag,

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1004,26 +1004,6 @@ export function exclude_from_object(obj, keys) {
 }
 
 /**
- * @template V
- * @param {V} value
- * @param {() => V} fallback lazy because could contain side effects
- * @returns {V}
- */
-export function value_or_fallback(value, fallback) {
-	return value === undefined ? fallback() : value;
-}
-
-/**
- * @template V
- * @param {V} value
- * @param {() => Promise<V>} fallback lazy because could contain side effects
- * @returns {Promise<V>}
- */
-export async function value_or_fallback_async(value, fallback) {
-	return value === undefined ? fallback() : value;
-}
-
-/**
  * @param {Record<string, unknown>} props
  * @param {any} runes
  * @param {Function} [fn]

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -516,7 +516,7 @@ export { push_element, pop_element } from './dev.js';
 
 export { snapshot } from '../shared/clone.js';
 
-export { value_or_fallback, value_or_fallback_async } from '../shared/utils.js';
+export { value_or_fallback } from '../shared/utils.js';
 
 export {
 	invalid_default_snippet,

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -384,26 +384,6 @@ export function unsubscribe_stores(store_values) {
 }
 
 /**
- * @template V
- * @param {V} value
- * @param {() => V} fallback lazy because could contain side effects
- * @returns {V}
- */
-export function value_or_fallback(value, fallback) {
-	return value === undefined ? fallback() : value;
-}
-
-/**
- * @template V
- * @param {V} value
- * @param {() => Promise<V>} fallback lazy because could contain side effects
- * @returns {Promise<V>}
- */
-export async function value_or_fallback_async(value, fallback) {
-	return value === undefined ? fallback() : value;
-}
-
-/**
  * @param {Payload} payload
  * @param {void | ((payload: Payload, props: Record<string, unknown>) => void)} slot_fn
  * @param {Record<string, unknown>} slot_props
@@ -535,6 +515,8 @@ export { push, pop } from './context.js';
 export { push_element, pop_element } from './dev.js';
 
 export { snapshot } from '../shared/clone.js';
+
+export { value_or_fallback, value_or_fallback_async } from '../shared/utils.js';
 
 export {
 	invalid_default_snippet,

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -516,7 +516,7 @@ export { push_element, pop_element } from './dev.js';
 
 export { snapshot } from '../shared/clone.js';
 
-export { value_or_fallback } from '../shared/utils.js';
+export { fallback } from '../shared/utils.js';
 
 export {
 	invalid_default_snippet,

--- a/packages/svelte/src/internal/shared/utils.js
+++ b/packages/svelte/src/internal/shared/utils.js
@@ -56,13 +56,3 @@ export function run_all(arr) {
 export function value_or_fallback(value, fallback) {
 	return value === undefined ? fallback() : value;
 }
-
-/**
- * @template V
- * @param {V} value
- * @param {() => Promise<V>} fallback lazy because could contain side effects
- * @returns {Promise<V>}
- */
-export async function value_or_fallback_async(value, fallback) {
-	return value === undefined ? fallback() : value;
-}

--- a/packages/svelte/src/internal/shared/utils.js
+++ b/packages/svelte/src/internal/shared/utils.js
@@ -53,6 +53,6 @@ export function run_all(arr) {
  * @param {() => V} fallback lazy because could contain side effects
  * @returns {V}
  */
-export function value_or_fallback(value, fallback) {
+export function fallback(value, fallback) {
 	return value === undefined ? fallback() : value;
 }

--- a/packages/svelte/src/internal/shared/utils.js
+++ b/packages/svelte/src/internal/shared/utils.js
@@ -46,3 +46,23 @@ export function run_all(arr) {
 		arr[i]();
 	}
 }
+
+/**
+ * @template V
+ * @param {V} value
+ * @param {() => V} fallback lazy because could contain side effects
+ * @returns {V}
+ */
+export function value_or_fallback(value, fallback) {
+	return value === undefined ? fallback() : value;
+}
+
+/**
+ * @template V
+ * @param {V} value
+ * @param {() => Promise<V>} fallback lazy because could contain side effects
+ * @returns {Promise<V>}
+ */
+export async function value_or_fallback_async(value, fallback) {
+	return value === undefined ? fallback() : value;
+}

--- a/packages/svelte/src/internal/shared/utils.js
+++ b/packages/svelte/src/internal/shared/utils.js
@@ -50,9 +50,14 @@ export function run_all(arr) {
 /**
  * @template V
  * @param {V} value
- * @param {() => V} fallback lazy because could contain side effects
+ * @param {V | (() => V)} fallback
+ * @param {boolean} [lazy]
  * @returns {V}
  */
-export function fallback(value, fallback) {
-	return value === undefined ? fallback() : value;
+export function fallback(value, fallback, lazy = false) {
+	return value === undefined
+		? lazy
+			? /** @type {() => V} */ (fallback)()
+			: /** @type {V} */ (fallback)
+		: value;
 }


### PR DESCRIPTION
Was reminded of this by #12781. We currently make things very complicated when rewriting destructuring patterns that have default values — this...

```js
[a = await promise] = stuff();
```

...becomes this...

```js
await (async () => {
  const tmp = stuff();

  (
    $.set(a, $.proxy(await $.value_or_fallback_async(tmp[0], async () => await promise)))
  );

  return tmp;
})();
```

As of #12780 it becomes this instead, which is simpler...

```js
await (async ($$value) => (
  $.set(a, $.proxy(await $.value_or_fallback_async($$value[0], async () => await promise)))
))(stuff());
```

...but really it should just be this:

```js
await (async ($$value) => (
  $.set(a, $.proxy(await $.fallback($$value[0], promise)))
))(stuff());
```

This PR makes a few changes:

- it renames `value_or_fallback` to just `fallback`, and moves it to the `shared` directory since it's currently duplicated between server and client
- it removes `value_or_fallback_async`, which doesn't do anything
- it adds a `build_fallback` function instead of duplicating logic between the various places that need to create `$.fallback` code
- it makes lazy fallback values the exception. If we have something `[answer = 42]`, we don't need to wrap the `42` in a thunk
- the same goes for `await` expressions — we don't need to wrap the fallback value in an async thunk it it's just something like `await promise`, we can just await the whole expression

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
