### PR TITLE
feat: migrate slot usages

### DIFF
--- a/.changeset/small-suns-lie.md
+++ b/.changeset/small-suns-lie.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: migrate slot usages

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1043,8 +1043,17 @@ function migrate_slot_usage(node, path, state) {
 		}
 	} else {
 		// Named slot or `svelte:fragment`: wrap element itself in a snippet
-		state.str.prependRight(node.start, `{#snippet ${snippet_name}(${props})}`);
-		state.str.appendLeft(node.end, `{/snippet}`);
+		state.str.prependLeft(
+			node.start,
+			`{#snippet ${snippet_name}(${props})}\n${state.indent.repeat(path.length - 2)}`
+		);
+		state.str.indent(state.indent, {
+			exclude: [
+				[0, node.start],
+				[node.end, state.str.original.length]
+			]
+		});
+		state.str.appendLeft(node.end, `\n${state.indent.repeat(path.length - 2)}{/snippet}`);
 	}
 }
 

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -10,7 +10,11 @@ import { regex_valid_component_name } from '../phases/1-parse/state/element.js';
 import { analyze_component } from '../phases/2-analyze/index.js';
 import { get_rune } from '../phases/scope.js';
 import { reset, reset_warning_filter } from '../state.js';
-import { extract_identifiers, extract_all_identifiers_from_expression } from '../utils/ast.js';
+import {
+	extract_identifiers,
+	extract_all_identifiers_from_expression,
+	is_text_attribute
+} from '../utils/ast.js';
 import { migrate_svelte_ignore } from '../utils/extract_svelte_ignore.js';
 import { validate_component_options } from '../validate-options.js';
 import { is_svg, is_void } from '../../utils.js';
