### PR TITLE
chore: put module variables above template for later inlining

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -457,7 +457,7 @@ export function client_component(analysis, options) {
 		analysis.uses_slots ||
 		analysis.slot_names.size > 0;
 
-	const body = [...state.hoisted, ...module.body];
+	const body = [...module.body, ...state.hoisted];
 
 	const component = b.function_declaration(
 		b.id(analysis.name),

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -458,9 +458,9 @@ export interface Attribute extends BaseNode {
 	type: 'Attribute';
 	name: string;
 	/**
-	 * The attribute may be omitted when false.
-	 * String values are represented by an array since it may be a combination of text and expression
-	 * values such as `style="color: {color} !import"`.
+	 * A boolean attribute is either present (true) or not.
+	 * Quoted/string values are represented as an array of alternating text and expressions whether
+	 * complex (`"foo{x}bar"`) or just a single expression like `"{x}"`.
 	 */
 	value: true | ExpressionTag | Array<Text | ExpressionTag>;
 	metadata: {

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -458,7 +458,6 @@ export interface Attribute extends BaseNode {
 	type: 'Attribute';
 	name: string;
 	/**
-	 * A boolean attribute is either present (true) or not.
 	 * Quoted/string values are represented by an array, even if they contain a single expression like `"{x}"`
 	 */
 	value: true | ExpressionTag | Array<Text | ExpressionTag>;

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -457,6 +457,11 @@ export type Block = EachBlock | IfBlock | AwaitBlock | KeyBlock | SnippetBlock;
 export interface Attribute extends BaseNode {
 	type: 'Attribute';
 	name: string;
+	/**
+	 * The attribute may be omitted when false.
+	 * String values are represented by an array since it may be a combination of text and expression
+	 * values such as `style="color: {color} !import"`.
+	 */
 	value: true | ExpressionTag | Array<Text | ExpressionTag>;
 	metadata: {
 		expression: ExpressionMetadata;

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -460,7 +460,7 @@ export interface Attribute extends BaseNode {
 	/**
 	 * A boolean attribute is either present (true) or not.
 	 * Quoted/string values are represented as an array of alternating text and expressions whether
-	 * complex (`"foo{x}bar"`) or just a single expression like `"{x}"`.
+	 * complex (`"foo{x}bar"`) or holding just a single expression like `"{x}"`.
 	 */
 	value: true | ExpressionTag | Array<Text | ExpressionTag>;
 	metadata: {

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -459,8 +459,7 @@ export interface Attribute extends BaseNode {
 	name: string;
 	/**
 	 * A boolean attribute is either present (true) or not.
-	 * Quoted/string values are represented as an array of alternating text and expressions whether
-	 * complex (`"foo{x}bar"`) or holding just a single expression like `"{x}"`.
+	 * Quoted/string values are represented by an array, even if they contain a single expression like `"{x}"`
 	 */
 	value: true | ExpressionTag | Array<Text | ExpressionTag>;
 	metadata: {

--- a/packages/svelte/tests/snapshot/_config.js
+++ b/packages/svelte/tests/snapshot/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/snapshot/samples/inline-module-vars/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/inline-module-vars/_expected/client/index.svelte.js
@@ -1,0 +1,33 @@
+import "svelte/internal/disclose-version";
+
+const __ENHANCED_IMG_1__ = "__VITE_ASSET__2AM7_y_a__";
+const __ENHANCED_IMG_2__ = "__VITE_ASSET__2AM7_y_b__";
+const __ENHANCED_IMG_3__ = "__VITE_ASSET__2AM7_y_c__";
+const __ENHANCED_IMG_4__ = "__VITE_ASSET__2AM7_y_d__";
+const __ENHANCED_IMG_5__ = "__VITE_ASSET__2AM7_y_e__";
+const __ENHANCED_IMG_6__ = "__VITE_ASSET__2AM7_y_f__";
+
+import * as $ from "svelte/internal/client";
+
+var root = $.template(`<picture><source type="image/avif"> <source type="image/webp"> <source type="image/png"> <img alt="production test" width="1440" height="1440"></picture>`);
+
+export default function Inline_module_vars($$anchor) {
+	var picture = root();
+	var source = $.child(picture);
+
+	$.set_attribute(source, "srcset", __ENHANCED_IMG_1__ + " 1440w, " + __ENHANCED_IMG_2__ + " 960w");
+
+	var source_1 = $.sibling(source, 2);
+
+	$.set_attribute(source_1, "srcset", __ENHANCED_IMG_3__ + " 1440w, " + __ENHANCED_IMG_4__ + " 960w");
+
+	var source_2 = $.sibling(source_1, 2);
+
+	$.set_attribute(source_2, "srcset", __ENHANCED_IMG_5__ + " 1440w, " + __ENHANCED_IMG_6__ + " 960w");
+
+	var img = $.sibling(source_2, 2);
+
+	$.set_attribute(img, "src", __ENHANCED_IMG_5__);
+	$.reset(picture);
+	$.append($$anchor, picture);
+}

--- a/packages/svelte/tests/snapshot/samples/inline-module-vars/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/inline-module-vars/_expected/server/index.svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/server";
+
+const __ENHANCED_IMG_1__ = "__VITE_ASSET__2AM7_y_a__";
+const __ENHANCED_IMG_2__ = "__VITE_ASSET__2AM7_y_b__";
+const __ENHANCED_IMG_3__ = "__VITE_ASSET__2AM7_y_c__";
+const __ENHANCED_IMG_4__ = "__VITE_ASSET__2AM7_y_d__";
+const __ENHANCED_IMG_5__ = "__VITE_ASSET__2AM7_y_e__";
+const __ENHANCED_IMG_6__ = "__VITE_ASSET__2AM7_y_f__";
+
+export default function Inline_module_vars($$payload) {
+	$$payload.out += `<picture><source${$.attr("srcset", __ENHANCED_IMG_1__ + " 1440w, " + __ENHANCED_IMG_2__ + " 960w")} type="image/avif"> <source${$.attr("srcset", __ENHANCED_IMG_3__ + " 1440w, " + __ENHANCED_IMG_4__ + " 960w")} type="image/webp"> <source${$.attr("srcset", __ENHANCED_IMG_5__ + " 1440w, " + __ENHANCED_IMG_6__ + " 960w")} type="image/png"> <img${$.attr("src", __ENHANCED_IMG_5__)} alt="production test" width="1440" height="1440"></picture>`;
+}

--- a/packages/svelte/tests/snapshot/samples/inline-module-vars/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/inline-module-vars/index.svelte
@@ -1,0 +1,17 @@
+<svelte:options runes={true} />
+
+<script module>
+	const __ENHANCED_IMG_1__ = "__VITE_ASSET__2AM7_y_a__";
+	const __ENHANCED_IMG_2__ = "__VITE_ASSET__2AM7_y_b__";
+	const __ENHANCED_IMG_3__ = "__VITE_ASSET__2AM7_y_c__";
+	const __ENHANCED_IMG_4__ = "__VITE_ASSET__2AM7_y_d__";
+	const __ENHANCED_IMG_5__ = "__VITE_ASSET__2AM7_y_e__";
+	const __ENHANCED_IMG_6__ = "__VITE_ASSET__2AM7_y_f__";
+</script>
+
+<picture>
+	<source srcset={__ENHANCED_IMG_1__ + " 1440w, " + __ENHANCED_IMG_2__ + " 960w"} type="image/avif" />
+	<source srcset={__ENHANCED_IMG_3__ + " 1440w, " + __ENHANCED_IMG_4__ + " 960w"} type="image/webp" />
+	<source srcset={__ENHANCED_IMG_5__ + " 1440w, " + __ENHANCED_IMG_6__ + " 960w"} type="image/png" />
+	<img src={__ENHANCED_IMG_5__} alt="production test" width=1440 height=1440 />
+</picture>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1918,6 +1918,11 @@ declare module 'svelte/compiler' {
 	interface Attribute extends BaseNode {
 		type: 'Attribute';
 		name: string;
+		/**
+		 * The attribute may be omitted when false.
+		 * String values are represented by an array since it may be a combination of text and expression
+		 * values such as `style="color: {color} !import"`.
+		 */
 		value: true | ExpressionTag | Array<Text | ExpressionTag>;
 		metadata: {
 			expression: ExpressionMetadata;

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1919,9 +1919,9 @@ declare module 'svelte/compiler' {
 		type: 'Attribute';
 		name: string;
 		/**
-		 * The attribute may be omitted when false.
-		 * String values are represented by an array since it may be a combination of text and expression
-		 * values such as `style="color: {color} !import"`.
+		 * A boolean attribute is either present (true) or not.
+		 * Quoted/string values are represented as an array of alternating text and expressions whether
+		 * complex (`"foo{x}bar"`) or just a single expression like `"{x}"`.
 		 */
 		value: true | ExpressionTag | Array<Text | ExpressionTag>;
 		metadata: {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1919,9 +1919,7 @@ declare module 'svelte/compiler' {
 		type: 'Attribute';
 		name: string;
 		/**
-		 * A boolean attribute is either present (true) or not.
-		 * Quoted/string values are represented as an array of alternating text and expressions whether
-		 * complex (`"foo{x}bar"`) or holding just a single expression like `"{x}"`.
+		 * Quoted/string values are represented by an array, even if they contain a single expression like `"{x}"`
 		 */
 		value: true | ExpressionTag | Array<Text | ExpressionTag>;
 		metadata: {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1921,7 +1921,7 @@ declare module 'svelte/compiler' {
 		/**
 		 * A boolean attribute is either present (true) or not.
 		 * Quoted/string values are represented as an array of alternating text and expressions whether
-		 * complex (`"foo{x}bar"`) or just a single expression like `"{x}"`.
+		 * complex (`"foo{x}bar"`) or holding just a single expression like `"{x}"`.
 		 */
 		value: true | ExpressionTag | Array<Text | ExpressionTag>;
 		metadata: {


### PR DESCRIPTION
I thought I'd provide a test as a start for https://github.com/sveltejs/svelte/issues/12995

I was going to try to implement more of this, but it's been quite a long time since I've looked at this code and things have changed a fair amount since then