### PR TITLE
fix: more robust re-subscribe detection for `fromStore`

### DIFF
--- a/.changeset/eighty-pianos-sip.md
+++ b/.changeset/eighty-pianos-sip.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: more robust re-subscribe detection for `fromStore`

--- a/packages/svelte/src/store/index-client.js
+++ b/packages/svelte/src/store/index-client.js
@@ -130,9 +130,12 @@ export function fromStore(store) {
 				subscribers += 1;
 
 				return () => {
-					subscribers -= 1;
-
 					tick().then(() => {
+						// Only count down after timeout, else we would reach 0 before our own render effect reruns,
+						// but reach 1 again when the tick callback of the prior teardown runs. That would mean we
+						// re-subcribe unnecessarily and create a memory leak because the old subscription is never cleaned up.
+						subscribers -= 1;
+
 						if (subscribers === 0) {
 							unsubscribe();
 						}

--- a/packages/svelte/tests/store/test.ts
+++ b/packages/svelte/tests/store/test.ts
@@ -666,6 +666,33 @@ describe('fromStore', () => {
 		teardown();
 	});
 
+	it('creates state from a writable store that updates after timeout', async () => {
+		const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
+		const store = {
+			subscribe: (cb: any) => {
+				// new object each time to force updates of underlying signals,
+				// to test the whole thing doesn't rerun more often than it should
+				setTimeout(() => cb({}), 0);
+				return () => {};
+			}
+		};
+
+		const count = fromStore(store);
+		const log: any[] = [];
+
+		const teardown = effect_root(() => {
+			render_effect(() => {
+				log.push(count.current);
+			});
+		});
+
+		await wait();
+
+		assert.deepEqual(log, [undefined, {}]);
+
+		teardown();
+	});
+
 	it('creates state from a readable store', () => {
 		const store = readable(0);
 


### PR DESCRIPTION
Only count down after timeout, else we would reach 0 before our own render effect reruns, but reach 1 again when the tick callback of the prior teardown runs. That would mean we re-subcribe unnecessarily and create a memory leak because the old subscription is never cleaned up.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
