### PR TITLE
fix: use WAAPI to control timing of JS-based animations

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -405,6 +405,7 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 			animation.finished
 				.then(() => {
 					on_finish?.();
+					on_finish = undefined;
 
 					if (t2 === 1) {
 						animation.cancel();
@@ -433,7 +434,8 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 		task = loop((now) => {
 			if (now >= end) {
 				tick(t2, 1 - t2);
-				if (!css) on_finish?.();
+				on_finish?.();
+				on_finish = undefined;
 				return false;
 			}
 

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -422,22 +422,23 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 					}
 				});
 		});
-	} else {
+	}
+	if (tick) {
 		// Timer
 		if (t1 === 0) {
-			tick?.(0, 1); // TODO put in nested effect, to avoid interleaved reads/writes?
+			tick(0, 1); // TODO put in nested effect, to avoid interleaved reads/writes?
 		}
 
 		task = loop((now) => {
 			if (now >= end) {
-				tick?.(t2, 1 - t2);
-				on_finish?.();
+				tick(t2, 1 - t2);
+				on_finish?.(); // TODO is this supposed to not be called when tick == undefined?
 				return false;
 			}
 
 			if (now >= start) {
 				var p = t1 + delta * easing((now - start) / duration);
-				tick?.(p, 1 - p);
+				tick(p, 1 - p);
 			}
 
 			return true;

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -423,6 +423,7 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 				});
 		});
 	}
+
 	if (tick) {
 		// Timer
 		if (t1 === 0) {
@@ -432,7 +433,7 @@ function animate(element, options, counterpart, t2, on_finish, on_abort) {
 		task = loop((now) => {
 			if (now >= end) {
 				tick(t2, 1 - t2);
-				on_finish?.(); // TODO is this supposed to not be called when tick == undefined?
+				if (!css) on_finish?.();
 				return false;
 			}
 

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -121,7 +121,7 @@ export interface Animation {
 	/** Resets an animation to its starting state, if it uses `tick`. Exposed as a separate method so that an aborted `out:` can still reset even if the `outro` had already completed */
 	reset: () => void;
 	/** Get the `t` value (between `0` and `1`) of the animation, so that its counterpart can start from the right place */
-	t: (now: number) => number;
+	t: () => number;
 }
 
 export type TransitionFn<P> = (

--- a/packages/svelte/tests/animation-helpers.js
+++ b/packages/svelte/tests/animation-helpers.js
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte';
 import { raf as svelte_raf } from 'svelte/internal/client';
 
 export const raf = {
@@ -23,6 +24,7 @@ export const raf = {
  */
 function tick(time) {
 	raf.time = time;
+	flushSync();
 	for (const animation of raf.animations) {
 		animation._update();
 	}
@@ -44,6 +46,7 @@ class Animation {
 	target;
 	currentTime = 0;
 	startTime = 0;
+	playState = 'running';
 
 	/**
 	 * @param {HTMLElement} target

--- a/packages/svelte/tests/runtime-legacy/samples/transition-css-and-js/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-css-and-js/_config.js
@@ -1,0 +1,30 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+export default test({
+	test({ assert, component, target, raf, logs }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+		const div = target.querySelector('div');
+		ok(div);
+
+		let ended = 0;
+		div.addEventListener('introend', () => {
+			ended += 1;
+		});
+
+		assert.equal(div.style.scale, '0');
+		assert.deepEqual(logs, ['tick: 0']);
+
+		raf.tick(50);
+		assert.equal(div.style.scale, '0.5');
+		assert.deepEqual(logs, ['tick: 0', 'tick: 0.5']);
+
+		raf.tick(100);
+		assert.equal(div.style.scale, '');
+		assert.deepEqual(logs, ['tick: 0', 'tick: 0.5', 'tick: 1']);
+
+		assert.equal(ended, 1);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/transition-css-and-js/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-css-and-js/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let visible = false;
+
+	function foo() {
+		return {
+			duration: 100,
+			css: (t) => {
+				return `scale: ${t}`;
+			},
+			tick: (t) => {
+				console.log(`tick: ${t}`);
+			}
+		};
+	}
+</script>
+
+<button on:click={() => (visible = !visible)}>toggle</button>
+
+{#if visible}
+	<div transition:foo></div>
+{/if}


### PR DESCRIPTION
Follow-up to #12883.

Currently we assume that a transition can have a `css` method or a `tick` method but not both. #12883 allows both, but insists on at least one. In fact, we need to support all four cases — `css`, `tick`, `css` + `tick` and neither.

In https://github.com/sveltejs/svelte/pull/12883#issuecomment-2307192712 I proposed always creating a `task` and putting the completion logic in there, but that's no good — we _don't_ want to create a `task` if there's no `tick` method, because that would create extra power-consuming work.

This PR flips it on its head. Here, we always create a Web Animation, but we only provide it with keyframes if `css` is provided. If there's a `tick` method, the loop gets the current time from the animation, rather than from the `requestAnimationFrame` callback argument, and when the animation completes we call `tick?.(t2, 1 - t2)`.

This gives us something I've wanted for a long time:

<img width="810" alt="image" src="https://github.com/user-attachments/assets/e88fb751-fd75-4bb8-bb67-46e7c18a35a4">

By using a primitive that the browser deeply understands, we can do stuff like slow the transition down using devtools, and without causing callbacks to be called prematurely — even when using JS transitions:

https://github.com/user-attachments/assets/ff5032e3-c7c4-47e3-b1e1-dea286f9d957

Right now a bunch of tests fail. Since our test suite uses a bootleg `Animation` shim it's hard to tell which failures are legit (if any) and which just need some finagling — will look into it more tomorrow.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
