### PR TITLE
fix: ensure each block consistency to internal mutations to the collection

### DIFF
--- a/.changeset/happy-eggs-rest.md
+++ b/.changeset/happy-eggs-rest.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure bind_checked defers mutation to ensure reactive graph stability

--- a/.changeset/happy-eggs-rest.md
+++ b/.changeset/happy-eggs-rest.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure bind_checked defers mutation to ensure reactive graph stability
+fix: ensure each block consistency to internal mutations to the collection

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -205,6 +205,10 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 
 		if (!hydrating) {
 			reconcile(array, state, anchor, render_fn, flags, get_key);
+			// Reconciling can cause the collection to become unstable if any inner effects
+			// have mutated the collection since reconcialtion. Reading the collection again
+			// will fix this
+			get_collection();
 		}
 
 		if (fallback_fn !== null) {

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -229,8 +229,9 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 		// When we mount the each block for the first time, the collection won't be
 		// connected to this effect as the effect hasn't finished running yet and its deps
 		// won't be assigned. However, it's possible that when reconciling the each block
-		// that a mutation occured and it's made the collection MAYBE_DIRTY, so reading the
-		// collection again can provide consistency to the reactive grpah again
+		// that a mutation occurred and it's made the collection MAYBE_DIRTY, so reading the
+		// collection again can provide consistency to the reactive graph again as the deriveds
+		// will now be `CLEAN`.
 		get_collection();
 	});
 

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -205,10 +205,6 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 
 		if (!hydrating) {
 			reconcile(array, state, anchor, render_fn, flags, get_key);
-			// Reconciling can cause the collection to become unstable if any inner effects
-			// have mutated the collection since reconcialtion. Reading the collection again
-			// will fix this
-			get_collection();
 		}
 
 		if (fallback_fn !== null) {
@@ -229,6 +225,13 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 			// continue in hydration mode
 			set_hydrating(true);
 		}
+
+		// When we mount the each block for the first time, the collection won't be
+		// connected to this effect as the effect hasn't finished running yet and its deps
+		// won't be assigned. However, it's possible that when reconciling the each block
+		// that a mutation occured and it's made the collection MAYBE_DIRTY, so reading the
+		// collection again can provide consistency to the reactive grpah again
+		get_collection();
 	});
 
 	if (hydrating) {

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -180,14 +180,9 @@ export function bind_checked(input, get, set = get) {
 		set(value);
 	});
 
-	// We defer setting the value as we might already be in an active
-	// block like an each block where that effect hasn't yet hooked up
-	// to the reactivity graph
-	queue_micro_task(() => {
-		if (get() == undefined) {
-			set(false);
-		}
-	});
+	if (get() == undefined) {
+		set(false);
+	}
 
 	render_effect(() => {
 		var value = get();

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -180,9 +180,14 @@ export function bind_checked(input, get, set = get) {
 		set(value);
 	});
 
-	if (get() == undefined) {
-		set(false);
-	}
+	// We defer setting the value as we might already be in an active
+	// block like an each block where that effect hasn't yet hooked up
+	// to the reactivity graph
+	queue_micro_task(() => {
+		if (get() == undefined) {
+			set(false);
+		}
+	});
 
 	render_effect(() => {
 		var value = get();

--- a/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/_config.js
@@ -10,7 +10,7 @@ export default test({
 
 		assert.htmlEqual(
 			target.innerHTML,
-			`<button>Add</button><label><input type="checkbox">\n1</label><label><input type="checkbox">\nfoo</label>`
+			`<button>Add</button><label><input type="checkbox"></label><label><input type="checkbox"></label>`
 		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/_config.js
@@ -11,6 +11,6 @@ export default test({
 		assert.htmlEqual(
 			target.innerHTML,
 			`<button>Add</button><label><input type="checkbox">\n1</label><label><input type="checkbox">\nfoo</label>`
-		)
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		button?.click();
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>Add</button><label><input type="checkbox">\n1</label><label><input type="checkbox">\nfoo</label>`
+		)
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/checkbox.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/checkbox.svelte
@@ -1,0 +1,8 @@
+<script>
+  let { value = $bindable(), config } = $props();
+</script>
+
+<label>
+  <input type="checkbox" bind:checked={value} />
+  {config.title}
+</label>

--- a/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/checkbox.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/checkbox.svelte
@@ -1,8 +1,7 @@
 <script>
-  let { value = $bindable(), config } = $props();
+  let { value = $bindable() } = $props();
 </script>
 
 <label>
   <input type="checkbox" bind:checked={value} />
-  {config.title}
 </label>

--- a/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/main.svelte
@@ -4,23 +4,18 @@
 	let foo = $state({})
 
 	const schema = $state({
-    properties: {
-      foo: true,
-    },
+    foo: true,
   })
 
-	function retrieveSchema(schema, value) {
-		const cloned = { ...schema, properties: { ...schema.properties } }
-		for (const key of Object.keys(value)) {
-			cloned.properties[key] = key
+	function retrieveSchema() {
+		const cloned = { ...schema }
+		for (const key of Object.keys(foo)) {
+			cloned[key] = key
 		}
 		return cloned
 	}
 
-	const retrieved = $derived(retrieveSchema(schema, foo));
-	const required = $derived(new Set(retrieved.required));
-	const properties = $derived(retrieved.properties);
-	const keys = $derived(Object.keys(properties));
+	const keys = $derived(Object.keys(retrieveSchema()));
 	let nextKey = 1;
 </script>
 
@@ -29,6 +24,5 @@
 }}>Add</button>
 
 {#each keys as key (key)}
-	{@const config = { title: key, required: required.has(key) }}
-	<Checkbox bind:value={foo[key]} {config} />
+	<Checkbox bind:value={foo[key]} />
 {/each}

--- a/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/checkbox-binding-derived/main.svelte
@@ -1,0 +1,34 @@
+<script>
+	import Checkbox from './checkbox.svelte';
+
+	let foo = $state({})
+
+	const schema = $state({
+    properties: {
+      foo: true,
+    },
+  })
+
+	function retrieveSchema(schema, value) {
+		const cloned = { ...schema, properties: { ...schema.properties } }
+		for (const key of Object.keys(value)) {
+			cloned.properties[key] = key
+		}
+		return cloned
+	}
+
+	const retrieved = $derived(retrieveSchema(schema, foo));
+	const required = $derived(new Set(retrieved.required));
+	const properties = $derived(retrieved.properties);
+	const keys = $derived(Object.keys(properties));
+	let nextKey = 1;
+</script>
+
+<button onclick={() => {
+	foo[nextKey++] = true
+}}>Add</button>
+
+{#each keys as key (key)}
+	{@const config = { title: key, required: required.has(key) }}
+	<Checkbox bind:value={foo[key]} {config} />
+{/each}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13604. 

When we mount the each block for the first time, the collection won't be connected to this effect as the effect hasn't finished running yet and its deps won't be assigned. However, it's possible that when reconciling the each block that a mutation occurred and it's made the collection `MAYBE_DIRTY`, so reading the collection again can provide consistency to the reactive graph again as the deriveds will now be `CLEAN`.