### PR TITLE
chore: tweak MountOptions docs

### DIFF
--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -320,19 +320,21 @@ export type MountOptions<Props extends Record<string, any> = Record<string, any>
 	 */
 	target: Document | Element | ShadowRoot;
 	/**
-	 * Optional node inside `target` and when specified, it is used to render the component immediately before it.
+	 * Optional node inside `target`. When specified, it is used to render the component immediately before it.
 	 */
 	anchor?: Node;
 	/**
 	 * Allows the specification of events.
+	 * @deprecated Use callback props instead.
 	 */
 	events?: Record<string, (e: any) => any>;
 	/**
-	 * Used to define context at the component level.
+	 * Context that can be access via `getContext()` at the component level.
 	 */
 	context?: Map<any, any>;
 	/**
-	 * Used to control transition playback on initial render.  The default value is `true` to run transitions.
+	 * Whether or not to play transitions on initial render.
+	 * @default true
 	 */
 	intro?: boolean;
 } & ({} extends Props

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -329,7 +329,7 @@ export type MountOptions<Props extends Record<string, any> = Record<string, any>
 	 */
 	events?: Record<string, (e: any) => any>;
 	/**
-	 * Context that can be access via `getContext()` at the component level.
+	 * Can be accessed via `getContext()` at the component level.
 	 */
 	context?: Map<any, any>;
 	/**

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -326,7 +326,7 @@ declare module 'svelte' {
 		 */
 		events?: Record<string, (e: any) => any>;
 		/**
-		 * Context that can be access via `getContext()` at the component level.
+		 * Can be accessed via `getContext()` at the component level.
 		 */
 		context?: Map<any, any>;
 		/**

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -317,19 +317,21 @@ declare module 'svelte' {
 		 */
 		target: Document | Element | ShadowRoot;
 		/**
-		 * Optional node inside `target` and when specified, it is used to render the component immediately before it.
+		 * Optional node inside `target`. When specified, it is used to render the component immediately before it.
 		 */
 		anchor?: Node;
 		/**
 		 * Allows the specification of events.
+		 * @deprecated Use callback props instead.
 		 */
 		events?: Record<string, (e: any) => any>;
 		/**
-		 * Used to define context at the component level.
+		 * Context that can be access via `getContext()` at the component level.
 		 */
 		context?: Map<any, any>;
 		/**
-		 * Used to control transition playback on initial render.  The default value is `true` to run transitions.
+		 * Whether or not to play transitions on initial render.
+		 * @default true
 		 */
 		intro?: boolean;
 	} & ({} extends Props


### PR DESCRIPTION
a few wording tweaks, and most importantly mark `events` as deprecated - we don't want to encourage its use.
