### PR TITLE
fix: remove metadata from legacy AST

### DIFF
--- a/.changeset/strong-dogs-obey.md
+++ b/.changeset/strong-dogs-obey.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove metadata from legacy AST

--- a/packages/svelte/src/compiler/legacy.js
+++ b/packages/svelte/src/compiler/legacy.js
@@ -204,7 +204,9 @@ export function convert(source, ast) {
 					ignores: extract_svelte_ignore(node.start, node.data, false)
 				};
 			},
-			ComplexSelector(node) {
+			ComplexSelector(node, { next }) {
+				next(); // delete inner metadata/parent properties
+
 				const children = [];
 
 				for (const child of node.children) {


### PR DESCRIPTION
Besides being private API that shouldn't be exposed, they caused our AST explorer on the Svelte site to traverse endlessly

fixes https://github.com/sveltejs/svelte.dev/issues/480
