### PR TITLE
fix: do not comment out unused selectors that are inside an unused selector

### DIFF
--- a/.changeset/moody-kids-brake.md
+++ b/.changeset/moody-kids-brake.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: do not comment out unused selectors that are inside an unused selector

--- a/packages/svelte/tests/css/samples/has/_config.js
+++ b/packages/svelte/tests/css/samples/has/_config.js
@@ -88,16 +88,30 @@ export default test({
 		},
 		{
 			code: 'css_unused_selector',
-			message: 'Unused CSS selector "x:has(> z)"',
+			message: 'Unused CSS selector ".unused:has(.unused)"',
 			start: {
-				line: 88,
+				line: 84,
 				column: 1,
-				character: 968
+				character: 934
 			},
 			end: {
-				line: 88,
+				line: 84,
+				column: 21,
+				character: 954
+			}
+		},
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector "x:has(> z)"',
+			start: {
+				line: 91,
+				column: 1,
+				character: 1021
+			},
+			end: {
+				line: 91,
 				column: 11,
-				character: 978
+				character: 1031
 			}
 		}
 	]

--- a/packages/svelte/tests/css/samples/has/expected.css
+++ b/packages/svelte/tests/css/samples/has/expected.css
@@ -75,6 +75,9 @@
 	/* (unused) .unused x:has(y) {
 		color: red;
 	}*/
+	/* (unused) .unused:has(.unused)*/ x.svelte-xyz:has(y:where(.svelte-xyz)) {
+		color: green;
+	}
 
 	x.svelte-xyz:has(> y:where(.svelte-xyz)) {
 		color: green;

--- a/packages/svelte/tests/css/samples/has/input.svelte
+++ b/packages/svelte/tests/css/samples/has/input.svelte
@@ -81,6 +81,9 @@
 	.unused x:has(y) {
 		color: red;
 	}
+	.unused:has(.unused), x:has(y) {
+		color: green;
+	}
 
 	x:has(> y) {
 		color: green;


### PR DESCRIPTION
fixes #13680

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
