### PR TITLE
fix: ensure props internally untracks current_value on sets

### DIFF
--- a/.changeset/short-jokes-speak.md
+++ b/.changeset/short-jokes-speak.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure props internally untracks current_value on sets

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -401,8 +401,6 @@ export function prop(props, key, flags, fallback) {
 
 			return value;
 		}
-		var current = get(current_value);
-
-		return current;
+		return get(current_value);
 	};
 }

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -373,8 +373,6 @@ export function prop(props, key, flags, fallback) {
 	if (!immutable) current_value.equals = safe_equals;
 
 	return function (/** @type {any} */ value, /** @type {boolean} */ mutation) {
-		var current = get(current_value);
-
 		// legacy nonsense — need to ensure the source is invalidated when necessary
 		// also needed for when handling inspect logic so we can inspect the correct source signal
 		if (is_signals_recorded) {
@@ -398,11 +396,12 @@ export function prop(props, key, flags, fallback) {
 				if (fallback_used && fallback_value !== undefined) {
 					fallback_value = new_value;
 				}
-				get(current_value); // force a synchronisation immediately
+				untrack(() => get(current_value)); // force a synchronisation immediately
 			}
 
 			return value;
 		}
+		var current = get(current_value);
 
 		return current;
 	};

--- a/packages/svelte/tests/runtime-runes/samples/props-assignment-tracking/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-assignment-tracking/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, logs, target }) {
+		const btn = target.querySelector('button');
+
+		flushSync(() => {
+			btn?.click();
+			btn?.click();
+			btn?.click();
+		});
+
+		assert.deepEqual(logs, ['effect']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/props-assignment-tracking/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-assignment-tracking/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let {display = true} = $props();
+
+	$effect(()=>{
+		display = true;
+		console.log("effect")
+	});
+</script>
+
+<button onclick={() => display = !display} >display</button>


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/13813. We shouldn't be tracking `current_value` when doing sets to props, otherwise we oversubscribe.