### PR TITLE
fix: disable promise callback when {#await} is destroyed

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -147,7 +147,7 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 		}
 
 		// Set the input to null, in order to disable the promise callbacks
-		return () => input = null;
+		return () => (input = null);
 	});
 
 	if (hydrating) {

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -40,7 +40,7 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 	/** @type {any} */
 	var component_function = DEV ? component_context?.function : null;
 
-	/** @type {V | Promise<V>} */
+	/** @type {V | Promise<V> | null} */
 	var input;
 
 	/** @type {Effect | null} */
@@ -146,9 +146,8 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 			update(THEN, false);
 		}
 
-		// Inert effects are proactively detached from the effect tree. Returning a noop
-		// teardown function is an easy way to ensure that this is not discarded
-		return noop;
+		// Set the input to null, in order to disable the promise callbacks
+		return () => input = null;
 	});
 
 	if (hydrating) {

--- a/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/_config.js
@@ -1,31 +1,94 @@
-import { flushSync } from 'svelte';
 import { test } from '../../test';
 
+/**
+ * Polyfill for Promise.withResolver()
+ * @returns { {promise: Promise<string>, resolve: (value: any)=>void, reject: (reason?: any) => void} }
+ */
+function promiseWithResolver() {
+	let resolve, reject;
+	const promise = new Promise((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	// @ts-ignore
+	return { promise, resolve, reject };
+}
+
 export default test({
-	async test({ component, assert, target, logs }) {
-		// Set a promise on the component
-		const p1 = new Promise((resolve) => setTimeout(resolve, 32));
-		component.promise = p1;
-		// And wait the end of the promise
-		await p1;
-		await Promise.resolve();
-		// {#await} and {:then} block must be rendered
-		assert.deepEqual(logs, ['await', 'then']);
+	async test({ component, assert, logs }) {
+		{
+			// Set a promise on the component
+			const { promise, resolve } = promiseWithResolver();
+			component.promise = promise;
+			// wait for rendering
+			await Promise.resolve();
+			// resolve promise
+			resolve('ok');
+			// And wait the end of the promise
+			await promise;
+			// {#await} and {:then} block must be rendered
+			assert.deepEqual(logs, ['await', 'then:ok']);
+		}
 
 		// clear logs
 		logs.length = 0;
 
-		// Set a promise on the component
-		const p2 = new Promise((resolve) => setTimeout(resolve, 32));
-		component.promise = p2;
-		// Clear the component's promise
-		await Promise.resolve();
-		component.promise = null;
-		// Wait for the end of the initial promise
-		await p2;
-		// More wait to avoid scheduling problems
-		await new Promise((resolve) => setTimeout(resolve, 32));
-		// Only {#await} block must be rendered
-		assert.deepEqual(logs, ['await']);
+		{
+			// Set a promise on the component
+			const { promise, reject } = promiseWithResolver();
+			component.promise = promise;
+			// wait for rendering
+			await Promise.resolve();
+			// reject promise
+			reject('error');
+			// And wait the end of the promise
+			await promise.catch((ignore) => {});
+			// {#await} and {:catch} block must be rendered
+			assert.deepEqual(logs, ['await', 'catch:error']);
+		}
+
+		// clear logs
+		logs.length = 0;
+
+		{
+			// Set a promise on the component
+			const { promise, resolve } = promiseWithResolver();
+			component.promise = promise;
+			// wait for rendering
+			await Promise.resolve();
+
+			// remove the promise
+			component.promise = null;
+			await Promise.resolve();
+
+			// resolve promise
+			resolve('ok');
+			// And wait the end of the promise
+			await promise;
+			// Only {#await} block must be rendered
+			assert.deepEqual(logs, ['await']);
+		}
+
+		// clear logs
+		logs.length = 0;
+
+		{
+			// Set a promise on the component
+			const { promise, reject } = promiseWithResolver();
+			component.promise = promise;
+			// wait for rendering
+			await Promise.resolve();
+
+			// remove the promise
+			component.promise = null;
+			await Promise.resolve();
+
+			// reject promise
+			reject('error');
+			// And wait the end of the promise
+			await promise.catch((ignore) => {});
+			// Only {#await} block must be rendered
+			assert.deepEqual(logs, ['await']);
+		}
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/_config.js
@@ -1,0 +1,32 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ component, assert, target, logs}) {
+		
+		// Set a promise on the component
+		const p1 = new Promise( (resolve) => setTimeout(resolve, 32) );
+		component.promise = p1;
+		// And wait the end of the promise
+		await p1;
+		await Promise.resolve();
+		// {#await} and {:then} block must be rendered
+		assert.deepEqual(logs, ['await', 'then']);
+
+		// clear logs
+		logs.length = 0;
+
+		// Set a promise on the component
+		const p2 = new Promise( (resolve) => setTimeout(resolve, 32) );
+		component.promise = p2
+		// Clear the component's promise
+		await Promise.resolve();
+		component.promise = null;
+		// Wait for the end of the initial promise
+		await p2;
+		// More wait to avoid scheduling problems
+		await new Promise( (resolve) => setTimeout(resolve, 32) );
+		// Only {#await} block must be rendered
+		assert.deepEqual(logs, ['await']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/_config.js
@@ -2,10 +2,9 @@ import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	async test({ component, assert, target, logs}) {
-		
+	async test({ component, assert, target, logs }) {
 		// Set a promise on the component
-		const p1 = new Promise( (resolve) => setTimeout(resolve, 32) );
+		const p1 = new Promise((resolve) => setTimeout(resolve, 32));
 		component.promise = p1;
 		// And wait the end of the promise
 		await p1;
@@ -17,15 +16,15 @@ export default test({
 		logs.length = 0;
 
 		// Set a promise on the component
-		const p2 = new Promise( (resolve) => setTimeout(resolve, 32) );
-		component.promise = p2
+		const p2 = new Promise((resolve) => setTimeout(resolve, 32));
+		component.promise = p2;
 		// Clear the component's promise
 		await Promise.resolve();
 		component.promise = null;
 		// Wait for the end of the initial promise
 		await p2;
 		// More wait to avoid scheduling problems
-		await new Promise( (resolve) => setTimeout(resolve, 32) );
+		await new Promise((resolve) => setTimeout(resolve, 32));
 		// Only {#await} block must be rendered
 		assert.deepEqual(logs, ['await']);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	let { promise } = $props();
+</script>
+
+
+	{#if promise}
+		{#await promise}
+			{console.log("await")}
+		{:then r}
+			{console.log("then")}
+		{:catch err}
+			{console.log("catch")}
+		{/await}
+	{/if}
+
+

--- a/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-pending-destroy/main.svelte
@@ -7,9 +7,9 @@
 		{#await promise}
 			{console.log("await")}
 		{:then r}
-			{console.log("then")}
+			{console.log("then:"+r)}
 		{:catch err}
-			{console.log("catch")}
+			{console.log("catch:"+err)}
 		{/await}
 	{/if}
 


### PR DESCRIPTION
The promise callbacks used on `{#await}` can resolve after the block has been destroyed, which leads to other errors.

See #13236 

A simple solution : set the `input` to **null** in order to disable the callbacks.


## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
