### PR TITLE
fix: don't throw with nullish actions

### DIFF
--- a/.changeset/afraid-worms-clean.md
+++ b/.changeset/afraid-worms-clean.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't throw with nullish actions

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/UseDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/UseDirective.js
@@ -20,7 +20,10 @@ export function UseDirective(node, context) {
 		context.state.node,
 		b.arrow(
 			params,
-			b.call(/** @type {Expression} */ (context.visit(parse_directive_name(node.name))), ...params)
+			b.maybe_call(
+				/** @type {Expression} */ (context.visit(parse_directive_name(node.name))),
+				...params
+			)
 		)
 	];
 

--- a/packages/svelte/tests/runtime-runes/samples/nullish-actions/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/nullish-actions/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: '<div></div> <div></div>'
+});

--- a/packages/svelte/tests/runtime-runes/samples/nullish-actions/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/nullish-actions/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { action_prop } = $props();
+	let action = $state();
+</script>
+
+<div use:action></div>
+<div use:action_prop></div>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13555 ...this may need some discussion because i don't know if it was done on purpose but it was simple enough i said, why not.

Also working on this i noticed we are creating an unnecessary thunk where we could just pass the action in (especially since it's not reactive)...should we fix this too?

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
