### PR TITLE
remove STATE_SYMBOL from objects

### DIFF
--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -181,17 +181,13 @@ export interface ProxyMetadata<T = Record<string | symbol, any>> {
 	/** `true` if the proxified object is an array */
 	a: boolean;
 	/** The associated proxy */
-	p: ProxyStateObject<T>;
+	p: T;
 	/** The original target this proxy was created for */
 	t: T;
 	/** Dev-only — the components that 'own' this state, if any. `null` means no owners, i.e. everyone can mutate this state. */
-	owners: null | Set<Function>;
+	owners?: null | Set<Function>;
 	/** Dev-only — the parent metadata object */
-	parent: null | ProxyMetadata;
+	parent?: null | ProxyMetadata;
 }
-
-export type ProxyStateObject<T = Record<string | symbol, any>> = T & {
-	[STATE_SYMBOL]: ProxyMetadata;
-};
 
 export * from './reactivity/types';

--- a/packages/svelte/tests/runtime-runes/samples/proxy-cyclical/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-cyclical/_config.js
@@ -11,6 +11,6 @@ export default test({
 			btn?.click();
 		});
 
-		assert.htmlEqual(target.innerHTML, `<button>goodbye!</button>`);
+		assert.htmlEqual(target.innerHTML, `<button>hello!</button>`);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/proxy-nested/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-nested/_config.js
@@ -2,7 +2,7 @@ import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	html: `<button>clicks: 0</button>`,
+	html: `<button>clicks: 0/0</button>`,
 
 	test({ assert, target }) {
 		const btn = target.querySelector('button');
@@ -11,6 +11,6 @@ export default test({
 			btn?.click();
 		});
 
-		assert.htmlEqual(target.innerHTML, `<button>clicks: 1</button>`);
+		assert.htmlEqual(target.innerHTML, `<button>clicks: 0/1</button>`);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/proxy-nested/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-nested/main.svelte
@@ -1,7 +1,7 @@
 <script>
 	const inner = $state({
 		count: 0
-	})
+	});
 
 	const object = $state({
 		outer: {
@@ -10,6 +10,6 @@
 	});
 </script>
 
-<button onclick={() => inner.count += 1}>
-	clicks: {object.outer.inner.count}
+<button onclick={() => (inner.count += 1)}>
+	clicks: {object.outer.inner.count}/{inner.count}
 </button>

--- a/packages/svelte/tests/runtime-runes/samples/proxy-shared/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-shared/_config.js
@@ -18,7 +18,7 @@ export default test({
 			target.innerHTML,
 			`
 				<button>1</button>
-				<button>1</button>
+				<button>0</button>
 			`
 		);
 
@@ -29,8 +29,8 @@ export default test({
 		assert.htmlEqual(
 			target.innerHTML,
 			`
-				<button>2</button>
-				<button>2</button>
+				<button>1</button>
+				<button>1</button>
 			`
 		);
 	}


### PR DESCRIPTION
This is an attempt to remove `STATE_SYMBOL`  from objects passed into `$state(...)`, the thinking being that post-#12847 it makes sense to leave these objects completely untouched and just use them to initialise the state proxies.

It would also allow us to remove the awkward `is_frozen` check, which prevents a frozen object from being proxied (even though the app author might not have been responsible for the freezing), because you can't add a symbol to a frozen object.

The approach I took was to make the `ProxyMetadata` object the target of the proxy, rather than the original value. This makes the proxy traps a bit neater, in general, but it turns out there are some flaws to this approach — e.g. `Array.isArray` doesn't work any more unless we make the `metadata` object an array with a bunch of non-numeric properties. I suspect we'll have to file this under 'nice idea, but doesn't actually work'.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
