### PR TITLE
docs: fix typo in migration guide

### DIFF
--- a/documentation/docs/07-misc/07-v5-migration-guide.md
+++ b/documentation/docs/07-misc/07-v5-migration-guide.md
@@ -353,7 +353,7 @@ In Svelte 4, the easiest way to pass a piece of UI to the child was using a `<sl
 </script>
 
 ---<slot />---
-+++{@render children?.()}+++
++++{@render children()}+++
 ```
 
 ### Multiple content placeholders


### PR DESCRIPTION
This is how the guide looks right now:
<img width="722" alt="image" src="https://github.com/user-attachments/assets/b3a0ecec-bf3f-49c3-abd7-86573436a649">


I removed the extra `?.` - is it necessary?
