### PR TITLE
chore: refactor migration composition logic

### DIFF
--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -251,7 +251,6 @@ export function migrate(source) {
 			}
 		}
 
-	
 		if (!parsed.instance && need_script) {
 			str.appendRight(insertion_point, '\n</script>\n\n');
 		}

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -108,7 +108,6 @@ export function migrate(source) {
 
 		const need_script =
 			state.legacy_imports.size > 0 ||
-			state.derived_components.size > 0 ||
 			state.script_insertions.size > 0 ||
 			state.props.length > 0 ||
 			analysis.uses_rest_props ||

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -114,8 +114,7 @@ export function migrate(source) {
 			analysis.uses_props;
 
 		if (!parsed.instance && need_script) {
-			const to_prepend = '<script>';
-			str.appendRight(0, to_prepend);
+			str.appendRight(0, '<script>');
 		}
 
 		const specifiers = [...state.legacy_imports].map((imported) => {

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -102,13 +102,42 @@ export function migrate(source) {
 		state = { ...state, scope: analysis.template.scope };
 		walk(parsed.fragment, state, template);
 
+		let insertion_point = parsed.instance
+			? /** @type {number} */ (parsed.instance.content.start)
+			: 0;
+
+		const need_script =
+			state.legacy_imports.size > 0 ||
+			state.derived_components.size > 0 ||
+			state.script_insertions.size > 0 ||
+			state.props.length > 0 ||
+			analysis.uses_rest_props ||
+			analysis.uses_props;
+
+		if (!parsed.instance && need_script) {
+			const to_prepend = '<script>';
+			str.appendRight(0, to_prepend);
+		}
+
 		const specifiers = [...state.legacy_imports].map((imported) => {
 			const local = state.names[imported];
 			return imported === local ? imported : `${imported} as ${local}`;
 		});
 
-		const legacy_import = `import { ${specifiers.join(', ')} } from 'svelte/legacy';`;
-		let added_legacy_import = false;
+		const legacy_import = `import { ${specifiers.join(', ')} } from 'svelte/legacy';\n`;
+
+		if (state.legacy_imports.size > 0) {
+			str.appendRight(insertion_point, `\n${indent}${legacy_import}`);
+		}
+
+		if (state.script_insertions.size > 0) {
+			str.appendRight(
+				insertion_point,
+				`\n${indent}${[...state.script_insertions].join(`\n${indent}`)}`
+			);
+		}
+
+		insertion_point = state.props_insertion_point;
 
 		if (state.props.length > 0 || analysis.uses_rest_props || analysis.uses_props) {
 			const has_many_props = state.props.length > 3;
@@ -138,7 +167,7 @@ export function migrate(source) {
 
 			if (state.has_props_rune) {
 				// some render tags or forwarded event attributes to add
-				str.appendRight(state.props_insertion_point, ` ${props},`);
+				str.appendRight(insertion_point, ` ${props},`);
 			} else {
 				const uses_ts = parsed.instance?.attributes.some(
 					(attr) => attr.name === 'lang' && /** @type {any} */ (attr).value[0].data === 'ts'
@@ -177,20 +206,8 @@ export function migrate(source) {
 					props_declaration = `${props_declaration} = $props();`;
 				}
 
-				if (parsed.instance) {
-					props_declaration = `\n${indent}${props_declaration}`;
-					str.appendRight(state.props_insertion_point, props_declaration);
-				} else {
-					const imports = state.legacy_imports.size > 0 ? `${indent}${legacy_import}\n` : '';
-					const script_insertions =
-						state.script_insertions.size > 0
-							? `\n${indent}${[...state.script_insertions].join(`\n${indent}`)}`
-							: '';
-					str.prepend(
-						`<script>\n${imports}${indent}${props_declaration}${script_insertions}\n</script>\n\n`
-					);
-					added_legacy_import = true;
-				}
+				props_declaration = `\n${indent}${props_declaration}`;
+				str.appendRight(insertion_point, props_declaration);
 			}
 		}
 
@@ -235,24 +252,10 @@ export function migrate(source) {
 			}
 		}
 
-		if (state.legacy_imports.size > 0 && !added_legacy_import) {
-			const script_insertions =
-				state.script_insertions.size > 0
-					? `\n${indent}${[...state.script_insertions].join(`\n${indent}`)}`
-					: '';
-
-			if (parsed.instance) {
-				str.appendRight(
-					/** @type {number} */ (parsed.instance.content.start),
-					`\n${indent}${legacy_import}${script_insertions}\n`
-				);
-			} else {
-				str.prepend(
-					`<script>\n${indent}${legacy_import}\n${indent}${script_insertions}\n</script>\n\n`
-				);
-			}
+	
+		if (!parsed.instance && need_script) {
+			str.appendRight(insertion_point, '\n</script>\n\n');
 		}
-
 		return { code: str.toString() };
 	} catch (e) {
 		// eslint-disable-next-line no-console
@@ -841,22 +844,6 @@ function get_node_range(source, node) {
 	start = idx;
 
 	return { start, end };
-}
-
-/**
- * @param {AST.OnDirective} last
- * @param {State} state
- */
-function generate_event_name(last, state) {
-	const scope =
-		(last.expression && state.analysis.template.scopes.get(last.expression)) || state.scope;
-
-	let name = 'event';
-	if (!scope.get(name)) return name;
-
-	let i = 1;
-	while (scope.get(`${name}${i}`)) i += 1;
-	return `${name}${i}`;
 }
 
 /**

--- a/packages/svelte/tests/migrate/samples/event-handlers-with-alias/output.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers-with-alias/output.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { createBubbler as createBubbler_1, handlers as handlers_1, preventDefault as preventDefault_1, stopPropagation as stopPropagation_1, stopImmediatePropagation as stopImmediatePropagation_1, self as self_1, trusted as trusted_1, once as once_1, passive as passive_1, nonpassive as nonpassive_1 } from 'svelte/legacy';
-	const bubble_1 = createBubbler_1();
 
+	const bubble_1 = createBubbler_1();
 	let handlers;
 	let stopPropagation;
 	let preventDefault;

--- a/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
+++ b/packages/svelte/tests/migrate/samples/event-handlers/output.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { createBubbler, handlers, preventDefault, stopPropagation, stopImmediatePropagation, self, trusted, once, passive, nonpassive } from 'svelte/legacy';
-	
+
 	const bubble = createBubbler();
 </script>
 


### PR DESCRIPTION
## Svelte 5 rewrite

I was working on the migration for `svelte:component` but the code to compose together the instance was getting a bit messy because we were trying to add stuff all in the same place if there was no `script` or one by one if there was one. I changed this a bit by using an `insertion_point` variable that we can set to then insert stuff sequentially. It seems to work fine except some minor changes in whitespace but i would love an extra look from @dummdidumm 

I'm using this already locally to add the migration for svelte component.

P.s. i've also noticed another bug that i had to fix locally which is that we never visit the expression of `svelte:component` even in normal analysis. This means that if the expression is using `$$props` we don't have `uses_props` correctly initialized. Should i push this fix too?

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
