### PR TITLE
chore: ensure transition events are dispatched without current reaction

### DIFF
--- a/.changeset/famous-insects-sort.md
+++ b/.changeset/famous-insects-sort.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: ensure transition events are dispatched without current reaction

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -1,7 +1,13 @@
 /** @import { AnimateFn, Animation, AnimationConfig, EachItem, Effect, TransitionFn, TransitionManager } from '#client' */
 import { noop, is_function } from '../../../shared/utils.js';
 import { effect } from '../../reactivity/effects.js';
-import { active_effect, untrack } from '../../runtime.js';
+import {
+	active_effect,
+	active_reaction,
+	set_active_effect,
+	set_active_reaction,
+	untrack
+} from '../../runtime.js';
 import { loop } from '../../loop.js';
 import { should_intro } from '../../render.js';
 import { current_each_item } from '../blocks/each.js';
@@ -15,7 +21,16 @@ import { queue_micro_task } from '../task.js';
  * @returns {void}
  */
 function dispatch_event(element, type) {
-	element.dispatchEvent(new CustomEvent(type));
+	var previous_reaction = active_reaction;
+	var previous_effect = active_effect;
+	set_active_reaction(null);
+	set_active_effect(null);
+	try {
+		element.dispatchEvent(new CustomEvent(type));
+	} finally {
+		set_active_reaction(previous_reaction);
+		set_active_effect(previous_effect);
+	}
 }
 
 /**


### PR DESCRIPTION
I noticed that we weren't wrapping the transition events that we dispatch without the current reaction. Let's be consistent as this is a sync event and the handler will be executed sync too (because of `element.dispatchEvent`), so we should ensure intro and outro events aren't associated with the transition block effect.