### PR TITLE
fix: prevent fatal error after 'reset_elements' has been triggered

### DIFF
--- a/packages/svelte/src/internal/server/dev.js
+++ b/packages/svelte/src/internal/server/dev.js
@@ -89,5 +89,5 @@ export function push_element(payload, tag, line, column) {
 }
 
 export function pop_element() {
-	parent = /** @type {Element} */ (parent).parent;
+	parent = /** @type {Element} */ (parent)?.parent;
 }


### PR DESCRIPTION
In development mode, the function 'reset_elements' is executed. This function sets the 'parent' to null, which breaks the 'pop_element' function. This fix solves this.

I ran into this problem when I executed the following code. I had placed the "{@render hello()}" in a div.
https://github.com/sveltejs/svelte/pull/12425#issuecomment-2241184412

Code to reproduce the problem:

```
<script>
    import {createRawSnippet, hydrate} from 'svelte';
    import {render} from 'svelte/server';
    import Child from './Child.svelte';

    let {browser} = $props();

    let count = $state(0);

    const hello = createRawSnippet((count) => ({
        render: () => `
 			<div>${browser ? '' : render(Child).body}</div>
 		`,
        setup(target) {
            hydrate(Child, {target})
        }
    }));
</script>

<div>
{@render hello()}
</div>
```