### PR TITLE
fix: ensure inspect effects are skipped from effect parent logic

### DIFF
--- a/.changeset/stupid-cars-behave.md
+++ b/.changeset/stupid-cars-behave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure inspect effects are skipped from effect parent logic

--- a/packages/svelte/tests/runtime-runes/samples/inspect-nested-effect/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-nested-effect/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, logs }) {
+		assert.deepEqual(logs, ['init', 0, 'update', 1]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/inspect-nested-effect/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-nested-effect/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let a = $state(0);
+	let b = $derived.by(() => {
+		$effect(() => {
+			a = 1;
+		})
+		return a;
+	})
+
+	$inspect(b);
+</script>
+


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12806.