### PR TITLE
fix: flip animation not accounting for scaled lengths

### DIFF
--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -13,10 +13,13 @@ import { cubicOut } from '../easing/index.js';
  */
 export function flip(node, { from, to }, params = {}) {
 	const style = getComputedStyle(node);
+	// need to account for scaled vs unscaled lengths (https://drafts.csswg.org/css-viewport/#scaled).
+	const dsx = from.width / parseFloat(style.width);
+	const dsy = from.height / parseFloat(style.height);
 	const transform = style.transform === 'none' ? '' : style.transform;
 	const [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
-	const dx = from.left + (from.width * ox) / to.width - (to.left + ox);
-	const dy = from.top + (from.height * oy) / to.height - (to.top + oy);
+	const dx = (from.left + (from.width * ox) / to.width - (to.left + ox)) / dsx;
+	const dy = (from.top + (from.height * oy) / to.height - (to.top + oy)) / dsy;
 	const { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
 	return {
 		delay,


### PR DESCRIPTION
Closes #13093 .
FLIP animation now accounts for scaled/unscaled length ratio of elements, which fixes the overly-large distance elements with zoom scaling originate from when animated.
More about this [here](https://drafts.csswg.org/css-viewport/#scaled).

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
