### PR TITLE
track assignment locations for infinite loop reporting

### DIFF
--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -42,7 +42,9 @@
 
 ## effect_update_depth_exceeded
 
-> Maximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops
+> Maximum update depth exceeded. This usually indicates state is being updated inside an effect, which you should avoid. Svelte limits the number of nested updates to prevent infinite loops
+
+> Maximum update depth exceeded after assignment at %location%. This usually indicates state is being updated inside an effect that also depends on that state. Svelte limits the number of nested updates to prevent infinite loops
 
 ## hydration_failed
 

--- a/packages/svelte/src/internal/client/dev/assignment-stack.js
+++ b/packages/svelte/src/internal/client/dev/assignment-stack.js
@@ -1,0 +1,9 @@
+/** @type {string[]} */
+export const assignment_stack = [];
+
+/**
+ * @param {string} location
+ */
+export function track_assignment(location) {
+	assignment_stack.push(location);
+}

--- a/packages/svelte/src/internal/client/dev/utils.js
+++ b/packages/svelte/src/internal/client/dev/utils.js
@@ -1,0 +1,7 @@
+/**
+ * Append zero-width space to '/' characters to prevent devtools trying to make locations clickable
+ * @param {string} location
+ */
+export function sanitize_location(location) {
+	return location?.replace(/\//g, '/\u200b');
+}

--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -9,6 +9,7 @@ import { hash } from '../../../../utils.js';
 import { DEV } from 'esm-env';
 import { dev_current_component_function } from '../../runtime.js';
 import { get_first_child, get_next_sibling } from '../operations.js';
+import { sanitize_location } from '../../dev/utils.js';
 
 /**
  * @param {Element} element
@@ -28,9 +29,7 @@ function check_hash(element, server_hash, value) {
 		location = `in ${dev_current_component_function[FILENAME]}`;
 	}
 
-	w.hydration_html_changed(
-		location?.replace(/\//g, '/\u200b') // prevent devtools trying to make it a clickable link by inserting a zero-width space
-	);
+	w.hydration_html_changed(location && sanitize_location(location));
 }
 
 /**

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -179,12 +179,13 @@ export function effect_orphan(rune) {
 }
 
 /**
- * Maximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops
+ * Maximum update depth exceeded after assignment at %location%. This usually indicates state is being updated inside an effect that also depends on that state. Svelte limits the number of nested updates to prevent infinite loops
+ * @param {string | undefined | null} [location]
  * @returns {never}
  */
-export function effect_update_depth_exceeded() {
+export function effect_update_depth_exceeded(location) {
 	if (DEV) {
-		const error = new Error(`effect_update_depth_exceeded\nMaximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops`);
+		const error = new Error(`effect_update_depth_exceeded\n${location ? `Maximum update depth exceeded after assignment at ${location}. This usually indicates state is being updated inside an effect that also depends on that state. Svelte limits the number of nested updates to prevent infinite loops` : "Maximum update depth exceeded. This usually indicates state is being updated inside an effect, which you should avoid. Svelte limits the number of nested updates to prevent infinite loops"}`);
 
 		error.name = 'Svelte error';
 		throw error;

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -1,4 +1,5 @@
 export { FILENAME, HMR } from '../../constants.js';
+export { track_assignment } from './dev/assignment-stack.js';
 export { cleanup_styles } from './dev/css.js';
 export { add_locations } from './dev/elements.js';
 export { hmr } from './dev/hmr.js';

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -31,6 +31,8 @@ import { update_derived } from './reactivity/deriveds.js';
 import * as e from './errors.js';
 import { lifecycle_outside_component } from '../shared/errors.js';
 import { FILENAME } from '../../constants.js';
+import { assignment_stack } from './dev/assignment-stack.js';
+import { sanitize_location } from './dev/utils.js';
 
 const FLUSH_MICROTASK = 0;
 const FLUSH_SYNC = 1;
@@ -62,8 +64,7 @@ export function set_is_destroying_effect(value) {
 let queued_root_effects = [];
 
 let flush_count = 0;
-/** @type {Effect[]} Stack of effects, dev only */
-let dev_effect_stack = [];
+
 // Handle signal reactivity tree dependencies and reactions
 
 /** @type {null | Reaction} */
@@ -451,10 +452,6 @@ export function update_effect(effect) {
 		var teardown = update_reaction(effect);
 		effect.teardown = typeof teardown === 'function' ? teardown : null;
 		effect.version = current_version;
-
-		if (DEV) {
-			dev_effect_stack.push(effect);
-		}
 	} catch (error) {
 		handle_error(/** @type {Error} */ (error), effect, previous_component_context);
 	} finally {
@@ -471,20 +468,12 @@ function infinite_loop_guard() {
 	if (flush_count > 1000) {
 		flush_count = 0;
 		if (DEV) {
+			let location = assignment_stack.pop();
+
 			try {
-				e.effect_update_depth_exceeded();
-			} catch (error) {
-				// stack is garbage, ignore. Instead add a console.error message.
-				define_property(error, 'stack', {
-					value: ''
-				});
-				// eslint-disable-next-line no-console
-				console.error(
-					'Last ten effects were: ',
-					dev_effect_stack.slice(-10).map((d) => d.fn)
-				);
-				dev_effect_stack = [];
-				throw error;
+				e.effect_update_depth_exceeded(location && sanitize_location(location));
+			} finally {
+				assignment_stack.length = 0;
 			}
 		} else {
 			e.effect_update_depth_exceeded();
@@ -560,16 +549,13 @@ function flush_queued_effects(effects) {
 
 function process_deferred() {
 	is_micro_task_queued = false;
-	if (flush_count > 1001) {
-		return;
-	}
 	const previous_queued_root_effects = queued_root_effects;
 	queued_root_effects = [];
 	flush_queued_root_effects(previous_queued_root_effects);
 	if (!is_micro_task_queued) {
 		flush_count = 0;
 		if (DEV) {
-			dev_effect_stack = [];
+			assignment_stack.length = 0;
 		}
 	}
 }
@@ -701,7 +687,7 @@ export function flush_sync(fn) {
 
 		flush_count = 0;
 		if (DEV) {
-			dev_effect_stack = [];
+			assignment_stack.length = 0;
 		}
 
 		return result;


### PR DESCRIPTION
An idea to close #13256. I haven't completely worked out if I like it or not.

Basically, it's tricky to add location information to effects, because sometimes template effects are grouped together (and the assignment that causes the infinite loop could be in a `<span>{n++}</span>` or whatever). But we can add location information for the assignments that _cause_ the infinite loops, which gives us more granular information:

<img width="677" alt="image" src="https://github.com/user-attachments/assets/494c1847-6e8e-4e54-85ca-7670204fca18">

Caveats:

- it can't track assignments that happen outside `.svelte`/`.svelte.js` files (though it fails gracefully in these cases)
- it doesn't (yet?) track array mutations or e.g. `Object.assign(...)` or `set.add(blah)`
- right now it just reports the most recent assignment, maybe that's insufficient

Notwithstanding those caveats, [I kinda prefer this](https://svelte-5-preview-git-gh-13256-svelte.vercel.app/#H4sIAAAAAAAAE3VPSwrCMBC9SgguWhTUbWwLnsO6qOkEgukkJBNBQu5u0oKuXL7vvElcaQOBi1viOC3ABb86xw-c3q6C8AJDUHCw0cvKdEF67WgYcSQDxKSNSKxnu0ATQXNqL0UpmoooSVtkGqWHBZCalqWqjLRl9j07VzPlLbEDpUBSU3z98M9a67vjbwN2j0hUzliURstnn7738rpxZYNgaW3KNb0lhvLVYmetNMxckI-Q7_kDKjK4UxABAAA=) to what we have currently.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
