### PR TITLE
fix: allow `&` to appear at the top when inside a `:global(...)`

### DIFF
--- a/packages/svelte/messages/compile-errors/style.md
+++ b/packages/svelte/messages/compile-errors/style.md
@@ -40,7 +40,7 @@
 
 ## css_nesting_selector_invalid_placement
 
-> Nesting selectors can only be used inside a rule
+> Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`
 
 ## css_selector_invalid
 

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -536,12 +536,12 @@ export function css_global_invalid_selector_list(node) {
 }
 
 /**
- * Nesting selectors can only be used inside a rule
+ * Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`
  * @param {null | number | NodeLike} node
  * @returns {never}
  */
 export function css_nesting_selector_invalid_placement(node) {
-	e(node, "css_nesting_selector_invalid_placement", "Nesting selectors can only be used inside a rule");
+	e(node, "css_nesting_selector_invalid_placement", "Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`");
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -224,12 +224,13 @@ const css_visitors = {
 		if (!parent_rule) {
 			// https://developer.mozilla.org/en-US/docs/Web/CSS/Nesting_selector#using_outside_nested_rule
 			const children = rule.prelude.children;
+			const selectors = children[0].children[0].selectors;
 			if (
 				children.length > 1 ||
-				children[0].children[0].selectors.length > 1 ||
-				children[0].children[0].selectors[0].type !== 'PseudoClassSelector' ||
-				children[0].children[0].selectors[0].name !== 'global' ||
-				children[0].children[0].selectors[0].args?.children[0]?.children[0].selectors[0] !== node
+				selectors.length > 1 ||
+				selectors[0].type !== 'PseudoClassSelector' ||
+				selectors[0].name !== 'global' ||
+				selectors[0].args?.children[0]?.children[0].selectors[0] !== node
 			) {
 				e.css_nesting_selector_invalid_placement(node);
 			}

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -222,7 +222,17 @@ const css_visitors = {
 		const parent_rule = rule.metadata.parent_rule;
 
 		if (!parent_rule) {
-			e.css_nesting_selector_invalid_placement(node);
+			// https://developer.mozilla.org/en-US/docs/Web/CSS/Nesting_selector#using_outside_nested_rule
+			const children = rule.prelude.children;
+			if (
+				children.length > 1 ||
+				children[0].children[0].selectors.length > 1 ||
+				children[0].children[0].selectors[0].type !== 'PseudoClassSelector' ||
+				children[0].children[0].selectors[0].name !== 'global' ||
+				children[0].children[0].selectors[0].args?.children[0]?.children[0].selectors[0] !== node
+			) {
+				e.css_nesting_selector_invalid_placement(node);
+			}
 		} else if (
 			// :global { &.foo { ... } } is invalid
 			parent_rule.metadata.is_global_block &&

--- a/packages/svelte/tests/compiler-errors/samples/css-nesting-selector-root/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/css-nesting-selector-root/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'css_nesting_selector_invalid_placement',
+		message:
+			'Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`',
+		position: [151, 152]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/css-nesting-selector-root/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/css-nesting-selector-root/main.svelte
@@ -1,0 +1,16 @@
+<style>
+	/* valid */
+	:global(&) {
+		color: blue;
+	}
+	:global(& div) {
+		color: blue;
+	}
+	:global(&) div {
+		color: blue;
+	}
+	/* error */
+	:global(div &) {
+		color: blue;
+	}
+</style>


### PR DESCRIPTION
It's a valid CSS rule, which means "select the scope root": https://developer.mozilla.org/en-US/docs/Web/CSS/Nesting_selector#using_outside_nested_rule

Found out while reading up more on `&` as part of #13209

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
