### PR TITLE
fix: widen ownership upon property access if necessary

### DIFF
--- a/.changeset/five-birds-check.md
+++ b/.changeset/five-birds-check.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: widen ownership upon property access if necessary

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -131,6 +131,22 @@ export function proxy(value, parent = null, prev) {
 
 			if (s !== undefined) {
 				var v = get(s);
+
+				// In case of something like `foo = bar.map(...)`, foo would have ownership
+				// of the array itself, while the individual items would have ownership
+				// of the component that created the proxy. That means if we later do
+				// `foo[0].baz = 42`, we could get a false-positive ownership violation,
+				// since the two proxies are not connected to each other via the parent
+				// relationship. For this reason, we need to widen the ownership of the
+				// children upon access when we detect they are not connected.
+				if (DEV) {
+					/** @type {ProxyMetadata | undefined} */
+					var prop_metadata = v?.[STATE_SYMBOL_METADATA];
+					if (prop_metadata && prop_metadata?.parent !== metadata) {
+						widen_ownership(metadata, prop_metadata);
+					}
+				}
+
 				return v === UNINITIALIZED ? undefined : v;
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/Component1.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/Component1.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Component2 from './Component2.svelte';
+
+	let { rows = $bindable([]) } = $props();
+
+	let rows2 = $state([]);
+
+	$effect(() => {
+		rows2 = rows.slice();
+	});
+</script>
+
+<Component2 bind:rows={rows2} />

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/Component2.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/Component2.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { rows = $bindable([]) } = $props();
+</script>
+
+{#if rows.length}
+	<input type="checkbox" bind:checked={rows[0].check} />
+{/if}

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/_config.js
@@ -1,0 +1,22 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+// Tests that proxies widen ownership correctly even if not directly connected to each other
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, warnings }) {
+		const input = target.querySelector('input');
+		ok(input);
+
+		input.checked = true;
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		flushSync();
+
+		assert.deepEqual(warnings, []);
+	},
+
+	warnings: []
+});

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-7/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Component1 from './Component1.svelte';
+
+	let rows = $state([{}]);
+</script>
+
+<Component1 bind:rows />


### PR DESCRIPTION
In case of something like `foo = bar.map(...)`, foo would have ownership of the array itself, while the individual items would have ownership of the component that created the proxy. That means if we later do `foo[0].baz = 42`, we could get a false-positive ownership violation, since the two proxies are not connected to each other via the parent relationship. For this reason, we need to widen the ownership of the children upon access when we detect they are not connected.

I'm a tiny bit worried about the potential overhead of this being invoked in a hot path (more likely with reads) but it should be fine since it only goes one level deep.

Fixes #13137

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
