### PR TITLE
chore: add link to sync-docs README

### DIFF
--- a/.github/workflows/sync-request.yml
+++ b/.github/workflows/sync-request.yml
@@ -1,3 +1,4 @@
+# https://github.com/sveltejs/svelte.dev/blob/main/apps/svelte.dev/scripts/sync-docs/README.md
 name: Sync request
 
 on:


### PR DESCRIPTION
goes with https://github.com/sveltejs/svelte.dev/pull/730