### PR TITLE
feat: fix accessors and support migration of accessors

### DIFF
--- a/.changeset/large-rules-hang.md
+++ b/.changeset/large-rules-hang.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: fix accessors and support migration of accessors

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -276,6 +276,13 @@ export function client_component(analysis, options) {
 			}
 		}
 
+		if (binding?.kind === 'prop' || binding?.kind === 'bindable_prop') {
+			return [
+				getter,
+				b.set(alias ?? name, [b.stmt(b.call(name, b.call('$.proxy', b.id('$$value'))))])
+			];
+		}
+
 		if (binding?.kind === 'state' || binding?.kind === 'raw_state') {
 			const value = binding.kind === 'state' ? b.call('$.proxy', b.id('$$value')) : b.id('$$value');
 			return [getter, b.set(alias ?? name, [b.stmt(b.call('$.set', b.id(name), value))])];

--- a/packages/svelte/tests/migrate/samples/accessors/input.svelte
+++ b/packages/svelte/tests/migrate/samples/accessors/input.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	type $$Props = {
+		test: string;
+	}
+	
+	export let count = 0;
+	export let stuff;
+</script>
+
+<button>
+	<slot name="cool" />
+</button>
+
+<svelte:options accessors immutable/>

--- a/packages/svelte/tests/migrate/samples/accessors/output.svelte
+++ b/packages/svelte/tests/migrate/samples/accessors/output.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	
+	
+	interface Props {
+		test: string;
+		count?: number;
+		stuff: any;
+		cool?: import('svelte').Snippet;
+	}
+
+	let {
+		test,
+		count = 0,
+		stuff,
+		cool
+	}: Props = $props();
+
+	export {
+		test,
+		count,
+		stuff,
+		cool,
+	}
+</script>
+
+<button>
+	{@render cool?.()}
+</button>
+
+<svelte:options immutable/>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13453

This both fixes `accessors` when defined as exports and implement the migration from a component with `<svelte:options accessors />` removing the `accessors` option and exporting all the props.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
