### PR TITLE
docs: Add spread guidance for multiple event handlers

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/04-event-handlers.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/04-event-handlers.md
@@ -178,14 +178,14 @@ Duplicate attributes/properties on elements — which now includes event handler
 </button>
 ```
 
-When spreading props, the chained event handler should be specified after the spread. Otherwise, the props event handler will override the chained event handler.
+When spreading props, local event handlers must go _after_ the spread, or they risk being overwritten:
 
 ```svelte
 <button
-	{...everythingElse}
+	{...props}
 	onclick={(e) => {
-		one(e);
-		everythingElse.onclick(e);
+		doStuff(e);
+		props.onclick?.(e);
 	}}
 >
 	...

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/04-event-handlers.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/04-event-handlers.md
@@ -185,7 +185,7 @@ When spreading props, the chained event handler should be specified after the sp
 	{...everythingElse}
 	onclick={(e) => {
 		one(e);
-		props.onclick(e);
+		everythingElse.onclick(e);
 	}}
 >
 	...

--- a/sites/svelte-5-preview/src/routes/docs/content/01-api/04-event-handlers.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/01-api/04-event-handlers.md
@@ -178,6 +178,20 @@ Duplicate attributes/properties on elements — which now includes event handler
 </button>
 ```
 
+When spreading props, the chained event handler should be specified after the spread. Otherwise, the props event handler will override the chained event handler.
+
+```svelte
+<button
+	{...everythingElse}
+	onclick={(e) => {
+		one(e);
+		props.onclick(e);
+	}}
+>
+	...
+</button>
+```
+
 ## Why the change?
 
 By deprecating `createEventDispatcher` and the `on:` directive in favour of callback props and normal element properties, we:


### PR DESCRIPTION
Added documentation on managing multiple event handlers and spreading props.

This will help folks avoid this issue while waiting for a compiler warning.
#12533  Svelte 5: Adding local event handler to elements with spread props looks like a pitfall.  
