### PR TITLE
fix: missing space when importing run as in migration

### DIFF
--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -71,7 +71,7 @@ export function migrate(source) {
 		state = { ...state, scope: analysis.template.scope };
 		walk(parsed.fragment, state, template);
 
-		const run_import = `import { run${state.run_name === 'run' ? '' : `as ${state.run_name}`} } from 'svelte/legacy';`;
+		const run_import = `import { run${state.run_name === 'run' ? '' : ` as ${state.run_name}`} } from 'svelte/legacy';`;
 		let added_legacy_import = false;
 
 		if (state.props.length > 0 || analysis.uses_rest_props || analysis.uses_props) {

--- a/packages/svelte/tests/migrate/samples/effects-with-alias-run/input.svelte
+++ b/packages/svelte/tests/migrate/samples/effects-with-alias-run/input.svelte
@@ -1,0 +1,14 @@
+<script>
+	let count = 0;
+	let run = true;
+	$: console.log(count);
+	$: if (count > 10 && run) {
+		alert('too high')
+	}
+	$: {
+		console.log('foo');
+		if (x) break $;
+		console.log('bar');
+	}
+	$: $count = 1;
+</script>

--- a/packages/svelte/tests/migrate/samples/effects-with-alias-run/output.svelte
+++ b/packages/svelte/tests/migrate/samples/effects-with-alias-run/output.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { run as run_1 } from 'svelte/legacy';
+
+	let count = 0;
+	let run = true;
+	run_1(() => {
+		console.log(count);
+	});
+	run_1(() => {
+		if (count > 10 && run) {
+			alert('too high')
+		}
+	});
+	run_1(() => {
+		console.log('foo');
+		if (x) return;
+		console.log('bar');
+	});
+	run_1(() => {
+		$count = 1;
+	});
+</script>


### PR DESCRIPTION
## Svelte 5 rewrite

When importing run if there's already a function called run we alias our own run. There was a missing space resulting in broken code.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
