### PR TITLE
fix: small legibility improvement

### DIFF
--- a/.changeset/rich-ladybugs-admire.md
+++ b/.changeset/rich-ladybugs-admire.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: small legibility improvement

--- a/.changeset/rich-ladybugs-admire.md
+++ b/.changeset/rich-ladybugs-admire.md
@@ -2,4 +2,4 @@
 "svelte": patch
 ---
 
-fix: small legibility improvement
+fix: small legibility improvement in `Snippet` type hint

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -285,9 +285,9 @@ export interface Snippet<Parameters extends unknown[] = []> {
 		// rest parameter type, which is not supported. If rest parameters are added
 		// in the future, the condition can be removed.
 		...args: number extends Parameters['length'] ? never : Parameters
-	): typeof SnippetReturn & {
-		_: "functions passed to {@render ...} tags must use the `Snippet` type imported from 'svelte'";
-	};
+	): {
+		'{@render ...} must be called with a Snippet': "import type { Snippet } from 'svelte'";
+	} & typeof SnippetReturn;
 }
 
 interface DispatchOptions {

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -286,7 +286,7 @@ export interface Snippet<Parameters extends unknown[] = []> {
 		// in the future, the condition can be removed.
 		...args: number extends Parameters['length'] ? never : Parameters
 	): typeof SnippetReturn & {
-		_: 'functions passed to {@render ...} tags must use the `Snippet` type imported from "svelte"';
+		_: "functions passed to {@render ...} tags must use the `Snippet` type imported from 'svelte'";
 	};
 }
 

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -283,7 +283,7 @@ declare module 'svelte' {
 			// in the future, the condition can be removed.
 			...args: number extends Parameters['length'] ? never : Parameters
 		): typeof SnippetReturn & {
-			_: 'functions passed to {@render ...} tags must use the `Snippet` type imported from "svelte"';
+			_: "functions passed to {@render ...} tags must use the `Snippet` type imported from 'svelte'";
 		};
 	}
 

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -282,9 +282,9 @@ declare module 'svelte' {
 			// rest parameter type, which is not supported. If rest parameters are added
 			// in the future, the condition can be removed.
 			...args: number extends Parameters['length'] ? never : Parameters
-		): typeof SnippetReturn & {
-			_: "functions passed to {@render ...} tags must use the `Snippet` type imported from 'svelte'";
-		};
+		): {
+			'{@render ...} must be called with a Snippet': "import type { Snippet } from 'svelte'";
+		} & typeof SnippetReturn;
 	}
 
 	interface DispatchOptions {


### PR DESCRIPTION
Minimal update to slightly improve the legibility of the hint, because `"` is displayed as `\"`

Before:

![image](https://github.com/user-attachments/assets/1f4bd874-7194-458a-83f1-fc314bbb5874)

After:

![image](https://github.com/user-attachments/assets/d1084127-9918-422a-92a6-9145b5352e6e)

---

While we're at it, we may provide a copy-pasteable hint:

```ts
{
	'Function passed to {@render ...} tag must be of type Snippet': "import type { Snippet } from 'svelte'";
} & typeof SnippetReturn
```

* Swapped hint and symbol so that the hint is displayed first
* Replaced `_` key with `"problem": "solution"` structure
* Made a copy-pasteable solution

It renders as:

![image](https://github.com/user-attachments/assets/a5ce966d-d861-406e-af10-2dbc55f146fa)

What do you think of this?

It's not possible to make a multi-line hint, as new lines are displayed as `\n`. 

---

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
