### PR TITLE
feat: better `flip` animations

### DIFF
--- a/.changeset/cold-socks-learn.md
+++ b/.changeset/cold-socks-learn.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+feat: account for `zoom` when calculating animation transforms

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -13,10 +13,13 @@ import { cubicOut } from '../easing/index.js';
  */
 export function flip(node, { from, to }, params = {}) {
 	const style = getComputedStyle(node);
+	// need to account for scaled vs unscaled lengths (https://drafts.csswg.org/css-viewport/#scaled).
+	const dsx = from.width / parseFloat(style.width);
+	const dsy = from.height / parseFloat(style.height);
 	const transform = style.transform === 'none' ? '' : style.transform;
 	const [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
-	const dx = from.left + (from.width * ox) / to.width - (to.left + ox);
-	const dy = from.top + (from.height * oy) / to.height - (to.top + oy);
+	const dx = (from.left + (from.width * ox) / to.width - (to.left + ox)) / dsx;
+	const dy = (from.top + (from.height * oy) / to.height - (to.top + oy)) / dsy;
 	const { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
 	return {
 		delay,

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -13,14 +13,14 @@ import { cubicOut } from '../easing/index.js';
  */
 export function flip(node, { from, to }, params = {}) {
 	const style = getComputedStyle(node);
-	// need to account for scaled vs unscaled lengths (https://drafts.csswg.org/css-viewport/#scaled).
-	const dsx = from.width / parseFloat(style.width);
-	const dsy = from.height / parseFloat(style.height);
+
+	const zoom = from.width / parseFloat(style.width); // https://drafts.csswg.org/css-viewport/#effective-zoom
 	const transform = style.transform === 'none' ? '' : style.transform;
 	const [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
-	const dx = (from.left + (from.width * ox) / to.width - (to.left + ox)) / dsx;
-	const dy = (from.top + (from.height * oy) / to.height - (to.top + oy)) / dsy;
+	const dx = (from.left + (from.width * ox) / to.width - (to.left + ox)) / zoom;
+	const dy = (from.top + (from.height * oy) / to.height - (to.top + oy)) / zoom;
 	const { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
+
 	return {
 		delay,
 		duration: typeof duration === 'function' ? duration(Math.sqrt(dx * dx + dy * dy)) : duration,

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -13,12 +13,13 @@ import { cubicOut } from '../easing/index.js';
  */
 export function flip(node, { from, to }, params = {}) {
 	var style = getComputedStyle(node);
+	var zoom = get_zoom(node); // https://drafts.csswg.org/css-viewport/#effective-zoom
 
-	var zoom = from.width / parseFloat(style.width); // https://drafts.csswg.org/css-viewport/#effective-zoom
 	var transform = style.transform === 'none' ? '' : style.transform;
 	var [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
 	var dsx = from.width / to.width;
 	var dsy = from.height / to.height;
+
 	var dx = (from.left + dsx * ox - (to.left + ox)) / zoom;
 	var dy = (from.top + dsy * oy - (to.top + oy)) / zoom;
 	var { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
@@ -35,4 +36,24 @@ export function flip(node, { from, to }, params = {}) {
 			return `transform: ${transform} scale(${sx}, ${sy}) translate(${x}px, ${y}px);`;
 		}
 	};
+}
+
+/**
+ * @param {Element} element
+ */
+function get_zoom(element) {
+	if ('currentCSSZoom' in element) {
+		return /** @type {number} */ (element.currentCSSZoom);
+	}
+
+	/** @type {Element | null} */
+	var current = element;
+	var zoom = 1;
+
+	while (current !== null) {
+		zoom *= +getComputedStyle(current).zoom;
+		current = /** @type {Element | null} */ (current.parentNode);
+	}
+
+	return zoom;
 }

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -17,8 +17,10 @@ export function flip(node, { from, to }, params = {}) {
 	const zoom = from.width / parseFloat(style.width); // https://drafts.csswg.org/css-viewport/#effective-zoom
 	const transform = style.transform === 'none' ? '' : style.transform;
 	const [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
-	const dx = (from.left + (from.width * ox) / to.width - (to.left + ox)) / zoom;
-	const dy = (from.top + (from.height * oy) / to.height - (to.top + oy)) / zoom;
+	const dsx = from.width / to.width;
+	const dsy = from.height / to.height;
+	const dx = (from.left + dsx * ox - (to.left + ox)) / zoom;
+	const dy = (from.top + dsy * oy - (to.top + oy)) / zoom;
 	const { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
 
 	return {
@@ -28,8 +30,8 @@ export function flip(node, { from, to }, params = {}) {
 		css: (t, u) => {
 			const x = u * dx;
 			const y = u * dy;
-			const sx = t + (u * from.width) / to.width;
-			const sy = t + (u * from.height) / to.height;
+			const sx = t + u * dsx;
+			const sy = t + u * dsy;
 			return `transform: ${transform} translate(${x}px, ${y}px) scale(${sx}, ${sy});`;
 		}
 	};

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -12,26 +12,26 @@ import { cubicOut } from '../easing/index.js';
  * @returns {AnimationConfig}
  */
 export function flip(node, { from, to }, params = {}) {
-	const style = getComputedStyle(node);
+	var style = getComputedStyle(node);
 
-	const zoom = from.width / parseFloat(style.width); // https://drafts.csswg.org/css-viewport/#effective-zoom
-	const transform = style.transform === 'none' ? '' : style.transform;
-	const [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
-	const dsx = from.width / to.width;
-	const dsy = from.height / to.height;
-	const dx = (from.left + dsx * ox - (to.left + ox)) / zoom;
-	const dy = (from.top + dsy * oy - (to.top + oy)) / zoom;
-	const { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
+	var zoom = from.width / parseFloat(style.width); // https://drafts.csswg.org/css-viewport/#effective-zoom
+	var transform = style.transform === 'none' ? '' : style.transform;
+	var [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
+	var dsx = from.width / to.width;
+	var dsy = from.height / to.height;
+	var dx = (from.left + dsx * ox - (to.left + ox)) / zoom;
+	var dy = (from.top + dsy * oy - (to.top + oy)) / zoom;
+	var { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
 
 	return {
 		delay,
 		duration: typeof duration === 'function' ? duration(Math.sqrt(dx * dx + dy * dy)) : duration,
 		easing,
 		css: (t, u) => {
-			const x = u * dx;
-			const y = u * dy;
-			const sx = t + u * dsx;
-			const sy = t + u * dsy;
+			var x = u * dx;
+			var y = u * dy;
+			var sx = t + u * dsx;
+			var sy = t + u * dsy;
 			return `transform: ${transform} translate(${x}px, ${y}px) scale(${sx}, ${sy});`;
 		}
 	};

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -32,7 +32,7 @@ export function flip(node, { from, to }, params = {}) {
 			var y = u * dy;
 			var sx = t + u * dsx;
 			var sy = t + u * dsy;
-			return `transform: ${transform} translate(${x}px, ${y}px) scale(${sx}, ${sy});`;
+			return `transform: ${transform} scale(${sx}, ${sy}) translate(${x}px, ${y}px);`;
 		}
 	};
 }


### PR DESCRIPTION
Continuation of #13107. I've tried so far in vain to solve the Firefox bugs, and will likely admit defeat since it's a real edge case.

It turns out we can't infer the effective zoom level from `style.width` relative to the bounding client rect, because of CSS transforms. Instead we need to read `element.currentCSSZoom` or — in Safari, which doesn't support it — calculate it manually by walking up the DOM.

I did find [some other issues](https://svelte-5-preview-git-better-flip-svelte.vercel.app/#H4sIAAAAAAAAE4WU3Y6bMBCFX2VKKwFVAiTZVSUCkfoAfYLNXjjGBGuNbdlD2hTx7pX5y6ZIyZUHn-_MwIxN65VcMOulb60nSc281Puptbfy8Krdg70wgcxbeVY1hrqdzFLDNR6O8oi81sogtFAKrqGD0qga_METE8lrgszfH6VjBUMQDJEZCzl8s0iQBT450YL5kdWCY-D7Ybif2L9K1TcQTcPCMVPZSIpcSbBVU5aCBSG0bn_wccinOpFg8ozVfhB_V1wwCPh6PfNHpEpaBAM5_CJYRaVQygR9aIgsVB2E8B14uL_nsda3Km_mfZZvW590vtS507HWo9C5pTvKLL41V2anBlFJUJIKTj_yNgghP0AwNuaLW8PugOp8FqxvVxYPlkf2uWfdHMO9rzIQD1HBL0AFsTZ12fuJt18ZodU8SGLHEIJhDbvhizKriRzMeTtIHYwnInWnJW9bKBpD3CBT2CZJsoKCCXJNIYGuO0ymLHaZhtqxq923qeCX4RUtXgXr1b7gONeCW92n4lJwydYnoejHfmzyBKcSqzWtuCiCzXwiLCWCpZBErw_w7RL_8Yjf_c9vHsAvCzjaPkr-uuTv8IhMOhoibalMnUIfCnexkhUk4R1_esZvEv3n3kKfWbYLS_HMsltY2DPLy8LS35XR5eIUdpOexdPZ8VZerQpeclZ4qfvRdO_dP0dvoDAYBQAA) relating to existing transforms, which get particularly fun to think about when there are individual `scale`/`translate` rules in addition to `transform` ones.

It _may_ be better to worry about these details later, and at least release the improvements so far...

- [current](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAE21SS47bMAy9CusWcFJMPmh3thOgB-gJkiwUWYqJkSVDoqdIDd29ouVJpmgXIkWRj59HTYVGo0JRnabCil4VVfFjGIqXgu4DG-FNGVLJDm70kl-aID0OdDzbM2E_OE8wgTY4QATtXQ9lxuyExV6QKmuO5GMUQTqkfIADfAmUvKtTKcoXKK8sJIuWhWKhWdxYdCywvKzr9zy_Xar0SKKFCWp2JrcerSR0FkI3am3Uag3T3MIMxIRamtgaZW_U5f7oV5eIgBVuNo_4M0lnA4FPmJ-Cuq02zvnVfPXCtq5Pub8Cruu_46kfnlVO_vJwP58--PFfP7I_ZVkckVUSze7JvW2uI1Ga0llpUL4eptTL4fhOzCfW8UjudktTsdHsMuD_4IWrOK91MbjgR0zns27xDaQRIVScd0ZMn5WQ3WO7IixXWGW9jnmSJgzCwvIzKv41h2mCdvSCN1bBt_1-DzEepwyLaeIEyCV2XGJmITWQOwl0Nyq3zHmXtbUYBiPuFaA1aNXmapx8rRcOWW1nkpZovlfwvX5yPCdNX753LWpUbVGRH1W8xD9v4-ynLQMAAA==)
- [this PR](https://svelte-5-preview-git-better-flip-svelte.vercel.app/#H4sIAAAAAAAAE21SS47bMAy9CusWcFJMPmh3thOgB-gJkiwUWYqJkSVDoqdIDd29ouVJpmgXIkWRj59HTYVGo0JRnabCil4VVfFjGIqXgu4DG-FNGVLJDm70kl-aID0OdDzbM2E_OE8wgTY4QATtXQ9lxuyExV6QKmuO5GMUQTqkfIADfAmUvKtTKcoXKK8sJIuWhWKhWdxYdCywvKzr9zy_Xar0SKKFCWp2JrcerSR0FkI3am3Uag3T3MIMxIRamtgaZW_U5f7oV5eIgBVuNo_4M0lnA4FPmJ-Cuq02zvnVfPXCtq5Pub8Cruu_46kfnlVO_vJwP58--PFfP7I_ZVkckVUSze7JvW2uI1Ga0llpUL4eptTL4fhOzCfW8UjudktTsdHsMuD_4IWrOK91MbjgR0zns27xDaQRIVScd0ZMn5WQ3WO7IixXWGW9jnmSJgzCwvIzKv41h2mCdvSCN1bBt_1-DzEepwyLaeIEyCV2XGJmITWQOwl0Nyq3zHmXtbUYBiPuFaA1aNXmapx8rRcOWW1nkpZovlfwvX5yPCdNX753LWpUbVGRH1W8xD9v4-ynLQMAAA==)

...but for now I'll leave this here in draft mode.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
