### PR TITLE
fix: internally wrap store subscribe in untrack

### DIFF
--- a/.changeset/little-hotels-poke.md
+++ b/.changeset/little-hotels-poke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: internally wrap store subscribe in untrack

--- a/packages/svelte/src/store/utils.js
+++ b/packages/svelte/src/store/utils.js
@@ -1,4 +1,5 @@
 /** @import { Readable } from './public' */
+import { untrack } from '../index-client.js';
 import { noop } from '../internal/shared/utils.js';
 
 /**
@@ -20,11 +21,11 @@ export function subscribe_to_store(store, run, invalidate) {
 	}
 
 	// Svelte store takes a private second argument
-	const unsub = store.subscribe(
+	const unsub = untrack(() => store.subscribe(
 		run,
 		// @ts-expect-error
 		invalidate
-	);
+	));
 
 	// Also support RxJS
 	// @ts-expect-error TODO fix this in the types?

--- a/packages/svelte/src/store/utils.js
+++ b/packages/svelte/src/store/utils.js
@@ -21,11 +21,13 @@ export function subscribe_to_store(store, run, invalidate) {
 	}
 
 	// Svelte store takes a private second argument
-	const unsub = untrack(() => store.subscribe(
-		run,
-		// @ts-expect-error
-		invalidate
-	));
+	const unsub = untrack(() =>
+		store.subscribe(
+			run,
+			// @ts-expect-error
+			invalidate
+		)
+	);
 
 	// Also support RxJS
 	// @ts-expect-error TODO fix this in the types?

--- a/packages/svelte/src/store/utils.js
+++ b/packages/svelte/src/store/utils.js
@@ -21,6 +21,7 @@ export function subscribe_to_store(store, run, invalidate) {
 	}
 
 	// Svelte store takes a private second argument
+	// StartStopNotifier could mutate state, and we want to silence the corresponding validation error
 	const unsub = untrack(() =>
 		store.subscribe(
 			run,

--- a/packages/svelte/tests/runtime-runes/samples/store-unsubscribe-not-referenced-after/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-unsubscribe-not-referenced-after/main.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { untrack } from "svelte";
 	import { writable, derived } from "svelte/store";
 
 	const obj = writable({ a: 1 });
@@ -8,9 +7,7 @@
 
 	function watch (prop) {
 		return derived(obj, (o) => {
-			untrack(() => {
-				count++;
-			});
+			count++;
 			return o[prop];
 		});
 	}


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/13840. This issue keeps coming up time and time again. I think we can make the process of migration smoother by just internally wrapping the `subscribe` function in an `untrack` internally – which is what people would have had to have done in their functions anyway.