### PR TITLE
chore: ensure effect destruction of deriveds is consistent

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -4,7 +4,6 @@ import {
 	component_context,
 	active_effect,
 	active_reaction,
-	destroy_effect_children,
 	dev_current_component_function,
 	update_effect,
 	get,
@@ -42,6 +41,7 @@ import * as e from '../errors.js';
 import { DEV } from 'esm-env';
 import { define_property } from '../../shared/utils.js';
 import { get_next_sibling } from '../dom/operations.js';
+import { destroy_derived } from './deriveds.js';
 
 /**
  * @param {'$effect' | '$effect.pre' | '$inspect'} rune
@@ -364,6 +364,54 @@ export function execute_effect_teardown(effect) {
 }
 
 /**
+ * @param {Effect} signal
+ * @returns {void}
+ */
+export function destroy_effect_deriveds(signal) {
+	var deriveds = signal.deriveds;
+
+	if (deriveds !== null) {
+		signal.deriveds = null;
+
+		for (var i = 0; i < deriveds.length; i += 1) {
+			destroy_derived(deriveds[i]);
+		}
+	}
+}
+
+/**
+ * @param {Effect} signal
+ * @param {boolean} remove_dom
+ * @returns {void}
+ */
+export function destroy_effect_children(signal, remove_dom = false) {
+	var effect = signal.first;
+	signal.first = signal.last = null;
+
+	while (effect !== null) {
+		var next = effect.next;
+		destroy_effect(effect, remove_dom);
+		effect = next;
+	}
+}
+
+/**
+ * @param {Effect} signal
+ * @returns {void}
+ */
+export function destroy_block_effect_children(signal) {
+	var effect = signal.first;
+
+	while (effect !== null) {
+		var next = effect.next;
+		if ((effect.f & BRANCH_EFFECT) === 0) {
+			destroy_effect(effect);
+		}
+		effect = next;
+	}
+}
+
+/**
  * @param {Effect} effect
  * @param {boolean} [remove_dom]
  * @returns {void}
@@ -387,6 +435,7 @@ export function destroy_effect(effect, remove_dom = true) {
 		removed = true;
 	}
 
+	destroy_effect_deriveds(effect);
 	destroy_effect_children(effect, remove_dom && !removed);
 	remove_reactions(effect, 0);
 	set_signal_status(effect, DESTROYED);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -2,7 +2,10 @@
 import { DEV } from 'esm-env';
 import { define_property, get_descriptors, get_prototype_of } from '../shared/utils.js';
 import {
+	destroy_block_effect_children,
 	destroy_effect,
+	destroy_effect_children,
+	destroy_effect_deriveds,
 	effect,
 	execute_effect_teardown,
 	unlink_effect
@@ -404,48 +407,6 @@ export function remove_reactions(signal, start_index) {
 }
 
 /**
- * @param {Effect} signal
- * @param {boolean} remove_dom
- * @returns {void}
- */
-export function destroy_effect_children(signal, remove_dom = false) {
-	var deriveds = signal.deriveds;
-
-	if (deriveds !== null) {
-		signal.deriveds = null;
-
-		for (var i = 0; i < deriveds.length; i += 1) {
-			destroy_derived(deriveds[i]);
-		}
-	}
-
-	var effect = signal.first;
-	signal.first = signal.last = null;
-
-	while (effect !== null) {
-		var next = effect.next;
-		destroy_effect(effect, remove_dom);
-		effect = next;
-	}
-}
-
-/**
- * @param {Effect} signal
- * @returns {void}
- */
-export function destroy_block_effect_children(signal) {
-	var effect = signal.first;
-
-	while (effect !== null) {
-		var next = effect.next;
-		if ((effect.f & BRANCH_EFFECT) === 0) {
-			destroy_effect(effect);
-		}
-		effect = next;
-	}
-}
-
-/**
  * @param {Effect} effect
  * @returns {void}
  */
@@ -470,6 +431,7 @@ export function update_effect(effect) {
 	}
 
 	try {
+		destroy_effect_deriveds(effect);
 		if ((flags & BLOCK_EFFECT) !== 0) {
 			destroy_block_effect_children(effect);
 		} else {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -3,7 +3,6 @@ import { DEV } from 'esm-env';
 import { define_property, get_descriptors, get_prototype_of } from '../shared/utils.js';
 import {
 	destroy_block_effect_children,
-	destroy_effect,
 	destroy_effect_children,
 	destroy_effect_deriveds,
 	effect,


### PR DESCRIPTION
Addresses the comment made in https://github.com/sveltejs/svelte/pull/13660#discussion_r1807121465. This PR makes effect cleanup more consistent and ensures we always remove any deriveds in an effect regardless of if it's a block effect or not. I also moved the functions into `effects.js` as that seems a better location for them all.