### PR TITLE
chore: remove unused DESTROYED check

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -612,8 +612,7 @@ function process_effects(effect, collected_effects) {
 
 	main_loop: while (current_effect !== null) {
 		var flags = current_effect.f;
-		// TODO: we probably don't need to check for destroyed as it shouldn't be encountered?
-		var is_active = (flags & (DESTROYED | INERT)) === 0;
+		var is_active = (flags & INERT) === 0;
 		var is_branch = (flags & BRANCH_EFFECT) !== 0;
 		var is_clean = (flags & CLEAN) !== 0;
 		var child = current_effect.first;
@@ -646,6 +645,7 @@ function process_effects(effect, collected_effects) {
 				}
 			}
 		}
+
 		var sibling = current_effect.next;
 
 		if (sibling === null) {


### PR DESCRIPTION
small thing while looking into #13282 — we don't encounter destroyed effects here, so we can remove the `// TODO` and just check for inertness