### PR TITLE
breaking: scope `:has(...)` selectors

### DIFF
--- a/.changeset/silly-houses-promise.md
+++ b/.changeset/silly-houses-promise.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+breaking: scope `:has(...)` selectors

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -311,7 +311,7 @@ const visitors = {
 		context.state.specificity.bumped = before_bumped;
 	},
 	PseudoClassSelector(node, context) {
-		if (node.name === 'is' || node.name === 'where') {
+		if (node.name === 'is' || node.name === 'where' || node.name === 'has') {
 			context.next();
 		}
 	}

--- a/packages/svelte/src/compiler/types/css.d.ts
+++ b/packages/svelte/src/compiler/types/css.d.ts
@@ -62,6 +62,7 @@ export namespace Css {
 		children: RelativeSelector[];
 		metadata: {
 			rule: null | Rule;
+			/** True if this selector applies to an element. For global selectors, this is defined in css-analyze, for others in css-prune while scoping */
 			used: boolean;
 		};
 	}

--- a/packages/svelte/src/compiler/types/css.d.ts
+++ b/packages/svelte/src/compiler/types/css.d.ts
@@ -30,6 +30,7 @@ export namespace Css {
 		type: 'Rule';
 		prelude: SelectorList;
 		block: Block;
+		/** @internal */
 		metadata: {
 			parent_rule: null | Rule;
 			has_local_selectors: boolean;
@@ -60,6 +61,7 @@ export namespace Css {
 		 * The `a`, `b` and `c` in `a b c {}`
 		 */
 		children: RelativeSelector[];
+		/** @internal */
 		metadata: {
 			rule: null | Rule;
 			/** True if this selector applies to an element. For global selectors, this is defined in css-analyze, for others in css-prune while scoping */
@@ -80,6 +82,7 @@ export namespace Css {
 		 * The `b:is(...)` in `> b:is(...)`
 		 */
 		selectors: SimpleSelector[];
+		/** @internal */
 		metadata: {
 			/**
 			 * `true` if the whole selector is unscoped, e.g. `:global(...)` or `:global` or `:global.x`.

--- a/packages/svelte/tests/css/samples/has/_config.js
+++ b/packages/svelte/tests/css/samples/has/_config.js
@@ -1,0 +1,90 @@
+import { test } from '../../test';
+
+export default test({
+	warnings: [
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector ".unused:has(y)"',
+			start: {
+				character: 269,
+				column: 1,
+				line: 27
+			},
+			end: {
+				character: 283,
+				column: 15,
+				line: 27
+			}
+		},
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector ".unused:has(:global(y))"',
+			start: {
+				character: 304,
+				column: 1,
+				line: 30
+			},
+			end: {
+				character: 327,
+				column: 24,
+				line: 30
+			}
+		},
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector "x:has(.unused)"',
+			start: {
+				character: 348,
+				column: 1,
+				line: 33
+			},
+			end: {
+				character: 362,
+				column: 15,
+				line: 33
+			}
+		},
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector "x:has(y):has(.unused)"',
+			start: {
+				character: 517,
+				column: 1,
+				line: 46
+			},
+			end: {
+				character: 538,
+				column: 22,
+				line: 46
+			}
+		},
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector ".unused"',
+			start: {
+				character: 743,
+				column: 2,
+				line: 65
+			},
+			end: {
+				character: 750,
+				column: 9,
+				line: 65
+			}
+		},
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector ".unused x:has(y)"',
+			start: {
+				character: 897,
+				column: 1,
+				line: 81
+			},
+			end: {
+				character: 913,
+				column: 17,
+				line: 81
+			}
+		}
+	]
+});

--- a/packages/svelte/tests/css/samples/has/expected.css
+++ b/packages/svelte/tests/css/samples/has/expected.css
@@ -1,0 +1,77 @@
+
+	x.svelte-xyz:has(y:where(.svelte-xyz)) {
+		color: green;
+	}
+	x.svelte-xyz:has(z:where(.svelte-xyz)) {
+		color: green;
+	}
+	x.svelte-xyz:has(y) {
+		color: green;
+	}
+	x.svelte-xyz:has(z) {
+		color: green;
+	}
+	x.svelte-xyz:has(.foo) {
+		color: green;
+	}
+	.foo:has(y.svelte-xyz) {
+		color: green;
+	}
+
+	/* (unused) .unused:has(y) {
+		color: red;
+	}*/
+	/* (unused) .unused:has(:global(y)) {
+		color: red;
+	}*/
+	/* (unused) x:has(.unused) {
+		color: red;
+	}*/
+	.foo:has(.unused.svelte-xyz) {
+		color: red;
+	}
+
+	x.svelte-xyz:has(y:where(.svelte-xyz) /* (unused) .unused*/) {
+		color: green;
+	}
+	x.svelte-xyz:has(y:where(.svelte-xyz), .foo) {
+		color: green;
+	}
+	/* (unused) x:has(y):has(.unused) {
+		color: red;
+	}*/
+	x.svelte-xyz:has(y:where(.svelte-xyz)):has(.foo) {
+		color: green;
+	}
+
+	x.svelte-xyz:has(y:where(.svelte-xyz)) z:where(.svelte-xyz) {
+		color: green;
+	}
+	x.svelte-xyz:has(y:where(.svelte-xyz)) {
+		z:where(.svelte-xyz) {
+			color: green;
+		}
+	}
+	x.svelte-xyz:has(y:where(.svelte-xyz)) .foo {
+		color: green;
+	}
+	/* (empty) x:has(y) {
+		.unused {
+			color: red;
+		}
+	}*/
+
+	x.svelte-xyz y:where(.svelte-xyz):has(z:where(.svelte-xyz)) {
+		color: green;
+	}
+	x.svelte-xyz {
+		y:where(.svelte-xyz):has(z:where(.svelte-xyz)) {
+			color: green;
+		}
+	}
+	.foo x.svelte-xyz:has(y:where(.svelte-xyz)) {
+		color: green;
+	}
+	/* (unused) .unused x:has(y) {
+		color: red;
+	}*/

--- a/packages/svelte/tests/css/samples/has/input.svelte
+++ b/packages/svelte/tests/css/samples/has/input.svelte
@@ -1,0 +1,84 @@
+<x>
+	<y>
+		<z></z>
+	</y>
+</x>
+
+<style>
+	x:has(y) {
+		color: green;
+	}
+	x:has(z) {
+		color: green;
+	}
+	x:has(:global(y)) {
+		color: green;
+	}
+	x:has(:global(z)) {
+		color: green;
+	}
+	x:has(:global(.foo)) {
+		color: green;
+	}
+	:global(.foo):has(y) {
+		color: green;
+	}
+
+	.unused:has(y) {
+		color: red;
+	}
+	.unused:has(:global(y)) {
+		color: red;
+	}
+	x:has(.unused) {
+		color: red;
+	}
+	:global(.foo):has(.unused) {
+		color: red;
+	}
+
+	x:has(y, .unused) {
+		color: green;
+	}
+	x:has(y, :global(.foo)) {
+		color: green;
+	}
+	x:has(y):has(.unused) {
+		color: red;
+	}
+	x:has(y):has(:global(.foo)) {
+		color: green;
+	}
+
+	x:has(y) z {
+		color: green;
+	}
+	x:has(y) {
+		z {
+			color: green;
+		}
+	}
+	x:has(y) :global(.foo) {
+		color: green;
+	}
+	x:has(y) {
+		.unused {
+			color: red;
+		}
+	}
+
+	x y:has(z) {
+		color: green;
+	}
+	x {
+		y:has(z) {
+			color: green;
+		}
+	}
+	:global(.foo) x:has(y) {
+		color: green;
+	}
+	.unused x:has(y) {
+		color: red;
+	}
+</style>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1331,6 +1331,7 @@ declare module 'svelte/compiler' {
 			children: RelativeSelector[];
 			metadata: {
 				rule: null | Rule;
+				/** True if this selector applies to an element. For global selectors, this is defined in css-analyze, for others in css-prune while scoping */
 				used: boolean;
 			};
 		}

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1299,14 +1299,6 @@ declare module 'svelte/compiler' {
 			type: 'Rule';
 			prelude: SelectorList;
 			block: Block;
-			metadata: {
-				parent_rule: null | Rule;
-				has_local_selectors: boolean;
-				/**
-				 * `true` if the rule contains a `:global` selector, and therefore everything inside should be unscoped
-				 */
-				is_global_block: boolean;
-			};
 		}
 
 		/**
@@ -1329,11 +1321,6 @@ declare module 'svelte/compiler' {
 			 * The `a`, `b` and `c` in `a b c {}`
 			 */
 			children: RelativeSelector[];
-			metadata: {
-				rule: null | Rule;
-				/** True if this selector applies to an element. For global selectors, this is defined in css-analyze, for others in css-prune while scoping */
-				used: boolean;
-			};
 		}
 
 		/**
@@ -1349,16 +1336,6 @@ declare module 'svelte/compiler' {
 			 * The `b:is(...)` in `> b:is(...)`
 			 */
 			selectors: SimpleSelector[];
-			metadata: {
-				/**
-				 * `true` if the whole selector is unscoped, e.g. `:global(...)` or `:global` or `:global.x`.
-				 * Selectors like `:global(...).x` are not considered global, because they still need scoping.
-				 */
-				is_global: boolean;
-				/** `:root`, `:host`, `::view-transition`, or selectors after a `:global` */
-				is_global_like: boolean;
-				scoped: boolean;
-			};
 		}
 
 		export interface TypeSelector extends BaseNode {

--- a/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
+++ b/sites/svelte-5-preview/src/routes/docs/content/03-appendix/02-breaking-changes.md
@@ -293,9 +293,9 @@ Svelte 5 is more strict about the HTML structure and will throw a compiler error
 
 Assignments to destructured parts of a `@const` declaration are no longer allowed. It was an oversight that this was ever allowed.
 
-### :is(...) and :where(...) are scoped
+### :is(...), :where(...) and :has(...) are scoped
 
-Previously, Svelte did not analyse selectors inside `:is(...)` and `:where(...)`, effectively treating them as global. Svelte 5 analyses them in the context of the current component. As such, some selectors may now be treated as unused if they were relying on this treatment. To fix this, use `:global(...)` inside the `:is(...)/:where(...)` selectors.
+Previously, Svelte did not analyse selectors inside `:is(...)`, `:where(...)` and `:has(...)`, effectively treating them as global. Svelte 5 analyses them in the context of the current component. As such, some selectors may now be treated as unused if they were relying on this treatment. To fix this, use `:global(...)` inside the `:is(...)/:where(...)/:has(...)` selectors.
 
 When using Tailwind's `@apply` directive, add a `:global` selector to preserve rules that use Tailwind-generated `:is(...)` selectors:
 


### PR DESCRIPTION
The main part of #13395

This implements scoping for selectors inside `:has(...)`. The approach is to first descend into the contents of a `:has(...)` selector, then in case of a match, try to match the rest of the selector ignoring the `:has(...)` part. In other words, `.x:has(y)` is essentially treated as `x y` with `y` being matched first, then walking up the selector chain taking into account combinators.

This is a breaking change because people could've used `:has(.unknown)` with `.unknown` not appearing in the HTML, and so they need to do `:has(:global(.unknown))` instead

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
