### PR TITLE
fix: allow combinator at start of nested CSS selector

### DIFF
--- a/.changeset/young-ducks-punch.md
+++ b/.changeset/young-ducks-punch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow combinator at start of nested CSS selector

--- a/packages/svelte/src/compiler/phases/1-parse/read/style.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/style.js
@@ -351,11 +351,7 @@ function read_selector(parser, inside_pseudo_class = false) {
 		const combinator = read_combinator(parser);
 
 		if (combinator) {
-			if (relative_selector.selectors.length === 0) {
-				if (!inside_pseudo_class) {
-					e.css_selector_invalid(start);
-				}
-			} else {
+			if (relative_selector.selectors.length > 0) {
 				relative_selector.end = index;
 				children.push(relative_selector);
 			}

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -124,7 +124,7 @@ const css_visitors = {
 			parent.children[0] === node &&
 			context.path.at(-3)?.type !== 'PseudoClassSelector'
 		) {
-			e.css_selector_invalid(node.start); // only highlight the combinator
+			e.css_selector_invalid(node.combinator);
 		}
 
 		node.metadata.is_global = node.selectors.length >= 1 && is_global(node);

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -116,6 +116,17 @@ const css_visitors = {
 		);
 	},
 	RelativeSelector(node, context) {
+		const parent = /** @type {Css.ComplexSelector} */ (context.path.at(-1));
+
+		if (
+			node.combinator != null &&
+			!context.state.rule?.metadata.parent_rule &&
+			parent.children[0] === node &&
+			context.path.at(-3)?.type !== 'PseudoClassSelector'
+		) {
+			e.css_selector_invalid(node.start); // only highlight the combinator
+		}
+
 		node.metadata.is_global = node.selectors.length >= 1 && is_global(node);
 
 		if (node.selectors.length === 1) {

--- a/packages/svelte/tests/css/samples/nested-css-combinator/_config.js
+++ b/packages/svelte/tests/css/samples/nested-css-combinator/_config.js
@@ -1,0 +1,20 @@
+import { test } from '../../test';
+
+export default test({
+	warnings: [
+		{
+			code: 'css_unused_selector',
+			end: {
+				character: 109,
+				column: 11,
+				line: 11
+			},
+			message: 'Unused CSS selector "~ .unused"',
+			start: {
+				character: 100,
+				column: 2,
+				line: 11
+			}
+		}
+	]
+});

--- a/packages/svelte/tests/css/samples/nested-css-combinator/expected.css
+++ b/packages/svelte/tests/css/samples/nested-css-combinator/expected.css
@@ -1,0 +1,10 @@
+
+	.foo.svelte-xyz {
+		> .bar:where(.svelte-xyz) {
+			color: red;
+		}
+
+		/* (unused) ~ .unused {
+			color: red;
+		}*/
+	}

--- a/packages/svelte/tests/css/samples/nested-css-combinator/input.svelte
+++ b/packages/svelte/tests/css/samples/nested-css-combinator/input.svelte
@@ -1,0 +1,15 @@
+<div class="foo">
+	<div class="bar"></div>
+</div>
+
+<style>
+	.foo {
+		> .bar {
+			color: red;
+		}
+
+		~ .unused {
+			color: red;
+		}
+	}
+</style>

--- a/packages/svelte/tests/validator/samples/css-invalid-combinator-selector-1/errors.json
+++ b/packages/svelte/tests/validator/samples/css-invalid-combinator-selector-1/errors.json
@@ -8,7 +8,7 @@
 		},
 		"end": {
 			"line": 10,
-			"column": 1
+			"column": 2
 		}
 	}
 ]

--- a/packages/svelte/tests/validator/samples/css-invalid-combinator-selector-2/errors.json
+++ b/packages/svelte/tests/validator/samples/css-invalid-combinator-selector-2/errors.json
@@ -8,7 +8,7 @@
 		},
 		"end": {
 			"line": 8,
-			"column": 1
+			"column": 2
 		}
 	}
 ]

--- a/packages/svelte/tests/validator/samples/css-invalid-combinator-selector-3/errors.json
+++ b/packages/svelte/tests/validator/samples/css-invalid-combinator-selector-3/errors.json
@@ -8,7 +8,7 @@
 		},
 		"end": {
 			"line": 5,
-			"column": 2
+			"column": 3
 		}
 	}
 ]


### PR DESCRIPTION
Solved by moving the combinator positioning validation into the analysis phase

Fixes #13433

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
