### PR TITLE
fix: add missing `autocomplete` tokens

### DIFF
--- a/.changeset/hot-peaches-clean.md
+++ b/.changeset/hot-peaches-clean.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add missing `autocomplete` attribute tokens

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -61,6 +61,16 @@ export type TransitionEventHandler<T extends EventTarget> = EventHandler<Transit
 export type MessageEventHandler<T extends EventTarget> = EventHandler<MessageEvent, T>;
 export type ToggleEventHandler<T extends EventTarget> = EventHandler<ToggleEvent, T>;
 
+export type FullAutoFill =
+	| 'bday'
+	| `${OptionalPrefixToken<AutoFillAddressKind>}${'cc-additional-name'}`
+	| 'nickname'
+	| 'language'
+	| 'organization-title'
+	| 'photo'
+	| 'sex'
+	| 'url';
+
 //
 // DOM Attributes
 // ----------------------------------------------------------------------
@@ -1025,7 +1035,7 @@ export type HTMLInputTypeAttribute =
 export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	accept?: string | undefined | null;
 	alt?: string | undefined | null;
-	autocomplete?: AutoFill | undefined | null;
+	autocomplete?: FullAutoFill | undefined | null;
 	capture?: boolean | 'user' | 'environment' | undefined | null; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
 	checked?: boolean | undefined | null;
 	dirname?: string | undefined | null;
@@ -1244,7 +1254,7 @@ export interface HTMLScriptAttributes extends HTMLAttributes<HTMLScriptElement> 
 }
 
 export interface HTMLSelectAttributes extends HTMLAttributes<HTMLSelectElement> {
-	autocomplete?: AutoFill | undefined | null;
+	autocomplete?: FullAutoFill | undefined | null;
 	disabled?: boolean | undefined | null;
 	form?: string | undefined | null;
 	multiple?: boolean | undefined | null;
@@ -1289,7 +1299,7 @@ export interface HTMLTableAttributes extends HTMLAttributes<HTMLTableElement> {
 }
 
 export interface HTMLTextareaAttributes extends HTMLAttributes<HTMLTextAreaElement> {
-	autocomplete?: AutoFill | undefined | null;
+	autocomplete?: FullAutoFill | undefined | null;
 	cols?: number | undefined | null;
 	dirname?: string | undefined | null;
 	disabled?: boolean | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -62,6 +62,7 @@ export type MessageEventHandler<T extends EventTarget> = EventHandler<MessageEve
 export type ToggleEventHandler<T extends EventTarget> = EventHandler<ToggleEvent, T>;
 
 export type FullAutoFill =
+	| AutoFill
 	| 'bday'
 	| `${OptionalPrefixToken<AutoFillAddressKind>}${'cc-additional-name'}`
 	| 'nickname'


### PR DESCRIPTION
As noticed by in https://github.com/sveltejs/svelte/issues/13201#issuecomment-2348313554_ the ts `AutoFill` type is missing a few valid tokens for the `autofill` field

https://html.spec.whatwg.org/#autofill-field

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
