### PR TITLE
chore: tweak each block logic

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -277,8 +277,7 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 
 			if (item !== undefined) {
 				item.a?.measure();
-				if (to_animate === undefined) to_animate = new Set();
-				to_animate.add(item);
+				(to_animate ??= new Set()).add(item);
 			}
 		}
 	}

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -319,8 +319,7 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 			resume_effect(item.e);
 			if (is_animated) {
 				item.a?.unfix();
-				if (to_animate === undefined) to_animate = new Set();
-				to_animate.delete(item);
+				(to_animate ??= new Set()).delete(item);
 			}
 		}
 

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -243,7 +243,7 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 	var current = first;
 
 	/** @type {undefined | Set<EachItem>} */
-	var seen;;
+	var seen;
 
 	/** @type {EachItem | null} */
 	var prev = null;

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -372,8 +372,7 @@ function reconcile(array, state, anchor, render_fn, flags, get_key) {
 			stashed = [];
 
 			while (current !== null && current.k !== key) {
-				if (seen === undefined) seen = new Set();
-				seen.add(current);
+				(seen ??= new Set()).add(current);
 				stashed.push(current);
 				current = current.next;
 			}


### PR DESCRIPTION
Tweaks the each block logic so it's slightly more efficient. `Array.from` isn't free, even on an empty array. So if we can avoid doing that work entirely, then it's a win win. 

Additionally, we don't need to eagerly create `Set`s for things that might never happen. It means we do a bunch of `has` checks when that might not even be needed. Not to mention that creating the Sets each time we reconcile has a memory cost, even if we don't use them.