### PR TITLE
fix: trim whitespace while migrating blocks

### DIFF
--- a/.changeset/tasty-frogs-boil.md
+++ b/.changeset/tasty-frogs-boil.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: trim whitespace while migrating blocks

--- a/packages/svelte/tests/migrate/samples/remove-blocks-whitespace/input.svelte
+++ b/packages/svelte/tests/migrate/samples/remove-blocks-whitespace/input.svelte
@@ -1,0 +1,27 @@
+{  @html "some html"   }
+
+{     #if false && {
+	
+}.x === 34    }
+	true
+{    :else if false  }
+	false
+{/if}
+
+{     #await []    }
+	{   @const x = 43   }
+	{x}
+{   :then i   }
+	{i}
+{  :catch e  }
+	dlkdj
+{/await}
+
+{   #await [] then i   }
+stuff
+{/await}
+
+{      #key count    }
+	dlkdj
+{/key}
+

--- a/packages/svelte/tests/migrate/samples/remove-blocks-whitespace/output.svelte
+++ b/packages/svelte/tests/migrate/samples/remove-blocks-whitespace/output.svelte
@@ -1,0 +1,26 @@
+{@html "some html"}
+
+{#if false && {
+	
+}.x === 34}
+	true
+{:else if false}
+	false
+{/if}
+
+{#await []}
+	{@const x = 43}
+	{x}
+{:then i}
+	{i}
+{:catch e}
+	dlkdj
+{/await}
+
+{#await [] then i}
+stuff
+{/await}
+
+{#key count}
+	dlkdj
+{/key}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

This kinda closes #13933...since now having no whitespace before the blocks is enforced by svelte let's trim everything while migrating.

Edit this will also close #13483 (we can't really fix the inconsistencies without a breaking change unfortunately)

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
