### PR TITLE
docs: improve lazy import example

### DIFF
--- a/documentation/docs/03-template-syntax/05-await.md
+++ b/documentation/docs/03-template-syntax/05-await.md
@@ -72,8 +72,8 @@ Similarly, if you only want to show the error state, you can omit the `then` blo
 > [!NOTE] You can use `#await` with [`import(...)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) to render components lazily:
 >
 > ```svelte
-> {#await import('./Component.svelte') then module}
-> 	<module.default />
+> {#await import('./Component.svelte') then { default: Component }}
+> 	<Component />
 > {/await}
 > ```
 

--- a/documentation/docs/03-template-syntax/05-await.md
+++ b/documentation/docs/03-template-syntax/05-await.md
@@ -69,11 +69,11 @@ Similarly, if you only want to show the error state, you can omit the `then` blo
 {/await}
 ```
 
-> [!NOTE] You can use `#await` to render dynamic components with the help of the `import()` function:
+> [!NOTE] You can use `#await` with [`import(...)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) to render components lazily:
 >
 > ```svelte
-> {#await import('./Component.svelte') then Component}
-> 	<Component.default />
+> {#await import('./Component.svelte') then module}
+> 	<module.default />
 > {/await}
 > ```
 


### PR DESCRIPTION
The language added in #13993 is a little confusing:

- it's not a 'dynamic component', it's just a component
- `import()` isn't a function, it's a function-like expression
- the result of calling it is a module, not a component