### PR TITLE
fix: use `internal_set` in `await` block

### DIFF
--- a/.changeset/forty-chicken-heal.md
+++ b/.changeset/forty-chicken-heal.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: use `internal_set` in `await` block

--- a/packages/svelte/tests/runtime-runes/samples/await-non-promise/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-non-promise/_config.js
@@ -1,0 +1,9 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+	test() {}
+});

--- a/packages/svelte/tests/runtime-runes/samples/await-non-promise/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-non-promise/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let count = $state(43);
+</script>
+
+{#await count}
+	loading
+{:then count}
+	{count}
+{/await}


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13641

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
