### PR TITLE
fix: silence snapshot warnings inside `$inspect`

### DIFF
--- a/.changeset/unlucky-spies-flow.md
+++ b/.changeset/unlucky-spies-flow.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: silence snapshot warnings inside `$inspect`

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -12,7 +12,7 @@ export function inspect(get_value, inspector = console.log) {
 	let initial = true;
 
 	inspect_effect(() => {
-		inspector(initial ? 'init' : 'update', ...snapshot(get_value()));
+		inspector(initial ? 'init' : 'update', ...snapshot(get_value(), true));
 		initial = false;
 	});
 }


### PR DESCRIPTION
It's not really actionable and also confusing because the user doesn't see `$state.snapshot` anywhere in their code

Came up in https://discord.com/channels/457912077277855764/1153350350158450758/1286319132639363193
