### PR TITLE
Revert "chore: CompileDiagnostic no longer extends Error"

### DIFF
--- a/packages/svelte/src/compiler/utils/compile_diagnostic.js
+++ b/packages/svelte/src/compiler/utils/compile_diagnostic.js
@@ -48,7 +48,7 @@ function get_code_frame(source, line, column) {
  */
 
 /** @implements {ICompileDiagnostic} */
-export class CompileDiagnostic {
+export class CompileDiagnostic extends Error {
 	name = 'CompileDiagnostic';
 
 	/**
@@ -57,8 +57,8 @@ export class CompileDiagnostic {
 	 * @param {[number, number] | undefined} position
 	 */
 	constructor(code, message, position) {
+		super(message);
 		this.code = code;
-		this.message = message;
 
 		if (state.filename) {
 			this.filename = state.filename;


### PR DESCRIPTION
Reverts sveltejs/svelte#13651

Closes #13933 (at least aprtially).

The PR was to allow the Error to be passed via `postMessage` from the Worker in the playground...but this caused the issue in #13933 because `vite-plugin-svelte` throw the error after converting it to a `RollupError` and it's showing the stack when the build fails.

We can find another way to make this work cross Worker but i think we should revert this PR in the meantime.

Output before:

<img width="1372" alt="image" src="https://github.com/user-attachments/assets/37c950b2-a053-408a-b48d-b3cbcabb03ae">

Output after:

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/4a5c645d-e109-4972-871a-0139c3a30f95">

Another option could be to generate a stack and add a stack property on the element like this

```ts
/** @implements {ICompileDiagnostic} */
export class CompileDiagnostic {
    name = 'CompileDiagnostic';
    stack = undefined;

    /**
     * @param {string} code
     * @param {string} message
     * @param {[number, number] | undefined} position
     */
    constructor(code, message, position) {
        this.code = code;
        this.message = message;
        this.stack = new Error().stack;
```
but this feels a bit weird (it would solve the error in the playground (because it doesn't extend Error anymore) while keeping a good looking error if we fail on build (although i wonder if the reason postmessage was failing was because of the stack property that maybe adds too much stuff...i don't know).
