### PR TITLE
fix: ensure signal graph is consistent before triggering $inspect signals

### DIFF
--- a/.changeset/chatty-snails-train.md
+++ b/.changeset/chatty-snails-train.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure signal graph is consistent before triggering $inspect signals

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -15,7 +15,8 @@ import {
 	increment_version,
 	update_effect,
 	derived_sources,
-	set_derived_sources
+	set_derived_sources,
+	flush_sync
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import {
@@ -159,7 +160,11 @@ export function set(source, value) {
 			}
 		}
 
-		if (DEV) {
+		if (DEV && inspect_effects.size > 0) {
+			// Triggering an effect sync can tear the signal graph, so to avoid this we need
+			// to ensure the graph has been flushed before triggering any inspect effects.
+			// This is expensive, but given this is a DEV mode only feature, it should be fine
+			flush_sync();
 			for (const effect of inspect_effects) {
 				update_effect(effect);
 			}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13146.

Sync effects are not possible with Svelte 5's push-pull system because they can make can break the reactive graph – which is also why we don't permit writes within a derived too. The same problem is occurring here, as inspect effects are run sync – they are actually happening as part of an existing derived – which means they're a bit like writes in a derived and can cause tearing to the reactive signal graph. To avoid this we can call `flushSync` just before invoking these effects, as that should ensure the graph is made consistent again.

@paoloricciuti If you could help me create a minimal test case for this, that would be great.