### PR TITLE
fix: simplify and robustify appending styles

### DIFF
--- a/.changeset/silent-elephants-film.md
+++ b/.changeset/silent-elephants-film.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: simplify and robustify appending styles

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -386,9 +386,7 @@ export function client_component(analysis, options) {
 		state.hoisted.push(b.const('$$css', b.object([b.init('hash', hash), b.init('code', code)])));
 
 		component_block.body.unshift(
-			b.stmt(
-				b.call('$.append_styles', b.id('$$anchor'), b.id('$$css'), options.customElement && b.true)
-			)
+			b.stmt(b.call('$.append_styles', b.id('$$anchor'), b.id('$$css')))
 		);
 	}
 

--- a/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/Child.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/Child.svelte
@@ -1,10 +1,13 @@
 <svelte:options css="injected" />
 
 <script>
+	import GrandChild from "./GrandChild.svelte";
+
 	let { count } = $props();
 </script>
 
 <h1>count: {count}</h1>
+<GrandChild {count} />
 
 <style>
 	h1 {

--- a/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/GrandChild.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/GrandChild.svelte
@@ -1,0 +1,9 @@
+<svelte:options css="injected" />
+
+<h1>inner</h1>
+
+<style>
+	h1 {
+		color: blue;
+	}
+</style>

--- a/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/mount-in-iframe/_config.js
@@ -5,18 +5,20 @@ export default test({
 	async test({ target, assert }) {
 		const button = target.querySelector('button');
 		const h1 = () =>
-			/** @type {HTMLHeadingElement} */ (
+			/** @type {NodeListOf<HTMLHeadingElement>} */ (
 				/** @type {Window} */ (
 					target.querySelector('iframe')?.contentWindow
-				).document.querySelector('h1')
+				).document.querySelectorAll('h1')
 			);
 
-		assert.equal(h1().textContent, 'count: 0');
-		assert.equal(getComputedStyle(h1()).color, 'rgb(255, 0, 0)');
+		assert.equal(h1()[0].textContent, 'count: 0');
+		assert.equal(getComputedStyle(h1()[0]).color, 'rgb(255, 0, 0)');
+		assert.equal(getComputedStyle(h1()[1]).color, 'rgb(0, 0, 255)');
 
 		flushSync(() => button?.click());
 
-		assert.equal(h1().textContent, 'count: 1');
-		assert.equal(getComputedStyle(h1()).color, 'rgb(255, 0, 0)');
+		assert.equal(h1()[0].textContent, 'count: 1');
+		assert.equal(getComputedStyle(h1()[0]).color, 'rgb(255, 0, 0)');
+		assert.equal(getComputedStyle(h1()[1]).color, 'rgb(0, 0, 255)');
 	}
 });


### PR DESCRIPTION
#13225 did not fully fix the described issue: As soon as you have a child component, that child component's anchor will not be in the right ownerDocument yet, and so the logic falls down.

To fix that, we would need to move the ownerDocument check into the microtask - and that map check was mainly done to avoid just that. So instead I opted to simplify the code and just remove the map checks. According to my benchmarking (https://jsbench.me/3hm17l0bxl/1) this has no impact on performance assuming that you'll have cache hits roughly half the time - and even if you'd have much more cache hits, the performance loss is microscopic. Given that the default mode is to not inject styles, this will not be common anyway, so I favor removing that map.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
