### PR TITLE
fix: ownership getting tricked by proxies

### DIFF
--- a/.changeset/nice-brooms-battle.md
+++ b/.changeset/nice-brooms-battle.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ownership getting tricked by proxies

--- a/.changeset/nice-brooms-battle.md
+++ b/.changeset/nice-brooms-battle.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ownership getting tricked by proxies
+fix: make ownership widening more robust to userland proxies

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -170,14 +170,13 @@ function add_owner_to_object(object, owner, seen) {
 
 	if (metadata) {
 		// this is a state proxy, add owner directly, if not globally shared
-		if (metadata.owners !== null) {
+		if ('owners' in metadata && metadata.owners != null) {
 			metadata.owners.add(owner);
 		}
 	} else if (object && typeof object === 'object') {
 		if (seen.has(object)) return;
 		seen.add(object);
-
-		if (object[ADD_OWNER]) {
+		if (ADD_OWNER in object && object[ADD_OWNER]) {
 			// this is a class with state fields. we put this in a render effect
 			// so that if state is replaced (e.g. `instance.name = { first, last }`)
 			// the new state is also co-owned by the caller of `getContext`

--- a/packages/svelte/tests/runtime-runes/samples/ownership-with-proxy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-with-proxy/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/ownership-with-proxy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-with-proxy/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { setContext, getContext } from "svelte";
+
+	setContext("", new Proxy({}, {
+		get(){
+			return {}
+		}
+	}));
+
+	getContext("");
+</script>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13376

This fixes the problem but i fear we might have this problem elsewhere and this can still be somewhat tricked unless we specify a lot of constraint. The problem when someone returns some non null value from a proxy regardless of the key eg

```svelte
<script>
    import { setContext, getContext } from "svelte";

    setContext("", new Proxy({}, {
        get(){
            return {};
        }
    }));

    getContext("");
</script>
```
inside the ownership validation function we assume that if it has metadata it's the svelte metadata object (honestly a reasonable assumption considering it's a Symbol). But in this case the object will always be this empty object. So when trying to access `owners.add` on it or `[ADD_OWNER]` we end up with a runtime error.

By adding `owners in object` check it's fixed but that will fail if the proxy looks like this

```svelte
<script>
    import { setContext, getContext } from "svelte";

    setContext("", new Proxy({}, {
        get(){
            return {};
        },
        has(){
             return true;
        }
    }));

    getContext("");
</script>
```

So i'm not really sure if we should go mad with checks before invoking anything or find a better general solution.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
