### PR TITLE
breaking: make non-bindable props read-only

### DIFF
--- a/.changeset/two-ties-guess.md
+++ b/.changeset/two-ties-guess.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: make non-bindable props read-only

--- a/packages/svelte/messages/compile-errors/script.md
+++ b/packages/svelte/messages/compile-errors/script.md
@@ -6,6 +6,8 @@
 
 > Cannot assign to %thing%
 
+> Cannot assign to %thing%. %suggestion%
+
 ## constant_binding
 
 > Cannot bind to %thing%

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -69,13 +69,14 @@ export function bindable_invalid_location(node) {
 }
 
 /**
- * Cannot assign to %thing%
+ * Cannot assign to %thing%. %suggestion%
  * @param {null | number | NodeLike} node
  * @param {string} thing
+ * @param {string | undefined | null} [suggestion]
  * @returns {never}
  */
-export function constant_assignment(node, thing) {
-	e(node, "constant_assignment", `Cannot assign to ${thing}`);
+export function constant_assignment(node, thing, suggestion) {
+	e(node, "constant_assignment", suggestion ? `Cannot assign to ${thing}. ${suggestion}` : `Cannot assign to ${thing}`);
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
@@ -23,6 +23,14 @@ export function validate_assignment(node, argument, state) {
 				e.constant_assignment(node, 'derived state');
 			}
 
+			if (binding?.kind === 'prop') {
+				e.constant_assignment(
+					node,
+					'a non-bindable prop',
+					'Use `$state.link(...)` to create a local copy of the value'
+				);
+			}
+
 			if (binding?.kind === 'each') {
 				e.each_item_invalid_assignment(node);
 			}

--- a/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/Counter.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/Counter.svelte
@@ -14,7 +14,3 @@
 <button onclick={() => (non_bindable.count += 1)}>
 	mutate: {non_bindable.count}
 </button>
-
-<button onclick={() => (non_bindable = { count: non_bindable.count + 1 })}>
-	reassign: {non_bindable.count}
-</button>

--- a/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-reactivity/_config.js
@@ -6,11 +6,10 @@ export default test({
 		<button>mutate: 0</button>
 		<button>reassign: 0</button>
 		<button>mutate: 0</button>
-		<button>reassign: 0</button>
 	`,
 
 	async test({ assert, target }) {
-		const [btn1, btn2, btn3, btn4] = target.querySelectorAll('button');
+		const [btn1, btn2, btn3] = target.querySelectorAll('button');
 
 		flushSync(() => {
 			btn1?.click();
@@ -22,7 +21,6 @@ export default test({
 				<button>mutate: 1</button>
 				<button>reassign: 1</button>
 				<button>mutate: 0</button>
-				<button>reassign: 0</button>
 			`
 		);
 
@@ -36,7 +34,6 @@ export default test({
 				<button>mutate: 2</button>
 				<button>reassign: 2</button>
 				<button>mutate: 0</button>
-				<button>reassign: 0</button>
 			`
 		);
 
@@ -50,7 +47,6 @@ export default test({
 				<button>mutate: 3</button>
 				<button>reassign: 3</button>
 				<button>mutate: 0</button>
-				<button>reassign: 0</button>
 			`
 		);
 
@@ -64,35 +60,6 @@ export default test({
 				<button>mutate: 3</button>
 				<button>reassign: 3</button>
 				<button>mutate: 0</button>
-				<button>reassign: 0</button>
-			`
-		);
-
-		flushSync(() => {
-			btn4?.click();
-		});
-
-		assert.htmlEqual(
-			target.innerHTML,
-			`
-				<button>mutate: 3</button>
-				<button>reassign: 3</button>
-				<button>mutate: 2</button>
-				<button>reassign: 2</button>
-			`
-		);
-
-		flushSync(() => {
-			btn3?.click();
-		});
-
-		assert.htmlEqual(
-			target.innerHTML,
-			`
-				<button>mutate: 3</button>
-				<button>reassign: 3</button>
-				<button>mutate: 2</button>
-				<button>reassign: 2</button>
 			`
 		);
 	}


### PR DESCRIPTION
Now that [`$state.link`](https://svelte-5-preview.vercel.app/docs/runes#$state-link) exists, we can make props a bit less weird. Rather than allowing them to be written to, causing a temporary divergence between the parent and child values, we can make that behaviour explicit with `$state.link` and make it a compile error to reassign a non-bindable prop.

This change likely also creates some opportunities for simplification — leaving in draft status until I've looked into that

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
