### PR TITLE
fix: ensure types are easier to follow for TypeScript

### DIFF
--- a/.changeset/metal-cameras-jump.md
+++ b/.changeset/metal-cameras-jump.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure types are easier to follow for TypeScript

--- a/packages/svelte/scripts/generate-types.js
+++ b/packages/svelte/scripts/generate-types.js
@@ -60,3 +60,14 @@ if (bad_links.length > 0) {
 
 	process.exit(1);
 }
+
+if (types.includes('\texport { ')) {
+	// eslint-disable-next-line no-console
+	console.error(
+		`The generated types file should not contain 'export { ... }' statements. ` +
+			`TypeScript is bad at following these: when creating d.ts files through @sveltejs/package, and one of these types is used, ` +
+			`TypeScript will likely fail at generating a d.ts file. ` +
+			`To prevent this, do 'export interface Foo {}' instead of 'interface Foo {}' and then 'export { Foo }'`
+	);
+	process.exit(1);
+}

--- a/packages/svelte/src/reactivity/index-client.js
+++ b/packages/svelte/src/reactivity/index-client.js
@@ -3,28 +3,3 @@ export { SvelteSet } from './set.js';
 export { SvelteMap } from './map.js';
 export { SvelteURL } from './url.js';
 export { SvelteURLSearchParams } from './url-search-params.js';
-
-/** @deprecated Use `SvelteDate` instead */
-export function Date() {
-	throw new Error('Date has been removed, use SvelteDate instead.');
-}
-
-/** @deprecated Use `SvelteSet` instead */
-export function Set() {
-	throw new Error('Set has been removed, use SvelteSet instead.');
-}
-
-/** @deprecated Use `SvelteMap` instead */
-export function Map() {
-	throw new Error('Map has been removed, use SvelteMap instead.');
-}
-
-/** @deprecated Use `SvelteURL` instead */
-export function URL() {
-	throw new Error('URL has been removed, use SvelteURL instead.');
-}
-
-/** @deprecated Use `SvelteURLSearchParams` instead */
-export function URLSearchParams() {
-	throw new Error('URLSearchParams has been removed, use SvelteURLSearchParams instead.');
-}

--- a/packages/svelte/src/reactivity/index-server.js
+++ b/packages/svelte/src/reactivity/index-server.js
@@ -3,28 +3,3 @@ export const SvelteSet = globalThis.Set;
 export const SvelteMap = globalThis.Map;
 export const SvelteURL = globalThis.URL;
 export const SvelteURLSearchParams = globalThis.URLSearchParams;
-
-/** @deprecated Use `SvelteDate` instead */
-export function Date() {
-	throw new Error('Date has been removed, use SvelteDate instead.');
-}
-
-/** @deprecated Use `SvelteSet` instead */
-export function Set() {
-	throw new Error('Set has been removed, use SvelteSet instead.');
-}
-
-/** @deprecated Use `SvelteMap` instead */
-export function Map() {
-	throw new Error('Map has been removed, use SvelteMap instead.');
-}
-
-/** @deprecated Use `SvelteURL` instead */
-export function URL() {
-	throw new Error('URL has been removed, use SvelteURL instead.');
-}
-
-/** @deprecated Use `SvelteURLSearchParams` instead */
-export function URLSearchParams() {
-	throw new Error('URLSearchParams has been removed, use SvelteURLSearchParams instead.');
-}

--- a/packages/svelte/src/store/public.d.ts
+++ b/packages/svelte/src/store/public.d.ts
@@ -1,11 +1,11 @@
 /** Callback to inform of a value updates. */
-type Subscriber<T> = (value: T) => void;
+export type Subscriber<T> = (value: T) => void;
 
 /** Unsubscribes from value updates. */
-type Unsubscriber = () => void;
+export type Unsubscriber = () => void;
 
 /** Callback to update a value. */
-type Updater<T> = (value: T) => T;
+export type Updater<T> = (value: T) => T;
 
 /**
  * Start and stop notification callbacks.
@@ -16,13 +16,13 @@ type Updater<T> = (value: T) => T;
  * @returns {void | (() => void)} Optionally, a cleanup function that is called when the last remaining
  * subscriber unsubscribes.
  */
