### PR TITLE
docs: typo `footer` instead it was `header`

### DIFF
--- a/documentation/docs/07-misc/07-v5-migration-guide.md
+++ b/documentation/docs/07-misc/07-v5-migration-guide.md
@@ -376,7 +376,7 @@ If you wanted multiple UI placeholders, you had to use named slots. In Svelte 5,
 </main>
 
 <footer>
-	---<slot name="header" />---
+	---<slot name="footer" />---
 	+++{@render footer()}+++
 </footer>
 ```


### PR DESCRIPTION
```diff
-<footer>
-  ---<slot name="header" />---
-  +++{@render footer()}+++
-</footer>

+<footer>
+  ---<slot name="footer" />---
+  +++{@render footer()}+++
+</footer>
```
this slot name should be `footer` instead it was `header`
