### PR TITLE
fix: ensure component effects have the correct reaction owner

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -203,7 +203,8 @@ export function user_effect(fn) {
 		var context = /** @type {ComponentContext} */ (component_context);
 		(context.e ??= []).push({
 			fn,
-			parent: active_effect
+			effect: active_effect,
+			reaction: active_reaction
 		});
 	} else {
 		var signal = effect(fn);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -860,7 +860,7 @@ export function untrack(fn) {
 	}
 }
 
-const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN | DESTROYED);
+const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
 
 /**
  * @param {Signal} signal

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -860,7 +860,7 @@ export function untrack(fn) {
 	}
 }
 
-const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
+const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN | DESTROYED);
 
 /**
  * @param {Signal} signal
@@ -1063,15 +1063,18 @@ export function pop(component) {
 		const component_effects = context_stack_item.e;
 		if (component_effects !== null) {
 			var previous_effect = active_effect;
+			var previous_reaction = active_reaction;
 			context_stack_item.e = null;
 			try {
 				for (var i = 0; i < component_effects.length; i++) {
 					var component_effect = component_effects[i];
-					set_active_effect(component_effect.parent);
+					set_active_effect(component_effect.effect);
+					set_active_reaction(component_effect.reaction);
 					effect(component_effect.fn);
 				}
 			} finally {
 				set_active_effect(previous_effect);
+				set_active_reaction(previous_reaction);
 			}
 		}
 		component_context = context_stack_item.p;

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -1,6 +1,6 @@
 import type { Store } from '#shared';
 import { STATE_SYMBOL } from './constants.js';
-import type { Effect, Source, Value } from './reactivity/types.js';
+import type { Effect, Source, Value, Reaction } from './reactivity/types.js';
 
 type EventCallback = (event: Event) => boolean;
 export type EventCallbackMap = Record<string, EventCallback | EventCallback[]>;
@@ -15,7 +15,7 @@ export type ComponentContext = {
 	/** context */
 	c: null | Map<unknown, unknown>;
 	/** deferred effects */
-	e: null | Array<{ fn: () => void | (() => void); parent: null | Effect }>;
+	e: null | Array<{ fn: () => void | (() => void); effect: null | Effect, reaction: null | Reaction }>;
 	/** mounted */
 	m: boolean;
 	/**

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -15,7 +15,11 @@ export type ComponentContext = {
 	/** context */
 	c: null | Map<unknown, unknown>;
 	/** deferred effects */
-	e: null | Array<{ fn: () => void | (() => void); effect: null | Effect, reaction: null | Reaction }>;
+	e: null | Array<{
+		fn: () => void | (() => void);
+		effect: null | Effect;
+		reaction: null | Reaction;
+	}>;
 	/** mounted */
 	m: boolean;
 	/**


### PR DESCRIPTION
I missed this on my PR that added the effect parent to the deferred component effects, meaning the owner if a derived was never being connected to the effect. I don't believe this fixes anything standalone, but it's the correct thing to do given how the internal mechanics around ownership work.