### PR TITLE
fix: enable bound store props in runes mode components

### DIFF
--- a/.changeset/cool-clocks-march.md
+++ b/.changeset/cool-clocks-march.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: enable bound store props in runes mode components

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -194,7 +194,7 @@ export function build_component(node, component_name, context, anchor = context.
 
 				if (is_store_sub) {
 					push_prop(
-						b.get(attribute.name, [b.stmt(b.call('$.mark_store_sub')), b.return(expression)])
+						b.get(attribute.name, [b.stmt(b.call('$.mark_store_binding')), b.return(expression)])
 					);
 				} else {
 					push_prop(b.get(attribute.name, [b.return(expression)]));

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -188,7 +188,17 @@ export function build_component(node, component_name, context, anchor = context.
 					);
 				}
 
-				push_prop(b.get(attribute.name, [b.return(expression)]));
+				const is_store_sub =
+					attribute.expression.type === 'Identifier' &&
+					context.state.scope.get(attribute.expression.name)?.kind === 'store_sub';
+
+				if (is_store_sub) {
+					push_prop(
+						b.get(attribute.name, [b.stmt(b.call('$.mark_store_sub')), b.return(expression)])
+					);
+				} else {
+					push_prop(b.get(attribute.name, [b.return(expression)]));
+				}
 
 				const assignment = b.assignment('=', attribute.expression, b.id('$$value'));
 				push_prop(

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -122,7 +122,7 @@ export {
 	store_unsub,
 	update_pre_store,
 	update_store,
-	mark_store_sub
+	mark_store_binding
 } from './reactivity/store.js';
 export { set_text } from './render.js';
 export {

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -121,7 +121,8 @@ export {
 	store_set,
 	store_unsub,
 	update_pre_store,
-	update_store
+	update_store,
+	mark_store_sub
 } from './reactivity/store.js';
 export { set_text } from './render.js';
 export {

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -23,7 +23,7 @@ import { safe_equals } from './equality.js';
 import * as e from '../errors.js';
 import { BRANCH_EFFECT, DESTROYED, LEGACY_DERIVED_PROP, ROOT_EFFECT } from '../constants.js';
 import { proxy } from '../proxy.js';
-import { capture_marked_store_sub } from './store.js';
+import { capture_store_binding } from './store.js';
 
 /**
  * @param {((value?: number) => number)} fn
@@ -278,7 +278,7 @@ export function prop(props, key, flags, fallback) {
 	var prop_value;
 
 	if (bindable) {
-		[prop_value, is_store_sub] = capture_marked_store_sub(() => /** @type {V} */ (props[key]));
+		[prop_value, is_store_sub] = capture_store_binding(() => /** @type {V} */ (props[key]));
 	} else {
 		prop_value = /** @type {V} */ (props[key]);
 	}

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -171,10 +171,10 @@ export function mark_store_binding() {
  */
 export function capture_marked_store_sub(fn) {
 	var previous_marked_store_sub = marked_store_sub;
+
 	try {
 		marked_store_sub = false;
-		var value = fn();
-		return [value, marked_store_sub];
+		return [fn(), marked_store_sub];
 	} finally {
 		marked_store_sub = previous_marked_store_sub;
 	}

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -157,7 +157,7 @@ export function update_pre_store(store, store_value, d = 1) {
 /**
  * Called inside prop getters to communicate that the prop is a store binding
  */
-export function mark_store_sub() {
+export function mark_store_binding() {
 	marked_store_sub = true;
 }
 

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -6,6 +6,11 @@ import { get } from '../runtime.js';
 import { teardown } from './effects.js';
 import { mutable_source, set } from './sources.js';
 
+/**
+ * Whether or not the prop currently being read is a store binding, as in
+ * `<Child bind:x={$y} />`. If it is, we treat the prop as mutable even in
+ * runes mode, and skip `binding_property_non_reactive` validation
+ */
 let marked_store_sub = false;
 
 /**
@@ -149,11 +154,17 @@ export function update_pre_store(store, store_value, d = 1) {
 	return value;
 }
 
+/**
+ * Called inside prop getters to communicate that the prop is a store binding
+ */
 export function mark_store_sub() {
 	marked_store_sub = true;
 }
 
 /**
+ * Returns a tuple that indicates whether `fn()` reads a prop that is a store binding.
+ * Used to prevent `binding_property_non_reactive` validation false positives and
+ * ensure that these props are treated as mutable even in runes mode
  * @template T
  * @param {() => T} fn
  * @returns {[T, boolean]}

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -6,6 +6,8 @@ import { get } from '../runtime.js';
 import { teardown } from './effects.js';
 import { mutable_source, set } from './sources.js';
 
+let marked_store_sub = false;
+
 /**
  * Gets the current value of a store. If the store isn't subscribed to yet, it will create a proxy
  * signal that will be updated when the store is. The store references container is needed to
@@ -145,4 +147,24 @@ export function update_pre_store(store, store_value, d = 1) {
 	const value = store_value + d;
 	store.set(value);
 	return value;
+}
+
+export function mark_store_sub() {
+	marked_store_sub = true;
+}
+
+/**
+ * @template T
+ * @param {() => T} fn
+ * @returns {[T, boolean]}
+ */
+export function capture_marked_store_sub(fn) {
+	var previous_marked_store_sub = marked_store_sub;
+	try {
+		marked_store_sub = false;
+		var value = fn();
+		return [value, marked_store_sub];
+	} finally {
+		marked_store_sub = previous_marked_store_sub;
+	}
 }

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -11,7 +11,7 @@ import { mutable_source, set } from './sources.js';
  * `<Child bind:x={$y} />`. If it is, we treat the prop as mutable even in
  * runes mode, and skip `binding_property_non_reactive` validation
  */
-let marked_store_sub = false;
+let is_store_binding = false;
 
 /**
  * Gets the current value of a store. If the store isn't subscribed to yet, it will create a proxy
@@ -158,7 +158,7 @@ export function update_pre_store(store, store_value, d = 1) {
  * Called inside prop getters to communicate that the prop is a store binding
  */
 export function mark_store_binding() {
-	marked_store_sub = true;
+	is_store_binding = true;
 }
 
 /**
@@ -169,13 +169,13 @@ export function mark_store_binding() {
  * @param {() => T} fn
  * @returns {[T, boolean]}
  */
-export function capture_marked_store_sub(fn) {
-	var previous_marked_store_sub = marked_store_sub;
+export function capture_store_binding(fn) {
+	var previous_is_store_binding = is_store_binding;
 
 	try {
-		marked_store_sub = false;
-		return [fn(), marked_store_sub];
+		is_store_binding = false;
+		return [fn(), is_store_binding];
 	} finally {
-		marked_store_sub = previous_marked_store_sub;
+		is_store_binding = previous_is_store_binding;
 	}
 }

--- a/packages/svelte/src/internal/client/validate.js
+++ b/packages/svelte/src/internal/client/validate.js
@@ -4,6 +4,7 @@ import * as e from './errors.js';
 import { FILENAME } from '../../constants.js';
 import { render_effect } from './reactivity/effects.js';
 import * as w from './warnings.js';
+import { capture_marked_store_sub } from './reactivity/store.js';
 
 /** regex of all html void element names */
 const void_element_names =
@@ -84,7 +85,10 @@ export function validate_binding(binding, get_object, get_property, line, column
 	render_effect(() => {
 		if (warned) return;
 
-		var object = get_object();
+		var [object, is_store_sub] = capture_marked_store_sub(get_object);
+
+		if (is_store_sub) return;
+
 		var property = get_property();
 
 		var ran = false;

--- a/packages/svelte/src/internal/client/validate.js
+++ b/packages/svelte/src/internal/client/validate.js
@@ -4,7 +4,7 @@ import * as e from './errors.js';
 import { FILENAME } from '../../constants.js';
 import { render_effect } from './reactivity/effects.js';
 import * as w from './warnings.js';
-import { capture_marked_store_sub } from './reactivity/store.js';
+import { capture_store_binding } from './reactivity/store.js';
 
 /** regex of all html void element names */
 const void_element_names =
@@ -85,7 +85,7 @@ export function validate_binding(binding, get_object, get_property, line, column
 	render_effect(() => {
 		if (warned) return;
 
-		var [object, is_store_sub] = capture_marked_store_sub(get_object);
+		var [object, is_store_sub] = capture_store_binding(get_object);
 
 		if (is_store_sub) return;
 

--- a/packages/svelte/tests/runtime-runes/samples/bound-store-sub/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bound-store-sub/Child.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { form = $bindable() } = $props();
+</script>
+
+<p>
+	<input type="number" bind:value={form.count} />
+</p>

--- a/packages/svelte/tests/runtime-runes/samples/bound-store-sub/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bound-store-sub/_config.js
@@ -1,0 +1,25 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+import { ok } from 'assert';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	html: `<p><input type="number"></p>\n{"count":0}`,
+	ssrHtml: `<p><input type="number" value="0"></p>\n{"count":0}`,
+
+	test({ assert, target }) {
+		const input = target.querySelector('input');
+		ok(input);
+		const inputEvent = new window.InputEvent('input');
+
+		input.value = '10';
+		input.dispatchEvent(inputEvent);
+
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<p><input type="number"></p>\n{"count":10}`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bound-store-sub/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bound-store-sub/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { writable } from 'svelte/store';
+	import Child from './Child.svelte';
+
+	let form = writable({
+		count: 0
+	});
+</script>
+
+<Child bind:form={$form} />
+{JSON.stringify($form)}


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/13825.

This is an interesting one.

1. In legacy mode, we allow bound stores to persist and have their properties update – however, you get a warning that you're writing to a non-reactive property when doing so – this removes that warning as things work fine.
2. In runes mode, we allow bound store subs to work like they do in legacy mode. We do this by marking the bound store sub inside the prop getter and then capturing this and using this logic to apply the different heuristics.