### PR TITLE
fix: ensure SvelteMap reactivity persists through deriveds

### DIFF
--- a/.changeset/hungry-dogs-happen.md
+++ b/.changeset/hungry-dogs-happen.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure SvelteMap reactivity persists through deriveds

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -102,10 +102,12 @@ export class SvelteMap extends Map {
 			increment(version);
 		} else if (prev_res !== value) {
 			increment(s);
-			// If no one listening to this property yet, but version is
-			// being listened to, then also increment version to keep
-			// those cases in sync
-			if (s.reactions === null || version.reactions === null) {
+			// If no one listening to this property and is listening to the version, or
+			// the inverse, then we should increment the version to be safe
+			if (
+				(s.reactions === null && version.reactions !== null) ||
+				(s.reactions !== null && version.reactions === null)
+			) {
 				increment(version);
 			}
 		}

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -106,7 +106,7 @@ export class SvelteMap extends Map {
 			// being listened to, then also increment version to keep
 			// those cases in sync
 			if (s.reactions === null || version.reactions === null) {
-				increment(this.#version);
+				increment(version);
 			}
 		}
 

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -94,13 +94,20 @@ export class SvelteMap extends Map {
 		var s = sources.get(key);
 		var prev_res = super.get(key);
 		var res = super.set(key, value);
+		var version = this.#version;
 
 		if (s === undefined) {
 			sources.set(key, source(0));
 			set(this.#size, super.size);
-			increment(this.#version);
+			increment(version);
 		} else if (prev_res !== value) {
 			increment(s);
+			// If no one listening to this property yet, but version is
+			// being listened to, then also increment version to keep
+			// those cases in sync
+			if (s.reactions === null || version.reactions === null) {
+				increment(this.#version);
+			}
 		}
 
 		return res;

--- a/packages/svelte/tests/runtime-runes/samples/derived-map/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-map/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `Loading`,
+
+	async test({ assert, target }) {
+		await Promise.resolve();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `1`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-map/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-map/main.svelte
@@ -1,0 +1,34 @@
+<script>
+	import { untrack } from 'svelte';
+	import { SvelteMap } from 'svelte/reactivity';
+
+	const cache = new SvelteMap();
+
+	function get_async(id) {
+		const model = cache.get(id);
+
+		if (!model) {
+			const promise = new Promise(async () => {
+				await Promise.resolve();
+				cache.set(id, id.toString());
+			}).then(() => cache.get(id));
+
+			untrack(() => {
+				cache.set(id, promise);
+			});
+
+			return promise;
+		}
+
+		return model;
+	}
+
+	const value = $derived(get_async(1));
+</script>
+
+{#if value instanceof Promise}
+	Loading
+{:else}
+	{value}
+{/if}
+


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/13817. Quite an edge-case but one we need to support. When using a SvelteMap inside a reactive context such as a derived for the first time, registering of dependencies that get "upgraded" from a version to a property source might get missed as the context hasn't yet been registered to the sources. To avoid this, we can further increment the version when a further set is applied to a SvelteMap property signal, and where that signal hasn't yet been wired up. The increment to version will ensure on stale references get hooked up accordingly.