### PR TITLE
fix: allow component to be mounted in iframe

### DIFF
--- a/.changeset/silly-fishes-deny.md
+++ b/.changeset/silly-fishes-deny.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: allow custom element styles to be updated in HMR mode

--- a/.changeset/wild-mice-look.md
+++ b/.changeset/wild-mice-look.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: inject styles correctly when mounting inside an iframe

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -492,18 +492,7 @@ export function client_component(analysis, options) {
 
 		if (analysis.css.hash) {
 			// remove existing `<style>` element, in case CSS changed
-			accept_fn_body.unshift(
-				b.stmt(
-					b.call(
-						b.member(
-							b.call('document.querySelector', b.literal('#' + analysis.css.hash)),
-							'remove',
-							false,
-							true
-						)
-					)
-				)
-			);
+			accept_fn_body.unshift(b.stmt(b.call('$.cleanup_styles', b.literal(analysis.css.hash))));
 		}
 
 		const hmr = b.block([

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -386,9 +386,7 @@ export function client_component(analysis, options) {
 		state.hoisted.push(b.const('$$css', b.object([b.init('hash', hash), b.init('code', code)])));
 
 		component_block.body.unshift(
-			b.stmt(
-				b.call('$.append_styles', b.id('$$anchor'), b.id('$$css'))
-			)
+			b.stmt(b.call('$.append_styles', b.id('$$anchor'), b.id('$$css')))
 		);
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -387,7 +387,7 @@ export function client_component(analysis, options) {
 
 		component_block.body.unshift(
 			b.stmt(
-				b.call('$.append_styles', b.id('$$anchor'), b.id('$$css'), options.customElement && b.true)
+				b.call('$.append_styles', b.id('$$anchor'), b.id('$$css'))
 			)
 		);
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -386,7 +386,9 @@ export function client_component(analysis, options) {
 		state.hoisted.push(b.const('$$css', b.object([b.init('hash', hash), b.init('code', code)])));
 
 		component_block.body.unshift(
-			b.stmt(b.call('$.append_styles', b.id('$$anchor'), b.id('$$css')))
+			b.stmt(
+				b.call('$.append_styles', b.id('$$anchor'), b.id('$$css'), options.customElement && b.true)
+			)
 		);
 	}
 

--- a/packages/svelte/src/internal/client/dev/css.js
+++ b/packages/svelte/src/internal/client/dev/css.js
@@ -1,32 +1,31 @@
 /** @type {Map<String, Set<HTMLStyleElement>} */
-var styles_cleanup = new Map();
+var all_styles = new Map();
 
 /**
  * @param {String} hash
  * @param {HTMLStyleElement} style
  */
-export function register_css_cleanup(hash, style) {
-	let hash_cleanup = styles_cleanup.get(hash);
+export function register_style(hash, style) {
+	var styles = all_styles.get(hash);
 
-	if (!hash_cleanup) {
-		hash_cleanup = new Set();
-		styles_cleanup.set(hash, hash_cleanup);
+	if (!styles) {
+		styles = new Set();
+		all_styles.set(hash, styles);
 	}
 
-	hash_cleanup.add(style);
+	styles.add(style);
 }
 
 /**
  * @param {String} hash
  */
 export function cleanup_styles(hash) {
-	const hash_cleanup = styles_cleanup.get(hash);
+	var styles = all_styles.get(hash);
+	if (!styles) return;
 
-	if (hash_cleanup) {
-		for (const style of hash_cleanup) {
-			style.remove();
-		}
-
-		styles_cleanup.delete(hash);
+	for (const style of styles) {
+		style.remove();
 	}
+
+	all_styles.delete(hash);
 }

--- a/packages/svelte/src/internal/client/dev/css.js
+++ b/packages/svelte/src/internal/client/dev/css.js
@@ -1,0 +1,30 @@
+/** @type {Map<String, Set<() => void>>} */
+var styles_cleanup = new Map();
+
+/**
+ * @param {String} hash
+ * @param {() => void} cleanup
+ */
+export function register_css_cleanup(hash, cleanup) {
+	let hash_cleanup = styles_cleanup.get(hash);
+	if (!hash_cleanup) {
+		hash_cleanup = new Set();
+		styles_cleanup.set(hash, hash_cleanup);
+	}
+
+	hash_cleanup.add(cleanup);
+}
+
+/**
+ * @param {String} hash
+ */
+export function cleanup_styles(hash) {
+	const hash_cleanup = styles_cleanup.get(hash);
+	if (hash_cleanup) {
+		for (const cleanup of hash_cleanup) {
+			cleanup();
+		}
+
+		styles_cleanup.delete(hash);
+	}
+}

--- a/packages/svelte/src/internal/client/dev/css.js
+++ b/packages/svelte/src/internal/client/dev/css.js
@@ -1,18 +1,19 @@
-/** @type {Map<String, Set<() => void>>} */
+/** @type {Map<String, Set<HTMLStyleElement>} */
 var styles_cleanup = new Map();
 
 /**
  * @param {String} hash
- * @param {() => void} cleanup
+ * @param {HTMLStyleElement} style
  */
-export function register_css_cleanup(hash, cleanup) {
+export function register_css_cleanup(hash, style) {
 	let hash_cleanup = styles_cleanup.get(hash);
+
 	if (!hash_cleanup) {
 		hash_cleanup = new Set();
 		styles_cleanup.set(hash, hash_cleanup);
 	}
 
-	hash_cleanup.add(cleanup);
+	hash_cleanup.add(style);
 }
 
 /**
@@ -20,9 +21,10 @@ export function register_css_cleanup(hash, cleanup) {
  */
 export function cleanup_styles(hash) {
 	const hash_cleanup = styles_cleanup.get(hash);
+
 	if (hash_cleanup) {
-		for (const cleanup of hash_cleanup) {
-			cleanup();
+		for (const style of hash_cleanup) {
+			style.remove();
 		}
 
 		styles_cleanup.delete(hash);

--- a/packages/svelte/src/internal/client/dev/css.js
+++ b/packages/svelte/src/internal/client/dev/css.js
@@ -1,4 +1,4 @@
-/** @type {Map<String, Set<HTMLStyleElement>} */
+/** @type {Map<String, Set<HTMLStyleElement>>} */
 var all_styles = new Map();
 
 /**

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -19,7 +19,7 @@ export function append_styles(anchor, css) {
 				seen = new Set();
 				root_seen.set(root, seen);
 			}
-			
+
 			if (seen.has(css)) return;
 			seen.add(css);
 		}

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,5 +1,6 @@
 import { DEV } from 'esm-env';
 import { queue_micro_task } from './task.js';
+import { register_css_cleanup } from '../dev/css.js';
 
 var root_seen = new WeakMap();
 
@@ -34,6 +35,10 @@ export function append_styles(anchor, css) {
 			style.textContent = css.code;
 
 			target.appendChild(style);
+
+			if (DEV) {
+				register_css_cleanup(css.hash, () => target.removeChild(style));
+			}
 		}
 	});
 }

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -37,7 +37,7 @@ export function append_styles(anchor, css, is_custom_element) {
 			target.appendChild(style);
 
 			if (DEV) {
-				register_css_cleanup(css.hash, () => target.removeChild(style));
+				register_css_cleanup(css.hash, style);
 			}
 		}
 	});

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,6 +1,6 @@
 import { DEV } from 'esm-env';
 import { queue_micro_task } from './task.js';
-import { register_css_cleanup } from '../dev/css.js';
+import { register_style } from '../dev/css.js';
 
 var roots = new WeakMap();
 
@@ -37,7 +37,7 @@ export function append_styles(anchor, css, is_custom_element) {
 			target.appendChild(style);
 
 			if (DEV) {
-				register_css_cleanup(css.hash, style);
+				register_style(css.hash, style);
 			}
 		}
 	});

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -1,4 +1,5 @@
 export { FILENAME, HMR } from '../../constants.js';
+export { cleanup_styles } from './dev/css.js';
 export { add_locations } from './dev/elements.js';
 export { hmr } from './dev/hmr.js';
 export {

--- a/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/App.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/App.svelte
@@ -1,0 +1,19 @@
+<script>
+	import { mount } from 'svelte';
+	import Child from './Child.svelte';
+
+	let { count } = $props();
+
+	let iframe;
+
+	$effect(() => {
+		mount(Child, {
+			target: iframe.contentWindow.document.body,
+			props: {
+				count
+			}
+		});
+	});
+</script>
+
+<iframe title="container" bind:this={iframe}></iframe>

--- a/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/Child.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/Child.svelte
@@ -1,0 +1,13 @@
+<svelte:options css="injected" />
+
+<script>
+	let { count } = $props();
+</script>
+
+<h1>count: {count}</h1>
+
+<style>
+	h1 {
+		color: red;
+	}
+</style>

--- a/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/_config.js
@@ -4,12 +4,17 @@ import { test } from '../../assert';
 export default test({
 	async test({ target, assert }) {
 		const button = target.querySelector('button');
-		const h1 = () => target.querySelector('iframe').contentWindow.document.querySelector('h1');
+		const h1 = () =>
+			/** @type {HTMLHeadingElement} */ (
+				/** @type {Window} */ (
+					target.querySelector('iframe')?.contentWindow
+				).document.querySelector('h1')
+			);
 
 		assert.equal(h1().textContent, 'count: 0');
 		assert.equal(getComputedStyle(h1()).color, 'rgb(255, 0, 0)');
 
-		flushSync(() => button.click());
+		flushSync(() => button?.click());
 
 		assert.equal(h1().textContent, 'count: 1');
 		assert.equal(getComputedStyle(h1()).color, 'rgb(255, 0, 0)');

--- a/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../assert';
+
+export default test({
+	async test({ target, assert }) {
+		const button = target.querySelector('button');
+		const h1 = () => target.querySelector('iframe').contentWindow.document.querySelector('h1');
+
+		assert.equal(h1().textContent, 'count: 0');
+		assert.equal(getComputedStyle(h1()).color, 'rgb(255, 0, 0)');
+
+		flushSync(() => button.click());
+
+		assert.equal(h1().textContent, 'count: 1');
+		assert.equal(getComputedStyle(h1()).color, 'rgb(255, 0, 0)');
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import App from './App.svelte';
+
+	let count = $state(0);
+</script>
+
+<button onclick={() => (count += 1)}>remount</button>
+
+{#key count}
+	<App {count} />
+{/key}


### PR DESCRIPTION
Hello Svelte Team,

I use Svelte to create injectable widgets in other apps.
I found a good way to do this with svelte by mounting component into an `iframe`.
This way, it allows a good resource cleanup and good responsive layout.

I used to do this in Svelte 4 and in Svelte 5 prior PR #12374.
In the specified PR, the process of injecting css into dom was changed.

This breaks some cases of mounting a component into an `iframe`:
- If the component is destroyed then remounted, the css is not injected again
- In dev, HMR does not work anymore (i did not succeed to make it work for now)

This PR enhances `append_styles` to allow it to be aware of the current component context and correctly inject css.
It also fix the need to pass `is_custom_element` to `append_styles` since it's a similar case.

**HMR Problem:**
This PR does not fix the HMR problem.
The HMR problem is that when we cleanup styles ([transform-client.js:495](https://github.com/sveltejs/svelte/blob/main/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js#L495)), we are outside of the component context so we try to clean styles in the global document.
However, in custom element and iframe contexts, we need to cleanup styles in the context of the mounted component (ie. root for custom element, iframe document for iframe).

Maybe we could keep track of mounted component to ensure we cleanup styles for each components context. 
What do you think? Do you have a better solution?

Thanks for watching this and for your amazing work 👍 !
