### PR TITLE
fix: prevent nullish snippet for rendering empty content

### DIFF
--- a/.changeset/tame-frogs-shave.md
+++ b/.changeset/tame-frogs-shave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent nullish snippet for rendering empty content

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -48,6 +48,10 @@
 
 > Failed to hydrate the application
 
+## invalid_snippet
+
+> Could not `{@render}` snippet due to the expression being `null` or `undefined`. Consider using optional chaining `{@render snippet?.()}`
+
 ## lifecycle_legacy_only
 
 > `%name%(...)` cannot be used in runes mode

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -48,10 +48,6 @@
 
 > Failed to hydrate the application
 
-## invalid_snippet
-
-> Could not `{@render}` snippet due to the expression being `null` or `undefined`. Consider using optional chaining `{@render snippet?.()}`
-
 ## lifecycle_legacy_only
 
 > `%name%(...)` cannot be used in runes mode

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -50,7 +50,7 @@
 
 ## invalid_snippet
 
-> Could not `{@render}` snippet due to the expression being null or undefined. Consider using optional chaining `{@render snippet?.()}`
+> Could not `{@render}` snippet due to the expression being `null` or `undefined`. Consider using optional chaining `{@render snippet?.()}`
 
 ## lifecycle_legacy_only
 

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -48,6 +48,10 @@
 
 > Failed to hydrate the application
 
