### PR TITLE
feat: warn on invalid event handlers

### DIFF
--- a/.changeset/brown-months-flow.md
+++ b/.changeset/brown-months-flow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: warn on invalid event handlers

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -4,6 +4,10 @@
 
 > `%binding%` (%location%) is binding to a non-reactive property
 
+## event_handler_invalid
+
+> %handler% should be a function. Did you mean to %suggestion%?
+
 ## hydration_attribute_changed
 
 > The `%attribute%` attribute on `%html%` changed its value between server and client renders. The client value, `%value%`, will be ignored in favour of the server value

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/events.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/events.js
@@ -1,7 +1,8 @@
 /** @import { Expression } from 'estree' */
-/** @import { Attribute, ExpressionMetadata, ExpressionTag, OnDirective, SvelteNode } from '#compiler' */
+/** @import { Attribute, ExpressionMetadata, ExpressionTag, SvelteNode } from '#compiler' */
 /** @import { ComponentContext } from '../../types' */
-import { is_capture_event, is_passive_event } from '../../../../../../utils.js';
+import { is_capture_event } from '../../../../../../utils.js';
+import { dev, locator } from '../../../../../state.js';
 import * as b from '../../../../../utils/builders.js';
 
 /**
@@ -136,9 +137,23 @@ export function build_event_handler(node, metadata, context) {
 	}
 
 	// wrap the handler in a function, so the expression is re-evaluated for each event
-	return b.function(
-		null,
-		[b.rest(b.id('$$args'))],
-		b.block([b.stmt(b.call(b.member(handler, b.id('apply'), false, true), b.this, b.id('$$args')))])
-	);
+	let call = b.call(b.member(handler, b.id('apply'), false, true), b.this, b.id('$$args'));
+
+	if (dev && node.type === 'CallExpression') {
+		const loc = locator(/** @type {number} */ (node.start));
+
+		const remove_parens = node.arguments.length === 0 && node.callee.type === 'Identifier';
+
+		call = b.call(
+			'$.apply',
+			b.thunk(handler),
+			b.this,
+			b.id('$$args'),
+			b.id(context.state.analysis.name),
+			loc && b.array([b.literal(loc.line), b.literal(loc.column)]),
+			remove_parens && b.true
+		);
+	}
+
+	return b.function(null, [b.rest(b.id('$$args'))], b.block([b.stmt(call)]));
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/events.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/events.js
@@ -139,7 +139,7 @@ export function build_event_handler(node, metadata, context) {
 	// wrap the handler in a function, so the expression is re-evaluated for each event
 	let call = b.call(b.member(handler, b.id('apply'), false, true), b.this, b.id('$$args'));
 
-	if (dev && has_side_effects(node)) {
+	if (dev) {
 		const loc = locator(/** @type {number} */ (node.start));
 
 		const remove_parens =
@@ -154,6 +154,7 @@ export function build_event_handler(node, metadata, context) {
 			b.id('$$args'),
 			b.id(context.state.analysis.name),
 			loc && b.array([b.literal(loc.line), b.literal(loc.column)]),
+			has_side_effects(node) && b.true,
 			remove_parens && b.true
 		);
 	}

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -1,7 +1,11 @@
+/** @import { Location } from 'locate-character' */
 import { teardown } from '../../reactivity/effects.js';
 import { define_property, is_array } from '../../../shared/utils.js';
 import { hydrating } from '../hydration.js';
 import { queue_micro_task } from '../task.js';
+import { dev_current_component_function } from '../../runtime.js';
+import { FILENAME } from '../../../../constants.js';
+import * as w from '../../warnings.js';
 
 /** @type {Set<string>} */
 export const all_registered_events = new Set();
@@ -271,5 +275,47 @@ export function handle_event_propagation(event) {
 		event.__root = handler_element;
 		// @ts-expect-error is used above
 		current_target = handler_element;
+	}
+}
+
+/**
+ * In dev, warn if an event handler is not a function, as it means the
+ * user probably called the handler or forgot to add a `() =>`
+ * @param {() => (event: Event, ...args: any) => void} thunk
+ * @param {EventTarget} element
+ * @param {[Event, ...any]} args
+ * @param {any} component
+ * @param {[number, number]} [loc]
+ * @param {boolean} [remove_parens]
+ */
+export function apply(thunk, element, args, component, loc, remove_parens = false) {
+	let handler;
+	let error;
+
+	try {
+		handler = thunk();
+	} catch (e) {
+		error = e;
+	}
+
+	if (typeof handler === 'function') {
+		handler.apply(element, args);
+	} else {
+		const filename = component?.[FILENAME];
+		const location = filename
+			? loc
+				? ` at ${filename}:${loc[0]}:${loc[1]}`
+				: ` in ${filename}`
+			: '';
+
+		const event_name = args[0].type;
+		const description = `\`${event_name}\` handler${location}`;
+		const suggestion = remove_parens ? 'remove the trailing `()`' : 'add a leading `() =>`';
+
+		w.event_handler_invalid(description, suggestion);
+
+		if (error) {
+			throw error;
+		}
 	}
 }

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -288,7 +288,15 @@ export function handle_event_propagation(event) {
  * @param {[number, number]} [loc]
  * @param {boolean} [remove_parens]
  */
-export function apply(thunk, element, args, component, loc, remove_parens = false) {
+export function apply(
+	thunk,
+	element,
+	args,
+	component,
+	loc,
+	has_side_effects = false,
+	remove_parens = false
+) {
 	let handler;
 	let error;
 
@@ -300,7 +308,7 @@ export function apply(thunk, element, args, component, loc, remove_parens = fals
 
 	if (typeof handler === 'function') {
 		handler.apply(element, args);
-	} else {
+	} else if (has_side_effects || handler != null) {
 		const filename = component?.[FILENAME];
 		const location = filename
 			? loc

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -36,7 +36,7 @@ export {
 	set_checked
 } from './dom/elements/attributes.js';
 export { set_class, set_svg_class, set_mathml_class, toggle_class } from './dom/elements/class.js';
-export { event, delegate, replay_events } from './dom/elements/events.js';
+export { apply, event, delegate, replay_events } from './dom/elements/events.js';
 export { autofocus, remove_textarea_child } from './dom/elements/misc.js';
 export { set_style } from './dom/elements/style.js';
 export { animation, transition } from './dom/elements/transitions.js';

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -91,6 +91,8 @@ let stack = [];
  * @returns {void}
  */
 export function update_derived(derived) {
+	var value;
+
 	if (DEV) {
 		try {
 			if (stack.includes(derived)) {
@@ -100,13 +102,13 @@ export function update_derived(derived) {
 			stack.push(derived);
 
 			destroy_derived_children(derived);
-			var value = update_reaction(derived);
+			value = update_reaction(derived);
 		} finally {
 			stack.pop();
 		}
 	} else {
 		destroy_derived_children(derived);
-		var value = update_reaction(derived);
+		value = update_reaction(derived);
 	}
 
 	var status =

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -92,18 +92,21 @@ let stack = [];
  */
 export function update_derived(derived) {
 	if (DEV) {
-		if (stack.includes(derived)) {
-			e.derived_references_self();
+		try {
+			if (stack.includes(derived)) {
+				e.derived_references_self();
+			}
+
+			stack.push(derived);
+
+			destroy_derived_children(derived);
+			var value = update_reaction(derived);
+		} finally {
+			stack.pop();
 		}
-
-		stack.push(derived);
-	}
-
-	destroy_derived_children(derived);
-	var value = update_reaction(derived);
-
-	if (DEV) {
-		stack.pop();
+	} else {
+		destroy_derived_children(derived);
+		var value = update_reaction(derived);
 	}
 
 	var status =

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -20,6 +20,20 @@ export function binding_property_non_reactive(binding, location) {
 }
 
 /**
+ * %handler% should be a function. Did you mean to %suggestion%?
+ * @param {string} handler
+ * @param {string} suggestion
+ */
+export function event_handler_invalid(handler, suggestion) {
+	if (DEV) {
+		console.warn(`%c[svelte] event_handler_invalid\n%c${handler} should be a function. Did you mean to ${suggestion}?`, bold, normal);
+	} else {
+		// TODO print a link to the documentation
+		console.warn("event_handler_invalid");
+	}
+}
+
+/**
  * The `%attribute%` attribute on `%html%` changed its value between server and client renders. The client value, `%value%`, will be ignored in favour of the server value
  * @param {string} attribute
  * @param {string} html

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-component-invalid-warning/Button.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-component-invalid-warning/Button.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { children, onclick } = $props();
+</script>
+
+<button {onclick}>
+	{@render children()}
+</button>

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-component-invalid-warning/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-component-invalid-warning/_config.js
@@ -1,0 +1,17 @@
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, warnings }) {
+		target.querySelector('button')?.click();
+
+		assert.deepEqual(warnings, [
+			'`click` handler at Button.svelte:5:9 should be a function. Did you mean to add a leading `() =>`?'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-component-invalid-warning/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-component-invalid-warning/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Button from './Button.svelte';
+
+	let count = $state(0);
+</script>
+
+<Button onclick={count++}>
+	clicks: {count}
+</Button>

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-invalid-warning/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-invalid-warning/_config.js
@@ -1,0 +1,17 @@
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, warnings }) {
+		target.querySelector('button')?.click();
+
+		assert.deepEqual(warnings, [
+			'`click` handler at main.svelte:9:17 should be a function. Did you mean to remove the trailing `()`?'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-invalid-warning/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-invalid-warning/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	let count = $state(0);
+
+	function increment() {
+		count += 1;
+	}
+</script>
+
+<button onclick={increment()}>
+	clicks: {count}
+</button>


### PR DESCRIPTION
[Demo](https://svelte-5-preview-git-invalid-event-handler-warning-svelte.vercel.app/#H4sIAAAAAAAAE6WQzQrCMBCEX2UJHioVf661FXwO66GmWwymm5JsBAl9d9MU0YPgwePuzDezbBCd0uhEcQqCmh5FIY7DIFaCH8M0uDtqxjg7462cNqWTVg18qKlmjQzSeGKoYOG4Ycy2y31UotZ5kqwMgSJpsUfibAlhUmqembyC3WTmcSakIcdwbajVaF2MDG8WoqfcvKupvHjmmG5IaiVvVfioGdNxae8KCKkt8TPznX_1rv8NSq48_8XGn_amVZ3CVhRsPY7n8Qkyw_pxjgEAAA==)

People coming from certain other frameworks, such as one that rhymes with 'foo', are often in the unfortunate habit of calling their event handlers inline, rather than simply passing a function:

```svelte
<button onclick={increment()}>
  increment
</button>
```

```svelte
<button onclick={count += 1}>
  increment
</button>
```

We can catch a lot of these cases: if the handler is something like a call expression or an assignment expression, and the value isn't a function at the time we try to call it, print a warning. That's what this PR does.

~~What this _doesn't_ capture is the case where `onclick` is a prop, because `onclick={undefined}` is acceptable. Though as I type this it occurs to me that we can warn in case of a handler that is not a function and is _also_ not nullish, as would be the case here:~~

```js
<Button onclick={count += 1}>
```

~~Will update the PR.~~ done

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
