### PR TITLE
chore: CompileDiagnostic no longer extends Error

### DIFF
--- a/.changeset/violet-buses-cross.md
+++ b/.changeset/violet-buses-cross.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: CompileDiagnostic no longer extends Error

--- a/packages/svelte/src/compiler/utils/compile_diagnostic.js
+++ b/packages/svelte/src/compiler/utils/compile_diagnostic.js
@@ -48,7 +48,7 @@ function get_code_frame(source, line, column) {
  */
 
 /** @implements {ICompileDiagnostic} */
-export class CompileDiagnostic extends Error {
+export class CompileDiagnostic {
 	name = 'CompileDiagnostic';
 
 	/**
@@ -57,8 +57,8 @@ export class CompileDiagnostic extends Error {
 	 * @param {[number, number] | undefined} position
 	 */
 	constructor(code, message, position) {
-		super(message);
 		this.code = code;
+		this.message = message;
 
 		if (state.filename) {
 			this.filename = state.filename;


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/13628.