### PR TITLE
fix: switch around conditionals in type

### DIFF
--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -251,10 +251,10 @@ export type ComponentProps<Comp extends SvelteComponent | Component<any, any>> =
  * ```
  */
 export type ComponentExports<TComponent extends Component<any, any> | typeof SvelteComponent<any>> =
-	TComponent extends typeof SvelteComponent<any>
-		? InstanceType<TComponent>
-		: TComponent extends Component<any, infer TExports>
-			? TExports
+	TComponent extends Component<any, infer TExports>
+		? TExports
+		: TComponent extends typeof SvelteComponent<any>
+			? InstanceType<TComponent>
 			: never;
 
 /**

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -248,10 +248,10 @@ declare module 'svelte' {
 	 * ```
 	 */
 	export type ComponentExports<TComponent extends Component<any, any> | typeof SvelteComponent<any>> =
-		TComponent extends typeof SvelteComponent<any>
-			? InstanceType<TComponent>
-			: TComponent extends Component<any, infer TExports>
-				? TExports
+		TComponent extends Component<any, infer TExports>
+			? TExports
+			: TComponent extends typeof SvelteComponent<any>
+				? InstanceType<TComponent>
 				: never;
 
 	/**


### PR DESCRIPTION
language-tools sometimes creates a type which satisfies both conditions, and we want the new one to take precedence.

Follow-up to #13441, no changeset because not released yet