### PR TITLE
fix: mark custom element with virtual class attribute as dynamic

### DIFF
--- a/.changeset/tiny-ads-press.md
+++ b/.changeset/tiny-ads-press.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: mark custom element with virtual class attribute as dynamic

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -151,7 +151,8 @@ export default function element(parser) {
 						svg: false,
 						mathml: false,
 						scoped: false,
-						has_spread: false
+						has_spread: false,
+						path: []
 					},
 					parent: null
 				}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -9,7 +9,7 @@ import { extract_identifiers, is_text_attribute } from '../../utils/ast.js';
 import * as b from '../../utils/builders.js';
 import { Scope, ScopeRoot, create_scopes, get_rune, set_scope } from '../scope.js';
 import check_graph_for_cycles from './utils/check_graph_for_cycles.js';
-import { create_attribute } from '../nodes.js';
+import { create_attribute, is_custom_element_node } from '../nodes.js';
 import { analyze_css } from './css/css-analyze.js';
 import { prune } from './css/css-prune.js';
 import { hash, is_rune } from '../../../utils.js';
@@ -745,8 +745,7 @@ export function analyze_component(root, source, options) {
 						])
 					);
 					if (
-						element.type === 'RegularElement' &&
-						element.name.includes('-') &&
+						is_custom_element_node(element) &&
 						element.attributes.length === 1 &&
 						element.metadata.path
 					) {

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -746,8 +746,7 @@ export function analyze_component(root, source, options) {
 					);
 					if (
 						is_custom_element_node(element) &&
-						element.attributes.length === 1 &&
-						element.metadata.path
+						element.attributes.length === 1
 					) {
 						mark_subtree_dynamic(element.metadata.path);
 					}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -744,10 +744,7 @@ export function analyze_component(root, source, options) {
 							}
 						])
 					);
-					if (
-						is_custom_element_node(element) &&
-						element.attributes.length === 1
-					) {
+					if (is_custom_element_node(element) && element.attributes.length === 1) {
 						mark_subtree_dynamic(element.metadata.path);
 					}
 				}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -747,7 +747,8 @@ export function analyze_component(root, source, options) {
 					if (
 						element.type === 'RegularElement' &&
 						element.name.includes('-') &&
-						element.attributes.length === 1
+						element.attributes.length === 1 &&
+						element.metadata.path
 					) {
 						mark_subtree_dynamic(element.metadata.path);
 					}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -67,6 +67,7 @@ import { UpdateExpression } from './visitors/UpdateExpression.js';
 import { UseDirective } from './visitors/UseDirective.js';
 import { VariableDeclarator } from './visitors/VariableDeclarator.js';
 import is_reference from 'is-reference';
+import { mark_subtree_dynamic } from './visitors/shared/fragment.js';
 
 /**
  * @type {Visitors}
@@ -743,6 +744,13 @@ export function analyze_component(root, source, options) {
 							}
 						])
 					);
+					if (
+						element.type === 'RegularElement' &&
+						element.name.includes('-') &&
+						element.attributes.length === 1
+					) {
+						mark_subtree_dynamic(element.metadata.path);
+					}
 				}
 			}
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/RegularElement.js
@@ -22,6 +22,8 @@ export function RegularElement(node, context) {
 
 	check_element(node, context.state);
 
+	node.metadata.path = [...context.path];
+
 	context.state.analysis.elements.push(node);
 
 	// Special case: Move the children of <textarea> into a value attribute if they are dynamic

--- a/packages/svelte/src/compiler/phases/nodes.js
+++ b/packages/svelte/src/compiler/phases/nodes.js
@@ -23,7 +23,7 @@ export function is_element_node(node) {
 
 /**
  * @param {AST.RegularElement | AST.SvelteElement} node
- * @returns {boolean}
+ * @returns {node is AST.RegularElement}
  */
 export function is_custom_element_node(node) {
 	return node.type === 'RegularElement' && node.name.includes('-');

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -303,6 +303,7 @@ export namespace AST {
 			/** `true` if contains a SpreadAttribute */
 			has_spread: boolean;
 			scoped: boolean;
+			path: SvelteNode[];
 		};
 	}
 

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -303,7 +303,7 @@ export namespace AST {
 			/** `true` if contains a SpreadAttribute */
 			has_spread: boolean;
 			scoped: boolean;
-			path?: SvelteNode[];
+			path: SvelteNode[];
 		};
 	}
 

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -303,7 +303,7 @@ export namespace AST {
 			/** `true` if contains a SpreadAttribute */
 			has_spread: boolean;
 			scoped: boolean;
-			path: SvelteNode[];
+			path?: SvelteNode[];
 		};
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-svelte-class/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-svelte-class/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [my_element, my_element_1] = target.querySelectorAll('my-element');
+		assert.equal(my_element.classList.contains('svelte-1koh33s'), true);
+		assert.equal(my_element_1.classList.contains('svelte-1koh33s'), true);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-svelte-class/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-svelte-class/main.svelte
@@ -1,0 +1,11 @@
+<div>
+	<my-element></my-element>
+</div>
+<my-element></my-element>
+
+
+<style>
+	my-element{
+		background: red;
+	}
+</style>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13426 

Initially i just marked every custom element as dynamic but that would've been a lot more code generated if there was a custom element that was actually skipped (this was problematic only because that custom element ends up having an attribute (the virtual class file). Since i needed the `path` to mark the tree as dynamic i've added it to the metadata because i didn't find a way to get the path from the element itself but if there's a better approach i can change it obviously.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
