### PR TITLE
fix: date test fail for some timezone

### DIFF
--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -38,15 +38,23 @@ test('date.setDate and date.setUTCDate', () => {
 		date.setUTCDate(date.getUTCDate() + 1);
 	});
 
+	// Date/UTCDate may vary on some timezones
+	const datePlusZero = new Date(initial_date);
+	datePlusZero.setDate(a.getDate());
+	const datePlusOne = new Date(initial_date);
+	datePlusOne.setDate(a.getDate() + 1);
+	const datePlusTwo = new Date(initial_date);
+	datePlusTwo.setDate(a.getDate() + 2);
+
 	assert.deepEqual(log, [
 		initial_date.getDate(),
 		initial_date.getUTCDate(),
-		a.getDate(),
-		a.getUTCDate(),
-		a.getDate() + 1,
-		a.getUTCDate() + 1,
-		a.getDate() + 2,
-		a.getUTCDate() + 2
+		datePlusZero.getDate(),
+		datePlusZero.getUTCDate(),
+		datePlusOne.getDate(),
+		datePlusOne.getUTCDate(),
+		datePlusTwo.getDate(),
+		datePlusTwo.getUTCDate()
 	]);
 
 	cleanup();

--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -39,22 +39,22 @@ test('date.setDate and date.setUTCDate', () => {
 	});
 
 	// Date/UTCDate may vary on some timezones
-	const datePlusZero = new Date(initial_date);
-	datePlusZero.setDate(a.getDate());
-	const datePlusOne = new Date(initial_date);
-	datePlusOne.setDate(a.getDate() + 1);
-	const datePlusTwo = new Date(initial_date);
-	datePlusTwo.setDate(a.getDate() + 2);
+	const date_plus_zero = new Date(initial_date);
+	date_plus_zero.setDate(a.getDate());
+	const date_plus_one = new Date(initial_date);
+	date_plus_one.setDate(a.getDate() + 1);
+	const date_plus_two = new Date(initial_date);
+	date_plus_two.setDate(a.getDate() + 2);
 
 	assert.deepEqual(log, [
 		initial_date.getDate(),
 		initial_date.getUTCDate(),
-		datePlusZero.getDate(),
-		datePlusZero.getUTCDate(),
-		datePlusOne.getDate(),
-		datePlusOne.getUTCDate(),
-		datePlusTwo.getDate(),
-		datePlusTwo.getUTCDate()
+		date_plus_zero.getDate(),
+		date_plus_zero.getUTCDate(),
+		date_plus_one.getDate(),
+		date_plus_one.getUTCDate(),
+		date_plus_two.getDate(),
+		date_plus_two.getUTCDate()
 	]);
 
 	cleanup();


### PR DESCRIPTION
The test for `SvelteDate` fail on some timezone, like mine (CEDT/CEST "France/Paris").

=> This is because the initial date is set to midnight, and the Date/UTCDate may differ based on the user timezone.

I changed the test in order to redo the same calculations with Date.
I think this should work on all timezone.


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
