### PR TITLE
fix: properly handle proxied array length mutations

### DIFF
--- a/.changeset/khaki-donkeys-jump.md
+++ b/.changeset/khaki-donkeys-jump.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: properly handle proxied array length mutations

--- a/packages/svelte/src/internal/client/proxy.test.ts
+++ b/packages/svelte/src/internal/client/proxy.test.ts
@@ -96,3 +96,38 @@ test('deletes a property', () => {
 	// deleting a non-existent property should succeed
 	delete state.c;
 });
+
+test('handles array.push', () => {
+	const original = [1, 2, 3];
+	const state = proxy(original);
+
+	state.push(4);
+	assert.deepEqual(original.length, 3);
+	assert.deepEqual(original, [1, 2, 3]);
+	assert.deepEqual(state.length, 4);
+	assert.deepEqual(state, [1, 2, 3, 4]);
+});
+
+test('handles array mutation', () => {
+	const original = [1, 2, 3];
+	const state = proxy(original);
+
+	state[3] = 4;
+	assert.deepEqual(original.length, 3);
+	assert.deepEqual(original, [1, 2, 3]);
+	assert.deepEqual(state.length, 4);
+	assert.deepEqual(state, [1, 2, 3, 4]);
+});
+
+test('handles array length mutation', () => {
+	const original = [1, 2, 3];
+	const state = proxy(original);
+
+	state.length = 0;
+	assert.deepEqual(original.length, 3);
+	assert.deepEqual(original, [1, 2, 3]);
+	assert.deepEqual(original[0], 1);
+	assert.deepEqual(state.length, 0);
+	assert.deepEqual(state, []);
+	assert.deepEqual(state[0], undefined);
+});


### PR DESCRIPTION
With the change to not mutate the underlying object anymore, some bugs related to array mutation occured. To fix those we need to initialize the `length` property source eagerly to catch the initial value, and then properly update it at the right times.

fixes #13022

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
