### PR TITLE
chore: fallback to looking in props for the slot block

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/slot.js
+++ b/packages/svelte/src/internal/client/dom/blocks/slot.js
@@ -1,4 +1,6 @@
+import { DEV } from 'esm-env';
 import { hydrate_next, hydrating } from '../hydration.js';
+import { validated_snippets } from './snippet.js';
 
 /**
  * @param {Comment} anchor
@@ -12,7 +14,18 @@ export function slot(anchor, $$props, name, slot_props, fallback_fn) {
 		hydrate_next();
 	}
 
-	var slot_fn = $$props.$$slots?.[name] || $$props[name];
+	var slot_fn = $$props.$$slots?.[name];
+
+	if (slot_fn === undefined) {
+		var possible_snippet = $$props[name];
+		if (
+			typeof possible_snippet === 'function' &&
+			(!DEV || validated_snippets.has(possible_snippet))
+		) {
+			slot_fn = possible_snippet;
+		}
+	}
+
 	// Interop: Can use snippets to fill slots
 	var is_interop = false;
 	if (slot_fn === true) {

--- a/packages/svelte/src/internal/client/dom/blocks/slot.js
+++ b/packages/svelte/src/internal/client/dom/blocks/slot.js
@@ -12,7 +12,7 @@ export function slot(anchor, $$props, name, slot_props, fallback_fn) {
 		hydrate_next();
 	}
 
-	var slot_fn = $$props.$$slots?.[name];
+	var slot_fn = $$props.$$slots?.[name] || $$props[name];
 	// Interop: Can use snippets to fill slots
 	var is_interop = false;
 	if (slot_fn === true) {

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -16,6 +16,8 @@ import { DEV } from 'esm-env';
 import { get_first_child, get_next_sibling } from '../operations.js';
 import { noop } from '../../../shared/utils.js';
 
+export var validated_snippets = new WeakSet();
+
 /**
  * @template {(node: TemplateNode, ...args: any[]) => void} SnippetFn
  * @param {TemplateNode} node
@@ -60,7 +62,7 @@ export function snippet(node, get_snippet, ...args) {
  * @param {(node: TemplateNode, ...args: any[]) => void} fn
  */
 export function wrap_snippet(component, fn) {
-	return (/** @type {TemplateNode} */ node, /** @type {any[]} */ ...args) => {
+	var wrapped_snippet = (/** @type {TemplateNode} */ node, /** @type {any[]} */ ...args) => {
 		var previous_component_function = dev_current_component_function;
 		set_dev_current_component_function(component);
 
@@ -70,6 +72,10 @@ export function wrap_snippet(component, fn) {
 			set_dev_current_component_function(previous_component_function);
 		}
 	};
+	if (DEV) {
+		validated_snippets.add(wrapped_snippet);
+	}
+	return wrapped_snippet;
 }
 
 /**


### PR DESCRIPTION
This should allow the pattern I mention in this comment:

https://github.com/sveltejs/svelte/issues/13649

I also added a layer of protection and validation in DEV to ensure people don't try and pass in arbitrary functions pretending to be snippets.

I think this would be impactful for migration but might have other benefits too. @dummdidumm does this check out to you?