### PR TITLE
fix: ensure inserted code is preserved during migration

### DIFF
--- a/.changeset/cool-apes-confess.md
+++ b/.changeset/cool-apes-confess.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: moving deriveds during migration deletes part of the inserted code

--- a/.changeset/cool-apes-confess.md
+++ b/.changeset/cool-apes-confess.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: moving deriveds during migration deletes part of the inserted code
+fix: ensure inserted code is preserved during migration 

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -273,7 +273,12 @@ export function migrate(source, { filename } = {}) {
 				const { start, end } = get_node_range(source, node);
 				str.appendLeft(end, '\n');
 				str.move(start, end, /** @type {number} */ (parsed.instance?.content.end));
-				str.remove(start - (source[start - 2] === '\r' ? 2 : 1), start);
+				const carriage_idx = start - (source[start - 2] === '\r' ? 2 : 1);
+				// we might end up injecting something at the position we are about to remove
+				// since we only want to remove the carriage if we add the trimmed length
+				// of the transformed string to prevent removing something we added.
+				const transformed = state.str.snip(carriage_idx, start).toString().trim();
+				str.remove(carriage_idx + transformed.length, start);
 			}
 		}
 

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -273,12 +273,7 @@ export function migrate(source, { filename } = {}) {
 				const { start, end } = get_node_range(source, node);
 				str.appendLeft(end, '\n');
 				str.move(start, end, /** @type {number} */ (parsed.instance?.content.end));
-				const carriage_idx = start - (source[start - 2] === '\r' ? 2 : 1);
-				// we might end up injecting something at the position we are about to remove
-				// since we only want to remove the carriage if we add the trimmed length
-				// of the transformed string to prevent removing something we added.
-				const transformed = state.str.snip(carriage_idx, start).toString().trim();
-				str.remove(carriage_idx + transformed.length, start);
+				str.update(start - (source[start - 2] === '\r' ? 2 : 1), start, '');
 			}
 		}
 

--- a/packages/svelte/tests/migrate/samples/reactive-statements-reorder-not-deleting-additions/input.svelte
+++ b/packages/svelte/tests/migrate/samples/reactive-statements-reorder-not-deleting-additions/input.svelte
@@ -1,0 +1,12 @@
+<script>
+	export let data
+	$: ({ foo } = data)
+
+	import { blah } from './blah.js'
+
+	let bar
+	$: {
+		bar = []
+		let baz
+	}
+</script>

--- a/packages/svelte/tests/migrate/samples/reactive-statements-reorder-not-deleting-additions/output.svelte
+++ b/packages/svelte/tests/migrate/samples/reactive-statements-reorder-not-deleting-additions/output.svelte
@@ -7,7 +7,6 @@
 	let { data } = $props();
 
 	let bar = $state()
-
 	let { foo } = $derived(data)
 	run(() => {
 		bar = []

--- a/packages/svelte/tests/migrate/samples/reactive-statements-reorder-not-deleting-additions/output.svelte
+++ b/packages/svelte/tests/migrate/samples/reactive-statements-reorder-not-deleting-additions/output.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { run } from 'svelte/legacy';
+
+
+	import { blah } from './blah.js'
+	/** @type {{data: any}} */
+	let { data } = $props();
+
+	let bar = $state()
+
+	let { foo } = $derived(data)
+	run(() => {
+		bar = []
+		let baz
+	});
+</script>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13615

Not super happy with this but didn't find a better way. The problem is that the code assumes that we will remove one character in case of `\n` or 2 in case of `\r\n`. However based on how `MagicString` works if we inserted a character at that position before removing at that position will also remove the inserted character.

To fix this i snip the already transformed string to take a look at what we are removing and i trim it...any character left is added to the remove starting point.

I don't think we can find a situation where we have a character after the carriage so this should work.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
