### PR TITLE
fix: rethrow errors from await block if no catch block exists

### DIFF
--- a/.changeset/blue-boats-call.md
+++ b/.changeset/blue-boats-call.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-chore: highlight swallowed errors from await blocks in DEV
+fix: rethrow errors from await block if no catch block exists

--- a/.changeset/blue-boats-call.md
+++ b/.changeset/blue-boats-call.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: highlight swallowed errors from await blocks in DEV

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -80,9 +80,13 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 			else then_effect = branch(() => then_fn(anchor, input_source));
 		}
 
-		if (state === CATCH && catch_fn) {
-			if (catch_effect) resume_effect(catch_effect);
-			else catch_effect = branch(() => catch_fn(anchor, error_source));
+		if (state === CATCH) {
+			if (catch_fn) {
+				if (catch_effect) resume_effect(catch_effect);
+				else catch_effect = branch(() => catch_fn(anchor, error_source));
+			} else if (DEV) {
+				console.error(error_source.v);
+			}
 		}
 
 		if (state !== PENDING && pending_effect) {

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -80,13 +80,9 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 			else then_effect = branch(() => then_fn(anchor, input_source));
 		}
 
-		if (state === CATCH) {
-			if (catch_fn) {
+		if (state === CATCH && catch_fn) {
 				if (catch_effect) resume_effect(catch_effect);
 				else catch_effect = branch(() => catch_fn(anchor, error_source));
-			} else if (DEV) {
-				console.error(error_source.v);
-			}
 		}
 
 		if (state !== PENDING && pending_effect) {
@@ -135,6 +131,10 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 					// but let's use internal_set for consistency and just to be safe
 					internal_set(error_source, error);
 					update(CATCH, true);
+					if (!catch_fn && DEV) {
+						// eslint-disable-next-line no-console
+						console.error(error_source.v);
+					}
 				}
 			);
 

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -131,9 +131,9 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 					// but let's use internal_set for consistency and just to be safe
 					internal_set(error_source, error);
 					update(CATCH, true);
-					if (!catch_fn && DEV) {
-						// eslint-disable-next-line no-console
-						console.error(error_source.v);
+					if (!catch_fn) {
+						// Rethrow the error if no catch block exists
+						throw error_source.v;
 					}
 				}
 			);

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -81,8 +81,8 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 		}
 
 		if (state === CATCH && catch_fn) {
-				if (catch_effect) resume_effect(catch_effect);
-				else catch_effect = branch(() => catch_fn(anchor, error_source));
+			if (catch_effect) resume_effect(catch_effect);
+			else catch_effect = branch(() => catch_fn(anchor, error_source));
 		}
 
 		if (state !== PENDING && pending_effect) {

--- a/packages/svelte/tests/runtime-runes/samples/await-no-catch-error/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-no-catch-error/_config.js
@@ -1,0 +1,22 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const b1 = target.querySelector('button');
+
+		let err = '';
+		window.addEventListener('error', (e) => {
+			e.preventDefault();
+			err = e.message;
+		});
+
+		b1?.click();
+		await Promise.resolve();
+		flushSync();
+
+		assert.throws(() => {
+			throw err;
+		}, /Test/);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/await-no-catch-error/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-no-catch-error/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	const promise = new Promise((res, rej) => {
+		rej(new Error('Test'));
+	})
+	let toggle = $state(false);
+</script>
+
+<button onclick={() => toggle = !toggle}>toggle</button>
+
+{#if toggle}
+	{#await promise}{/await}
+{/if}

--- a/packages/svelte/tests/runtime-runes/samples/await-no-catch-error/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-no-catch-error/main.svelte
@@ -1,7 +1,5 @@
 <script>
-	const promise = new Promise((res, rej) => {
-		rej(new Error('Test'));
-	})
+	const promise = Promise.reject('Test');
 	let toggle = $state(false);
 </script>
 


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/13817