### PR TITLE
fix: ensure element effects are executed in the correct order

### DIFF
--- a/.changeset/witty-fishes-cover.md
+++ b/.changeset/witty-fishes-cover.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure element effects are executed in the correct order

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
@@ -245,7 +245,7 @@ export function BindDirective(node, context) {
 		const has_action_directive =
 			parent.type === 'RegularElement' && parent.attributes.find((a) => a.type === 'UseDirective');
 
-		context.state.after_update.push(
+		context.state.init.push(
 			b.stmt(has_action_directive ? b.call('$.effect', b.thunk(call)) : call)
 		);
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -11,11 +11,7 @@ import {
 } from '../../../../../utils.js';
 import { escape_html } from '../../../../../escaping.js';
 import { dev, is_ignored, locator } from '../../../../state.js';
-import {
-	get_attribute_expression,
-	is_event_attribute,
-	is_text_attribute
-} from '../../../../utils/ast.js';
+import { is_event_attribute, is_text_attribute } from '../../../../utils/ast.js';
 import * as b from '../../../../utils/builders.js';
 import { is_custom_element_node } from '../../../nodes.js';
 import { clean_nodes, determine_namespace_for_children } from '../../utils.js';
@@ -158,17 +154,15 @@ export function RegularElement(node, context) {
 	}
 
 	/** @type {typeof state} */
-	const element_after_update_state = { ...context.state, after_update: [] };
+	const element_state = { ...context.state, init: [], after_update: [] };
 
 	for (const attribute of other_directives) {
 		if (attribute.type === 'OnDirective') {
 			const handler = /** @type {Expression} */ (context.visit(attribute));
 
-			element_after_update_state.after_update.push(
-				b.stmt(has_use ? b.call('$.effect', b.thunk(handler)) : handler)
-			);
+			element_state.init.push(b.stmt(has_use ? b.call('$.effect', b.thunk(handler)) : handler));
 		} else {
-			context.visit(attribute, element_after_update_state);
+			context.visit(attribute, element_state);
 		}
 	}
 
@@ -399,20 +393,19 @@ export function RegularElement(node, context) {
 		context.state.init.push(
 			b.block([
 				...child_state.init,
+				...element_state.init,
 				child_state.update.length > 0 ? build_render_statement(child_state.update) : b.empty,
 				...child_state.after_update,
-				...element_after_update_state.after_update
+				...element_state.after_update
 			])
 		);
 	} else if (node.fragment.metadata.dynamic) {
-		context.state.init.push(...child_state.init);
+		context.state.init.push(...child_state.init, ...element_state.init);
 		context.state.update.push(...child_state.update);
-		context.state.after_update.push(
-			...child_state.after_update,
-			...element_after_update_state.after_update
-		);
+		context.state.after_update.push(...child_state.after_update, ...element_state.after_update);
 	} else {
-		context.state.after_update.push(...element_after_update_state.after_update);
+		context.state.init.push(...element_state.init);
+		context.state.after_update.push(...element_state.after_update);
 	}
 
 	if (lookup.has('dir')) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/UseDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/UseDirective.js
@@ -29,6 +29,6 @@ export function UseDirective(node, context) {
 	}
 
 	// actions need to run after attribute updates in order with bindings/events
-	context.state.after_update.push(b.stmt(b.call('$.action', ...args)));
+	context.state.init.push(b.stmt(b.call('$.action', ...args)));
 	context.next();
 }

--- a/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
@@ -1,4 +1,4 @@
-import { render_effect, teardown } from '../../../reactivity/effects.js';
+import { effect, render_effect, teardown } from '../../../reactivity/effects.js';
 import { listen } from './shared.js';
 
 /**
@@ -14,19 +14,21 @@ export function bind_content_editable(property, element, get, set = get) {
 		set(element[property]);
 	});
 
-	render_effect(() => {
-		var value = get();
+	effect(() => {
+		render_effect(() => {
+			var value = get();
 
-		if (element[property] !== value) {
-			if (value == null) {
-				// @ts-ignore
-				var non_null_value = element[property];
-				set(non_null_value);
-			} else {
-				// @ts-ignore
-				element[property] = value + '';
+			if (element[property] !== value) {
+				if (value == null) {
+					// @ts-ignore
+					var non_null_value = element[property];
+					set(non_null_value);
+				} else {
+					// @ts-ignore
+					element[property] = value + '';
+				}
 			}
-		}
+		});
 	});
 }
 

--- a/packages/svelte/tests/runtime-legacy/samples/deconflict-contextual-action/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/deconflict-contextual-action/_config.js
@@ -14,6 +14,6 @@ export default test({
 		};
 	},
 	test({ assert }) {
-		assert.deepEqual(result, ['each_action', 'import_action']); // ideally this would be reversed, but it doesn't matter a whole lot
+		assert.deepEqual(result, ['import_action', 'each_action']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-6/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-6/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, logs }) {
+		assert.deepEqual(logs, [0, 1, 2, 3, 4, 5, 6]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-6/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-6/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	function create_action() {
+		let index = 0;
+		return () => {
+			console.log(index++);
+		};
+	}
+
+	const content = create_action();
+</script>
+
+{#if true}
+	<div use:content></div>
+{/if}
+
+<div use:content></div>
+
+{#each { length: 5 } as _}
+	<div>
+		<div use:content></div>
+	</div>
+{/each}

--- a/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/state-proxy-literal/_expected/client/index.svelte.js
@@ -17,16 +17,16 @@ export default function State_proxy_literal($$anchor) {
 	var input = $.first_child(fragment);
 
 	$.remove_input_defaults(input);
+	$.bind_value(input, () => $.get(str), ($$value) => $.set(str, $$value));
 
 	var input_1 = $.sibling(input, 2);
 
 	$.remove_input_defaults(input_1);
+	$.bind_value(input_1, () => $.get(tpl), ($$value) => $.set(tpl, $$value));
 
 	var button = $.sibling(input_1, 2);
 
 	button.__click = [reset, str, tpl];
-	$.bind_value(input, () => $.get(str), ($$value) => $.set(str, $$value));
-	$.bind_value(input_1, () => $.get(tpl), ($$value) => $.set(tpl, $$value));
 	$.append($$anchor, fragment);
 }
 


### PR DESCRIPTION
This PR changes the ordering of event handlers, bindings and actions so they're now created in order of usage – which means that they fall in line with the logic and control-flow ordering too. However, this has meant that we now wrap bindings with an `effect` which sucks a bit, but I couldn't think of any other way. This is to ensure that the bindings get processed after the `template_effect`. 

I wonder if we can somehow make the `template_effect` happen straightaway. @dummdidumm might be a good one to pair up on.