### PR TITLE
chore: improve runtime performance of derived signals

### DIFF
--- a/.changeset/shiny-jobs-judge.md
+++ b/.changeset/shiny-jobs-judge.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: improve runtime performance of derived signals

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -801,7 +801,7 @@ export function get(signal) {
 			set_signal_status(active_effect, DIRTY);
 			schedule_effect(active_effect);
 		}
-	} else if (is_derived) {
+	} else if (is_derived && /** @type {Derived} */ (signal).deps === null) {
 		var derived = /** @type {Derived} */ (signal);
 		var parent = derived.parent;
 


### PR DESCRIPTION
Missed an opportunity to check if `deps` was already populated or not. If it is populated, we know that we don't need to add or check for ownership on the derived having `deps` means we've already done this work before – avoiding the need to do a O(n) lookup in the parents.