### PR TITLE
fix: don't blank css on migration error

### DIFF
--- a/.changeset/healthy-bees-wave.md
+++ b/.changeset/healthy-bees-wave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't blank css on migration error

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -34,6 +34,7 @@ let has_migration_task = false;
  * @returns {{ code: string; }}
  */
 export function migrate(source, { filename } = {}) {
+	let og_source = source;
 	try {
 		has_migration_task = false;
 		// Blank CSS, could contain SCSS or similar that needs a preprocessor.
@@ -303,7 +304,7 @@ export function migrate(source, { filename } = {}) {
 		console.error('Error while migrating Svelte code', e);
 		has_migration_task = true;
 		return {
-			code: `<!-- @migration-task Error while migrating Svelte code: ${/** @type {any} */ (e).message} -->\n${source}`
+			code: `<!-- @migration-task Error while migrating Svelte code: ${/** @type {any} */ (e).message} -->\n${og_source}`
 		};
 	} finally {
 		if (has_migration_task) {

--- a/packages/svelte/tests/migrate/samples/not-blank-css-if-error/input.svelte
+++ b/packages/svelte/tests/migrate/samples/not-blank-css-if-error/input.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let error = true;
+</script>
+
+{$$props}
+
+<style lang="postcss">
+	div{
+		color: red;
+	}
+</style>

--- a/packages/svelte/tests/migrate/samples/not-blank-css-if-error/output.svelte
+++ b/packages/svelte/tests/migrate/samples/not-blank-css-if-error/output.svelte
@@ -1,0 +1,12 @@
+<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
+<script>
+	export let error = true;
+</script>
+
+{$$props}
+
+<style lang="postcss">
+	div{
+		color: red;
+	}
+</style>


### PR DESCRIPTION
## Svelte 5 rewrite

This
```svelte
<script>
	export let error = true;
</script>

<div>
	{$$props}
</div>

<style lang="postcss">
	div{
		color: red;
	}
</style>
```
 was erroneusly migrated to

```svelte
<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
<script>
	export let error = true;
</script>

<div>
	{$$props}
</div>

<style lang="postcss">/*$$__STYLE_CONTENT__$$*/</style>
````

Please note that [the Svelte codebase is currently being rewritten for Svelte 5](https://svelte.dev/blog/runes). Changes should target Svelte 5, which lives on the default branch (`main`).

If your PR concerns Svelte 4 (including updates to [svelte.dev.docs](https://svelte.dev/docs)), please ensure the base branch is `svelte-4` and not `main`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
