### PR TITLE
fix: ensure bind:group works as intended with proxied state objects

### DIFF
--- a/.changeset/giant-bags-wash.md
+++ b/.changeset/giant-bags-wash.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure bind:group works as intended with proxied state objects

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -2,7 +2,7 @@ import { DEV } from 'esm-env';
 import { render_effect, teardown } from '../../../reactivity/effects.js';
 import { listen_to_event_and_reset_event } from './shared.js';
 import * as e from '../../../errors.js';
-import { get_proxied_value, is } from '../../../proxy.js';
+import { is } from '../../../proxy.js';
 import { queue_micro_task } from '../../task.js';
 import { hydrating } from '../../hydration.js';
 import { is_runes } from '../../../runtime.js';
@@ -126,7 +126,7 @@ export function bind_group(inputs, group_index, input, get, set = get) {
 		if (is_checkbox) {
 			value = value || [];
 			// @ts-ignore
-			input.checked = get_proxied_value(value).includes(get_proxied_value(input.__value));
+			input.checked = value.includes(input.__value);
 		} else {
 			// @ts-ignore
 			input.checked = is(input.__value, value);

--- a/packages/svelte/tests/runtime-runes/samples/state-bind-group/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-bind-group/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<button>+</button><input type="checkbox" value="1"><input type="checkbox" value="2"><input type="checkbox" value="3">\n[]`,
+
+	test({ assert, target }) {
+		const btn = target.querySelector('button');
+
+		btn?.click();
+		flushSync();
+
+		assert.equal(target.querySelectorAll('input')[1].checked, true);
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>+</button><input type="checkbox" value="1"><input type="checkbox" value="2"><input type="checkbox" value="3">\n["2"]`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-bind-group/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-bind-group/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let checkboxes = $state([]);
+	let values = ['1', '2', '3'];
+</script>
+
+<button onclick={() => checkboxes.push('2')}>+</button>
+
+{#each values as val, i}
+	<input type="checkbox" value={val} bind:group={checkboxes} />
+{/each}
+
+{JSON.stringify(checkboxes)}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13894. We forgot to remove this logic when we made proxies no longer mutate the backing object.