### PR TITLE
feat: more efficient checking for missing SSR text node

### DIFF
--- a/.changeset/orange-laws-drop.md
+++ b/.changeset/orange-laws-drop.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: more efficient checking for missing SSR text node

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
@@ -30,13 +30,16 @@ export function process_children(nodes, expression, is_element, { visit, state }
 
 			if (node.type === 'Text') {
 				let prev = expression;
-				expression = () => b.call('$.sibling', prev(true));
+				expression = () => b.call('$.sibling', prev(false));
 				state.template.push(node.raw);
 				return;
 			}
 		}
 
-		const id = get_node_id(expression(true), state, 'text');
+		// if this is a standalone `{expression}`, make sure we handle the case where
+		// no text node was created because the expression was empty during SSR
+		const needs_hydration_check = sequence.length === 1;
+		const id = get_node_id(expression(needs_hydration_check), state, 'text');
 
 		state.template.push(' ');
 

--- a/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/bind-component-snippet/_expected/client/index.svelte.js
@@ -27,7 +27,7 @@ export default function Bind_component_snippet($$anchor) {
 		}
 	});
 
-	var text_1 = $.sibling(node, true);
+	var text_1 = $.sibling(node);
 
 	$.template_effect(() => $.set_text(text_1, ` value: ${$.get(value) ?? ""}`));
 	$.append($$anchor, fragment);

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -9,17 +9,17 @@ export default function Main($$anchor) {
 	let y = () => 'test';
 	var fragment = root();
 	var div = $.first_child(fragment);
-	var svg = $.sibling($.sibling(div, true));
-	var custom_element = $.sibling($.sibling(svg, true));
-	var div_1 = $.sibling($.sibling(custom_element, true));
+	var svg = $.sibling($.sibling(div));
+	var custom_element = $.sibling($.sibling(svg));
+	var div_1 = $.sibling($.sibling(custom_element));
 
 	$.template_effect(() => $.set_attribute(div_1, "foobar", y()));
 
-	var svg_1 = $.sibling($.sibling(div_1, true));
+	var svg_1 = $.sibling($.sibling(div_1));
 
 	$.template_effect(() => $.set_attribute(svg_1, "viewBox", y()));
 
-	var custom_element_1 = $.sibling($.sibling(svg_1, true));
+	var custom_element_1 = $.sibling($.sibling(svg_1));
 
 	$.template_effect(() => $.set_custom_element_data(custom_element_1, "fooBar", y()));
 

--- a/packages/svelte/tests/snapshot/samples/purity/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/purity/_expected/client/index.svelte.js
@@ -13,11 +13,11 @@ export default function Purity($$anchor) {
 
 	p.textContent = `${Math.max(min, Math.min(max, number)) ?? ""}`;
 
-	var p_1 = $.sibling($.sibling(p, true));
+	var p_1 = $.sibling($.sibling(p));
 
 	p_1.textContent = `${location.href ?? ""}`;
 
-	var node = $.sibling($.sibling(p_1, true));
+	var node = $.sibling($.sibling(p_1));
 
 	Child(node, { prop: encodeURIComponent(value) });
 	$.append($$anchor, fragment);

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -18,11 +18,11 @@ export default function State_proxy_literal($$anchor) {
 
 	$.remove_input_defaults(input);
 
-	var input_1 = $.sibling($.sibling(input, true));
+	var input_1 = $.sibling($.sibling(input));
 
 	$.remove_input_defaults(input_1);
 
-	var button = $.sibling($.sibling(input_1, true));
+	var button = $.sibling($.sibling(input_1));
 
 	button.__click = [reset, str, tpl];
 	$.bind_value(input, () => $.get(str), ($$value) => $.set(str, $$value));


### PR DESCRIPTION
We handle the case where an `{expression}` is empty during SSR, resulting in no text node being created, by passing a flag to `first_child` and `sibling`. But we do it more often than we need to — it only needs to happen when dealing with a single `ExpressionTag`, rather than a `Text` node or a sequence of the two.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
