### PR TITLE
docs: update 02-getting-started.md

### DIFF
--- a/documentation/docs/01-introduction/02-getting-started.md
+++ b/documentation/docs/01-introduction/02-getting-started.md
@@ -13,7 +13,7 @@ npm run dev
 
 Don't worry if you don't know Svelte yet! You can ignore all the nice features SvelteKit brings on top for now and dive into it later.
 
-### Alternatives to SvelteKit
+## Alternatives to SvelteKit
 
 You can also use Svelte directly with Vite by running `npm create vite@latest` and selecting the `svelte` option. With this, `npm run build` will generate HTML, JS and CSS files inside the `dist` directory using [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte). In most cases, you will probably need to [choose a routing library](faq#Is-there-a-router) as well.
 


### PR DESCRIPTION
looks a little weird having an `<h3>` before the first `<h2>`, and there's no particular reason the hierarchy needs to be this way