### PR TITLE
fix: avoid assigning input.value if the value is the same to fix `minlength`

### DIFF
--- a/.changeset/slow-badgers-invite.md
+++ b/.changeset/slow-badgers-invite.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid assigning input.value if the value is the same to fix `minlength`

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -55,8 +55,8 @@ export function remove_input_defaults(input) {
 export function set_value(element, value) {
 	// @ts-expect-error
 	var attributes = (element.__attributes ??= {});
-
-	if (attributes.value === (attributes.value = value)) return;
+	// @ts-expect-error
+	if (attributes.value === (attributes.value = value) || element.value === value) return;
 	// @ts-expect-error
 	element.value = value;
 }

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -60,8 +60,12 @@ export function bind_value(input, get, set = get) {
 			return;
 		}
 
-		// @ts-expect-error the value is coerced on assignment
-		input.value = value ?? '';
+		// don't set the value of the input if it's the same to allow
+		// minlength to work properly
+		if (value !== input.value) {
+			// @ts-expect-error the value is coerced on assignment
+			input.value = value ?? '';
+		}
 	});
 }
 


### PR DESCRIPTION
Closes #13565 no test because apparently JSDom doesn't support this stuff.

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
