### PR TITLE
fix : reactivity bug with single script in svelte:head

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -270,6 +270,19 @@ export function clean_nodes(
 
 	var first = trimmed[0];
 
+	// Special case: Add a comment if this is a lone script tag. This ensures that our run_scripts logic in template.js
+	// will always be able to call node.replaceWith() on the script tag in order to make it run. If we don't add this
+	// and would still call node.replaceWith() on the script tag, it would be a no-op because the script tag has no parent.
+	if (trimmed.length === 1 && first.type === 'RegularElement' && first.name === 'script') {
+		trimmed.push({
+			type: 'Comment',
+			data: '',
+			parent: first.parent,
+			start: -1,
+			end: -1
+		});
+	}
+
 	return {
 		hoisted,
 		trimmed,

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -73,19 +73,23 @@ export function template(content, flags) {
 /*#__NO_SIDE_EFFECTS__*/
 export function template_with_script(content, flags) {
 	var first = true;
-	var fn = template(content, flags);
+	var fn = template(content, flags | TEMPLATE_FRAGMENT);
 
 	return () => {
 		if (hydrating) return fn();
 
-		var node = /** @type {Element | DocumentFragment} */ (fn());
+		var fragment = /** @type {DocumentFragment} */ (fn());
 
 		if (first) {
 			first = false;
-			run_scripts(node);
+			run_scripts(fragment);
 		}
 
-		return node;
+		if ((flags & TEMPLATE_FRAGMENT) !== 0) {
+			return fragment;
+		}
+
+		return /** @type {Node} */ (fragment.firstChild);
 	};
 }
 
@@ -152,19 +156,23 @@ export function ns_template(content, flags, ns = 'svg') {
 /*#__NO_SIDE_EFFECTS__*/
 export function svg_template_with_script(content, flags) {
 	var first = true;
-	var fn = ns_template(content, flags);
+	var fn = ns_template(content, flags | TEMPLATE_FRAGMENT);
 
 	return () => {
 		if (hydrating) return fn();
 
-		var node = /** @type {Element | DocumentFragment} */ (fn());
+		var fragment = /** @type {DocumentFragment} */ (fn());
 
 		if (first) {
 			first = false;
-			run_scripts(node);
+			run_scripts(fragment);
 		}
 
-		return node;
+		if ((flags & TEMPLATE_FRAGMENT) !== 0) {
+			return fragment;
+		}
+
+		return /** @type {Node} */ (fragment.firstChild);
 	};
 }
 
@@ -181,20 +189,15 @@ export function mathml_template(content, flags) {
 /**
  * Creating a document fragment from HTML that contains script tags will not execute
  * the scripts. We need to replace the script tags with new ones so that they are executed.
- * @param {Element | DocumentFragment} node
+ * @param {DocumentFragment} fragment
  */
-function run_scripts(node) {
+function run_scripts(fragment) {
 	// scripts were SSR'd, in which case they will run
 	if (hydrating) return;
 
-	const is_fragment = node.nodeType === 11;
-	const scripts =
-		/** @type {HTMLElement} */ (node).tagName === 'SCRIPT'
-			? [/** @type {HTMLScriptElement} */ (node)]
-			: node.querySelectorAll('script');
 	const effect = /** @type {Effect} */ (active_effect);
 
-	for (const script of scripts) {
+	for (const script of fragment.querySelectorAll('script')) {
 		const clone = document.createElement('script');
 		for (var attribute of script.attributes) {
 			clone.setAttribute(attribute.name, attribute.value);
@@ -202,27 +205,15 @@ function run_scripts(node) {
 
 		clone.textContent = script.textContent;
 
-		const replace = () => {
-			// The script has changed - if it's at the edges, the effect now points at dead nodes
-			if (is_fragment ? node.firstChild === script : node === script) {
-				effect.nodes_start = clone;
-			}
-			if (is_fragment ? node.lastChild === script : node === script) {
-				effect.nodes_end = clone;
-			}
-
-			script.replaceWith(clone);
-		};
-
-		// If node === script tag, replaceWith will do nothing because there's no parent yet,
-		// waiting until that's the case using an effect solves this.
-		// Don't do it in other circumstances or we could accidentally execute scripts
-		// in an adjacent @html tag that was instantiated in the meantime.
-		if (script === node) {
-			queue_micro_task(replace);
-		} else {
-			replace();
+		// The script has changed - if it's at the edges, the effect now points at dead nodes
+		if (fragment.firstChild === script) {
+			effect.nodes_start = clone;
 		}
+		if (fragment.lastChild === script) {
+			effect.nodes_end = clone;
+		}
+
+		script.replaceWith(clone);
 	}
 }
 

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -185,13 +185,7 @@ function run_scripts(node) {
 			effect.nodes_end = clone;
 		}
 
-		// If node === script tag, replaceWith will do nothing because there's no parent yet
-		if (script === node) {
-			// but we can returns the cloned <script> immediately
-			return clone;
-		} else {
-			script.replaceWith(clone);
-		}
+		script.replaceWith(clone);
 	}
 	return node;
 }

--- a/packages/svelte/tests/runtime-browser/samples/head-scripts/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/head-scripts/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../assert';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, window }) {
+		// wait the script to load (maybe there a better way)
+		await new Promise((resolve) => setTimeout(resolve, 1));
+		assert.htmlEqual(
+			window.document.body.innerHTML,
+			`<main><b id="r1">1</b><b id="r2">2</b><b id="r3">3</b></main>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/head-scripts/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/head-scripts/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	function jssrc(src) {
+		return 'data:text/javascript;base64, ' + btoa(src);
+	}
+
+	const scriptSrcs = [ 1, 2, 3 ]
+		.map(n => jssrc(`document.getElementById('r${n}').innerText = '${n}';`));
+</script>
+
+<svelte:head>
+	{#each scriptSrcs as src}
+    	<script src={src} async defer></script>
+	{/each}
+</svelte:head>
+
+<b id="r1">?</b><b id="r2">?</b><b id="r3">?</b>


### PR DESCRIPTION
`template_with_script()` is buggy when it contains only one `<script>` element, because the `run_scripts()` will clone and replace the scripts.

There no problem when using a DocumentFragment because they are replaced immediately inside the fragment.
But with a single node the element cannot be replaced, and it's done later with queue_micro_task().

=> So the cloned script is put on the DOM, but `template_with_script()` will return the previous script element (so reactivity is broken).

See #13378 


Should I make a test for that ?


## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
