### PR TITLE
fix: allow for nesting selector in pseudoclasses

### DIFF
--- a/.changeset/tough-snails-chew.md
+++ b/.changeset/tough-snails-chew.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow for nesting selector in pseudoclasses

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -73,9 +73,23 @@ const visitors = {
 		const inner = selectors[selectors.length - 1];
 
 		if (node.metadata.rule?.metadata.parent_rule && selectors.length > 0) {
-			const has_explicit_nesting_selector = selectors.some((selector) =>
-				selector.selectors.some((s) => s.type === 'NestingSelector')
-			);
+			let has_explicit_nesting_selector = false;
+
+			// nesting could be inside pseudo classes like :is, :has or :where
+			for (let selector of selectors) {
+				walk(
+					selector,
+					{},
+					{
+						// @ts-ignore
+						NestingSelector() {
+							has_explicit_nesting_selector = true;
+						}
+					}
+				);
+				// if we found one we can break from the others
+				if (has_explicit_nesting_selector) break;
+			}
 
 			if (!has_explicit_nesting_selector) {
 				selectors[0] = {

--- a/packages/svelte/tests/css/samples/nested-in-pseudo/_config.js
+++ b/packages/svelte/tests/css/samples/nested-in-pseudo/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	warnings: []
+});

--- a/packages/svelte/tests/css/samples/nested-in-pseudo/expected.css
+++ b/packages/svelte/tests/css/samples/nested-in-pseudo/expected.css
@@ -1,0 +1,5 @@
+
+/* (empty) nav{
+	header:has(&){
+	}
+}*/	

--- a/packages/svelte/tests/css/samples/nested-in-pseudo/expected.css
+++ b/packages/svelte/tests/css/samples/nested-in-pseudo/expected.css
@@ -1,5 +1,6 @@
 
-/* (empty) nav{
-	header:has(&){
+nav.svelte-xyz{
+	header:where(.svelte-xyz):has(&){
+		color: red;
 	}
-}*/	
+}	

--- a/packages/svelte/tests/css/samples/nested-in-pseudo/expected.html
+++ b/packages/svelte/tests/css/samples/nested-in-pseudo/expected.html
@@ -1,0 +1,1 @@
+<header class="svelte-xyz"><nav class="svelte-xyz"></nav></header>

--- a/packages/svelte/tests/css/samples/nested-in-pseudo/input.svelte
+++ b/packages/svelte/tests/css/samples/nested-in-pseudo/input.svelte
@@ -1,0 +1,10 @@
+<header>
+	<nav></nav>		
+</header>
+
+<style>
+nav{
+	header:has(&){
+	}
+}	
+</style>

--- a/packages/svelte/tests/css/samples/nested-in-pseudo/input.svelte
+++ b/packages/svelte/tests/css/samples/nested-in-pseudo/input.svelte
@@ -5,6 +5,7 @@
 <style>
 nav{
 	header:has(&){
+		color: red;
 	}
 }	
 </style>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13203

The problem is that we were checking for `NestingSelectors` only in the selectors of the immediate child of the selectors. Since Nesting could be in selectors like `:is` or `:where` or `:has` that can also be nested i think we need to walk the selectors to find if there's a selector or not.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
