### PR TITLE
fix: ensure element effects are executed in the correct order

### DIFF
--- a/.changeset/thin-icons-sort.md
+++ b/.changeset/thin-icons-sort.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure element effects are executed in the correct order

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BindDirective.js
@@ -245,8 +245,12 @@ export function BindDirective(node, context) {
 		const has_action_directive =
 			parent.type === 'RegularElement' && parent.attributes.find((a) => a.type === 'UseDirective');
 
-		context.state.after_update.push(
-			b.stmt(has_action_directive ? b.call('$.effect', b.thunk(call)) : call)
-		);
+		if (has_action_directive) {
+			context.state.init.push(
+				b.stmt(has_action_directive ? b.call('$.effect', b.thunk(call)) : call)
+			);
+		} else {
+			context.state.after_update.push(b.stmt(call));
+		}
 	}
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/UseDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/UseDirective.js
@@ -29,6 +29,6 @@ export function UseDirective(node, context) {
 	}
 
 	// actions need to run after attribute updates in order with bindings/events
-	context.state.after_update.push(b.stmt(b.call('$.action', ...args)));
+	context.state.init.push(b.stmt(b.call('$.action', ...args)));
 	context.next();
 }

--- a/packages/svelte/tests/runtime-legacy/samples/deconflict-contextual-action/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/deconflict-contextual-action/_config.js
@@ -14,6 +14,6 @@ export default test({
 		};
 	},
 	test({ assert }) {
-		assert.deepEqual(result, ['each_action', 'import_action']); // ideally this would be reversed, but it doesn't matter a whole lot
+		assert.deepEqual(result, ['import_action', 'each_action']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-6/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-6/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, logs }) {
+		assert.deepEqual(logs, [0, 1, 2, 3, 4, 5, 6]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-6/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/lifecycle-render-order-for-children-6/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	function create_action() {
+		let index = 0;
+		return () => {
+			console.log(index++);
+		};
+	}
+
+	const content = create_action();
+</script>
+
+{#if true}
+	<div use:content></div>
+{/if}
+
+<div use:content></div>
+
+{#each { length: 5 } as _}
+	<div>
+		<div use:content></div>
+	</div>
+{/each}


### PR DESCRIPTION
This PR changes the ordering of event handlers, bindings and actions so they're now created in order of usage – which means that they fall in line with the logic and control-flow ordering too.