### PR TITLE
fix: more accurately detect `$derived` migration use cases

### DIFF
--- a/.changeset/nasty-geese-turn.md
+++ b/.changeset/nasty-geese-turn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: more accurately detect `$derived` migration opportunities

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -739,7 +739,7 @@ const instance_script = {
 			);
 			const bindings = ids.map((id) => state.scope.get(id.name));
 			const reassigned_bindings = bindings.filter((b) => b?.reassigned);
-			if (reassigned_bindings.length === 0 && !bindings.some((b) => b?.kind === 'store_sub')) {
+			if (reassigned_bindings.length === 0 && !bindings.some((b) => b?.kind === 'store_sub') && node.body.expression.left.type === "Identifier") {
 				let { start, end } = /** @type {{ start: number, end: number }} */ (
 					node.body.expression.right
 				);

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -739,7 +739,11 @@ const instance_script = {
 			);
 			const bindings = ids.map((id) => state.scope.get(id.name));
 			const reassigned_bindings = bindings.filter((b) => b?.reassigned);
-			if (reassigned_bindings.length === 0 && !bindings.some((b) => b?.kind === 'store_sub') && node.body.expression.left.type === "Identifier") {
+			if (
+				reassigned_bindings.length === 0 &&
+				!bindings.some((b) => b?.kind === 'store_sub') &&
+				node.body.expression.left.type !== 'MemberExpression'
+			) {
 				let { start, end } = /** @type {{ start: number, end: number }} */ (
 					node.body.expression.right
 				);

--- a/packages/svelte/tests/migrate/samples/derivations/input.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations/input.svelte
@@ -6,6 +6,11 @@
 	// no semicolon at the end
 	$: time_8 = count * 8
 	$: ({ time_16 } = { time_16: count * 16 })
+	// preceeding let that doesn't do anything
+	let time_32;
+	$: time_32 = count * doubled;
+	let very_high;
+	$: very_high = time_32 * count;
 </script>
 
 {count} / {doubled} / {quadrupled} / {time_8} / {time_16}

--- a/packages/svelte/tests/migrate/samples/derivations/output.svelte
+++ b/packages/svelte/tests/migrate/samples/derivations/output.svelte
@@ -6,6 +6,11 @@
 	// no semicolon at the end
 	let time_8 = $derived(count * 8)
 	let { time_16 } = $derived({ time_16: count * 16 })
+	// preceeding let that doesn't do anything
+	let time_32 = $derived(count * doubled);
+	
+	let very_high = $derived(time_32 * count);
+	
 </script>
 
 {count} / {doubled} / {quadrupled} / {time_8} / {time_16}

--- a/packages/svelte/tests/migrate/samples/effects/input.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/input.svelte
@@ -10,7 +10,7 @@
 		console.log('bar');
 	}
 	$: $count = 1;
-	$: $count.x = count;
+	$: foo.x = count;
 </script>
 
 <button onclick={() => count++}>increment</button>

--- a/packages/svelte/tests/migrate/samples/effects/input.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/input.svelte
@@ -10,4 +10,7 @@
 		console.log('bar');
 	}
 	$: $count = 1;
+	$: $count.x = count;
 </script>
+
+<button onclick={() => count++}>increment</button>

--- a/packages/svelte/tests/migrate/samples/effects/output.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/output.svelte
@@ -19,7 +19,7 @@
 		$count = 1;
 	});
 	run(() => {
-		$count.x = count;
+		foo.x = count;
 	});
 </script>
 

--- a/packages/svelte/tests/migrate/samples/effects/output.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/output.svelte
@@ -19,3 +19,5 @@
 		$count = 1;
 	});
 </script>
+
+<button onclick={() => count++}>increment</button>

--- a/packages/svelte/tests/migrate/samples/effects/output.svelte
+++ b/packages/svelte/tests/migrate/samples/effects/output.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { run } from 'svelte/legacy';
 
-	let count = 0;
+	let count = $state(0);
 	run(() => {
 		console.log(count);
 	});
@@ -17,6 +17,9 @@
 	});
 	run(() => {
 		$count = 1;
+	});
+	run(() => {
+		$count.x = count;
 	});
 </script>
 


### PR DESCRIPTION
- detect store mutations and not use `$derived` in that case, fixes #13723
- better detect `let x` that can be folded into `$derived`, fixes #13727

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
