### PR TITLE
add parameters to `in:fly`

### DIFF
--- a/documentation/docs/03-template-syntax/14-in-and-out.md
+++ b/documentation/docs/03-template-syntax/14-in-and-out.md
@@ -17,6 +17,6 @@ The `in:` and `out:` directives are identical to [`transition:`](transition), ex
 </label>
 
 {#if visible}
-	<div in:fly out:fade>flies in, fades out</div>
+	<div in:fly={{ y: 200 }} out:fade>flies in, fades out</div>
 {/if}
 ```


### PR DESCRIPTION
Without a `y` value, `fly` is indistinguishable from `fade`