### PR TITLE
fix: apply class/style directives after attributes

### DIFF
--- a/.changeset/eighty-hornets-breathe.md
+++ b/.changeset/eighty-hornets-breathe.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: apply class/style directives after attributes

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -535,6 +535,8 @@ function build_element_attribute_update_assignment(element, node_id, attribute, 
 
 	if (name === 'class') {
 		if (attribute.metadata.expression.has_state && has_call) {
+			// ensure we're not creating a separate template effect for this so that
+			// potential class directives are added to the same effect and therefore always apply
 			const id = b.id(state.scope.generate('class_derived'));
 			state.init.push(b.const(id, create_derived(state, b.thunk(value))));
 			value = b.call('$.get', id);
@@ -555,6 +557,8 @@ function build_element_attribute_update_assignment(element, node_id, attribute, 
 		update = b.stmt(b.assignment('=', b.member(node_id, name), value));
 	} else {
 		if (name === 'style' && attribute.metadata.expression.has_state && has_call) {
+			// ensure we're not creating a separate template effect for this so that
+			// potential style directives are added to the same effect and therefore always apply
 			const id = b.id(state.scope.generate('style_derived'));
 			state.init.push(b.const(id, create_derived(state, b.thunk(value))));
 			value = b.call('$.get', id);

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-attribute-and-attribute-directive-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-attribute-and-attribute-directive-2/_config.js
@@ -1,0 +1,37 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ target, logs, assert }) {
+		const [div, div2] = target.querySelectorAll('div');
+		const button = target.querySelector('button');
+
+		assert.deepEqual(logs, [
+			'updated class attribute',
+			'updated class directive',
+			'updated style attribute',
+			'updated style directive'
+		]);
+
+		assert.ok(div.classList.contains('dark'));
+		assert.ok(div.classList.contains('small'));
+
+		assert.equal(div2.getAttribute('style'), 'background: green; color: green;');
+
+		flushSync(() => button?.click());
+
+		assert.deepEqual(logs, [
+			'updated class attribute',
+			'updated class directive',
+			'updated style attribute',
+			'updated style directive',
+			'updated class attribute',
+			'updated style attribute'
+		]);
+
+		assert.ok(div.classList.contains('dark'));
+		assert.ok(div.classList.contains('big'));
+
+		assert.equal(div2.getAttribute('style'), 'background: red; color: green;');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-attribute-and-attribute-directive-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-attribute-and-attribute-directive-2/main.svelte
@@ -1,0 +1,23 @@
+<script>
+	let value = $state(0);
+	function dark(){
+		console.log('updated class directive');
+		return true;
+	}
+	function get_class(){
+		console.log('updated class attribute');
+		return value % 2 ? 'big' : 'small';
+	}
+	function color(){
+		console.log('updated style directive');
+		return "green";
+	}
+	function get_style(){
+		console.log('updated style attribute');
+		return value % 2 ? 'background: red' : 'background: green';
+	}
+</script>
+
+<div class:dark={dark()} class={get_class()}></div>
+<div style:color={color()} style={get_style()}></div>
+<button onclick={()=> value++}>switch</button>


### PR DESCRIPTION
## Svelte 5 rewrite

Since the issue has come up multiple times and i didn't see much activity on #13338 (sorry @Rich-Harris if you were working on it) i took a shot at it. This PR make the test pass (i've also added the same logic for `style` attribute and directive since it also can be overridden by the directive. I've used the same technique that we use for the class and style directive of creating a derived for the function and change the `value` there. There's a bit of duplication which i don't particularly like but maybe it's better for readability.

Are there are better ways of doing this?

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
