### PR TITLE
chore: ensure we null effect fields

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -417,7 +417,6 @@ export function destroy_effect(effect, remove_dom = true) {
 		effect.teardown =
 		effect.ctx =
 		effect.deps =
-		effect.next =
 		effect.parent =
 		effect.fn =
 		effect.nodes_start =


### PR DESCRIPTION
Noticed these were missing when profiling.