+## invalid_snippet
+
+> Could not `{@render}` snippet due to the expression being null or undefined. Consider using optional chaining `{@render snippet?.()}`
+
 ## lifecycle_legacy_only
 
 > `%name%(...)` cannot be used in runes mode

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
@@ -32,7 +32,7 @@ export function RenderTag(node, context) {
 	if (node.metadata.dynamic) {
 		// If we have a chain expression then ensure a nullish snippet function gets turned into an empty one
 		if (node.expression.type === 'ChainExpression') {
-			snippet_function = b.logical('??', snippet_function, b.id('$.empty_snippet'));
+			snippet_function = b.logical('??', snippet_function, b.id('$.noop'));
 		}
 
 		context.state.init.push(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
@@ -31,7 +31,15 @@ export function RenderTag(node, context) {
 
 	if (node.metadata.dynamic) {
 		context.state.init.push(
-			b.stmt(b.call('$.snippet', context.state.node, b.thunk(snippet_function), ...args))
+			b.stmt(
+				b.call(
+					'$.snippet',
+					context.state.node,
+					b.thunk(snippet_function),
+					b.literal(node.expression.type === 'ChainExpression'),
+					...args,
+				)
+			)
 		);
 	} else {
 		context.state.init.push(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
@@ -30,16 +30,13 @@ export function RenderTag(node, context) {
 	let snippet_function = /** @type {Expression} */ (context.visit(callee));
 
 	if (node.metadata.dynamic) {
+		// If we have a chain expression then ensure a nullish snippet function gets turned into an empty one
+		if (b.literal(node.expression.type === 'ChainExpression')) {
+			snippet_function = b.logical('??', snippet_function, b.id('$.empty_snippet'));
+		}
+
 		context.state.init.push(
-			b.stmt(
-				b.call(
-					'$.snippet',
-					context.state.node,
-					b.thunk(snippet_function),
-					b.literal(node.expression.type === 'ChainExpression'),
-					...args
-				)
-			)
+			b.stmt(b.call('$.snippet', context.state.node, b.thunk(snippet_function), ...args))
 		);
 	} else {
 		context.state.init.push(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
@@ -37,7 +37,7 @@ export function RenderTag(node, context) {
 					context.state.node,
 					b.thunk(snippet_function),
 					b.literal(node.expression.type === 'ChainExpression'),
-					...args,
+					...args
 				)
 			)
 		);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RenderTag.js
@@ -31,7 +31,7 @@ export function RenderTag(node, context) {
 
 	if (node.metadata.dynamic) {
 		// If we have a chain expression then ensure a nullish snippet function gets turned into an empty one
-		if (b.literal(node.expression.type === 'ChainExpression')) {
+		if (node.expression.type === 'ChainExpression') {
 			snippet_function = b.logical('??', snippet_function, b.id('$.empty_snippet'));
 		}
 

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -11,21 +11,24 @@ import { hydrate_next, hydrate_node, hydrating } from '../hydration.js';
 import { create_fragment_from_html } from '../reconciler.js';
 import { assign_nodes } from '../template.js';
 import * as w from '../../warnings.js';
+import * as e from '../../errors.js';
 import { DEV } from 'esm-env';
 import { get_first_child, get_next_sibling } from '../operations.js';
+import { UNINITIALIZED } from '../../../../constants.js';
 
 /**
  * @template {(node: TemplateNode, ...args: any[]) => void} SnippetFn
  * @param {TemplateNode} node
  * @param {() => SnippetFn | null | undefined} get_snippet
+ * @param {boolean} is_chain
  * @param {(() => any)[]} args
  * @returns {void}
  */
-export function snippet(node, get_snippet, ...args) {
+export function snippet(node, get_snippet, is_chain, ...args) {
 	var anchor = node;
 
-	/** @type {SnippetFn | null | undefined} */
-	var snippet;
+	/** @type {SnippetFn | null | undefined | typeof UNINITIALIZED} */
+	var snippet = UNINITIALIZED;
 
 	/** @type {Effect | null} */
 	var snippet_effect;
@@ -40,6 +43,8 @@ export function snippet(node, get_snippet, ...args) {
 
 		if (snippet) {
 			snippet_effect = branch(() => /** @type {SnippetFn} */ (snippet)(anchor, ...args));
+		} else if (!is_chain) {
+			e.invalid_snippet();
 		}
 	}, EFFECT_TRANSPARENT);
 

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -11,24 +11,21 @@ import { hydrate_next, hydrate_node, hydrating } from '../hydration.js';
 import { create_fragment_from_html } from '../reconciler.js';
 import { assign_nodes } from '../template.js';
 import * as w from '../../warnings.js';
-import * as e from '../../errors.js';
 import { DEV } from 'esm-env';
 import { get_first_child, get_next_sibling } from '../operations.js';
-import { UNINITIALIZED } from '../../../../constants.js';
 
 /**
  * @template {(node: TemplateNode, ...args: any[]) => void} SnippetFn
  * @param {TemplateNode} node
  * @param {() => SnippetFn | null | undefined} get_snippet
- * @param {boolean} is_chain
  * @param {(() => any)[]} args
  * @returns {void}
  */
-export function snippet(node, get_snippet, is_chain, ...args) {
+export function snippet(node, get_snippet, ...args) {
 	var anchor = node;
 
-	/** @type {SnippetFn | null | undefined | typeof UNINITIALIZED} */
-	var snippet = UNINITIALIZED;
+	/** @type {SnippetFn | null | undefined} */
+	var snippet = /** @type {SnippetFn} */ (empty_snippet);
 
 	/** @type {Effect | null} */
 	var snippet_effect;
@@ -41,17 +38,17 @@ export function snippet(node, get_snippet, is_chain, ...args) {
 			snippet_effect = null;
 		}
 
-		if (snippet != null) {
-			snippet_effect = branch(() => /** @type {SnippetFn} */ (snippet)(anchor, ...args));
-		} else if (!is_chain) {
-			e.invalid_snippet();
-		}
+		snippet_effect = branch(() => /** @type {SnippetFn} */ (snippet)(anchor, ...args));
 	}, EFFECT_TRANSPARENT);
 
 	if (hydrating) {
 		anchor = hydrate_node;
 	}
 }
+
+// Just an empty function
+/** @type {(...args: any[]) => void} */
+export const empty_snippet = () => {};
 
 /**
  * In development, wrap the snippet function so that it passes validation, and so that the

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -41,7 +41,7 @@ export function snippet(node, get_snippet, is_chain, ...args) {
 			snippet_effect = null;
 		}
 
-		if (snippet) {
+		if (snippet != null) {
 			snippet_effect = branch(() => /** @type {SnippetFn} */ (snippet)(anchor, ...args));
 		} else if (!is_chain) {
 			e.invalid_snippet();

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -11,8 +11,10 @@ import { hydrate_next, hydrate_node, hydrating } from '../hydration.js';
 import { create_fragment_from_html } from '../reconciler.js';
 import { assign_nodes } from '../template.js';
 import * as w from '../../warnings.js';
+import * as e from '../../errors.js';
 import { DEV } from 'esm-env';
 import { get_first_child, get_next_sibling } from '../operations.js';
+import { noop } from '../../../shared/utils.js';
 
 /**
  * @template {(node: TemplateNode, ...args: any[]) => void} SnippetFn
@@ -25,7 +27,8 @@ export function snippet(node, get_snippet, ...args) {
 	var anchor = node;
 
 	/** @type {SnippetFn | null | undefined} */
-	var snippet = /** @type {SnippetFn} */ (empty_snippet);
+	// @ts-ignore
+	var snippet = noop;
 
 	/** @type {Effect | null} */
 	var snippet_effect;
@@ -38,6 +41,10 @@ export function snippet(node, get_snippet, ...args) {
 			snippet_effect = null;
 		}
 
+		if (DEV && snippet == null) {
+			e.invalid_snippet();
+		}
+
 		snippet_effect = branch(() => /** @type {SnippetFn} */ (snippet)(anchor, ...args));
 	}, EFFECT_TRANSPARENT);
 
@@ -45,10 +52,6 @@ export function snippet(node, get_snippet, ...args) {
 		anchor = hydrate_node;
 	}
 }
-
-// Just an empty function
-/** @type {(...args: any[]) => void} */
-export const empty_snippet = () => {};
 
 /**
  * In development, wrap the snippet function so that it passes validation, and so that the

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -211,6 +211,22 @@ export function hydration_failed() {
 }
 
 /**
+ * Could not `{@render}` snippet due to the expression being `null` or `undefined`. Consider using optional chaining `{@render snippet?.()}`
+ * @returns {never}
+ */
+export function invalid_snippet() {
+	if (DEV) {
+		const error = new Error(`invalid_snippet\nCould not \`{@render}\` snippet due to the expression being \`null\` or \`undefined\`. Consider using optional chaining \`{@render snippet?.()}\``);
+
+		error.name = 'Svelte error';
+		throw error;
+	} else {
+		// TODO print a link to the documentation
+		throw new Error("invalid_snippet");
+	}
+}
+
+/**
  * `%name%(...)` cannot be used in runes mode
  * @param {string} name
  * @returns {never}

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -211,6 +211,22 @@ export function hydration_failed() {
 }
 
 /**
+ * Could not `{@render}` snippet due to the expression being null or undefined. Consider using optional chaining `{@render snippet?.()}`
+ * @returns {never}
+ */
+export function invalid_snippet() {
+	if (DEV) {
+		const error = new Error(`invalid_snippet\nCould not \`{@render}\` snippet due to the expression being null or undefined. Consider using optional chaining \`{@render snippet?.()}\``);
+
+		error.name = 'Svelte error';
+		throw error;
+	} else {
+		// TODO print a link to the documentation
+		throw new Error("invalid_snippet");
+	}
+}
+
+/**
  * `%name%(...)` cannot be used in runes mode
  * @param {string} name
  * @returns {never}

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -211,22 +211,6 @@ export function hydration_failed() {
 }
 
 /**
- * Could not `{@render}` snippet due to the expression being `null` or `undefined`. Consider using optional chaining `{@render snippet?.()}`
- * @returns {never}
- */
-export function invalid_snippet() {
-	if (DEV) {
-		const error = new Error(`invalid_snippet\nCould not \`{@render}\` snippet due to the expression being \`null\` or \`undefined\`. Consider using optional chaining \`{@render snippet?.()}\``);
-
-		error.name = 'Svelte error';
-		throw error;
-	} else {
-		// TODO print a link to the documentation
-		throw new Error("invalid_snippet");
-	}
-}
-
-/**
  * `%name%(...)` cannot be used in runes mode
  * @param {string} name
  * @returns {never}

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -211,12 +211,12 @@ export function hydration_failed() {
 }
 
 /**
- * Could not `{@render}` snippet due to the expression being null or undefined. Consider using optional chaining `{@render snippet?.()}`
+ * Could not `{@render}` snippet due to the expression being `null` or `undefined`. Consider using optional chaining `{@render snippet?.()}`
  * @returns {never}
  */
 export function invalid_snippet() {
 	if (DEV) {
-		const error = new Error(`invalid_snippet\nCould not \`{@render}\` snippet due to the expression being null or undefined. Consider using optional chaining \`{@render snippet?.()}\``);
+		const error = new Error(`invalid_snippet\nCould not \`{@render}\` snippet due to the expression being \`null\` or \`undefined\`. Consider using optional chaining \`{@render snippet?.()}\``);
 
 		error.name = 'Svelte error';
 		throw error;

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -18,7 +18,7 @@ export { css_props } from './dom/blocks/css-props.js';
 export { index, each } from './dom/blocks/each.js';
 export { html } from './dom/blocks/html.js';
 export { sanitize_slots, slot } from './dom/blocks/slot.js';
-export { snippet, wrap_snippet, empty_snippet } from './dom/blocks/snippet.js';
+export { snippet, wrap_snippet } from './dom/blocks/snippet.js';
 export { component } from './dom/blocks/svelte-component.js';
 export { element } from './dom/blocks/svelte-element.js';
 export { head } from './dom/blocks/svelte-head.js';

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -18,7 +18,7 @@ export { css_props } from './dom/blocks/css-props.js';
 export { index, each } from './dom/blocks/each.js';
 export { html } from './dom/blocks/html.js';
 export { sanitize_slots, slot } from './dom/blocks/slot.js';
-export { snippet, wrap_snippet } from './dom/blocks/snippet.js';
+export { snippet, wrap_snippet, empty_snippet } from './dom/blocks/snippet.js';
 export { component } from './dom/blocks/svelte-component.js';
 export { element } from './dom/blocks/svelte-element.js';
 export { head } from './dom/blocks/svelte-head.js';

--- a/packages/svelte/tests/runtime-runes/samples/snippet-undefined/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-undefined/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const btn = target.querySelector('button');
+
+		assert.throws(() => {
+			btn?.click();
+			flushSync();
+		}, /invalid_snippet/);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-undefined/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-undefined/_config.js
@@ -8,6 +8,6 @@ export default test({
 		assert.throws(() => {
 			btn?.click();
 			flushSync();
-		}, /snippet is not a function/);
+		}, /invalid_snippet/);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/snippet-undefined/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-undefined/_config.js
@@ -8,6 +8,6 @@ export default test({
 		assert.throws(() => {
 			btn?.click();
 			flushSync();
-		}, /invalid_snippet/);
+		}, /snippet is not a function/);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/snippet-undefined/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-undefined/main.svelte
@@ -1,0 +1,13 @@
+<script>
+  let state = $state({
+		value: counter
+	});
+</script>
+
+{#snippet counter()}
+  Test
+{/snippet}
+
+{@render state.value()}
+
+<button onclick={() => state.value = undefined}>change</button>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/12999.

If the snippet function is nullish and not a chain expression we now throw an error to have parity with non-dynamic references.