### PR TITLE
breaking: stronger enumerated types 

### DIFF
--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1362,7 +1362,7 @@ export interface HTMLTdAttributes extends HTMLAttributes<HTMLTableCellElement> {
 	colspan?: number | undefined | null;
 	headers?: string | undefined | null;
 	rowspan?: number | undefined | null;
-	scope?: string | undefined | null;
+	scope?: 'col' | 'colgroup' | 'row' | 'rowgroup' | undefined | null;
 	abbr?: string | undefined | null;
 	height?: number | string | undefined | null;
 	width?: number | string | undefined | null;
@@ -1374,7 +1374,7 @@ export interface HTMLThAttributes extends HTMLAttributes<HTMLTableCellElement> {
 	colspan?: number | undefined | null;
 	headers?: string | undefined | null;
 	rowspan?: number | undefined | null;
-	scope?: string | undefined | null;
+	scope?: 'col' | 'colgroup' | 'row' | 'rowgroup' | undefined | null;
 	abbr?: string | undefined | null;
 }
 

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -771,7 +771,6 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	vocab?: string | undefined | null;
 
 	// Non-standard Attributes
-	autocorrect?: string | undefined | null;
 	autosave?: string | undefined | null;
 	color?: string | undefined | null;
 	itemprop?: string | undefined | null;
@@ -1051,6 +1050,8 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	accept?: string | undefined | null;
 	alt?: string | undefined | null;
 	autocomplete?: FullAutoFill | undefined | null;
+	// Safari only https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#autocorrect
+	autocorrect?: 'on' | 'off' | '' | undefined | null;
 	capture?: boolean | 'user' | 'environment' | undefined | null; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
 	checked?: boolean | undefined | null;
 	dirname?: string | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1199,7 +1199,14 @@ export interface HTMLMediaAttributes<T extends HTMLMediaElement> extends HTMLAtt
 export interface HTMLMetaAttributes extends HTMLAttributes<HTMLMetaElement> {
 	charset?: string | undefined | null;
 	content?: string | undefined | null;
-	'http-equiv'?: string | undefined | null;
+	'http-equiv'?:
+		| 'content-security-policy'
+		| 'content-type'
+		| 'default-style'
+		| 'refresh'
+		| 'x-ua-compatible'
+		| undefined
+		| null;
 	name?: string | undefined | null;
 	media?: string | undefined | null;
 }

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -886,7 +886,12 @@ export interface HTMLButtonAttributes extends HTMLAttributes<HTMLButtonElement> 
 	disabled?: boolean | undefined | null;
 	form?: string | undefined | null;
 	formaction?: string | undefined | null;
-	formenctype?: string | undefined | null;
+	formenctype?:
+		| 'application/x-www-form-urlencoded'
+		| 'multipart/form-data'
+		| 'text/plain'
+		| undefined
+		| null;
 	formmethod?: 'dialog' | 'get' | 'post' | undefined | null;
 	formnovalidate?: boolean | undefined | null;
 	formtarget?: string | undefined | null;
@@ -952,7 +957,12 @@ export interface HTMLFormAttributes extends HTMLAttributes<HTMLFormElement> {
 	acceptcharset?: string | undefined | null;
 	action?: string | undefined | null;
 	autocomplete?: AutoFillBase | undefined | null;
-	enctype?: string | undefined | null;
+	enctype?:
+		| 'application/x-www-form-urlencoded'
+		| 'multipart/form-data'
+		| 'text/plain'
+		| undefined
+		| null;
 	method?: 'dialog' | 'get' | 'post' | undefined | null;
 	name?: string | undefined | null;
 	novalidate?: boolean | undefined | null;
@@ -1046,7 +1056,12 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	disabled?: boolean | undefined | null;
 	form?: string | undefined | null;
 	formaction?: string | undefined | null;
-	formenctype?: string | undefined | null;
+	formenctype?:
+		| 'application/x-www-form-urlencoded'
+		| 'multipart/form-data'
+		| 'text/plain'
+		| undefined
+		| null;
 	formmethod?: 'dialog' | 'get' | 'post' | undefined | null;
 	formnovalidate?: boolean | undefined | null;
 	formtarget?: string | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1384,7 +1384,7 @@ export interface HTMLTimeAttributes extends HTMLAttributes<HTMLTimeElement> {
 
 export interface HTMLTrackAttributes extends HTMLAttributes<HTMLTrackElement> {
 	default?: boolean | undefined | null;
-	kind?: string | undefined | null;
+	kind?: 'captions' | 'chapters' | 'descriptions' | 'metadata' | 'subtitles' | undefined | null;
 	label?: string | undefined | null;
 	src?: string | undefined | null;
 	srclang?: string | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1169,7 +1169,7 @@ export interface HTMLMediaAttributes<T extends HTMLMediaElement> extends HTMLAtt
 	mediagroup?: string | undefined | null;
 	muted?: boolean | undefined | null;
 	playsinline?: boolean | undefined | null;
-	preload?: string | undefined | null;
+	preload?: 'auto' | 'none' | 'metadata' | '' | undefined | null;
 	src?: string | undefined | null;
 	/**
 	 * a value between 0 and 1
@@ -1783,7 +1783,7 @@ export interface HTMLWebViewAttributes extends HTMLAttributes<HTMLElement> {
 	nodeintegration?: boolean | undefined | null;
 	partition?: string | undefined | null;
 	plugins?: boolean | undefined | null;
-	preload?: string | undefined | null;
+	preload?: 'auto' | 'none' | 'metadata' | '' | undefined | null;
 	src?: string | undefined | null;
 	useragent?: string | undefined | null;
 	webpreferences?: string | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -770,7 +770,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	vocab?: string | undefined | null;
 
 	// Non-standard Attributes
-	autocapitalize?: string | undefined | null;
+	autocapitalize?: 'characters' | 'off' | 'on' | 'none' | 'sentences' | 'words' | undefined | null;
 	autocorrect?: string | undefined | null;
 	autosave?: string | undefined | null;
 	color?: string | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -725,7 +725,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	class?: string | undefined | null;
 	contenteditable?: Booleanish | 'inherit' | 'plaintext-only' | undefined | null;
 	contextmenu?: string | undefined | null;
-	dir?: string | undefined | null;
+	dir?: 'ltr' | 'rtl' | 'auto' | undefined | null;
 	draggable?: Booleanish | undefined | null;
 	elementtiming?: string | undefined | null;
 	enterkeyhint?:

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1786,6 +1786,10 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	[key: `data-${string}`]: any;
 }
 
+export interface HTMLTemplateAttributes extends HTMLAttributes<HTMLElement> {
+	shadowrootmode?: 'open' | 'closed' | undefined | null;
+}
+
 export interface HTMLWebViewAttributes extends HTMLAttributes<HTMLElement> {
 	allowfullscreen?: boolean | undefined | null;
 	allowpopups?: boolean | undefined | null;
@@ -1910,7 +1914,7 @@ export interface SvelteHTMLElements {
 	summary: HTMLAttributes<HTMLElement>;
 	sup: HTMLAttributes<HTMLElement>;
 	table: HTMLTableAttributes;
-	template: HTMLAttributes<HTMLTemplateElement>;
+	template: HTMLTemplateAttributes;
 	tbody: HTMLAttributes<HTMLTableSectionElement>;
 	td: HTMLTdAttributes;
 	textarea: HTMLTextareaAttributes;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -751,6 +751,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	translate?: 'yes' | 'no' | '' | undefined | null;
 	inert?: boolean | undefined | null;
 	popover?: 'auto' | 'manual' | '' | undefined | null;
+	writingsuggestions?: Booleanish | undefined | null;
 
 	// Unknown
 	radiogroup?: string | undefined | null; // <command>, <menuitem>

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -887,7 +887,7 @@ export interface HTMLButtonAttributes extends HTMLAttributes<HTMLButtonElement> 
 	form?: string | undefined | null;
 	formaction?: string | undefined | null;
 	formenctype?: string | undefined | null;
-	formmethod?: string | undefined | null;
+	formmethod?: 'dialog' | 'get' | 'post' | undefined | null;
 	formnovalidate?: boolean | undefined | null;
 	formtarget?: string | undefined | null;
 	name?: string | undefined | null;
@@ -953,7 +953,7 @@ export interface HTMLFormAttributes extends HTMLAttributes<HTMLFormElement> {
 	action?: string | undefined | null;
 	autocomplete?: AutoFillBase | undefined | null;
 	enctype?: string | undefined | null;
-	method?: string | undefined | null;
+	method?: 'dialog' | 'get' | 'post' | undefined | null;
 	name?: string | undefined | null;
 	novalidate?: boolean | undefined | null;
 	target?: string | undefined | null;
@@ -1047,7 +1047,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	form?: string | undefined | null;
 	formaction?: string | undefined | null;
 	formenctype?: string | undefined | null;
-	formmethod?: string | undefined | null;
+	formmethod?: 'dialog' | 'get' | 'post' | undefined | null;
 	formnovalidate?: boolean | undefined | null;
 	formtarget?: string | undefined | null;
 	height?: number | string | undefined | null;
@@ -1486,7 +1486,8 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	lang?: string | undefined | null;
 	max?: number | string | undefined | null;
 	media?: string | undefined | null;
-	method?: string | undefined | null;
+	// On the `textPath` element
+	method?: 'align' | 'stretch' | undefined | null;
 	min?: number | string | undefined | null;
 	name?: string | undefined | null;
 	style?: string | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -868,7 +868,7 @@ export interface HTMLAreaAttributes extends HTMLAttributes<HTMLAreaElement> {
 	media?: string | undefined | null;
 	referrerpolicy?: ReferrerPolicy | undefined | null;
 	rel?: string | undefined | null;
-	shape?: string | undefined | null;
+	shape?: 'circle' | 'default' | 'poly' | 'rect' | undefined | null;
 	target?: string | undefined | null;
 	ping?: string | undefined | null;
 }

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -721,6 +721,7 @@ export type AriaRole =
 export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, DOMAttributes<T> {
 	// Standard HTML Attributes
 	accesskey?: string | undefined | null;
+	autocapitalize?: 'characters' | 'off' | 'on' | 'none' | 'sentences' | 'words' | undefined | null;
 	autofocus?: boolean | undefined | null;
 	class?: string | undefined | null;
 	contenteditable?: Booleanish | 'inherit' | 'plaintext-only' | undefined | null;
@@ -770,7 +771,6 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	vocab?: string | undefined | null;
 
 	// Non-standard Attributes
-	autocapitalize?: 'characters' | 'off' | 'on' | 'none' | 'sentences' | 'words' | undefined | null;
 	autocorrect?: string | undefined | null;
 	autosave?: string | undefined | null;
 	color?: string | undefined | null;

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1100,7 +1100,33 @@ export interface HTMLLiAttributes extends HTMLAttributes<HTMLLIElement> {
 }
 
 export interface HTMLLinkAttributes extends HTMLAttributes<HTMLLinkElement> {
-	as?: string | undefined | null;
+	as?:
+		| 'fetch'
+		| 'audio'
+		| 'audioworklet'
+		| 'document'
+		| 'embed'
+		| 'font'
+		| 'frame'
+		| 'iframe'
+		| 'image'
+		| 'json'
+		| 'manifest'
+		| 'object'
+		| 'paintworklet'
+		| 'report'
+		| 'script'
+		| 'serviceworker'
+		| 'sharedworker'
+		| 'style'
+		| 'track'
+		| 'video'
+		| 'webidentity'
+		| 'worker'
+		| 'xslt'
+		| ''
+		| undefined
+		| null;
 	crossorigin?: 'anonymous' | 'use-credentials' | '' | undefined | null;
 	href?: string | undefined | null;
 	hreflang?: string | undefined | null;


### PR DESCRIPTION
Systematic review of all enumerated attributes, with the following modifications:

- `as` can be `script`, `image`, `style` etc. (any [potential destination](https://fetch.spec.whatwg.org/#concept-potential-destination))
- the [`autocapitalize`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize) global attribute
- the [`autocorrect`](https://html.spec.whatwg.org/#attr-autocorrect) attribute
- [`dir`](https://html.spec.whatwg.org/#the-dir-attribute) can be `ltr`, `rtl`, `auto`
- [`enctype`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#enctype) for forms 
- [`http-equiv`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv) can be a pragma directives like `content-security-policy` or `content-type` (but is not needed with the `charset` attribute and managed csp in kit)
- `kind` specifies the type of [text track](https://html.spec.whatwg.org/#the-track-element) as `captions`, `subtitles` etc
- [`preload`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload) hint to the browser for best user experience
- the `method` and `formmethod` attributes for forms and inputs ([ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method)) and also a `method` attribute for [`textPath`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/textPath) svg elements
- the [`scope`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope) of a table header 
-  the [`shape`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area#shape) of an `area` can be `circle`, `rect` etc

Also define an `HTMLTemplateAttributes` for the [`template`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) element with `shadowrootmode`

Add the [`writingsuggestions`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/writingsuggestions) global attribute



## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
