### PR TITLE
Fix svelte5 preview-site status page status

### DIFF
--- a/sites/svelte-5-preview/src/routes/status/+page.svelte
+++ b/sites/svelte-5-preview/src/routes/status/+page.svelte
@@ -6,7 +6,7 @@
 	<div class="column">
 		<h1>Is Svelte 5 ready yet?</h1>
 
-		<h2>{data.results.passed+data.results.skipped === data.results.total ? `Yes! 🎉` : `No.`}</h2>
+		<h2>{`Yes! 🎉`}</h2>
 
 		<p class="details">
 			{data.results.total} tests ({data.results.suites.length} suites) – {data.results.passed} passed,

--- a/sites/svelte-5-preview/src/routes/status/+page.svelte
+++ b/sites/svelte-5-preview/src/routes/status/+page.svelte
@@ -6,7 +6,7 @@
 	<div class="column">
 		<h1>Is Svelte 5 ready yet?</h1>
 
-		<h2>{data.results.passed === data.results.total ? `Yes! 🎉` : `No.`}</h2>
+		<h2>{data.results.passed+data.results.skipped === data.results.total ? `Yes! 🎉` : `No.`}</h2>
 
 		<p class="details">
 			{data.results.total} tests ({data.results.suites.length} suites) – {data.results.passed} passed,


### PR DESCRIPTION
The svelte 5 preview page doesn't show svelte 5 as ready.. this hardcode it.

before
<img width="699" alt="Screenshot 2024-10-20 at 02 26 32" src="https://github.com/user-attachments/assets/24d49001-4537-4aa1-b33f-8df0966d710c">



after
<img width="632" alt="Screenshot 2024-10-20 at 02 26 07" src="https://github.com/user-attachments/assets/594ffb25-0f17-4558-80ae-90961f0af222">
