### PR TITLE
docs: note browser condition earlier

### DIFF
--- a/documentation/docs/07-misc/02-testing.md
+++ b/documentation/docs/07-misc/02-testing.md
@@ -21,8 +21,17 @@ Then adjust your `vite.config.js`:
 /// file: vite.config.js
 import { defineConfig } from +++'vitest/config'+++;
 
-export default defineConfig({ /* ... */ })
+export default defineConfig({
+	// ...
+	// Tell Vitest to use the `browser` entry points in `package.json` files, even though it's running in Node
+	resolve: process.env.VITEST
+		? {
+				conditions: ['browser']
+			}
+		: undefined
 ```
+
+> [!NOTE] If loading the browser version of all your packages is undesireable, because you for example also test backend libraries, [you may need to resort to an alias configuration](https://github.com/testing-library/svelte-testing-library/issues/222#issuecomment-1909993331)
 
 You can now write unit tests for code inside your `.js/.ts` files:
 

--- a/documentation/docs/07-misc/02-testing.md
+++ b/documentation/docs/07-misc/02-testing.md
@@ -31,7 +31,7 @@ export default defineConfig({
 		: undefined
 ```
 
-> [!NOTE] If loading the browser version of all your packages is undesireable, because you for example also test backend libraries, [you may need to resort to an alias configuration](https://github.com/testing-library/svelte-testing-library/issues/222#issuecomment-1909993331)
+> [!NOTE] If loading the browser version of all your packages is undesirable, because (for example) you also test backend libraries, [you may need to resort to an alias configuration](https://github.com/testing-library/svelte-testing-library/issues/222#issuecomment-1909993331)
 
 You can now write unit tests for code inside your `.js/.ts` files:
 


### PR DESCRIPTION
The browser condition is also necessary to test runes, so it makes sense to add it to the first occurence to the vite config. Also add a note about more fine-grained alias conditions.

Closes #13961

