### PR TITLE
fix: ensure outro animation is not prematurely aborted

### DIFF
--- a/.changeset/lazy-carrots-buy.md
+++ b/.changeset/lazy-carrots-buy.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure outro animation is not prematurely aborted

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -251,8 +251,6 @@ export function transition(flags, element, get_fn, get_params) {
 					0,
 					() => {
 						dispatch_event(element, 'outroend');
-						// Ensure we cancel the animation to prevent leaking
-						outro?.abort();
 						outro = current_options = undefined;
 						fn?.();
 					},


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12844#issuecomment-2292019099. I also confirmed this did not regress the memory leak that https://github.com/sveltejs/svelte/pull/12759 fixed. It seems we only need to abort the intro, rather than the outro – I must have added to both call-sites because it seemed right, but clearly that wasn't right.