### PR TITLE
fix: do no rerun the each block when array change from empty to empty

### DIFF
--- a/.changeset/loud-walls-wave.md
+++ b/.changeset/loud-walls-wave.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: do no rerun the each block when array change from empty to empty

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -132,7 +132,7 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 	/** @type {Effect | null} */
 	var fallback = null;
 
-	var empty = false;
+	var was_empty = false;
 
 	block(() => {
 		var collection = get_collection();
@@ -145,12 +145,12 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 
 		var length = array.length;
 
-		if (empty && length === 0) {
+		if (was_empty && length === 0) {
 			// ignore updates if the array is empty,
 			// and it already was empty on previous run
 			return;
 		}
-		empty = length === 0;
+		was_empty = length === 0;
 
 		/** `true` if there was a hydration mismatch. Needs to be a `let` or else it isn't treeshaken out */
 		let mismatch = false;

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -132,6 +132,8 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 	/** @type {Effect | null} */
 	var fallback = null;
 
+	var empty = false;
+
 	block(() => {
 		var collection = get_collection();
 
@@ -142,6 +144,13 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 				: array_from(collection);
 
 		var length = array.length;
+
+		if (empty && length === 0) {
+			// ignore updates if the array is empty,
+			// and it already was empty on previous run
+			return;
+		}
+		empty = length === 0;
 
 		/** `true` if there was a hydration mismatch. Needs to be a `let` or else it isn't treeshaken out */
 		let mismatch = false;

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -507,9 +507,12 @@ export { await_block as await };
 
 /** @param {any} array_like_or_iterator */
 export function ensure_array_like(array_like_or_iterator) {
-	return array_like_or_iterator?.length !== undefined
-		? array_like_or_iterator
-		: Array.from(array_like_or_iterator);
+	if (array_like_or_iterator) {
+		return array_like_or_iterator.length !== undefined
+			? array_like_or_iterator
+			: Array.from(array_like_or_iterator);
+	}
+	return [];
 }
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/each-was-empty/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-was-empty/_config.js
@@ -1,0 +1,37 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+// https://github.com/sveltejs/svelte/issues/13550
+// https://github.com/sveltejs/svelte/pull/13553
+export default test({
+	html: `<button>clicks: 0</button><button>undefined</button><button>null</button><button>empty</button><button>[1,2,3]</button><ul><li>count = <span>0</span></li></ul>`,
+
+	async test({ assert, target }) {
+		const [ increment, set_undefined, set_null, set_empty, set_list ] = target.querySelectorAll('button');
+		
+		const [ span ] = target.querySelectorAll("span");
+
+		let count = 0;
+		assert.equal(span.innerHTML, `${count}`);
+
+		for (const button of [set_undefined, set_null, set_empty, set_undefined, set_null, set_empty]) {
+			flushSync(() => {
+				button.click();
+			});
+			flushSync(() => {
+				increment.click();
+				count++;
+			});
+			assert.equal(span.innerHTML, `${count}`);
+		}
+
+		flushSync(() => {
+			set_list.click();
+		});
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>clicks: ${count}</button><button>undefined</button><button>null</button><button>empty</button><button>[1,2,3]</button><ul><li>item : 1</li><li>item : 2</li><li>item : 3</li></ul>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-was-empty/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-was-empty/_config.js
@@ -10,29 +10,71 @@ export default test({
 		const [increment, set_undefined, set_null, set_empty, set_list] =
 			target.querySelectorAll('button');
 
-		const [span] = target.querySelectorAll('span');
+		let [span] = target.querySelectorAll('span');
 
-		let count = 0;
-		assert.equal(span.innerHTML, `${count}`);
+		// initial value
+		assert.exists(span);
+		assert.equal(span.innerHTML, '0');
 
-		for (const button of [set_undefined, set_null, set_empty, set_undefined, set_null, set_empty]) {
-			flushSync(() => {
-				button.click();
-			});
-			flushSync(() => {
-				increment.click();
-				count++;
-			});
-			assert.equal(span.innerHTML, `${count}`);
-		}
+		// increment value
+		flushSync(() => increment.click());
+		assert.equal(span.innerHTML, '1');
 
-		flushSync(() => {
-			set_list.click();
-		});
+		// change collection to undefined
+		flushSync(() => set_undefined.click());
+		// increment value
+		flushSync(() => increment.click());
+		assert.equal(span.innerHTML, '2');
+
+		// change collection to null
+		flushSync(() => set_null.click());
+		// increment value
+		flushSync(() => increment.click());
+		assert.equal(span.innerHTML, '3');
+
+		// change collection to empty
+		flushSync(() => set_empty.click());
+		// increment value
+		flushSync(() => increment.click());
+		assert.equal(span.innerHTML, '4');
+
+		// change collection to undefined
+		flushSync(() => set_undefined.click());
+		// increment value
+		flushSync(() => increment.click());
+		assert.equal(span.innerHTML, '5');
+
+		// change collection to [1,2,3]
+		flushSync(() => set_list.click());
+		[span] = target.querySelectorAll('span');
+		assert.notExists(span);
+		assert.equal(target.querySelectorAll('li').length, 3);
+
+		// change collection to undefined
+		flushSync(() => set_undefined.click());
+		[span] = target.querySelectorAll('span');
+		assert.exists(span);
+		assert.equal(span.innerHTML, '5');
+
+		// increment value
+		flushSync(() => increment.click());
+		assert.equal(span.innerHTML, '6');
+
+		// change collection to null
+		flushSync(() => set_null.click());
+		// increment value
+		flushSync(() => increment.click());
+		assert.equal(span.innerHTML, '7');
+
+		// change collection to empty
+		flushSync(() => set_empty.click());
+		// increment value
+		flushSync(() => increment.click());
+		assert.equal(span.innerHTML, '8');
 
 		assert.htmlEqual(
 			target.innerHTML,
-			`<button>clicks: ${count}</button><button>undefined</button><button>null</button><button>empty</button><button>[1,2,3]</button><ul><li>item : 1</li><li>item : 2</li><li>item : 3</li></ul>`
+			`<button>clicks: 8</button><button>undefined</button><button>null</button><button>empty</button><button>[1,2,3]</button><ul><li>count = <span>8</span></li></ul>`
 		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/each-was-empty/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-was-empty/_config.js
@@ -7,9 +7,10 @@ export default test({
 	html: `<button>clicks: 0</button><button>undefined</button><button>null</button><button>empty</button><button>[1,2,3]</button><ul><li>count = <span>0</span></li></ul>`,
 
 	async test({ assert, target }) {
-		const [ increment, set_undefined, set_null, set_empty, set_list ] = target.querySelectorAll('button');
-		
-		const [ span ] = target.querySelectorAll("span");
+		const [increment, set_undefined, set_null, set_empty, set_list] =
+			target.querySelectorAll('button');
+
+		const [span] = target.querySelectorAll('span');
 
 		let count = 0;
 		assert.equal(span.innerHTML, `${count}`);

--- a/packages/svelte/tests/runtime-runes/samples/each-was-empty/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-was-empty/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	let list = $state()
+	let count = $state(0);
+
+	function increment() {
+		count += 1;
+	}
+</script>
+
+<button onclick={increment}>clicks: {count}</button>
+<button onclick={()=>list=undefined}>undefined</button>
+<button onclick={()=>list=null}>null</button>
+<button onclick={()=>list=[]}>empty</button>
+<button onclick={()=>list=[1,2,3]}>[1,2,3]</button>
+
+<ul>
+{#each list as a}
+	<li>item : {a}</li>
+{:else}
+	<li>count = <span>{count}</span></li>
+{/each}
+</ul>


### PR DESCRIPTION
Fix #13550 

The `block()` function inside `each()` can run multiples times when the collection is a different falsy array (ex. `array = undefined` and then `array = null` or `array = []`).

It seems that this is causing a conflict between `reconcile()` and the `fallback_fn` effect, which is no longer reactive.

=> When the array change from empty to empty, it is better to do nothing at all.


All tests are OK.
Should I add a test for this specific case ?

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
