### PR TITLE
fix: allow additional unquoted attribute values

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -14,7 +14,7 @@ import { get_attribute_expression, is_expression_attribute } from '../../../util
 import { closing_tag_omitted } from '../../../../html-tree-validation.js';
 import { list } from '../../../utils/string.js';
 
-const regex_invalid_unquoted_attribute_value = /^(\/>|[\s"'=<>`])/;
+const regex_invalid_unquoted_attribute_value = /^(\/>|[\s"'<>`]|=[^/])/;
 const regex_closing_textarea_tag = /^<\/textarea(\s[^>]*)?>/i;
 const regex_closing_comment = /-->/;
 const regex_whitespace_or_slash_or_closing_tag = /(\s|\/|>)/;


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/7782

Changed regex_invalid_unquoted_attribute_value with new expression which now supports = followed by / only.

Updated this particular line `const regex_invalid_unquoted_attribute_value = /^(\/>|[\s"'<>`]|=[^/])/;`
so that it can support html5 symbol and does not declare invalid to this <a href=/>Home</a>