### PR TITLE
fix: allow more characters in the unicode range as component identifiers

### DIFF
--- a/.changeset/ten-singers-repair.md
+++ b/.changeset/ten-singers-repair.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow more characters in the unicode range as component identifiers

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -24,7 +24,9 @@ const regex_attribute_value = /^(?:"([^"]*)"|'([^'])*'|([^>\s]+))/;
 const regex_valid_element_name =
 	/^(?:![a-zA-Z]+|[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9])$/;
 const regex_valid_component_name =
-	/^(?:[A-Z][A-Za-z0-9_$.]*|[a-z][A-Za-z0-9_$]*(?:\.[A-Za-z0-9_$]+)+)$/;
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers adjusted for our needs
+	// (must start with uppercase letter if no dots, can contain dots)
+	/^(?:\p{Lu}[$\u200c\u200d\p{ID_Continue}.]*|\p{ID_Start}[$\u200c\u200d\p{ID_Continue}]*(?:\.[$\u200c\u200d\p{ID_Continue}]+)+)$/u;
 
 /** @type {Map<string, ElementLike['type']>} */
 const root_only_meta_tags = new Map([

--- a/packages/svelte/tests/compiler-errors/samples/component-invalid-name/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/component-invalid-name/_config.js
@@ -5,6 +5,6 @@ export default test({
 		code: 'tag_invalid_name',
 		message:
 			'Expected a valid element or component name. Components must have a valid variable name or dot notation expression',
-		position: [1, 14]
+		position: [71, 84]
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/component-invalid-name/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/component-invalid-name/main.svelte
@@ -1,1 +1,7 @@
+<!-- ok -->
+<Component />
+<Wunderschön />
+<Cæжαकン中 />
+
+<!-- error -->
 <Components[1] />


### PR DESCRIPTION
fixes #13194

We narrowed the allowed characters in #13057, but didn't take into account all possible (and for JavaScript identifiers allowed) unicode characters. This widens that, which also removes the accidental breaking change (because in Svelte 4 you were allowed to use these unicode characters).

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