@@ -711,7 +715,8 @@ const template = {
 	Identifier(node, { state, path }) {
 		handle_identifier(node, state, path);
 	},
-	RegularElement(node, { state, next }) {
+	RegularElement(node, { state, path, next }) {
+		migrate_slot_usage(node, path, state);
 		handle_events(node, state);
 		// Strip off any namespace from the beginning of the node name.
 		const node_name = node.name.replace(/[a-zA-Z-]*:/g, '');
@@ -724,7 +729,9 @@ const template = {
 		}
 		next();
 	},
-	SvelteElement(node, { state, next }) {
+	SvelteElement(node, { state, path, next }) {
+		migrate_slot_usage(node, path, state);
+
 		if (node.tag.type === 'Literal') {
 			let is_static = true;
 
@@ -748,8 +755,14 @@ const template = {
 		handle_events(node, state);
 		next();
 	},
+	Component(node, { state, path, next }) {
+		next();
+		migrate_slot_usage(node, path, state);
+	},
 	SvelteComponent(node, { state, next, path }) {
 		next();
+
+		migrate_slot_usage(node, path, state);
 
 		let expression = state.str
 			.snip(
@@ -816,6 +829,10 @@ const template = {
 		const end_pos = state.str.original.indexOf('}', node.expression.end) + 1;
 		state.str.remove(this_pos, end_pos);
 	},
+	SvelteFragment(node, { state, path, next }) {
+		migrate_slot_usage(node, path, state);
+		next();
+	},
 	SvelteWindow(node, { state, next }) {
 		handle_events(node, state);
 		next();
@@ -828,7 +845,9 @@ const template = {
 		handle_events(node, state);
 		next();
 	},
-	SlotElement(node, { state, next, visit }) {
+	SlotElement(node, { state, path, next, visit }) {
+		migrate_slot_usage(node, path, state);
+
 		if (state.analysis.custom_element) return;
 		let name = 'children';
 		let slot_name = 'default';
@@ -914,6 +933,98 @@ const template = {
 		}
 	}
 };
+
+/**
+ * @param {AST.RegularElement | AST.SvelteElement | AST.SvelteComponent | AST.Component | AST.SlotElement | AST.SvelteFragment} node
+ * @param {SvelteNode[]} path
+ * @param {State} state
+ */
+function migrate_slot_usage(node, path, state) {
+	const parent = path.at(-2);
+	// Bail on custom element slot usage
+	if (
+		parent?.type !== 'Component' &&
+		parent?.type !== 'SvelteComponent' &&
+		node.type !== 'Component' &&
+		node.type !== 'SvelteComponent'
+	) {
+		return;
+	}
+
+	let snippet_name = 'children';
+	let snippet_props = [];
+
+	for (let attribute of node.attributes) {
+		if (
+			attribute.type === 'Attribute' &&
+			attribute.name === 'slot' &&
+			is_text_attribute(attribute)
+		) {
+			snippet_name = attribute.value[0].data;
+			state.str.remove(attribute.start, attribute.end);
+		}
+		if (attribute.type === 'LetDirective') {
+			snippet_props.push(
+				attribute.name +
+					(attribute.expression
+						? `: ${state.str.original.substring(/** @type {number} */ (attribute.expression.start), /** @type {number} */ (attribute.expression.end))}`
+						: '')
+			);
+			state.str.remove(attribute.start, attribute.end);
+		}
+	}
+
+	if (node.type === 'SvelteFragment' && node.fragment.nodes.length > 0) {
+		// remove node itself, keep content
+		state.str.remove(node.start, node.fragment.nodes[0].start);
+		state.str.remove(node.fragment.nodes[node.fragment.nodes.length - 1].end, node.end);
+	}
+
+	const props = snippet_props.length > 0 ? `{ ${snippet_props.join(', ')} }` : '';
+
+	if (snippet_name === 'children' && node.type !== 'SvelteFragment') {
+		if (snippet_props.length === 0) return; // nothing to do
+
+		// Default slot: wrap children in a snippet (TODO: named slots)
+		const inner_start = node.fragment.nodes[0].start;
+		let inner_end = node.fragment.nodes[node.fragment.nodes.length - 1].end;
+		for (let i = 0; i < node.fragment.nodes.length; i++) {
+			const inner = node.fragment.nodes[i];
+			if (
+				(inner.type === 'RegularElement' ||
+					inner.type === 'SvelteElement' ||
+					inner.type === 'Component' ||
+					inner.type === 'SvelteComponent' ||
+					inner.type === 'SlotElement' ||
+					inner.type === 'SvelteFragment') &&
+				inner.attributes.some((attr) => attr.type === 'Attribute' && attr.name === 'slot')
+			) {
+				// Assumption: People don't have default content mixed with named slots
+				inner_end = inner.start;
+				break;
+			}
+		}
+
+		state.str.appendLeft(
+			inner_start,
+			`\n${state.indent.repeat(path.length)}{#snippet ${snippet_name}(${props})}`
+		);
+		state.str.indent(state.indent, {
+			exclude: [
+				[0, inner_start],
+				[inner_end, state.str.original.length]
+			]
+		});
+		state.str.prependLeft(
+			inner_end,
+			`${state.indent.repeat(path.length)}{/snippet}\n${state.indent.repeat(path.length - 1)}`
+		);
+	} else {
+		// Named slot or `svelte:fragment`: wrap element itself in a snippet
+		state.str.prependLeft(node.start, `{#snippet ${snippet_name}(${props})}`);
+		state.str.appendRight(node.end, `{/snippet}`);
+	}
+}
 
 /**
  * @param {VariableDeclarator} declarator

--- a/packages/svelte/tests/migrate/samples/slot-usages/_config.js
+++ b/packages/svelte/tests/migrate/samples/slot-usages/_config.js
@@ -1,1 +1,0 @@
-export default { solo: false };

--- a/packages/svelte/tests/migrate/samples/slot-usages/_config.js
+++ b/packages/svelte/tests/migrate/samples/slot-usages/_config.js
@@ -1,0 +1,1 @@
+export default { solo: false };

--- a/packages/svelte/tests/migrate/samples/slot-usages/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-usages/input.svelte
@@ -44,6 +44,32 @@
     <svelte:fragment slot="named" let:foo>{foo}</svelte:fragment>
 </Component>
 
+<Component>
+    <div slot="foo">foo</div>
+    OMG WHY
+    <div slot="bar">bar</div>
+</Component>
+
+<Component>
+    If you do mix slots like this
+    <div slot="foo">foo</div>
+    you're a monster
+    <div slot="bar">bar</div>
+</Component>
+
+<Component let:omg>
+    <div slot="foo">foo</div>
+    {omg} WHY
+    <div slot="bar">bar</div>
+</Component>
+
+<Component let:monster>
+    If you do mix slots like this
+    <div slot="foo">foo</div>
+    you're a {monster}
+    <div slot="bar">bar</div>
+</Component>
+
 <c-e>
     <div slot="named">unchanged</div>
 </c-e>

--- a/packages/svelte/tests/migrate/samples/slot-usages/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-usages/input.svelte
@@ -23,6 +23,13 @@
 </Component>
 
 <Component>
+    <div slot="named">
+        <p>multi</p>
+        <p>line</p>
+    </div>
+</Component>
+
+<Component>
     <svelte:element this={'div'} slot="named">x</svelte:element>
 </Component>
 

--- a/packages/svelte/tests/migrate/samples/slot-usages/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-usages/input.svelte
@@ -1,0 +1,49 @@
+<Component>
+    unchanged
+</Component>
+
+<svelte:component this={Component}>
+    unchanged
+</svelte:component>
+
+<Component let:foo>
+    <div>{foo}</div>
+</Component>
+
+<Component let:foo={bar}>
+    <div>{bar}</div>
+</Component>
+
+<svelte:component this={Component} let:foo>
+    <div>{foo}</div>
+</svelte:component>
+
+<Component>
+    <div slot="named">x</div>
+</Component>
+
+<Component>
+    <svelte:element this={'div'} slot="named">x</svelte:element>
+</Component>
+
+<Component>
+    <div slot="foo" let:foo>{foo}</div>
+    <div slot="bar" let:foo={bar}>{bar}</div>
+</Component>
+
+<Component let:foo>
+    {foo}
+    <div slot="named">x</div>
+</Component>
+
+<Component>
+    <svelte:fragment let:foo>{foo}</svelte:fragment>
+</Component>
+
+<Component>
+    <svelte:fragment slot="named" let:foo>{foo}</svelte:fragment>
+</Component>
+
+<c-e>
+    <div slot="named">unchanged</div>
+</c-e>

--- a/packages/svelte/tests/migrate/samples/slot-usages/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-usages/output.svelte
@@ -1,0 +1,57 @@
+<Component>
+    unchanged
+</Component>
+
+<Component>
+    unchanged
+</Component>
+
+<Component >
+    {#snippet children({ foo })}
+        <div>{foo}</div>
+    {/snippet}
+</Component>
+
+<Component >
+    {#snippet children({ foo: bar })}
+        <div>{bar}</div>
+    {/snippet}
+</Component>
+
+<Component >
+    {#snippet children({ foo })}
+        <div>{foo}</div>
+    {/snippet}
+</Component>
+
+<Component>
+    {#snippet named()}<div >x</div>{/snippet}
+</Component>
+
+<Component>
+    {#snippet named()}<svelte:element this={'div'} >x</svelte:element>{/snippet}
+</Component>
+
+<Component>
+    {#snippet foo({ foo })}<div  >{foo}</div>{/snippet}
+    {#snippet bar({ foo: bar })}<div  >{bar}</div>{/snippet}
+</Component>
+
+<Component >
+    {#snippet children({ foo })}
+        {foo}
+            {/snippet}
+{#snippet named()}<div >x</div>{/snippet}
+</Component>
+
+<Component>
+    {#snippet children({ foo })}{foo}{/snippet}
+</Component>
+
+<Component>
+    {#snippet named({ foo })}{foo}{/snippet}
+</Component>
+
+<c-e>
+    <div slot="named">unchanged</div>
+</c-e>

--- a/packages/svelte/tests/migrate/samples/slot-usages/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-usages/output.svelte
@@ -25,52 +25,87 @@
 </Component>
 
 <Component>
-    {#snippet named()}<div >x</div>{/snippet}
+    {#snippet named()}
+        <div >x</div>
+    {/snippet}
 </Component>
 
 <Component>
-    {#snippet named()}<svelte:element this={'div'} >x</svelte:element>{/snippet}
+    {#snippet named()}
+        <div >
+            <p>multi</p>
+            <p>line</p>
+        </div>
+    {/snippet}
 </Component>
 
 <Component>
-    {#snippet foo({ foo })}<div  >{foo}</div>{/snippet}
-    {#snippet bar({ foo: bar })}<div  >{bar}</div>{/snippet}
+    {#snippet named()}
+        <svelte:element this={'div'} >x</svelte:element>
+    {/snippet}
+</Component>
+
+<Component>
+    {#snippet foo({ foo })}
+        <div  >{foo}</div>
+    {/snippet}
+    {#snippet bar({ foo: bar })}
+        <div  >{bar}</div>
+    {/snippet}
 </Component>
 
 <Component >
     {#snippet children({ foo })}
         {foo}
         {/snippet}
-    {#snippet named()}<div >x</div>{/snippet}
+    {#snippet named()}
+        <div >x</div>
+    {/snippet}
 </Component>
 
 <Component>
-    {#snippet children({ foo })}{foo}{/snippet}
+    {#snippet children({ foo })}
+        {foo}
+    {/snippet}
 </Component>
 
 <Component>
-    {#snippet named({ foo })}{foo}{/snippet}
+    {#snippet named({ foo })}
+        {foo}
+    {/snippet}
 </Component>
 
 <Component>
-    {#snippet foo()}<div >foo</div>{/snippet}
+    {#snippet foo()}
+        <div >foo</div>
+    {/snippet}
     OMG WHY
-    {#snippet bar()}<div >bar</div>{/snippet}
+    {#snippet bar()}
+        <div >bar</div>
+    {/snippet}
 </Component>
 
 <Component>
     If you do mix slots like this
-    {#snippet foo()}<div >foo</div>{/snippet}
+    {#snippet foo()}
+        <div >foo</div>
+    {/snippet}
     you're a monster
-    {#snippet bar()}<div >bar</div>{/snippet}
+    {#snippet bar()}
+        <div >bar</div>
+    {/snippet}
 </Component>
 
 <Component >
-    {#snippet foo()}<div >foo</div>{/snippet}
+    {#snippet foo()}
+        <div >foo</div>
+    {/snippet}
     {#snippet children({ omg })}
         {omg} WHY
         {/snippet}
-    {#snippet bar()}<div >bar</div>{/snippet}
+    {#snippet bar()}
+        <div >bar</div>
+    {/snippet}
 </Component>
 
 <Component >{#snippet children({ monster })}
@@ -78,8 +113,12 @@
         If you do mix slots like this
          
     you're a {monster}{/snippet}
-    {#snippet foo()}<div >foo</div>{/snippet}
-    {#snippet bar()}<div >bar</div>{/snippet}
+    {#snippet foo()}
+        <div >foo</div>
+    {/snippet}
+    {#snippet bar()}
+        <div >bar</div>
+    {/snippet}
 </Component>
 
 <c-e>

--- a/packages/svelte/tests/migrate/samples/slot-usages/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-usages/output.svelte
@@ -40,8 +40,8 @@
 <Component >
     {#snippet children({ foo })}
         {foo}
-            {/snippet}
-{#snippet named()}<div >x</div>{/snippet}
+        {/snippet}
+    {#snippet named()}<div >x</div>{/snippet}
 </Component>
 
 <Component>
@@ -50,6 +50,36 @@
 
 <Component>
     {#snippet named({ foo })}{foo}{/snippet}
+</Component>
+
+<Component>
+    {#snippet foo()}<div >foo</div>{/snippet}
+    OMG WHY
+    {#snippet bar()}<div >bar</div>{/snippet}
+</Component>
+
+<Component>
+    If you do mix slots like this
+    {#snippet foo()}<div >foo</div>{/snippet}
+    you're a monster
+    {#snippet bar()}<div >bar</div>{/snippet}
+</Component>
+
+<Component >
+    {#snippet foo()}<div >foo</div>{/snippet}
+    {#snippet children({ omg })}
+        {omg} WHY
+        {/snippet}
+    {#snippet bar()}<div >bar</div>{/snippet}
+</Component>
+
+<Component >{#snippet children({ monster })}
+    
+        If you do mix slots like this
+         
+    you're a {monster}{/snippet}
+    {#snippet foo()}<div >foo</div>{/snippet}
+    {#snippet bar()}<div >bar</div>{/snippet}
 </Component>
 
 <c-e>

--- a/packages/svelte/tests/migrate/samples/svelte-component/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-component/output.svelte
@@ -7,74 +7,86 @@
 	const SvelteComponent_10 = $derived(Math.random() > .5 ? rest.heads : rest.tail);
 </script>
 
-<Component let:Comp>
-	<Comp />
+<Component >
+	{#snippet children({ Comp })}
+		<Comp />
+	{/snippet}
 </Component>
 
-<Component let:comp>
-	{@const SvelteComponent = comp}
+<Component >
+	{#snippet children({ comp })}
+		{@const SvelteComponent = comp}
 	<SvelteComponent />
+	{/snippet}
 </Component>
 
-<Component let:comp={stuff}>
-	{@const SvelteComponent_1 = stuff}
+<Component >
+	{#snippet children({ comp: stuff })}
+		{@const SvelteComponent_1 = stuff}
 	<SvelteComponent_1 />
+	{/snippet}
 </Component>
 
 <Component>
 	{@const SvelteComponent_2 = stuff}
-	<div slot="x" let:comp={stuff}>
+	{#snippet x({ comp: stuff })}<div  >
 		<SvelteComponent_2 />
-	</div>
+	</div>{/snippet}
 </Component>
 
 <Component>
 	{@const SvelteComponent_3 = stuff}
-	<svelte:fragment slot="x" let:comp={stuff}>
+	{#snippet x({ comp: stuff })}
 		<SvelteComponent_3 />
-	</svelte:fragment>
+	{/snippet}
 </Component>
 
 <Component>
 	{@const SvelteComponent_4 = stuff}
-	<svelte:element this={"div"} slot="x" let:comp={stuff}>
+	{#snippet x({ comp: stuff })}<svelte:element this={"div"}  >
 		<SvelteComponent_4 />
-	</svelte:element>
+	</svelte:element>{/snippet}
 </Component>
 
-<Component let:Comp>
-	<Comp />
+<Component >
+	{#snippet children({ Comp })}
+		<Comp />
+	{/snippet}
 </Component>
 
-<Component let:comp>
-	{@const SvelteComponent_5 = comp}
+<Component >
+	{#snippet children({ comp })}
+		{@const SvelteComponent_5 = comp}
 	<SvelteComponent_5 />
+	{/snippet}
 </Component>
 
-<Component let:comp={stuff}>
-	{@const SvelteComponent_6 = stuff}
+<Component >
+	{#snippet children({ comp: stuff })}
+		{@const SvelteComponent_6 = stuff}
 	<SvelteComponent_6 />
+	{/snippet}
 </Component>
 
 <Component>
 	{@const SvelteComponent_7 = stuff}
-	<div slot="x" let:comp={stuff}>
+	{#snippet x({ comp: stuff })}<div  >
 		<SvelteComponent_7 />
-	</div>
+	</div>{/snippet}
 </Component>
 
 <Component>
 	{@const SvelteComponent_8 = stuff}
-	<svelte:fragment slot="x" let:comp={stuff}>
+	{#snippet x({ comp: stuff })}
 		<SvelteComponent_8 />
-	</svelte:fragment>
+	{/snippet}
 </Component>
 
 <Component>
 	{@const SvelteComponent_9 = stuff}
-	<svelte:element this={"div"} slot="x" let:comp={stuff}>
+	{#snippet x({ comp: stuff })}<svelte:element this={"div"}  >
 		<SvelteComponent_9 />
-	</svelte:element>
+	</svelte:element>{/snippet}
 </Component>
 
 <Component />

--- a/packages/svelte/tests/migrate/samples/svelte-component/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-component/output.svelte
@@ -28,24 +28,30 @@
 </Component>
 
 <Component>
-	{#snippet x({ comp: stuff })}{@const SvelteComponent_2 = stuff}
+	{#snippet x({ comp: stuff })}
+		{@const SvelteComponent_2 = stuff}
 	<div  >
-		<SvelteComponent_2 />
-	</div>{/snippet}
-</Component>
-
-<Component>
-	{#snippet x({ comp: stuff })}{@const SvelteComponent_3 = stuff}
-	
-		<SvelteComponent_3 />
+			<SvelteComponent_2 />
+		</div>
 	{/snippet}
 </Component>
 
 <Component>
-	{#snippet x({ comp: stuff })}{@const SvelteComponent_4 = stuff}
+	{#snippet x({ comp: stuff })}
+	{@const SvelteComponent_3 = stuff}
+	
+			<SvelteComponent_3 />
+		
+	{/snippet}
+</Component>
+
+<Component>
+	{#snippet x({ comp: stuff })}
+		{@const SvelteComponent_4 = stuff}
 	<svelte:element this={"div"}  >
-		<SvelteComponent_4 />
-	</svelte:element>{/snippet}
+			<SvelteComponent_4 />
+		</svelte:element>
+	{/snippet}
 </Component>
 
 <Component >
@@ -69,24 +75,30 @@
 </Component>
 
 <Component>
-	{#snippet x({ comp: stuff })}{@const SvelteComponent_7 = stuff}
+	{#snippet x({ comp: stuff })}
+		{@const SvelteComponent_7 = stuff}
 	<div  >
-		<SvelteComponent_7 />
-	</div>{/snippet}
-</Component>
-
-<Component>
-	{#snippet x({ comp: stuff })}{@const SvelteComponent_8 = stuff}
-	
-		<SvelteComponent_8 />
+			<SvelteComponent_7 />
+		</div>
 	{/snippet}
 </Component>
 
 <Component>
-	{#snippet x({ comp: stuff })}{@const SvelteComponent_9 = stuff}
+	{#snippet x({ comp: stuff })}
+	{@const SvelteComponent_8 = stuff}
+	
+			<SvelteComponent_8 />
+		
+	{/snippet}
+</Component>
+
+<Component>
+	{#snippet x({ comp: stuff })}
+		{@const SvelteComponent_9 = stuff}
 	<svelte:element this={"div"}  >
-		<SvelteComponent_9 />
-	</svelte:element>{/snippet}
+			<SvelteComponent_9 />
+		</svelte:element>
+	{/snippet}
 </Component>
 
 <Component />

--- a/packages/svelte/tests/migrate/samples/svelte-component/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-component/output.svelte
@@ -28,22 +28,22 @@
 </Component>
 
 <Component>
-	{@const SvelteComponent_2 = stuff}
-	{#snippet x({ comp: stuff })}<div  >
+	{#snippet x({ comp: stuff })}{@const SvelteComponent_2 = stuff}
+	<div  >
 		<SvelteComponent_2 />
 	</div>{/snippet}
 </Component>
 
 <Component>
-	{@const SvelteComponent_3 = stuff}
-	{#snippet x({ comp: stuff })}
+	{#snippet x({ comp: stuff })}{@const SvelteComponent_3 = stuff}
+	
 		<SvelteComponent_3 />
 	{/snippet}
 </Component>
 
 <Component>
-	{@const SvelteComponent_4 = stuff}
-	{#snippet x({ comp: stuff })}<svelte:element this={"div"}  >
+	{#snippet x({ comp: stuff })}{@const SvelteComponent_4 = stuff}
+	<svelte:element this={"div"}  >
 		<SvelteComponent_4 />
 	</svelte:element>{/snippet}
 </Component>
@@ -69,22 +69,22 @@
 </Component>
 
 <Component>
-	{@const SvelteComponent_7 = stuff}
-	{#snippet x({ comp: stuff })}<div  >
+	{#snippet x({ comp: stuff })}{@const SvelteComponent_7 = stuff}
+	<div  >
 		<SvelteComponent_7 />
 	</div>{/snippet}
 </Component>
 
 <Component>
-	{@const SvelteComponent_8 = stuff}
-	{#snippet x({ comp: stuff })}
+	{#snippet x({ comp: stuff })}{@const SvelteComponent_8 = stuff}
+	
 		<SvelteComponent_8 />
 	{/snippet}
 </Component>
 
 <Component>
-	{@const SvelteComponent_9 = stuff}
-	{#snippet x({ comp: stuff })}<svelte:element this={"div"}  >
+	{#snippet x({ comp: stuff })}{@const SvelteComponent_9 = stuff}
+	<svelte:element this={"div"}  >
 		<SvelteComponent_9 />
 	</svelte:element>{/snippet}
 </Component>


### PR DESCRIPTION
Now that snippets can fill slots, we can add logic to migrate slot usages

There's some cases where it doesn't look as nice due to indentation but I'm not sure how much time we should invest in that

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
