### PR TITLE
chore: redirect to new website

### DIFF
--- a/sites/svelte-5-preview/vercel.json
+++ b/sites/svelte-5-preview/vercel.json
@@ -3,6 +3,6 @@
 	"outputDirectory": "sites/svelte-5-preview/.vercel",
 	"buildCommand": "cd ../../ && pnpm build && (pnpm test-output || true) && pnpm preview-site",
 	"redirects": [
-		{ "source": "/", "destination": "https://svelte.dev/playground/", "permanent": true }
+		{ "source": "/", "destination": "https://svelte.dev/playground/untitled", "permanent": true }
 	]
 }

--- a/sites/svelte-5-preview/vercel.json
+++ b/sites/svelte-5-preview/vercel.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "http://openapi.vercel.sh/vercel.json",
 	"outputDirectory": "sites/svelte-5-preview/.vercel",
-	"buildCommand": "cd ../../ && pnpm build && (pnpm test-output || true) && pnpm preview-site"
+	"buildCommand": "cd ../../ && pnpm build && (pnpm test-output || true) && pnpm preview-site",
+	"redirects": [
+		{ "source": "/", "destination": "https://svelte.dev/", "permanent": true }
+	]
 }

--- a/sites/svelte-5-preview/vercel.json
+++ b/sites/svelte-5-preview/vercel.json
@@ -3,6 +3,6 @@
 	"outputDirectory": "sites/svelte-5-preview/.vercel",
 	"buildCommand": "cd ../../ && pnpm build && (pnpm test-output || true) && pnpm preview-site",
 	"redirects": [
-		{ "source": "/", "destination": "https://svelte.dev/", "permanent": true }
+		{ "source": "/", "destination": "https://svelte.dev/playground/", "permanent": true }
 	]
 }


### PR DESCRIPTION
This keeps around the preview for now, but redirects users to the new site