### PR TITLE
fix : Rapidly toggling element with out: transition causes incorrect node removal

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -427,6 +427,10 @@ function animate(element, options, counterpart, t2, on_finish) {
 				animation.cancel();
 				// This prevents memory leaks in Chromium
 				animation.effect = null;
+				// This prevents onfinish to be launched after cancel(),
+				// which can happen in some rare cases
+				// see https://github.com/sveltejs/svelte/issues/13681
+				animation.onfinish = null;
 			}
 		},
 		deactivate: () => {

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -430,7 +430,7 @@ function animate(element, options, counterpart, t2, on_finish) {
 				// This prevents onfinish to be launched after cancel(),
 				// which can happen in some rare cases
 				// see https://github.com/sveltejs/svelte/issues/13681
-				animation.onfinish = null;
+				animation.onfinish = noop;
 			}
 		},
 		deactivate: () => {


### PR DESCRIPTION
Fix https://github.com/sveltejs/svelte/issues/13681

On some rare case when a out transition is quickly canceled, the "dummy transition" `onfinish` can be executed after the cancel, and the node will be removed from the DOM.

It seems that setting onfinish back to `noop` fixes the problem.
However the bug is not systematic (the joys of race conditions), and I can't come up with a proper test for this.


### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
