### PR TITLE
fix: use `analysis.name` when migrating `<svelte:self>`

### DIFF
--- a/.changeset/soft-stingrays-attend.md
+++ b/.changeset/soft-stingrays-attend.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: use `analysis.name` when migrating `<svelte:self>`

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -42,7 +42,7 @@ export function migrate(source, { filename } = {}) {
 		});
 
 		reset_warning_filter(() => false);
-		reset(source, { filename: filename ?? 'migrate.svelte' });
+		reset(source, { filename: filename ?? '(unknown)' });
 
 		let parsed = parse(source);
 
@@ -52,7 +52,8 @@ export function migrate(source, { filename } = {}) {
 		const combined_options = {
 			...validate_component_options({}, ''),
 			...parsed_options,
-			customElementOptions
+			customElementOptions,
+			filename: filename ?? '(unknown)'
 		};
 
 		const str = new MagicString(source);
@@ -93,7 +94,7 @@ export function migrate(source, { filename } = {}) {
 				bubble: analysis.root.unique('bubble').name,
 				passive: analysis.root.unique('passive').name,
 				nonpassive: analysis.root.unique('nonpassive').name,
-				svelte_self: analysis.root.unique('SvelteSelf').name
+				svelte_self: analysis.name
 			},
 			legacy_imports: new Set(),
 			script_insertions: new Set(),

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -93,8 +93,7 @@ export function migrate(source, { filename } = {}) {
 				createBubbler: analysis.root.unique('createBubbler').name,
 				bubble: analysis.root.unique('bubble').name,
 				passive: analysis.root.unique('passive').name,
-				nonpassive: analysis.root.unique('nonpassive').name,
-				svelte_self: analysis.name
+				nonpassive: analysis.root.unique('nonpassive').name
 			},
 			legacy_imports: new Set(),
 			script_insertions: new Set(),
@@ -138,7 +137,7 @@ export function migrate(source, { filename } = {}) {
 			const file = filename.split('/').pop();
 			str.appendRight(
 				insertion_point,
-				`\n${indent}import ${state.names.svelte_self} from './${file}';`
+				`\n${indent}import ${state.analysis.name} from './${file}';`
 			);
 		}
 
@@ -760,14 +759,14 @@ const template = {
 		state.str.overwrite(
 			node.start + 1,
 			node.start + 1 + 'svelte:self'.length,
-			`${state.names.svelte_self}`
+			`${state.analysis.name}`
 		);
 		// if it has a fragment we need to overwrite the closing tag too
 		if (node.fragment.nodes.length > 0) {
 			state.str.overwrite(
 				state.str.original.lastIndexOf('<', node.end) + 2,
 				node.end - 1,
-				`${state.names.svelte_self}`
+				`${state.analysis.name}`
 			);
 		} else if (!source.endsWith('/>')) {
 			// special case for case `<svelte:self></svelte:self>` it has no fragment but
@@ -775,7 +774,7 @@ const template = {
 			state.str.overwrite(
 				node.start + source.lastIndexOf('</', node.end) + 2,
 				node.end - 1,
-				`${state.names.svelte_self}`
+				`${state.analysis.name}`
 			);
 		}
 		state.has_svelte_self = true;

--- a/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/input.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/input.svelte
@@ -1,5 +1,5 @@
 <script>
-	let SvelteSelf;
+	let Output;
 </script>
 
 {#if false}

--- a/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self-name-conflict/output.svelte
@@ -1,22 +1,22 @@
 <script>
-	import SvelteSelf_1 from './output.svelte';
+	import Output_1 from './output.svelte';
 	/** @type {Record<string, any>} */
 	let { ...props } = $props();
-	let SvelteSelf;
+	let Output;
 </script>
 
 {#if false}
-	<SvelteSelf_1 />
-	<SvelteSelf_1 with_attributes/>
-	<SvelteSelf_1 count={count+1}/>
-	<SvelteSelf_1>
+	<Output_1 />
+	<Output_1 with_attributes/>
+	<Output_1 count={count+1}/>
+	<Output_1>
 		child
-	</SvelteSelf_1>
-	<SvelteSelf_1 count={count+1}>
+	</Output_1>
+	<Output_1 count={count+1}>
 		child
-	</SvelteSelf_1>
-	<SvelteSelf_1 count={props.count}     >
+	</Output_1>
+	<Output_1 count={props.count}     >
 		child
-	</SvelteSelf_1>
-	<SvelteSelf_1></SvelteSelf_1>
+	</Output_1>
+	<Output_1></Output_1>
 {/if}

--- a/packages/svelte/tests/migrate/samples/svelte-self/output.svelte
+++ b/packages/svelte/tests/migrate/samples/svelte-self/output.svelte
@@ -1,21 +1,21 @@
 <script>
-	import SvelteSelf from './output.svelte';
+	import Output from './output.svelte';
 	/** @type {Record<string, any>} */
 	let { ...props } = $props();
 </script>
 
 {#if false}
-	<SvelteSelf />
-	<SvelteSelf with_attributes/>
-	<SvelteSelf count={count+1}/>
-	<SvelteSelf>
+	<Output />
+	<Output with_attributes/>
+	<Output count={count+1}/>
+	<Output>
 		child
-	</SvelteSelf>
-	<SvelteSelf count={count+1}>
+	</Output>
+	<Output count={count+1}>
 		child
-	</SvelteSelf>
-	<SvelteSelf count={props.count}     >
+	</Output>
+	<Output count={props.count}     >
 		child
-	</SvelteSelf>
-	<SvelteSelf></SvelteSelf>
+	</Output>
+	<Output></Output>
 {/if}


### PR DESCRIPTION
follow-up to #13504 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
