### PR TITLE
fix: don't consider used rules with atrules in the block

### DIFF
--- a/.changeset/lazy-queens-agree.md
+++ b/.changeset/lazy-queens-agree.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't consider used rules with atrules in the block

--- a/.changeset/lazy-queens-agree.md
+++ b/.changeset/lazy-queens-agree.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: don't consider used rules with atrules in the block
+fix: don't consider children of rules when checking whether they are used or not

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -348,10 +348,6 @@ function is_used(rule) {
 
 	for (const child of rule.block.children) {
 		if (child.type === 'Rule' && is_used(child)) return true;
-
-		if (child.type === 'Atrule') {
-			return true; // TODO
-		}
 	}
 
 	return false;

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -340,19 +340,9 @@ function is_empty(rule) {
 	return true;
 }
 
-/** @param {Css.Rule | Css.Atrule} rule */
+/** @param {Css.Rule} rule */
 function is_used(rule) {
-	if (rule.type === 'Rule') {
-		for (const selector of rule.prelude.children) {
-			if (selector.metadata.used) return true;
-		}
-	}
-
-	for (const child of rule.block?.children || []) {
-		if ((child.type === 'Rule' || child.type === 'Atrule') && is_used(child)) return true;
-	}
-
-	return false;
+	return rule.prelude.children.some((selector) => selector.metadata.used);
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -333,21 +333,23 @@ function is_empty(rule) {
 		}
 
 		if (child.type === 'Atrule') {
-			return false; // TODO
+			if (child.block === null || child.block.children.length > 0) return false;
 		}
 	}
 
 	return true;
 }
 
-/** @param {Css.Rule} rule */
+/** @param {Css.Rule | Css.Atrule} rule */
 function is_used(rule) {
-	for (const selector of rule.prelude.children) {
-		if (selector.metadata.used) return true;
+	if (rule.type === 'Rule') {
+		for (const selector of rule.prelude.children) {
+			if (selector.metadata.used) return true;
+		}
 	}
 
-	for (const child of rule.block.children) {
-		if (child.type === 'Rule' && is_used(child)) return true;
+	for (const child of rule.block?.children || []) {
+		if ((child.type === 'Rule' || child.type === 'Atrule') && is_used(child)) return true;
 	}
 
 	return false;

--- a/packages/svelte/tests/css/samples/unused-nested-at-rule/_config.js
+++ b/packages/svelte/tests/css/samples/unused-nested-at-rule/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../test';
+
+export default test({
+	warnings: [
+		{
+			filename: 'SvelteComponent.svelte',
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector ".unused"',
+			start: {
+				line: 2,
+				column: 1,
+				character: 9
+			},
+			end: {
+				line: 2,
+				column: 8,
+				character: 16
+			}
+		}
+	]
+});

--- a/packages/svelte/tests/css/samples/unused-nested-at-rule/expected.css
+++ b/packages/svelte/tests/css/samples/unused-nested-at-rule/expected.css
@@ -1,0 +1,6 @@
+
+	/* (unused) .unused {
+		@media (min-width: 400px) {
+			color: red;
+		}
+	}*/

--- a/packages/svelte/tests/css/samples/unused-nested-at-rule/input.svelte
+++ b/packages/svelte/tests/css/samples/unused-nested-at-rule/input.svelte
@@ -1,0 +1,7 @@
+<style>
+	.unused {
+		@media (min-width: 400px) {
+			color: red;
+		}
+	}
+</style>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13390

I spend quite a bit of time to try to fix this just to realise that there's no reason a nested AtRule should mark the wrapping rule as used.

```css
.foo {
  display: grid;
  @media (orientation: landscape) {
    grid-auto-flow: column;
  }
}
```
this is equivalent to
```css
.foo {
  display: grid;
}

@media (orientation: landscape) {
  .foo {
    grid-auto-flow: column;
  }
}
```
but if foo is unused it will still be unused inside the media query.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
