### PR TITLE
docs: better docs for css injected and `render`

### DIFF
--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -99,11 +99,11 @@ import App from './App.svelte';
 
 In Svelte 4, rendering a component to a string also returned the CSS of all components. In Svelte 5, this is no longer the case by default because most of the time you're using a tooling chain that takes care of it in other ways (like SvelteKit). If you need CSS to be returned from `render`, you can set the `css` compiler option to `'injected'` and it will add `<style>` elements to the `head`.
 
-You can set this option:
+There are several ways to set this option:
 
-- Globally through the `compilerOption` property in your svelte config.
-- On a per component basis through the `<svelte:options css="injected" />` tag.
-- Dynamically using the [`dynamicCompileOption`](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#dynamiccompileoptions) property of `vite-plugin-svelte`
+- Globally, via the `compilerOptions.css` option in your `svelte.config.js` or the options passed to `svelte.compile`
+- Dynamically, using [`dynamicCompileOptions`](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#dynamiccompileoptions) in `vite-plugin-svelte`
+- Per-component, with `<svelte:options css="injected" />` (this will override options set any other way)
 
 ### Component typing changes
 

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -99,6 +99,12 @@ import App from './App.svelte';
 
 In Svelte 4, rendering a component to a string also returned the CSS of all components. In Svelte 5, this is no longer the case by default because most of the time you're using a tooling chain that takes care of it in other ways (like SvelteKit). If you need CSS to be returned from `render`, you can set the `css` compiler option to `'injected'` and it will add `<style>` elements to the `head`.
 
+You can set this option:
+
+- Globally through the `compilerOption` property in your svelte config.
+- On a per component basis through the `<svelte:options css="injected" />` tag.
+- Dynamically using the [`dynamicCompileOption`](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#dynamiccompileoptions) property of `vite-plugin-svelte`
+
 ### Component typing changes
 
 The change from classes towards functions is also reflected in the typings: `SvelteComponent`, the base class from Svelte 4, is deprecated in favour of the new `Component` type which defines the function shape of a Svelte component. To manually define a component shape in a `d.ts` file:


### PR DESCRIPTION
## Svelte 5 rewrite

On discord a user was asking about how to get the css in svelte 5, this is just making the docs a bit more explicit about how to use the `render` api to do it.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
