### PR TITLE
fix: skip unnecessary `$$legacy` flag

### DIFF
--- a/.changeset/tricky-coats-shop.md
+++ b/.changeset/tricky-coats-shop.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip unnecessary `$$legacy` flag

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -298,7 +298,10 @@ export function build_component(node, component_name, context, anchor = context.
 		push_prop(b.init('$$slots', b.object(serialized_slots)));
 	}
 
-	if (!context.state.analysis.runes) {
+	if (
+		!context.state.analysis.runes &&
+		node.attributes.some((attribute) => attribute.type === 'BindDirective')
+	) {
 		push_prop(b.init('$$legacy', b.true));
 	}
 

--- a/packages/svelte/tests/snapshot/samples/purity/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/purity/_expected/client/index.svelte.js
@@ -23,10 +23,6 @@ export default function Purity($$anchor) {
 
 	var node = $.sibling($.sibling(p_1, true));
 
-	Child(node, {
-		prop: encodeURIComponent(value),
-		$$legacy: true
-	});
-
+	Child(node, { prop: encodeURIComponent(value) });
 	$.append($$anchor, fragment);
 }


### PR DESCRIPTION
We only need this flag if there's a binding. Otherwise it's just wasteful

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
