### PR TITLE
fix: cleanup non-branch effects created inside block effects

### DIFF
--- a/.changeset/eleven-humans-kneel.md
+++ b/.changeset/eleven-humans-kneel.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: cleanup non-branch effects created inside block effects

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -459,10 +459,10 @@ export function update_effect(effect) {
 	}
 
 	try {
-		if ((flags & BLOCK_EFFECT) === 0) {
-			destroy_effect_children(effect);
-		} else {
+		if ((flags & BLOCK_EFFECT) !== 0) {
 			destroy_block_effect_children(effect);
+		} else {
+			destroy_effect_children(effect);
 		}
 
 		execute_effect_teardown(effect);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -419,6 +419,22 @@ export function destroy_effect_children(signal, remove_dom = false) {
 }
 
 /**
+ * @param {Effect} signal
+ * @returns {void}
+ */
+export function destroy_block_effect_children(signal) {
+	var effect = signal.first;
+
+	while (effect !== null) {
+		var next = effect.next;
+		if ((effect.f & BRANCH_EFFECT) === 0) {
+			destroy_effect(effect);
+		}
+		effect = next;
+	}
+}
+
+/**
  * @param {Effect} effect
  * @returns {void}
  */
@@ -445,6 +461,8 @@ export function update_effect(effect) {
 	try {
 		if ((flags & BLOCK_EFFECT) === 0) {
 			destroy_effect_children(effect);
+		} else {
+			destroy_block_effect_children(effect);
 		}
 
 		execute_effect_teardown(effect);

--- a/packages/svelte/tests/runtime-runes/samples/clean-block-inner-effects/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/clean-block-inner-effects/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, instance, logs }) {
+		const button = target.querySelector('button');
+		assert.deepEqual(logs, ['effect', 1]);
+		flushSync(() => {
+			button?.click();
+		});
+		assert.deepEqual(logs, ['effect', 1, 'clean', 1, 'effect', 2]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/clean-block-inner-effects/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/clean-block-inner-effects/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	let count = $state(1);
+	function track(value){
+		let val = value;
+		$effect(() => {
+			console.log("effect", val);
+			return ()=>{
+				console.log("clean", val);
+			}
+		});
+		return value;
+	}
+</script>
+
+{#if track(count)}
+{/if}
+
+<button onclick={()=> count++}></button>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13573. Alternative to https://github.com/sveltejs/svelte/pull/13586