### PR TITLE
sanitize template strings once assembled

### DIFF
--- a/.changeset/good-zebras-turn.md
+++ b/.changeset/good-zebras-turn.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: wait until template strings are complete before sanitizing

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -54,10 +54,10 @@ export function build_template_literal(values, visit, state) {
 		const node = values[i];
 
 		if (node.type === 'Text') {
-			quasi.value.raw += sanitize_template_string(node.data);
+			quasi.value.cooked += node.data;
 		} else if (node.type === 'ExpressionTag' && node.expression.type === 'Literal') {
 			if (node.expression.value != null) {
-				quasi.value.raw += sanitize_template_string(node.expression.value + '');
+				quasi.value.cooked += node.expression.value + '';
 			}
 		} else {
 			if (contains_multiple_call_expression) {
@@ -89,6 +89,10 @@ export function build_template_literal(values, visit, state) {
 			quasi = b.quasi('', i + 1 === values.length);
 			quasis.push(quasi);
 		}
+	}
+
+	for (const quasi of quasis) {
+		quasi.value.raw = sanitize_template_string(/** @type {string} */ (quasi.value.cooked));
 	}
 
 	const value = b.template(quasis, expressions);

--- a/packages/svelte/src/compiler/utils/sanitize_template_string.js
+++ b/packages/svelte/src/compiler/utils/sanitize_template_string.js
@@ -3,5 +3,5 @@
  * @returns {string}
  */
 export function sanitize_template_string(str) {
-	return str.replace(/(`|\${|^{|\\)/g, '\\$1');
+	return str.replace(/(`|\${|\\)/g, '\\$1');
 }


### PR DESCRIPTION
see https://github.com/sveltejs/svelte/pull/13262#issuecomment-2352749832. This feels like a more 'correct' fix, and results in tighter output in cases like `{'{'}`