### PR TITLE
fix: handle deletions of state proxy properties

### DIFF
--- a/.changeset/beige-lamps-ring.md
+++ b/.changeset/beige-lamps-ring.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: always return true from `deleteProperty` trap

--- a/.changeset/green-windows-tap.md
+++ b/.changeset/green-windows-tap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: handle deletions of previously-unread state proxy properties

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -19,7 +19,7 @@ import * as e from './errors.js';
  * @param {T} value
  * @param {ProxyMetadata | null} [parent]
  * @param {Source<T>} [prev] dev mode only
- * @returns {ProxyStateObject<T> | T}
+ * @returns {T}
  */
 export function proxy(value, parent = null, prev) {
 	// if non-proxyable, or is already a proxy, return `value`
@@ -91,17 +91,17 @@ export function proxy(value, parent = null, prev) {
 
 		deleteProperty(target, prop) {
 			var s = sources.get(prop);
-			var exists = s !== undefined ? s.v !== UNINITIALIZED : prop in target;
 
-			if (s !== undefined) {
+			if (s === undefined) {
+				if (prop in target) {
+					sources.set(prop, source(UNINITIALIZED));
+				}
+			} else {
 				set(s, UNINITIALIZED);
-			}
-
-			if (exists) {
 				update_version(version);
 			}
 
-			return exists;
+			return true;
 		},
 
 		get(target, prop, receiver) {

--- a/packages/svelte/src/internal/client/proxy.test.ts
+++ b/packages/svelte/src/internal/client/proxy.test.ts
@@ -85,3 +85,14 @@ test('does not re-proxy proxies', () => {
 	assert.equal(inner.count, 1);
 	assert.equal(outer.inner.count, 1);
 });
+
+test('deletes a property', () => {
+	const state = proxy({ a: 1, b: 2 } as { a?: number; b?: number; c?: number });
+
+	delete state.a;
+	assert.equal(JSON.stringify(state), '{"b":2}');
+	delete state.a;
+
+	// deleting a non-existent property should succeed
+	delete state.c;
+});


### PR DESCRIPTION
closes #13003. We were doing a couple of things wrong — the `deleteProperty` trap should always return `true`, not just when the property previously existed (I was surprised by this, but try it — `delete {}.foo`), and we need to create an `UNINITIALIZED` source when deleting a property that exists on the target otherwise it will show up in `ownKeys`

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
