### PR TITLE
fix: recognize all custom element prop definitions

### DIFF
--- a/.changeset/warm-eyes-protect.md
+++ b/.changeset/warm-eyes-protect.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: recognize all custom element prop definitions

--- a/documentation/docs/07-misc/04-custom-elements.md
+++ b/documentation/docs/07-misc/04-custom-elements.md
@@ -49,6 +49,8 @@ console.log(el.name);
 el.name = 'everybody';
 ```
 
+Note that you need to list out all properties explicitly, i.e. doing `let props = $props()` without declaring `props` in the [component options](#Component-options) means that Svelte can't know which props to expose as properties on the DOM element.
+
 ## Component lifecycle
 
 Custom elements are created from Svelte components using a wrapper approach. This means the inner Svelte component has no knowledge that it is a custom element. The custom element wrapper takes care of handling its lifecycle appropriately.

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/props-rune-attributes/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/props-rune-attributes/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../assert';
+const tick = () => Promise.resolve();
+
+export default test({
+	async test({ assert, target }) {
+		target.innerHTML = '<custom-element foo-bar="1" bar="2" b-az="3"></custom-element>';
+		await tick();
+
+		/** @type {any} */
+		const el = target.querySelector('custom-element');
+
+		assert.htmlEqual(
+			el.shadowRoot.innerHTML,
+			`
+			<p>1</p>
+			<p>2</p>
+			<p>3</p>
+		`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/props-rune-attributes/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/props-rune-attributes/main.svelte
@@ -1,0 +1,14 @@
+<svelte:options
+	customElement={{
+		tag: "custom-element",
+		props: { foo: { attribute: 'foo-bar' } },
+	}}
+/>
+
+<script>
+	let { bar, 'b-az': baz, ...rest } = $props();
+</script>
+
+<p>{rest.foo}</p>
+<p>{bar}</p>
+<p>{baz}</p>

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/props-rune-attributes/my-widget.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/props-rune-attributes/my-widget.svelte
@@ -1,0 +1,14 @@
+<svelte:options
+	customElement={{
+		tag: "my-widget",
+		props: { foo: { attribute: 'foo-bar' } },
+	}}
+/>
+
+<script>
+	let { bar, 'b-az': baz, ...rest } = $props();
+</script>
+
+<p>{rest.foo}</p>
+<p>{bar}</p>
+<p>{baz}</p>


### PR DESCRIPTION
We didn't account for the `$props` rune being writtin in a way that makes some props unknown, and they would only be visible through the `customElement.props` definition. This changes the iteration to account for that and also adds a note to the documentation that you need to list out the properties explicitly.

fixes #13785

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
