### PR TITLE
feat: better compiler warnings for non-reactive dependencies of reactive statements

### DIFF
--- a/.changeset/strange-pillows-greet.md
+++ b/.changeset/strange-pillows-greet.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: better compiler warnings for non-reactive dependencies of reactive statements

--- a/packages/svelte/messages/compile-warnings/script.md
+++ b/packages/svelte/messages/compile-warnings/script.md
@@ -26,9 +26,13 @@
 
 > Reactive declarations only exist at the top level of the instance script
 
-## reactive_declaration_module_script
+## reactive_declaration_module_script_dependency
 
-> All dependencies of the reactive declaration are declared in a module script and will not be reactive
+> Reassignments of module-level declarations will not cause reactive statements to update
+
+## reactive_declaration_non_reactive_property
+
+> Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
 
 ## state_referenced_locally
 

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
@@ -145,5 +145,13 @@ export function Identifier(node, context) {
 		) {
 			w.state_referenced_locally(node);
 		}
+
+		if (
+			context.state.reactive_statement &&
+			binding.scope === context.state.analysis.module.scope &&
+			binding.reassigned
+		) {
+			w.reactive_declaration_module_script_dependency(node);
+		}
 	}
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/LabeledStatement.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/LabeledStatement.js
@@ -4,6 +4,7 @@
 import * as e from '../../../errors.js';
 import { extract_identifiers, object } from '../../../utils/ast.js';
 import * as w from '../../../warnings.js';
+import { is_state_source } from '../../3-transform/client/utils.js';
 
 /**
  * @param {LabeledStatement} node
@@ -65,15 +66,6 @@ export function LabeledStatement(node, context) {
 			}
 
 			context.state.reactive_statements.set(node, reactive_statement);
-
-			if (
-				reactive_statement.dependencies.length &&
-				reactive_statement.dependencies.every(
-					(d) => d.scope === context.state.analysis.module.scope && d.declaration_kind !== 'const'
-				)
-			) {
-				w.reactive_declaration_module_script(node);
-			}
 
 			if (
 				node.body.type === 'ExpressionStatement' &&

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/MemberExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/MemberExpression.js
@@ -1,9 +1,8 @@
-/** @import { MemberExpression } from 'estree' */
+/** @import { MemberExpression, Node } from 'estree' */
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
 import * as w from '../../../warnings.js';
 import { object } from '../../../utils/ast.js';
