### PR TITLE
feat: support migration of single assignment labeled statements

### DIFF
--- a/.changeset/great-dots-wonder.md
+++ b/.changeset/great-dots-wonder.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: support migration of single assignment labeled statements

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -493,8 +493,10 @@ const instance_script = {
 				);
 
 				const labeled_has_single_assignment =
-					labeled_statement?.body.type === 'BlockStatement' &&
-					labeled_statement.body.body.length === 1;
+					(labeled_statement?.body.type === 'BlockStatement' &&
+						labeled_statement.body.body.length === 1) ||
+					(labeled_statement?.body.type === 'ExpressionStatement' &&
+						labeled_statement.body.expression.type === 'AssignmentExpression');
 
 				if (
 					possible_derived &&

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
@@ -46,8 +46,6 @@
 
 	let should_be_state;
 	$: should_be_state = 42;
-
-	$: should_be_state_too = 42;
 </script>
 
 <button on:click={()=>{

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
@@ -43,6 +43,11 @@
 
 	let almost_infinity;
 	$: almost_infinity = count * 128;
+
+	let should_be_state;
+	$: should_be_state = 42;
+
+	$: should_be_state_too = 42;
 </script>
 
 <button on:click={()=>{

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
@@ -46,10 +46,12 @@
 
 	let should_be_state;
 	$: should_be_state = 42;
+	$: should_be_state_too = 42;
 </script>
 
 <button on:click={()=>{
 	count++;
 	eight_times++;
 	sixteen_times += 1;
+	should_be_state_too++;
 }}>click</button>

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
@@ -40,6 +40,9 @@
 		evenmore = count * 64;
 		evenmore_doubled = evenmore * 2;
 	}
+
+	let almost_infinity;
+	$: almost_infinity = count * 128;
 </script>
 
 <button on:click={()=>{

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/input.svelte
@@ -1,0 +1,49 @@
+<script>
+	let count = 0;
+	let double;
+	$:{
+		double = count * 2;
+	}
+	
+	let quadruple;
+	$:{
+		quadruple = count * 4;
+		console.log("i have a side effect")
+	}
+
+	let eight_times;
+	$:{
+		// updated
+		eight_times = count * 8;
+	}
+
+	let sixteen_times;
+	$:{
+		// reassigned outside labeled statement
+		sixteen_times = count * 16;
+	}
+
+	let alot_times;
+	$:{
+		// reassigned in multiple labeled
+		alot_times = count * 32;
+	}
+	$:{
+		// reassigned in multiple labeled
+		alot_times = count * 32;
+	}
+
+	let evenmore;
+	let evenmore_doubled;
+	$:{
+		// multiple stuff in label
+		evenmore = count * 64;
+		evenmore_doubled = evenmore * 2;
+	}
+</script>
+
+<button on:click={()=>{
+	count++;
+	eight_times++;
+	sixteen_times += 1;
+}}>click</button>

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
@@ -1,0 +1,49 @@
+<script>
+	import { run } from 'svelte/legacy';
+
+	let count = $state(0);
+	let double = $derived(count * 2);
+	
+	
+	let quadruple = $state();
+	run(() => {
+		quadruple = count * 4;
+		console.log("i have a side effect")
+	});
+
+	let eight_times = $state();
+	run(() => {
+		// updated
+		eight_times = count * 8;
+	});
+
+	let sixteen_times = $state();
+	run(() => {
+		// reassigned outside labeled statement
+		sixteen_times = count * 16;
+	});
+
+	let alot_times = $state();
+	run(() => {
+		// reassigned in multiple labeled
+		alot_times = count * 32;
+	});
+	run(() => {
+		// reassigned in multiple labeled
+		alot_times = count * 32;
+	});
+
+	let evenmore = $state();
+	let evenmore_doubled = $state();
+	run(() => {
+		// multiple stuff in label
+		evenmore = count * 64;
+		evenmore_doubled = evenmore * 2;
+	});
+</script>
+
+<button onclick={()=>{
+	count++;
+	eight_times++;
+	sixteen_times += 1;
+}}>click</button>

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
@@ -46,10 +46,13 @@
 
 	let should_be_state = $state(42);
 	
+	let should_be_state_too = $state(42);
+	
 </script>
 
 <button onclick={()=>{
 	count++;
 	eight_times++;
 	sixteen_times += 1;
+	should_be_state_too++;
 }}>click</button>

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
@@ -46,8 +46,6 @@
 
 	let should_be_state = $state(42);
 	
-
-	let should_be_state_too = $derived(42);
 </script>
 
 <button onclick={()=>{

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
@@ -43,6 +43,11 @@
 
 	let almost_infinity = $derived(count * 128);
 	
+
+	let should_be_state = $state(42);
+	
+
+	let should_be_state_too = $derived(42);
 </script>
 
 <button onclick={()=>{

--- a/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
+++ b/packages/svelte/tests/migrate/samples/single-assignment-labeled/output.svelte
@@ -40,6 +40,9 @@
 		evenmore = count * 64;
 		evenmore_doubled = evenmore * 2;
 	});
+
+	let almost_infinity = $derived(count * 128);
+	
 </script>
 
 <button onclick={()=>{


### PR DESCRIPTION
## Svelte 5 rewrite

I took a shot at closing #13460

Also closes #13459

It seems to work fine but i don't know if i'm missing some weird use case i was not able to think about.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
