### PR TITLE
docs: Typo in Context Docs

### DIFF
--- a/documentation/docs/04-runtime/02-context.md
+++ b/documentation/docs/04-runtime/02-context.md
@@ -82,7 +82,7 @@ Context is not inherently reactive. If you need reactive values in context then 
 <script>
 	import { setContext } from 'svelte';
 
-	const value = setContext('counter');
+	const value = getContext('counter');
 </script>
 
 <p>Count is {value.count}</p>

--- a/documentation/docs/04-runtime/02-context.md
+++ b/documentation/docs/04-runtime/02-context.md
@@ -80,7 +80,7 @@ Context is not inherently reactive. If you need reactive values in context then 
 ```svelte
 <!--- file: Child.svelte --->
 <script>
-	import { setContext } from 'svelte';
+	import { getContext } from 'svelte';
 
 	const value = getContext('counter');
 </script>


### PR DESCRIPTION
- Change "setContext" to "getContext" in docs about context when reading assigning a variable so that the docs show the correct information on this page: https://svelte-omnisite.vercel.app/docs/svelte/context

Solves the following issue:
https://github.com/sveltejs/svelte/issues/13739

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X ] This message body should clearly illustrate what problems it solves.