### PR TITLE
fix: migrate `$$Props` without creating non existent props

### DIFF
--- a/.changeset/funny-houses-kick.md
+++ b/.changeset/funny-houses-kick.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: migrate `$$Props` without creating non existent props

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -150,6 +150,7 @@ export function migrate(source) {
 				props = `...${state.names.props}`;
 			} else {
 				props = state.props
+					.filter((prop) => !prop.type_only)
 					.map((prop) => {
 						let prop_str =
 							prop.local === prop.exported ? prop.local : `${prop.exported}: ${prop.local}`;
@@ -282,7 +283,7 @@ export function migrate(source) {
  *  str: MagicString;
  *  analysis: ComponentAnalysis;
  *  indent: string;
- *  props: Array<{ local: string; exported: string; init: string; bindable: boolean; slot_name?: string; optional: boolean; type: string; comment?: string }>;
+ *  props: Array<{ local: string; exported: string; init: string; bindable: boolean; slot_name?: string; optional: boolean; type: string; comment?: string, type_only?: boolean }>;
  *  props_insertion_point: number;
  *  has_props_rune: boolean;
  *  end: number;
@@ -419,6 +420,7 @@ const instance_script = {
 						: '';
 					prop.bindable = binding.updated;
 					prop.exported = binding.prop_alias || name;
+					prop.type_only = false;
 				} else {
 					state.props.push({
 						local: name,
@@ -989,7 +991,8 @@ function handle_identifier(node, state, path) {
 							bindable: false,
 							optional: member.optional,
 							type,
-							comment
+							comment,
+							type_only: true
 						});
 					}
 				}

--- a/packages/svelte/tests/migrate/samples/props-interface/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-interface/input.svelte
@@ -3,6 +3,8 @@
 		/** foo */
 		foo: string;
 		bar: boolean;
+		/** should not create a prop */
+		type_only: boolean;
 	}
 
 	export let foo: $$Props['foo'];

--- a/packages/svelte/tests/migrate/samples/props-interface/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-interface/output.svelte
@@ -5,6 +5,8 @@
 		/** foo */
 		foo: string;
 		bar: boolean;
+		/** should not create a prop */
+		type_only: boolean;
 	}
 
 	let { foo = $bindable(), bar = true }: Props = $props();


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13471

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
