### PR TITLE
chore: improve signal perf by using Set rather than array for reactions

### DIFF
--- a/.changeset/calm-clocks-raise.md
+++ b/.changeset/calm-clocks-raise.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: improve signal perf by using Set rather than array for reactions

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -139,10 +139,8 @@ function mark_reactions(signal, status) {
 	if (reactions === null) return;
 
 	var runes = is_runes();
-	var length = reactions.length;
 
-	for (var i = 0; i < length; i++) {
-		var reaction = reactions[i];
+	for (var reaction of reactions) {
 		var flags = reaction.f;
 
 		// Skip any effects that are already dirty

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -9,7 +9,7 @@ export interface Signal {
 
 export interface Value<V = unknown> extends Signal {
 	/** Signals that read from this signal */
-	reactions: null | Reaction[];
+	reactions: null | Set<Reaction>;
 	/** Equality function */
 	equals: Equals;
 	/** The latest value for this signal */

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -327,7 +327,7 @@ export function update_reaction(reaction) {
 					var reactions = dependency.reactions;
 
 					if (reactions === null) {
-						reactions = dependency.reactions = new Set()
+						reactions = dependency.reactions = new Set();
 					}
 					reactions.add(reaction);
 				}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -327,8 +327,7 @@ export function update_reaction(reaction) {
 					var reactions = dependency.reactions;
 
 					if (reactions === null) {
-						reactions = dependency.reactions = new Set();
-						reactions.add(reaction);
+						(dependency.reactions = new Set()).add(reaction);
 					} else if (!reactions.has(reaction)) {
 						reactions.add(reaction);
 					}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -327,10 +327,9 @@ export function update_reaction(reaction) {
 					var reactions = dependency.reactions;
 
 					if (reactions === null) {
-						(dependency.reactions = new Set()).add(reaction);
-					} else if (!reactions.has(reaction)) {
-						reactions.add(reaction);
+						reactions = dependency.reactions = new Set()
 					}
+					reactions.add(reaction);
 				}
 			}
 		} else if (deps !== null && skipped_deps < deps.length) {

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -236,13 +236,13 @@ describe('signals', () => {
 		return () => {
 			flushSync(() => set(count, 1));
 			// Ensure we're not leaking consumers
-			assert.deepEqual(count.reactions?.length, 1);
+			assert.deepEqual(count.reactions?.size, 1);
 			flushSync(() => set(count, 2));
 			// Ensure we're not leaking consumers
-			assert.deepEqual(count.reactions?.length, 1);
+			assert.deepEqual(count.reactions?.size, 1);
 			flushSync(() => set(count, 3));
 			// Ensure we're not leaking consumers
-			assert.deepEqual(count.reactions?.length, 1);
+			assert.deepEqual(count.reactions?.size, 1);
 			assert.deepEqual(log, [0, 1, 2, 3]);
 		};
 	});
@@ -304,8 +304,8 @@ describe('signals', () => {
 			flushSync(() => set(count, 4));
 			flushSync(() => set(count, 0));
 			// Ensure we're not leaking consumers
-			assert.deepEqual(count.reactions?.length, 1);
-			assert.deepEqual(calc.reactions?.length, 1);
+			assert.deepEqual(count.reactions?.size, 1);
+			assert.deepEqual(calc.reactions?.size, 1);
 			assert.deepEqual(log, [0, 2, 'limit', 0]);
 			destroy();
 			// Ensure we're not leaking consumers
@@ -484,7 +484,7 @@ describe('signals', () => {
 		return () => {
 			flushSync();
 			assert.equal(a?.deps?.length, 1);
-			assert.equal(state?.reactions?.length, 1);
+			assert.equal(state?.reactions?.size, 1);
 			destroy();
 			assert.equal(a?.deps?.length, 1);
 			assert.equal(state?.reactions, null);
@@ -658,12 +658,12 @@ describe('signals', () => {
 			});
 
 			assert.equal($.get(d), 0);
-			assert.equal(count.reactions?.length, 1);
+			assert.equal(count.reactions?.size, 1);
 			assert.equal(d.deps?.length, 1);
 
 			set(count, 1);
 			assert.equal($.get(d), 2);
-			assert.equal(count.reactions?.length, 1);
+			assert.equal(count.reactions?.size, 1);
 			assert.equal(d.deps?.length, 1);
 
 			destroy();


### PR DESCRIPTION
This shouldn't cause any issues, but I'm adding a changeset around it just in case. Profiling this and whilst Sets do add a slight bit of overhead compared to arrays when small, arrays are terrible compared to Sets with lots of dependencies – such as when used in each blocks.