### PR TITLE
fix: skip comment nodes in snippet validation logic

### DIFF
--- a/.changeset/shy-penguins-beg.md
+++ b/.changeset/shy-penguins-beg.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip comment nodes in snippet validation logic

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SnippetBlock.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SnippetBlock.js
@@ -46,7 +46,10 @@ export function SnippetBlock(node, context) {
 	) {
 		if (
 			parent.fragment.nodes.some(
-				(node) => node.type !== 'SnippetBlock' && (node.type !== 'Text' || node.data.trim())
+				(node) =>
+					node.type !== 'SnippetBlock' &&
+					(node.type !== 'Text' || node.data.trim()) &&
+					node.type !== 'Comment'
 			)
 		) {
 			e.snippet_conflict(node);

--- a/packages/svelte/tests/runtime-runes/samples/snippet-comment-sibling/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-comment-sibling/Child.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { children } = $props();
+</script>
+
+{@render children()}

--- a/packages/svelte/tests/runtime-runes/samples/snippet-comment-sibling/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-comment-sibling/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `The content`
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-comment-sibling/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-comment-sibling/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Child from "./Child.svelte"
+</script>
+
+<Child>
+	<!-- I'm just a poor comment -->
+	{#snippet children()}
+		The content
+	{/snippet}
+</Child>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13865. We forgot to skip comment nodes in the validation logic.