### PR TITLE
chore: avoid reporting inspections when an exception occurs

### DIFF
--- a/.changeset/light-crews-deny.md
+++ b/.changeset/light-crews-deny.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: avoid reporting inspections when an exception occurs

--- a/packages/svelte/src/internal/client/dev/inspect.js
+++ b/packages/svelte/src/internal/client/dev/inspect.js
@@ -18,11 +18,13 @@ export function inspect(get_value, inspector = console.log) {
 
 		// Capturing the value might result in an exception due to the inspect effect being
 		// sync and thus operating on stale data. In the case we encounter an exception we
-		// can bail-out of reporting the value
+		// can bail-out of reporting the value. Instead we simply console.error the error
+		// so at least it's known that an error occured, but we don't stop execution
 		try {
 			value = get_value();
-		} catch {
-			// NO-OP
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.error(error);
 		}
 
 		if (value !== UNINITIALIZED) {

--- a/packages/svelte/tests/runtime-runes/samples/inspect-exception/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-exception/Component.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	let { a = $bindable() } = $props();
+
+	$inspect(a).with((t, c) => console.log(t, c));
+
+</script>
+<p>{a}</p>

--- a/packages/svelte/tests/runtime-runes/samples/inspect-exception/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-exception/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, target, logs }) {
+		const b1 = target.querySelector('button');
+		b1?.click();
+		flushSync();
+
+		assert.deepEqual(logs, ['init', 'a', 'init', 'b']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/inspect-exception/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-exception/main.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Component from './Component.svelte';
+
+	let s = $state({ a: {"1": "a", "2": "b"} });
+</script>
+
+<button onclick={() => (s = {})}>Set State</button>
+
+{#if s.a}
+	{#each Object.entries(s.a) as [k, v]}
+		<Component bind:a={s.a[k]} />
+	{/each}
+{/if}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13577. If we encounter a runtime exception when getting the values for an inspection we bail out reporting the inspection. This can occur naturally because inspect effects are run sync, and thus they can operate before a parent render effect runs that would have invalidated the inspect effect had they not be sync.