### PR TITLE
fix: ensure event currentTarget is reset after propagation logic

### DIFF
--- a/.changeset/seven-news-live.md
+++ b/.changeset/seven-news-live.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure event currentTarget is reset after propgation logic

--- a/.changeset/seven-news-live.md
+++ b/.changeset/seven-news-live.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure event currentTarget is reset after propgation logic
+fix: ensure event currentTarget is reset after propagation logic

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -3,7 +3,6 @@ import { teardown } from '../../reactivity/effects.js';
 import { define_property, is_array } from '../../../shared/utils.js';
 import { hydrating } from '../hydration.js';
 import { queue_micro_task } from '../task.js';
-import { dev_current_component_function } from '../../runtime.js';
 import { FILENAME } from '../../../../constants.js';
 import * as w from '../../warnings.js';
 
@@ -273,8 +272,8 @@ export function handle_event_propagation(event) {
 	} finally {
 		// @ts-expect-error is used above
 		event.__root = handler_element;
-		// @ts-expect-error is used above
-		current_target = handler_element;
+		// @ts-ignore remove proxy on currentTarget
+		delete event.currentTarget;
 	}
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-8/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-8/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const btn = target.querySelector('button');
+
+		btn?.click();
+		await Promise.resolve();
+		assert.deepEqual(logs, ['#app', true, 'document', true]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-8/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-8/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	$effect(() => {
+		const doc_listener = (e) => {
+			console.log('document', e.currentTarget === document);
+		}
+
+		document.addEventListener('click', doc_listener);
+		document.getElementById('app')?.addEventListener('click', (e) => {
+			console.log('#app', e.currentTarget === document.getElementById('app'));
+		});
+
+		return () => {
+			document.removeEventListener('click', doc_listener);
+		};
+	});
+
+	function onclick() {}
+</script>
+
+<div id="app">
+	<button {onclick}>click me</button>
+</div>


### PR DESCRIPTION
Fixes #13030. We just need to remove our custom `currentTarget` handler after we're done with the event.