### PR TITLE
fix: ensure typings for `<svelte:options>` are picked up (Svelte 5 version)

### DIFF
--- a/.changeset/brown-radios-itch.md
+++ b/.changeset/brown-radios-itch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure typings for `<svelte:options>` are picked up

--- a/packages/svelte/svelte-html.d.ts
+++ b/packages/svelte/svelte-html.d.ts
@@ -243,8 +243,8 @@ declare global {
 			'svelte:body': HTMLProps<'svelte:body', HTMLAttributes>;
 			'svelte:document': HTMLProps<'svelte:document', HTMLAttributes>;
 			'svelte:fragment': { slot?: string };
-			'svelte:options': HTMLProps<'svelte:options', HTMLAttributes>;
 			'svelte:head': { [name: string]: any };
+			// don't type svelte:options, it would override the types in svelte/elements and it isn't extendable anyway
 
 			[name: string]: { [name: string]: any };
 		}


### PR DESCRIPTION
fixes #12886

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
