### PR TITLE
fix: migrated snippet shadowing prop and let directive removal

### DIFF
--- a/.changeset/ten-vans-divide.md
+++ b/.changeset/ten-vans-divide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: migrated snippet shadowing prop and let directive removal

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1097,6 +1097,11 @@ function migrate_slot_usage(node, path, state) {
 	let snippet_name = 'children';
 	let snippet_props = [];
 
+	// if we stop the transform because the name is not correct we don't want to
+	// remove the let directive and they could come before the name
+	let removal_queue = [];
+	let slot_name_found = false;
+
 	for (let attribute of node.attributes) {
 		if (
 			attribute.type === 'Attribute' &&
@@ -1112,6 +1117,24 @@ function migrate_slot_usage(node, path, state) {
 				);
 				return;
 			}
+			if (parent?.type === 'Component' || parent?.type === 'SvelteComponent') {
+				for (let attribute of parent.attributes) {
+					if (attribute.type === 'Attribute' || attribute.type === 'BindDirective') {
+						if (attribute.name === snippet_name) {
+							state.str.appendLeft(
+								node.start,
+								`<!-- @migration-task: migrate this slot by hand, \`${snippet_name}\` would shadow a prop on the parent component -->\n${state.indent}`
+							);
+							return;
+						}
+					}
+				}
+			}
+			slot_name_found = true;
+			// flush the queue after we found the name
+			for (let remove_let of removal_queue) {
+				remove_let();
+			}
 			state.str.remove(attribute.start, attribute.end);
 		}
 		if (attribute.type === 'LetDirective') {
@@ -1121,7 +1144,21 @@ function migrate_slot_usage(node, path, state) {
 						? `: ${state.str.original.substring(/** @type {number} */ (attribute.expression.start), /** @type {number} */ (attribute.expression.end))}`
 						: '')
 			);
-			state.str.remove(attribute.start, attribute.end);
+			function remove_let() {
+				state.str.remove(attribute.start, attribute.end);
+			}
+			// if we didn't find the name yet we just add to the queue else we call immediately
+			if (slot_name_found) {
+				remove_let();
+			} else {
+				removal_queue.push(remove_let);
+			}
+		}
+	}
+
+	if (!slot_name_found && removal_queue.length > 0) {
+		for (let remove_let of removal_queue) {
+			remove_let();
 		}
 	}
 

--- a/packages/svelte/tests/migrate/samples/slot-non-identifier/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-non-identifier/input.svelte
@@ -42,25 +42,25 @@
 <!-- don't remove the let directive if we don't migrate -->
 
 <Comp>
-	<div let:shoudl_stay slot="cool:stuff">
+	<div let:should_stay slot="cool:stuff">
 		cool
 	</div>
 </Comp>
 
 <Comp>
-	<div let:shoudl_stay slot="cool stuff">
+	<div let:should_stay slot="cool stuff">
 		cool
 	</div>
 </Comp>
 
 <Comp>
-	<svelte:fragment let:shoudl_stay slot="cool:stuff">
+	<svelte:fragment let:should_stay slot="cool:stuff">
 		cool
 	</svelte:fragment>
 </Comp>
 
 <Comp>
-	<svelte:fragment let:shoudl_stay slot="cool stuff">
+	<svelte:fragment let:should_stay slot="cool stuff">
 		cool
 	</svelte:fragment>
 </Comp>

--- a/packages/svelte/tests/migrate/samples/slot-non-identifier/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-non-identifier/input.svelte
@@ -37,3 +37,30 @@
 		cool
 	</svelte:fragment>
 </Comp>
+
+
+<!-- don't remove the let directive if we don't migrate -->
+
+<Comp>
+	<div let:shoudl_stay slot="cool:stuff">
+		cool
+	</div>
+</Comp>
+
+<Comp>
+	<div let:shoudl_stay slot="cool stuff">
+		cool
+	</div>
+</Comp>
+
+<Comp>
+	<svelte:fragment let:shoudl_stay slot="cool:stuff">
+		cool
+	</svelte:fragment>
+</Comp>
+
+<Comp>
+	<svelte:fragment let:shoudl_stay slot="cool stuff">
+		cool
+	</svelte:fragment>
+</Comp>

--- a/packages/svelte/tests/migrate/samples/slot-non-identifier/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-non-identifier/output.svelte
@@ -51,28 +51,28 @@
 
 <Comp>
 	<!-- @migration-task: migrate this slot by hand, `cool:stuff` is an invalid identifier -->
