### PR TITLE
fix: ensure event context is reset before invoking callback

### DIFF
--- a/.changeset/giant-plants-shout.md
+++ b/.changeset/giant-plants-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure event context is reset before invoking callback

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -1,13 +1,7 @@
 /** @import { AnimateFn, Animation, AnimationConfig, EachItem, Effect, TransitionFn, TransitionManager } from '#client' */
 import { noop, is_function } from '../../../shared/utils.js';
 import { effect } from '../../reactivity/effects.js';
-import {
-	active_effect,
-	active_reaction,
-	set_active_effect,
-	set_active_reaction,
-	untrack
-} from '../../runtime.js';
+import { active_effect, untrack } from '../../runtime.js';
 import { loop } from '../../loop.js';
 import { should_intro } from '../../render.js';
 import { current_each_item } from '../blocks/each.js';
@@ -21,16 +15,7 @@ import { queue_micro_task } from '../task.js';
  * @returns {void}
  */
 function dispatch_event(element, type) {
-	var previous_reaction = active_reaction;
-	var previous_effect = active_effect;
-	set_active_reaction(null);
-	set_active_effect(null);
-	try {
-		element.dispatchEvent(new CustomEvent(type));
-	} finally {
-		set_active_reaction(previous_reaction);
-		set_active_effect(previous_effect);
-	}
+	element.dispatchEvent(new CustomEvent(type));
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -15,8 +15,7 @@ import {
 	set_is_destroying_effect,
 	set_is_flushing_effect,
 	set_signal_status,
-	untrack,
-	set_active_effect
+	untrack
 } from '../runtime.js';
 import {
 	DIRTY,
@@ -423,26 +422,13 @@ export function destroy_effect(effect, remove_dom = true) {
 		/** @type {TemplateNode | null} */
 		var node = effect.nodes_start;
 		var end = effect.nodes_end;
-		var previous_reaction = active_reaction;
-		var previous_effect = active_effect;
 
-		// Really we only need to do this in Chromium because of https://chromestatus.com/feature/5128696823545856,
-		// as removal of the DOM can cause sync `blur` events to fire, which can cause logic to run inside
-		// the current `active_reaction`, which isn't what we want at all. Additionally, the blur event handler
-		// might create a derived or effect and they will be incorrectly attached to the wrong thing
-		set_active_reaction(null);
-		set_active_effect(null);
-		try {
-			while (node !== null) {
-				/** @type {TemplateNode | null} */
-				var next = node === end ? null : /** @type {TemplateNode} */ (get_next_sibling(node));
+		while (node !== null) {
+			/** @type {TemplateNode | null} */
+			var next = node === end ? null : /** @type {TemplateNode} */ (get_next_sibling(node));
 
-				node.remove();
-				node = next;
-			}
-		} finally {
-			set_active_reaction(previous_reaction);
-			set_active_effect(previous_effect);
+			node.remove();
+			node = next;
 		}
 
 		removed = true;

--- a/packages/svelte/tests/runtime-runes/samples/event-context/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-context/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target, logs }) {
+		const [b1] = target.querySelectorAll('button');
+
+		b1?.click();
+		b1?.click();
+		b1?.click();
+		flushSync();
+		assert.htmlEqual(target.innerHTML, '<button>4</button>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-context/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-context/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let count = $state(0);
+	let button = $state();
+
+	function do_thing() {
+		button?.click();
+		return false;
+	}
+</script>
+
+<button bind:this={button} onclick={() => count++ }>{count}</button>
+
+{#if do_thing()}{/if}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13684 and is a better approach than https://github.com/sveltejs/svelte/pull/13694 https://github.com/sveltejs/svelte/pull/13719.

Essentially, we have a complicated issue that only affects Chromium and they're well aware of it https://chromestatus.com/feature/5128696823545856. If you have an element with `onblur`, the event will fire _synchronously_ if that element is removed from the DOM or if the element or its parent moves in certain cases. This behaviour was discovered because of the improved validation around block effects erroring on state mutations – but has nothing to do with this issue at all, it actually was great that it helped show this huge issue. 

In the ideal world, event handlers are always without a reactive context – because this is how it works in 99% of cases. The case where it's not true is synchronous events handlers – either because of this strange Chromium bug or because someone does `element.focus()` or `element.click()`. If there is a reactive context, it's likely the wrong one that just happens to be active at the time of dispatch, which can cause very bad bugs:

- if the event handler reads state, the active context now has a dependency on it too, or you get an invalid mutation error from writing to state
- if the event handler creates an effect or derived, it's now incorrectly connected to the wrong thing

Now, how I thought we could tackle this is to wrap the call-sites where we do the actual DOM mutations, such as removals or moves with the try/finally logic that sets the context. However, I was recently made aware that these changes have caused performance to degrade significantly – our removal logic is now 3.3x slower than before! Try/finally wrapping clearly has overhead. For even more investigation I wrapped the each `move` function logic and saw what the impact would be on reversing an array of 100 items – it was `78ms`, compared to `9ms`. That's unacceptable.

So instead, what if we deal with removing the context when we invoke the event handler through Svelte's event system instead? This has the least overhead and works nicely in that it's predictable and can be applied to all events – which I think is desirable. I don't want an event handler to have a context, even if you call `element.click()` from within another context as it's a nightmare to debug these cases when it comes to event propagation. This also applied to our `on` event listener too.

However, that raises the question, what if someone does their own event handling without `on`? Well they'll unfortunately run into the same issues from before, and for that I have no good solution. FWIW this issue affects all the other signals frameworks too – and it causes the same buggy behaviour there in my testing. So it would be good to be the first framework to solve this from Chromium browsers.