### PR TITLE
feat: add `ComponentExports` utility type

### DIFF
--- a/.changeset/rotten-cups-float.md
+++ b/.changeset/rotten-cups-float.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: provide `ComponentExports` utility type

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -248,8 +248,12 @@ export type ComponentProps<Comp extends SvelteComponent | Component<any, any>> =
  * <MyComponent bind:this={component} />
  * ```
  */
-export type ComponentExports<TComponent extends Component<any, any>> =
-	TComponent extends Component<any, infer TExports> ? TExports : never;
+export type ComponentExports<TComponent extends Component<any, any> | typeof SvelteComponent<any>> =
+	TComponent extends typeof SvelteComponent<any>
+		? InstanceType<TComponent>
+		: TComponent extends Component<any, infer TExports>
+			? TExports
+			: never;
 
 /**
  * @deprecated This type is obsolete when working with the new `Component` type.

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -236,6 +236,22 @@ export type ComponentProps<Comp extends SvelteComponent | Component<any, any>> =
 			: never;
 
 /**
+ * Convenience type to get the properties that given component exports.
+ *
+ * Example: Typing the `bind:this` for a component named `MyComponent`
+ * ```
+ * <script lang="ts">
+ * 	import MyComponent from '$lib/component';
+ * 	let component: ComponentExports<typeof MyComponent> | undefined = undefined;
+ * <script>
+ *
+ * <MyComponent bind:this={component} />
+ * ```
+ */
+export type ComponentExports<TComponent extends Component<any, any>> =
+	TComponent extends Component<any, infer TExports> ? TExports : never;
+
+/**
  * @deprecated This type is obsolete when working with the new `Component` type.
  *
  * @description

--- a/packages/svelte/tests/types/component.ts
+++ b/packages/svelte/tests/types/component.ts
@@ -7,7 +7,8 @@ import {
 	mount,
 	hydrate,
 	type Component,
-	type ComponentInternals
+	type ComponentInternals,
+	type ComponentExports
 } from 'svelte';
 import { render } from 'svelte/server';
 
@@ -180,6 +181,16 @@ render(NewComponent, {
 	}
 });
 
+const newComponentExports: ComponentExports<typeof NewComponent> = {
+	anExport: '',
+	$$events_def: null as any,
+	$$prop_def: null as any,
+	$$slot_def: null as any,
+	$set: null as any,
+	$destroy: null as any,
+	$on: null as any
+};
+
 // --------------------------------------------------------------------------- interop
 
 const AsLegacyComponent = asClassComponent(newComponent);
@@ -336,6 +347,19 @@ render(functionComponent, {
 		readonly: 1
 	}
 });
+
+const functionComponentExports: ComponentExports<typeof functionComponent> = {
+	foo: 'bar',
+	// @ts-expect-error
+	x: ''
+};
+
+type AdhocFunctionComponent = (a: unknown, b: { a: true }) => { foo: string };
+const adhocFunctionComponentExport: ComponentExports<AdhocFunctionComponent> = {
+	foo: 'bar',
+	// @ts-expect-error
+	x: ''
+};
 
 // --------------------------------------------------------------------------- *.svelte components
 

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -233,6 +233,22 @@ declare module 'svelte' {
 				: never;
 
 	/**
+	 * Convenience type to get the properties that given component exports.
+	 *
+	 * Example: Typing the `bind:this` for a component named `MyComponent`
+	 * ```
+	 * <script lang="ts">
+	 * 	import MyComponent from '$lib/component';
+	 * 	let component: ComponentExports<typeof MyComponent> | undefined = undefined;
+	 * <script>
+	 *
+	 * <MyComponent bind:this={component} />
+	 * ```
+	 */
+	export type ComponentExports<TComponent extends Component<any, any>> =
+		TComponent extends Component<any, infer TExports> ? TExports : never;
+
+	/**
 	 * @deprecated This type is obsolete when working with the new `Component` type.
 	 *
 	 * @description

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -245,8 +245,12 @@ declare module 'svelte' {
 	 * <MyComponent bind:this={component} />
 	 * ```
 	 */
-	export type ComponentExports<TComponent extends Component<any, any>> =
-		TComponent extends Component<any, infer TExports> ? TExports : never;
+	export type ComponentExports<TComponent extends Component<any, any> | typeof SvelteComponent<any>> =
+		TComponent extends typeof SvelteComponent<any>
+			? InstanceType<TComponent>
+			: TComponent extends Component<any, infer TExports>
+				? TExports
+				: never;
 
 	/**
 	 * @deprecated This type is obsolete when working with the new `Component` type.


### PR DESCRIPTION
With the type change for `bind:this` on components (related issues are [this language-tools issue](https://github.com/sveltejs/language-tools/issues/2522) and [13430](https://github.com/sveltejs/svelte/issues/13430)).
Recommended way is to do this (per [this](https://github.com/sveltejs/language-tools/issues/2522#issuecomment-2380048973) comment):
> ```diff
> <script lang="ts">
>     import CloneWorkflowDialog from './dialogs/CloneWorkflowDialog.svelte';
> 
> -   let cloneWorkflowDialog : CloneWorkflowDialog;
> +   let cloneWorkflowDialog : ReturnType<typeof CloneWorkflowDialog>;
> </script>
> ```

Since we currently have the `Component` type exported by svelte that has the `Exports` we can rely on that and do this instead:
```diff
<script lang="ts">
    import CloneWorkflowDialog from './dialogs/CloneWorkflowDialog.svelte';
    // in a utility type, preferably provided by Svelte package itself. 
+   type ComponentExports<TComponent extends Component<any, any>> =
+	TComponent extends Component<any, infer TExports> ? TExports : never;
 
-  let cloneWorkflowDialog : ReturnType<typeof CloneWorkflowDialog>;
+  let cloneWorkflowDialog : ComponentExports<typeof CloneWorkflowDialog>;
</script>
```

## Whats the problem with using `ReturnType`?
This is the safer/forward-compatibale way that the svelte can decide on the type.



## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
