### PR TITLE
fix: typo in `Action` types

### DIFF
--- a/.changeset/strong-buttons-juggle.md
+++ b/.changeset/strong-buttons-juggle.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: typo in `Action` types

--- a/packages/svelte/src/action/public.d.ts
+++ b/packages/svelte/src/action/public.d.ts
@@ -48,7 +48,7 @@ export interface ActionReturn<
  *   // ...
  * }
  * ```
- * `Action<HTMLDivElement>` and `Action<HTMLDiveElement, undefined>` both signal that the action accepts no parameters.
+ * `Action<HTMLDivElement>` and `Action<HTMLDivElement, undefined>` both signal that the action accepts no parameters.
  *
  * You can return an object with methods `update` and `destroy` from the function and type which additional attributes and events it has.
  * See interface `ActionReturn` for more details.

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -546,7 +546,7 @@ declare module 'svelte/action' {
 	 *   // ...
 	 * }
 	 * ```
-	 * `Action<HTMLDivElement>` and `Action<HTMLDiveElement, undefined>` both signal that the action accepts no parameters.
+	 * `Action<HTMLDivElement>` and `Action<HTMLDivElement, undefined>` both signal that the action accepts no parameters.
 	 *
 	 * You can return an object with methods `update` and `destroy` from the function and type which additional attributes and events it has.
 	 * See interface `ActionReturn` for more details.


### PR DESCRIPTION
Fix a typo

Unsure of if this doc is generated here or in the svelte types file.