-type StartStopNotifier<T> = (
+export type StartStopNotifier<T> = (
 	set: (value: T) => void,
 	update: (fn: Updater<T>) => void
 ) => void | (() => void);
 
 /** Readable interface for subscribing. */
-interface Readable<T> {
+export interface Readable<T> {
 	/**
 	 * Subscribe on value changes.
 	 * @param run subscription callback
@@ -32,7 +32,7 @@ interface Readable<T> {
 }
 
 /** Writable interface for both updating and subscribing. */
-interface Writable<T> extends Readable<T> {
+export interface Writable<T> extends Readable<T> {
 	/**
 	 * Set value and inform subscribers.
 	 * @param value to set
@@ -45,7 +45,5 @@ interface Writable<T> extends Readable<T> {
 	 */
 	update(this: void, updater: Updater<T>): void;
 }
-
-export { Readable, StartStopNotifier, Subscriber, Unsubscriber, Updater, Writable };
 
 export * from './index-client.js';

--- a/packages/svelte/src/transition/public.d.ts
+++ b/packages/svelte/src/transition/public.d.ts
@@ -1,6 +1,6 @@
-type EasingFunction = (t: number) => number;
+export type EasingFunction = (t: number) => number;
 
-interface TransitionConfig {
+export interface TransitionConfig {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
@@ -8,7 +8,7 @@ interface TransitionConfig {
 	tick?: (t: number, u: number) => void;
 }
 
-interface BlurParams {
+export interface BlurParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
@@ -16,13 +16,13 @@ interface BlurParams {
 	opacity?: number;
 }
 
-interface FadeParams {
+export interface FadeParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
 }
 
-interface FlyParams {
+export interface FlyParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
@@ -31,14 +31,14 @@ interface FlyParams {
 	opacity?: number;
 }
 
-interface SlideParams {
+export interface SlideParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
 	axis?: 'x' | 'y';
 }
 
-interface ScaleParams {
+export interface ScaleParams {
 	delay?: number;
 	duration?: number;
 	easing?: EasingFunction;
@@ -46,29 +46,17 @@ interface ScaleParams {
 	opacity?: number;
 }
 
-interface DrawParams {
+export interface DrawParams {
 	delay?: number;
 	speed?: number;
 	duration?: number | ((len: number) => number);
 	easing?: EasingFunction;
 }
 
-interface CrossfadeParams {
+export interface CrossfadeParams {
 	delay?: number;
 	duration?: number | ((len: number) => number);
 	easing?: EasingFunction;
 }
-
-export {
-	EasingFunction,
-	TransitionConfig,
-	BlurParams,
-	FadeParams,
-	FlyParams,
-	SlideParams,
-	ScaleParams,
-	DrawParams,
-	CrossfadeParams
-};
 
 export * from './index.js';

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1700,16 +1700,6 @@ declare module 'svelte/motion' {
 }
 
 declare module 'svelte/reactivity' {
-	/** @deprecated Use `SvelteDate` instead */
-	function Date_1(): void;
-	/** @deprecated Use `SvelteSet` instead */
-	function Set_1(): void;
-	/** @deprecated Use `SvelteMap` instead */
-	function Map_1(): void;
-	/** @deprecated Use `SvelteURL` instead */
-	function URL_1(): void;
-	/** @deprecated Use `SvelteURLSearchParams` instead */
-	function URLSearchParams_1(): void;
 	export class SvelteDate extends Date {
 		
 		constructor(...params: any[]);
@@ -1740,7 +1730,7 @@ declare module 'svelte/reactivity' {
 		#private;
 	}
 
-	export { Date_1 as Date, Set_1 as Set, Map_1 as Map, URL_1 as URL, URLSearchParams_1 as URLSearchParams };
+	export {};
 }
 
 declare module 'svelte/server' {
@@ -1777,13 +1767,13 @@ declare module 'svelte/server' {
 
 declare module 'svelte/store' {
 	/** Callback to inform of a value updates. */
-	type Subscriber<T> = (value: T) => void;
+	export type Subscriber<T> = (value: T) => void;
 
 	/** Unsubscribes from value updates. */
-	type Unsubscriber = () => void;
+	export type Unsubscriber = () => void;
 
 	/** Callback to update a value. */
-	type Updater<T> = (value: T) => T;
+	export type Updater<T> = (value: T) => T;
 
 	/**
 	 * Start and stop notification callbacks.
@@ -1794,13 +1784,13 @@ declare module 'svelte/store' {
 	 * @returns Optionally, a cleanup function that is called when the last remaining
 	 * subscriber unsubscribes.
 	 */
-	type StartStopNotifier<T> = (
+	export type StartStopNotifier<T> = (
 		set: (value: T) => void,
 		update: (fn: Updater<T>) => void
 	) => void | (() => void);
 
 	/** Readable interface for subscribing. */
-	interface Readable<T> {
+	export interface Readable<T> {
 		/**
 		 * Subscribe on value changes.
 		 * @param run subscription callback
@@ -1810,7 +1800,7 @@ declare module 'svelte/store' {
 	}
 
 	/** Writable interface for both updating and subscribing. */
-	interface Writable<T> extends Readable<T> {
+	export interface Writable<T> extends Readable<T> {
 		/**
 		 * Set value and inform subscribers.
 		 * @param value to set
@@ -1882,13 +1872,13 @@ declare module 'svelte/store' {
 	type StoresValues<T> =
 		T extends Readable<infer U> ? U : { [K in keyof T]: T[K] extends Readable<infer U> ? U : never };
 
-	export { Subscriber, Unsubscriber, Updater, StartStopNotifier, Readable, Writable };
+	export {};
 }
 
 declare module 'svelte/transition' {
-	type EasingFunction = (t: number) => number;
+	export type EasingFunction = (t: number) => number;
 
-	interface TransitionConfig {
+	export interface TransitionConfig {
 		delay?: number;
 		duration?: number;
 		easing?: EasingFunction;
@@ -1896,7 +1886,7 @@ declare module 'svelte/transition' {
 		tick?: (t: number, u: number) => void;
 	}
 
-	interface BlurParams {
+	export interface BlurParams {
 		delay?: number;
 		duration?: number;
 		easing?: EasingFunction;
@@ -1904,13 +1894,13 @@ declare module 'svelte/transition' {
 		opacity?: number;
 	}
 
-	interface FadeParams {
+	export interface FadeParams {
 		delay?: number;
 		duration?: number;
 		easing?: EasingFunction;
 	}
 
-	interface FlyParams {
+	export interface FlyParams {
 		delay?: number;
 		duration?: number;
 		easing?: EasingFunction;
@@ -1919,14 +1909,14 @@ declare module 'svelte/transition' {
 		opacity?: number;
 	}
 
-	interface SlideParams {
+	export interface SlideParams {
 		delay?: number;
 		duration?: number;
 		easing?: EasingFunction;
 		axis?: 'x' | 'y';
 	}
 
-	interface ScaleParams {
+	export interface ScaleParams {
 		delay?: number;
 		duration?: number;
 		easing?: EasingFunction;
@@ -1934,14 +1924,14 @@ declare module 'svelte/transition' {
 		opacity?: number;
 	}
 
-	interface DrawParams {
+	export interface DrawParams {
 		delay?: number;
 		speed?: number;
 		duration?: number | ((len: number) => number);
 		easing?: EasingFunction;
 	}
 
-	interface CrossfadeParams {
+	export interface CrossfadeParams {
 		delay?: number;
 		duration?: number | ((len: number) => number);
 		easing?: EasingFunction;
@@ -1997,7 +1987,7 @@ declare module 'svelte/transition' {
 		key: any;
 	}) => () => TransitionConfig];
 
-	export { EasingFunction, TransitionConfig, BlurParams, FadeParams, FlyParams, SlideParams, ScaleParams, DrawParams, CrossfadeParams };
+	export {};
 }
 
 declare module 'svelte/events' {


### PR DESCRIPTION
As a byproduct of #12239 some types were changed from being directly exported to indirectly exported. TypeScript is bad at following these types while generating d.ts files, so we can't do that. A check at the end of the types generation was added to prevent regressions in the future. Fixes #13128

Also removes the old types from `svelte/reactivity` which are deprecated for a while now.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
