### PR TITLE
fix: add media listeners immediately when using `bind:paused`

### DIFF
--- a/.changeset/fair-items-bathe.md
+++ b/.changeset/fair-items-bathe.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add media listeners immediately when using `bind:paused`

--- a/packages/svelte/src/internal/client/dom/elements/bindings/media.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/media.js
@@ -150,7 +150,9 @@ export function bind_paused(media, get, set = get) {
 	// Listen to the canplay event to get notified of this situation.
 	listen(media, ['play', 'pause', 'canplay'], update, paused == null);
 
-	render_effect(() => {
+	// Needs to be an effect to ensure media element is mounted: else, if paused is `false` (i.e. should play right away)
+	// a "The play() request was interrupted by a new load request" error would be thrown because the resource isn't loaded yet.
+	effect(() => {
 		if ((paused = !!get()) !== media.paused) {
 			if (paused) {
 				media.pause();


### PR DESCRIPTION
I'm a little nervous about this because the code I deleted _looks_ like it's doing something useful, and it's basically impossible to test for, but:

- I don't really understand what, and
- Right now, media elements are broken — toggling `paused` doesn't cause a media element with `bind:paused` to start playing

This fixes it, as far as I can tell. I've tested `mount` and `hydrate` with media elements that are rendered immediately, media elements that are rendered after a state change, and media elements with an artificial network delay that I would expect to trigger whatever `canplay` timing edge cases we'd encounter.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
