### PR TITLE
chore: refactor `RegularElement` visitor

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -83,7 +83,7 @@ export function RegularElement(node, context) {
 	/** @type {AST.StyleDirective[]} */
 	const style_directives = [];
 
-	/** @type {Array<AST.AnimateDirective | AST.BindDirective | AST.OnDirective | AST.TransitionDirective | AST.UseDirective} */
+	/** @type {Array<AST.AnimateDirective | AST.BindDirective | AST.OnDirective | AST.TransitionDirective | AST.UseDirective>} */
 	const other_directives = [];
 
 	/** @type {ExpressionStatement[]} */

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -277,7 +277,7 @@ export function RegularElement(node, context) {
 
 	context.state.template.push('>');
 
-	const child_metadata = {
+	const metadata = {
 		...context.state.metadata,
 		namespace: determine_namespace_for_children(node, context.state.metadata.namespace)
 	};
@@ -290,14 +290,14 @@ export function RegularElement(node, context) {
 			(contenteditable.value === true ||
 				(is_text_attribute(contenteditable) && contenteditable.value[0].data === 'true'))
 		) {
-			child_metadata.bound_contenteditable = true;
+			metadata.bound_contenteditable = true;
 		}
 	}
 
 	/** @type {ComponentClientTransformState} */
 	const state = {
 		...context.state,
-		metadata: child_metadata,
+		metadata,
 		locations: [],
 		scope: /** @type {Scope} */ (context.state.scopes.get(node.fragment)),
 		preserve_whitespace:
@@ -308,7 +308,7 @@ export function RegularElement(node, context) {
 		node,
 		node.fragment.nodes,
 		context.path,
-		child_metadata.namespace,
+		state.metadata.namespace,
 		state,
 		node.name === 'script' || state.preserve_whitespace,
 		state.options.preserveComments

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -58,6 +58,16 @@ export function RegularElement(node, context) {
 		return;
 	}
 
+	const is_custom_element = is_custom_element_node(node);
+
+	if (is_custom_element) {
+		// cloneNode is faster, but it does not instantiate the underlying class of the
+		// custom element until the template is connected to the dom, which would
+		// cause problems when setting properties on the custom element.
+		// Therefore we need to use importNode instead, which doesn't have this caveat.
+		context.state.metadata.context.template_needs_import_node = true;
+	}
+
 	if (node.name === 'script') {
 		context.state.metadata.context.template_contains_script_tag = true;
 	}
@@ -78,16 +88,6 @@ export function RegularElement(node, context) {
 
 	/** @type {ExpressionStatement[]} */
 	const lets = [];
-
-	const is_custom_element = is_custom_element_node(node);
-
-	if (is_custom_element) {
-		// cloneNode is faster, but it does not instantiate the underlying class of the
-		// custom element until the template is connected to the dom, which would
-		// cause problems when setting properties on the custom element.
-		// Therefore we need to use importNode instead, which doesn't have this caveat.
-		context.state.metadata.context.template_needs_import_node = true;
-	}
 
 	/** @type {Map<string, AST.Attribute>} */
 	const lookup = new Map();

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -89,8 +89,6 @@ export function RegularElement(node, context) {
 	let value_binding = null;
 
 	let is_content_editable = false;
-	let has_direction_attribute = false;
-	let has_style_attribute = false;
 
 	if (is_custom_element) {
 		// cloneNode is faster, but it does not instantiate the underlying class of the
@@ -117,12 +115,6 @@ export function RegularElement(node, context) {
 		if (attribute.type === 'Attribute') {
 			names.add(attribute.name);
 
-			if (attribute.name === 'dir') {
-				has_direction_attribute = true;
-			}
-			if (attribute.name === 'style') {
-				has_style_attribute = true;
-			}
 			if (
 				(attribute.name === 'value' || attribute.name === 'checked') &&
 				!is_text_attribute(attribute)
@@ -275,7 +267,7 @@ export function RegularElement(node, context) {
 		node_id,
 		context,
 		is_attributes_reactive,
-		has_style_attribute || node.metadata.has_spread
+		names.has('style') || node.metadata.has_spread
 	);
 
 	if (
@@ -380,7 +372,7 @@ export function RegularElement(node, context) {
 		context.state.after_update.push(...child_state.after_update);
 	}
 
-	if (has_direction_attribute) {
+	if (names.has('dir')) {
 		// This fixes an issue with Chromium where updates to text content within an element
 		// does not update the direction when set to auto. If we just re-assign the dir, this fixes it.
 		const dir = b.member(node_id, 'dir');

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -294,14 +294,11 @@ export function RegularElement(node, context) {
 
 	context.state.template.push('>');
 
-	/** @type {SourceLocation[]} */
-	const child_locations = [];
-
 	/** @type {ComponentClientTransformState} */
 	const state = {
 		...context.state,
 		metadata: child_metadata,
-		locations: child_locations,
+		locations: [],
 		scope: /** @type {Scope} */ (context.state.scopes.get(node.fragment)),
 		preserve_whitespace:
 			context.state.preserve_whitespace || node.name === 'pre' || node.name === 'textarea'
@@ -391,9 +388,9 @@ export function RegularElement(node, context) {
 		context.state.update.push(b.stmt(b.assignment('=', dir, dir)));
 	}
 
-	if (child_locations.length > 0) {
+	if (state.locations.length > 0) {
 		// @ts-expect-error
-		location.push(child_locations);
+		location.push(state.locations);
 	}
 
 	if (!is_void(node.name)) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -314,9 +314,6 @@ export function RegularElement(node, context) {
 		state.options.preserveComments
 	);
 
-	/** Whether or not we need to wrap the children in `{...}` to avoid declaration conflicts */
-	const has_declaration = node.fragment.nodes.some((node) => node.type === 'SnippetBlock');
-
 	/** @type {typeof state} */
 	const child_state = { ...state, init: [], update: [], after_update: [] };
 
@@ -367,7 +364,8 @@ export function RegularElement(node, context) {
 		}
 	}
 
-	if (has_declaration) {
+	if (node.fragment.nodes.some((node) => node.type === 'SnippetBlock')) {
+		// Wrap children in `{...}` to avoid declaration conflicts
 		context.state.init.push(
 			b.block([
 				...child_state.init,

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -62,11 +62,6 @@ export function RegularElement(node, context) {
 		context.state.metadata.context.template_contains_script_tag = true;
 	}
 
-	const child_metadata = {
-		...context.state.metadata,
-		namespace: determine_namespace_for_children(node, context.state.metadata.namespace)
-	};
-
 	context.state.template.push(`<${node.name}`);
 
 	/** @type {Array<AST.Attribute | AST.SpreadAttribute>} */
@@ -161,18 +156,6 @@ export function RegularElement(node, context) {
 			);
 		} else {
 			context.visit(attribute);
-		}
-	}
-
-	if (bindings.has('innerHTML') || bindings.has('innerText') || bindings.has('textContent')) {
-		const contenteditable = lookup.get('contenteditable');
-
-		if (
-			contenteditable &&
-			(contenteditable.value === true ||
-				(is_text_attribute(contenteditable) && contenteditable.value[0].data === 'true'))
-		) {
-			child_metadata.bound_contenteditable = true;
 		}
 	}
 
@@ -293,6 +276,23 @@ export function RegularElement(node, context) {
 	}
 
 	context.state.template.push('>');
+
+	const child_metadata = {
+		...context.state.metadata,
+		namespace: determine_namespace_for_children(node, context.state.metadata.namespace)
+	};
+
+	if (bindings.has('innerHTML') || bindings.has('innerText') || bindings.has('textContent')) {
+		const contenteditable = lookup.get('contenteditable');
+
+		if (
+			contenteditable &&
+			(contenteditable.value === true ||
+				(is_text_attribute(contenteditable) && contenteditable.value[0].data === 'true'))
+		) {
+			child_metadata.bound_contenteditable = true;
+		}
+	}
 
 	/** @type {ComponentClientTransformState} */
 	const state = {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -105,9 +105,8 @@ export function RegularElement(node, context) {
 
 	for (const attribute of node.attributes) {
 		switch (attribute.type) {
-			case 'SpreadAttribute':
-				attributes.push(attribute);
-				has_spread = true;
+			case 'AnimateDirective':
+				other_directives.push(attribute);
 				break;
 
 			case 'Attribute':
@@ -124,26 +123,30 @@ export function RegularElement(node, context) {
 				class_directives.push(attribute);
 				break;
 
-			case 'StyleDirective':
-				style_directives.push(attribute);
-				break;
-
 			case 'LetDirective':
 				// visit let directives before everything else, to set state
 				lets.push(/** @type {ExpressionStatement} */ (context.visit(attribute)));
-				break;
-
-			case 'UseDirective':
-				has_use = true;
-				other_directives.push(attribute);
 				break;
 
 			case 'OnDirective':
 				other_directives.push(attribute);
 				break;
 
-			case 'AnimateDirective':
+			case 'SpreadAttribute':
+				attributes.push(attribute);
+				has_spread = true;
+				break;
+
+			case 'StyleDirective':
+				style_directives.push(attribute);
+				break;
+
 			case 'TransitionDirective':
+				other_directives.push(attribute);
+				break;
+
+			case 'UseDirective':
+				has_use = true;
 				other_directives.push(attribute);
 				break;
 		}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -85,8 +85,6 @@ export function RegularElement(node, context) {
 	const is_custom_element = is_custom_element_node(node);
 	let needs_content_reset = false;
 
-	let is_content_editable = false;
-
 	if (is_custom_element) {
 		// cloneNode is faster, but it does not instantiate the underlying class of the
 		// custom element until the template is connected to the dom, which would
@@ -119,12 +117,6 @@ export function RegularElement(node, context) {
 				!is_text_attribute(attribute)
 			) {
 				needs_content_reset = true;
-			} else if (
-				attribute.name === 'contenteditable' &&
-				(attribute.value === true ||
-					(is_text_attribute(attribute) && attribute.value[0].data === 'true'))
-			) {
-				is_content_editable = true;
 			}
 		} else if (attribute.type === 'SpreadAttribute') {
 			has_spread = true;
@@ -156,9 +148,17 @@ export function RegularElement(node, context) {
 		}
 	}
 
-	child_metadata.bound_contenteditable =
-		is_content_editable &&
-		(bindings.has('innerHTML') || bindings.has('innerText') || bindings.has('textContent'));
+	if (bindings.has('innerHTML') || bindings.has('innerText') || bindings.has('textContent')) {
+		const contenteditable = lookup.get('contenteditable');
+
+		if (
+			contenteditable &&
+			(contenteditable.value === true ||
+				(is_text_attribute(contenteditable) && contenteditable.value[0].data === 'true'))
+		) {
+			child_metadata.bound_contenteditable = true;
+		}
+	}
 
 	if (
 		node.name === 'input' &&


### PR DESCRIPTION
This is a precursor to #13270. We need to change how we deal with the combination of attributes and class/style directives, and ideally unify how attributes are handled between `RegularElement` and `SvelteElement`. A first step towards that is moving the special case logic (for specific elements like `<img>` or `<input>` or whatever) out of the loop in which we separate attributes out into their different types.

This PR just tries to make the logic a bit less entangled, and a bit easier to follow, with fewer variables declared far from their usage sites etc.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
