### PR TITLE
fix: add bindings generic to legacy class component

### DIFF
--- a/.changeset/light-items-cry.md
+++ b/.changeset/light-items-cry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add bindings generic to legacy class component for backwards compat

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -44,7 +44,8 @@ type Properties<Props, Slots> = Props &
 export class SvelteComponent<
 	Props extends Record<string, any> = Record<string, any>,
 	Events extends Record<string, any> = any,
-	Slots extends Record<string, any> = any
+	Slots extends Record<string, any> = any,
+	Bindings extends string = string
 > {
 	/** The custom element version of the component. Only present if compiled with the `customElement` compiler option */
 	static element?: typeof HTMLElement;
@@ -79,7 +80,7 @@ export class SvelteComponent<
 	 * Does not exist at runtime.
 	 * ### DO NOT USE!
 	 */
-	$$bindings?: string;
+	$$bindings?: Bindings;
 
 	/**
 	 * @deprecated This method only exists when using one of the legacy compatibility helpers, which
@@ -176,8 +177,9 @@ export interface Component<
 export class SvelteComponentTyped<
 	Props extends Record<string, any> = Record<string, any>,
 	Events extends Record<string, any> = any,
-	Slots extends Record<string, any> = any
-> extends SvelteComponent<Props, Events, Slots> {}
+	Slots extends Record<string, any> = any,
+	Bindings extends string = string
+> extends SvelteComponent<Props, Events, Slots, Bindings> {}
 
 /**
  * @deprecated The new `Component` type does not have a dedicated Events type. Use `ComponentProps` instead.

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -41,7 +41,8 @@ declare module 'svelte' {
 	export class SvelteComponent<
 		Props extends Record<string, any> = Record<string, any>,
 		Events extends Record<string, any> = any,
-		Slots extends Record<string, any> = any
+		Slots extends Record<string, any> = any,
+		Bindings extends string = string
 	> {
 		/** The custom element version of the component. Only present if compiled with the `customElement` compiler option */
 		static element?: typeof HTMLElement;
@@ -76,7 +77,7 @@ declare module 'svelte' {
 		 * Does not exist at runtime.
 		 * ### DO NOT USE!
 		 */
-		$$bindings?: string;
+		$$bindings?: Bindings;
 
 		/**
 		 * @deprecated This method only exists when using one of the legacy compatibility helpers, which
@@ -173,8 +174,9 @@ declare module 'svelte' {
 	export class SvelteComponentTyped<
 		Props extends Record<string, any> = Record<string, any>,
 		Events extends Record<string, any> = any,
-		Slots extends Record<string, any> = any
-	> extends SvelteComponent<Props, Events, Slots> {}
+		Slots extends Record<string, any> = any,
+		Bindings extends string = string
+	> extends SvelteComponent<Props, Events, Slots, Bindings> {}
 
 	/**
 	 * @deprecated The new `Component` type does not have a dedicated Events type. Use `ComponentProps` instead.


### PR DESCRIPTION
This is needed for backwards/forwards compatibility: language tools will for the foreseeable future transform components using the new type to the class component type. To keep having an error on invalid bindings, we therefore need to enhance the legacy class component to optionally accept a binding type.
