### PR TITLE
fix: treat `<img>` alt attribute as content for a11y labelling purposes

### DIFF
--- a/.changeset/nervous-chefs-exist.md
+++ b/.changeset/nervous-chefs-exist.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: treat `<img>` alt attribute as content for a11y labelling purposes

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y.js
@@ -1161,6 +1161,13 @@ function has_content(element) {
 		}
 
 		if (node.type === 'RegularElement' || node.type === 'SvelteElement') {
+			if (
+				node.name === 'img' &&
+				node.attributes.some((node) => node.type === 'Attribute' && node.name === 'alt')
+			) {
+				return true;
+			}
+
 			if (!has_content(node)) {
 				continue;
 			}

--- a/packages/svelte/tests/validator/samples/a11y-consider-explicit-label/input.svelte
+++ b/packages/svelte/tests/validator/samples/a11y-consider-explicit-label/input.svelte
@@ -9,3 +9,4 @@
 
 <button>Click me</button>
 <a href="/#">Link text</a>
+<a href="/#"><img src="./icon.svg" alt="Link text"></a>


### PR DESCRIPTION
fixes #13365, and will allow the SvelteKit tests to start passing again

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
