### PR TITLE
fix: prevent `svelte_component_invalid_this_value` false positives

### DIFF
--- a/.changeset/rotten-glasses-own.md
+++ b/.changeset/rotten-glasses-own.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent `svelte_component_invalid_this_value` false positives

--- a/packages/svelte/src/internal/client/validate.js
+++ b/packages/svelte/src/internal/client/validate.js
@@ -31,7 +31,7 @@ export function validate_dynamic_component(component_fn) {
 	} catch (err) {
 		const { message } = /** @type {Error} */ (err);
 
-		if (typeof message === 'string' && message.indexOf('is not a function') !== -1) {
+		if (typeof message === 'string' && message.indexOf('$$component is not a function') !== -1) {
 			e.svelte_component_invalid_this_value();
 		}
 


### PR DESCRIPTION
Also check for the function name: `$$component` is rare enough (if even allowed - it's not inside `.svelte(.js)` files) to remove most if not all false positives

fixes #12857 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
