### PR TITLE
fix: follow spec for `customElement` option

### DIFF
--- a/.changeset/stale-rats-check.md
+++ b/.changeset/stale-rats-check.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: follow spec for `customElement` option

--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -344,11 +344,15 @@ HTML restricts where certain elements can appear. In case of a violation the bro
 
 ## svelte_options_invalid_tagname
 
-> Tag name must be two or more words joined by the "-" character
+> Tag name must be lowercase and hyphenated
+
+See https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name for more information on valid tag names
 
 ## svelte_options_reserved_tagname
 
-> Tag name is reserved and conflicts with standard element names
+> Tag name is reserved
+
+See https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name for more information on valid tag names
 
 ## svelte_options_unknown_attribute
 

--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -346,6 +346,10 @@ HTML restricts where certain elements can appear. In case of a violation the bro
 
 > Tag name must be two or more words joined by the "-" character
 
+## svelte_options_reserved_tagname
+
+> Tag name is reserved and conflicts with standard element names
+
 ## svelte_options_unknown_attribute
 
 > `<svelte:options>` unknown attribute '%name%'

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -1352,21 +1352,21 @@ export function svelte_options_invalid_customelement_shadow(node) {
 }
 
 /**
- * Tag name must be two or more words joined by the "-" character
+ * Tag name must be lowercase and hyphenated
  * @param {null | number | NodeLike} node
  * @returns {never}
  */
 export function svelte_options_invalid_tagname(node) {
-	e(node, "svelte_options_invalid_tagname", "Tag name must be two or more words joined by the \"-\" character");
+	e(node, "svelte_options_invalid_tagname", "Tag name must be lowercase and hyphenated");
 }
 
 /**
- * Tag name is reserved and conflicts with standard element names
+ * Tag name is reserved
  * @param {null | number | NodeLike} node
  * @returns {never}
  */
 export function svelte_options_reserved_tagname(node) {
-	e(node, "svelte_options_reserved_tagname", "Tag name is reserved and conflicts with standard element names");
+	e(node, "svelte_options_reserved_tagname", "Tag name is reserved");
 }
 
 /**

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -1361,6 +1361,15 @@ export function svelte_options_invalid_tagname(node) {
 }
 
 /**
+ * Tag name is reserved and conflicts with standard element names
+ * @param {null | number | NodeLike} node
+ * @returns {never}
+ */
+export function svelte_options_reserved_tagname(node) {
+	e(node, "svelte_options_reserved_tagname", "Tag name is reserved and conflicts with standard element names");
+}
+
+/**
  * `<svelte:options>` unknown attribute '%name%'
  * @param {null | number | NodeLike} node
  * @param {string} name

--- a/packages/svelte/tests/validator/samples/tag-emoji/_config.js
+++ b/packages/svelte/tests/validator/samples/tag-emoji/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		customElement: true
+	}
+});

--- a/packages/svelte/tests/validator/samples/tag-emoji/input.svelte
+++ b/packages/svelte/tests/validator/samples/tag-emoji/input.svelte
@@ -1,0 +1,1 @@
+<svelte:options customElement="emotion-😍" />

--- a/packages/svelte/tests/validator/samples/tag-hyphen/_config.js
+++ b/packages/svelte/tests/validator/samples/tag-hyphen/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		customElement: true
+	}
+});

--- a/packages/svelte/tests/validator/samples/tag-hyphen/input.svelte
+++ b/packages/svelte/tests/validator/samples/tag-hyphen/input.svelte
@@ -1,0 +1,1 @@
+<svelte:options customElement="custom-" />

--- a/packages/svelte/tests/validator/samples/tag-invalid/errors.json
+++ b/packages/svelte/tests/validator/samples/tag-invalid/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "svelte_options_invalid_tagname",
-		"message": "Tag name must be two or more words joined by the \"-\" character",
+		"message": "Tag name must be lowercase and hyphenated",
 		"start": {
 			"line": 1,
 			"column": 16

--- a/packages/svelte/tests/validator/samples/tag-reserved/errors.json
+++ b/packages/svelte/tests/validator/samples/tag-reserved/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "svelte_options_reserved_tagname",
-		"message": "Tag name is reserved and conflicts with standard element names",
+		"message": "Tag name is reserved",
 		"start": {
 			"line": 1,
 			"column": 16

--- a/packages/svelte/tests/validator/samples/tag-reserved/errors.json
+++ b/packages/svelte/tests/validator/samples/tag-reserved/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "svelte_options_reserved_tagname",
+		"message": "Tag name is reserved and conflicts with standard element names",
+		"start": {
+			"line": 1,
+			"column": 16
+		},
+		"end": {
+			"line": 1,
+			"column": 41
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/tag-reserved/input.svelte
+++ b/packages/svelte/tests/validator/samples/tag-reserved/input.svelte
@@ -1,0 +1,1 @@
+<svelte:options customElement="font-face" />


### PR DESCRIPTION
Fixes #13244. Follows the [WHATWG spec](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) when validating the `customElement` option in `<svelte:options>`.

This is _technically_ a breaking change because the validator would no longer accept uppercase letters in `customElement`; however, any code that did do this is invalid and would error immediately at runtime anyway, so I argue that it isn't a breaking change.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
