### PR TITLE
chore: remove links from docs

### DIFF
--- a/packages/svelte/src/action/public.d.ts
+++ b/packages/svelte/src/action/public.d.ts
@@ -23,8 +23,6 @@
  * 	};
  * }
  * ```
- *
- * Docs: https://svelte.dev/docs/svelte-action
  */
 export interface ActionReturn<
 	Parameter = undefined,
@@ -54,8 +52,6 @@ export interface ActionReturn<
  *
  * You can return an object with methods `update` and `destroy` from the function and type which additional attributes and events it has.
  * See interface `ActionReturn` for more details.
- *
- * Docs: https://svelte.dev/docs/svelte-action
  */
 export interface Action<
 	Element = HTMLElement,

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -5,7 +5,6 @@ import { cubicOut } from '../easing/index.js';
  * The flip function calculates the start and end position of an element and animates between them, translating the x and y values.
  * `flip` stands for [First, Last, Invert, Play](https://aerotwist.com/blog/flip-your-animations/).
  *
- * https://svelte.dev/docs/svelte-animate#flip
  * @param {Element} node
  * @param {{ from: DOMRect; to: DOMRect }} fromTo
  * @param {FlipParams} params

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -15,7 +15,6 @@ export { default as preprocess } from './preprocess/index.js';
 /**
  * `compile` converts your `.svelte` source code into a JavaScript module that exports a component
  *
- * https://svelte.dev/docs/svelte-compiler#svelte-compile
  * @param {string} source The component source code
  * @param {CompileOptions} options The compiler options
  * @returns {CompileResult}
@@ -54,7 +53,6 @@ export function compile(source, options) {
 /**
  * `compileModule` takes your JavaScript source code containing runes, and turns it into a JavaScript module.
  *
- * https://svelte.dev/docs/svelte-compiler#svelte-compile
  * @param {string} source The component source code
  * @param {ModuleCompileOptions} options
  * @returns {CompileResult}
@@ -74,7 +72,6 @@ export function compileModule(source, options) {
  * The `modern` option (`false` by default in Svelte 5) makes the parser return a modern AST instead of the legacy AST.
  * `modern` will become `true` by default in Svelte 6, and the option will be removed in Svelte 7.
  *
- * https://svelte.dev/docs/svelte-compiler#svelte-parse
  * @overload
  * @param {string} source
  * @param {{ filename?: string; modern: true }} options
@@ -87,7 +84,6 @@ export function compileModule(source, options) {
  * The `modern` option (`false` by default in Svelte 5) makes the parser return a modern AST instead of the legacy AST.
  * `modern` will become `true` by default in Svelte 6, and the option will be removed in Svelte 7.
  *
- * https://svelte.dev/docs/svelte-compiler#svelte-parse
  * @overload
  * @param {string} source
  * @param {{ filename?: string; modern?: false }} [options]
@@ -100,7 +96,6 @@ export function compileModule(source, options) {
  * The `modern` option (`false` by default in Svelte 5) makes the parser return a modern AST instead of the legacy AST.
  * `modern` will become `true` by default in Svelte 6, and the option will be removed in Svelte 7.
  *
- * https://svelte.dev/docs/svelte-compiler#svelte-parse
  * @param {string} source
  * @param {{ filename?: string; rootDir?: string; modern?: boolean }} [options]
  * @returns {AST.Root | LegacyRoot}

--- a/packages/svelte/src/compiler/preprocess/index.js
+++ b/packages/svelte/src/compiler/preprocess/index.js
@@ -330,7 +330,6 @@ async function process_markup(process, source) {
  * The preprocess function provides convenient hooks for arbitrarily transforming component source code.
  * For example, it can be used to convert a <style lang="sass"> block into vanilla CSS.
  *
- * https://svelte.dev/docs/svelte-compiler#svelte-preprocess
  * @param {string} source
  * @param {PreprocessorGroup | PreprocessorGroup[]} preprocessor
  * @param {{ filename?: string }} [options]

--- a/packages/svelte/src/easing/index.js
+++ b/packages/svelte/src/easing/index.js
@@ -4,7 +4,6 @@ Distributed under MIT License https://github.com/mattdesl/eases/blob/master/LICE
 */
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -13,7 +12,6 @@ export function linear(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -24,7 +22,6 @@ export function backInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -34,7 +31,6 @@ export function backIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -44,7 +40,6 @@ export function backOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -66,7 +61,6 @@ export function bounceOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -75,7 +69,6 @@ export function bounceInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -84,7 +77,6 @@ export function bounceIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -94,7 +86,6 @@ export function circInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -103,7 +94,6 @@ export function circIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -112,7 +102,6 @@ export function circOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -121,7 +110,6 @@ export function cubicInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -130,7 +118,6 @@ export function cubicIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -140,7 +127,6 @@ export function cubicOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -154,7 +140,6 @@ export function elasticInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -163,7 +148,6 @@ export function elasticIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -172,7 +156,6 @@ export function elasticOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -185,7 +168,6 @@ export function expoInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -194,7 +176,6 @@ export function expoIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -203,7 +184,6 @@ export function expoOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -215,7 +195,6 @@ export function quadInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -224,7 +203,6 @@ export function quadIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -233,7 +211,6 @@ export function quadOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -242,7 +219,6 @@ export function quartInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -251,7 +227,6 @@ export function quartIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -260,7 +235,6 @@ export function quartOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -270,7 +244,6 @@ export function quintInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -279,7 +252,6 @@ export function quintIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -288,7 +260,6 @@ export function quintOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -297,7 +268,6 @@ export function sineInOut(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -308,7 +278,6 @@ export function sineIn(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */

--- a/packages/svelte/src/index-client.js
+++ b/packages/svelte/src/index-client.js
@@ -16,7 +16,6 @@ import { lifecycle_outside_component } from './internal/shared/errors.js';
  *
  * `onMount` does not run inside a [server-side component](https://svelte.dev/docs#run-time-server-side-component-api).
  *
- * https://svelte.dev/docs/svelte#onmount
  * @template T
  * @param {() => NotFunction<T> | Promise<NotFunction<T>> | (() => any)} fn
  * @returns {void}
@@ -42,7 +41,6 @@ export function onMount(fn) {
  * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the
  * only one that runs inside a server-side component.
  *
- * https://svelte.dev/docs/svelte#ondestroy
  * @param {() => any} fn
  * @returns {void}
  */
@@ -84,7 +82,6 @@ function create_custom_event(type, detail, { bubbles = false, cancelable = false
  * }>();
  * ```
  *
