### PR TITLE
feat: add `migration-task` comment after errors

### DIFF
--- a/.changeset/slimy-garlics-beg.md
+++ b/.changeset/slimy-garlics-beg.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: add `migration-task` comment after errors

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-beforeUpdate-afterUpdate/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-beforeUpdate-afterUpdate/input.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { beforeUpdate, afterUpdate } from "svelte";
+
+	beforeUpdate(()=>{
+
+	});
+
+	afterUpdate(()=>{
+
+	});
+</script>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-beforeUpdate-afterUpdate/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-beforeUpdate-afterUpdate/output.svelte
@@ -1,0 +1,12 @@
+<!-- @migration-task Error while migrating Svelte code: Can't migrate code with beforeUpdate and afterUpdate. Please migrate by hand. -->
+<script>
+	import { beforeUpdate, afterUpdate } from "svelte";
+
+	beforeUpdate(()=>{
+
+	});
+
+	afterUpdate(()=>{
+
+	});
+</script>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-prop-and-$$props/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-prop-and-$$props/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let value = 42;
+</script>
+
+{$$props}

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-prop-and-$$props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-prop-and-$$props/output.svelte
@@ -1,0 +1,6 @@
+<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
+<script>
+	export let value = 42;
+</script>
+
+{$$props}

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-prop-non-identifier/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-prop-non-identifier/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	let props = { value: 42 };
+
+	export let { value } = props;
+</script>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-prop-non-identifier/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-prop-non-identifier/output.svelte
@@ -1,0 +1,6 @@
+<!-- @migration-task Error while migrating Svelte code: Encountered an export declaration pattern that is not supported for automigration. -->
+<script>
+	let props = { value: 42 };
+
+	export let { value } = props;
+</script>

--- a/packages/svelte/tests/migrate/samples/unused-beforeUpdate-afterUpdate-extra-imports/input.svelte
+++ b/packages/svelte/tests/migrate/samples/unused-beforeUpdate-afterUpdate-extra-imports/input.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { beforeUpdate, afterUpdate, onMount } from "svelte";
+
+	let count = 0;
+
+	onMount(()=>{
+		console.log(count);
+	})
+</script>
+
+<button on:click={()=> count++}></button>

--- a/packages/svelte/tests/migrate/samples/unused-beforeUpdate-afterUpdate-extra-imports/output.svelte
+++ b/packages/svelte/tests/migrate/samples/unused-beforeUpdate-afterUpdate-extra-imports/output.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { onMount } from "svelte";
+
+	let count = $state(0);
+
+	onMount(()=>{
+		console.log(count);
+	})
+</script>
+
+<button onclick={()=> count++}></button>

--- a/packages/svelte/tests/migrate/samples/unused-beforeUpdate-afterUpdate/input.svelte
+++ b/packages/svelte/tests/migrate/samples/unused-beforeUpdate-afterUpdate/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { beforeUpdate, afterUpdate } from "svelte";
+
+	let count = 0;
+</script>
+
+<button on:click={()=> count++}></button>

--- a/packages/svelte/tests/migrate/samples/unused-beforeUpdate-afterUpdate/output.svelte
+++ b/packages/svelte/tests/migrate/samples/unused-beforeUpdate-afterUpdate/output.svelte
@@ -1,0 +1,7 @@
+<script>
+	
+
+	let count = $state(0);
+</script>
+
+<button onclick={()=> count++}></button>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13464

I've added a migration task comment at the beginning and since `afterUpdate` and `beforeUpdate` was not throwing i added the throw for them too. Since i was at it i thought that sometimes we just left imports lingering there and it would be a shame not migrating an otherwise migratable file just for this so i added a bit of "treeshake" logic to remove the import if it's not used.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
