### PR TITLE
fix: ensure $effect.tracking returns false inside transition functions

### DIFF
--- a/.changeset/few-rocks-remain.md
+++ b/.changeset/few-rocks-remain.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure $effect.tracking returns false inside transition functions

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-transition/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-transition/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const b1 = target.querySelector('button');
+
+		b1?.click();
+		flushSync();
+		assert.deepEqual(logs, [false]);
+
+		b1?.click();
+		flushSync();
+		assert.deepEqual(logs, [false, false]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-transition/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-transition/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let visible = $state(0);
+
+	function customTransition() {
+		console.log($effect.tracking());
+	}
+</script>
+
+<button onclick={() => visible = !visible}>Toggle</button>
+
+{#if visible}
+	<div transition:customTransition>clicks</div>
+{/if}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13773. Similar to https://github.com/sveltejs/svelte/pull/13774, but targeting the source of the issue in this case