### PR TITLE
fix: ensure `:has` selectors followed by other selectors match

### DIFF
--- a/.changeset/strong-feet-happen.md
+++ b/.changeset/strong-feet-happen.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure `:has` selectors followed by other selectors match

--- a/packages/svelte/tests/css/samples/has/_config.js
+++ b/packages/svelte/tests/css/samples/has/_config.js
@@ -6,112 +6,112 @@ export default test({
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused:has(y)"',
 			start: {
-				character: 269,
+				line: 28,
 				column: 1,
-				line: 27
+				character: 277
 			},
 			end: {
-				character: 283,
+				line: 28,
 				column: 15,
-				line: 27
+				character: 291
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused:has(:global(y))"',
 			start: {
-				character: 304,
+				line: 31,
 				column: 1,
-				line: 30
+				character: 312
 			},
 			end: {
-				character: 327,
+				line: 31,
 				column: 24,
-				line: 30
+				character: 335
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "x:has(.unused)"',
 			start: {
-				character: 348,
+				line: 34,
 				column: 1,
-				line: 33
+				character: 356
 			},
 			end: {
-				character: 362,
+				line: 34,
 				column: 15,
-				line: 33
+				character: 370
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "x:has(y):has(.unused)"',
 			start: {
-				character: 517,
+				line: 47,
 				column: 1,
-				line: 46
+				character: 525
 			},
 			end: {
-				character: 538,
+				line: 47,
 				column: 22,
-				line: 46
+				character: 546
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused"',
 			start: {
-				character: 743,
+				line: 66,
 				column: 2,
-				line: 65
+				character: 751
 			},
 			end: {
-				character: 750,
+				line: 66,
 				column: 9,
-				line: 65
+				character: 758
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused x:has(y)"',
 			start: {
-				character: 897,
+				line: 82,
 				column: 1,
-				line: 81
+				character: 905
 			},
 			end: {
-				character: 913,
+				line: 82,
 				column: 17,
-				line: 81
+				character: 921
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused:has(.unused)"',
 			start: {
-				line: 84,
+				line: 85,
 				column: 1,
-				character: 934
+				character: 942
 			},
 			end: {
-				line: 84,
+				line: 85,
 				column: 21,
-				character: 954
+				character: 962
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "x:has(> z)"',
 			start: {
-				line: 91,
+				line: 92,
 				column: 1,
-				character: 1021
+				character: 1029
 			},
 			end: {
-				line: 91,
+				line: 92,
 				column: 11,
-				character: 1031
+				character: 1039
 			}
 		}
 	]

--- a/packages/svelte/tests/css/samples/has/expected.css
+++ b/packages/svelte/tests/css/samples/has/expected.css
@@ -88,3 +88,10 @@
 	x.svelte-xyz > y:where(.svelte-xyz):has(z:where(.svelte-xyz)) {
 		color: green;
 	}
+
+	x.svelte-xyz:has(y:where(.svelte-xyz)) z:where(.svelte-xyz) {
+		color: green;
+	}
+	x.svelte-xyz:has(y:where(.svelte-xyz)) + c:where(.svelte-xyz) {
+		color: green;
+	}

--- a/packages/svelte/tests/css/samples/has/input.svelte
+++ b/packages/svelte/tests/css/samples/has/input.svelte
@@ -3,6 +3,7 @@
 		<z></z>
 	</y>
 </x>
+<c></c>
 
 <style>
 	x:has(y) {
@@ -92,6 +93,13 @@
 		color: red;
 	}
 	x > y:has(z) {
+		color: green;
+	}
+
+	x:has(y) z {
+		color: green;
+	}
+	x:has(y) + c {
 		color: green;
 	}
 </style>


### PR DESCRIPTION
I resisted this previously because it felt a bit wasteful, but I now think that there's really no way around this: Instead of only going upwards the tree while matching, for `:has` we go _down_ the tree to see what matches. More specifically, we're collecting the children of the current element and then check if one of those does match the selectors inside `:has`.

This makes the way the code works easier to reason about and also removes some boolean tracking we had to add for the previous approach.

Fixes #13779

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
