### PR TITLE
fix: move labeled statements that need reordering after props insertion point

### DIFF
--- a/.changeset/many-fishes-warn.md
+++ b/.changeset/many-fishes-warn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: move labeled statements that need reordering after props insertion point

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -236,7 +236,9 @@ export function migrate(source) {
 				dependencies.some(
 					(dep) =>
 						!ids.includes(dep) &&
-						/** @type {number} */ (dep.node.start) > /** @type {number} */ (node.start)
+						(dep.kind === 'prop' || dep.kind === 'bindable_prop'
+							? state.props_insertion_point
+							: /** @type {number} */ (dep.node.start)) > /** @type {number} */ (node.start)
 				)
 			) {
 				needs_reordering = true;

--- a/packages/svelte/tests/migrate/samples/props-and-labeled/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-and-labeled/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	export let readonly;
+	$: writable = !readonly;
+	export let optional = 'foo';
+</script>
+
+{readonly} {optional} {writable}

--- a/packages/svelte/tests/migrate/samples/props-and-labeled/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-and-labeled/output.svelte
@@ -1,0 +1,7 @@
+<script>
+	/** @type {{readonly: any, optional?: string}} */
+	let { readonly, optional = 'foo' } = $props();
+	let writable = $derived(!readonly);
+</script>
+
+{readonly} {optional} {writable}


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13470 

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
