### PR TITLE
fix: ensure reactivity system remains consistent with removals

### DIFF
--- a/.changeset/chilly-waves-count.md
+++ b/.changeset/chilly-waves-count.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure reactivity system remains consistent with removals

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -389,7 +389,7 @@ export function destroy_effect(effect, remove_dom = true) {
 	var parent = effect.parent;
 
 	// If the parent doesn't have any children, then skip this work altogether
-	if (parent !== null && (effect.f & BRANCH_EFFECT) !== 0 && parent.first !== null) {
+	if (parent !== null && parent.first !== null) {
 		unlink_effect(effect);
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -1,4 +1,4 @@
-/** @import { ComponentContext, ComponentContextLegacy, Effect, Reaction, TemplateNode, TransitionManager } from '#client' */
+/** @import { ComponentContext, ComponentContextLegacy, Derived, Effect, Reaction, TemplateNode, TransitionManager } from '#client' */
 import {
 	check_dirtiness,
 	current_component_context,
@@ -60,7 +60,7 @@ export function validate_effect(rune) {
 
 /**
  * @param {Effect} effect
- * @param {Reaction} parent_effect
+ * @param {Effect} parent_effect
  */
 function push_effect(effect, parent_effect) {
 	var parent_last = parent_effect.last;
@@ -146,7 +146,8 @@ function create_effect(type, fn, sync, push = true) {
 
 		// if we're in a derived, add the effect there too
 		if (current_reaction !== null && (current_reaction.f & DERIVED) !== 0) {
-			push_effect(effect, current_reaction);
+			var derived = /** @type {Derived} */ (current_reaction);
+			(derived.children ??= []).push(effect);
 		}
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -21,17 +21,13 @@ export interface Reaction extends Signal {
 	fn: null | Function;
 	/** Signals that this signal reads from */
 	deps: null | Value[];
-	/** First child effect created inside this signal */
-	first: null | Effect;
-	/** Last child effect created inside this signal */
-	last: null | Effect;
 }
 
 export interface Derived<V = unknown> extends Value<V>, Reaction {
 	/** The derived function */
 	fn: () => V;
-	/** Deriveds created inside this signal */
-	deriveds: null | Derived[];
+	/** Reactions created inside this signal */
+	children: null | Reaction[];
 }
 
 export interface Effect extends Reaction {
@@ -56,6 +52,10 @@ export interface Effect extends Reaction {
 	prev: null | Effect;
 	/** Next sibling child effect created inside the parent signal */
 	next: null | Effect;
+	/** First child effect created inside this signal */
+	first: null | Effect;
+	/** Last child effect created inside this signal */
+	last: null | Effect;
 	/** Dev only */
 	component_function?: any;
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -601,9 +601,9 @@ function process_effects(effect, collected_effects) {
 			if ((flags & RENDER_EFFECT) !== 0) {
 				if (!is_branch && check_dirtiness(current_effect)) {
 					update_effect(current_effect);
-					// Child might have been mutated since running the effect
-					child = current_effect.first;
 				}
+				// Child might have been mutated since running the effect or checking dirtiness
+				child = current_effect.first;
 
 				if (child !== null) {
 					current_effect = child;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -392,7 +392,7 @@ export function remove_reactions(signal, start_index) {
 }
 
 /**
- * @param {Reaction} signal
+ * @param {Effect} signal
  * @param {boolean} remove_dom
  * @returns {void}
  */

--- a/packages/svelte/tests/runtime-runes/samples/store-from-state-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-state-2/_config.js
@@ -1,0 +1,15 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => {
+			button?.click();
+			button?.click();
+			button?.click();
+		});
+		assert.htmlEqual(target.innerHTML, `<div>3</div><div>3,  6</div><button>increment</button>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/store-from-state-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-state-2/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { fromStore } from 'svelte/store';
+	import { writable } from 'svelte/store';
+
+	const store = writable(0);
+
+	const value = fromStore(store);
+</script>
+
+<div>{$store}</div>
+
+{#if true}
+	{@const doubled = value.current * 2}
+	<div>{value.current}, {doubled}</div>
+{/if}
+
+<button onclick={() => $store++}>increment</button>

--- a/packages/svelte/tests/runtime-runes/samples/store-from-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-state/_config.js
@@ -1,0 +1,15 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => {
+			button?.click();
+			button?.click();
+			button?.click();
+		});
+		assert.htmlEqual(target.innerHTML, `\n3\n<button>Increment</button><br>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/store-from-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-from-state/main.svelte
@@ -1,0 +1,23 @@
+<script>
+  import { writable, fromStore } from 'svelte/store';
+	const store = writable(0)
+	const state_from_store= fromStore(store)
+
+	const derived_value= $derived.by(() => {
+		if (state_from_store.current > 10) {
+			return state_from_store.current
+		}
+		else{
+			return 10
+		}
+	})
+
+	function increment() {
+		$store += 1;
+	}
+</script>
+
+{state_from_store.current}
+<button onclick={increment}>Increment</button><br>
+
+{#if derived_value > 10 }Exceeded 10!{/if}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13002.

There were actually a few issues that needed resolving:
- we weren't correctly disconnecting effects from the parents effects (if an effect is created in a derived, and that derived is in a branch, then the child effect will go to the branch)
- we had a linked list on deriveds for ownership of effects, which was pointless as it was also the same linked list used on effects – meaning a deriveds child would incorrectly then link to when to the effect graph – causing all sorts of random things being destroyed. I have no idea how this went missed, but we just now use a single array called `children` to store any effects or deriveds that are owned by a derived.
- when we execute effects we need to ensure that the child is the latest after updating deriveds