### PR TITLE
fix: ensure `$store` reads are properly transformed

### DIFF
--- a/.changeset/nervous-adults-sell.md
+++ b/.changeset/nervous-adults-sell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure `$store` reads are properly transformed

--- a/packages/svelte/tests/runtime-runes/samples/store-from-derived/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-derived/_config.js
@@ -1,0 +1,11 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<button>false</button>`,
+	test({ assert, target }) {
+		target.querySelector('button')?.click();
+		flushSync();
+		assert.htmlEqual(target.innerHTML, `<button>true</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/store-from-derived/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-derived/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { writable } from 'svelte/store';
+	let data = { store: writable(false) };
+	let { store } = $derived(data);
+</script>
+
+<button onclick={() => ($store = true)}>{$store}</button>


### PR DESCRIPTION
The backing `store` variable of a `$store` read could be a variable that itself needs a transformer, which is why we need to move the setup of the store transformers to the end of the chain

fixes #12859


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
