### PR TITLE
chore: increase debug stack trace

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,10 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Run sandbox",
-			"program": "${workspaceFolder}/playgrounds/sandbox/run.js"
+			"program": "${workspaceFolder}/playgrounds/sandbox/run.js",
+			"env": {
+				"NODE_OPTIONS": "--stack-trace-limit=10000"
+			}
 		}
 	],
 	"compounds": [


### PR DESCRIPTION
pulling this out of #12780 — Node's default stack trace length of 10 lines is dumb as all hell. it's completely useless for any serious debugging