### PR TITLE
fix: escape `<` in attribute strings

### DIFF
--- a/.changeset/itchy-ties-argue.md
+++ b/.changeset/itchy-ties-argue.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: escape `<` in attribute strings

--- a/packages/svelte/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.js
+++ b/packages/svelte/src/compiler/compile/render_ssr/handlers/shared/get_attribute_value.js
@@ -1,6 +1,6 @@
 import { string_literal } from '../../../utils/stringify.js';
 import { x } from 'code-red';
-import { regex_double_quotes } from '../../../../utils/patterns.js';
+import { escape } from '../../../../../shared/utils/escape.js';
 
 /**
  * @param {import('../../../nodes/Attribute.js').default} attribute
@@ -37,9 +37,7 @@ export function get_attribute_value(attribute) {
 	return attribute.chunks
 		.map((chunk) => {
 			return chunk.type === 'Text'
-				? /** @type {import('estree').Expression} */ (
-						string_literal(chunk.data.replace(regex_double_quotes, '&quot;'))
-				  )
+				? /** @type {import('estree').Expression} */ (string_literal(escape(chunk.data, true)))
 				: x`@escape(${chunk.node}, ${is_textarea_value ? 'false' : 'true'})`;
 		})
 		.reduce((lhs, rhs) => x`${lhs} + ${rhs}`);

--- a/packages/svelte/src/runtime/internal/ssr.js
+++ b/packages/svelte/src/runtime/internal/ssr.js
@@ -2,7 +2,9 @@ import { set_current_component, current_component } from './lifecycle.js';
 import { run_all, blank_object } from './utils.js';
 import { boolean_attributes } from '../../shared/boolean_attributes.js';
 import { ensure_array_like } from './each.js';
+import { escape } from '../../shared/utils/escape.js';
 export { is_void } from '../../shared/utils/names.js';
+export { escape };
 
 export const invalid_attribute_name_character =
 	/[\s'">/=\u{FDD0}-\u{FDEF}\u{FFFE}\u{FFFF}\u{1FFFE}\u{1FFFF}\u{2FFFE}\u{2FFFF}\u{3FFFE}\u{3FFFF}\u{4FFFE}\u{4FFFF}\u{5FFFE}\u{5FFFF}\u{6FFFE}\u{6FFFF}\u{7FFFE}\u{7FFFF}\u{8FFFE}\u{8FFFF}\u{9FFFE}\u{9FFFF}\u{AFFFE}\u{AFFFF}\u{BFFFE}\u{BFFFF}\u{CFFFE}\u{CFFFF}\u{DFFFE}\u{DFFFF}\u{EFFFE}\u{EFFFF}\u{FFFFE}\u{FFFFF}\u{10FFFE}\u{10FFFF}]/u;
@@ -65,30 +67,6 @@ export function merge_ssr_styles(style_attribute, style_directive) {
 		}
 	}
 	return style_object;
-}
-
-const ATTR_REGEX = /[&"]/g;
-const CONTENT_REGEX = /[&<]/g;
-
-/**
- * Note: this method is performance sensitive and has been optimized
- * https://github.com/sveltejs/svelte/pull/5701
- * @param {unknown} value
- * @returns {string}
- */
-export function escape(value, is_attr = false) {
-	const str = String(value);
-	const pattern = is_attr ? ATTR_REGEX : CONTENT_REGEX;
-	pattern.lastIndex = 0;
-	let escaped = '';
-	let last = 0;
-	while (pattern.test(str)) {
-		const i = pattern.lastIndex - 1;
-		const ch = str[i];
-		escaped += str.substring(last, i) + (ch === '&' ? '&amp;' : ch === '"' ? '&quot;' : '&lt;');
-		last = i + 1;
-	}
-	return escaped + str.substring(last);
 }
 
 export function escape_attribute_value(value) {

--- a/packages/svelte/src/shared/utils/escape.js
+++ b/packages/svelte/src/shared/utils/escape.js
@@ -1,0 +1,23 @@
+const ATTR_REGEX = /[&"<]/g;
+const CONTENT_REGEX = /[&<]/g;
+
+/**
+ * Note: this method is performance sensitive and has been optimized
+ * https://github.com/sveltejs/svelte/pull/5701
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function escape(value, is_attr = false) {
+	const str = String(value);
+	const pattern = is_attr ? ATTR_REGEX : CONTENT_REGEX;
+	pattern.lastIndex = 0;
+	let escaped = '';
+	let last = 0;
+	while (pattern.test(str)) {
+		const i = pattern.lastIndex - 1;
+		const ch = str[i];
+		escaped += str.substring(last, i) + (ch === '&' ? '&amp;' : ch === '"' ? '&quot;' : '&lt;');
+		last = i + 1;
+	}
+	return escaped + str.substring(last);
+}

--- a/packages/svelte/test/server-side-rendering/samples/escaped-attr-2/_expected.html
+++ b/packages/svelte/test/server-side-rendering/samples/escaped-attr-2/_expected.html
@@ -1,0 +1,3 @@
+<noscript
+	><a href="&lt;/noscript>&lt;script>console.log('should not run')&lt;/script>">test</a></noscript
+>

--- a/packages/svelte/test/server-side-rendering/samples/escaped-attr-2/main.svelte
+++ b/packages/svelte/test/server-side-rendering/samples/escaped-attr-2/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	const x = `</noscript><script>console.log('should not run')<` + `/script>`
+</script>
+
+<noscript>
+	<a href={x}>test</a>
+</noscript>
+

--- a/packages/svelte/test/server-side-rendering/samples/escaped-attr-3/_expected.html
+++ b/packages/svelte/test/server-side-rendering/samples/escaped-attr-3/_expected.html
@@ -1,0 +1,1 @@
+<div title="&amp;&lt;">blah</div>

--- a/packages/svelte/test/server-side-rendering/samples/escaped-attr-3/main.svelte
+++ b/packages/svelte/test/server-side-rendering/samples/escaped-attr-3/main.svelte
@@ -1,0 +1,1 @@
+<div title="&amp;&lt;">blah</div>

--- a/packages/svelte/test/server-side-rendering/samples/escaped-attr/_expected.html
+++ b/packages/svelte/test/server-side-rendering/samples/escaped-attr/_expected.html
@@ -1,0 +1,1 @@
+<noscript><a href="&lt;/noscript>&lt;script>throw new Error('fooo')&lt;/script>">test</a></noscript>

--- a/packages/svelte/test/server-side-rendering/samples/escaped-attr/main.svelte
+++ b/packages/svelte/test/server-side-rendering/samples/escaped-attr/main.svelte
@@ -1,0 +1,3 @@
+<noscript>
+	<a href="</noscript><script>throw new Error('fooo')</script>">test</a>
+</noscript>


### PR DESCRIPTION
Svelte 4 version of #11411

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
