### PR TITLE
Revert "fix: avoid extra work in mark_reactions"

### DIFF
--- a/.changeset/flat-moose-arrive.md
+++ b/.changeset/flat-moose-arrive.md
@@ -1,5 +1,0 @@
----
-'svelte': patch
----
-
-fix: avoid extra work in mark_reactions

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -145,8 +145,8 @@ function mark_reactions(signal, status) {
 		var reaction = reactions[i];
 		var flags = reaction.f;
 
-		// If a reaction is already dirty, skip it (but always mark unowned deriveds)
-		if ((flags & (CLEAN | UNOWNED)) === 0) continue;
+		// Skip any effects that are already dirty
+		if ((flags & DIRTY) !== 0) continue;
 
 		// In legacy mode, skip the current effect to prevent infinite loops
 		if (!runes && reaction === current_effect) continue;


### PR DESCRIPTION
Reverts sveltejs/svelte#12921. This breaks https://github.com/sveltejs/svelte/pull/12545