### PR TITLE
fix: ensure locally mutated bindable props persist with spreading props

### DIFF
--- a/.changeset/fuzzy-tigers-swim.md
+++ b/.changeset/fuzzy-tigers-swim.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure locally mutated bindable props persist with spreading props

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -241,7 +241,7 @@ export function prop(props, key, flags, fallback) {
 	var fallback_used = false;
 
 	var get_fallback = () => {
-		fallback_used = true
+		fallback_used = true;
 		if (lazy && fallback_dirty) {
 			fallback_dirty = false;
 			fallback_value = untrack(/** @type {() => V} */ (fallback));

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -242,9 +242,13 @@ export function prop(props, key, flags, fallback) {
 
 	var get_fallback = () => {
 		fallback_used = true;
-		if (lazy && fallback_dirty) {
+		if (fallback_dirty) {
 			fallback_dirty = false;
-			fallback_value = untrack(/** @type {() => V} */ (fallback));
+			if (lazy) {
+				fallback_value = untrack(/** @type {() => V} */ (fallback));
+			} else {
+				fallback_value = /** @type {V} */ (fallback);
+			}
 		}
 
 		return fallback_value;
@@ -266,6 +270,7 @@ export function prop(props, key, flags, fallback) {
 			var value = /** @type {V} */ (props[key]);
 			if (value === undefined) return get_fallback();
 			fallback_dirty = true;
+			fallback_used = false;
 			return value;
 		};
 	} else {
@@ -355,7 +360,7 @@ export function prop(props, key, flags, fallback) {
 				set(inner_current_value, new_value);
 				// To ensure the fallback value is consistent when used with proxies, we
 				// update the local fallback_value, but only if the fallback is actively used
-				if (fallback_dirty && fallback_used && fallback_value !== undefined) {
+				if (fallback_used && fallback_value !== undefined) {
 					fallback_value = new_value;
 				}
 				get(current_value); // force a synchronisation immediately

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -238,8 +238,10 @@ export function prop(props, key, flags, fallback) {
 
 	var fallback_value = /** @type {V} */ (fallback);
 	var fallback_dirty = true;
+	var fallback_used = false;
 
 	var get_fallback = () => {
+		fallback_used = true
 		if (lazy && fallback_dirty) {
 			fallback_dirty = false;
 			fallback_value = untrack(/** @type {() => V} */ (fallback));
@@ -351,6 +353,11 @@ export function prop(props, key, flags, fallback) {
 			if (!current_value.equals(new_value)) {
 				from_child = true;
 				set(inner_current_value, new_value);
+				// To ensure the fallback value is consistent when used with proxies, we
+				// update the local fallback_value, but only if the fallback is actively used
+				if (fallback_dirty && fallback_used && fallback_value !== undefined) {
+					fallback_value = new_value;
+				}
 				get(current_value); // force a synchronisation immediately
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/_config.js
@@ -5,11 +5,27 @@ export default test({
 	accessors: false,
 
 	test({ assert, target }) {
-		const [btn] = target.querySelectorAll('button');
+		const [btn1, btn2] = target.querySelectorAll('button');
 
-		btn.click();
+		btn1.click();
 		flushSync();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>set color</button> <button>set options</button> bar bar`
+		);
 
-		assert.htmlEqual(target.innerHTML, `<button>change</button>\nbar\nbar`);
+		btn2.click();
+		flushSync();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>set color</button> <button>set options</button> baz bar`
+		);
+
+		btn1.click();
+		flushSync();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>set color</button> <button>set options</button> foo bar`
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/_config.js
@@ -1,0 +1,15 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	accessors: false,
+
+	test({ assert, target }) {
+		const [btn] = target.querySelectorAll('button');
+
+		btn.click();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<button>change</button>\nbar\nbar`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/inner.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/inner.svelte
@@ -1,0 +1,7 @@
+<script>
+  let { options = $bindable('foo') } = $props();
+
+  options = 'bar'
+</script>
+
+{options}

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/main.svelte
@@ -1,0 +1,17 @@
+<script >
+  import Inner from "./inner.svelte";
+
+  let testProps = $state({
+    color: "red"
+  });
+</script>
+
+<button onclick={() => {
+	testProps = {
+		color: "blue"
+	};
+}}>change</button>
+
+<Inner {...testProps} />
+
+<Inner color={testProps.color} />

--- a/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-default-value-rest/main.svelte
@@ -10,7 +10,14 @@
 	testProps = {
 		color: "blue"
 	};
-}}>change</button>
+}}>set color</button>
+
+<button onclick={() => {
+	testProps = {
+		color: "pink",
+		options: 'baz'
+	};
+}}>set options</button>
 
 <Inner {...testProps} />
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13187. This ensures that we update the local fallback value in the case where the fallback is used so that we persist local changes to bindable props. Otherwise, any incoming changes from the outside will reset the incoming value back to the old fallback value.