### PR TITLE
fix: broken property name derivation in keyframe generation

### DIFF
--- a/.changeset/dull-wolves-judge.md
+++ b/.changeset/dull-wolves-judge.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Fix property name conversion in custom transitions

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -25,10 +25,18 @@ function dispatch_event(element, type) {
 }
 
 /**
+ * Converts a property to the camel-case format expected by Element.animate(), KeyframeEffect(), and KeyframeEffect.setKeyframes().
  * @param {string} style
  * @returns {string}
  */
-function css_style_from_camel_case(style) {
+function css_property_to_camelcase(style) {
+	// in compliance with spec
+	if (style === 'float') return 'cssFloat';
+	if (style === 'offset') return 'cssOffset';
+
+	// do not rename custom @properties
+	if (style.startsWith('--')) return style;
+
 	const parts = style.split('-');
 	if (parts.length === 1) return parts[0];
 	return (
@@ -52,7 +60,7 @@ function css_to_keyframe(css) {
 		const [property, value] = part.split(':');
 		if (!property || value === undefined) break;
 
-		const formatted_property = css_style_from_camel_case(property.trim());
+		const formatted_property = css_property_to_camelcase(property.trim());
 		keyframe[formatted_property] = value.trim();
 	}
 	return keyframe;


### PR DESCRIPTION
Custom CSS properties are being renamed in Svelte 5 while used inside custom transitions. This was working fine in Svelte 4, and I just stumbled across an error in this code. The failure uncovered that these cases were not handled correctly.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Unrelated tests are failing on my machine (runtime-runes).
