### PR TITLE
fix: `method` is case insensitive

### DIFF
--- a/.changeset/khaki-mirrors-warn.md
+++ b/.changeset/khaki-mirrors-warn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: `method` attribute is case insensitive

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -892,7 +892,7 @@ export interface HTMLButtonAttributes extends HTMLAttributes<HTMLButtonElement> 
 		| 'text/plain'
 		| undefined
 		| null;
-	formmethod?: 'dialog' | 'get' | 'post' | undefined | null;
+	formmethod?: 'dialog' | 'get' | 'post' | 'DIALOG' | 'GET' | 'POST' | undefined | null;
 	formnovalidate?: boolean | undefined | null;
 	formtarget?: string | undefined | null;
 	name?: string | undefined | null;
@@ -963,7 +963,7 @@ export interface HTMLFormAttributes extends HTMLAttributes<HTMLFormElement> {
 		| 'text/plain'
 		| undefined
 		| null;
-	method?: 'dialog' | 'get' | 'post' | undefined | null;
+	method?: 'dialog' | 'get' | 'post' | 'DIALOG' | 'GET' | 'POST' | undefined | null;
 	name?: string | undefined | null;
 	novalidate?: boolean | undefined | null;
 	target?: string | undefined | null;
@@ -1064,7 +1064,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 		| 'text/plain'
 		| undefined
 		| null;
-	formmethod?: 'dialog' | 'get' | 'post' | undefined | null;
+	formmethod?: 'dialog' | 'get' | 'post' | 'DIALOG' | 'GET' | 'POST' | undefined | null;
 	formnovalidate?: boolean | undefined | null;
 	formtarget?: string | undefined | null;
 	height?: number | string | undefined | null;


### PR DESCRIPTION
closes #13634 

## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
