### PR TITLE
fix: always call tick() if defined in transitions

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -422,22 +422,23 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 					}
 				});
 		});
-	} else {
+	}
+	if (tick) {
 		// Timer
 		if (t1 === 0) {
-			tick?.(0, 1); // TODO put in nested effect, to avoid interleaved reads/writes?
+			tick(0, 1); // TODO put in nested effect, to avoid interleaved reads/writes?
 		}
 
 		task = loop((now) => {
 			if (now >= end) {
-				tick?.(t2, 1 - t2);
-				on_finish?.();
+				tick(t2, 1 - t2);
+				on_finish?.(); // TODO is this supposed to not be called when tick == undefined?
 				return false;
 			}
 
 			if (now >= start) {
 				var p = t1 + delta * easing((now - start) / duration);
-				tick?.(p, 1 - p);
+				tick(p, 1 - p);
 			}
 
 			return true;


### PR DESCRIPTION
Closes #12730

Call `tick()` if it's defined, not if `css` is undefined.

**Note for maintainers:** the call to `on_finished()` used to be wrapped in `if (!css)`, was it intended for it to never be called for CSS transitions? Regardless I left it as-is as I'm not sure + added a TODO, now it's only called when `tick` is defined instead.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
