### PR TITLE
fix: ensure effect_tracking correctly handles tracking reactions

### DIFF
--- a/.changeset/clean-badgers-battle.md
+++ b/.changeset/clean-badgers-battle.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure effect_tracking correctly handles tracking reactions

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -15,7 +15,8 @@ import {
 	set_is_destroying_effect,
 	set_is_flushing_effect,
 	set_signal_status,
-	untrack
+	untrack,
+	skip_reaction
 } from '../runtime.js';
 import {
 	DIRTY,
@@ -167,7 +168,9 @@ export function effect_tracking() {
 		return false;
 	}
 
-	return (active_reaction.f & UNOWNED) === 0;
+	// If it's skipped, that's because we're inside an unowned
+	// that is not being tracked by another reaction
+	return !skip_reaction;
 }
 
 /**

--- a/packages/svelte/src/store/index-client.js
+++ b/packages/svelte/src/store/index-client.js
@@ -112,9 +112,9 @@ export function fromStore(store) {
 	let unsubscribe = noop;
 
 	function current() {
-		get_source(version);
-
 		if (effect_tracking()) {
+			get_source(version);
+
 			render_effect(() => {
 				if (subscribers === 0) {
 					let ran = false;

--- a/packages/svelte/src/store/index-client.js
+++ b/packages/svelte/src/store/index-client.js
@@ -112,9 +112,9 @@ export function fromStore(store) {
 	let unsubscribe = noop;
 
 	function current() {
-		if (effect_tracking()) {
-			get_source(version);
+		get_source(version);
 
+		if (effect_tracking()) {
 			render_effect(() => {
 				if (subscribers === 0) {
 					let ran = false;

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-10/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-10/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		let btn1 = target.querySelector('button');
+
+		btn1?.click();
+		flushSync();
+
+		btn1?.click();
+		flushSync();
+
+		btn1?.click();
+		flushSync();
+
+		assert.deepEqual(logs, ['light', 'dark', 'light']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-10/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-10/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { store, themeState } from './theme.svelte.js';
+
+	let i = 0;
+
+	const increment = () => {
+		store.update(() => ({ theme: ++i % 2 == 0 ? 'dark' : 'light' }));
+	}
+</script>
+
+<button onclick={increment}>+</button>
+
+{themeState.value.theme}

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-10/theme.svelte.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-10/theme.svelte.js
@@ -1,0 +1,18 @@
+import { fromStore, writable } from 'svelte/store';
+
+export const store = writable({ theme: 'dark' });
+
+class ThemeState {
+	#storeState = fromStore(store);
+	value = $derived(this.#storeState.current);
+
+	constructor() {
+		$effect.root(() => {
+			$effect(() => {
+				console.log(this.value.theme);
+			});
+		});
+	}
+}
+
+export const themeState = new ThemeState();


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14002. In `effect_tracking` we shouldn't be tracking if the derived is purely unowned – because even unowned deriveds can be reactive if they're used in another reactive context – thus `$effect.tracking()` should return `true` in those cases.