### PR TITLE
fix: ensure await scope shadowing is computed in the correct order

### DIFF
--- a/.changeset/popular-news-happen.md
+++ b/.changeset/popular-news-happen.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure `{#await}` scope shadowing is computed in the correct order

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitBlock.js
@@ -11,6 +11,9 @@ import { create_derived_block_argument } from '../utils.js';
 export function AwaitBlock(node, context) {
 	context.state.template.push('<!>');
 
+	// Visit {#await <expression>} first to ensure that scopes are in the correct order
+	const expression = b.thunk(/** @type {Expression} */ (context.visit(node.expression)));
+
 	let then_block;
 	let catch_block;
 
@@ -45,7 +48,7 @@ export function AwaitBlock(node, context) {
 			b.call(
 				'$.await',
 				context.state.node,
-				b.thunk(/** @type {Expression} */ (context.visit(node.expression))),
+				expression,
 				node.pending
 					? b.arrow([b.id('$$anchor')], /** @type {BlockStatement} */ (context.visit(node.pending)))
 					: b.literal(null),

--- a/packages/svelte/tests/runtime-legacy/samples/await-then-shadowed/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/await-then-shadowed/_config.js
@@ -1,8 +1,6 @@
 import { test } from '../../test';
 
 export default test({
-	solo: true,
-
 	html: '<div>Loading...</div>',
 
 	async test({ assert, target }) {

--- a/packages/svelte/tests/runtime-legacy/samples/await-then-shadowed/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/await-then-shadowed/_config.js
@@ -1,0 +1,12 @@
+import { test } from '../../test';
+
+export default test({
+	solo: true,
+
+	html: '<div>Loading...</div>',
+
+	async test({ assert, target }) {
+		await Promise.resolve();
+		assert.htmlEqual(target.innerHTML, '<div>10</div>');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/await-then-shadowed/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/await-then-shadowed/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	const x = Promise.resolve(10);
+</script>
+
+<div>
+	{#await x}
+		Loading...
+	{:then x}
+		{x}
+	{/await}
+</div>


### PR DESCRIPTION
Attempt to address #12944

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
