### PR TITLE
fix: error on incorrect attributes for svelte:body

### DIFF
--- a/.changeset/eleven-icons-sniff.md
+++ b/.changeset/eleven-icons-sniff.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: error on spreading attributes for svelte:body

--- a/.changeset/eleven-icons-sniff.md
+++ b/.changeset/eleven-icons-sniff.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: error on spreading attributes for svelte:body
+fix: error on incorrect attributes for svelte:body

--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -276,7 +276,7 @@ HTML restricts where certain elements can appear. In case of a violation the bro
 
 ## svelte_body_illegal_attribute
 
-> `<svelte:body>` cannot have spread attributes
+> `<svelte:body>` does not support non-event attributes or spread attributes
 
 ## svelte_component_invalid_this
 

--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -274,6 +274,10 @@ HTML restricts where certain elements can appear. In case of a violation the bro
 
 > A component can have a single top-level `<style>` element
 
+## svelte_body_illegal_attribute
+
+> `<svelte:body>` cannot have spread attributes
+
 ## svelte_component_invalid_this
 
 > Invalid component definition — must be an `{expression}`

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -1238,6 +1238,15 @@ export function svelte_head_illegal_attribute(node) {
 }
 
 /**
+ * `<svelte:body>` cannot have spread attributes
+ * @param {null | number | NodeLike} node
+ * @returns {never}
+ */
+export function svelte_body_illegal_attribute(node) {
+	e(node, "svelte_body_illegal_attribute", "`<svelte:body>` cannot have spread attributes");
+}
+
+/**
  * A component can only have one `<%name%>` element
  * @param {null | number | NodeLike} node
  * @param {string} name

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -1184,6 +1184,15 @@ export function style_duplicate(node) {
 }
 
 /**
+ * `<svelte:body>` does not support non-event attributes or spread attributes
+ * @param {null | number | NodeLike} node
+ * @returns {never}
+ */
+export function svelte_body_illegal_attribute(node) {
+	e(node, "svelte_body_illegal_attribute", "`<svelte:body>` does not support non-event attributes or spread attributes");
+}
+
+/**
  * Invalid component definition — must be an `{expression}`
  * @param {null | number | NodeLike} node
  * @returns {never}
@@ -1235,15 +1244,6 @@ export function svelte_fragment_invalid_placement(node) {
  */
 export function svelte_head_illegal_attribute(node) {
 	e(node, "svelte_head_illegal_attribute", "`<svelte:head>` cannot have attributes nor directives");
-}
-
-/**
- * `<svelte:body>` cannot have spread attributes
- * @param {null | number | NodeLike} node
- * @returns {never}
- */
-export function svelte_body_illegal_attribute(node) {
-	e(node, "svelte_body_illegal_attribute", "`<svelte:body>` cannot have spread attributes");
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
@@ -1,6 +1,7 @@
 /** @import { SvelteBody } from '#compiler' */
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
+import { is_event_attribute } from '../../../utils/ast.js';
 import { disallow_children } from './shared/special-element.js';
 
 /**
@@ -10,7 +11,10 @@ import { disallow_children } from './shared/special-element.js';
 export function SvelteBody(node, context) {
 	disallow_children(node);
 	for (const attribute of node.attributes) {
-		if (attribute.type === 'SpreadAttribute') {
+		if (
+			attribute.type === 'SpreadAttribute' ||
+			(attribute.type === 'Attribute' && !is_event_attribute(attribute))
+		) {
 			e.svelte_body_illegal_attribute(attribute);
 		}
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
@@ -1,5 +1,6 @@
 /** @import { SvelteBody } from '#compiler' */
 /** @import { Context } from '../types' */
+import * as e from '../../../errors.js';
 import { disallow_children } from './shared/special-element.js';
 
 /**
@@ -8,5 +9,10 @@ import { disallow_children } from './shared/special-element.js';
  */
 export function SvelteBody(node, context) {
 	disallow_children(node);
+	for (const attribute of node.attributes) {
+		if (attribute.type === 'SpreadAttribute') {
+			e.svelte_body_illegal_attribute(attribute);
+		}
+	}
 	context.next();
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/special_element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/special_element.js
@@ -1,7 +1,6 @@
 /** @import { Expression } from 'estree' */
 /** @import { SvelteBody, SvelteDocument, SvelteWindow } from '#compiler' */
 /** @import { ComponentContext } from '../../types' */
-import { is_event_attribute } from '../../../../../utils/ast.js';
 import * as b from '../../../../../utils/builders.js';
 
 /**


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13021. We should be throwing an error when spreading to `<svelte:body>` as there might be an expectation that these work (they don't work today).