### PR TITLE
fix: ensure SVG element attributes have case preserved

### DIFF
--- a/.changeset/gentle-bulldogs-cough.md
+++ b/.changeset/gentle-bulldogs-cough.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure SVG element attributes have case preserved

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
@@ -101,7 +101,7 @@ export function SvelteElement(node, context) {
 			node,
 			element_id,
 			attributes_id,
-			b.binary('!==', b.member(element_id, 'namespaceURI'), b.id('$.NAMESPACE_SVG')),
+			b.binary('===', b.member(element_id, 'namespaceURI'), b.id('$.NAMESPACE_SVG')),
 			b.call(b.member(b.member(element_id, 'nodeName'), 'includes'), b.literal('-')),
 			context.state
 		);

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -170,6 +170,7 @@ export function set_attributes(
 	var current = prev || {};
 	var is_option_element = element.tagName === 'OPTION';
 
+
 	for (var key in prev) {
 		if (!(key in next)) {
 			next[key] = null;

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -170,7 +170,6 @@ export function set_attributes(
 	var current = prev || {};
 	var is_option_element = element.tagName === 'OPTION';
 
-
 	for (var key in prev) {
 		if (!(key in next)) {
 			next[key] = null;

--- a/packages/svelte/tests/runtime-runes/samples/svg-attribute-case/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svg-attribute-case/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<svg viewBox="0 0 10 10"></svg><svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"></svg><svg viewBox=""></svg`
+});

--- a/packages/svelte/tests/runtime-runes/samples/svg-attribute-case/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svg-attribute-case/_config.js
@@ -1,5 +1,5 @@
 import { test } from '../../test';
 
 export default test({
-	html: `<svg viewBox="0 0 10 10"></svg><svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"></svg><svg viewBox=""></svg`
+	html: `<svg viewBox="0 0 10 10"></svg><svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"></svg><svg viewBox=""></svg>`
 });

--- a/packages/svelte/tests/runtime-runes/samples/svg-attribute-case/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svg-attribute-case/main.svelte
@@ -1,0 +1,4 @@
+<svelte:options namespace="svg" />
+<svelte:element this="svg" viewBox="0 0 10 10" />
+<svelte:element this="svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" />
+<svg viewBox="" />


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13878