### PR TITLE
fix: ensure toStore subscription correctly syncs latest value

### DIFF
--- a/.changeset/shaggy-frogs-fetch.md
+++ b/.changeset/shaggy-frogs-fetch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure toStore subscription correctly syncs latest value

--- a/packages/svelte/src/store/index-client.js
+++ b/packages/svelte/src/store/index-client.js
@@ -43,7 +43,7 @@ export { derived, get, readable, readonly, writable } from './shared/index.js';
  */
 export function toStore(get, set) {
 	let init_value = get();
-	const store = writable(get(), (set) => {
+	const store = writable(init_value, (set) => {
 		// If the value has changed before we call subscribe, then
 		// we need to treat the value as already having run
 		let ran = init_value !== get();

--- a/packages/svelte/src/store/index-client.js
+++ b/packages/svelte/src/store/index-client.js
@@ -42,8 +42,11 @@ export { derived, get, readable, readonly, writable } from './shared/index.js';
  * @returns {Writable<V> | Readable<V>}
  */
 export function toStore(get, set) {
+	let init_value = get();
 	const store = writable(get(), (set) => {
-		let ran = false;
+		// If the value has changed before we call subscribe, then
+		// we need to treat the value as already having run
+		let ran = init_value !== get();
 
 		// TODO do we need a different implementation on the server?
 		const teardown = effect_root(() => {

--- a/packages/svelte/tests/runtime-runes/samples/toStore-subscribe/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/toStore-subscribe/_config.js
@@ -1,0 +1,6 @@
+import { test } from '../../test';
+
+export default test({
+	html: `1`,
+	mode: ['client', 'hydrate']
+});

--- a/packages/svelte/tests/runtime-runes/samples/toStore-subscribe/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/toStore-subscribe/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { toStore } from 'svelte/store';
+
+	let count = $state(0);
+
+	const store = toStore(
+		() => count,
+		(v) => (count = v)
+	);
+
+	store.set(1);
+</script>
+
+{$store}


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/14010. Whilst reading the store value with a `console.log` isn't guaranteed to be the latest value (as stores are subscriptions and effects run on microtasks) the template should definitely eventually get in sync, and from the example, it doesn't on initial render. This PR fixes that by checking if intermittent value changes during subscription.