### PR TITLE
fix: ensure custom element attribute/prop changes are in their own context

### DIFF
--- a/.changeset/wild-parents-begin.md
+++ b/.changeset/wild-parents-begin.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure custom element attribute/prop changes are in their own context

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/element-effect-context/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/element-effect-context/_config.js
@@ -1,0 +1,24 @@
+import { test } from '../../assert';
+const tick = () => Promise.resolve();
+
+export default test({
+	async test({ assert, target }) {
+		target.innerHTML = '<my-app/>';
+		await tick();
+		await tick();
+
+		/** @type {any} */
+		const el = target.querySelector('my-app');
+		const button = el.shadowRoot.querySelector('button');
+		const p = el.shadowRoot.querySelector('my-tracking').shadowRoot.querySelector('p');
+
+		assert.equal(button.innerHTML, '0');
+		assert.equal(p.innerHTML, 'false');
+
+		button.click();
+		await tick();
+
+		assert.equal(button.innerHTML, '1');
+		assert.equal(p.innerHTML, 'false');
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/element-effect-context/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/element-effect-context/main.svelte
@@ -12,7 +12,7 @@
 
         constructor() {
             super();
-            this.attachShadow({ mode: 'open' });tracking
+            this.attachShadow({ mode: 'open' });
         }
 
 		render() {

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/element-effect-context/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/element-effect-context/main.svelte
@@ -1,0 +1,32 @@
+<svelte:options customElement="my-app" />
+
+<script module>
+	class Tracking extends HTMLElement {
+		static observedAttributes = ["count"];
+        tracking = false;
+
+        set count(_) {
+            this.tracking = $effect.tracking();
+            this.render();
+        }
+
+        constructor() {
+            super();
+            this.attachShadow({ mode: 'open' });tracking
+        }
+
+		render() {
+			this.shadowRoot.innerHTML = `<p>${this.tracking}</p>`;
+		}
+	}
+
+	customElements.define("my-tracking", Tracking);
+</script>
+
+<script>
+	import "./Counter.svelte";
+    let count = $state(0);
+</script>
+
+<button onclick={() => (count += 1)}>{count}</button>
+<my-tracking {count}></my-tracking>

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/element-effect-context/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/element-effect-context/main.svelte
@@ -24,7 +24,6 @@
 </script>
 
 <script>
-	import "./Counter.svelte";
     let count = $state(0);
 </script>
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/13848.

When we set custom element attributes/props, we should be doing so without the current effect/reaction active. Otherwise, the custom element lifecycle might attach effects/dependencies to the wrong reaction and all manner of things can incorrectly occur. I tried to create a test for this using our Playwright testing but I couldn't get it to load up multiple custom elements so I gave up.