### PR TITLE
chore: update client check for smaller bundle size

### DIFF
--- a/.changeset/rare-ears-agree.md
+++ b/.changeset/rare-ears-agree.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: update client check for smaller bundle size

--- a/packages/svelte/src/internal/client/timing.js
+++ b/packages/svelte/src/internal/client/timing.js
@@ -1,11 +1,11 @@
 /** @import { Raf } from '#client' */
 import { noop } from '../shared/utils.js';
 
-const is_client = typeof window !== 'undefined';
+import { BROWSER } from 'esm-env';
 
-const request_animation_frame = is_client ? requestAnimationFrame : noop;
+const request_animation_frame = BROWSER ? requestAnimationFrame : noop;
 
-const now = is_client ? () => performance.now() : () => Date.now();
+const now = BROWSER ? () => performance.now() : () => Date.now();
 
 /** @type {Raf} */
 export const raf = {


### PR DESCRIPTION
I noticed that we were doing a `typeof window !== 'undefined'` check in the client output, which seems unnecessary to me. If we use `esm-env` the bundler will replace `BROWSER` with `true` and should eliminate the unused branches.

Do we even need this check though? I notice `client` in the directory name...