### PR TITLE
fix: cleanup non render effects created inside block effects

### DIFF
--- a/.changeset/friendly-mice-perform.md
+++ b/.changeset/friendly-mice-perform.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: cleanup non render effects created inside block effects

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -19,6 +19,7 @@ export const LEGACY_DERIVED_PROP = 1 << 16;
 export const INSPECT_EFFECT = 1 << 17;
 export const HEAD_EFFECT = 1 << 18;
 export const EFFECT_HAS_DERIVED = 1 << 19;
+export const PRE_EFFECT = 1 << 20;
 
 export const STATE_SYMBOL = Symbol('$state');
 export const STATE_SYMBOL_METADATA = Symbol('$state metadata');

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -35,7 +35,8 @@ import {
 	INSPECT_EFFECT,
 	HEAD_EFFECT,
 	MAYBE_DIRTY,
-	EFFECT_HAS_DERIVED
+	EFFECT_HAS_DERIVED,
+	PRE_EFFECT
 } from '../constants.js';
 import { set } from './sources.js';
 import * as e from '../errors.js';
@@ -226,7 +227,7 @@ export function user_pre_effect(fn) {
 			value: '$effect.pre'
 		});
 	}
-	return render_effect(fn);
+	return render_effect(fn, PRE_EFFECT);
 }
 
 /** @param {() => void | (() => void)} fn */
@@ -308,10 +309,11 @@ export function legacy_pre_effect_reset() {
 
 /**
  * @param {() => void | (() => void)} fn
+ * @param {number} flags
  * @returns {Effect}
  */
-export function render_effect(fn) {
-	return create_effect(RENDER_EFFECT, fn, true);
+export function render_effect(fn, flags = 0) {
+	return create_effect(RENDER_EFFECT | flags, fn, true);
 }
 
 /**
@@ -386,7 +388,7 @@ export function destroy_effect(effect, remove_dom = true) {
 		removed = true;
 	}
 
-	destroy_effect_children(effect, remove_dom && !removed);
+	destroy_effect_children(effect, remove_dom && !removed, true);
 	remove_reactions(effect, 0);
 	set_signal_status(effect, DESTROYED);
 

--- a/packages/svelte/tests/runtime-runes/samples/clean-block-inner-effects/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/clean-block-inner-effects/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, instance, logs }) {
+		const button = target.querySelector('button');
+		assert.deepEqual(logs, ['effect', 1]);
+		flushSync(() => {
+			button?.click();
+		});
+		assert.deepEqual(logs, ['effect', 1, 'clean', 1, 'effect', 2]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/clean-block-inner-effects/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/clean-block-inner-effects/main.svelte
@@ -1,0 +1,19 @@
+<script>
+	let count = $state(1);
+
+	function track(value){
+		let val = value;
+		$effect(() => {
+			console.log("effect", val);
+			return ()=>{
+				console.log("clean", val);
+			}
+		});
+		return value;
+	}
+</script>
+
+{#if track(count)}
+{/if}
+
+<button onclick={()=> count++}></button>


### PR DESCRIPTION
## Svelte 5 rewrite

This closes #13573.

Needed note: i'm not familiar with the whole effects orchestration so this code is the result of debugging the cause + trying to fix the issue + debugging the bugs caused by the issue. This means there might be a far easier way to achieve the same thing that i missed. I tried to cleanup the code as much as possible but there might be a cleaner way to achieve the same thing (i will also try to look at this tomorrow with a fresh mind to see if i missed something stupid). In the meantime this could at least be used as a starting point to:

1. understand the issue
2. maybe have a better idea for the implementation

A small recap of the issue is: when updating effects children of `BLOCK_EFFECT` were never cleaned up. This usually it's not a problem because those are generally template effects that will either be handled by the block itself (with `pause` and `resume`) or cleaned up when the component unmounts. However if the user does something like the test that i've added they are creating an effect in the block which needs to be cleaned up. So my solution was to move the check to avoid cleaning up `RENDER_EFFECT`'s inside the `destroy_effect_children` while also adding the logic to keep the linked list up to date. I've also had to add a `force` parameter because if we are coming from  `destroy_effect` rather than `update_effect` we want to clean everything and i had to add a constant to differenciate between `RENDER_EFFECT` and `PRE_EFFECT` because otherwise `PRE_EFFECTS` would not be cleaned up (originally they were `RENDER_EFFECTS`.

I opted into still making`PRE_EFFECT`'s also a `RENDER_EFFECT` to avoid touching too much and i think it's probably fine like this.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
