### PR TITLE
fix: correctly ensure prop bindings are reactive when bound

### DIFF
--- a/.changeset/eighty-days-wave.md
+++ b/.changeset/eighty-days-wave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly ensure prop bindings are reactive when bound

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -184,6 +184,7 @@ export function get_prop_source(binding, state, name, initial) {
 
 	if (
 		state.analysis.accessors ||
+		binding.updated ||
 		(state.analysis.immutable
 			? binding.reassigned || (state.analysis.runes && binding.mutated)
 			: binding.mutated)

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -184,10 +184,9 @@ export function get_prop_source(binding, state, name, initial) {
 
 	if (
 		state.analysis.accessors ||
-		binding.updated ||
 		(state.analysis.immutable
 			? binding.reassigned || (state.analysis.runes && binding.mutated)
-			: binding.mutated)
+			: binding.update)
 	) {
 		flags |= PROPS_IS_UPDATED;
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -186,7 +186,7 @@ export function get_prop_source(binding, state, name, initial) {
 		state.analysis.accessors ||
 		(state.analysis.immutable
 			? binding.reassigned || (state.analysis.runes && binding.mutated)
-			: binding.update)
+			: binding.updated)
 	) {
 		flags |= PROPS_IS_UPDATED;
 	}

--- a/packages/svelte/tests/runtime-legacy/samples/binding-value-prop/Field.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-value-prop/Field.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let value;
+</script>
+
+<input type="text" bind:value />

--- a/packages/svelte/tests/runtime-legacy/samples/binding-value-prop/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-value-prop/_config.js
@@ -1,0 +1,21 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+export default test({
+	html: `<input type="text">\naaa`,
+	ssrHtml: `<input type="text" value="aaa">\naaa`,
+
+	test({ assert, target }) {
+		const input = target.querySelector('input');
+		ok(input);
+
+		const event = new window.Event('input');
+
+		input.value = 'aaa2';
+		input.dispatchEvent(event);
+
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<input type="text">\naaa2`);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/binding-value-prop/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-value-prop/_config.js
@@ -2,6 +2,7 @@ import { flushSync } from 'svelte';
 import { ok, test } from '../../test';
 
 export default test({
+	accessors: false,
 	html: `<input type="text">\naaa`,
 	ssrHtml: `<input type="text" value="aaa">\naaa`,
 

--- a/packages/svelte/tests/runtime-legacy/samples/binding-value-prop/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-value-prop/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Field from './Field.svelte';
+	import { writable } from 'svelte/store';
+
+	const value = writable('aaa');
+
+</script>
+
+<Field bind:value={$value} /> {$value}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12860. This was a recent regression from https://github.com/sveltejs/svelte/pull/12843 where the binding identifier is marked as `reassigned` but not `mutated` in legacy mode, meaning that we didn't correctly put in the correct `flags` for the prop runtime. We can instead just look for `binding.updated` as this captures either, and fixes this issue.