### PR TITLE
docs: Update in and out docs to show the imports

### DIFF
--- a/documentation/docs/03-template-syntax/14-in-and-out.md
+++ b/documentation/docs/03-template-syntax/14-in-and-out.md
@@ -5,6 +5,10 @@ title: in: and out:
 The `in:` and `out:` directives are identical to [`transition:`](transition), except that the resulting transitions are not bidirectional — an `in` transition will continue to 'play' alongside the `out` transition, rather than reversing, if the block is outroed while the transition is in progress. If an out transition is aborted, transitions will restart from scratch.
 
 ```svelte
+<script>
+  import { fade, fly } from 'svelte/transition';
+</script>
+
 {#if visible}
 	<div in:fly out:fade>flies in, fades out</div>
 {/if}

--- a/documentation/docs/03-template-syntax/14-in-and-out.md
+++ b/documentation/docs/03-template-syntax/14-in-and-out.md
@@ -7,7 +7,14 @@ The `in:` and `out:` directives are identical to [`transition:`](transition), ex
 ```svelte
 <script>
   import { fade, fly } from 'svelte/transition';
+  
+  let visible = $state(false);
 </script>
+
+<label>
+  <input type="checkbox" bind:checked={visible}>
+  visible
+</label>
 
 {#if visible}
 	<div in:fly out:fade>flies in, fades out</div>


### PR DESCRIPTION
This is my first PR in the docs. I'd like to contribute more, so please be easy on me. I noticed the [in and out](https://svelte.dev/docs/svelte/in-and-out) docs wouldn't work without the correct import from transition. This will make it a bit obvious.
