### PR TITLE
fix: ensure correct parent effect is associated with render effects

### DIFF
--- a/.changeset/khaki-camels-punch.md
+++ b/.changeset/khaki-camels-punch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure correct parent effect is associated with render effects

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -201,7 +201,10 @@ export function user_effect(fn) {
 
 	if (defer) {
 		var context = /** @type {ComponentContext} */ (current_component_context);
-		(context.e ??= []).push(fn);
+		(context.e ??= []).push({
+			fn,
+			parent: current_effect
+		});
 	} else {
 		var signal = effect(fn);
 		return signal;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1052,16 +1052,16 @@ export function pop(component) {
 		}
 		const component_effects = context_stack_item.e;
 		if (component_effects !== null) {
-			var previous_effect = current_effect;
+			var previous_effect = active_effect;
 			context_stack_item.e = null;
 			try {
 				for (var i = 0; i < component_effects.length; i++) {
 					var component_effect = component_effects[i];
-					set_current_effect(component_effect.parent);
+					set_active_effect(component_effect.parent);
 					effect(component_effect.fn);
 				}
 			} finally {
-				set_current_effect(previous_effect);
+				set_active_effect(previous_effect);
 			}
 		}
 		component_context = context_stack_item.p;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1054,11 +1054,18 @@ export function pop(component) {
 		if (component !== undefined) {
 			context_stack_item.x = component;
 		}
-		const effects = context_stack_item.e;
-		if (effects !== null) {
+		const component_effects = context_stack_item.e;
+		if (component_effects !== null) {
+			var previous_effect = current_effect;
 			context_stack_item.e = null;
-			for (var i = 0; i < effects.length; i++) {
-				effect(effects[i]);
+			try {
+				for (var i = 0; i < component_effects.length; i++) {
+					var component_effect = component_effects[i];
+					set_current_effect(component_effect.parent);
+					effect(component_effect.fn);
+				}
+			} finally {
+				set_current_effect(previous_effect);
 			}
 		}
 		current_component_context = context_stack_item.p;

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -15,7 +15,7 @@ export type ComponentContext = {
 	/** context */
 	c: null | Map<unknown, unknown>;
 	/** deferred effects */
-	e: null | Array<() => void | (() => void)>;
+	e: null | Array<{ fn: () => void | (() => void); parent: null | Effect }>;
 	/** mounted */
 	m: boolean;
 	/**

--- a/packages/svelte/tests/runtime-runes/samples/effect-order-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order-4/_config.js
@@ -1,0 +1,19 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [b1] = target.querySelectorAll('button');
+		flushSync(() => {
+			b1.click();
+		});
+		flushSync(() => {
+			b1.click();
+		});
+		assert.deepEqual(logs, [
+			{ count: 0, doubled: 0 },
+			{ count: 1, doubled: 2 },
+			{ count: 2, doubled: 4 }
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-order-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-order-4/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	let count = $state(0);
+
+	function increment() {
+		count += 1;
+	}
+
+	$effect.pre(() => {
+		const doubled = count * 2;
+		$effect(() => {
+			console.log({ count, doubled });
+		});
+	});
+</script>
+
+<button onclick={increment}>
+	clicks: {count}
+</button>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13251.

When we invoke `$effect`s in a component, we defer them so that we have child -> parent sequencing. However, this doesn't take into account the fact an `$effect` might have been created inside another nested `$effect.pre` or template effect – in which case, we incorrectly associate the `$effect` with the component's effect rather than the correct `$effect.pre` or template effect. So this adds support for knowledge of the parent.