### PR TITLE
chore: simplify `process_effects`

### DIFF
--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -18,6 +18,7 @@ export const EFFECT_TRANSPARENT = 1 << 15;
 export const LEGACY_DERIVED_PROP = 1 << 16;
 export const INSPECT_EFFECT = 1 << 17;
 export const HEAD_EFFECT = 1 << 18;
+export const EFFECT_HAS_DIRTY_CHILDREN = 1 << 19;
 
 export const STATE_SYMBOL = Symbol('$state');
 export const STATE_SYMBOL_METADATA = Symbol('$state metadata');

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -583,17 +583,21 @@ export function schedule_effect(signal) {
 
 	var effect = signal;
 
-	while (effect.parent !== null) {
-		effect = effect.parent;
-
+	while (true) {
 		if ((effect.f & EFFECT_HAS_DIRTY_CHILDREN) !== 0) {
 			return;
 		}
 
-		effect.f |= EFFECT_HAS_DIRTY_CHILDREN;
-	}
+		var parent = effect.parent;
 
-	queued_root_effects.push(effect);
+		if (parent === null) {
+			queued_root_effects.push(effect);
+			return;
+		}
+
+		effect.f |= EFFECT_HAS_DIRTY_CHILDREN;
+		effect = parent;
+	}
 }
 
 /**
@@ -608,10 +612,6 @@ export function schedule_effect(signal) {
  * @returns {void}
  */
 function process_effects(effect, collected_effects) {
-	if ((effect.f & EFFECT_HAS_DIRTY_CHILDREN) !== 0) {
-		effect.f ^= EFFECT_HAS_DIRTY_CHILDREN;
-	}
-
 	var current_effect = effect.first;
 	var deferred = [];
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -615,7 +615,7 @@ function process_effects(effect, collected_effects) {
 	var current_effect = effect.first;
 	var deferred = [];
 
-	main_loop: while (current_effect !== null) {
+	while (current_effect !== null) {
 		var flags = current_effect.f;
 
 		var has_dirty_children = (flags & EFFECT_HAS_DIRTY_CHILDREN) !== 0;
@@ -641,22 +641,16 @@ function process_effects(effect, collected_effects) {
 			}
 		}
 
-		var sibling = current_effect.next;
+		while (current_effect !== null) {
+			var sibling = current_effect.next;
 
-		if (sibling === null) {
-			let parent = current_effect.parent;
-
-			while (parent !== null) {
-				var parent_sibling = parent.next;
-				if (parent_sibling !== null) {
-					current_effect = parent_sibling;
-					continue main_loop;
-				}
-				parent = parent.parent;
+			if (sibling) {
+				current_effect = sibling;
+				break;
 			}
-		}
 
-		current_effect = sibling;
+			current_effect = current_effect.parent;
+		}
 	}
 
 	// We might be dealing with many effects here, far more than can be spread into

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -618,10 +618,10 @@ function process_effects(effect, collected_effects) {
 	while (current_effect !== null) {
 		var flags = current_effect.f;
 
-		var has_dirty_children = (flags & EFFECT_HAS_DIRTY_CHILDREN) !== 0;
-		if (has_dirty_children) current_effect.f ^= EFFECT_HAS_DIRTY_CHILDREN;
-
 		if ((flags & INERT) === 0) {
+			var has_dirty_children = (flags & EFFECT_HAS_DIRTY_CHILDREN) !== 0;
+			if (has_dirty_children) current_effect.f ^= EFFECT_HAS_DIRTY_CHILDREN;
+
 			if (check_dirtiness(current_effect)) {
 				if ((flags & RENDER_EFFECT) !== 0) {
 					update_effect(current_effect);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -625,6 +625,7 @@ function process_effects(effect, collected_effects) {
 			if (check_dirtiness(current_effect)) {
 				if ((flags & RENDER_EFFECT) !== 0) {
 					update_effect(current_effect);
+					has_dirty_children = true;
 				} else {
 					effects.push(current_effect);
 				}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -631,8 +631,12 @@ function process_effects(effect, collected_effects) {
 			}
 
 			if (has_dirty_children) {
-				current_effect = current_effect.first;
-				continue;
+				var first = current_effect.first;
+
+				if (first) {
+					current_effect = first;
+					continue;
+				}
 			}
 		}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -647,9 +647,6 @@ function process_effects(effect, collected_effects) {
 			let parent = current_effect.parent;
 
 			while (parent !== null) {
-				if (effect === parent) {
-					break main_loop;
-				}
 				var parent_sibling = parent.next;
 				if (parent_sibling !== null) {
 					current_effect = parent_sibling;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -613,7 +613,7 @@ function process_effects(effect, collected_effects) {
 	}
 
 	var current_effect = effect.first;
-	var effects = [];
+	var deferred = [];
 
 	main_loop: while (current_effect !== null) {
 		var flags = current_effect.f;
@@ -627,7 +627,7 @@ function process_effects(effect, collected_effects) {
 					update_effect(current_effect);
 					has_dirty_children = true;
 				} else {
-					effects.push(current_effect);
+					deferred.push(current_effect);
 				}
 			}
 
@@ -661,8 +661,8 @@ function process_effects(effect, collected_effects) {
 
 	// We might be dealing with many effects here, far more than can be spread into
 	// an array push call (callstack overflow). So let's deal with each effect in a loop.
-	for (var i = 0; i < effects.length; i++) {
-		var child = effects[i];
+	for (var i = 0; i < deferred.length; i++) {
+		var child = deferred[i];
 		collected_effects.push(child);
 		process_effects(child, collected_effects);
 	}

--- a/packages/svelte/src/reactivity/map.test.ts
+++ b/packages/svelte/src/reactivity/map.test.ts
@@ -192,14 +192,14 @@ test('map handling of undefined values', () => {
 		render_effect(() => {
 			log.push(map.get(1));
 		});
+	});
 
-		flushSync(() => {
-			map.delete(1);
-		});
+	flushSync(() => {
+		map.delete(1);
+	});
 
-		flushSync(() => {
-			map.set(1, 1);
-		});
+	flushSync(() => {
+		map.set(1, 1);
 	});
 
 	assert.deepEqual(log, [undefined, undefined, 1]);
@@ -220,14 +220,14 @@ test('not invoking reactivity when value is not in the map after changes', () =>
 		render_effect(() => {
 			log.push(map.get(2));
 		});
+	});
 
-		flushSync(() => {
-			map.delete(1);
-		});
+	flushSync(() => {
+		map.delete(1);
+	});
 
-		flushSync(() => {
-			map.set(1, 1);
-		});
+	flushSync(() => {
+		map.set(1, 1);
 	});
 
 	assert.deepEqual(log, [1, undefined, undefined, undefined, 1, undefined]);

--- a/playgrounds/sandbox/vite.config.js
+++ b/playgrounds/sandbox/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
 		inspect(),
 		svelte({
 			compilerOptions: {
-				hmr: false
+				hmr: true
 			}
 		})
 	],

--- a/playgrounds/sandbox/vite.config.js
+++ b/playgrounds/sandbox/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
 		inspect(),
 		svelte({
 			compilerOptions: {
-				hmr: true
+				hmr: false
 			}
 		})
 	],


### PR DESCRIPTION
Follow-up to https://github.com/sveltejs/svelte/pull/13282#pullrequestreview-2310090630, alternative to #13282. This adds a new `EFFECT_HAS_DIRTY_CHILDREN` flag on effects which allows us to make `schedule_effect` and `process_effects` more self-explanatory.

Before, `schedule_effect` would set the `MAYBE_DIRTY` flag on branches as a proxy for 'this branch has dirty children'. But that's imperfect — it means that we only bail out when we hit a branch, and it means that branches are regarded as potentially dirty even though that's impossible (they are nodes in the effect tree, but unlike other effects they themselves do not update).

Using `MAYBE_DIRTY` as a proxy value also required some logic inside `process_effects` that candidly I am not clever enough to comprehend. The code in this PR feels a good deal simpler, at least to me.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
