### PR TITLE
feat: hidden until found and beforematch

### DIFF
--- a/.changeset/bright-seas-brake.md
+++ b/.changeset/bright-seas-brake.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add hidden until-found and beforematch

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -428,6 +428,9 @@ export interface DOMAttributes<T extends EventTarget> {
 	onvisibilitychangecapture?: EventHandler<Event, T> | undefined | null;
 
 	// Global Events
+	'on:beforematch'?: EventHandler<Event, T> | undefined | null;
+	onbeforematch?: EventHandler<Event, T> | undefined | null;
+	onbeforematchcapture?: EventHandler<Event, T> | undefined | null;
 	'on:cancel'?: EventHandler<Event, T> | undefined | null;
 	oncancel?: EventHandler<Event, T> | undefined | null;
 	oncancelcapture?: EventHandler<Event, T> | undefined | null;
@@ -735,7 +738,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 		| 'send'
 		| undefined
 		| null;
-	hidden?: boolean | undefined | null;
+	hidden?: boolean | 'until-found' | '' | undefined | null;
 	id?: string | undefined | null;
 	lang?: string | undefined | null;
 	part?: string | undefined | null;


### PR DESCRIPTION
The `until-found` value of the `hidden` attributes allows find-in-page functionnality, and the `beforematch` event can intercept it. 

[spec](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute) [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden#using_until-found) [REPL](<https://svelte-5-preview.vercel.app/#H4sIAAAAAAAAE0WMwWrDMBBEf0VMLwm4zd21BPmObA-utYoF8q6xZIdg_O9FJNDT8OYxsyPExBntbYf0E6PFdZ7RoDznCnnjVBgNsq7LUJuuN-PCwRI-8qgPgqvRXXpHQtL5uJEYE70lvHzFMXrPYgmrlJg-g67iq6Gi8stBF576Mox2P_HZWGf2OjJmUMma-Cvp_UR4r87fVR4Hifu_JukuPm6OBA0m9TFE9mjLsvLxc_wBJY1zmuYAAAA=>) 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
