### PR TITLE
fix: keep bound inputs in sync in runes mode

### DIFF
--- a/.changeset/brown-pens-repeat.md
+++ b/.changeset/brown-pens-repeat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep bound inputs in sync in runes mode

--- a/packages/svelte/tests/runtime-runes/samples/bind-value-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-value-state/_config.js
@@ -1,0 +1,27 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<input type="number"><div>0</div>`,
+	mode: ['client', 'hydrate'],
+
+	async test({ assert, target }) {
+		const [input1] = target.querySelectorAll('input');
+		assert.equal(input1.value, '0');
+
+		input1.value = '1';
+		input1.dispatchEvent(new window.InputEvent('input'));
+
+		flushSync();
+
+		assert.equal(input1.value, '1');
+		assert.htmlEqual(target.innerHTML, `<input type="number"><div>1</div>`);
+
+		input1.value = '101';
+		input1.dispatchEvent(new window.InputEvent('input'));
+		flushSync();
+
+		assert.equal(input1.value, '100');
+		assert.htmlEqual(target.innerHTML, `<input type="number"><div>100</div>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bind-value-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-value-state/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	let v = $state(0)
+	let count = {
+		get v() { return v },
+		set v(x) { {
+			v = Math.min(100, +x)
+		}},
+	};
+</script>
+<input bind:value={count.v} type="number">
+<div>{count.v}</div>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13326.