### PR TITLE
fix: better migration for leading and trailing comments

### DIFF
--- a/.changeset/popular-dolphins-shake.md
+++ b/.changeset/popular-dolphins-shake.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better migration for leading and trailing comments

--- a/packages/svelte/tests/migrate/samples/reactive-statements-reorder-with-comments/input.svelte
+++ b/packages/svelte/tests/migrate/samples/reactive-statements-reorder-with-comments/input.svelte
@@ -1,0 +1,27 @@
+<script>
+	let count = 0;
+
+	$: {
+		console.log({ count, double });
+	}
+
+	// this comment should remain attached to this declaration after migration
+	$: double = count * 2; // this too
+
+	// triple
+	let triple;
+	$: {
+		// update triple
+		triple = count * 3;
+		// trailing comment
+		// in triple
+	}
+
+	function increment() {
+		count += 1;
+	}
+</script>
+
+<button onclick={increment}>
+	clicks: {count}
+</button>

--- a/packages/svelte/tests/migrate/samples/reactive-statements-reorder-with-comments/output.svelte
+++ b/packages/svelte/tests/migrate/samples/reactive-statements-reorder-with-comments/output.svelte
@@ -1,0 +1,27 @@
+<script>
+	import { run } from 'svelte/legacy';
+
+	let count = $state(0);
+
+
+
+	// triple
+	//  update triple
+	let triple = $derived(count * 3)
+	//  trailing comment
+	//  in triple;
+
+	function increment() {
+		count += 1;
+	}
+	// this comment should remain attached to this declaration after migration
+	let double = $derived(count * 2); // this too
+	run(() => {
+		console.log({ count, double });
+	});
+	
+</script>
+
+<button onclick={increment}>
+	clicks: {count}
+</button>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13618 

There's also another situation that i think we should fix somehow but i think it involves a bit of discussion so i'll open a new issue about it.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
