### PR TITLE
feat: Reactive actions

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/UseDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/UseDirective.js
@@ -11,7 +11,10 @@ import { parse_directive_name } from './shared/utils.js';
 export function UseDirective(node, context) {
 	let action = /** @type {Expression} */ (context.visit(parse_directive_name(node.name)));
 	if (action.type === 'MemberExpression') {
-		action = b.maybe_call(b.member(action, 'bind', false, true), /** @type {Expression} */ (action.object));
+		action = b.maybe_call(
+			b.member(action, 'bind', false, true),
+			/** @type {Expression} */ (action.object)
+		);
 	}
 
 	const get_action = b.arrow([], action);

--- a/packages/svelte/src/internal/client/dom/elements/actions.js
+++ b/packages/svelte/src/internal/client/dom/elements/actions.js
@@ -6,12 +6,16 @@ import { deep_read_state, untrack } from '../../runtime.js';
 /**
  * @template P
  * @param {Element} dom
- * @param {(dom: Element, value?: P) => ActionPayload<P>} action
+ * @param {() => (((dom: Element, value?: P) => ActionPayload<P>) | null | undefined)} get_action
  * @param {() => P} [get_value]
  * @returns {void}
  */
-export function action(dom, action, get_value) {
+export function action(dom, get_action, get_value) {
 	effect(() => {
+		const action = get_action();
+		if (action == null) {
+			return;
+		}
 		var payload = untrack(() => action(dom, get_value?.()) || {});
 
 		if (get_value && payload?.update) {

--- a/packages/svelte/tests/runtime-runes/samples/action-reactive/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/action-reactive/Child.svelte
@@ -1,0 +1,4 @@
+<script>
+    let { action, value } = $props();
+</script>
+<div use:action={value}></div>

--- a/packages/svelte/tests/runtime-runes/samples/action-reactive/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/action-reactive/_config.js
@@ -1,0 +1,49 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<div></div><button>set_action1</button><button>set_action2</button><button>set_null</button><button>increment</button>`,
+
+	async test({ assert, target }) {
+		const [div] = target.querySelectorAll('div');
+		const [set_action1, set_action2, set_null, increment] = target.querySelectorAll('button');
+
+		assert.equal(div.innerText, undefined);
+
+		flushSync(() => set_action1.click());
+		assert.equal(div.innerText, 'action1 value=0');
+
+		flushSync(() => increment.click());
+		assert.equal(div.innerText, 'action1 updated=1');
+
+		flushSync(() => set_null.click());
+		assert.equal(div.innerText, 'action1 destroyed');
+
+		flushSync(() => set_action2.click());
+		assert.equal(div.innerText, '1');
+
+		flushSync(() => increment.click());
+		assert.equal(div.innerText, '2');
+
+		flushSync(() => set_null.click());
+		assert.equal(div.innerText, '');
+
+		flushSync(() => increment.click());
+		assert.equal(div.innerText, '');
+
+		flushSync(() => set_action1.click());
+		assert.equal(div.innerText, 'action1 value=3');
+
+		flushSync(() => increment.click());
+		assert.equal(div.innerText, 'action1 updated=4');
+
+		flushSync(() => set_action1.click());
+		assert.equal(div.innerText, 'action1 updated=4');
+
+		flushSync(() => increment.click());
+		assert.equal(div.innerText, 'action1 updated=5');
+
+		flushSync(() => set_action2.click());
+		assert.equal(div.innerText, '5');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/action-reactive/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/action-reactive/main.svelte
@@ -1,0 +1,36 @@
+<script>
+	import Child from "./Child.svelte";
+
+    let action = $state();
+    let value = $state(0);
+
+    function action1(node, value) {
+        node.innerText="action1 value=" + value;
+        return {
+            update(new_value) {
+                node.innerText="action1 updated=" + new_value;
+            },
+            destroy() {
+                node.innerText="action1 destroyed";
+            }
+        }
+    }
+
+    function action2(node, value) {
+        node.innerText=value;
+        return {
+            update(new_value) {
+                node.innerText=new_value;
+            },
+            destroy() {
+                node.innerText="";
+            }
+        }
+    }
+</script>
+
+<Child {action} {value}/>
+<button onclick={()=>action=action1}>set_action1</button>
+<button onclick={()=>action=action2}>set_action2</button>
+<button onclick={()=>action=null}>set_null</button>
+<button onclick={()=>value++}>increment</button>


### PR DESCRIPTION
Simple implementation for reactive actions on the `use:action` directive.

* `action` can be a reactive value, and will be created/destroyed accordingly.
* `action` can be null/undefined, and will be ignored.

Fix issues : #6754 #6942 #13555 

Demo here [REPL](https://adiguba-svelte-5-test-git-reactive-actions-adigubas-projects.vercel.app/#H4sIAAAAAAAACrWUzW7jIBDHXwXRHhIlitsc_SVVfYW9rVeV10waVAwWDNlGlt99-VKcqKrqHsqJGeY3A38YRnrgAgzNf49Utj3QnD4NA91SPA_eMCcQCM42yurOe0rTaT5g3cgGeT8ojeT5yAUjB6160tBdFsxdJBtauEBJ3BCApO2QK0kqcm-wRViti3nt1AoL89LD-kIerIxcxB9XUjHYRmBNxhjkh_fvuJSgf8E7Vg1NQAx1NtnEaTEzGtBqeZ3FDzswvwkJ_14-lvmyXKRZLHjJUdxmmLa3NgODWp1X3yuVKGBB6Zv8s5mm0yeC7pcK-nPa_YxIyzQps_lJy_KvRXTKKNkJ3r1V42pd1VGmKmk-1QbwJRllFoF6Cbq_RvcLUWmFiJyffQUFETebqeay09CDxGsiduoYM09kDNFTVrsG7xXjBw6M5qidb3v5DwKz7EfwgvpWHtPDSk-KTL6tB60GEzr-SvCS8ROxBvJ02LSjuszcQrwQg2cB4bvxsaOfNNi3-pXLnDxCTx6K6DsCfz1iTvbQJ4-yKLgEFza8E6MEZ-Su67qwGi8-5P54-j_Tfwmw9NkZBQAA)


Notes :
* This PR changes the signature of the `$.action()` function. I don't know if this should be considered as an incompatibilit, and if we have to manage the 2 types of calls (before/after this PR)
* I have not created the chanset, because I don't known what king of change to select : patch or minor ?


### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
