### PR TITLE
fix: blank CSS contents while migrating

### DIFF
--- a/.changeset/early-needles-bake.md
+++ b/.changeset/early-needles-bake.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: blank CSS contents while migrating

--- a/packages/svelte/tests/migrate/samples/css-ignore/input.svelte
+++ b/packages/svelte/tests/migrate/samples/css-ignore/input.svelte
@@ -1,0 +1,15 @@
+<script>
+	export let name;
+</script>
+
+<div>{name}</div>
+
+<style lang="scss">
+	$font-stack: Helvetica, sans-serif;
+	$primary-color: #333;
+
+	body {
+		font: 100% $font-stack;
+		color: $primary-color;
+	}
+</style>

--- a/packages/svelte/tests/migrate/samples/css-ignore/output.svelte
+++ b/packages/svelte/tests/migrate/samples/css-ignore/output.svelte
@@ -1,0 +1,16 @@
+<script>
+	/** @type {{name: any}} */
+	let { name } = $props();
+</script>
+
+<div>{name}</div>
+
+<style lang="scss">
+	$font-stack: Helvetica, sans-serif;
+	$primary-color: #333;
+
+	body {
+		font: 100% $font-stack;
+		color: $primary-color;
+	}
+</style>


### PR DESCRIPTION
Blank CSS, could contain SCSS or similar that needs a preprocessor. Since we don't care about CSS in this migration, we'll just ignore it.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