-	<div let:shoudl_stay slot="cool:stuff">
+	<div let:should_stay slot="cool:stuff">
 		cool
 	</div>
 </Comp>
 
 <Comp>
 	<!-- @migration-task: migrate this slot by hand, `cool stuff` is an invalid identifier -->
-	<div let:shoudl_stay slot="cool stuff">
+	<div let:should_stay slot="cool stuff">
 		cool
 	</div>
 </Comp>
 
 <Comp>
 	<!-- @migration-task: migrate this slot by hand, `cool:stuff` is an invalid identifier -->
-	<svelte:fragment let:shoudl_stay slot="cool:stuff">
+	<svelte:fragment let:should_stay slot="cool:stuff">
 		cool
 	</svelte:fragment>
 </Comp>
 
 <Comp>
 	<!-- @migration-task: migrate this slot by hand, `cool stuff` is an invalid identifier -->
-	<svelte:fragment let:shoudl_stay slot="cool stuff">
+	<svelte:fragment let:should_stay slot="cool stuff">
 		cool
 	</svelte:fragment>
 </Comp>

--- a/packages/svelte/tests/migrate/samples/slot-non-identifier/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-non-identifier/output.svelte
@@ -45,3 +45,34 @@
 		
 	{/snippet}
 </Comp>
+
+
+<!-- don't remove the let directive if we don't migrate -->
+
+<Comp>
+	<!-- @migration-task: migrate this slot by hand, `cool:stuff` is an invalid identifier -->
+	<div let:shoudl_stay slot="cool:stuff">
+		cool
+	</div>
+</Comp>
+
+<Comp>
+	<!-- @migration-task: migrate this slot by hand, `cool stuff` is an invalid identifier -->
+	<div let:shoudl_stay slot="cool stuff">
+		cool
+	</div>
+</Comp>
+
+<Comp>
+	<!-- @migration-task: migrate this slot by hand, `cool:stuff` is an invalid identifier -->
+	<svelte:fragment let:shoudl_stay slot="cool:stuff">
+		cool
+	</svelte:fragment>
+</Comp>
+
+<Comp>
+	<!-- @migration-task: migrate this slot by hand, `cool stuff` is an invalid identifier -->
+	<svelte:fragment let:shoudl_stay slot="cool stuff">
+		cool
+	</svelte:fragment>
+</Comp>

--- a/packages/svelte/tests/migrate/samples/slot-shadow-props/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-shadow-props/input.svelte
@@ -1,0 +1,29 @@
+<script>
+	import Comp from "./Component.svelte";
+</script>
+
+<Comp stuff="cool">
+	<div slot="stuff">
+		cool
+	</div>
+</Comp>
+
+<Comp stuff="cool">
+	<svelte:fragment slot="stuff">
+		cool
+	</svelte:fragment>
+</Comp>
+
+<!-- don't remove the let if we are not migrating -->
+
+<Comp stuff="cool">
+	<div let:should_stay slot="stuff">
+		cool
+	</div>
+</Comp>
+
+<Comp stuff="cool">
+	<svelte:fragment let:should_stay slot="stuff">
+		cool
+	</svelte:fragment>
+</Comp>

--- a/packages/svelte/tests/migrate/samples/slot-shadow-props/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-shadow-props/output.svelte
@@ -1,0 +1,33 @@
+<script>
+	import Comp from "./Component.svelte";
+</script>
+
+<Comp stuff="cool">
+	<!-- @migration-task: migrate this slot by hand, `stuff` would shadow a prop on the parent component -->
+	<div slot="stuff">
+		cool
+	</div>
+</Comp>
+
+<Comp stuff="cool">
+	<!-- @migration-task: migrate this slot by hand, `stuff` would shadow a prop on the parent component -->
+	<svelte:fragment slot="stuff">
+		cool
+	</svelte:fragment>
+</Comp>
+
+<!-- don't remove the let if we are not migrating -->
+
+<Comp stuff="cool">
+	<!-- @migration-task: migrate this slot by hand, `stuff` would shadow a prop on the parent component -->
+	<div let:should_stay slot="stuff">
+		cool
+	</div>
+</Comp>
+
+<Comp stuff="cool">
+	<!-- @migration-task: migrate this slot by hand, `stuff` would shadow a prop on the parent component -->
+	<svelte:fragment let:should_stay slot="stuff">
+		cool
+	</svelte:fragment>
+</Comp>


### PR DESCRIPTION
## Svelte 5 rewrite

Closes #13665

While fixing i also noticed that we were incorrectly removing the let directive in the case where we don't migrate the slot if the let directive were there before the name of the slot.

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
