### PR TITLE
fix: throw warnings when directive is not defined

### DIFF
--- a/.changeset/small-icons-carry.md
+++ b/.changeset/small-icons-carry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: throw warnings when directive is not defined

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -30,6 +30,10 @@
 
 > `<%name%>` will be treated as an HTML element unless it begins with a capital letter
 
+## directive_not_defined
+
+> `%name%` is not defined. Consider declaring, getting it via prop or importing the directive
+
 ## element_invalid_self_closing_tag
 
 > Self-closing HTML tags for non-void elements are ambiguous — use `<%name% ...></%name%>` rather than `<%name% ... />`

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -16,6 +16,7 @@ import { hash, is_rune } from '../../../utils.js';
 import { warn_unused } from './css/css-warn.js';
 import { extract_svelte_ignore } from '../../utils/extract_svelte_ignore.js';
 import { ignore_map, ignore_stack, pop_ignore, push_ignore } from '../../state.js';
+import { AnimateDirective } from './visitors/AnimateDirective.js';
 import { ArrowFunctionExpression } from './visitors/ArrowFunctionExpression.js';
 import { AssignmentExpression } from './visitors/AssignmentExpression.js';
 import { Attribute } from './visitors/Attribute.js';
@@ -63,6 +64,7 @@ import { SvelteWindow } from './visitors/SvelteWindow.js';
 import { TaggedTemplateExpression } from './visitors/TaggedTemplateExpression.js';
 import { Text } from './visitors/Text.js';
 import { TitleElement } from './visitors/TitleElement.js';
+import { TransitionDirective } from './visitors/TransitionDirective.js';
 import { UpdateExpression } from './visitors/UpdateExpression.js';
 import { UseDirective } from './visitors/UseDirective.js';
 import { VariableDeclarator } from './visitors/VariableDeclarator.js';
@@ -125,6 +127,7 @@ const visitors = {
 			pop_ignore();
 		}
 	},
+	AnimateDirective,
 	ArrowFunctionExpression,
 	AssignmentExpression,
 	Attribute,
