### PR TITLE
chore: refactor `set_attributes` code generation

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
@@ -38,8 +38,7 @@ export function build_set_attributes(
 
 			if (
 				is_event_attribute(attribute) &&
-				(get_attribute_expression(attribute).type === 'ArrowFunctionExpression' ||
-					get_attribute_expression(attribute).type === 'FunctionExpression')
+				(value.type === 'ArrowFunctionExpression' || value.type === 'FunctionExpression')
 			) {
 				// Give the event handler a stable ID so it isn't removed and readded on every update
 				const id = context.state.scope.generate('event_handler');

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
@@ -1,10 +1,93 @@
-/** @import { Expression, Identifier } from 'estree' */
+/** @import { Expression, Identifier, ObjectExpression } from 'estree' */
 /** @import { AST, Namespace } from '#compiler' */
 /** @import { ComponentContext } from '../../types' */
 import { normalize_attribute } from '../../../../../../utils.js';
+import { is_ignored } from '../../../../../state.js';
+import { get_attribute_expression, is_event_attribute } from '../../../../../utils/ast.js';
 import * as b from '../../../../../utils/builders.js';
 import { build_getter, create_derived } from '../../utils.js';
 import { build_template_literal, build_update } from './utils.js';
+
+/**
+ * @param {Array<AST.Attribute | AST.SpreadAttribute>} attributes
+ * @param {ComponentContext} context
+ * @param {AST.RegularElement | AST.SvelteElement} element
+ * @param {Identifier} element_id
+ * @param {Identifier} attributes_id
+ * @param {false | Expression} preserve_attribute_case
+ * @param {false | Expression} is_custom_element
+ */
+export function build_set_attributes(
+	attributes,
+	context,
+	element,
+	element_id,
+	attributes_id,
+	preserve_attribute_case,
+	is_custom_element
+) {
+	let needs_isolation = false;
+	let is_reactive = false;
+
+	/** @type {ObjectExpression['properties']} */
+	const values = [];
+
+	for (const attribute of attributes) {
+		if (attribute.type === 'Attribute') {
+			const { value } = build_attribute_value(attribute.value, context);
+
+			if (
+				is_event_attribute(attribute) &&
+				(get_attribute_expression(attribute).type === 'ArrowFunctionExpression' ||
+					get_attribute_expression(attribute).type === 'FunctionExpression')
+			) {
+				// Give the event handler a stable ID so it isn't removed and readded on every update
+				const id = context.state.scope.generate('event_handler');
+				context.state.init.push(b.var(id, value));
+				values.push(b.init(attribute.name, b.id(id)));
+			} else {
+				values.push(b.init(attribute.name, value));
+			}
+		} else {
+			values.push(b.spread(/** @type {Expression} */ (context.visit(attribute))));
+		}
+
+		is_reactive ||=
+			attribute.metadata.expression.has_state ||
+			// objects could contain reactive getters -> play it safe and always assume spread attributes are reactive
+			attribute.type === 'SpreadAttribute';
+		needs_isolation ||=
+			attribute.type === 'SpreadAttribute' && attribute.metadata.expression.has_call;
+	}
+
+	const call = b.call(
+		'$.set_attributes',
+		element_id,
+		is_reactive ? attributes_id : b.literal(null),
+		b.object(values),
+		context.state.analysis.css.hash !== '' && b.literal(context.state.analysis.css.hash),
+		preserve_attribute_case,
+		is_custom_element,
+		is_ignored(element, 'hydration_attribute_changed') && b.true
+	);
+
+	if (is_reactive) {
+		context.state.init.push(b.let(attributes_id));
+
+		const update = b.stmt(b.assignment('=', attributes_id, call));
+
+		if (needs_isolation) {
+			context.state.init.push(build_update(update));
+			return false;
+		}
+
+		context.state.update.push(update);
+		return true;
+	}
+
+	context.state.init.push(b.stmt(call));
+	return false;
+}
 
 /**
  * Serializes each style directive into something like `$.set_style(element, style_property, value)`
@@ -101,6 +184,7 @@ export function build_class_directives(
 /**
  * @param {AST.Attribute['value']} value
  * @param {ComponentContext} context
+ * @returns {{ value: Expression, has_state: boolean, has_call: boolean }}
  */
 export function build_attribute_value(value, context) {
 	if (value === true) {
@@ -127,9 +211,8 @@ export function build_attribute_value(value, context) {
 /**
  * @param {AST.RegularElement | AST.SvelteElement} element
  * @param {AST.Attribute} attribute
- * @param {{ state: { metadata: { namespace: Namespace }}}} context
  */
-export function get_attribute_name(element, attribute, context) {
+export function get_attribute_name(element, attribute) {
 	if (!element.metadata.svg && !element.metadata.mathml) {
 		return normalize_attribute(attribute.name);
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -36,6 +36,7 @@ export function get_states_and_calls(values) {
  * @param {Array<AST.Text | AST.ExpressionTag>} values
  * @param {(node: SvelteNode, state: any) => any} visit
  * @param {ComponentClientTransformState} state
+ * @returns {{ value: Expression, has_state: boolean, has_call: boolean }}
  */
 export function build_template_literal(values, visit, state) {
 	/** @type {Expression[]} */

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
@@ -217,7 +217,7 @@ export function build_element_attributes(node, context) {
 	} else {
 		for (const attribute of /** @type {AST.Attribute[]} */ (attributes)) {
 			if (attribute.value === true || is_text_attribute(attribute)) {
-				const name = get_attribute_name(node, attribute, context);
+				const name = get_attribute_name(node, attribute);
 				const literal_value = /** @type {Literal} */ (
 					build_attribute_value(
 						attribute.value,
@@ -239,7 +239,7 @@ export function build_element_attributes(node, context) {
 				continue;
 			}
 
-			const name = get_attribute_name(node, attribute, context);
+			const name = get_attribute_name(node, attribute);
 			const value = build_attribute_value(
 				attribute.value,
 				context,
@@ -264,9 +264,8 @@ export function build_element_attributes(node, context) {
 /**
  * @param {AST.RegularElement | AST.SvelteElement} element
  * @param {AST.Attribute} attribute
- * @param {{ state: { namespace: Namespace }}} context
  */
-function get_attribute_name(element, attribute, context) {
+function get_attribute_name(element, attribute) {
 	let name = attribute.name;
 	if (!element.metadata.svg && !element.metadata.mathml) {
 		name = name.toLowerCase();
@@ -334,7 +333,7 @@ function build_element_spread_attributes(
 	const object = b.object(
 		attributes.map((attribute) => {
 			if (attribute.type === 'Attribute') {
-				const name = get_attribute_name(element, attribute, context);
+				const name = get_attribute_name(element, attribute);
 				const value = build_attribute_value(
 					attribute.value,
 					context,

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -149,9 +149,9 @@ export function set_custom_element_data(node, prop, value) {
  * @param {Record<string, any> | undefined} prev
  * @param {Record<string, any>} next New attributes - this function mutates this object
  * @param {string} [css_hash]
- * @param {boolean} preserve_attribute_case
- * @param {boolean} [skip_warning]
+ * @param {boolean} [preserve_attribute_case]
  * @param {boolean} [is_custom_element]
+ * @param {boolean} [skip_warning]
  * @returns {Record<string, any>}
  */
 export function set_attributes(
@@ -160,8 +160,8 @@ export function set_attributes(
 	next,
 	css_hash,
 	preserve_attribute_case = false,
-	skip_warning = false,
-	is_custom_element = false
+	is_custom_element = false,
+	skip_warning = false
 ) {
 	var current = prev || {};
 	var is_option_element = element.tagName === 'OPTION';


### PR DESCRIPTION
This extracts the refactoring stuff out of #13338. It doesn't change any behaviour, it just dries the code out — at present there's a ton of duplication between `RegularElement` with a `SpreadAttribute`, and `SvelteElement` (which always uses `set_attributes` because we need to be conservative about custom elements).

The next step will be to generate code differently so as to fix #13270, but merging this first will reduce the noise of that work substantially. I'll self-merge this once green, since it's just moving some code around, so that I can continue working on that.