### PR TITLE
fix: ensure local prop value is read during teardown

### DIFF
--- a/.changeset/clean-sloths-nail.md
+++ b/.changeset/clean-sloths-nail.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure local prop value is read during teardown

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -20,7 +20,7 @@ import {
 } from '../runtime.js';
 import { safe_equals } from './equality.js';
 import * as e from '../errors.js';
-import { BRANCH_EFFECT, DESTROYED, LEGACY_DERIVED_PROP, ROOT_EFFECT } from '../constants.js';
+import { BRANCH_EFFECT, LEGACY_DERIVED_PROP, ROOT_EFFECT } from '../constants.js';
 import { proxy } from '../proxy.js';
 import { teardown } from './effects.js';
 
@@ -369,6 +369,7 @@ export function prop(props, key, flags, fallback) {
 				was_from_child = true;
 				return child_value;
 			}
+
 			was_from_child = false;
 			return (inner_current_value.v = parent_value);
 		})

--- a/packages/svelte/tests/runtime-runes/samples/props-local-teardown/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-local-teardown/Component.svelte
@@ -1,0 +1,15 @@
+<script>
+	let { x } = $props();
+
+	$effect(() => {
+		console.log('init')
+
+		x = () => {
+			console.log('teardown')
+		}
+
+		return () => {
+			x();
+		}
+	})
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/props-local-teardown/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-local-teardown/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, logs, target }) {
+		const [btn1] = target.querySelectorAll('button');
+
+		btn1?.click();
+		flushSync();
+
+		btn1?.click();
+		flushSync();
+
+		btn1?.click();
+		flushSync();
+
+		assert.deepEqual(logs, ['init', 'teardown', 'init', 'teardown']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/props-local-teardown/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-local-teardown/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	import Component from "./Component.svelte";
+
+	let toggle = $state(true);
+</script>
+
+<button onclick={() => toggle = !toggle}>toggle</button>
+
+{#if toggle}
+	<Component />
+{/if}
+


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13605. Now we have ownership of deriveds, if we have the case where a prop is re-assigned locally then we need to ensure that upon teardown of the local component we switch to using that value and not that of the parent derived, as that derived will now be destroyed already.