### PR TITLE
fix: bail out if slot name changes and $$slots assigned to variable

### DIFF
--- a/.changeset/early-rockets-join.md
+++ b/.changeset/early-rockets-join.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: bail out if slot name changes and $$slots assigned to variable

--- a/packages/svelte/tests/migrate/samples/$$slots-used-as-variable-$$props/input.svelte
+++ b/packages/svelte/tests/migrate/samples/$$slots-used-as-variable-$$props/input.svelte
@@ -1,0 +1,10 @@
+<script>
+	let showMessage = $$slots.message;
+	$: extraTitle = $$slots.extra;
+</script>
+
+{#if showMessage}
+	<slot name="message" />
+{/if}
+
+{$$props}

--- a/packages/svelte/tests/migrate/samples/$$slots-used-as-variable-$$props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/$$slots-used-as-variable-$$props/output.svelte
@@ -1,0 +1,12 @@
+<script>
+	/** @type {{message?: import('svelte').Snippet, extra?: import('svelte').Snippet<[any]>, [key: string]: any}} */
+	let { ...props } = $props();
+	let showMessage = props.message;
+	let extraTitle = $derived(props.extra);
+</script>
+
+{#if showMessage}
+	{@render props.message?.()}
+{/if}
+
+{props}

--- a/packages/svelte/tests/migrate/samples/$$slots-used-as-variable/input.svelte
+++ b/packages/svelte/tests/migrate/samples/$$slots-used-as-variable/input.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let showMessage = $$slots.message;
+
+	let showTitle = $$slots.title;
+
+	$: extraTitle = $$slots.extra;
+</script>
+
+{#if showMessage}
+	<slot name="message" />
+{/if}

--- a/packages/svelte/tests/migrate/samples/$$slots-used-as-variable/output.svelte
+++ b/packages/svelte/tests/migrate/samples/$$slots-used-as-variable/output.svelte
@@ -1,0 +1,17 @@
+<script>
+	/** @type {{message?: import('svelte').Snippet, showMessage?: any, title?: import('svelte').Snippet<[any]>, extra?: import('svelte').Snippet<[any]>}} */
+	let {
+		message,
+		showMessage = message,
+		title,
+		extra
+	} = $props();
+
+	let showTitle = title;
+
+	let extraTitle = $derived(extra);
+</script>
+
+{#if showMessage}
+	{@render message?.()}
+{/if}

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-slot-change-name/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-slot-change-name/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	]
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-slot-change-name/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-slot-change-name/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	let body;
+</script>
+
+<slot name="body"></slot>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-slot-change-name/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-slot-change-name/output.svelte
@@ -1,0 +1,6 @@
+<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot making the component unusable -->
+<script>
+	let body;
+</script>
+
+<slot name="body"></slot>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-slot-non-identifier/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-slot-non-identifier/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	]
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-slot-non-identifier/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-slot-non-identifier/input.svelte
@@ -1,0 +1,1 @@
+<slot name="dashed-name"></slot>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-slot-non-identifier/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-slot-non-identifier/output.svelte
@@ -1,0 +1,2 @@
+<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot making the component unusable -->
+<slot name="dashed-name"></slot>

--- a/packages/svelte/tests/migrate/samples/slots-multiple/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-multiple/input.svelte
@@ -1,5 +1,2 @@
 <button><slot /></button>
 <button><slot /></button>
-
-<slot name="dashed-name" />
-<slot name="dashed-name" />

--- a/packages/svelte/tests/migrate/samples/slots-multiple/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-multiple/output.svelte
@@ -1,10 +1,7 @@
 <script>
-	/** @type {{children?: import('svelte').Snippet, dashed_name?: import('svelte').Snippet}} */
-	let { children, dashed_name } = $props();
+	/** @type {{children?: import('svelte').Snippet}} */
+	let { children } = $props();
 </script>
 
 <button>{@render children?.()}</button>
 <button>{@render children?.()}</button>
-
-{@render dashed_name?.()}
-{@render dashed_name?.()}

--- a/packages/svelte/tests/migrate/samples/slots-with-$$props/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-with-$$props/input.svelte
@@ -1,7 +1,7 @@
 <button><slot /></button>
 
-{#if foo}
-	<slot name="foo" {foo} />
+{#if foos}
+	<slot name="foo" foo={foos} />
 {/if}
 
 {#if $$slots.bar}
@@ -12,9 +12,5 @@
 {#if $$slots.default}foo{/if}
 
 {#if $$slots['default']}foo{/if}
-
-{#if $$slots['dashed-name']}foo{/if}
-
-<slot name="dashed-name" />
 
 <slot header="something" title={$$props.cool} {id} />

--- a/packages/svelte/tests/migrate/samples/slots-with-$$props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots-with-$$props/output.svelte
@@ -1,14 +1,12 @@
 <script>
-	/** @type {{children?: import('svelte').Snippet, foo_1?: import('svelte').Snippet<[any]>, bar?: import('svelte').Snippet, dashed_name?: import('svelte').Snippet, [key: string]: any}} */
-	let {
-		...props
-	} = $props();
+	/** @type {{children?: import('svelte').Snippet, foo?: import('svelte').Snippet<[any]>, bar?: import('svelte').Snippet, [key: string]: any}} */
+	let { ...props } = $props();
 </script>
 
 <button>{@render props.children?.()}</button>
 
-{#if foo}
-	{@render props.foo_1?.({ foo, })}
+{#if foos}
+	{@render props.foo?.({ foo: foos, })}
 {/if}
 
 {#if props.bar}
@@ -19,9 +17,5 @@
 {#if props.children}foo{/if}
 
 {#if props.children}foo{/if}
-
-{#if props.dashed_name}foo{/if}
-
-{@render props.dashed_name?.()}
 
 {@render props.children?.({ header: "something", title: props.cool, id, })}

--- a/packages/svelte/tests/migrate/samples/slots/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/input.svelte
@@ -1,7 +1,7 @@
 <button><slot /></button>
 
-{#if foo}
-	<slot name="foo" {foo} />
+{#if foos}
+	<slot name="foo" foo={foos} />
 {/if}
 
 {#if $$slots.bar}
@@ -12,9 +12,5 @@
 {#if $$slots.default}foo{/if}
 
 {#if $$slots['default']}foo{/if}
-
-{#if $$slots['dashed-name']}foo{/if}
-
-<slot name="dashed-name" />
 
 <slot header="something" title={my_title} {id} />

--- a/packages/svelte/tests/migrate/samples/slots/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slots/output.svelte
@@ -1,17 +1,12 @@
 <script>
-	/** @type {{children?: import('svelte').Snippet, foo_1?: import('svelte').Snippet<[any]>, bar?: import('svelte').Snippet, dashed_name?: import('svelte').Snippet}} */
-	let {
-		children,
-		foo_1,
-		bar,
-		dashed_name
-	} = $props();
+	/** @type {{children?: import('svelte').Snippet, foo?: import('svelte').Snippet<[any]>, bar?: import('svelte').Snippet}} */
+	let { children, foo, bar } = $props();
 </script>
 
 <button>{@render children?.()}</button>
 
-{#if foo}
-	{@render foo_1?.({ foo, })}
+{#if foos}
+	{@render foo?.({ foo: foos, })}
 {/if}
 
 {#if bar}
@@ -22,9 +17,5 @@
 {#if children}foo{/if}
 
 {#if children}foo{/if}
-
-{#if dashed_name}foo{/if}
-
-{@render dashed_name?.()}
 
 {@render children?.({ header: "something", title: my_title, id, })}


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13667

For the moment i've decided to bail out if we found a snippet that would change name. @dummdidumm was arguing that we should migrate `dashed-slot` to `dashed_slot` but since at the usage site we bail out if we found a non valid identifier i think we should bail inside the component too.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
