### PR TITLE
feat: `$derived.by` get current value as first argument

### DIFF
--- a/.changeset/gentle-mayflies-try.md
+++ b/.changeset/gentle-mayflies-try.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: `$derived.by` get current value as first argument

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -202,7 +202,7 @@ declare namespace $derived {
 	 *
 	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-by
 	 */
-	export function by<T>(fn: () => T): T;
+	export function by<T>(fn: (current: T | null) => T): T;
 
 	// prevent intellisense from being unhelpful
 	/** @deprecated */

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -419,16 +419,6 @@ export function template(elements, expressions) {
  * @returns {ESTree.Expression}
  */
 export function thunk(expression, async = false) {
-	if (
-		expression.type === 'CallExpression' &&
-		expression.callee.type !== 'Super' &&
-		expression.callee.type !== 'MemberExpression' &&
-		expression.callee.type !== 'CallExpression' &&
-		expression.arguments.length === 0
-	) {
-		return expression.callee;
-	}
-
 	const fn = arrow([], expression);
 	if (async) fn.async = true;
 	return fn;

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -17,7 +17,7 @@ import { inspect_effects, set_inspect_effects } from './sources.js';
 
 /**
  * @template V
- * @param {() => V} fn
+ * @param {(current: V | null ) => V} fn
  * @returns {Derived<V>}
  */
 /*#__NO_SIDE_EFFECTS__*/
@@ -47,7 +47,7 @@ export function derived(fn) {
 
 /**
  * @template V
- * @param {() => V} fn
+ * @param {(current: NoInfer<V> | null) => V} fn
  * @returns {Derived<V>}
  */
 /*#__NO_SIDE_EFFECTS__*/

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -25,7 +25,7 @@ export interface Reaction extends Signal {
 
 export interface Derived<V = unknown> extends Value<V>, Reaction {
 	/** The derived function */
-	fn: () => V;
+	fn: (current: V | null) => V;
 	/** Reactions created inside this signal */
 	children: null | Reaction[];
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -309,7 +309,11 @@ export function update_reaction(reaction) {
 	derived_sources = null;
 
 	try {
-		var result = /** @type {Function} */ (0, reaction.fn)();
+		var args = [];
+		if (reaction.f & DERIVED) {
+			args.push(/**@type {Derived}*/ (reaction).v);
+		}
+		var result = /** @type {Function} */ (0, reaction.fn)(...args);
 		var deps = reaction.deps;
 
 		if (new_deps !== null) {
@@ -783,7 +787,6 @@ export function get(signal) {
 			update_derived(derived);
 		}
 	}
-
 	return signal.v;
 }
 

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -471,7 +471,7 @@ describe('signals', () => {
 	});
 
 	test('owned deriveds correctly cleanup when no longer connected to graph', () => {
-		let a: Derived<unknown>;
+		let a: Derived<void>;
 		let s = state(0);
 
 		const destroy = effect_root(() => {

--- a/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/svelte-element/_expected/client/index.svelte.js
@@ -6,6 +6,6 @@ export default function Svelte_element($$anchor, $$props) {
 	var fragment = $.comment();
 	var node = $.first_child(fragment);
 
-	$.element(node, tag, false);
+	$.element(node, () => tag(), false);
 	$.append($$anchor, fragment);
 }

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2494,7 +2494,7 @@ declare namespace $derived {
 	 *
 	 * https://svelte-5-preview.vercel.app/docs/runes#$derived-by
 	 */
-	export function by<T>(fn: () => T): T;
+	export function by<T>(fn: (current: T | null) => T): T;
 
 	// prevent intellisense from being unhelpful
 	/** @deprecated */


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13249

This is an implementation but it needs discussion for sure for the following reasons:

1. it basically reverts #9841 ...the optimisation is cool but considering we are using functions that rely on `argument.length` (namely the value returned from `$.prop`) it's kinda risky because, like in this case, if we decide in the future to pass something in to the function that uses them removing the thunk will introduce a bug...this time luckily it was caught by two tests...but that's just two tests who knows in the future. The alternative should be a big refactor to always use `create_derived` and check in there if the binding is a prop or a reactive import. I went this route because it feels a micro optimisation relative to the difficult to debug bugs we could be getting.
2. as pointed out in https://github.com/sveltejs/svelte/issues/13249#issuecomment-2351613517 this implementation pass `null` as the first value...but this means that if the value is actually `null` you'd have no way of knowing if this the initialisation or the actual value. We could either pass a second argument to tell if it's the initialisation or pass a symbol instead of `null`. Both are not very appealing to me.
4. the code that i wrote to pass the argument
```ts
var args = [];
if (reaction.f & DERIVED) {
    args.push(/**@type {Derived}*/ (reaction).v);
}
var result = /** @type {Function} */ (0, reaction.fn)(...args);
```
could be simplified with just
```ts
var result = /** @type {Function} */ (0, reaction.fn)(reaction.v);
```
because `.v` is only defined for deriveds but i wanted to avoid the situation where in the future we change that and this introduces a bug (or if we read `arguments.length` somewhere else).
5. typescript is also not super-good here...if you actually get the value you need to type it or it will be `unknown` (i wasn't able to find a way to make TS infer that from the return value) and you also need to type it as `YourType | null` or it will complain.
6. Do we actually want this solution or do we prefer to go for something else?

No test for the moment but i'll add one when we reach a consensus.


Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
