### PR TITLE
fix: more exhaustive check during `SvelteMap.set` in deriveds

### DIFF
--- a/.changeset/sweet-candles-poke.md
+++ b/.changeset/sweet-candles-poke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: more exhaustive check during `SvelteMap.set` in deriveds

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -3,6 +3,7 @@ import { DEV } from 'esm-env';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { increment } from './utils.js';
+import { DERIVED } from '../internal/client/constants.js';
 
 /**
  * @template K
@@ -102,12 +103,10 @@ export class SvelteMap extends Map {
 			increment(version);
 		} else if (prev_res !== value) {
 			increment(s);
-			// If no one listening to this property and is listening to the version, or
-			// the inverse, then we should increment the version to be safe
-			if (
-				(s.reactions === null && version.reactions !== null) ||
-				(s.reactions !== null && version.reactions === null)
-			) {
+
+			// if not every reaction of s is a reaction of version we need to also include version
+			const needs_version_increase = !s.reactions?.every((r) => version.reactions?.includes(r));
+			if (needs_version_increase) {
 				increment(version);
 			}
 		}

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -105,7 +105,12 @@ export class SvelteMap extends Map {
 			increment(s);
 
 			// if not every reaction of s is a reaction of version we need to also include version
-			const needs_version_increase = !s.reactions?.every((r) => version.reactions?.includes(r));
+			var v_reactions = version.reactions === null ? null : new Set(version.reactions);
+			var needs_version_increase =
+				v_reactions === null ||
+				!s.reactions?.every((r) =>
+					/** @type {NonNullable<typeof v_reactions>} */ (v_reactions).has(r)
+				);
 			if (needs_version_increase) {
 				increment(version);
 			}

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -1,9 +1,8 @@
 /** @import { Source } from '#client' */
 import { DEV } from 'esm-env';
-import { source, set } from '../internal/client/reactivity/sources.js';
+import { set, source } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { increment } from './utils.js';
-import { DERIVED } from '../internal/client/constants.js';
 
 /**
  * @template K

--- a/packages/svelte/tests/runtime-runes/samples/derived-map/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-map/_config.js
@@ -3,10 +3,6 @@ import { test } from '../../test';
 
 export default test({
 	html: `Loading`,
-	compileOptions: {
-		// dev: true
-	},
-
 	async test({ assert, target }) {
 		await Promise.resolve();
 		flushSync();

--- a/packages/svelte/tests/runtime-runes/samples/derived-map/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-map/_config.js
@@ -3,6 +3,9 @@ import { test } from '../../test';
 
 export default test({
 	html: `Loading`,
+	compileOptions: {
+		// dev: true
+	},
 
 	async test({ assert, target }) {
 		await Promise.resolve();

--- a/packages/svelte/tests/runtime-runes/samples/derived-map/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-map/main.svelte
@@ -24,6 +24,10 @@
 	}
 
 	const value = $derived(get_async(1));
+	const value2 = $derived(get_async(1));
+	// both values are read before the set 
+	value;
+	value2;
 </script>
 
 {#if value instanceof Promise}


### PR DESCRIPTION
Closes #13947 ...i'm not sure this is the right fix and i'm not sure of the performance implications. The problem is that basically just checking for null and !null is not enough. In this case both have a reaction because of the second variable read but not every reaction in `s` are in `version`.

This seems to fix the issue and tests are green but i have the feeling this could overfire the increase of version.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
