### PR TITLE
fix: avoid chromium issue with dispatching blur on element removal

### DIFF
--- a/.changeset/seven-dancers-brush.md
+++ b/.changeset/seven-dancers-brush.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid chromium issue with dispatching blur on element removal

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.4.0",
-  "engines": {
-    "pnpm": "^9.0.0"
-  },
+
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sveltejs/svelte.git"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.4.0",
-
+  "engines": {
+    "pnpm": "^9.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sveltejs/svelte.git"

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -375,7 +375,12 @@ export function destroy_effect(effect, remove_dom = true) {
 		/** @type {TemplateNode | null} */
 		var node = effect.nodes_start;
 		var end = effect.nodes_end;
+		var previous_reaction = active_reaction;
 
+		// Really we only need to do this in Chromium because of https://chromestatus.com/feature/5128696823545856,
+		// as removal of the DOM can cause sync `blur` events to fire, which can cause logic to run inside
+		// the current `active_reaction`, which isn't what we want at all
+		set_active_reaction(null)
 		while (node !== null) {
 			/** @type {TemplateNode | null} */
 			var next = node === end ? null : /** @type {TemplateNode} */ (get_next_sibling(node));
@@ -383,6 +388,7 @@ export function destroy_effect(effect, remove_dom = true) {
 			node.remove();
 			node = next;
 		}
+		set_active_reaction(previous_reaction)
 
 		removed = true;
 	}


### PR DESCRIPTION
Glad we found this now! Addresses the issue found in https://github.com/sveltejs/svelte/issues/13684#issuecomment-2423754068 which is unrelated to block effects but rather a bug in Chromium https://chromestatus.com/feature/5128696823545856. This doesn't happen in any other browser engine.