### PR TITLE
feat: custom devtools formatters

### DIFF
--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -4,6 +4,10 @@
 
 > `%binding%` (%location%) is binding to a non-reactive property
 
+## enable_custom_formatters
+
+> We recommend enabling custom formatters for better results when logging `$state` objects — in your devtools, click the gear icon and check the 'Custom formatters' box
+
 ## event_handler_invalid
 
 > %handler% should be a function. Did you mean to %suggestion%?

--- a/packages/svelte/src/internal/client/dev/log.js
+++ b/packages/svelte/src/internal/client/dev/log.js
@@ -6,7 +6,7 @@ import * as w from '../warnings.js';
 export function install_custom_formatter() {
 	// Custom formatters are 'supported' in Firefox, but they're worse than useless.
 	// They're not supported in Firefox. We can maybe tweak this over time
-	var is_chrome = navigator.userAgent.includes('Chrome');
+	var is_chrome = typeof navigator !== 'undefined' && navigator.userAgent.includes('Chrome');
 	var custom_formatters_enabled = false;
 
 	if (is_chrome) {

--- a/packages/svelte/src/internal/client/dev/log.js
+++ b/packages/svelte/src/internal/client/dev/log.js
@@ -1,0 +1,43 @@
+import { STATE_SYMBOL } from '../constants.js';
+
+export function monkey_patch_console() {
+	for (const method of Object.keys(console)) {
+		// @ts-expect-error
+		const original = console[method];
+
+		// @ts-expect-error
+		console[method] = (...args) => {
+			for (const arg of args) {
+				if (contains_state_proxy(arg)) {
+					// TODO make this a proper warning
+					console.warn('contains state proxy!!!!');
+					break;
+				}
+			}
+
+			return original.apply(console, args);
+		};
+	}
+}
+
+/**
+ * @param {any} value
+ * @param {Set<any>} seen
+ * @returns {boolean}
+ */
+function contains_state_proxy(value, seen = new Set()) {
+	if (typeof value !== 'object' || value === null) return false;
+
+	if (seen.has(value)) return false;
+	seen.add(value);
+
+	if (STATE_SYMBOL in value) {
+		return true;
+	}
+
+	for (const key in value) {
+		if (contains_state_proxy(value[key], seen)) {
+			return true;
+		}
+	}
+}

--- a/packages/svelte/src/internal/client/dev/log.js
+++ b/packages/svelte/src/internal/client/dev/log.js
@@ -37,6 +37,7 @@ export function install_custom_formatter() {
 
 	// the arguments need to include an object, so that we discover
 	// whether custom formatters are enabled
+	// eslint-disable-next-line no-console
 	console.log(`Running Svelte in development mode`, { version: VERSION });
 
 	if (is_chrome && !custom_formatters_enabled) {

--- a/packages/svelte/src/internal/client/dev/log.js
+++ b/packages/svelte/src/internal/client/dev/log.js
@@ -35,6 +35,8 @@ export function install_custom_formatter() {
 		});
 	}
 
+	// the arguments need to include an object, so that we discover
+	// whether custom formatters are enabled
 	console.log(`Running Svelte in development mode`, { version: VERSION });
 
 	if (is_chrome && !custom_formatters_enabled) {

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -1,5 +1,5 @@
 import { DEV } from 'esm-env';
-import { monkey_patch_console } from './dev/log.js';
+import { install_custom_formatter } from './dev/log.js';
 
 export { FILENAME, HMR } from '../../constants.js';
 export { add_locations } from './dev/elements.js';
@@ -169,5 +169,5 @@ export {
 export { strict_equals, equals } from './dev/equality.js';
 
 if (DEV) {
-	monkey_patch_console();
+	install_custom_formatter();
 }

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -1,3 +1,6 @@
+import { DEV } from 'esm-env';
+import { monkey_patch_console } from './dev/log.js';
+
 export { FILENAME, HMR } from '../../constants.js';
 export { add_locations } from './dev/elements.js';
 export { hmr } from './dev/hmr.js';
@@ -164,3 +167,7 @@ export {
 	validate_void_dynamic_element
 } from '../shared/validate.js';
 export { strict_equals, equals } from './dev/equality.js';
+
+if (DEV) {
+	monkey_patch_console();
+}

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -139,3 +139,15 @@ export function state_proxy_equality_mismatch(operator) {
 		console.warn("state_proxy_equality_mismatch");
 	}
 }
+
+/**
+ * We recommend enabling custom formatters for better results when logging `$state` objects — in your devtools, click the gear icon and check the 'Custom formatters' box
+ */
+export function enable_custom_formatters() {
+	if (DEV) {
+		console.warn(`%c[svelte] enable_custom_formatters\n%cWe recommend enabling custom formatters for better results when logging \`$state\` objects — in your devtools, click the gear icon and check the 'Custom formatters' box`, bold, normal);
+	} else {
+		// TODO print a link to the documentation
+		console.warn("enable_custom_formatters");
+	}
+}

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -20,6 +20,18 @@ export function binding_property_non_reactive(binding, location) {
 }
 
 /**
+ * We recommend enabling custom formatters for better results when logging `$state` objects — in your devtools, click the gear icon and check the 'Custom formatters' box
+ */
+export function enable_custom_formatters() {
+	if (DEV) {
+		console.warn(`%c[svelte] enable_custom_formatters\n%cWe recommend enabling custom formatters for better results when logging \`$state\` objects — in your devtools, click the gear icon and check the 'Custom formatters' box`, bold, normal);
+	} else {
+		// TODO print a link to the documentation
+		console.warn("enable_custom_formatters");
+	}
+}
+
+/**
  * %handler% should be a function. Did you mean to %suggestion%?
  * @param {string} handler
  * @param {string} suggestion
@@ -137,17 +149,5 @@ export function state_proxy_equality_mismatch(operator) {
 	} else {
 		// TODO print a link to the documentation
 		console.warn("state_proxy_equality_mismatch");
-	}
-}
-
-/**
- * We recommend enabling custom formatters for better results when logging `$state` objects — in your devtools, click the gear icon and check the 'Custom formatters' box
- */
-export function enable_custom_formatters() {
-	if (DEV) {
-		console.warn(`%c[svelte] enable_custom_formatters\n%cWe recommend enabling custom formatters for better results when logging \`$state\` objects — in your devtools, click the gear icon and check the 'Custom formatters' box`, bold, normal);
-	} else {
-		// TODO print a link to the documentation
-		console.warn("enable_custom_formatters");
 	}
 }


### PR DESCRIPTION
A few people have been tripped up by the extremely useless way in which `Proxy` objects are logged to the console — rather than logging what the proxy itself reports about its shape, they print the original target object (albeit behind several clicks), along with (for reasons I cannot fathom) the handler. Since Svelte doesn't mutate the original object (for good reason) this makes the logs unhelpful.

The proper fix is to snapshot the object (`console.log($state.snapshot(object))`) or, better yet, use `$inspect`. But for people as-yet-unfamiliar with those tools, it would be nice if `console.log` gave a better experience.

I tried monkey-patching console methods so that we could at least print a warning ('use `$state.snapshot`, it's better') but that means you no longer get a clickable link to the place where the log happened, which sucks. 

It turns out, via @trueadm, that [custom formatters](https://firefox-source-docs.mozilla.org/devtools-user/custom_formatters/index.html#generating-child-elements) are a thing. This PR does two things — if you haven't enabled custom formatters, it prints a warning suggesting that you do so...

<img width="746" alt="image" src="https://github.com/user-attachments/assets/4bb880f7-4084-425a-a967-f0a8b6a0ce4b">

...and if you _have_, it prints this when you log state:

<img width="697" alt="image" src="https://github.com/user-attachments/assets/4ba1c6a2-65d2-4cca-896a-68f3162f01a0">

Annoyingly, there's no straightforward way to generate a preview (i.e. `$state ▸ Object { count: 1 }`), you always have to expand it to see the properties. 

More annoyingly, this only really works in Chrome. Firefox 'supports' custom formatters, but it's so broken (it seems to just log a non-expandable `Object {   }`, ignoring what the formatter returned and hiding the object contents) that once again I find myself wondering why they bother at all. Safari doesn't support it at all AFAICT.

Is this worth it? I can't tell.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