-import { is_state_source } from '../../3-transform/client/utils.js';
 import { is_pure, is_safe_identifier } from './shared/utils.js';
 
 /**
@@ -33,6 +32,8 @@ export function MemberExpression(node, context) {
 			const binding = context.state.scope.get(left.name);
 
 			if (binding && binding.kind === 'normal') {
+				const parent = /** @type {Node} */ (context.path.at(-1));
+
 				if (
 					binding.scope === context.state.analysis.module.scope ||
 					binding.declaration_kind === 'import' ||
@@ -40,7 +41,9 @@ export function MemberExpression(node, context) {
 						binding.initial.type !== 'ArrayExpression' &&
 						binding.initial.type !== 'ObjectExpression')
 				) {
-					w.reactive_declaration_non_reactive_property(node);
+					if (parent.type !== 'MemberExpression' && parent.type !== 'CallExpression') {
+						w.reactive_declaration_non_reactive_property(node);
+					}
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/MemberExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/MemberExpression.js
@@ -1,6 +1,9 @@
 /** @import { MemberExpression } from 'estree' */
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
+import * as w from '../../../warnings.js';
+import { object } from '../../../utils/ast.js';
+import { is_state_source } from '../../3-transform/client/utils.js';
 import { is_pure, is_safe_identifier } from './shared/utils.js';
 
 /**
@@ -21,6 +24,26 @@ export function MemberExpression(node, context) {
 
 	if (!is_safe_identifier(node, context.state.scope)) {
 		context.state.analysis.needs_context = true;
+	}
+
+	if (context.state.reactive_statement) {
+		const left = object(node);
+
+		if (left !== null) {
+			const binding = context.state.scope.get(left.name);
+
+			if (binding && binding.kind === 'normal') {
+				if (
+					binding.scope === context.state.analysis.module.scope ||
+					binding.declaration_kind === 'import' ||
+					(binding.initial &&
+						binding.initial.type !== 'ArrayExpression' &&
+						binding.initial.type !== 'ObjectExpression')
+				) {
+					w.reactive_declaration_non_reactive_property(node);
+				}
+			}
+		}
 	}
 
 	context.next();

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -1,6 +1,7 @@
 /** @import { ArrowFunctionExpression, Expression, FunctionDeclaration, FunctionExpression, Identifier, Pattern, PrivateIdentifier, Statement } from 'estree' */
 /** @import { Binding, SvelteNode } from '#compiler' */
 /** @import { ClientTransformState, ComponentClientTransformState, ComponentContext } from './types.js' */
+/** @import { Analysis } from '../../types.js' */
 /** @import { Scope } from '../../scope.js' */
 import * as b from '../../../utils/builders.js';
 import { extract_identifiers, is_simple_expression } from '../../../utils/ast.js';
@@ -16,13 +17,13 @@ import { get_value } from './visitors/shared/declarations.js';
 
 /**
  * @param {Binding} binding
- * @param {ClientTransformState} state
+ * @param {Analysis} analysis
  * @returns {boolean}
  */
-export function is_state_source(binding, state) {
+export function is_state_source(binding, analysis) {
 	return (
 		(binding.kind === 'state' || binding.kind === 'raw_state') &&
-		(!state.analysis.immutable || binding.reassigned || state.analysis.accessors)
+		(!analysis.immutable || binding.reassigned || analysis.accessors)
 	);
 }
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -126,7 +126,7 @@ export function VariableDeclaration(node, context) {
 					if (rune === '$state' && should_proxy(value, context.state.scope)) {
 						value = b.call('$.proxy', value);
 					}
-					if (is_state_source(binding, context.state)) {
+					if (is_state_source(binding, context.state.analysis)) {
 						value = b.call('$.source', value);
 					}
 					return value;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/declarations.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/declarations.js
@@ -18,7 +18,7 @@ export function get_value(node) {
 export function add_state_transformers(context) {
 	for (const [name, binding] of context.state.scope.declarations) {
 		if (
-			is_state_source(binding, context.state) ||
+			is_state_source(binding, context.state.analysis) ||
 			binding.kind === 'derived' ||
 			binding.kind === 'legacy_reactive'
 		) {

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -101,7 +101,8 @@ export const codes = [
 	"perf_avoid_inline_class",
 	"perf_avoid_nested_class",
 	"reactive_declaration_invalid_placement",
-	"reactive_declaration_module_script",
+	"reactive_declaration_non_reactive_property",
+	"reactive_declaration_module_script_dependency",
 	"state_referenced_locally",
 	"store_rune_conflict",
 	"css_unused_selector",
@@ -630,11 +631,19 @@ export function reactive_declaration_invalid_placement(node) {
 }
 
 /**
- * All dependencies of the reactive declaration are declared in a module script and will not be reactive
+ * Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
  * @param {null | NodeLike} node
  */
-export function reactive_declaration_module_script(node) {
-	w(node, "reactive_declaration_module_script", "All dependencies of the reactive declaration are declared in a module script and will not be reactive");
+export function reactive_declaration_non_reactive_property(node) {
+	w(node, "reactive_declaration_non_reactive_property", "Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update");
+}
+
+/**
+ * Reassignments of module-level declarations will not cause reactive statements to update
+ * @param {null | NodeLike} node
+ */
+export function reactive_declaration_module_script_dependency(node) {
+	w(node, "reactive_declaration_module_script_dependency", "Reassignments of module-level declarations will not cause reactive statements to update");
 }
 
 /**

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -101,8 +101,8 @@ export const codes = [
 	"perf_avoid_inline_class",
 	"perf_avoid_nested_class",
 	"reactive_declaration_invalid_placement",
-	"reactive_declaration_non_reactive_property",
 	"reactive_declaration_module_script_dependency",
+	"reactive_declaration_non_reactive_property",
 	"state_referenced_locally",
 	"store_rune_conflict",
 	"css_unused_selector",
@@ -631,19 +631,19 @@ export function reactive_declaration_invalid_placement(node) {
 }
 
 /**
- * Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
- * @param {null | NodeLike} node
- */
-export function reactive_declaration_non_reactive_property(node) {
-	w(node, "reactive_declaration_non_reactive_property", "Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update");
-}
-
-/**
  * Reassignments of module-level declarations will not cause reactive statements to update
  * @param {null | NodeLike} node
  */
 export function reactive_declaration_module_script_dependency(node) {
 	w(node, "reactive_declaration_module_script_dependency", "Reassignments of module-level declarations will not cause reactive statements to update");
+}
+
+/**
+ * Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
+ * @param {null | NodeLike} node
+ */
+export function reactive_declaration_non_reactive_property(node) {
+	w(node, "reactive_declaration_non_reactive_property", "Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update");
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/reactive-module-variable/input.svelte
+++ b/packages/svelte/tests/validator/samples/reactive-module-variable/input.svelte
@@ -1,6 +1,11 @@
 <script context="module">
-	let foo;
+	let foo = 0;
+
+	export function update() {
+		foo += 1;
+	}
 </script>
+
 <script>
 	$: bar = foo;
 </script>

--- a/packages/svelte/tests/validator/samples/reactive-module-variable/warnings.json
+++ b/packages/svelte/tests/validator/samples/reactive-module-variable/warnings.json
@@ -1,14 +1,14 @@
 [
 	{
-		"code": "reactive_declaration_module_script",
-		"message": "All dependencies of the reactive declaration are declared in a module script and will not be reactive",
+		"code": "reactive_declaration_module_script_dependency",
+		"message": "Reassignments of module-level declarations will not cause reactive statements to update",
 		"start": {
-			"column": 1,
-			"line": 5
+			"column": 10,
+			"line": 10
 		},
 		"end": {
-			"column": 14,
-			"line": 5
+			"column": 13,
+			"line": 10
 		}
 	}
 ]


### PR DESCRIPTION
closes #9287. ~~Right now, this causes a test failure, because of a case where we don't know that a binding is state until we've completed the analysis phase. Ideally, we would have a complete picture of state vs non-state by the time scopes have been generated — I've been meaning to fix that for a while now, and this forces the issue~~

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
