### PR TITLE
chore: set `binding.kind` before analysis

### DIFF
--- a/.changeset/pink-countries-repair.md
+++ b/.changeset/pink-countries-repair.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: set `binding.kind` before analysis

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -331,10 +331,7 @@ const instance_script = {
 
 				const binding = /** @type {Compiler.Binding} */ (state.scope.get(declarator.id.name));
 
-				if (
-					state.analysis.uses_props &&
-					(declarator.init || binding.mutated || binding.reassigned)
-				) {
+				if (state.analysis.uses_props && (declarator.init || binding.updated)) {
 					throw new Error(
 						'$$props is used together with named props in a way that cannot be automatically migrated.'
 					);
@@ -350,7 +347,7 @@ const instance_script = {
 							)
 						: '',
 					optional: !!declarator.init,
-					bindable: binding.mutated || binding.reassigned,
+					bindable: binding.updated,
 					...extract_type_and_comment(declarator, state.str, path)
 				});
 				state.props_insertion_point = /** @type {number} */ (declarator.end);

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -448,6 +448,19 @@ export function analyze_component(root, source, options) {
 				}
 			}
 		}
+
+		for (const binding of instance.scope.declarations.values()) {
+			if (binding.kind !== 'normal') continue;
+
+			for (const { node, path } of binding.references) {
+				if (node === binding.node) continue;
+
+				const types = path.map((node) => node.type);
+				if (types.at(-1) === 'StyleDirective' && (binding.reassigned || binding.mutated)) {
+					binding.kind = 'state';
+				}
+			}
+		}
 	}
 
 	if (root.options) {

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -458,7 +458,7 @@ export function analyze_component(root, source, options) {
 			for (const { node, path } of binding.references) {
 				if (node === binding.node) continue;
 
-				if (binding.mutated) {
+				if (binding.updated) {
 					if (
 						path[path.length - 1].type === 'StyleDirective' ||
 						path.some((node) => node.type === 'Fragment') ||
@@ -477,7 +477,7 @@ export function analyze_component(root, source, options) {
 				const scope = /** @type {Scope} */ (template.scopes.get(node));
 
 				for (const binding of scope.declarations.values()) {
-					if (binding.mutated) {
+					if (binding.updated) {
 						const state = { scope: /** @type {Scope} */ (scope.parent), scopes: template.scopes };
 
 						walk(node.expression, state, {
@@ -491,6 +491,7 @@ export function analyze_component(root, source, options) {
 
 									if (binding && binding.kind === 'normal') {
 										binding.kind = 'state';
+										binding.mutated = binding.updated = true;
 									}
 								}
 							}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -455,9 +455,14 @@ export function analyze_component(root, source, options) {
 			for (const { node, path } of binding.references) {
 				if (node === binding.node) continue;
 
-				const types = path.map((node) => node.type);
-				if (types.at(-1) === 'StyleDirective' && (binding.reassigned || binding.mutated)) {
-					binding.kind = 'state';
+				if (binding.mutated) {
+					if (
+						path[path.length - 1].type === 'StyleDirective' ||
+						path.some((node) => node.type === 'Fragment') ||
+						(path[1].type === 'LabeledStatement' && path[1].label.name === '$')
+					) {
+						binding.kind = 'state';
+					}
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -429,6 +429,23 @@ export function analyze_component(root, source, options) {
 						}
 					}
 				}
+			} else {
+				for (const specifier of node.specifiers) {
+					const binding = instance.scope.get(specifier.local.name);
+
+					if (
+						binding &&
+						(binding.declaration_kind === 'var' || binding.declaration_kind === 'let')
+					) {
+						binding.kind = 'bindable_prop';
+
+						if (specifier.exported.name !== specifier.local.name) {
+							binding.prop_alias = specifier.exported.name;
+						}
+					} else {
+						analysis.exports.push({ name: specifier.local.name, alias: specifier.exported.name });
+					}
+				}
 			}
 		}
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
@@ -134,7 +134,7 @@ function get_delegated_event(event_name, handler, context) {
 			return unhoisted;
 		}
 
-		if (binding !== null && binding.initial !== null && !binding.mutated && !binding.is_called) {
+		if (binding !== null && binding.initial !== null && !binding.updated && !binding.is_called) {
 			const binding_type = binding.initial.type;
 
 			if (
@@ -188,7 +188,7 @@ function get_delegated_event(event_name, handler, context) {
 				(((!context.state.analysis.runes && binding.kind === 'each') ||
 					// or any normal not reactive bindings that are mutated.
 					binding.kind === 'normal') &&
-					binding.mutated))
+					binding.updated))
 		) {
 			return unhoisted;
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/BindDirective.js
@@ -80,10 +80,6 @@ export function BindDirective(node, context) {
 				if (references.length > 0) {
 					parent.metadata.contains_group_binding = true;
 
-					for (const binding of parent.metadata.references) {
-						binding.mutated = true;
-					}
-
 					each_blocks.push(parent);
 					ids = ids.filter((id) => !references.includes(id));
 					ids.push(...extract_all_identifiers_from_expression(parent.expression)[1]);

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/BindDirective.js
@@ -39,7 +39,7 @@ export function BindDirective(node, context) {
 					binding.kind !== 'bindable_prop' &&
 					binding.kind !== 'each' &&
 					binding.kind !== 'store_sub' &&
-					!binding.mutated))
+					!binding.updated)) // TODO wut?
 		) {
 			e.bind_invalid_value(node.expression);
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
@@ -39,37 +39,6 @@ export function ExportNamedDeclaration(node, context) {
 		}
 	}
 
-	if (context.state.ast_type === 'instance' && !context.state.analysis.runes) {
-		context.state.analysis.needs_props = true;
-
-		if (node.declaration) {
-			if (
-				node.declaration.type === 'FunctionDeclaration' ||
-				node.declaration.type === 'ClassDeclaration'
-			) {
-				context.state.analysis.exports.push({
-					name: /** @type {Identifier} */ (node.declaration.id).name,
-					alias: null
-				});
-			} else if (node.declaration.type === 'VariableDeclaration') {
-				if (node.declaration.kind === 'const') {
-					for (const declarator of node.declaration.declarations) {
-						for (const node of extract_identifiers(declarator.id)) {
-							context.state.analysis.exports.push({ name: node.name, alias: null });
-						}
-					}
-				} else {
-					for (const declarator of node.declaration.declarations) {
-						for (const id of extract_identifiers(declarator.id)) {
-							const binding = /** @type {Binding} */ (context.state.scope.get(id.name));
-							binding.kind = 'bindable_prop';
-						}
-					}
-				}
-			}
-		}
-	}
-
 	if (context.state.analysis.runes) {
 		if (node.declaration && context.state.ast_type === 'instance') {
 			if (

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportSpecifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportSpecifier.js
@@ -18,28 +18,6 @@ export function ExportSpecifier(node, context) {
 
 			const binding = context.state.scope.get(node.local.name);
 			if (binding) binding.reassigned = true;
-		} else {
-			context.state.analysis.needs_props = true;
-
-			const binding = /** @type {Binding} */ (context.state.scope.get(node.local.name));
-
-			if (
-				binding !== null &&
-				(binding.kind === 'state' ||
-					binding.kind === 'raw_state' ||
-					(binding.kind === 'normal' &&
-						(binding.declaration_kind === 'let' || binding.declaration_kind === 'var')))
-			) {
-				binding.kind = 'bindable_prop';
-				if (node.exported.name !== node.local.name) {
-					binding.prop_alias = node.exported.name;
-				}
-			} else {
-				context.state.analysis.exports.push({
-					name: node.local.name,
-					alias: node.exported.name
-				});
-			}
 		}
 	} else {
 		validate_export(node, context.state.scope, node.local.name);

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportSpecifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportSpecifier.js
@@ -17,7 +17,7 @@ export function ExportSpecifier(node, context) {
 			});
 
 			const binding = context.state.scope.get(node.local.name);
-			if (binding) binding.reassigned = true;
+			if (binding) binding.reassigned = binding.updated = true;
 		}
 	} else {
 		validate_export(node, context.state.scope, node.local.name);

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
@@ -88,7 +88,7 @@ export function Identifier(node, context) {
 					context.state.analysis.template.scopes.get(ancestor)?.declarations.get(node.name) ===
 						binding
 				) {
-					for (const binding of ancestor.metadata.references) {
+					for (const binding of ancestor.metadata.expression.dependencies) {
 						if (binding.kind === 'normal') {
 							binding.kind = 'state';
 						}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
@@ -78,21 +78,7 @@ export function Identifier(node, context) {
 			context.state.analysis.uses_rest_props = true;
 		}
 
-		if (
-			binding?.kind === 'normal' &&
-			((binding.scope === context.state.instance_scope &&
-				binding.declaration_kind !== 'function') ||
-				binding.declaration_kind === 'import')
-		) {
-			if (
-				binding.declaration_kind !== 'import' &&
-				binding.mutated &&
-				// TODO could be more fine-grained - not every mention in the template implies a state binding
-				(context.state.reactive_statement || context.state.ast_type === 'template')
-			) {
-				binding.kind = 'state';
-			}
-		} else if (binding?.kind === 'each' && binding.mutated) {
+		if (binding?.kind === 'each' && binding.mutated) {
 			// Ensure that the array is marked as reactive even when only its entries are mutated
 			let i = context.path.length;
 			while (i--) {

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
@@ -91,12 +91,6 @@ export function Identifier(node, context) {
 				(context.state.reactive_statement || context.state.ast_type === 'template')
 			) {
 				binding.kind = 'state';
-			} else if (
-				context.state.reactive_statement &&
-				parent.type === 'AssignmentExpression' &&
-				parent.left === binding.node
-			) {
-				binding.kind = 'derived';
 			}
 		} else if (binding?.kind === 'each' && binding.mutated) {
 			// Ensure that the array is marked as reactive even when only its entries are mutated

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
@@ -78,19 +78,6 @@ export function Identifier(node, context) {
 		if (node.name === '$$restProps') {
 			context.state.analysis.uses_rest_props = true;
 		}
-
-		if (binding?.kind === 'each' && binding.mutated) {
-			// Ensure that the array is marked as reactive even when only its entries are mutated
-			const each_block = /** @type {EachBlock} */ (
-				context.path.findLast((node) => node.type === 'EachBlock')
-			);
-
-			for (const binding of each_block.metadata.expression.dependencies) {
-				if (binding.kind === 'normal') {
-					binding.kind = 'state';
-				}
-			}
-		}
 	}
 
 	if (binding) {

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/StyleDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/StyleDirective.js
@@ -17,10 +17,6 @@ export function StyleDirective(node, context) {
 		let binding = context.state.scope.get(node.name);
 
 		if (binding) {
-			if (!context.state.analysis.runes && binding.mutated) {
-				binding.kind = 'state';
-			}
-
 			if (binding.kind !== 'normal') {
 				node.metadata.expression.has_state = true;
 			}

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -235,7 +235,7 @@ export function is_prop_source(binding, state) {
 			binding.initial ||
 			// Until legacy mode is gone, we also need to use the prop source when only mutated is true,
 			// because the parent could be a legacy component which needs coarse-grained reactivity
-			binding.mutated)
+			binding.updated)
 	);
 }
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
@@ -114,7 +114,7 @@ export function EachBlock(node, context) {
 	const indirect_dependencies = collect_parent_each_blocks(context).flatMap((block) => {
 		const array = /** @type {Expression} */ (context.visit(block.expression));
 		const transitive_dependencies = build_transitive_dependencies(
-			block.metadata.references,
+			block.metadata.expression.dependencies,
 			context
 		);
 		return [array, ...transitive_dependencies];
@@ -126,7 +126,7 @@ export function EachBlock(node, context) {
 		indirect_dependencies.push(collection);
 
 		const transitive_dependencies = build_transitive_dependencies(
-			each_node_meta.references,
+			each_node_meta.expression.dependencies,
 			context
 		);
 		indirect_dependencies.push(...transitive_dependencies);
@@ -279,7 +279,7 @@ function collect_parent_each_blocks(context) {
 }
 
 /**
- * @param {Binding[]} references
+ * @param {Set<Binding>} references
  * @param {ComponentContext} context
  */
 function build_transitive_dependencies(references, context) {

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -506,17 +506,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 		},
 
 		EachBlock(node, { state, visit }) {
-			// Array part is still from the scope above
-			/** @type {Set<Identifier>} */
-			const references_within = new Set();
-			const idx = references.length;
 			visit(node.expression);
-			for (let i = idx; i < references.length; i++) {
-				const [scope, { node: id }] = references[i];
-				if (scope === state.scope) {
-					references_within.add(id);
-				}
-			}
 
 			// context and children are a new scope
 			const scope = state.scope.child();
@@ -582,9 +572,6 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 				index: scope.root.unique('$$index'),
 				item: node.context.type === 'Identifier' ? node.context : b.id('$$item'),
 				declarations: scope.declarations,
-				references: [...references_within]
-					.map((id) => /** @type {Binding} */ (state.scope.get(id.name)))
-					.filter(Boolean),
 				is_controlled: false
 			};
 		},

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -113,13 +113,14 @@ export class Scope {
 			references: [],
 			legacy_dependencies: [],
 			initial,
+			reassigned: false,
 			mutated: false,
+			updated: false,
 			scope: this,
 			kind,
 			declaration_kind,
 			is_called: false,
 			prop_alias: null,
-			reassigned: false,
 			metadata: null
 		};
 		this.declarations.set(node.name, binding);

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -708,6 +708,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 
 				const binding = scope.get(id.name);
 				if (binding && id !== binding.node) {
+					// TODO we should probably distinguish between these?
 					binding.mutated = true;
 					binding.reassigned = node.type === 'Identifier';
 				}

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -691,10 +691,9 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 		} else {
 			for (const expression of unwrap_pattern(node)) {
 				const left = object(expression);
-				if (left === null) return;
+				const binding = left && scope.get(left.name);
 
-				const binding = scope.get(left.name);
-				if (binding && left !== binding.node) {
+				if (binding !== null && left !== binding.node) {
 					// TODO we should probably distinguish between these?
 					binding.mutated = true;
 					binding.reassigned = left === expression;

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -689,17 +689,17 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			const binding = scope.get(/** @type {Identifier} */ (object).name);
 			if (binding) binding.mutated = true;
 		} else {
-			unwrap_pattern(node).forEach((node) => {
-				let id = node.type === 'Identifier' ? node : object(node);
-				if (id === null) return;
+			for (const expression of unwrap_pattern(node)) {
+				const left = object(expression);
+				if (left === null) return;
 
-				const binding = scope.get(id.name);
-				if (binding && id !== binding.node) {
+				const binding = scope.get(left.name);
+				if (binding && left !== binding.node) {
 					// TODO we should probably distinguish between these?
 					binding.mutated = true;
-					binding.reassigned = node.type === 'Identifier';
+					binding.reassigned = left === expression;
 				}
-			});
+			}
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -685,9 +685,13 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			const binding = left && scope.get(left.name);
 
 			if (binding !== null && left !== binding.node) {
-				// TODO we should probably distinguish between these?
-				binding.mutated = true;
-				binding.reassigned ||= left === expression;
+				binding.updated = true;
+
+				if (left === expression) {
+					binding.reassigned = true;
+				} else {
+					binding.mutated = true;
+				}
 			}
 		}
 	}

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -14,7 +14,6 @@ import {
 } from '../utils/ast.js';
 import { is_reserved, is_rune } from '../../utils.js';
 import { determine_slot } from '../utils/slot.js';
-import { filename } from '../state.js';
 
 export class Scope {
 	/** @type {ScopeRoot} */

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -671,7 +671,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 		// the css property
 		StyleDirective(node, { path, state, next }) {
 			if (node.value === true) {
-				state.scope.reference(b.id(node.name), path);
+				state.scope.reference(b.id(node.name), path.concat(node));
 			}
 			next();
 		}

--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -300,6 +300,8 @@ export interface Binding {
 	references: { node: Identifier; path: SvelteNode[] }[];
 	mutated: boolean;
 	reassigned: boolean;
+	/** `true` if mutated _or_ reassigned */
+	updated: boolean;
 	scope: Scope;
 	/** For `legacy_reactive`: its reactive dependencies */
 	legacy_dependencies: Binding[];

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -404,8 +404,6 @@ export interface EachBlock extends BaseNode {
 		index: Identifier;
 		item: Identifier;
 		declarations: Map<string, Binding>;
-		/** List of bindings that are referenced within the expression */
-		references: Binding[];
 		/**
 		 * Optimization path for each blocks: If the parent isn't a fragment and
 		 * it only has a single child, then we can classify the block as being "controlled".

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -949,6 +949,8 @@ declare module 'svelte/compiler' {
 		references: { node: Identifier; path: SvelteNode[] }[];
 		mutated: boolean;
 		reassigned: boolean;
+		/** `true` if mutated _or_ reassigned */
+		updated: boolean;
 		scope: Scope;
 		/** For `legacy_reactive`: its reactive dependencies */
 		legacy_dependencies: Binding[];
@@ -1859,8 +1861,6 @@ declare module 'svelte/compiler' {
 			index: Identifier;
 			item: Identifier;
 			declarations: Map<string, Binding>;
-			/** List of bindings that are referenced within the expression */
-			references: Binding[];
 			/**
 			 * Optimization path for each blocks: If the parent isn't a fragment and
 			 * it only has a single child, then we can classify the block as being "controlled".


### PR DESCRIPTION
Necessary for #12824. This sets `binding.kind` for all bindings _before_ we walk the AST in the analysis phase, but only in legacy mode.

(In runes mode it's more awkward because declarations can be anywhere, and we can't set `kind` at the declaration site until we know definitively whether we're in runes mode or not. When we get rid of legacy mode, this restriction will go away. In the meantime, it doesn't matter for #12824, because it's about `$:` statements which are only valid in legacy mode.)

Doing it this way means we can provide better warnings during the analysis phase.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ]  Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
