### PR TITLE
fix: ensure source and filename are known to compileModule's source map

### DIFF
--- a/.changeset/beige-donkeys-exercise.md
+++ b/.changeset/beige-donkeys-exercise.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure source and filename are known to compileModule's source map

--- a/packages/svelte/src/compiler/phases/3-transform/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/index.js
@@ -35,6 +35,7 @@ export function transform_component(analysis, source, options) {
 	const js_source_name = get_source_name(options.filename, options.outputFilename, 'input.svelte');
 	const js = print(program, {
 		// include source content; makes it easier/more robust looking up the source map code
+		// (else esrap does return null for source and sourceMapContent which may trip up tooling)
 		sourceMapContent: source,
 		sourceMapSource: js_source_name
 	});
@@ -91,7 +92,12 @@ export function transform_module(analysis, source, options) {
 	}
 
 	return {
-		js: print(program, {}),
+		js: print(program, {
+			// include source content; makes it easier/more robust looking up the source map code
+			// (else esrap does return null for source and sourceMapContent which may trip up tooling)
+			sourceMapContent: source,
+			sourceMapSource: get_source_name(options.filename, undefined, 'input.svelte.js')
+		}),
 		css: null,
 		metadata: {
 			runes: true


### PR DESCRIPTION
Similar to a change that was part of #10459

Fixes https://github.com/sveltejs/svelte-loader/issues/238

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
