### PR TITLE
chore: add a newline to multiline comment for proper syntax highlighting

### DIFF
--- a/packages/svelte/src/compiler/utils/compile_diagnostic.js
+++ b/packages/svelte/src/compiler/utils/compile_diagnostic.js
@@ -44,7 +44,8 @@ function get_code_frame(source, line, column) {
  * 	end?: Location;
  * 	position?: [number, number];
  * 	frame?: string;
- * }} ICompileDiagnostic */
+ * }} ICompileDiagnostic
+ */
 
 /** @implements {ICompileDiagnostic} */
 export class CompileDiagnostic extends Error {


### PR DESCRIPTION
### Changes

Just adding a new line to multiline comment of `typedef` definition.
It simply improves syntax highlighting(in VS Code).