### PR TITLE
fix: update return type of `parse` function

### DIFF
--- a/.changeset/little-ties-jam.md
+++ b/.changeset/little-ties-jam.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: update return type of `parse` function

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -87,7 +87,7 @@ export function compileModule(source, options) {
  * @overload
  * @param {string} source
  * @param {{ filename?: string; modern?: false }} [options]
- * @returns {Record<string, any>}
+ * @returns {LegacyRoot}
  */
 
 /**


### PR DESCRIPTION
we were missing the `LegacyRoot` return value on the overload. This fixes it

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
