### PR TITLE
feat : support transition with hidden (poc)

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -545,6 +545,8 @@ function build_element_attribute_update_assignment(element, node_id, attribute, 
 		update = b.stmt(b.call('$.set_value', node_id, value));
 	} else if (name === 'checked') {
 		update = b.stmt(b.call('$.set_checked', node_id, value));
+	} else if (name === 'hidden') {
+		update = b.stmt(b.call('$.set_hidden', node_id, value));
 	} else if (is_dom_property(name)) {
 		update = b.stmt(b.assignment('=', b.member(node_id, name), value));
 	} else {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/TransitionDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/TransitionDirective.js
@@ -1,7 +1,12 @@
 /** @import { Expression } from 'estree' */
 /** @import { AST } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
-import { TRANSITION_GLOBAL, TRANSITION_IN, TRANSITION_OUT } from '../../../../../constants.js';
+import {
+	TRANSITION_GLOBAL,
+	TRANSITION_HIDDEN,
+	TRANSITION_IN,
+	TRANSITION_OUT
+} from '../../../../../constants.js';
 import * as b from '../../../../utils/builders.js';
 import { parse_directive_name } from './shared/utils.js';
 
@@ -13,6 +18,9 @@ export function TransitionDirective(node, context) {
 	let flags = node.modifiers.includes('global') ? TRANSITION_GLOBAL : 0;
 	if (node.intro) flags |= TRANSITION_IN;
 	if (node.outro) flags |= TRANSITION_OUT;
+	if (node.modifiers.includes('hidden')) {
+		flags |= TRANSITION_HIDDEN;
+	}
 
 	const args = [
 		b.literal(flags),

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/TransitionDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/TransitionDirective.js
@@ -3,7 +3,7 @@
 /** @import { ComponentContext } from '../types' */
 import {
 	TRANSITION_GLOBAL,
-	TRANSITION_HIDDEN,
+	TRANSITION_THIS,
 	TRANSITION_IN,
 	TRANSITION_OUT
 } from '../../../../../constants.js';
@@ -18,8 +18,8 @@ export function TransitionDirective(node, context) {
 	let flags = node.modifiers.includes('global') ? TRANSITION_GLOBAL : 0;
 	if (node.intro) flags |= TRANSITION_IN;
 	if (node.outro) flags |= TRANSITION_OUT;
-	if (node.modifiers.includes('hidden')) {
-		flags |= TRANSITION_HIDDEN;
+	if (node.modifiers.includes('this')) {
+		flags |= TRANSITION_THIS;
 	}
 
 	const args = [

--- a/packages/svelte/src/compiler/types/legacy-nodes.d.ts
+++ b/packages/svelte/src/compiler/types/legacy-nodes.d.ts
@@ -187,7 +187,7 @@ export interface LegacyTransition extends BaseNode {
 	name: string;
 	/** The 'y' in `transition:x={y}` */
 	expression: null | Expression;
-	modifiers: Array<'local' | 'global'>;
+	modifiers: Array<'local' | 'global' | 'this'>;
 	/** True if this is a `transition:` or `in:` directive */
 	intro: boolean;
 	/** True if this is a `transition:` or `out:` directive */

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -251,7 +251,7 @@ export namespace AST {
 		name: string;
 		/** The 'y' in `transition:x={y}` */
 		expression: null | Expression;
-		modifiers: Array<'local' | 'global' | 'hidden'>;
+		modifiers: Array<'local' | 'global' | 'this'>;
 		/** True if this is a `transition:` or `in:` directive */
 		intro: boolean;
 		/** True if this is a `transition:` or `out:` directive */

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -251,7 +251,7 @@ export namespace AST {
 		name: string;
 		/** The 'y' in `transition:x={y}` */
 		expression: null | Expression;
-		modifiers: Array<'local' | 'global'>;
+		modifiers: Array<'local' | 'global' | 'hidden'>;
 		/** True if this is a `transition:` or `in:` directive */
 		intro: boolean;
 		/** True if this is a `transition:` or `out:` directive */

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -14,6 +14,7 @@ export const PROPS_IS_LAZY_INITIAL = 1 << 4;
 export const TRANSITION_IN = 1;
 export const TRANSITION_OUT = 1 << 1;
 export const TRANSITION_GLOBAL = 1 << 2;
+export const TRANSITION_HIDDEN = 1 << 3;
 
 export const TEMPLATE_FRAGMENT = 1;
 export const TEMPLATE_USE_IMPORT_NODE = 1 << 1;

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -14,7 +14,7 @@ export const PROPS_IS_LAZY_INITIAL = 1 << 4;
 export const TRANSITION_IN = 1;
 export const TRANSITION_OUT = 1 << 1;
 export const TRANSITION_GLOBAL = 1 << 2;
-export const TRANSITION_HIDDEN = 1 << 3;
+export const TRANSITION_THIS = 1 << 3;
 
 export const TEMPLATE_FRAGMENT = 1;
 export const TEMPLATE_USE_IMPORT_NODE = 1 << 1;

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -75,6 +75,28 @@ export function set_checked(element, checked) {
 }
 
 /**
+ * @param {Element & { hidden: boolean, __tm?: import('#client').TransitionManager}} element
+ * @param {boolean} hidden
+ */
+export function set_hidden(element, hidden) {
+	// @ts-expect-error
+	var attributes = (element.__attributes ??= {});
+
+	if (attributes.hidden === (attributes.hidden = !!hidden)) return;
+
+	if (element.__tm) {
+		if (hidden) {
+			element.__tm.out(() => (element.hidden = true));
+		} else {
+			element.hidden = false;
+			element.__tm.in();
+		}
+	} else {
+		element.hidden = hidden;
+	}
+}
+
+/**
  * @param {Element} element
  * @param {string} attribute
  * @param {string | null} value

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -7,7 +7,7 @@ import { should_intro } from '../../render.js';
 import { current_each_item } from '../blocks/each.js';
 import {
 	TRANSITION_GLOBAL,
-	TRANSITION_HIDDEN,
+	TRANSITION_THIS,
 	TRANSITION_IN,
 	TRANSITION_OUT
 } from '../../../../constants.js';
@@ -174,7 +174,7 @@ export function transition(flags, element, get_fn, get_params) {
 	var is_outro = (flags & TRANSITION_OUT) !== 0;
 	var is_both = is_intro && is_outro;
 	var is_global = (flags & TRANSITION_GLOBAL) !== 0;
-	var is_hidden = (flags & TRANSITION_HIDDEN) !== 0;
+	var is_this = (flags & TRANSITION_THIS) !== 0;
 
 	/** @type {'in' | 'out' | 'both'} */
 	var direction = is_both ? 'both' : is_intro ? 'in' : 'out';
@@ -249,9 +249,9 @@ export function transition(flags, element, get_fn, get_params) {
 		}
 	};
 
-	if (is_hidden) {
+	if (is_this) {
 		// @ts-expect-error
-		element.__tm = transition;
+		(element.__tm ??= []).push(transition);
 		return;
 	}
 

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -5,7 +5,12 @@ import { active_effect, untrack } from '../../runtime.js';
 import { loop } from '../../loop.js';
 import { should_intro } from '../../render.js';
 import { current_each_item } from '../blocks/each.js';
-import { TRANSITION_GLOBAL, TRANSITION_IN, TRANSITION_OUT } from '../../../../constants.js';
+import {
+	TRANSITION_GLOBAL,
+	TRANSITION_HIDDEN,
+	TRANSITION_IN,
+	TRANSITION_OUT
+} from '../../../../constants.js';
 import { BLOCK_EFFECT, EFFECT_RAN, EFFECT_TRANSPARENT } from '../../constants.js';
 import { queue_micro_task } from '../task.js';
 
@@ -169,6 +174,7 @@ export function transition(flags, element, get_fn, get_params) {
 	var is_outro = (flags & TRANSITION_OUT) !== 0;
 	var is_both = is_intro && is_outro;
 	var is_global = (flags & TRANSITION_GLOBAL) !== 0;
+	var is_hidden = (flags & TRANSITION_HIDDEN) !== 0;
 
 	/** @type {'in' | 'out' | 'both'} */
 	var direction = is_both ? 'both' : is_intro ? 'in' : 'out';
@@ -242,6 +248,12 @@ export function transition(flags, element, get_fn, get_params) {
 			outro?.abort();
 		}
 	};
+
+	if (is_hidden) {
+		// @ts-expect-error
+		element.__tm = transition;
+		return;
+	}
 
 	var e = /** @type {Effect} */ (active_effect);
 

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -33,7 +33,8 @@ export {
 	set_xlink_attribute,
 	handle_lazy_img,
 	set_value,
-	set_checked
+	set_checked,
+	set_hidden
 } from './dom/elements/attributes.js';
 export { set_class, set_svg_class, set_mathml_class, toggle_class } from './dom/elements/class.js';
 export { apply, event, delegate, replay_events } from './dom/elements/events.js';

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1060,7 +1060,7 @@ declare module 'svelte/compiler' {
 			name: string;
 			/** The 'y' in `transition:x={y}` */
 			expression: null | Expression;
-			modifiers: Array<'local' | 'global' | 'hidden'>;
+			modifiers: Array<'local' | 'global' | 'this'>;
 			/** True if this is a `transition:` or `in:` directive */
 			intro: boolean;
 			/** True if this is a `transition:` or `out:` directive */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1060,7 +1060,7 @@ declare module 'svelte/compiler' {
 			name: string;
 			/** The 'y' in `transition:x={y}` */
 			expression: null | Expression;
-			modifiers: Array<'local' | 'global'>;
+			modifiers: Array<'local' | 'global' | 'hidden'>;
 			/** True if this is a `transition:` or `in:` directive */
 			intro: boolean;
 			/** True if this is a `transition:` or `out:` directive */


### PR DESCRIPTION
A possible solution for #9976 

It's simple to show/hide a node with the `hidden` attribute (of `style:display`), but there no way to use the svelte's transition with that, and the `{#if}` block destroys its contents every time the condition changes, which is not necessarily desirable.

This PR proposes a new modifier for the `transition:` directive : `hidden`.
With this modifier, the transition will only be applied when the hidden attribute is modified.

Example : 
```svelte
<div transition:slide|hidden={options} hidden={condition}>

</div>
```

This would allow to show/hide elements using Svelte transitions.

[Demo REPL here](https://adiguba-svelte-5-test-git-hidden-transition-adigubas-projects.vercel.app/#H4sIAAAAAAAACo1UbW-bMBD-Kze6qYnUhKTavjBAmqZ9XlXtW1NNjjnArbGRfSStGP99toEm3TppQgj77rnn3umjUki0UXLXR4o1GCXRl7aNriJ6bv3FHlASurvVneFeklpuREv5Tu1INK02BF8ZQWl0A5fr2J3Xo9Hl5zNIb6UocJhgIyAmw5QVJLQasf6VSKBbVJDBe0uMcEGmw2XQc62s13oL6wB90RnmLwl8vN4MHuNQZae4FwLpqpK4WEIfyGmifee_gW_YqTQ-paPSfUfkDLXiUvDHrB8Zhnz8pvGoH7ENE-FEaSEOcEolCZn-olrYrJ9iHaAWRYEq64PzIR8DSvd5Z4WqJq3jnxW-ovHIHjv6fK5OfyHKUJ5hAr7l--R2ojvz5OxPbl45OnfVx6IMxZmTDE9q6VliAHj5XNZC2Fay5wRKiU9jH6kyolgRNk5BuOJado2yCWxL498ZxFonMthMdyZFpVbCmTmo672huUuTwxx8upPboyiodo3_9GEy3zP-WBndqSIBx1TTXnY46VpWFC79BK5P7gifaBV8JsBREZo33eWw_yvTvdT88WyEQl3ckjS6EKXAIkr80A5XLzvlyvyfO_Uy5q3bFGHRDazCI9yMt8XCoNXygMsst0g_RIO6o1l4BdebzWa5HKNdU41qAT8hy6FE4vViF9VErU3imLXCqzkjf-K6iQ_bWDSsQhtbZIbXu-gPHuN5zPrBarVYLqd9fbU-_QU7MvESeShkKvIbiczlEVTH2v1tQGrmu5HGwtn1iecHM8GbCqzhWW_uNvfrzsgBmKRsF-2iOIBdyLwGNBN-n3-7vf1-Cwn0XjbOdh-HQIa_xtazvx6f7WYzzw-zLXJahT-KU0AM20mj9w9eUwpyk6IPp0H5d-vvh9_Iu70OWgUAAA==) (edit : modified REPL to use `|this` instead of `|hidden`)

Remarks : 
* I don't really like the modifier's name `hidden`, but I couldn't find a better name...
* The implementation is quite simple.
* I just realized that this doesn't work with spreading, but I think it should be relatively easy to implement.
* Compatible SSR without change, as the hidden attribute will be set.
* Caveat : the `hidden` attribute is overridden by any CSS `display` value.
It's required to have a global CSS like that : 
```css
[hidden] {
    display: none !important;
}
```


Is it worth it?

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
