### PR TITLE
fix: don't access requestAnimationFrame eagerly

### DIFF
--- a/packages/svelte/src/internal/client/timing.js
+++ b/packages/svelte/src/internal/client/timing.js
@@ -3,13 +3,11 @@ import { noop } from '../shared/utils.js';
 
 import { BROWSER } from 'esm-env';
 
-const request_animation_frame = BROWSER ? requestAnimationFrame : noop;
-
 const now = BROWSER ? () => performance.now() : () => Date.now();
 
 /** @type {Raf} */
 export const raf = {
-	tick: /** @param {any} _ */ (_) => request_animation_frame(_),
+	tick: /** @param {any} _ */ (_) => (BROWSER ? requestAnimationFrame : noop)(_),
 	now: () => now(),
 	tasks: new Set()
 };


### PR DESCRIPTION
closes https://github.com/sveltejs/svelte/issues/13961

allows testing some browser code without jsdom

performance-wise these are equivalent because rollup will replace `BROWSER` and evaluate the ternary at compilation time