### PR TITLE
docs: fix runtime-warnings page

### DIFF
--- a/documentation/docs/98-reference/30-runtime-warnings.md
+++ b/documentation/docs/98-reference/30-runtime-warnings.md
@@ -4,8 +4,8 @@ title: 'Runtime warnings'
 
 ## Client errors
 
-@include .generated/client-errors.md
+@include .generated/client-warnings.md
 
 ## Shared errors
 
-@include .generated/shared-errors.md
+@include .generated/shared-warnings.md

--- a/documentation/docs/98-reference/30-runtime-warnings.md
+++ b/documentation/docs/98-reference/30-runtime-warnings.md
@@ -2,10 +2,10 @@
 title: 'Runtime warnings'
 ---
 
-## Client errors
+## Client warnings
 
 @include .generated/client-warnings.md
 
-## Shared errors
+## Shared warnings
 
 @include .generated/shared-warnings.md


### PR DESCRIPTION
this was importing the wrong stuff