### PR TITLE
fix: improve createRawSnippet types with cleanup type

### DIFF
--- a/.changeset/nasty-penguins-pump.md
+++ b/.changeset/nasty-penguins-pump.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: add cleanup function signature to `createRawSnippet`

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -72,7 +72,7 @@ export function wrap_snippet(component, fn) {
  * @template {unknown[]} Params
  * @param {(...params: Getters<Params>) => {
  *   render: () => string
- *   setup?: (element: Element) => void
+ *   setup?: (element: Element) => void | (() => void)
  * }} fn
  * @returns {Snippet<Params>}
  */

--- a/packages/svelte/src/internal/server/blocks/snippet.js
+++ b/packages/svelte/src/internal/server/blocks/snippet.js
@@ -7,7 +7,7 @@
  * @template {unknown[]} Params
  * @param {(...params: Getters<Params>) => {
  *   render: () => string
- *   setup?: (element: Element) => void
+ *   setup?: (element: Element) => void | (() => void)
  * }} fn
  * @returns {Snippet<Params>}
  */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -378,7 +378,7 @@ declare module 'svelte' {
 	 * */
 	export function createRawSnippet<Params extends unknown[]>(fn: (...params: Getters<Params>) => {
 		render: () => string;
-		setup?: (element: Element) => void;
+		setup?: (element: Element) => void | (() => void);
 	}): Snippet<Params>;
 	/** Anything except a function */
 	type NotFunction<T> = T extends Function ? never : T;


### PR DESCRIPTION
Add cleanup type to return value of setup function

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
