### PR TITLE
fix: ensure inner script tags are properly removed

### DIFF
--- a/.changeset/selfish-trainers-kiss.md
+++ b/.changeset/selfish-trainers-kiss.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure inner script tags are properly removed

--- a/packages/svelte/tests/runtime-browser/samples/sole-script-tag/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/sole-script-tag/_config.js
@@ -4,8 +4,12 @@ export default test({
 	// Test that template with sole script tag does execute when instantiated in the client.
 	// Needs to be in this test suite because JSDOM does not quite get this right.
 	mode: ['client'],
-	test({ window, assert }) {
+	async test({ target, assert }) {
 		// In here to give effects etc time to execute
-		assert.htmlEqual(window.document.body.innerHTML, 'this should be executed');
+		assert.htmlEqual(target.querySelector('div')?.innerHTML || '', 'this should be executed');
+		// Check that the script tag is properly removed
+		target.querySelector('button')?.click();
+		await new Promise((r) => setTimeout(r, 100));
+		assert.equal(target.querySelector('script'), null);
 	}
 });

--- a/packages/svelte/tests/runtime-browser/samples/sole-script-tag/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/sole-script-tag/main.svelte
@@ -1,4 +1,11 @@
-<div></div>
-{#if true}
-    <script>document.body.innerHTML = 'this should be executed'</script>
+<script lang="ts">
+	let visible = $state(true);
+</script>
+
+<button onclick={() => (visible = false)}>hide</button>
+{#if visible}
+	<script>
+		document.body.querySelector('.after').innerHTML = 'this should be executed';
+	</script>
 {/if}
+<div class="after">after</div>


### PR DESCRIPTION
We have a `run_scripts` function which is invoked in case a template block contains a script tag, and that function replaces the script tags (so that they actually run). If such a script tag is first or last in the template, the replacement is not picked up by our `node.first_node/last_node` logic anymore, and so it contains a stale tag. That means on cleanup the remove logic fails. In the case of the referenced issue, it just runs past the script tag till the very end of the head, removing the just added style tag from the new page.

Fixes #13086

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
