### PR TITLE
fix: wrap `:id`, `:where``:not` and `:has` with `:global` during migration

### DIFF
--- a/.changeset/sour-feet-carry.md
+++ b/.changeset/sour-feet-carry.md
@@ -1,5 +1,5 @@
 ---
-'svelte': minor
+'svelte': patch
 ---
 
-feat: migrate css `:id`, `:where``:not` and `:has`
+fix: wrap `:id`, `:where``:not` and `:has` with `:global` during migration

--- a/.changeset/sour-feet-carry.md
+++ b/.changeset/sour-feet-carry.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: migrate css `:id`, `:where``:not` and `:has`

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -47,7 +47,7 @@ function migrate_css(state) {
 
 	// since we already blank css we can't work directly on `state.str` so we will create a copy that we can update
 	const str = new MagicString(code);
-	while (!code.startsWith('</style>') && !!code.trim()) {
+	while (code) {
 		if (
 			code.startsWith(':has') ||
 			code.startsWith(':not') ||

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -54,8 +54,16 @@ function migrate_css(state) {
 			code.startsWith(':is') ||
 			code.startsWith(':where')
 		) {
-			let parenthesis = 1;
 			let start = code.indexOf('(') + 1;
+			let is_global = false;
+			const global_str = ':global';
+			const next_global = code.indexOf(global_str);
+			const str_between = code.substring(start, next_global);
+			if (!str_between.trim()) {
+				is_global = true;
+				start += global_str.length;
+			}
+			let parenthesis = 1;
 			let end = start;
 			let char = code[end];
 			// find the closing parenthesis
@@ -66,8 +74,10 @@ function migrate_css(state) {
 				char = code[end];
 			}
 			if (start && end) {
-				str.prependLeft(starting + start, ':global(');
-				str.appendRight(starting + end - 1, ')');
+				if (!is_global) {
+					str.prependLeft(starting + start, ':global(');
+					str.appendRight(starting + end - 1, ')');
+				}
 				starting += end - 1;
 				code = code.substring(end - 1);
 				continue;

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -322,7 +322,7 @@ export function migrate(source, { filename } = {}) {
 				.toString()
 				// for some reason replacing the magic string doesn't work
 				.replaceAll(
-					/(?<=<style[^>]*>[\s\S]*?:(?:is|not|where|has)\()([^)]+)(?=[\s\S]*?<\/style>)/gm,
+					/(?<=<style[^>]*>[\s\S]*?:(?:is|not|where|has)\()([\s\S]+)(?=\)[\s\S]*?<\/style>)/gm,
 					':global($1)'
 				)
 		};

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -317,7 +317,15 @@ export function migrate(source, { filename } = {}) {
 		if (!parsed.instance && need_script) {
 			str.appendRight(insertion_point, '\n</script>\n\n');
 		}
-		return { code: str.toString() };
+		return {
+			code: str
+				.toString()
+				// for some reason replacing the magic string doesn't work
+				.replaceAll(
+					/(?<=<style[^>]*>[\s\S]*?:(?:is|not|where|has)\()([^)]+)(?=[\s\S]*?<\/style>)/gm,
+					':global($1)'
+				)
+		};
 	} catch (e) {
 		if (!(e instanceof MigrationError)) {
 			// eslint-disable-next-line no-console

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
@@ -30,6 +30,17 @@ what if i'm talking about `:has()` in my blog?
 	div > :is(:is(span)){}
 	div > :where(:is(span)){}
 
+	div:has(.class:is(span)){}
+	div > :not(.class:is(span)){}
+	div > :is(.class:is(span)){}
+	div > :where(.class:is(span)){}
+
+	div :has(.class:is(span:where(:focus))){}
+	div :not(.class:is(span:where(:focus-within))){}
+	div :is(.class:is(span:is(:hover))){}
+	div :where(.class:is(span:has(* > *))){}
+
+
 	div{
 		p:has(&){
 

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
@@ -41,6 +41,12 @@ what if i'm talking about `:has()` in my blog?
 	div :where(.class:is(span:has(* > *))){}
 	div :is(.class:is(span:is(:hover)), .x){}
 
+	div :has(    :global(.class:is(span:where(:focus)))){}
+	div :not(:global(.class:is(span:where(:focus-within)))){}
+	div :is(:global(.class:is(span:is(:hover)))){}
+	div :where(:global(.class:is(span:has(* > *)))){}
+	div :is(:global(.class:is(span:is(:hover)), .x)){}
+
 	div{
 		p:has(&){
 

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
@@ -1,0 +1,20 @@
+<style lang="postcss">
+	div:has(span){}
+	div > :not(span){}
+	div > :is(span){}
+	div > :where(span){}
+
+	div:has(:is(span)){}
+	div > :not(:is(span)){}
+	div > :is(:is(span)){}
+	div > :where(:is(span)){}
+
+	div{
+		p:has(&){
+
+		}
+		:not(span > *){
+			:where(form){}
+		}
+	}
+</style>

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
@@ -39,7 +39,7 @@ what if i'm talking about `:has()` in my blog?
 	div :not(.class:is(span:where(:focus-within))){}
 	div :is(.class:is(span:is(:hover))){}
 	div :where(.class:is(span:has(* > *))){}
-
+div :is(.class:is(span:is(:hover)), .x){}
 
 	div{
 		p:has(&){

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
@@ -1,3 +1,24 @@
+<script>
+	function is(){}
+	function where(){}
+	function not(){}
+	function has(){}
+
+	// looks like css but it's not in style tag
+	const x = {
+		div:is(42),
+		span:where(42),
+		form:not(42),
+		input:has(42),
+	}
+</script>
+
+what if i'm talking about `:has()` in my blog?
+
+```css
+	:has(.is_cool)
+```
+
 <style lang="postcss">
 	div:has(span){}
 	div > :not(span){}

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/input.svelte
@@ -39,7 +39,7 @@ what if i'm talking about `:has()` in my blog?
 	div :not(.class:is(span:where(:focus-within))){}
 	div :is(.class:is(span:is(:hover))){}
 	div :where(.class:is(span:has(* > *))){}
-div :is(.class:is(span:is(:hover)), .x){}
+	div :is(.class:is(span:is(:hover)), .x){}
 
 	div{
 		p:has(&){

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
@@ -39,7 +39,7 @@ what if i'm talking about `:has()` in my blog?
 	div :not(:global(.class:is(span:where(:focus-within)))){}
 	div :is(:global(.class:is(span:is(:hover)))){}
 	div :where(:global(.class:is(span:has(* > *)))){}
-
+div :is(:global(.class:is(span:is(:hover)), .x)){}
 
 	div{
 		p:has(:global(&)){

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
@@ -39,7 +39,7 @@ what if i'm talking about `:has()` in my blog?
 	div :not(:global(.class:is(span:where(:focus-within)))){}
 	div :is(:global(.class:is(span:is(:hover)))){}
 	div :where(:global(.class:is(span:has(* > *)))){}
-div :is(:global(.class:is(span:is(:hover)), .x)){}
+	div :is(:global(.class:is(span:is(:hover)), .x)){}
 
 	div{
 		p:has(:global(&)){

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
@@ -30,6 +30,17 @@ what if i'm talking about `:has()` in my blog?
 	div > :is(:global(:is(span))){}
 	div > :where(:global(:is(span))){}
 
+	div:has(:global(.class:is(span))){}
+	div > :not(:global(.class:is(span))){}
+	div > :is(:global(.class:is(span))){}
+	div > :where(:global(.class:is(span))){}
+
+	div :has(:global(.class:is(span:where(:focus)))){}
+	div :not(:global(.class:is(span:where(:focus-within)))){}
+	div :is(:global(.class:is(span:is(:hover)))){}
+	div :where(:global(.class:is(span:has(* > *)))){}
+
+
 	div{
 		p:has(:global(&)){
 

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
@@ -1,3 +1,24 @@
+<script>
+	function is(){}
+	function where(){}
+	function not(){}
+	function has(){}
+
+	// looks like css but it's not in style tag
+	const x = {
+		div:is(42),
+		span:where(42),
+		form:not(42),
+		input:has(42),
+	}
+</script>
+
+what if i'm talking about `:has()` in my blog?
+
+```css
+	:has(.is_cool)
+```
+
 <style lang="postcss">
 	div:has(:global(span)){}
 	div > :not(:global(span)){}

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
@@ -1,0 +1,20 @@
+<style lang="postcss">
+	div:has(:global(span)){}
+	div > :not(:global(span)){}
+	div > :is(:global(span)){}
+	div > :where(:global(span)){}
+
+	div:has(:global(:is(span))){}
+	div > :not(:global(:is(span))){}
+	div > :is(:global(:is(span))){}
+	div > :where(:global(:is(span))){}
+
+	div{
+		p:has(:global(&)){
+
+		}
+		:not(:global(span > *)){
+			:where(:global(form)){}
+		}
+	}
+</style>

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
@@ -41,6 +41,12 @@ what if i'm talking about `:has()` in my blog?
 	div :where(:global(.class:is(span:has(* > *)))){}
 	div :is(:global(.class:is(span:is(:hover)), .x)){}
 
+	div :has(    :global(.class:is(span:where(:focus)))){}
+	div :not(:global(.class:is(span:where(:focus-within)))){}
+	div :is(:global(.class:is(span:is(:hover)))){}
+	div :where(:global(.class:is(span:has(* > *)))){}
+	div :is(:global(.class:is(span:is(:hover)), .x)){}
+
 	div{
 		p:has(:global(&)){
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

Closes #13765...if you can think of more weird case to test please let me know.

EDIT: i've added a slightly better test and realised that we could have a problem if the user has something like this

```svelte
{`
<style>
	.this :is(a .problem){}
</style>
`}
```
in the template...should we care?

Also weirdly `replaceAll` from `MagicString` did not got the job done, might be worth opening an issue there.

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
