### PR TITLE
chore: create effect root for custom element

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -1,5 +1,5 @@
 import { createClassComponent } from '../../../../legacy/legacy-client.js';
-import { destroy_effect, render_effect } from '../../reactivity/effects.js';
+import { destroy_effect, effect_root, render_effect } from '../../reactivity/effects.js';
 import { append } from '../template.js';
 import { define_property, get_descriptor, object_keys } from '../../../shared/utils.js';
 
@@ -145,24 +145,26 @@ if (typeof HTMLElement === 'function') {
 				});
 
 				// Reflect component props as attributes
-				this.$$me = render_effect(() => {
-					this.$$r = true;
-					for (const key of object_keys(this.$$c)) {
-						if (!this.$$p_d[key]?.reflect) continue;
-						this.$$d[key] = this.$$c[key];
-						const attribute_value = get_custom_element_value(
-							key,
-							this.$$d[key],
-							this.$$p_d,
-							'toAttribute'
-						);
-						if (attribute_value == null) {
-							this.removeAttribute(this.$$p_d[key].attribute || key);
-						} else {
-							this.setAttribute(this.$$p_d[key].attribute || key, attribute_value);
+				this.$$me = effect_root(() => {
+					render_effect(() => {
+						this.$$r = true;
+						for (const key of object_keys(this.$$c)) {
+							if (!this.$$p_d[key]?.reflect) continue;
+							this.$$d[key] = this.$$c[key];
+							const attribute_value = get_custom_element_value(
+								key,
+								this.$$d[key],
+								this.$$p_d,
+								'toAttribute'
+							);
+							if (attribute_value == null) {
+								this.removeAttribute(this.$$p_d[key].attribute || key);
+							} else {
+								this.setAttribute(this.$$p_d[key].attribute || key, attribute_value);
+							}
 						}
-					}
-					this.$$r = false;
+						this.$$r = false;
+					});
 				});
 
 				for (const type in this.$$l) {
@@ -196,7 +198,7 @@ if (typeof HTMLElement === 'function') {
 			Promise.resolve().then(() => {
 				if (!this.$$cn && this.$$c) {
 					this.$$c.$destroy();
-					destroy_effect(this.$$me);
+					this.$$me();
 					this.$$c = undefined;
 				}
 			});

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -516,16 +516,11 @@ function flush_queued_root_effects(root_effects) {
 				effect.f ^= EFFECT_QUEUED;
 			}
 
-			// When working with custom elements, the root effects might not have a root
-			if (effect.first === null && (effect.f & BRANCH_EFFECT) === 0) {
-				flush_queued_effects([effect]);
-			} else {
-				/** @type {Effect[]} */
-				var collected_effects = [];
+			/** @type {Effect[]} */
+			var collected_effects = [];
 
-				process_effects(effect, collected_effects);
-				flush_queued_effects(collected_effects);
-			}
+			process_effects(effect, collected_effects);
+			flush_queued_effects(collected_effects);
 		}
 	} finally {
 		is_flushing_effect = previously_flushing_effect;


### PR DESCRIPTION
An opportunity created by #13309 — if we create an effect root inside custom elements (which seems like the more correct thing to do anyway) then we can simplify `flush_queued_root_effects`.

Tests will fail until #13309 is merged

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
