### PR TITLE
feat: use a WeakMap instead of a symbol to link proxies to values

### DIFF
--- a/.changeset/grumpy-rivers-move.md
+++ b/.changeset/grumpy-rivers-move.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: allow frozen objects to be proxied

--- a/.changeset/ninety-beans-flash.md
+++ b/.changeset/ninety-beans-flash.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: use a WeakMap instead of a symbol to link proxies to values

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -19,5 +19,4 @@ export const LEGACY_DERIVED_PROP = 1 << 16;
 export const INSPECT_EFFECT = 1 << 17;
 export const HEAD_EFFECT = 1 << 18;
 
-export const STATE_SYMBOL = Symbol('$state');
 export const LOADING_ATTR_SYMBOL = Symbol('');

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -1,12 +1,12 @@
 /** @import { ProxyMetadata } from '#client' */
 /** @typedef {{ file: string, line: number, column: number }} Location */
 
-import { STATE_SYMBOL } from '../constants.js';
 import { render_effect, user_pre_effect } from '../reactivity/effects.js';
 import { dev_current_component_function } from '../runtime.js';
 import { get_prototype_of } from '../../shared/utils.js';
 import * as w from '../warnings.js';
 import { FILENAME } from '../../../constants.js';
+import { proxies } from '../proxy.js';
 
 /** @type {Record<string, Array<{ start: Location, end: Location, component: Function }>>} */
 const boundaries = {};
@@ -113,7 +113,8 @@ export function mark_module_end(component) {
 export function add_owner(object, owner, global = false, skip_warning = false) {
 	if (object && !global) {
 		const component = dev_current_component_function;
-		const metadata = object[STATE_SYMBOL];
+		const metadata = proxies.get(object);
+
 		if (metadata && !has_owner(metadata, component)) {
 			let original = get_owner(metadata);
 
@@ -166,7 +167,7 @@ export function widen_ownership(from, to) {
  * @param {Set<any>} seen
  */
 function add_owner_to_object(object, owner, seen) {
-	const metadata = /** @type {ProxyMetadata} */ (object?.[STATE_SYMBOL]);
+	const metadata = proxies.get(object);
 
 	if (metadata) {
 		// this is a state proxy, add owner directly, if not globally shared

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -27,8 +27,8 @@ import {
 	resume_effect
 } from '../../reactivity/effects.js';
 import { source, mutable_source, set } from '../../reactivity/sources.js';
-import { is_array, is_frozen } from '../../../shared/utils.js';
-import { INERT, STATE_SYMBOL } from '../../constants.js';
+import { is_array } from '../../../shared/utils.js';
+import { INERT } from '../../constants.js';
 import { queue_micro_task } from '../task.js';
 import { current_effect } from '../../runtime.js';
 

--- a/packages/svelte/src/internal/client/dom/elements/bindings/this.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/this.js
@@ -1,4 +1,4 @@
-import { STATE_SYMBOL } from '../../../constants.js';
+import { proxies } from '../../../proxy.js';
 import { effect, render_effect } from '../../../reactivity/effects.js';
 import { untrack } from '../../../runtime.js';
 import { queue_micro_task } from '../../task.js';
@@ -10,7 +10,7 @@ import { queue_micro_task } from '../../task.js';
  */
 function is_bound_this(bound_value, element_or_component) {
 	// Find the original target if the value is proxied.
-	var proxy_target = bound_value && bound_value[STATE_SYMBOL]?.t;
+	var proxy_target = bound_value && proxies.get(bound_value)?.t;
 	return bound_value === element_or_component || proxy_target === element_or_component;
 }
 

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -14,7 +14,7 @@ import { UNINITIALIZED } from '../../constants.js';
 import * as e from './errors.js';
 
 /**
- * @type {WeakMap<any, ProxyMetadata<any>}
+ * @type {WeakMap<any, ProxyMetadata<any>>}
  */
 export const proxies = new WeakMap();
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -18,7 +18,6 @@ import {
 	DESTROYED,
 	INERT,
 	BRANCH_EFFECT,
-	STATE_SYMBOL,
 	BLOCK_EFFECT,
 	ROOT_EFFECT,
 	LEGACY_DERIVED_PROP,
@@ -31,6 +30,7 @@ import { update_derived } from './reactivity/deriveds.js';
 import * as e from './errors.js';
 import { lifecycle_outside_component } from '../shared/errors.js';
 import { FILENAME } from '../../constants.js';
+import { proxies } from './proxy.js';
 
 const FLUSH_MICROTASK = 0;
 const FLUSH_SYNC = 1;
@@ -1047,12 +1047,12 @@ export function deep_read_state(value) {
 		return;
 	}
 
-	if (STATE_SYMBOL in value) {
+	if (proxies.has(value)) {
 		deep_read(value);
 	} else if (!Array.isArray(value)) {
 		for (let key in value) {
 			const prop = value[key];
-			if (typeof prop === 'object' && prop && STATE_SYMBOL in prop) {
+			if (typeof prop === 'object' && prop && proxies.has(prop)) {
 				deep_read(prop);
 			}
 		}

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -1,5 +1,4 @@
 import type { Store } from '#shared';
-import { STATE_SYMBOL } from './constants.js';
 import type { Effect, Source, Value } from './reactivity/types.js';
 
 type EventCallback = (event: Event) => boolean;
@@ -181,7 +180,7 @@ export interface ProxyMetadata<T = Record<string | symbol, any>> {
 	/** `true` if the proxified object is an array */
 	a: boolean;
 	/** The associated proxy */
-	p: ProxyStateObject<T>;
+	p: T;
 	/** The original target this proxy was created for */
 	t: T;
 	/** Dev-only — the components that 'own' this state, if any. `null` means no owners, i.e. everyone can mutate this state. */
@@ -189,9 +188,5 @@ export interface ProxyMetadata<T = Record<string | symbol, any>> {
 	/** Dev-only — the parent metadata object */
 	parent: null | ProxyMetadata;
 }
-
-export type ProxyStateObject<T = Record<string | symbol, any>> = T & {
-	[STATE_SYMBOL]: ProxyMetadata;
-};
 
 export * from './reactivity/types';

--- a/packages/svelte/src/internal/shared/utils.js
+++ b/packages/svelte/src/internal/shared/utils.js
@@ -3,7 +3,6 @@
 export var is_array = Array.isArray;
 export var array_from = Array.from;
 export var object_keys = Object.keys;
-export var is_frozen = Object.isFrozen;
 export var define_property = Object.defineProperty;
 export var get_descriptor = Object.getOwnPropertyDescriptor;
 export var get_descriptors = Object.getOwnPropertyDescriptors;


### PR DESCRIPTION
Since #12867 doesn't really work, I figured we could try a `WeakMap` approach. It's possible that the performance implications will be a dealbreaker.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
