### PR TITLE
fix: avoid flushing sync with $inspect

### DIFF
--- a/.changeset/hot-glasses-roll.md
+++ b/.changeset/hot-glasses-roll.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid flushing sync with $inspect

--- a/packages/svelte/tests/runtime-runes/samples/effect-order-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order-3/_config.js
@@ -1,0 +1,26 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [b1] = target.querySelectorAll('button');
+		flushSync(() => {
+			b1.click();
+		});
+		flushSync(() => {
+			b1.click();
+		});
+		assert.deepEqual(logs, [
+			'effect',
+			0,
+			'in-increment',
+			1,
+			'effect',
+			1,
+			'in-increment',
+			2,
+			'effect',
+			2
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-order-3/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order-3/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	let count = $state(0);
+
+	function increment() {
+		count += 1;
+		console.log("in-increment", count);
+	}
+
+	$effect(() => {
+		console.log("effect", count);
+	});
+
+	$inspect(count);
+</script>
+
+<button onclick={increment}>
+	clicks: {count}
+</button>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13237. Found out that we can likely avoid `flush_sync` when using `$inspect` because the real culprit turned out to be the fact we weren't setting the flushing flag, doh!