### PR TITLE
chore: skip over static elements during CSR

### DIFF
--- a/.changeset/mean-beans-try.md
+++ b/.changeset/mean-beans-try.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: skip over static elements during CSR

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -134,6 +134,16 @@ export function sibling(node, is_text = false) {
 /**
  * @template {Node} N
  * @param {N} node
+ * @returns {Node | null}
+ */
+/*#__NO_SIDE_EFFECTS__*/
+export function sibling_dangle(node) {
+	return node.nextSibling;
+}
+
+/**
+ * @template {Node} N
+ * @param {N} node
  * @returns {void}
  */
 export function clear_text_content(node) {

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -66,7 +66,7 @@ export {
 	bind_focused
 } from './dom/elements/bindings/universal.js';
 export { bind_window_scroll, bind_window_size } from './dom/elements/bindings/window.js';
-export { hydrate_template, next, reset } from './dom/hydration.js';
+export { hydrate_template, next, reset, hydrating } from './dom/hydration.js';
 export {
 	once,
 	preventDefault,
@@ -156,6 +156,7 @@ export {
 	child,
 	first_child,
 	sibling,
+	sibling_dangle,
 	$window as window,
 	$document as document
 } from './dom/operations.js';


### PR DESCRIPTION
Addresses the concern in https://github.com/sveltejs/svelte/pull/12849#issuecomment-2290992674. If we are rendering without hydration and we've encountered the last child element of a fragment, then we can likely dead code eliminate that `$.sibling` call if it's not referenced. To do this, we output a conditional that checks if we're hydrating and if not, outputs `$.sibling_dangle` which can be safely DCE.