### PR TITLE
fix: improved memory profile for transitions/animations

### DIFF
--- a/.changeset/thin-papayas-tap.md
+++ b/.changeset/thin-papayas-tap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improved memory profile for transitions/animations

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -404,13 +404,25 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 				fill: 'forwards'
 			});
 
-			animation.finished.then(() => {
-				on_finish?.();
+			animation.finished
+				.then(() => {
+					on_finish?.();
 
-				if (t2 === 1) {
-					animation.cancel();
-				}
-			});
+					if (t2 === 1) {
+						animation.cancel();
+					}
+				})
+				.catch((e) => {
+					// Error for DOMException: The user aborted a request. This results in two things:
+					// - startTime is `null`
+					// - currentTime is `null`
+					// We can't use the existence of an AbortError as this error and error code is shared
+					// with other Web APIs such as fetch().
+
+					if (animation.startTime !== null && animation.currentTime !== null) {
+						throw e;
+					}
+				});
 		});
 	} else {
 		// Timer


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12719.

[12759](https://github.com/sveltejs/svelte/pull/12759) previously would `null` the effect on animation. I thought it wasn't necessary, but clearly it still is (I removed transitions from my example and forgot to put them back in, oops). I think we should flag this with Chromium folks as it seems odd that we need to do this – having it makes no difference in Firefox.

I also noticed that the `catch` function retains the animation in Firefox. I don't think we even need it anymore, so that fixes the memory leak in Firefox. Strangely, this doesn't seem to affect Chromium.

Lastly, clearing `on_finish` and `on_abort` seems to help the memory profile in Firefox and Chromium. Given we do it in `deactivate`, it makes sense to do in `abort` too.