- * https://svelte.dev/docs/svelte#createeventdispatcher
  * @deprecated Use callback props and/or the `$host()` rune instead — see https://svelte-5-preview.vercel.app/docs/deprecations#createeventdispatcher
  * @template {Record<string, any>} [EventMap = any]
  * @returns {EventDispatcher<EventMap>}
@@ -124,7 +121,6 @@ export function createEventDispatcher() {
  *
  * In runes mode use `$effect.pre` instead.
  *
- * https://svelte.dev/docs/svelte#beforeupdate
  * @deprecated Use `$effect.pre` instead — see https://svelte-5-preview.vercel.app/docs/deprecations#beforeupdate-and-afterupdate
  * @param {() => void} fn
  * @returns {void}
@@ -148,7 +144,6 @@ export function beforeUpdate(fn) {
  *
  * In runes mode use `$effect` instead.
  *
- * https://svelte.dev/docs/svelte#afterupdate
  * @deprecated Use `$effect` instead — see https://svelte-5-preview.vercel.app/docs/deprecations#beforeupdate-and-afterupdate
  * @param {() => void} fn
  * @returns {void}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -859,7 +859,6 @@ export function set_signal_status(signal, status) {
  * Retrieves the context that belongs to the closest parent component with the specified `key`.
  * Must be called during component initialisation.
  *
- * https://svelte.dev/docs/svelte#getcontext
  * @template T
  * @param {any} key
  * @returns {T}
@@ -885,7 +884,6 @@ export function getContext(key) {
  *
  * Like lifecycle functions, this must be called during component initialisation.
  *
- * https://svelte.dev/docs/svelte#setcontext
  * @template T
  * @param {any} key
  * @param {T} context
@@ -901,7 +899,6 @@ export function setContext(key, context) {
  * Checks whether a given `key` has been set in the context of a parent component.
  * Must be called during component initialisation.
  *
- * https://svelte.dev/docs/svelte#hascontext
  * @param {any} key
  * @returns {boolean}
  */
@@ -915,7 +912,6 @@ export function hasContext(key) {
  * Must be called during component initialisation. Useful, for example, if you
  * programmatically create a component and want to pass the existing context to it.
  *
- * https://svelte.dev/docs/svelte#getallcontexts
  * @template {Map<any, any>} [T=Map<any, any>]
  * @returns {T}
  */

--- a/packages/svelte/src/motion/spring.js
+++ b/packages/svelte/src/motion/spring.js
@@ -53,7 +53,6 @@ function tick_spring(ctx, last_value, current_value, target_value) {
 /**
  * The spring function in Svelte creates a store whose value is animated, with a motion that simulates the behavior of a spring. This means when the value changes, instead of transitioning at a steady rate, it "bounces" like a spring would, depending on the physics parameters provided. This adds a level of realism to the transitions and can enhance the user experience.
  *
- * https://svelte.dev/docs/svelte-motion#spring
  * @template [T=any]
  * @param {T} [value]
  * @param {SpringOpts} [opts]

--- a/packages/svelte/src/motion/tweened.js
+++ b/packages/svelte/src/motion/tweened.js
@@ -76,7 +76,6 @@ function get_interpolator(a, b) {
 /**
  * A tweened store in Svelte is a special type of store that provides smooth transitions between state values over time.
  *
- * https://svelte.dev/docs/svelte-motion#tweened
  * @template T
  * @param {T} [value]
  * @param {TweenedOptions<T>} [defaults]

--- a/packages/svelte/src/store/shared/index.js
+++ b/packages/svelte/src/store/shared/index.js
@@ -12,7 +12,6 @@ const subscriber_queue = [];
 /**
  * Creates a `Readable` store that allows reading by subscription.
  *
- * https://svelte.dev/docs/svelte-store#readable
  * @template T
  * @param {T} [value] initial value
  * @param {StartStopNotifier<T>} [start]
@@ -27,7 +26,6 @@ export function readable(value, start) {
 /**
  * Create a `Writable` store that allows both updating and reading by subscription.
  *
- * https://svelte.dev/docs/svelte-store#writable
  * @template T
  * @param {T} [value] initial value
  * @param {StartStopNotifier<T>} [start]
@@ -100,7 +98,6 @@ export function writable(value, start = noop) {
  * Derived value store by synchronizing one or more readable stores and
  * applying an aggregation function over its input values.
  *
- * https://svelte.dev/docs/svelte-store#derived
  * @template {Stores} S
  * @template T
  * @overload
@@ -113,7 +110,6 @@ export function writable(value, start = noop) {
  * Derived value store by synchronizing one or more readable stores and
  * applying an aggregation function over its input values.
  *
- * https://svelte.dev/docs/svelte-store#derived
  * @template {Stores} S
  * @template T
  * @overload
@@ -187,7 +183,6 @@ export function derived(stores, fn, initial_value) {
 /**
  * Takes a store and returns a new one derived from the old one that is readable.
  *
- * https://svelte.dev/docs/svelte-store#readonly
  * @template T
  * @param {Readable<T>} store  - store to make readonly
  * @returns {Readable<T>}
@@ -202,7 +197,6 @@ export function readonly(store) {
 /**
  * Get the current value from a store by subscribing and immediately unsubscribing.
  *
- * https://svelte.dev/docs/svelte-store#get
  * @template T
  * @param {Readable<T>} store
  * @returns {T}

--- a/packages/svelte/src/transition/index.js
+++ b/packages/svelte/src/transition/index.js
@@ -9,7 +9,6 @@ function cubic_out(t) {
 }
 
 /**
- * https://svelte.dev/docs/svelte-easing
  * @param {number} t
  * @returns {number}
  */
@@ -28,7 +27,6 @@ function split_css_unit(value) {
 /**
  * Animates a `blur` filter alongside an element's opacity.
  *
- * https://svelte.dev/docs/svelte-transition#blur
  * @param {Element} node
  * @param {BlurParams} [params]
  * @returns {TransitionConfig}
@@ -53,7 +51,6 @@ export function blur(
 /**
  * Animates the opacity of an element from 0 to the current opacity for `in` transitions and from the current opacity to 0 for `out` transitions.
  *
- * https://svelte.dev/docs/svelte-transition#fade
  * @param {Element} node
  * @param {FadeParams} [params]
  * @returns {TransitionConfig}
@@ -71,7 +68,6 @@ export function fade(node, { delay = 0, duration = 400, easing = linear } = {}) 
 /**
  * Animates the x and y positions and the opacity of an element. `in` transitions animate from the provided values, passed as parameters to the element's default values. `out` transitions animate from the element's default values to the provided values.
  *
- * https://svelte.dev/docs/svelte-transition#fly
  * @param {Element} node
  * @param {FlyParams} [params]
  * @returns {TransitionConfig}
@@ -99,7 +95,6 @@ export function fly(
 /**
  * Slides an element in and out.
  *
- * https://svelte.dev/docs/svelte-transition#slide
  * @param {Element} node
  * @param {SlideParams} [params]
  * @returns {TransitionConfig}
@@ -143,7 +138,6 @@ export function slide(node, { delay = 0, duration = 400, easing = cubic_out, axi
 /**
  * Animates the opacity and scale of an element. `in` transitions animate from an element's current (default) values to the provided values, passed as parameters. `out` transitions animate from the provided values to an element's default values.
  *
- * https://svelte.dev/docs/svelte-transition#scale
  * @param {Element} node
  * @param {ScaleParams} [params]
  * @returns {TransitionConfig}
@@ -171,7 +165,6 @@ export function scale(
 /**
  * Animates the stroke of an SVG element, like a snake in a tube. `in` transitions begin with the path invisible and draw the path to the screen over time. `out` transitions start in a visible state and gradually erase the path. `draw` only works with elements that have a `getTotalLength` method, like `<path>` and `<polyline>`.
  *
- * https://svelte.dev/docs/svelte-transition#draw
  * @param {SVGElement & { getTotalLength(): number }} node
  * @param {DrawParams} [params]
  * @returns {TransitionConfig}
@@ -218,7 +211,6 @@ function assign(tar, src) {
 /**
  * The `crossfade` function creates a pair of [transitions](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.
  *
- * https://svelte.dev/docs/svelte-transition#crossfade
  * @param {CrossfadeParams & {
  * 	fallback?: (node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig;
  * }} params

--- a/packages/svelte/src/version.js
+++ b/packages/svelte/src/version.js
@@ -3,7 +3,6 @@
 /**
  * The current version, as set in package.json.
  *
- * https://svelte.dev/docs/svelte-compiler#svelte-version
  * @type {string}
  */
 export const VERSION = '5.0.0-next.259';

--- a/packages/svelte/src/version.js
+++ b/packages/svelte/src/version.js
@@ -3,6 +3,7 @@
 /**
  * The current version, as set in package.json.
  *
+ * https://svelte.dev/docs/svelte-compiler#svelte-version
  * @type {string}
  */
 export const VERSION = '5.0.0-next.259';

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -314,7 +314,6 @@ declare module 'svelte' {
 	 *
 	 * `onMount` does not run inside a [server-side component](https://svelte.dev/docs#run-time-server-side-component-api).
 	 *
-	 * https://svelte.dev/docs/svelte#onmount
 	 * */
 	export function onMount<T>(fn: () => NotFunction<T> | Promise<NotFunction<T>> | (() => any)): void;
 	/**
@@ -323,7 +322,6 @@ declare module 'svelte' {
 	 * Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the
 	 * only one that runs inside a server-side component.
 	 *
-	 * https://svelte.dev/docs/svelte#ondestroy
 	 * */
 	export function onDestroy(fn: () => any): void;
 	/**
@@ -345,7 +343,6 @@ declare module 'svelte' {
 	 * }>();
 	 * ```
 	 *
-	 * https://svelte.dev/docs/svelte#createeventdispatcher
 	 * @deprecated Use callback props and/or the `$host()` rune instead — see https://svelte-5-preview.vercel.app/docs/deprecations#createeventdispatcher
 	 * */
 	export function createEventDispatcher<EventMap extends Record<string, any> = any>(): EventDispatcher<EventMap>;
@@ -356,7 +353,6 @@ declare module 'svelte' {
 	 *
 	 * In runes mode use `$effect.pre` instead.
 	 *
-	 * https://svelte.dev/docs/svelte#beforeupdate
 	 * @deprecated Use `$effect.pre` instead — see https://svelte-5-preview.vercel.app/docs/deprecations#beforeupdate-and-afterupdate
 	 * */
 	export function beforeUpdate(fn: () => void): void;
@@ -367,7 +363,6 @@ declare module 'svelte' {
 	 *
 	 * In runes mode use `$effect` instead.
 	 *
-	 * https://svelte.dev/docs/svelte#afterupdate
 	 * @deprecated Use `$effect` instead — see https://svelte-5-preview.vercel.app/docs/deprecations#beforeupdate-and-afterupdate
 	 * */
 	export function afterUpdate(fn: () => void): void;
@@ -441,7 +436,6 @@ declare module 'svelte' {
 	 * Retrieves the context that belongs to the closest parent component with the specified `key`.
 	 * Must be called during component initialisation.
 	 *
-	 * https://svelte.dev/docs/svelte#getcontext
 	 * */
 	export function getContext<T>(key: any): T;
 	/**
@@ -451,14 +445,12 @@ declare module 'svelte' {
 	 *
 	 * Like lifecycle functions, this must be called during component initialisation.
 	 *
-	 * https://svelte.dev/docs/svelte#setcontext
 	 * */
 	export function setContext<T>(key: any, context: T): T;
 	/**
 	 * Checks whether a given `key` has been set in the context of a parent component.
 	 * Must be called during component initialisation.
 	 *
-	 * https://svelte.dev/docs/svelte#hascontext
 	 * */
 	export function hasContext(key: any): boolean;
 	/**
@@ -466,7 +458,6 @@ declare module 'svelte' {
 	 * Must be called during component initialisation. Useful, for example, if you
 	 * programmatically create a component and want to pass the existing context to it.
 	 *
-	 * https://svelte.dev/docs/svelte#getallcontexts
 	 * */
 	export function getAllContexts<T extends Map<any, any> = Map<any, any>>(): T;
 	type Getters<T> = {
@@ -502,8 +493,6 @@ declare module 'svelte/action' {
 	 * 	};
 	 * }
 	 * ```
-	 *
-	 * Docs: https://svelte.dev/docs/svelte-action
 	 */
 	export interface ActionReturn<
 		Parameter = undefined,
@@ -533,8 +522,6 @@ declare module 'svelte/action' {
 	 *
 	 * You can return an object with methods `update` and `destroy` from the function and type which additional attributes and events it has.
 	 * See interface `ActionReturn` for more details.
-	 *
-	 * Docs: https://svelte.dev/docs/svelte-action
 	 */
 	export interface Action<
 		Element = HTMLElement,
@@ -573,7 +560,6 @@ declare module 'svelte/animate' {
 	 * The flip function calculates the start and end position of an element and animates between them, translating the x and y values.
 	 * `flip` stands for [First, Last, Invert, Play](https://aerotwist.com/blog/flip-your-animations/).
 	 *
-	 * https://svelte.dev/docs/svelte-animate#flip
 	 * */
 	export function flip(node: Element, { from, to }: {
 		from: DOMRect;
@@ -590,7 +576,6 @@ declare module 'svelte/compiler' {
 	/**
 	 * `compile` converts your `.svelte` source code into a JavaScript module that exports a component
 	 *
-	 * https://svelte.dev/docs/svelte-compiler#svelte-compile
 	 * @param source The component source code
 	 * @param options The compiler options
 	 * */
@@ -598,7 +583,6 @@ declare module 'svelte/compiler' {
 	/**
 	 * `compileModule` takes your JavaScript source code containing runes, and turns it into a JavaScript module.
 	 *
-	 * https://svelte.dev/docs/svelte-compiler#svelte-compile
 	 * @param source The component source code
 	 * */
 	export function compileModule(source: string, options: ModuleCompileOptions): CompileResult;
@@ -608,7 +592,6 @@ declare module 'svelte/compiler' {
 	 * The `modern` option (`false` by default in Svelte 5) makes the parser return a modern AST instead of the legacy AST.
 	 * `modern` will become `true` by default in Svelte 6, and the option will be removed in Svelte 7.
 	 *
-	 * https://svelte.dev/docs/svelte-compiler#svelte-parse
 	 * */
 	export function parse(source: string, options: {
 		filename?: string;
@@ -620,7 +603,6 @@ declare module 'svelte/compiler' {
 	 * The `modern` option (`false` by default in Svelte 5) makes the parser return a modern AST instead of the legacy AST.
 	 * `modern` will become `true` by default in Svelte 6, and the option will be removed in Svelte 7.
 	 *
-	 * https://svelte.dev/docs/svelte-compiler#svelte-parse
 	 * */
 	export function parse(source: string, options?: {
 		filename?: string;
@@ -1267,7 +1249,6 @@ declare module 'svelte/compiler' {
 	 * The preprocess function provides convenient hooks for arbitrarily transforming component source code.
 	 * For example, it can be used to convert a <style lang="sass"> block into vanilla CSS.
 	 *
-	 * https://svelte.dev/docs/svelte-compiler#svelte-preprocess
 	 * */
 	export function preprocess(source: string, preprocessor: PreprocessorGroup | PreprocessorGroup[], options?: {
 		filename?: string;
@@ -1480,129 +1461,66 @@ declare module 'svelte/compiler' {
 }
 
 declare module 'svelte/easing' {
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
 	export function linear(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function backInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function backIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function backOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function bounceOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function bounceInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function bounceIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function circInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function circIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function circOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function cubicInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function cubicIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function cubicOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function elasticInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function elasticIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function elasticOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function expoInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function expoIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function expoOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quadInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quadIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quadOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quartInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quartIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quartOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quintInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quintIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function quintOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function sineInOut(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function sineIn(t: number): number;
-	/**
-	 * https://svelte.dev/docs/svelte-easing
-	 * */
+
 	export function sineOut(t: number): number;
 
 	export {};
@@ -1736,13 +1654,11 @@ declare module 'svelte/motion' {
 	/**
 	 * The spring function in Svelte creates a store whose value is animated, with a motion that simulates the behavior of a spring. This means when the value changes, instead of transitioning at a steady rate, it "bounces" like a spring would, depending on the physics parameters provided. This adds a level of realism to the transitions and can enhance the user experience.
 	 *
-	 * https://svelte.dev/docs/svelte-motion#spring
 	 * */
 	export function spring<T = any>(value?: T | undefined, opts?: SpringOpts | undefined): Spring<T>;
 	/**
 	 * A tweened store in Svelte is a special type of store that provides smooth transitions between state values over time.
 	 *
-	 * https://svelte.dev/docs/svelte-motion#tweened
 	 * */
 	export function tweened<T>(value?: T | undefined, defaults?: TweenedOptions<T> | undefined): Tweened<T>;
 
@@ -1877,14 +1793,12 @@ declare module 'svelte/store' {
 	/**
 	 * Creates a `Readable` store that allows reading by subscription.
 	 *
-	 * https://svelte.dev/docs/svelte-store#readable
 	 * @param value initial value
 	 * */
 	export function readable<T>(value?: T | undefined, start?: StartStopNotifier<T> | undefined): Readable<T>;
 	/**
 	 * Create a `Writable` store that allows both updating and reading by subscription.
 	 *
-	 * https://svelte.dev/docs/svelte-store#writable
 	 * @param value initial value
 	 * */
 	export function writable<T>(value?: T | undefined, start?: StartStopNotifier<T> | undefined): Writable<T>;
@@ -1892,27 +1806,23 @@ declare module 'svelte/store' {
 	 * Derived value store by synchronizing one or more readable stores and
 	 * applying an aggregation function over its input values.
 	 *
-	 * https://svelte.dev/docs/svelte-store#derived
 	 * */
 	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>, set: (value: T) => void, update: (fn: Updater<T>) => void) => Unsubscriber | void, initial_value?: T | undefined): Readable<T>;
 	/**
 	 * Derived value store by synchronizing one or more readable stores and
 	 * applying an aggregation function over its input values.
 	 *
-	 * https://svelte.dev/docs/svelte-store#derived
 	 * */
 	export function derived<S extends Stores, T>(stores: S, fn: (values: StoresValues<S>) => T, initial_value?: T | undefined): Readable<T>;
 	/**
 	 * Takes a store and returns a new one derived from the old one that is readable.
 	 *
-	 * https://svelte.dev/docs/svelte-store#readonly
 	 * @param store  - store to make readonly
 	 * */
 	export function readonly<T>(store: Readable<T>): Readable<T>;
 	/**
 	 * Get the current value from a store by subscribing and immediately unsubscribing.
 	 *
-	 * https://svelte.dev/docs/svelte-store#get
 	 * */
 	export function get<T>(store: Readable<T>): T;
 	/** One or more `Readable`s. */
@@ -1989,37 +1899,31 @@ declare module 'svelte/transition' {
 	/**
 	 * Animates a `blur` filter alongside an element's opacity.
 	 *
-	 * https://svelte.dev/docs/svelte-transition#blur
 	 * */
 	export function blur(node: Element, { delay, duration, easing, amount, opacity }?: BlurParams | undefined): TransitionConfig;
 	/**
 	 * Animates the opacity of an element from 0 to the current opacity for `in` transitions and from the current opacity to 0 for `out` transitions.
 	 *
-	 * https://svelte.dev/docs/svelte-transition#fade
 	 * */
 	export function fade(node: Element, { delay, duration, easing }?: FadeParams | undefined): TransitionConfig;
 	/**
 	 * Animates the x and y positions and the opacity of an element. `in` transitions animate from the provided values, passed as parameters to the element's default values. `out` transitions animate from the element's default values to the provided values.
 	 *
-	 * https://svelte.dev/docs/svelte-transition#fly
 	 * */
 	export function fly(node: Element, { delay, duration, easing, x, y, opacity }?: FlyParams | undefined): TransitionConfig;
 	/**
 	 * Slides an element in and out.
 	 *
-	 * https://svelte.dev/docs/svelte-transition#slide
 	 * */
 	export function slide(node: Element, { delay, duration, easing, axis }?: SlideParams | undefined): TransitionConfig;
 	/**
 	 * Animates the opacity and scale of an element. `in` transitions animate from an element's current (default) values to the provided values, passed as parameters. `out` transitions animate from the provided values to an element's default values.
 	 *
-	 * https://svelte.dev/docs/svelte-transition#scale
 	 * */
 	export function scale(node: Element, { delay, duration, easing, start, opacity }?: ScaleParams | undefined): TransitionConfig;
 	/**
 	 * Animates the stroke of an SVG element, like a snake in a tube. `in` transitions begin with the path invisible and draw the path to the screen over time. `out` transitions start in a visible state and gradually erase the path. `draw` only works with elements that have a `getTotalLength` method, like `<path>` and `<polyline>`.
 	 *
-	 * https://svelte.dev/docs/svelte-transition#draw
 	 * */
 	export function draw(node: SVGElement & {
 		getTotalLength(): number;
@@ -2027,7 +1931,6 @@ declare module 'svelte/transition' {
 	/**
 	 * The `crossfade` function creates a pair of [transitions](https://svelte.dev/docs#template-syntax-element-directives-transition-fn) called `send` and `receive`. When an element is 'sent', it looks for a corresponding element being 'received', and generates a transition that transforms the element to its counterpart's position and fades it out. When an element is 'received', the reverse happens. If there is no counterpart, the `fallback` transition is used.
 	 *
-	 * https://svelte.dev/docs/svelte-transition#crossfade
 	 * */
 	export function crossfade({ fallback, ...defaults }: CrossfadeParams & {
 		fallback?: (node: Element, params: CrossfadeParams, intro: boolean) => TransitionConfig;


### PR DESCRIPTION
there's truly no point in doc comments including links to a page that just includes the exact some content. It just creates extra work when generating the docs pages, since we would have to strip out the links (which sometimes have a `Docs: ` prefix and sometimes don't), and it creates the possibility of the links getting stale if we evolve the site structure.