@@ -172,6 +175,7 @@ const visitors = {
 	TaggedTemplateExpression,
 	Text,
 	TitleElement,
+	TransitionDirective,
 	UpdateExpression,
 	UseDirective,
 	VariableDeclarator

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/AnimateDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/AnimateDirective.js
@@ -1,16 +1,13 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
-import { mark_subtree_dynamic } from './shared/fragment.js';
 import * as w from '../../../warnings.js';
 
 /**
- * @param {AST.UseDirective} node
+ * @param {AST.AnimateDirective} node
  * @param {Context} context
  */
-export function UseDirective(node, context) {
+export function AnimateDirective(node, context) {
 	if (!context.state.scope.get(node.name)) {
 		w.directive_not_defined(node, node.name);
 	}
-	mark_subtree_dynamic(context.path);
-	context.next();
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ClassDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ClassDirective.js
@@ -1,10 +1,14 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
+import * as w from '../../../warnings.js';
 
 /**
  * @param {AST.ClassDirective} node
  * @param {Context} context
  */
 export function ClassDirective(node, context) {
+	if (node.expression.type === 'Identifier' && !context.state.scope.get(node.expression.name)) {
+		w.directive_not_defined(node, node.expression.name);
+	}
 	context.next({ ...context.state, expression: node.metadata.expression });
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/StyleDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/StyleDirective.js
@@ -1,6 +1,7 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
+import * as w from '../../../warnings.js';
 import { get_attribute_chunks } from '../../../utils/ast.js';
 import { mark_subtree_dynamic } from './shared/fragment.js';
 
@@ -21,10 +22,19 @@ export function StyleDirective(node, context) {
 			if (binding.kind !== 'normal') {
 				node.metadata.expression.has_state = true;
 			}
+		} else {
+			w.directive_not_defined(node, node.name);
 		}
 
 		mark_subtree_dynamic(context.path);
 	} else {
+		if (
+			!Array.isArray(node.value) &&
+			node.value.expression.type === 'Identifier' &&
+			!context.state.scope.get(node.value.expression.name)
+		) {
+			w.directive_not_defined(node, node.value.expression.name);
+		}
 		context.next();
 
 		for (const chunk of get_attribute_chunks(node.value)) {

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/TransitionDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/TransitionDirective.js
@@ -1,16 +1,13 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
-import { mark_subtree_dynamic } from './shared/fragment.js';
 import * as w from '../../../warnings.js';
 
 /**
- * @param {AST.UseDirective} node
+ * @param {AST.TransitionDirective} node
  * @param {Context} context
  */
-export function UseDirective(node, context) {
+export function TransitionDirective(node, context) {
 	if (!context.state.scope.get(node.name)) {
 		w.directive_not_defined(node, node.name);
 	}
-	mark_subtree_dynamic(context.path);
-	context.next();
 }

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -113,6 +113,7 @@ export const codes = [
 	"bind_invalid_each_rest",
 	"block_empty",
 	"component_name_lowercase",
+	"directive_not_defined",
 	"element_invalid_self_closing_tag",
 	"event_directive_deprecated",
 	"node_invalid_placement_ssr",
@@ -732,6 +733,15 @@ export function block_empty(node) {
  */
 export function component_name_lowercase(node, name) {
 	w(node, "component_name_lowercase", `\`<${name}>\` will be treated as an HTML element unless it begins with a capital letter`);
+}
+
+/**
+ * `%name%` is not defined. Consider declaring, getting it via prop or importing the directive
+ * @param {null | NodeLike} node
+ * @param {string} name
+ */
+export function directive_not_defined(node, name) {
+	w(node, "directive_not_defined", `\`${name}\` is not defined. Consider declaring, getting it via prop or importing the directive`);
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/directive-not-defined/input.svelte
+++ b/packages/svelte/tests/validator/samples/directive-not-defined/input.svelte
@@ -1,0 +1,27 @@
+<div transition:nonexistent>cool</div>
+
+<div in:nonexistent>cool</div>
+
+<div out:nonexistent>cool</div>
+
+<div out:nonexistent|global>cool</div>
+
+<div in:nonexistent|global>cool</div>
+
+<div transition:nonexistent|global>cool</div>
+
+{#if false}
+	<div use:nonexistent>cool</div>
+{/if}
+
+{#each [] as i (i)}
+	<div animate:nonexistent></div>
+{/each}
+
+<div style:color={nonexistent}></div>
+
+<div style:color></div>
+
+<div class:someclass={nonexistent}></div>
+
+<div class:nonexistent></div>

--- a/packages/svelte/tests/validator/samples/directive-not-defined/warnings.json
+++ b/packages/svelte/tests/validator/samples/directive-not-defined/warnings.json
@@ -1,0 +1,146 @@
+[
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 27,
+			"line": 1
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 1
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 19,
+			"line": 3
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 3
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 20,
+			"line": 5
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 5
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 27,
+			"line": 7
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 7
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 26,
+			"line": 9
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 9
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 34,
+			"line": 11
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 11
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 21,
+			"line": 14
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 6,
+			"line": 14
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 25,
+			"line": 18
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 6,
+			"line": 18
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 30,
+			"line": 21
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 21
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 16,
+			"line": 23
+		},
+		"message": "`color` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 23
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 34,
+			"line": 25
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 25
+		}
+	},
+	{
+		"code": "directive_not_defined",
+		"end": {
+			"column": 22,
+			"line": 27
+		},
+		"message": "`nonexistent` is not defined. Consider declaring, getting it via prop or importing the directive",
+		"start": {
+			"column": 5,
+			"line": 27
+		}
+	}
+]


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13144 

If we want to mode this to an error i can do it in this PR fairly quickly.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
