### PR TITLE
fix: add empty stack to `CompileDiagnostic` to show error on build

### DIFF
--- a/.changeset/brave-fans-sneeze.md
+++ b/.changeset/brave-fans-sneeze.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add empty stack to `CompileDiagnostic` to show error on build

--- a/packages/svelte/src/compiler/utils/compile_diagnostic.js
+++ b/packages/svelte/src/compiler/utils/compile_diagnostic.js
@@ -39,7 +39,7 @@ function get_code_frame(source, line, column) {
  * @typedef {{
  * 	code: string;
  * 	message: string;
- *  stack: string;
+ *  stack?: string;
  * 	filename?: string;
  * 	start?: Location;
  * 	end?: Location;

--- a/packages/svelte/src/compiler/utils/compile_diagnostic.js
+++ b/packages/svelte/src/compiler/utils/compile_diagnostic.js
@@ -39,6 +39,7 @@ function get_code_frame(source, line, column) {
  * @typedef {{
  * 	code: string;
  * 	message: string;
+ *  stack: string;
  * 	filename?: string;
  * 	start?: Location;
  * 	end?: Location;
@@ -50,6 +51,7 @@ function get_code_frame(source, line, column) {
 /** @implements {ICompileDiagnostic} */
 export class CompileDiagnostic {
 	name = 'CompileDiagnostic';
+	stack = '';
 
 	/**
 	 * @param {string} code

--- a/packages/svelte/src/compiler/utils/compile_diagnostic.js
+++ b/packages/svelte/src/compiler/utils/compile_diagnostic.js
@@ -51,6 +51,7 @@ function get_code_frame(source, line, column) {
 /** @implements {ICompileDiagnostic} */
 export class CompileDiagnostic {
 	name = 'CompileDiagnostic';
+	// adding an empty stack so that vite will show the file and frame during build
 	stack = '';
 
 	/**

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-with-errors/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-with-errors/_config.js
@@ -20,6 +20,7 @@ export default test({
                         ^`,
 			message: 'Unexpected end of input',
 			name: 'CompileError',
+			stack: '',
 			position: [30, 30],
 			start: {
 				character: 30,

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1458,7 +1458,7 @@ declare module 'svelte/compiler' {
 	type ICompileDiagnostic = {
 		code: string;
 		message: string;
-		stack: string;
+		stack?: string;
 		filename?: string;
 		start?: Location;
 		end?: Location;
@@ -2287,7 +2287,7 @@ declare module 'svelte/types/compiler/interfaces' {
 	type ICompileDiagnostic = {
 		code: string;
 		message: string;
-		stack: string;
+		stack?: string;
 		filename?: string;
 		start?: Location;
 		end?: Location;

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1458,6 +1458,7 @@ declare module 'svelte/compiler' {
 	type ICompileDiagnostic = {
 		code: string;
 		message: string;
+		stack: string;
 		filename?: string;
 		start?: Location;
 		end?: Location;
@@ -2286,6 +2287,7 @@ declare module 'svelte/types/compiler/interfaces' {
 	type ICompileDiagnostic = {
 		code: string;
 		message: string;
+		stack: string;
 		filename?: string;
 		start?: Location;
 		end?: Location;


### PR DESCRIPTION
As discussed in #13937 i'm adding an empty stack trace to the error to show the frame and info on the error if the build fails.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
