### PR TITLE
fix: render undefined html as the empty string

### DIFF
--- a/.changeset/eighty-mails-develop.md
+++ b/.changeset/eighty-mails-develop.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: render undefined html as the empty string

--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -50,7 +50,7 @@ export function html(node, get_value, svg, mathml, skip_warning) {
 	var effect;
 
 	block(() => {
-		if (value === (value = get_value())) {
+		if (value === (value = get_value() ?? '')) {
 			if (hydrating) {
 				hydrate_next();
 			}

--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -94,7 +94,7 @@ export function html(node, get_value, svg, mathml, skip_warning) {
 				return;
 			}
 
-			var html = (value == null) ? '' : value + '';
+			var html = value + '';
 			if (svg) html = `<svg>${html}</svg>`;
 			else if (mathml) html = `<math>${html}</math>`;
 

--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -94,7 +94,7 @@ export function html(node, get_value, svg, mathml, skip_warning) {
 				return;
 			}
 
-			var html = value + '';
+			var html = (value == null) ? '' : value + '';
 			if (svg) html = `<svg>${html}</svg>`;
 			else if (mathml) html = `<math>${html}</math>`;
 

--- a/packages/svelte/src/internal/server/blocks/html.js
+++ b/packages/svelte/src/internal/server/blocks/html.js
@@ -5,6 +5,7 @@ import { hash } from '../../../utils.js';
  * @param {string} value
  */
 export function html(value) {
-	var open = DEV ? `<!--${hash(String(value ?? ''))}-->` : '<!---->';
-	return `${open}${value}<!---->`;
+	var html = String(value ?? '');
+	var open = DEV ? `<!--${hash(html)}-->` : '<!---->';
+	return open + html + '<!---->';
 }

--- a/packages/svelte/tests/runtime-legacy/samples/binding-contenteditable-html-initial/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-contenteditable-html-initial/_config.js
@@ -15,7 +15,7 @@ export default test({
 
 	ssrHtml: `
 		<editor contenteditable="true"><b>world</b></editor>
-		<p>hello null</p>
+		<p>hello </p>
 	`,
 
 	async test({ assert, component, target, window }) {

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -303,7 +303,7 @@ async function run_test_variant(
 						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
 					withoutNormalizeHtml: !!config.withoutNormalizeHtml
 				});
-			} else if (config.html) {
+			} else if (config.html !== undefined) {
 				assert_html_equal_with_options(target.innerHTML, config.html, {
 					preserveComments:
 						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
@@ -369,7 +369,7 @@ async function run_test_variant(
 				assert.fail('Expected a runtime error');
 			}
 
-			if (config.html) {
+			if (config.html !== undefined) {
 				flushSync();
 				assert_html_equal_with_options(target.innerHTML, config.html, {
 					preserveComments:

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -303,7 +303,7 @@ async function run_test_variant(
 						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
 					withoutNormalizeHtml: !!config.withoutNormalizeHtml
 				});
-			} else if (config.html !== undefined) {
+			} else if (config.html) {
 				assert_html_equal_with_options(target.innerHTML, config.html, {
 					preserveComments:
 						config.withoutNormalizeHtml === 'only-strip-comments' ? false : undefined,
@@ -369,7 +369,7 @@ async function run_test_variant(
 				assert.fail('Expected a runtime error');
 			}
 
-			if (config.html !== undefined) {
+			if (config.html) {
 				flushSync();
 				assert_html_equal_with_options(target.innerHTML, config.html, {
 					preserveComments:

--- a/packages/svelte/tests/runtime-runes/samples/html-tag-empty/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/html-tag-empty/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: ''
+});

--- a/packages/svelte/tests/runtime-runes/samples/html-tag-empty/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/html-tag-empty/main.svelte
@@ -1,0 +1,1 @@
+{@html undefined}


### PR DESCRIPTION
Fix https://github.com/sveltejs/svelte/issues/13069 `{@html}` should handle null and undefined as empty string

I didn't have permission to write to https://github.com/sveltejs/svelte/pull/13072, so this is a follow up with the fixes.