### PR TITLE
fix: avoid creating unnnecessary deriveds for text nodes with call

### DIFF
--- a/.changeset/wild-mugs-cover.md
+++ b/.changeset/wild-mugs-cover.md
@@ -1,5 +1,0 @@
----
-'svelte': patch
----
-
-fix: avoid creating unnnecessary deriveds for text nodes with call

--- a/.changeset/wild-mugs-cover.md
+++ b/.changeset/wild-mugs-cover.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid creating unnnecessary deriveds for text nodes with call

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -32,7 +32,7 @@ import {
 	build_template_literal,
 	build_update,
 	build_update_assignment,
-	get_states_and_call
+	get_states_and_calls
 } from './shared/utils.js';
 import { visit_event_attribute } from './shared/events.js';
 
@@ -319,7 +319,7 @@ export function RegularElement(node, context) {
 	const states_and_calls =
 		trimmed.every((node) => node.type === 'Text' || node.type === 'ExpressionTag') &&
 		trimmed.some((node) => node.type === 'ExpressionTag') &&
-		get_states_and_call(trimmed);
+		get_states_and_calls(trimmed);
 
 	if (states_and_calls && states_and_calls.states === 0) {
 		child_state.init.push(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -31,7 +31,8 @@ import {
 	build_render_statement,
 	build_template_literal,
 	build_update,
-	build_update_assignment
+	build_update_assignment,
+	get_states_and_call
 } from './shared/utils.js';
 import { visit_event_attribute } from './shared/events.js';
 
@@ -315,14 +316,20 @@ export function RegularElement(node, context) {
 
 	// special case — if an element that only contains text, we don't need
 	// to descend into it if the text is non-reactive
-	const text_content =
+	const states_and_calls =
 		trimmed.every((node) => node.type === 'Text' || node.type === 'ExpressionTag') &&
 		trimmed.some((node) => node.type === 'ExpressionTag') &&
-		build_template_literal(trimmed, context.visit, child_state);
+		get_states_and_call(trimmed);
 
-	if (text_content && !text_content.has_state) {
+	if (states_and_calls && states_and_calls.states === 0) {
 		child_state.init.push(
-			b.stmt(b.assignment('=', b.member(context.state.node, 'textContent'), text_content.value))
+			b.stmt(
+				b.assignment(
+					'=',
+					b.member(context.state.node, 'textContent'),
+					build_template_literal(trimmed, context.visit, child_state).value
+				)
+			)
 		);
 	} else {
 		/** @type {Expression} */

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -13,7 +13,7 @@ import { locator } from '../../../../../state.js';
 /**
  * @param {Array<AST.Text | AST.ExpressionTag>} values
  */
-export function get_states_and_call(values) {
+export function get_states_and_calls(values) {
 	let states = 0;
 	let calls = 0;
 	for (let i = 0; i < values.length; i++) {
@@ -44,7 +44,7 @@ export function build_template_literal(values, visit, state) {
 	let quasi = b.quasi('');
 	const quasis = [quasi];
 
-	const { states, calls } = get_states_and_call(values);
+	const { states, calls } = get_states_and_calls(values);
 
 	let has_call = calls > 0;
 	let has_state = states > 0;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -12,6 +12,28 @@ import { locator } from '../../../../../state.js';
 
 /**
  * @param {Array<AST.Text | AST.ExpressionTag>} values
+ */
+export function get_states_and_call(values) {
+	let states = 0;
+	let calls = 0;
+	for (let i = 0; i < values.length; i++) {
+		const node = values[i];
+
+		if (node.type === 'ExpressionTag') {
+			if (node.metadata.expression.has_call) {
+				calls++;
+			}
+			if (node.metadata.expression.has_state) {
+				states++;
+			}
+		}
+	}
+
+	return { states, calls };
+}
+
+/**
+ * @param {Array<AST.Text | AST.ExpressionTag>} values
  * @param {(node: SvelteNode, state: any) => any} visit
  * @param {ComponentClientTransformState} state
  */
@@ -22,24 +44,11 @@ export function build_template_literal(values, visit, state) {
 	let quasi = b.quasi('');
 	const quasis = [quasi];
 
-	let has_call = false;
-	let has_state = false;
-	let contains_multiple_call_expression = false;
+	const { states, calls } = get_states_and_call(values);
 
-	for (let i = 0; i < values.length; i++) {
-		const node = values[i];
-
-		if (node.type === 'ExpressionTag') {
-			if (node.metadata.expression.has_call) {
-				if (has_call) {
-					contains_multiple_call_expression = true;
-				}
-				has_call = true;
-			}
-
-			has_state ||= node.metadata.expression.has_state;
-		}
-	}
+	let has_call = calls > 0;
+	let has_state = states > 0;
+	let contains_multiple_call_expression = calls > 1;
 
 	for (let i = 0; i < values.length; i++) {
 		const node = values[i];
@@ -53,7 +62,6 @@ export function build_template_literal(values, visit, state) {
 		} else {
 			if (contains_multiple_call_expression) {
 				const id = b.id(state.scope.generate('stringified_text'));
-
 				state.init.push(
 					b.const(
 						id,

--- a/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/client/index.svelte.js
@@ -1,0 +1,26 @@
+import "svelte/internal/disclose-version";
+import * as $ from "svelte/internal/client";
+
+var root = $.template(`<p> </p>`);
+
+export default function Text_nodes_deriveds($$anchor) {
+	let count1 = 0;
+	let count2 = 0;
+
+	function text1() {
+		return count1;
+	}
+
+	function text2() {
+		return count2;
+	}
+
+	var p = root();
+	const stringified_text = $.derived(() => text1() ?? "");
+	const stringified_text_1 = $.derived(() => text2() ?? "");
+	var text = $.child(p);
+
+	$.template_effect(() => $.set_text(text, `${$.get(stringified_text)}${$.get(stringified_text_1)}`));
+	$.reset(p);
+	$.append($$anchor, p);
+}

--- a/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/server/index.svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/server";
+
+export default function Text_nodes_deriveds($$payload) {
+	let count1 = 0;
+	let count2 = 0;
+
+	function text1() {
+		return count1;
+	}
+
+	function text2() {
+		return count2;
+	}
+
+	$$payload.out += `<p>${$.escape(text1())}${$.escape(text2())}</p>`;
+}

--- a/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/index.svelte
@@ -1,0 +1,14 @@
+<script>
+	let count1=$state(0);
+	let count2=$state(0);
+
+	function text1(){
+		return count1;
+	}
+
+	function text2(){
+		return count2;
+	}
+</script>
+
+<p>{text1()}{text2()}</p>


### PR DESCRIPTION
## Svelte 5 rewrite

As per https://github.com/sveltejs/svelte/pull/13171#issuecomment-2343763030 we were creating unnecessary deriveds in the compiled code.

This was a bit tricky to fix because in the `RegularElement` visitor we call `build_template` that if there's more than one call creates this deriveds and push them to the `init`. However in `RegularElement` if we realise that there's state the template that we just built is unused and we proceed to process the children which calls `build_template` again creating another set of deriveds (which this time will be actually pushed to the update).

To fix this i've splitted the logic to check how many states/calls are there in it's own function (used by `build_template`) so that i can use that function instead in `RegularElement`.

I went with snapshot tests because that's just unused code.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
