### PR TITLE
chore: add missing test for #13158

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/invalid-html-ssr/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/invalid-html-ssr/_config.js
@@ -5,7 +5,7 @@ export default test({
 		dev: true
 	},
 
-	html: `<p></p><h1>foo</h1><p></p><form></form>`,
+	html: `<p></p><h1>foo</h1><p></p><form></form> hello`,
 
 	recover: true,
 
@@ -13,7 +13,8 @@ export default test({
 
 	errors: [
 		'node_invalid_placement_ssr: `<p>` (main.svelte:6:0) cannot contain `<h1>` (h1.svelte:1:0)\n\nThis can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.',
-		'node_invalid_placement_ssr: `<form>` (main.svelte:9:0) cannot contain `<form>` (form.svelte:1:0)\n\nThis can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.'
+		'node_invalid_placement_ssr: `<form>` (main.svelte:9:0) cannot contain `<form>` (form.svelte:1:0)\n\nThis can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.',
+		'node_invalid_placement_ssr: `<td>` (main.svelte:12:0) needs a valid parent element\n\nThis can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.'
 	],
 
 	warnings: [

--- a/packages/svelte/tests/runtime-runes/samples/invalid-html-ssr/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/invalid-html-ssr/main.svelte
@@ -9,3 +9,4 @@
 <form>
 	<Form />
 </form>
+<td>hello</td>


### PR DESCRIPTION
Adds a test for #13158. I maintain that we should probably just fix the HTML rather than issuing a slightly cryptic message (why would we say _a_ valid parent element if we know _which_ parent element it should be, and if we know that why don't we just insert it?), but that work can happen separately.

Another thought: the list of elements... https://github.com/sveltejs/svelte/blob/501f4151909077020f26135a90425bf175b03c1d/packages/svelte/src/html-tree-validation.js#L185-L205 ...includes things like `<html>`. Does that preclude valid use cases, like defining a document (only a subtree of which gets hydrated) in a `.svelte` file?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
