### PR TITLE
chore: improve set_text perf

### DIFF
--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -47,7 +47,8 @@ export function set_text(text, value) {
 
 	if (prev !== value) {
 		// @ts-expect-error
-		text.nodeValue = text.__t = value;
+		text.__t = value;
+		text.nodeValue = value + '';
 	}
 }
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -48,6 +48,7 @@ export function set_text(text, value) {
 	if (prev !== value) {
 		// @ts-expect-error
 		text.__t = value;
+		// It's faster to make the value a string rather than passing a non-string to nodeValue
 		text.nodeValue = value + '';
 	}
 }

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -49,7 +49,7 @@ export function set_text(text, value) {
 		// @ts-expect-error
 		text.__t = value;
 		// It's faster to make the value a string rather than passing a non-string to nodeValue
-		text.nodeValue = value === undefined ? '' : value + '';
+		text.nodeValue = value == null ? '' : value + '';
 	}
 }
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -49,7 +49,7 @@ export function set_text(text, value) {
 		// @ts-expect-error
 		text.__t = value;
 		// It's faster to make the value a string rather than passing a non-string to nodeValue
-		text.nodeValue = value + '';
+		text.nodeValue = value === undefined ? '' : value + '';
 	}
 }
 


### PR DESCRIPTION
So it turns out that passing a non-string value to `nodeValue` is slower than first forcing the value to a string and passing it it in. This seems to add no overhead values that are already strings, nice!