### PR TITLE
fix: prevent migration script from adding `props.` to the `export let` identifier

### DIFF
--- a/.changeset/shaggy-seals-judge.md
+++ b/.changeset/shaggy-seals-judge.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent migration script from adding `props.` to the `export let` identifier

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1514,7 +1514,7 @@ function handle_identifier(node, state, path) {
 			);
 		} else {
 			const binding = state.scope.get(node.name);
-			if (binding?.kind === 'bindable_prop') {
+			if (binding?.kind === 'bindable_prop' && binding.node !== node) {
 				state.str.prependLeft(/** @type {number} */ (node.start), `${state.names.props}.`);
 			}
 		}

--- a/packages/svelte/tests/migrate/samples/not-prepend-props-to-export-let/input.svelte
+++ b/packages/svelte/tests/migrate/samples/not-prepend-props-to-export-let/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let stuff;
+
+	console.log($$props);
+</script>

--- a/packages/svelte/tests/migrate/samples/not-prepend-props-to-export-let/output.svelte
+++ b/packages/svelte/tests/migrate/samples/not-prepend-props-to-export-let/output.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { ...props } = $props();
+
+	console.log(props);
+</script>


### PR DESCRIPTION
Closes #13898

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
