### PR TITLE
feat: migrate `svelte:self`

### DIFF
--- a/.changeset/gold-pens-sell.md
+++ b/.changeset/gold-pens-sell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: support migrating `svelte:self`

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -747,6 +747,7 @@ const template = {
 				node.start,
 				`<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->\n${indent}`
 			);
+			next();
 			return;
 		}
 		// by default we overwrite until the end of the node - 1

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -763,10 +763,11 @@ const template = {
 		);
 		// if it has a fragment we need to overwrite the closing tag too
 		if (node.fragment.nodes.length > 0) {
-			const start_closing =
-				state.str.original.indexOf('<', node.fragment.nodes[node.fragment.nodes.length - 1].end) +
-				2;
-			state.str.overwrite(start_closing, node.end - 1, `${state.names.svelte_self}`);
+			state.str.overwrite(
+				state.str.original.lastIndexOf('<', node.end) + 2,
+				node.end - 1,
+				`${state.names.svelte_self}`
+			);
 		} else if (!source.endsWith('/>')) {
 			// special case for case `<svelte:self></svelte:self>` it has no fragment but
 			// we still need to overwrite the end tag

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -27,10 +27,10 @@ const style_placeholder = '/*$$__STYLE_CONTENT__$$*/';
  * May throw an error if the code is too complex to migrate automatically.
  *
  * @param {string} source
- * @param {string} [filename]
+ * @param {{filename?: string}} [options]
  * @returns {{ code: string; }}
  */
-export function migrate(source, filename) {
+export function migrate(source, { filename } = {}) {
 	try {
 		// Blank CSS, could contain SCSS or similar that needs a preprocessor.
 		// Since we don't care about CSS in this migration, we'll just ignore it.

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -750,7 +750,7 @@ const template = {
 			const indent = guess_indent(source);
 			state.str.prependRight(
 				node.start,
-				`<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->\n${indent}`
+				`<!-- @migration-task: svelte:self is deprecated, import this Svelte file into itself instead -->\n${indent}`
 			);
 			next();
 			return;

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -755,22 +755,12 @@ const template = {
 			next();
 			return;
 		}
-		// by default we overwrite until the end of the node - 1
-		let end = node.end - 1;
-		// if it has some children we need to overwrite from start to start of the fragment
-		if (node.fragment.nodes.length > 0) {
-			end = node.fragment.nodes[0].start;
-		} else if (!source.endsWith('/>')) {
-			// special case `<svelte:self></svelte:self>` it has no fragment but
-			// we still can't remove to the node end
-			end = node.start + source.lastIndexOf('><', node.end) + 1;
-		}
-		// if at has some attributes we stop at the start of the first
-		if (node.attributes.length > 0) {
-			end = node.attributes[0].start;
-		}
 		// overwrite the open tag
-		state.str.overwrite(node.start + 1, end - 1, `${state.names.svelte_self}`);
+		state.str.overwrite(
+			node.start + 1,
+			node.start + 1 + 'svelte:self'.length,
+			`${state.names.svelte_self}`
+		);
 		// if it has a fragment we need to overwrite the closing tag too
 		if (node.fragment.nodes.length > 0) {
 			const start_closing =

--- a/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/input.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/input.svelte
@@ -15,4 +15,5 @@
 	<svelte:self count={$$props.count}     >
 		child
 	</svelte:self>
+	<svelte:self></svelte:self>
 {/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/input.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/input.svelte
@@ -1,0 +1,18 @@
+<script>
+	let SvelteSelf;
+</script>
+
+{#if false}
+	<svelte:self />
+	<svelte:self with_attributes/>
+	<svelte:self count={count+1}/>
+	<svelte:self>
+		child
+	</svelte:self>
+	<svelte:self count={count+1}>
+		child
+	</svelte:self>
+	<svelte:self count={$$props.count}     >
+		child
+	</svelte:self>
+{/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/output.svelte
@@ -18,4 +18,5 @@
 	<SvelteSelf_1 count={props.count}     >
 		child
 	</SvelteSelf_1>
+	<SvelteSelf_1></SvelteSelf_1>
 {/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/output.svelte
@@ -6,7 +6,7 @@
 </script>
 
 {#if false}
-	<SvelteSelf_1/>
+	<SvelteSelf_1 />
 	<SvelteSelf_1 with_attributes/>
 	<SvelteSelf_1 count={count+1}/>
 	<SvelteSelf_1>

--- a/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/output.svelte
@@ -1,0 +1,21 @@
+<script>
+	import SvelteSelf_1 from './output.svelte';
+	/** @type {Record<string, any>} */
+	let { ...props } = $props();
+	let SvelteSelf;
+</script>
+
+{#if false}
+	<SvelteSelf_1/>
+	<SvelteSelf_1 with_attributes/>
+	<SvelteSelf_1 count={count+1}/>
+	<SvelteSelf_1>
+		child
+	</SvelteSelf_1>
+	<SvelteSelf_1 count={count+1}>
+		child
+	</SvelteSelf_1>
+	<SvelteSelf_1 count={props.count}     >
+		child
+	</SvelteSelf_1>
+{/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/_config.js
+++ b/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	skip_filename: true
+});

--- a/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/input.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/input.svelte
@@ -1,0 +1,15 @@
+{#if false}
+	<svelte:self />
+	<svelte:self with_attributes/>
+	<svelte:self count={count+1}/>
+	<svelte:self>
+		child
+	</svelte:self>
+	<svelte:self count={count+1}>
+		child
+	</svelte:self>
+	<svelte:self count={$$props.count}     >
+		child
+	</svelte:self>
+	<svelte:self></svelte:self>
+{/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/input.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/input.svelte
@@ -1,15 +1,3 @@
 {#if false}
 	<svelte:self />
-	<svelte:self with_attributes/>
-	<svelte:self count={count+1}/>
-	<svelte:self>
-		child
-	</svelte:self>
-	<svelte:self count={count+1}>
-		child
-	</svelte:self>
-	<svelte:self count={$$props.count}     >
-		child
-	</svelte:self>
-	<svelte:self></svelte:self>
 {/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/output.svelte
@@ -1,0 +1,27 @@
+<script>
+	/** @type {Record<string, any>} */
+	let { ...props } = $props();
+</script>
+
+{#if false}
+	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
+	<svelte:self />
+	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
+	<svelte:self with_attributes/>
+	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
+	<svelte:self count={count+1}/>
+	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
+	<svelte:self>
+		child
+	</svelte:self>
+	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
+	<svelte:self count={count+1}>
+		child
+	</svelte:self>
+	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
+	<svelte:self count={props.count}     >
+		child
+	</svelte:self>
+	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
+	<svelte:self></svelte:self>
+{/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-skip-filename/output.svelte
@@ -1,27 +1,4 @@
-<script>
-	/** @type {Record<string, any>} */
-	let { ...props } = $props();
-</script>
-
 {#if false}
-	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
+	<!-- @migration-task: svelte:self is deprecated, import this Svelte file into itself instead -->
 	<svelte:self />
-	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
-	<svelte:self with_attributes/>
-	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
-	<svelte:self count={count+1}/>
-	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
-	<svelte:self>
-		child
-	</svelte:self>
-	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
-	<svelte:self count={count+1}>
-		child
-	</svelte:self>
-	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
-	<svelte:self count={props.count}     >
-		child
-	</svelte:self>
-	<!-- @migration-task: migrate this by hand or call the migrate function with the filename of this file -->
-	<svelte:self></svelte:self>
 {/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self/input.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self/input.svelte
@@ -1,0 +1,14 @@
+{#if false}
+	<svelte:self />
+	<svelte:self with_attributes/>
+	<svelte:self count={count+1}/>
+	<svelte:self>
+		child
+	</svelte:self>
+	<svelte:self count={count+1}>
+		child
+	</svelte:self>
+	<svelte:self count={$$props.count}     >
+		child
+	</svelte:self>
+{/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self/input.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self/input.svelte
@@ -11,4 +11,5 @@
 	<svelte:self count={$$props.count}     >
 		child
 	</svelte:self>
+	<svelte:self></svelte:self>
 {/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self/output.svelte
@@ -5,7 +5,7 @@
 </script>
 
 {#if false}
-	<SvelteSelf/>
+	<SvelteSelf />
 	<SvelteSelf with_attributes/>
 	<SvelteSelf count={count+1}/>
 	<SvelteSelf>

--- a/packages/svelte/tests/migrate/samples/svelte-self/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self/output.svelte
@@ -1,0 +1,20 @@
+<script>
+	import SvelteSelf from './output.svelte';
+	/** @type {Record<string, any>} */
+	let { ...props } = $props();
+</script>
+
+{#if false}
+	<SvelteSelf/>
+	<SvelteSelf with_attributes/>
+	<SvelteSelf count={count+1}/>
+	<SvelteSelf>
+		child
+	</SvelteSelf>
+	<SvelteSelf count={count+1}>
+		child
+	</SvelteSelf>
+	<SvelteSelf count={props.count}     >
+		child
+	</SvelteSelf>
+{/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self/output.svelte
@@ -17,4 +17,5 @@
 	<SvelteSelf count={props.count}     >
 		child
 	</SvelteSelf>
+	<SvelteSelf></SvelteSelf>
 {/if}

--- a/packages/svelte/tests/migrate/test.ts
+++ b/packages/svelte/tests/migrate/test.ts
@@ -14,7 +14,9 @@ const { test, run } = suite<ParserTest>(async (config, cwd) => {
 		.replace(/\s+$/, '')
 		.replace(/\r/g, '');
 
-	const actual = migrate(input, config.skip_filename ? undefined : `${cwd}/output.svelte`).code;
+	const actual = migrate(input, {
+		filename: config.skip_filename ? undefined : `${cwd}/output.svelte`
+	}).code;
 
 	// run `UPDATE_SNAPSHOTS=true pnpm test migrate` to update parser tests
 	if (process.env.UPDATE_SNAPSHOTS || !fs.existsSync(`${cwd}/output.svelte`)) {

--- a/packages/svelte/tests/migrate/test.ts
+++ b/packages/svelte/tests/migrate/test.ts
@@ -12,7 +12,7 @@ const { test, run } = suite<ParserTest>(async (config, cwd) => {
 		.replace(/\s+$/, '')
 		.replace(/\r/g, '');
 
-	const actual = migrate(input).code;
+	const actual = migrate(input, `${cwd}/output.svelte`).code;
 
 	// run `UPDATE_SNAPSHOTS=true pnpm test migrate` to update parser tests
 	if (process.env.UPDATE_SNAPSHOTS || !fs.existsSync(`${cwd}/output.svelte`)) {

--- a/packages/svelte/tests/migrate/test.ts
+++ b/packages/svelte/tests/migrate/test.ts
@@ -4,7 +4,9 @@ import { migrate } from 'svelte/compiler';
 import { try_read_file } from '../helpers.js';
 import { suite, type BaseTest } from '../suite.js';
 
-interface ParserTest extends BaseTest {}
+interface ParserTest extends BaseTest {
+	skip_filename?: boolean;
+}
 
 const { test, run } = suite<ParserTest>(async (config, cwd) => {
 	const input = fs
@@ -12,7 +14,7 @@ const { test, run } = suite<ParserTest>(async (config, cwd) => {
 		.replace(/\s+$/, '')
 		.replace(/\r/g, '');
 
-	const actual = migrate(input, `${cwd}/output.svelte`).code;
+	const actual = migrate(input, config.skip_filename ? undefined : `${cwd}/output.svelte`).code;
 
 	// run `UPDATE_SNAPSHOTS=true pnpm test migrate` to update parser tests
 	if (process.env.UPDATE_SNAPSHOTS || !fs.existsSync(`${cwd}/output.svelte`)) {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1264,7 +1264,9 @@ declare module 'svelte/compiler' {
 	 * May throw an error if the code is too complex to migrate automatically.
 	 *
 	 * */
-	export function migrate(source: string, filename?: string | undefined): {
+	export function migrate(source: string, { filename }?: {
+		filename?: string;
+	} | undefined): {
 		code: string;
 	};
 	namespace Css {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1264,7 +1264,7 @@ declare module 'svelte/compiler' {
 	 * May throw an error if the code is too complex to migrate automatically.
 	 *
 	 * */
-	export function migrate(source: string): {
+	export function migrate(source: string, filename?: string | undefined): {
 		code: string;
 	};
 	namespace Css {

--- a/sites/svelte-5-preview/src/lib/Output/Compiler.js
+++ b/sites/svelte-5-preview/src/lib/Output/Compiler.js
@@ -80,7 +80,8 @@ export default class Compiler {
 			this.worker.postMessage({
 				id,
 				type: 'migrate',
-				source: file.source
+				source: file.source,
+				filename: `${file.name}.${file.type}`
 			});
 		});
 	}

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -133,9 +133,9 @@ function compile({ id, source, options, return_ast }) {
 }
 
 /** @param {import("../workers").MigrateMessageData} param0 */
-function migrate({ id, source }) {
+function migrate({ id, source, filename }) {
 	try {
-		const result = svelte.migrate(source);
+		const result = svelte.migrate(source, filename);
 
 		return {
 			id,

--- a/sites/svelte-5-preview/src/lib/workers/compiler/index.js
+++ b/sites/svelte-5-preview/src/lib/workers/compiler/index.js
@@ -135,7 +135,7 @@ function compile({ id, source, options, return_ast }) {
 /** @param {import("../workers").MigrateMessageData} param0 */
 function migrate({ id, source, filename }) {
 	try {
-		const result = svelte.migrate(source, filename);
+		const result = svelte.migrate(source, { filename });
 
 		return {
 			id,


### PR DESCRIPTION
## Svelte 5 rewrite

This adds the ability to migrate `svelte:self` which is deprecated. We need the filename to be able to auto-import so i've added it to the signature of the migrate function. If the user is using an older version of the cli which doesn't pass the filename in i've added a `@migration-task` as a comment.

Don't know if we want to do it but i'd say if we want to do it better do it now than later. I'll prepare a PR for `kit` too to pass the filename during the migration script.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
