### PR TITLE
fix: try catch `strict_equals` to avoid error accessing `STATE_SYMBOL`

### DIFF
--- a/.changeset/late-geckos-draw.md
+++ b/.changeset/late-geckos-draw.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: try catch `strict_equals` to avoid error accessing `STATE_SYMBOL`

--- a/packages/svelte/src/internal/client/dev/equality.js
+++ b/packages/svelte/src/internal/client/dev/equality.js
@@ -78,9 +78,11 @@ export function init_array_prototype_warnings() {
  * @returns {boolean}
  */
 export function strict_equals(a, b, equal = true) {
-	if ((a === b) !== (get_proxied_value(a) === get_proxied_value(b))) {
-		w.state_proxy_equality_mismatch(equal ? '===' : '!==');
-	}
+	try {
+		if ((a === b) !== (get_proxied_value(a) === get_proxied_value(b))) {
+			w.state_proxy_equality_mismatch(equal ? '===' : '!==');
+		}
+	} catch {}
 
 	return (a === b) === equal;
 }

--- a/packages/svelte/src/internal/client/dev/equality.js
+++ b/packages/svelte/src/internal/client/dev/equality.js
@@ -78,6 +78,8 @@ export function init_array_prototype_warnings() {
  * @returns {boolean}
  */
 export function strict_equals(a, b, equal = true) {
+	// try-catch needed because this tries to read properties of `a` and `b`,
+	// which could be disallowed for example in a secure context
 	try {
 		if ((a === b) !== (get_proxied_value(a) === get_proxied_value(b))) {
 			w.state_proxy_equality_mismatch(equal ? '===' : '!==');


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13214 

I'm not 100% sure with this fix but i don't think we can really do much here...it's a very niche case because you are trying to access something where you can't check if `STATE_SYMBOL` is there without causing trouble in the first place.

But since it's no harm i guess we can just try catch it. No test for the moment but i actually just thought of a way to test this so i'm gonna try to write a test.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
