### PR TITLE
fix: allow binding to const with spread in legacy mode

### DIFF
--- a/.changeset/nine-pigs-approve.md
+++ b/.changeset/nine-pigs-approve.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow binding to const with spread in legacy mode

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -177,6 +177,19 @@ const spread_props_handler = {
 			if (typeof p === 'object' && p !== null && key in p) return p[key];
 		}
 	},
+	set(target, key, value) {
+		let i = target.props.length;
+		while (i--) {
+			let p = target.props[i];
+			if (is_function(p)) p = p();
+			const desc = get_descriptor(p, key);
+			if (desc && desc.set) {
+				desc.set(value);
+				return true;
+			}
+		}
+		return false;
+	},
 	getOwnPropertyDescriptor(target, key) {
 		let i = target.props.length;
 		while (i--) {

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -270,7 +270,12 @@ export function spread_props(props) {
 	for (let i = 0; i < props.length; i++) {
 		const obj = props[i];
 		for (key in obj) {
-			merged_props[key] = obj[key];
+			const desc = Object.getOwnPropertyDescriptor(obj, key);
+			if (desc) {
+				Object.defineProperty(merged_props, key, desc);
+			} else {
+				merged_props[key] = obj[key];
+			}
 		}
 	}
 	return merged_props;

--- a/packages/svelte/tests/runtime-legacy/samples/bind-export-const-with-spread/Test.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/bind-export-const-with-spread/Test.svelte
@@ -1,0 +1,3 @@
+<script>
+	export const x = 42;
+</script>

--- a/packages/svelte/tests/runtime-legacy/samples/bind-export-const-with-spread/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/bind-export-const-with-spread/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<p>42</p>`,
+	async test({ target, assert }) {
+		const p = target.querySelector('p');
+		assert.equal(p?.innerHTML, '42');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/bind-export-const-with-spread/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/bind-export-const-with-spread/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import Test from "./Test.svelte";
+
+	let x;
+</script>
+
+<Test
+	bind:x
+	{...{}}
+/>
+<p>{x}</p>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

Closes #13844...initially i wanted to prevent binding when the binder was in legacy mode but this
```svelte
<script>
    import A from "./A.svelte";
    let x = $state();
</script>

<A
    bind:x
/>
{x}
```
works and we can't change it without a breaking (svelte 6 wen?) so disallow this
```svelte
```svelte
<script>
    import A from "./A.svelte";
    let x = $state();
</script>

<A
    bind:x
    {...{}}
/>
{x}
```
seems weird.

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
