### PR TITLE
WIP: Add `$effect.sync` rune

### DIFF
--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -16,7 +16,7 @@ export const EFFECT_RAN = 1 << 14;
 export const EFFECT_TRANSPARENT = 1 << 15;
 /** Svelte 4 legacy mode props need to be handled with deriveds and be recognized elsewhere, hence the dedicated flag */
 export const LEGACY_DERIVED_PROP = 1 << 16;
-export const INSPECT_EFFECT = 1 << 17;
+export const SYNC_EFFECT = 1 << 17;
 export const HEAD_EFFECT = 1 << 18;
 
 export const STATE_SYMBOL = Symbol('$state');

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -1,5 +1,5 @@
 import { snapshot } from '../../shared/clone.js';
-import { inspect_effect, validate_effect } from '../reactivity/effects.js';
+import { sync_effect, validate_effect } from '../reactivity/effects.js';
 
 /**
  * @param {() => any[]} get_value
@@ -11,7 +11,7 @@ export function inspect(get_value, inspector = console.log) {
 
 	let initial = true;
 
-	inspect_effect(() => {
+	sync_effect(() => {
 		inspector(initial ? 'init' : 'update', ...snapshot(get_value()));
 		initial = false;
 	});

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -32,7 +32,7 @@ import {
 	DERIVED,
 	UNOWNED,
 	CLEAN,
-	INSPECT_EFFECT,
+	SYNC_EFFECT,
 	HEAD_EFFECT
 } from '../constants.js';
 import { set } from './sources.js';
@@ -84,11 +84,9 @@ function create_effect(type, fn, sync, push = true) {
 	var is_root = (type & ROOT_EFFECT) !== 0;
 	var parent_effect = current_effect;
 
-	if (DEV) {
-		// Ensure the parent is never an inspect effect
-		while (parent_effect !== null && (parent_effect.f & INSPECT_EFFECT) !== 0) {
-			parent_effect = parent_effect.parent;
-		}
+	// Ensure the parent is never an inspect effect
+	while (parent_effect !== null && (parent_effect.f & SYNC_EFFECT) !== 0) {
+		parent_effect = parent_effect.parent;
 	}
 
 	/** @type {Effect} */
@@ -222,8 +220,8 @@ export function user_pre_effect(fn) {
 }
 
 /** @param {() => void | (() => void)} fn */
-export function inspect_effect(fn) {
-	return create_effect(INSPECT_EFFECT, fn, true);
+export function sync_effect(fn) {
+	return create_effect(SYNC_EFFECT, fn, true);
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -150,11 +150,17 @@ export function set(source, value) {
 			}
 		}
 
-		for (const effect of sync_effects) {
-			update_effect(effect);
-		}
+		if (sync_effects.size > 0) {
+			// Make sure the global map is reset to its base state
+			// BEFORE running the effects, which could themselves
+			// trigger other sync effects.
+			const effects_to_run = [...sync_effects];
+			sync_effects.clear();
 
-		sync_effects.clear();
+			for (const effect of effects_to_run) {
+				update_effect(effect);
+			}
+		}
 	}
 
 	return value;


### PR DESCRIPTION
# WORK IN PROGRESS

This PR adds a new `$effect.sync` rune for synchronous effects.

Based on [this off-topic conversation thread](https://github.com/sveltejs/svelte/pull/12943#issuecomment-2302696644) that I caused.

## Changes

* [x] add support for sync effects to the runtime.
* [ ] add `$effect.sync` as a supported rune to the compiler.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
