### PR TITLE
chore: improve derived ownership model

### DIFF
--- a/.changeset/nine-vans-admire.md
+++ b/.changeset/nine-vans-admire.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: improve derived ownership model

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -31,7 +31,7 @@ import { inspect_effects, set_inspect_effects } from './sources.js';
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function derived(fn) {
-	let flags = DERIVED | DIRTY;
+	var flags = DERIVED | DIRTY;
 
 	if (active_effect === null) {
 		flags |= UNOWNED;
@@ -57,9 +57,6 @@ export function derived(fn) {
 	if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
 		var derived = /** @type {Derived} */ (active_reaction);
 		(derived.children ??= []).push(signal);
-	}
-	if (active_effect !== null) {
-		(active_effect.deriveds ??= []).push(signal);
 	}
 
 	return signal;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -801,10 +801,17 @@ export function get(signal) {
 			set_signal_status(active_effect, DIRTY);
 			schedule_effect(active_effect);
 		}
+	} else if (is_derived) {
+		var derived = /** @type {Derived} */ (signal);
+		var parent = derived.parent;
+
+		if (parent !== null && !parent.deriveds?.includes(derived)) {
+			(parent.deriveds ??= []).push(derived);
+		}
 	}
 
 	if (is_derived) {
-		var derived = /** @type {Derived} */ (signal);
+		derived = /** @type {Derived} */ (signal);
 
 		if (check_dirtiness(derived)) {
 			update_derived(derived);

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -488,7 +488,7 @@ describe('signals', () => {
 			assert.equal(a?.deps?.length, 1);
 			assert.equal(s?.reactions?.length, 1);
 			destroy();
-			assert.equal(a?.deps, null);
+			assert.equal(a?.deps?.length, 1);
 			assert.equal(s?.reactions, null);
 		};
 	});

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -488,7 +488,6 @@ describe('signals', () => {
 			assert.equal(a?.deps?.length, 1);
 			assert.equal(s?.reactions?.length, 1);
 			destroy();
-			assert.equal(a?.deps?.length, 1);
 			assert.equal(s?.reactions, null);
 		};
 	});


### PR DESCRIPTION
https://github.com/sveltejs/svelte/pull/13563 introduced owned deriveds, but it turns out that eagerly attaching each derived to its parent effect upon creation wasn't ideal. Instead, we can lazily do it upon encountering a read on a derived in a context where there is no active reaction. I can't believe I didn't think of this sooner!

Before:
![Screenshot 2024-10-16 at 12 17 46](https://github.com/user-attachments/assets/11435995-f49c-4328-b860-190a00e6e8aa)

After:
![Screenshot 2024-10-16 at 12 18 12](https://github.com/user-attachments/assets/54b6d7c2-05cf-47d5-b677-16586ddb29da)

