### PR TITLE
feat: {@html} should handle null and undefined as empty string

### DIFF
--- a/.changeset/eighty-mails-develop.md
+++ b/.changeset/eighty-mails-develop.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: render undefined html as the empty string

--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -94,7 +94,7 @@ export function html(node, get_value, svg, mathml, skip_warning) {
 				return;
 			}
 
-			var html = value + '';
+			var html = (value == null) ? '' : value + '';
 			if (svg) html = `<svg>${html}</svg>`;
 			else if (mathml) html = `<math>${html}</math>`;
 

--- a/packages/svelte/src/internal/server/blocks/html.js
+++ b/packages/svelte/src/internal/server/blocks/html.js
@@ -5,6 +5,7 @@ import { hash } from '../../../utils.js';
  * @param {string} value
  */
 export function html(value) {
-	var open = DEV ? `<!--${hash(String(value ?? ''))}-->` : '<!---->';
-	return `${open}${value}<!---->`;
+	var html = String(value ?? '');
+	var open = DEV ? `<!--${hash(html)}-->` : '<!---->';
+	return open + html + '<!---->';
 }

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -303,7 +303,7 @@ async function run_test_variant(
 						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
 					withoutNormalizeHtml: !!config.withoutNormalizeHtml
 				});
-			} else if (config.html) {
+			} else if (config.html !== undefined) {
 				assert_html_equal_with_options(target.innerHTML, config.html, {
 					preserveComments:
 						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
@@ -369,7 +369,7 @@ async function run_test_variant(
 				assert.fail('Expected a runtime error');
 			}
 
-			if (config.html) {
+			if (config.html !== undefined) {
 				flushSync();
 				assert_html_equal_with_options(target.innerHTML, config.html, {
 					preserveComments:

--- a/packages/svelte/tests/runtime-runes/samples/html-tag-empty/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/html-tag-empty/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: ''
+});

--- a/packages/svelte/tests/runtime-runes/samples/html-tag-empty/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/html-tag-empty/main.svelte
@@ -1,0 +1,1 @@
+{@html undefined}


### PR DESCRIPTION
Fix #13069 `{@html}` should handle null and undefined as empty string


Note : I edited from github, so no test/lint :(

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
