### PR TITLE
fix: only set attribute as property if element has setter

### DIFF
--- a/.changeset/beige-clocks-notice.md
+++ b/.changeset/beige-clocks-notice.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only set attribute as property if element has setter

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -113,7 +113,7 @@ export function set_attribute(element, attribute, value, skip_warning) {
 
 	if (value == null) {
 		element.removeAttribute(attribute);
-	} else if (attribute in element && typeof value !== 'string') {
+	} else if (typeof value !== 'string' && get_setters(element).includes(attribute)) {
 		// @ts-ignore
 		element[attribute] = value;
 	} else {


### PR DESCRIPTION
I, err... broke the site. Turns out some elements (e.g. `<svg>`) have getter-only properties, and trying to set them as properties instead of attributes causes a crash. This fixes it. There's no test, because JSDOM appears to behave different than browsers.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
