### PR TITLE
chore: tidy up parser

### DIFF
--- a/.changeset/happy-dolls-joke.md
+++ b/.changeset/happy-dolls-joke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better compile errors for invalid tag names/placement

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -8,6 +8,7 @@ import * as e from '../../errors.js';
 import { create_fragment } from './utils/create.js';
 import read_options from './read/options.js';
 import { is_reserved } from '../../../utils.js';
+import { disallow_children } from '../2-analyze/visitors/shared/special-element.js';
 
 const regex_position_indicator = / \(\d+:\d+\)$/;
 
@@ -124,6 +125,9 @@ export class Parser {
 			const options = /** @type {SvelteOptionsRaw} */ (this.root.fragment.nodes[options_index]);
 			this.root.fragment.nodes.splice(options_index, 1);
 			this.root.options = read_options(options);
+
+			disallow_children(options);
+
 			// We need this for the old AST format
 			Object.defineProperty(this.root.options, '__raw__', {
 				value: options,

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -24,7 +24,7 @@ const regex_whitespace_or_slash_or_closing_tag = /(\s|\/|>)/;
 const regex_token_ending_character = /[\s=/>"']/;
 const regex_starts_with_quote_characters = /^["']/;
 const regex_attribute_value = /^(?:"([^"]*)"|'([^'])*'|([^>\s]+))/;
-const regex_valid_tag_name = /^\!?[a-zA-Z]{1,}:?[a-zA-Z0-9-]*/;
+const regex_valid_tag_name = /^!?[a-zA-Z]{1,}:?[a-zA-Z0-9-]*/;
 
 /** @type {Map<string, Compiler.ElementLike['type']>} */
 const root_only_meta_tags = new Map([

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -100,7 +100,7 @@ export default function element(parser) {
 	if (root_only_special_elements.has(name)) {
 		if (is_closing_tag) {
 			if (
-				['svelte:options', 'svelte:window', 'svelte:body', 'svelte:document'].includes(name) &&
+				['svelte:options'].includes(name) &&
 				/** @type {Compiler.ElementLike} */ (parent).fragment.nodes.length
 			) {
 				e.svelte_meta_invalid_content(

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -52,11 +52,14 @@ import { SlotElement } from './visitors/SlotElement.js';
 import { SnippetBlock } from './visitors/SnippetBlock.js';
 import { SpreadAttribute } from './visitors/SpreadAttribute.js';
 import { StyleDirective } from './visitors/StyleDirective.js';
+import { SvelteBody } from './visitors/SvelteBody.js';
 import { SvelteComponent } from './visitors/SvelteComponent.js';
+import { SvelteDocument } from './visitors/SvelteDocument.js';
 import { SvelteElement } from './visitors/SvelteElement.js';
 import { SvelteFragment } from './visitors/SvelteFragment.js';
 import { SvelteHead } from './visitors/SvelteHead.js';
 import { SvelteSelf } from './visitors/SvelteSelf.js';
+import { SvelteWindow } from './visitors/SvelteWindow.js';
 import { TaggedTemplateExpression } from './visitors/TaggedTemplateExpression.js';
 import { Text } from './visitors/Text.js';
 import { TitleElement } from './visitors/TitleElement.js';
@@ -158,11 +161,14 @@ const visitors = {
 	SnippetBlock,
 	SpreadAttribute,
 	StyleDirective,
-	SvelteHead,
+	SvelteBody,
+	SvelteComponent,
+	SvelteDocument,
 	SvelteElement,
 	SvelteFragment,
-	SvelteComponent,
+	SvelteHead,
 	SvelteSelf,
+	SvelteWindow,
 	TaggedTemplateExpression,
 	Text,
 	TitleElement,

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
@@ -1,0 +1,12 @@
+/** @import { SvelteBody } from '#compiler' */
+/** @import { Context } from '../types' */
+import { disallow_children } from './shared/special-element.js';
+
+/**
+ * @param {SvelteBody} node
+ * @param {Context} context
+ */
+export function SvelteBody(node, context) {
+	disallow_children(node);
+	context.next();
+}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteDocument.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteDocument.js
@@ -1,0 +1,12 @@
+/** @import { SvelteDocument } from '#compiler' */
+/** @import { Context } from '../types' */
+import { disallow_children } from './shared/special-element.js';
+
+/**
+ * @param {SvelteDocument} node
+ * @param {Context} context
+ */
+export function SvelteDocument(node, context) {
+	disallow_children(node);
+	context.next();
+}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteSelf.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteSelf.js
@@ -1,11 +1,24 @@
 /** @import { SvelteSelf } from '#compiler' */
 /** @import { Context } from '../types' */
 import { visit_component } from './shared/component.js';
+import * as e from '../../../errors.js';
 
 /**
  * @param {SvelteSelf} node
  * @param {Context} context
  */
 export function SvelteSelf(node, context) {
+	const valid = context.path.some(
+		(node) =>
+			node.type === 'IfBlock' ||
+			node.type === 'EachBlock' ||
+			node.type === 'Component' ||
+			node.type === 'SnippetBlock'
+	);
+
+	if (!valid) {
+		e.svelte_self_invalid_placement(node);
+	}
+
 	visit_component(node, context);
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteWindow.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteWindow.js
@@ -1,0 +1,12 @@
+/** @import { SvelteWindow } from '#compiler' */
+/** @import { Context } from '../types' */
+import { disallow_children } from './shared/special-element.js';
+
+/**
+ * @param {SvelteWindow} node
+ * @param {Context} context
+ */
+export function SvelteWindow(node, context) {
+	disallow_children(node);
+	context.next();
+}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/special-element.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/special-element.js
@@ -1,0 +1,16 @@
+/** @import { SvelteBody, SvelteDocument, SvelteWindow } from '#compiler' */
+import * as e from '../../../../errors.js';
+
+/**
+ * @param {SvelteBody | SvelteDocument | SvelteWindow} node
+ */
+export function disallow_children(node) {
+	const { nodes } = node.fragment;
+
+	if (nodes.length > 0) {
+		const first = nodes[0];
+		const last = nodes[nodes.length - 1];
+
+		e.svelte_meta_invalid_content({ start: first.start, end: last.end }, node.name);
+	}
+}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/special-element.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/special-element.js
@@ -1,8 +1,8 @@
-/** @import { SvelteBody, SvelteDocument, SvelteWindow } from '#compiler' */
+/** @import { SvelteBody, SvelteDocument, SvelteOptionsRaw, SvelteWindow } from '#compiler' */
 import * as e from '../../../../errors.js';
 
 /**
- * @param {SvelteBody | SvelteDocument | SvelteWindow} node
+ * @param {SvelteBody | SvelteDocument | SvelteOptionsRaw | SvelteWindow} node
  */
 export function disallow_children(node) {
 	const { nodes } = node.fragment;

--- a/packages/svelte/tests/compiler-errors/samples/options-children/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/options-children/_config.js
@@ -4,6 +4,6 @@ export default test({
 	error: {
 		code: 'svelte_meta_invalid_content',
 		message: '<svelte:options> cannot have children',
-		position: [16, 16]
+		position: [16, 24]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/self-reference/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/self-reference/_config.js
@@ -5,6 +5,6 @@ export default test({
 		code: 'svelte_self_invalid_placement',
 		message:
 			'`<svelte:self>` components can only exist inside `{#if}` blocks, `{#each}` blocks, `{#snippet}` blocks or slots passed to components',
-		position: [1, 1]
+		position: [0, 14]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/svelte-selfdestructive/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/svelte-selfdestructive/_config.js
@@ -5,6 +5,6 @@ export default test({
 		code: 'svelte_meta_invalid_tag',
 		message:
 			'Valid `<svelte:...>` tag names are svelte:head, svelte:options, svelte:window, svelte:document, svelte:body, svelte:element, svelte:component, svelte:self or svelte:fragment',
-		position: [10, 10]
+		position: [10, 32]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/window-children/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/window-children/_config.js
@@ -4,6 +4,6 @@ export default test({
 	error: {
 		code: 'svelte_meta_invalid_content',
 		message: '<svelte:window> cannot have children',
-		position: [15, 15]
+		position: [15, 23]
 	}
 });


### PR DESCRIPTION
Started working on #12925 and found a bunch of things we can improve first:

- we should do as much validation during analysis, rather than parsing, as possible — it makes it much easier to (for example) have squigglies that cover a meaningful range, rather than being between two characters
- we're generating every element twice! once for the opening tag, once for the closing tag. the second one just gets discarded. this is silly and wasteful and almost certainly my bad
- the order of stuff in this file is all over the place. tidied it up — consts, export default, helper functions — rather than leaving everything weirdly interleaved

Aside from the squigglies, this doesn't change anything so I'll self-merge once green to unblock

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
