### PR TITLE
docs: clarify why we need to use the derived rune

### DIFF
--- a/documentation/docs/02-runes/03-$derived.md
+++ b/documentation/docs/02-runes/03-$derived.md
@@ -2,19 +2,7 @@
 title: $derived
 ---
 
-
-Svelte's `<script>` blocks are run only when the component is created, so assignments within a `<script>` block are not automatically run again when a prop updates. 
-
-```svelte
-<script>
-	let count = $state(0);  
-	// this will only set `doubled` on component creation
-	// it will not update when `count` does
-	let doubled = count * 2;
-</script>
-```
-
-We can make any variable based on others reactive by declaring them a Derived state using the `$derived` rune:
+Derived state is declared with the `$derived` rune:
 
 ```svelte
 <script>
@@ -32,6 +20,8 @@ We can make any variable based on others reactive by declaring them a Derived st
 The expression inside `$derived(...)` should be free of side-effects. Svelte will disallow state changes (e.g. `count++`) inside derived expressions.
 
 As with `$state`, you can mark class fields as `$derived`.
+
+> [!NOTE] Code in Svelte components is only executed once at creation, without the `$derived` rune `double` would maintain it's original value.
 
 ## `$derived.by`
 

--- a/documentation/docs/02-runes/03-$derived.md
+++ b/documentation/docs/02-runes/03-$derived.md
@@ -2,7 +2,19 @@
 title: $derived
 ---
 
-Derived state is declared with the `$derived` rune:
+
+Svelte's `<script>` blocks are run only when the component is created, so assignments within a `<script>` block are not automatically run again when a prop updates. 
+
+```svelte
+<script>
+	let count = $state(0);  
+	// this will only set `doubled` on component creation
+	// it will not update when `count` does
+	let doubled = count * 2;
+</script>
+```
+
+We can make any variable based on others reactive by declaring them a Derived state using the `$derived` rune:
 
 ```svelte
 <script>


### PR DESCRIPTION
In the v4 docs it was clearly explained why we need to use `$:` to re-evaluate assignments, this is missing for the `$derived` rune and could be a pitfall for people new to the framework.

Note: should be fixed in the tutorial as well.
