### PR TITLE
fix: stronger types for the `autocomplete` attribute

### DIFF
--- a/.changeset/curvy-foxes-wink.md
+++ b/.changeset/curvy-foxes-wink.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Better types for the `autocomplete` attribute

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -937,7 +937,7 @@ export interface HTMLFieldsetAttributes extends HTMLAttributes<HTMLFieldSetEleme
 export interface HTMLFormAttributes extends HTMLAttributes<HTMLFormElement> {
 	acceptcharset?: string | undefined | null;
 	action?: string | undefined | null;
-	autocomplete?: string | undefined | null;
+	autocomplete?: AutoFillBase | undefined | null;
 	enctype?: string | undefined | null;
 	method?: string | undefined | null;
 	name?: string | undefined | null;
@@ -1025,7 +1025,7 @@ export type HTMLInputTypeAttribute =
 export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	accept?: string | undefined | null;
 	alt?: string | undefined | null;
-	autocomplete?: string | undefined | null;
+	autocomplete?: AutoFill | undefined | null;
 	capture?: boolean | 'user' | 'environment' | undefined | null; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
 	checked?: boolean | undefined | null;
 	dirname?: string | undefined | null;
@@ -1244,7 +1244,7 @@ export interface HTMLScriptAttributes extends HTMLAttributes<HTMLScriptElement> 
 }
 
 export interface HTMLSelectAttributes extends HTMLAttributes<HTMLSelectElement> {
-	autocomplete?: string | undefined | null;
+	autocomplete?: AutoFill | undefined | null;
 	disabled?: boolean | undefined | null;
 	form?: string | undefined | null;
 	multiple?: boolean | undefined | null;
@@ -1289,7 +1289,7 @@ export interface HTMLTableAttributes extends HTMLAttributes<HTMLTableElement> {
 }
 
 export interface HTMLTextareaAttributes extends HTMLAttributes<HTMLTextAreaElement> {
-	autocomplete?: string | undefined | null;
+	autocomplete?: AutoFill | undefined | null;
 	cols?: number | undefined | null;
 	dirname?: string | undefined | null;
 	disabled?: boolean | undefined | null;


### PR DESCRIPTION
The attribute value is either the keyword `off` or `on`, or a space-separated `<token-list>` that describes the meaning of the autocompletion value.

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
