### PR TITLE
fix: ensure value is correctly set to zero on the progress element

### DIFF
--- a/.changeset/late-wombats-cheer.md
+++ b/.changeset/late-wombats-cheer.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure value is correctly set to zero on the progress element

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -54,8 +54,12 @@ export function remove_input_defaults(input) {
 export function set_value(element, value) {
 	// @ts-expect-error
 	var attributes = (element.__attributes ??= {});
-	// @ts-expect-error
-	if (attributes.value === (attributes.value = value) || element.value === value) return;
+	if (
+		attributes.value === (attributes.value = value) ||
+		// @ts-expect-error <progress> elements report 0 value, but that might not really be 0
+		(element.value === value && (value !== 0 || element.nodeName !== 'PROGRESS'))
+	)
+		return;
 	// @ts-expect-error
 	element.value = value;
 }

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -56,7 +56,8 @@ export function set_value(element, value) {
 	var attributes = (element.__attributes ??= {});
 	if (
 		attributes.value === (attributes.value = value) ||
-		// @ts-expect-error <progress> elements report 0 value, but that might not really be 0
+		// @ts-expect-error 
+		// `progress` elements always need their value set when its `0`
 		(element.value === value && (value !== 0 || element.nodeName !== 'PROGRESS'))
 	)
 		return;

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -56,7 +56,7 @@ export function set_value(element, value) {
 	var attributes = (element.__attributes ??= {});
 	if (
 		attributes.value === (attributes.value = value) ||
-		// @ts-expect-error 
+		// @ts-expect-error
 		// `progress` elements always need their value set when its `0`
 		(element.value === value && (value !== 0 || element.nodeName !== 'PROGRESS'))
 	)


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13686. JSDOM didn't report any difference, so wasn't sure how to test this nicely.