### PR TITLE
docs: Update 7guis-timer example to support SSR context

### DIFF
--- a/documentation/examples/20-7guis/04-7guis-timer/App.svelte
+++ b/documentation/examples/20-7guis/04-7guis-timer/App.svelte
@@ -8,7 +8,7 @@
 
 	onMount(() => {
 		let last_time = performance.now();
-		
+
 		let frame = requestAnimationFrame(function update(time) {
 			frame = requestAnimationFrame(update);
 

--- a/documentation/examples/20-7guis/04-7guis-timer/App.svelte
+++ b/documentation/examples/20-7guis/04-7guis-timer/App.svelte
@@ -6,28 +6,25 @@
 	let elapsed = 0;
 	let duration = 5000;
 
-	let last_time
-	let frame;
+	onMount(() => {
+		let last_time = performance.now();
+		
+		let frame = requestAnimationFrame(function update(time) {
+			frame = requestAnimationFrame(update);
 
-	const update = () => {
-		frame = requestAnimationFrame(update);
+			elapsed += Math.min(time - last_time, duration - elapsed);
+			last_time = time;
+		});
 
-		const time = window.performance.now();
-		elapsed += Math.min(time - last_time, duration - elapsed);
-
-		last_time = time;
-	};
-
-  onMount(() => {
-    update()
-
-    return () => cancelAnimationFrame(frame)
+		return () => {
+			cancelAnimationFrame(frame);
+		};
 	});
 </script>
 
 <label>
 	elapsed time:
-	<progress value={elapsed / duration} />
+	<progress value={elapsed / duration}></progress>
 </label>
 
 <div>{(elapsed / 1000).toFixed(1)}s</div>

--- a/documentation/examples/20-7guis/04-7guis-timer/App.svelte
+++ b/documentation/examples/20-7guis/04-7guis-timer/App.svelte
@@ -6,7 +6,7 @@
 	let elapsed = 0;
 	let duration = 5000;
 
-	let last_time = window.performance.now();
+	let last_time
 	let frame;
 
 	const update = () => {

--- a/documentation/examples/20-7guis/04-7guis-timer/App.svelte
+++ b/documentation/examples/20-7guis/04-7guis-timer/App.svelte
@@ -1,7 +1,7 @@
 <!-- https://eugenkiss.github.io/7guis/tasks#timer -->
 
 <script>
-	import { onDestroy } from 'svelte';
+	import { onMount } from 'svelte';
 
 	let elapsed = 0;
 	let duration = 5000;
@@ -9,17 +9,19 @@
 	let last_time = window.performance.now();
 	let frame;
 
-	(function update() {
+	const update = () => {
 		frame = requestAnimationFrame(update);
 
 		const time = window.performance.now();
 		elapsed += Math.min(time - last_time, duration - elapsed);
 
 		last_time = time;
-	})();
+	};
 
-	onDestroy(() => {
-		cancelAnimationFrame(frame);
+  onMount(() => {
+    update()
+
+    return () => cancelAnimationFrame(frame)
 	});
 </script>
 


### PR DESCRIPTION
The example doesn't work when copied to a fresh sveltekit project, it produces errors such as `ReferenceError: window is not defined` and `ReferenceError: requestAnimationFrame is not defined`

- an example of this pattern used else where in the codebase [link](https://github.com/sveltejs/svelte/blob/main/documentation/tutorial/06-bindings/12-bind-this/app-b/App.svelte)
- relevant discord convo [link](https://discord.com/channels/457912077277855764/1286736007613644800)

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
