### PR TITLE
fix: reset `reset_element` in `render` to prevent runtime error

### DIFF
--- a/.changeset/witty-shirts-confess.md
+++ b/.changeset/witty-shirts-confess.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: reset `reset_element` in `render` to prevent runtime error

--- a/packages/svelte/src/internal/server/dev.js
+++ b/packages/svelte/src/internal/server/dev.js
@@ -53,7 +53,11 @@ function print_error(payload, parent, child) {
 }
 
 export function reset_elements() {
+	let old_parent = parent;
 	parent = null;
+	return () => {
+		parent = old_parent;
+	};
 }
 
 /**

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -101,9 +101,11 @@ export function render(component, options = {}) {
 	on_destroy = [];
 	payload.out += BLOCK_OPEN;
 
+	let reset_reset_element;
+
 	if (DEV) {
 		// prevent parent/child element state being corrupted by a bad render
-		reset_elements();
+		reset_reset_element = reset_elements();
 	}
 
 	if (options.context) {
@@ -116,6 +118,10 @@ export function render(component, options = {}) {
 
 	if (options.context) {
 		pop();
+	}
+
+	if (reset_reset_element) {
+		reset_reset_element();
 	}
 
 	payload.out += BLOCK_CLOSE;

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw-component-ssr-dev/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw-component-ssr-dev/Child.svelte
@@ -1,0 +1,7 @@
+<script>
+	let count = $state(0);
+</script>
+
+<button onclick={() => (count += 1)}>
+	clicks: {count}
+</button>

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw-component-ssr-dev/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw-component-ssr-dev/_config.js
@@ -1,0 +1,23 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	props: {
+		browser: true
+	},
+
+	server_props: {
+		browser: false
+	},
+	compileOptions: {
+		dev: true
+	},
+	html: `<div><div><button>clicks: 0</button></div></div>`,
+
+	test({ target, assert }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+		assert.htmlEqual(target.innerHTML, `<div><div><button>clicks: 1</button></div></div>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-raw-component-ssr-dev/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-raw-component-ssr-dev/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { createRawSnippet, hydrate } from 'svelte';
+	import { render } from 'svelte/server';
+	import Child from './Child.svelte';
+
+	let { browser } = $props();
+
+	let count = $state(0);
+
+	const hello = createRawSnippet((count) => ({
+		render: () => `
+			<div>${browser ? '' : render(Child).body}</div>
+		`,
+		setup(target) {
+			hydrate(Child, { target })
+		}
+	}));
+</script>
+
+<div>
+	{@render hello()}
+</div>


### PR DESCRIPTION
## Svelte 5 rewrite

Fixes the problem delineated in #13654...the problem is when you render a snippet that render a component inside an element. This is because the code looks like this

```ts
App[$.FILENAME] = "App.svelte";

import * as $ from "svelte/internal/server";
import { createRawSnippet, mount } from 'svelte';
import Child from './Child.svelte';

function App($$payload, $$props) {
	$.push(App);

	let count = 0;

	const hello = createRawSnippet((count) => ({
		render: () => `<div></div>`,
		setup(target) {
			mount(Child, { target });
		}
	}));

	$$payload.out += `<div>`;
	$.push_element($$payload, "div", 15, 0);
	hello($$payload);
	$$payload.out += `<!----></div>`;
	$.pop_element();
	$.pop();
}

App.render = function () {
	throw new Error("Component.render(...) is no longer valid in Svelte 5. See https://svelte-5-preview.vercel.app/docs/breaking-changes#components-are-no-longer-classes for more information");
};

export default App;
```
specifically we are `pushing_element` before rendering the snippet and popping the element after. However inside the `render` in snippet we do

```ts
if (DEV) {
	// prevent parent/child element state being corrupted by a bad render
	reset_elements();
}
```
which set the parent to `null`...since this is happening within the div `pop_element` doesn't find the parent and errors out.

The original PR just safe guarded the `parent.parent` access which might be a solution nonetheless? My solution is storing the old parent and restoring it after rendering the component which seems a bit better but i'm not fully aware of the consequences.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
