### PR TITLE
fix: Remove unnecessary closure on bind with props

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
@@ -38,10 +38,12 @@ export function BindDirective(node, context) {
 
 	const getter = b.thunk(/** @type {Expression} */ (context.visit(expression)));
 
-	const setter = b.unthunk(b.arrow(
-		[b.id('$$value')],
-		/** @type {Expression} */ (context.visit(b.assignment('=', expression, b.id('$$value'))))
-	));
+	const setter = b.unthunk(
+		b.arrow(
+			[b.id('$$value')],
+			/** @type {Expression} */ (context.visit(b.assignment('=', expression, b.id('$$value'))))
+		)
+	);
 
 	/** @type {CallExpression} */
 	let call;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
@@ -38,10 +38,10 @@ export function BindDirective(node, context) {
 
 	const getter = b.thunk(/** @type {Expression} */ (context.visit(expression)));
 
-	const setter = b.arrow(
+	const setter = b.unthunk(b.arrow(
 		[b.id('$$value')],
 		/** @type {Expression} */ (context.visit(b.assignment('=', expression, b.id('$$value'))))
-	);
+	));
 
 	/** @type {CallExpression} */
 	let call;

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -419,19 +419,9 @@ export function template(elements, expressions) {
  * @returns {ESTree.Expression}
  */
 export function thunk(expression, async = false) {
-	if (
-		expression.type === 'CallExpression' &&
-		expression.callee.type !== 'Super' &&
-		expression.callee.type !== 'MemberExpression' &&
-		expression.callee.type !== 'CallExpression' &&
-		expression.arguments.length === 0
-	) {
-		return expression.callee;
-	}
-
 	const fn = arrow([], expression);
 	if (async) fn.async = true;
-	return fn;
+	return unthunk(fn);
 }
 
 /**

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -446,12 +446,11 @@ export function unthunk(expression) {
 		expression.body.type === 'CallExpression' &&
 		expression.body.callee.type === 'Identifier' &&
 		expression.params.length === expression.body.arguments.length &&
-		expression.params.every( (param, index) => {
-			const arg = /** @type {ESTree.SimpleCallExpression} */(expression.body).arguments[index];
-			return param.type === 'Identifier'
-				&& arg.type === 'Identifier'
-				&& param.name === arg.name;
-		})) {
+		expression.params.every((param, index) => {
+			const arg = /** @type {ESTree.SimpleCallExpression} */ (expression.body).arguments[index];
+			return param.type === 'Identifier' && arg.type === 'Identifier' && param.name === arg.name;
+		})
+	) {
 		return expression.body.callee;
 	}
 	return expression;

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -435,6 +435,29 @@ export function thunk(expression, async = false) {
 }
 
 /**
+ * Replace "(arg) => func(arg)" to "func"
+ * @param {ESTree.Expression} expression
+ * @returns {ESTree.Expression}
+ */
+export function unthunk(expression) {
+	if (
+		expression.type === 'ArrowFunctionExpression' &&
+		expression.async === false &&
+		expression.body.type === 'CallExpression' &&
+		expression.body.callee.type === 'Identifier' &&
+		expression.params.length === expression.body.arguments.length &&
+		expression.params.every( (param, index) => {
+			const arg = /** @type {ESTree.SimpleCallExpression} */(expression.body).arguments[index];
+			return param.type === 'Identifier'
+				&& arg.type === 'Identifier'
+				&& param.name === arg.name;
+		})) {
+		return expression.body.callee;
+	}
+	return expression;
+}
+
+/**
  *
  * @param {string | ESTree.Expression} expression
  * @param  {...ESTree.Expression} args


### PR DESCRIPTION
I did a PR directly.
I don't know if it would have been better to do an issuer before...

But there just a very little thing that bothers me when we bind a prop :
```svelte
<script>
	let { prop } = $props();
</script>

<input type="text" bind:value={prop} />
```

In the code above, the `bind:value={prop}` is compiled as the following line :
```js
$.bind_value(input, prop, ($$value) => prop($$value));
```

But the closure `($$value) => prop($$value)` is unnecessary, and can be directly replaced by `prop` : 
```diff
-$.bind_value(input, prop, ($$value) => prop($$value));
+$.bind_value(input, prop, prop);
```

I added a **unthunk()** function that detect such call and return the callee.
It was used on **BindDirective()** to detech such code and fix it.
Maybe this could be used somewhere else...


Remarks :
* **pnpm lint** is OK
* **pnpm test** returns 2 errors, but this was already the case before this modification, and unrelated to this (packages/svelte/src/reactivity/date.test.ts and packages/svelte/src/reactivity/date.test.ts)



## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
