### PR TITLE
fix : $.component() break transition

### DIFF
--- a/.changeset/eight-pans-worry.md
+++ b/.changeset/eight-pans-worry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix : $.component() break transition

--- a/.changeset/eight-pans-worry.md
+++ b/.changeset/eight-pans-worry.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix : $.component() break transition
+fix: transitions within dynamic components now function correctly

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
@@ -1,4 +1,5 @@
 /** @import { TemplateNode, Dom, Effect } from '#client' */
+import { EFFECT_TRANSPARENT } from '../../constants.js';
 import { block, branch, pause_effect } from '../../reactivity/effects.js';
 import { hydrate_next, hydrate_node, hydrating } from '../hydration.js';
 
@@ -34,7 +35,7 @@ export function component(node, get_component, render_fn) {
 		if (component) {
 			effect = branch(() => render_fn(anchor, component));
 		}
-	});
+	}, EFFECT_TRANSPARENT);
 
 	if (hydrating) {
 		anchor = hydrate_node;

--- a/packages/svelte/tests/runtime-runes/samples/transition-component/Foo.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/transition-component/Foo.svelte
@@ -1,0 +1,13 @@
+<script>
+	function fade(_) {
+		return {
+			duration: 100,
+			css: (t) => `opacity: ${t}`
+		};
+	}
+
+
+</script>
+
+<p transition:fade>foo</p>
+

--- a/packages/svelte/tests/runtime-runes/samples/transition-component/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/transition-component/_config.js
@@ -1,0 +1,32 @@
+import { flushSync } from '../../../../src/index-client.js';
+import { test } from '../../test';
+
+/**
+ * $.component() should not break transition
+ * https://github.com/sveltejs/svelte/issues/13645
+ */
+export default test({
+	test({ assert, raf, target }) {
+		const btn = target.querySelector('button');
+
+		// in
+		btn?.click();
+		flushSync();
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="opacity: 0;">foo</p><p style="opacity: 0;">foo</p>'
+		);
+
+		raf.tick(50);
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="opacity: 0.5;">foo</p><p style="opacity: 0.5;">foo</p>'
+		);
+
+		raf.tick(100);
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>toggle</button><p style="">foo</p><p style="">foo</p>'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/transition-component/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/transition-component/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Foo from './Foo.svelte';
+	const Comp = { Foo };
+
+	let visible = $state(false);
+</script>
+
+<button onclick={() => (visible = !visible)}>toggle</button>
+
+{#if visible}
+	<Foo />
+	<Comp.Foo />
+{/if}


### PR DESCRIPTION
Fix #13645 

The block() used in `$.component()` must use the flag `EFFECT_TRANSPARENT` in order to preserve transition.


## Svelte 5 rewrite

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
