### PR TITLE
fix: avoid migrating slots in custom elements

### DIFF
--- a/.changeset/eight-waves-mate.md
+++ b/.changeset/eight-waves-mate.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid migrating slots in custom elements

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -583,6 +583,7 @@ const template = {
 		next();
 	},
 	SlotElement(node, { state, next }) {
+		if (state.analysis.custom_element) return;
 		let name = 'children';
 		let slot_name = 'default';
 		let slot_props = '{ ';

--- a/packages/svelte/tests/migrate/samples/slots-custom-element/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-custom-element/input.svelte
@@ -1,0 +1,16 @@
+<svelte:options customElement="my-element" />
+
+<button><slot /></button>
+
+{#if foo}
+	<slot name="foo" {foo} />
+{/if}
+
+{#if $$slots.bar}
+	{$$slots}
+	<slot name="bar" />
+{/if}
+
+{#if $$slots.default}foo{/if}
+
+<slot name="dashed-name" />

--- a/packages/svelte/tests/migrate/samples/slots-custom-element/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-custom-element/input.svelte
@@ -1,6 +1,13 @@
 <svelte:options customElement="my-element" />
 
-<button><slot /></button>
+<script>
+	// to show that it doesn't bail out from the whole migration
+	let count = 0;
+</script>
+
+<button on:click={()=>count++}><slot /></button>
+
+{count}
 
 {#if foo}
 	<slot name="foo" {foo} />

--- a/packages/svelte/tests/migrate/samples/slots-custom-element/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-custom-element/output.svelte
@@ -1,6 +1,13 @@
 <svelte:options customElement="my-element" />
 
-<button><slot /></button>
+<script>
+	// to show that it doesn't bail out from the whole migration
+	let count = $state(0);
+</script>
+
+<button onclick={()=>count++}><slot /></button>
+
+{count}
 
 {#if foo}
 	<slot name="foo" {foo} />

--- a/packages/svelte/tests/migrate/samples/slots-custom-element/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-custom-element/output.svelte
@@ -1,0 +1,16 @@
+<svelte:options customElement="my-element" />
+
+<button><slot /></button>
+
+{#if foo}
+	<slot name="foo" {foo} />
+{/if}
+
+{#if bar}
+	{$$slots}
+	<slot name="bar" />
+{/if}
+
+{#if children}foo{/if}
+
+<slot name="dashed-name" />


### PR DESCRIPTION
## Svelte 5 rewrite

No issue, it was reported by Theo on discord.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
