### PR TITLE
fix: support for :has() pseudo-class in CSS parser (#13779)

### DIFF
--- a/packages/svelte/src/compiler/types/css.d.ts
+++ b/packages/svelte/src/compiler/types/css.d.ts
@@ -128,7 +128,11 @@ export namespace Css {
 	export interface PseudoClassSelector extends BaseNode {
 		type: 'PseudoClassSelector';
 		name: string;
-		args: SelectorList | null;
+		/**
+		 * The arguments to the pseudo-class, which can be a SelectorList (e.g. for :has(), :is(), :not(), etc.)
+		 * or can be null for simple pseudo-classes like :hover or :focus
+		 */
+		args: SelectorList | ComplexSelector | SimpleSelector | null;
 	}
 
 	export interface Percentage extends BaseNode {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [X] This PR will fix the issue https://github.com/sveltejs/svelte/issues/13779  
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
