### PR TITLE
fix: correctly migrate sequence expressions

### DIFF
--- a/.changeset/brave-candles-serve.md
+++ b/.changeset/brave-candles-serve.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly migrate sequence expressions

--- a/packages/svelte/tests/migrate/samples/derivations-no-colon/input.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations-no-colon/input.svelte
@@ -1,7 +1,0 @@
-<script>
-	let count = 0;
-	$: doubled = count * 2
-	$: ({ quadrupled } = { quadrupled: count * 4 })
-</script>
-
-{count} / {doubled} / {quadrupled}

--- a/packages/svelte/tests/migrate/samples/derivations-no-colon/output.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations-no-colon/output.svelte
@@ -1,7 +1,0 @@
-<script>
-	let count = 0;
-	let doubled = $derived(count * 2);
-	let { quadrupled } = $derived({ quadrupled: count * 4 });
-</script>
-
-{count} / {doubled} / {quadrupled}

--- a/packages/svelte/tests/migrate/samples/derivations/input.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations/input.svelte
@@ -1,7 +1,11 @@
 <script>
 	let count = 0;
+	// semicolon at the end
 	$: doubled = count * 2;
 	$: ({ quadrupled } = { quadrupled: count * 4 });
+	// no semicolon at the end
+	$: time_8 = count * 8
+	$: ({ time_16 } = { time_16: count * 16 })
 </script>
 
-{count} / {doubled} / {quadrupled}
+{count} / {doubled} / {quadrupled} / {time_8} / {time_16}

--- a/packages/svelte/tests/migrate/samples/derivations/output.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations/output.svelte
@@ -1,7 +1,11 @@
 <script>
 	let count = 0;
+	// semicolon at the end
 	let doubled = $derived(count * 2);
 	let { quadrupled } = $derived({ quadrupled: count * 4 });
+	// no semicolon at the end
+	let time_8 = $derived(count * 8)
+	let { time_16 } = $derived({ time_16: count * 16 })
 </script>
 
-{count} / {doubled} / {quadrupled}
+{count} / {doubled} / {quadrupled} / {time_8} / {time_16}

--- a/packages/svelte/tests/migrate/samples/state-and-derivations-sequence/input.svelte
+++ b/packages/svelte/tests/migrate/samples/state-and-derivations-sequence/input.svelte
@@ -1,0 +1,14 @@
+<script>
+	let count = (void 0, 0);
+	// semicolon at the end
+	$: doubled = (void 0, count * 2);
+	$: ({ quadrupled } = (void 0, { quadrupled: count * 4 }));
+	// no semicolon at the end
+	$: time_8 = (void 0, count * 8)
+	$: ({ time_16 } = (void 0, { time_16: count * 16 }))
+</script>
+
+<!-- reassign to migrate to state -->
+<button onclick={()=> count++}></button>
+
+{count} / {doubled} / {quadrupled} / {time_8} / {time_16}

--- a/packages/svelte/tests/migrate/samples/state-and-derivations-sequence/output.svelte
+++ b/packages/svelte/tests/migrate/samples/state-and-derivations-sequence/output.svelte
@@ -1,0 +1,14 @@
+<script>
+	let count = ($state((void 0, 0)));
+	// semicolon at the end
+	let doubled = ($derived((void 0, count * 2)));
+	let { quadrupled } = ($derived((void 0, { quadrupled: count * 4 })));
+	// no semicolon at the end
+	let time_8 = ($derived((void 0, count * 8)))
+	let { time_16 } = ($derived((void 0, { time_16: count * 16 })))
+</script>
+
+<!-- reassign to migrate to state -->
+<button onclick={()=> count++}></button>
+
+{count} / {doubled} / {quadrupled} / {time_8} / {time_16}

--- a/packages/svelte/tests/migrate/samples/state-and-derivations-sequence/output.svelte
+++ b/packages/svelte/tests/migrate/samples/state-and-derivations-sequence/output.svelte
@@ -1,11 +1,11 @@
 <script>
-	let count = ($state((void 0, 0)));
+	let count = $state((void 0, 0));
 	// semicolon at the end
-	let doubled = ($derived((void 0, count * 2)));
-	let { quadrupled } = ($derived((void 0, { quadrupled: count * 4 })));
+	let doubled = $derived((void 0, count * 2));
+	let { quadrupled } = $derived((void 0, { quadrupled: count * 4 }));
 	// no semicolon at the end
-	let time_8 = ($derived((void 0, count * 8)))
-	let { time_16 } = ($derived((void 0, { time_16: count * 16 })))
+	let time_8 = $derived((void 0, count * 8))
+	let { time_16 } = $derived((void 0, { time_16: count * 16 }))
 </script>
 
 <!-- reassign to migrate to state -->


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13278

While working on this i noticed that the sequence expression was a problem for `$state` too. Also while the migration correctly migrate this

```ts
$: double = (console.log(double), count * 2);
```

the resulting code will actually error at runtime because a derived is accessing himself. This however is a bit harder to migrate effectively because either we should move it to state+effect (kinda 🤮) or we should have an external non stateful variable. Regardless i think we should do this in a separate PR.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
