### PR TITLE
fix: handle leading combinators within `:has(...)`

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -371,6 +371,16 @@ function relative_selector_might_apply_to_node(
 
 			for (const complex_selector of complex_selectors) {
 				const selectors = truncate(complex_selector);
+				const left_most_combinator = selectors[0]?.combinator ?? descendant_combinator;
+				// In .x:has(> y), we want to search for y, ignoring the left-most combinator
+				// (else it would try to walk further up and fail because there are no selectors left)
+				if (selectors.length > 0) {
+					selectors[0] = {
+						...selectors[0],
+						combinator: null
+					};
+				}
+
 				if (
 					selectors.length === 0 /* is :global(...) */ ||
 					apply_selector(selectors, rule, element, stylesheet, check_has)
@@ -379,7 +389,7 @@ function relative_selector_might_apply_to_node(
 					// and now looking upwards for the .x part.
 					if (
 						apply_combinator(
-							selectors[0]?.combinator ?? descendant_combinator,
+							left_most_combinator,
 							selectors[0] ?? [],
 							[relative_selector],
 							rule,

--- a/packages/svelte/tests/css/samples/has/_config.js
+++ b/packages/svelte/tests/css/samples/has/_config.js
@@ -85,6 +85,20 @@ export default test({
 				column: 17,
 				line: 81
 			}
+		},
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector "x:has(> z)"',
+			start: {
+				line: 88,
+				column: 1,
+				character: 968
+			},
+			end: {
+				line: 88,
+				column: 11,
+				character: 978
+			}
 		}
 	]
 });

--- a/packages/svelte/tests/css/samples/has/expected.css
+++ b/packages/svelte/tests/css/samples/has/expected.css
@@ -75,3 +75,10 @@
 	/* (unused) .unused x:has(y) {
 		color: red;
 	}*/
+
+	x.svelte-xyz:has(> y:where(.svelte-xyz)) {
+		color: green;
+	}
+	/* (unused) x:has(> z) {
+		color: red;
+	}*/

--- a/packages/svelte/tests/css/samples/has/input.svelte
+++ b/packages/svelte/tests/css/samples/has/input.svelte
@@ -81,4 +81,11 @@
 	.unused x:has(y) {
 		color: red;
 	}
+
+	x:has(> y) {
+		color: green;
+	}
+	x:has(> z) {
+		color: red;
+	}
 </style>


### PR DESCRIPTION
We need to ignore the leading combinator within a `:has(...)`, else it would not stop matching, assuming there are more parent selectors (which there aren't) and always fail.

https://github.com/sveltejs/svelte/pull/13567#issuecomment-2412405131

No changeset because not released yet

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
