### PR TITLE
fix: allow custom element events on slot to bubble inside custom element

### DIFF
--- a/.changeset/flat-flies-know.md
+++ b/.changeset/flat-flies-know.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow custom element events on slot to bubble inside custom element

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -233,7 +233,10 @@ export function handle_event_propagation(event) {
 		while (current_target !== null) {
 			/** @type {null | Element} */
 			var parent_element =
-				current_target.parentNode || /** @type {any} */ (current_target).host || null;
+				current_target.assignedSlot ||
+				current_target.parentNode ||
+				/** @type {any} */ (current_target).host ||
+				null;
 
 			try {
 				// @ts-expect-error

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/events-slotted/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/events-slotted/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../assert';
+const tick = () => Promise.resolve();
+
+export default test({
+	async test({ assert, target }) {
+		target.innerHTML = '<custom-element><span></span></custom-element>';
+
+		const custom_element = target.querySelector('custom-element');
+
+		const logs = [];
+		custom_element.callback = () => {
+			logs.push('called');
+		};
+
+		await tick();
+		/** @type {any} */
+		const span = target.querySelector('span');
+		span.click();
+		assert.deepEqual(logs, ['called']);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/events-slotted/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/events-slotted/main.svelte
@@ -1,0 +1,7 @@
+<svelte:options customElement="custom-element" />
+
+<button onclick={(e)=>{
+	$host().callback();
+}}>
+<slot></slot>
+</button>

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/events-slotted/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/events-slotted/main.svelte
@@ -3,5 +3,5 @@
 <button onclick={(e)=>{
 	$host().callback();
 }}>
-<slot></slot>
+	<slot></slot>
 </button>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13162

We were going from parentNode to parentNode but if something is a slot of a custom element we should first go to the `assignedSlot` or else the inside of the custom element will be skipped.

P.s. i paired on this with @oscard0m and was hella fun to figure out! 😈

I manually checked that if you wrap the custom element with a div and add an `onclick` on it event delegation still works and i wanted to also add a test for this but i struggled to figure out a way to do it...if you think it's necessary i can try tomorrow (and if you have any ideas on how to do it it would be cool 😄).

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
