### PR TITLE
fix: correctly migrate `$$slots` with bracket member expressions & slots with static props

### DIFF
--- a/.changeset/nine-kids-whisper.md
+++ b/.changeset/nine-kids-whisper.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly migrate `$$slots` with bracket member expressions

--- a/.changeset/nine-kids-whisper.md
+++ b/.changeset/nine-kids-whisper.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: correctly migrate `$$slots` with bracket member expressions
+fix: correctly migrate `$$slots` with bracket member expressions & slots with static props

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -943,8 +943,6 @@ function handle_identifier(node, state, path) {
 	const parent = path.at(-1);
 	if (parent?.type === 'MemberExpression' && parent.property === node) return;
 
-	console.log(node);
-
 	if (state.analysis.uses_props && node.name !== '$$slots') {
 		if (node.name === '$$props' || node.name === '$$restProps') {
 			// not 100% correct for $$restProps but it'll do

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -189,7 +189,7 @@ export function migrate(source) {
 					}
 				} else {
 					if (analysis.uses_props || analysis.uses_rest_props) {
-						type = `{Record<string, any>}`;
+						type = `Record<string, any>`;
 					} else {
 						type = `{${state.props
 							.map((prop) => {

--- a/packages/svelte/tests/migrate/samples/props-rest-props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-rest-props/output.svelte
@@ -1,5 +1,5 @@
 <script>
-    /** @type {{Record<string, any>}} */
+    /** @type {Record<string, any>} */
     let { foo, ...rest } = $props();
 </script>
 

--- a/packages/svelte/tests/migrate/samples/slots-custom-element/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-custom-element/input.svelte
@@ -20,4 +20,8 @@
 
 {#if $$slots.default}foo{/if}
 
+{#if $$slots['default']}foo{/if}
+
+{#if $$slots['dashed-name']}foo{/if}
+
 <slot name="dashed-name" />

--- a/packages/svelte/tests/migrate/samples/slots-custom-element/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-custom-element/output.svelte
@@ -13,11 +13,15 @@
 	<slot name="foo" {foo} />
 {/if}
 
-{#if bar}
+{#if $$slots.bar}
 	{$$slots}
 	<slot name="bar" />
 {/if}
 
-{#if children}foo{/if}
+{#if $$slots.default}foo{/if}
+
+{#if $$slots['default']}foo{/if}
+
+{#if $$slots['dashed-name']}foo{/if}
 
 <slot name="dashed-name" />

--- a/packages/svelte/tests/migrate/samples/slots-with-$$props/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-with-$$props/input.svelte
@@ -1,0 +1,20 @@
+<button><slot /></button>
+
+{#if foo}
+	<slot name="foo" {foo} />
+{/if}
+
+{#if $$slots.bar}
+	{$$slots}
+	<slot name="bar" />
+{/if}
+
+{#if $$slots.default}foo{/if}
+
+{#if $$slots['default']}foo{/if}
+
+{#if $$slots['dashed-name']}foo{/if}
+
+<slot name="dashed-name" />
+
+<slot header="something" title={$$props.cool} {id} />

--- a/packages/svelte/tests/migrate/samples/slots-with-$$props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-with-$$props/output.svelte
@@ -1,0 +1,27 @@
+<script>
+	/** @type {Record<string, any>} */
+	let {
+		...props
+	} = $props();
+</script>
+
+<button>{@render props.children?.()}</button>
+
+{#if foo}
+	{@render props.foo_1?.({ foo, })}
+{/if}
+
+{#if props.bar}
+	{$$slots}
+	{@render props.bar?.()}
+{/if}
+
+{#if props.children}foo{/if}
+
+{#if props.children}foo{/if}
+
+{#if props.dashed_name}foo{/if}
+
+{@render props.dashed_name?.()}
+
+{@render props.children?.({ header: "something", title: props.cool, id, })}

--- a/packages/svelte/tests/migrate/samples/slots/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/input.svelte
@@ -16,3 +16,5 @@
 {#if $$slots['dashed-name']}foo{/if}
 
 <slot name="dashed-name" />
+
+<slot header="something" title={my_title} {id} />

--- a/packages/svelte/tests/migrate/samples/slots/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/input.svelte
@@ -11,4 +11,8 @@
 
 {#if $$slots.default}foo{/if}
 
+{#if $$slots['default']}foo{/if}
+
+{#if $$slots['dashed-name']}foo{/if}
+
 <slot name="dashed-name" />

--- a/packages/svelte/tests/migrate/samples/slots/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/output.svelte
@@ -21,4 +21,8 @@
 
 {#if children}foo{/if}
 
+{#if children}foo{/if}
+
+{#if dashed_name}foo{/if}
+
 {@render dashed_name?.()}

--- a/packages/svelte/tests/migrate/samples/slots/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/output.svelte
@@ -26,3 +26,5 @@
 {#if dashed_name}foo{/if}
 
 {@render dashed_name?.()}
+
+{@render children?.({ header: "something", title: my_title, id, })}

--- a/packages/svelte/tests/migrate/samples/svelte-component/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-component/output.svelte
@@ -1,5 +1,5 @@
 <script>
-	/** @type {{Record<string, any>}} */
+	/** @type {Record<string, any>} */
 	let { ...rest } = $props();
 	let Component;
 	let fallback;


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13467 (i've also fixed a bug regarding the migration of `$$slots` when the component is a custom element.

EDIT: it was simple enough so i also fixed #13466 

EDIT to the EDIT: i also fixed #13472 in this PR...since it was not reviewed yet i just pushed here, if you need a clearer vision while reviewing you can just look at the separate commits since they are pretty much self contained.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
