### PR TITLE
feat: skip static nodes

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
@@ -26,7 +26,7 @@ export function process_children(nodes, initial, is_element, { visit, state }) {
 	/** @param {boolean} check */
 	let expression = (check) => {
 		if (skipped === 0) return initial(check);
-		return b.call('$.next', initial(false), b.literal(skipped), check && b.true);
+		return b.call('$.sibling', initial(false), b.literal(skipped), check && b.true);
 	};
 
 	/**
@@ -42,9 +42,7 @@ export function process_children(nodes, initial, is_element, { visit, state }) {
 			state.init.push(b.var(id, init));
 		}
 
-		console.log(skipped, id, init);
-
-		expression = (check) => b.call('$.next', id, b.literal(skipped), check && b.true);
+		expression = (check) => b.call('$.sibling', id, b.literal(skipped), check && b.true);
 		skipped = 0;
 
 		return id;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
@@ -26,7 +26,12 @@ export function process_children(nodes, initial, is_element, { visit, state }) {
 	/** @param {boolean} check */
 	let expression = (check) => {
 		if (skipped === 0) return initial(check);
-		return b.call('$.sibling', initial(false), b.literal(skipped), check && b.true);
+		return b.call(
+			'$.sibling',
+			initial(false),
+			(check || skipped !== 1) && b.literal(skipped),
+			check && b.true
+		);
 	};
 
 	/**
@@ -42,7 +47,8 @@ export function process_children(nodes, initial, is_element, { visit, state }) {
 			state.init.push(b.var(id, init));
 		}
 
-		expression = (check) => b.call('$.sibling', id, b.literal(skipped), check && b.true);
+		expression = (check) =>
+			b.call('$.sibling', id, (check || skipped !== 1) && b.literal(skipped), check && b.true);
 		skipped = 0;
 
 		return id;

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -137,17 +137,21 @@ export function first_child(fragment, is_text) {
 
 /**
  * Don't mark this as side-effect-free, hydration needs to walk all nodes
- * @template {Node} N
- * @param {N} node
+ * @param {TemplateNode} node
+ * @param {number} count
  * @param {boolean} is_text
  * @returns {Node | null}
  */
-export function sibling(node, is_text = false) {
-	if (!hydrating) {
-		return /** @type {TemplateNode} */ (get_next_sibling(node));
+export function sibling(node, count = 1, is_text = false) {
+	let next_sibling = hydrating ? hydrate_node : node;
+
+	while (count--) {
+		next_sibling = /** @type {TemplateNode} */ (get_next_sibling(next_sibling));
 	}
 
-	var next_sibling = /** @type {TemplateNode} */ (get_next_sibling(hydrate_node));
+	if (!hydrating) {
+		return next_sibling;
+	}
 
 	var type = next_sibling.nodeType;
 

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -70,6 +70,7 @@ export function create_text(value = '') {
  * @param {N} node
  * @returns {Node | null}
  */
+/*@__NO_SIDE_EFFECTS__*/
 export function get_first_child(node) {
 	return first_child_getter.call(node);
 }
@@ -79,6 +80,7 @@ export function get_first_child(node) {
  * @param {N} node
  * @returns {Node | null}
  */
+/*@__NO_SIDE_EFFECTS__*/
 export function get_next_sibling(node) {
 	return next_sibling_getter.call(node);
 }

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -9,17 +9,17 @@ export default function Main($$anchor) {
 	let y = () => 'test';
 	var fragment = root();
 	var div = $.first_child(fragment);
-	var svg = $.sibling($.sibling(div));
-	var custom_element = $.sibling($.sibling(svg));
-	var div_1 = $.sibling($.sibling(custom_element));
+	var svg = $.sibling(div, 2);
+	var custom_element = $.sibling(svg, 2);
+	var div_1 = $.sibling(custom_element, 2);
 
 	$.template_effect(() => $.set_attribute(div_1, "foobar", y()));
 
-	var svg_1 = $.sibling($.sibling(div_1));
+	var svg_1 = $.sibling(div_1, 2);
 
 	$.template_effect(() => $.set_attribute(svg_1, "viewBox", y()));
 
-	var custom_element_1 = $.sibling($.sibling(svg_1));
+	var custom_element_1 = $.sibling(svg_1, 2);
 
 	$.template_effect(() => $.set_custom_element_data(custom_element_1, "fooBar", y()));
 

--- a/packages/svelte/tests/snapshot/samples/purity/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/purity/_expected/client/index.svelte.js
@@ -13,11 +13,11 @@ export default function Purity($$anchor) {
 
 	p.textContent = Math.max(min, Math.min(max, number));
 
-	var p_1 = $.sibling($.sibling(p));
+	var p_1 = $.sibling(p, 2);
 
 	p_1.textContent = location.href;
 
-	var node = $.sibling($.sibling(p_1));
+	var node = $.sibling(p_1, 2);
 
 	Child(node, { prop: encodeURIComponent(value) });
 	$.append($$anchor, fragment);

--- a/packages/svelte/tests/snapshot/samples/skip-static-subtree/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/skip-static-subtree/_expected/client/index.svelte.js
@@ -1,10 +1,20 @@
 import "svelte/internal/disclose-version";
 import * as $ from "svelte/internal/client";
 
-var root = $.template(`<header><nav><a href="/">Home</a> <a href="/away">Away</a></nav></header>`);
+var root = $.template(`<header><nav><a href="/">Home</a> <a href="/away">Away</a></nav></header> <main><h1> </h1> <div class="static"><p>we don't need to traverse these nodes</p></div> <p>or</p> <p>these</p> <p>ones</p> <!></main>`, 1);
 
-export default function Skip_static_subtree($$anchor) {
-	var header = root();
+export default function Skip_static_subtree($$anchor, $$props) {
+	var fragment = root();
+	var main = $.sibling($.first_child(fragment), 2);
+	var h1 = $.child(main);
+	var text = $.child(h1);
 
-	$.append($$anchor, header);
+	$.reset(h1);
+
+	var node = $.sibling(h1, 10);
+
+	$.html(node, () => $$props.content, false, false);
+	$.reset(main);
+	$.template_effect(() => $.set_text(text, $$props.title));
+	$.append($$anchor, fragment);
 }

--- a/packages/svelte/tests/snapshot/samples/skip-static-subtree/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/skip-static-subtree/_expected/server/index.svelte.js
@@ -1,5 +1,7 @@
 import * as $ from "svelte/internal/server";
 
-export default function Skip_static_subtree($$payload) {
-	$$payload.out += `<header><nav><a href="/">Home</a> <a href="/away">Away</a></nav></header>`;
+export default function Skip_static_subtree($$payload, $$props) {
+	let { title, content } = $$props;
+
+	$$payload.out += `<header><nav><a href="/">Home</a> <a href="/away">Away</a></nav></header> <main><h1>${$.escape(title)}</h1> <div class="static"><p>we don't need to traverse these nodes</p></div> <p>or</p> <p>these</p> <p>ones</p> ${$.html(content)}</main>`;
 }

--- a/packages/svelte/tests/snapshot/samples/skip-static-subtree/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/skip-static-subtree/index.svelte
@@ -1,6 +1,21 @@
+<script>
+	let { title, content } = $props();
+</script>
+
 <header>
 	<nav>
 		<a href="/">Home</a>
 		<a href="/away">Away</a>
 	</nav>
 </header>
+
+<main>
+	<h1>{title}</h1>
+	<div class="static">
+		<p>we don't need to traverse these nodes</p>
+	</div>
+	<p>or</p>
+	<p>these</p>
+	<p>ones</p>
+	{@html content}
+</main>

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -18,11 +18,11 @@ export default function State_proxy_literal($$anchor) {
 
 	$.remove_input_defaults(input);
 
-	var input_1 = $.sibling($.sibling(input));
+	var input_1 = $.sibling(input, 2);
 
 	$.remove_input_defaults(input_1);
 
-	var button = $.sibling($.sibling(input_1));
+	var button = $.sibling(input_1, 2);
 
 	button.__click = [reset, str, tpl];
 	$.bind_value(input, () => $.get(str), ($$value) => $.set(str, $$value));

--- a/playgrounds/sandbox/run.js
+++ b/playgrounds/sandbox/run.js
@@ -57,7 +57,7 @@ for (const generate of /** @type {const} */ (['client', 'server'])) {
 		}
 
 		const compiled = compile(source, {
-			dev: true,
+			dev: false,
 			filename: input,
 			generate,
 			runes: argv.values.runes


### PR DESCRIPTION
follow-up to #12849. implements https://github.com/sveltejs/svelte/pull/12855#issuecomment-2291534183.

Basically, given some code like this...

```svelte
<p>{before}</p>
<p>one</p>
<p>two</p>
<p>three</p>
<p>{after}</p>
```

...we can skip over all the static stuff between `{before}` and `{after}`:

```diff
export default function App($$anchor) {
  var fragment = root();
  var p = $.first_child(fragment);

  p.textContent = before;

- var p_1 = $.sibling($.sibling(p));
- var p_2 = $.sibling($.sibling(p_1));
- var p_3 = $.sibling($.sibling(p_2));
- var p_4 = $.sibling($.sibling(p_3));
+ var p_1 = $.sibling(p, 8);

- p_4.textContent = after;
+ p_1.textContent = after;
  $.append($$anchor, fragment);
}
```

It's a little messy, hence draft status, but you get the idea. It should result in a decent reduction in generated code size for mdsvex files etc.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
