### PR TITLE
fix: ensure SvelteMap and SvelteSet work with generators in dev

### DIFF
--- a/.changeset/selfish-chicken-argue.md
+++ b/.changeset/selfish-chicken-argue.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure SvelteMap and SvelteSet work with generators in dev

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -1,4 +1,5 @@
 /** @import { Source } from '#client' */
+import { DEV } from 'esm-env';
 import { set, source } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { increment } from './utils.js';
@@ -19,6 +20,9 @@ export class SvelteMap extends Map {
 	 */
 	constructor(value) {
 		super();
+
+		// If the value is invalid then the native exception will fire here
+		if (DEV) value = new Map(value);
 
 		if (value) {
 			for (var [key, v] of value) {

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -1,5 +1,4 @@
 /** @import { Source } from '#client' */
-import { DEV } from 'esm-env';
 import { set, source } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { increment } from './utils.js';
@@ -20,9 +19,6 @@ export class SvelteMap extends Map {
 	 */
 	constructor(value) {
 		super();
-
-		// If the value is invalid then the native exception will fire here
-		if (DEV) new Map(value);
 
 		if (value) {
 			for (var [key, v] of value) {

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -29,7 +29,7 @@ export class SvelteSet extends Set {
 		if (DEV) value = new Set(value);
 
 		if (value) {
-			for (let element of value) {
+			for (var element of value) {
 				super.add(element);
 			}
 			this.#size.v = super.size;

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -26,8 +26,9 @@ export class SvelteSet extends Set {
 		super();
 
 		// If the value is invalid then the native exception will fire here
-		// @ts-ignore
-		if (DEV) value = new Set(Array.from(value));
+		if (DEV) {
+			value = new Set(value);
+		}
 
 		if (value) {
 			for (let element of value) {

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -1,5 +1,4 @@
 /** @import { Source } from '#client' */
-import { DEV } from 'esm-env';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { increment } from './utils.js';
@@ -25,11 +24,8 @@ export class SvelteSet extends Set {
 	constructor(value) {
 		super();
 
-		// If the value is invalid then the native exception will fire here
-		if (DEV) new Set(value);
-
 		if (value) {
-			for (var element of value) {
+			for (let element of value) {
 				super.add(element);
 			}
 			this.#size.v = super.size;

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -1,4 +1,5 @@
 /** @import { Source } from '#client' */
+import { DEV } from 'esm-env';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { get } from '../internal/client/runtime.js';
 import { increment } from './utils.js';
@@ -23,6 +24,10 @@ export class SvelteSet extends Set {
 	 */
 	constructor(value) {
 		super();
+
+		// If the value is invalid then the native exception will fire here
+		// @ts-ignore
+		if (DEV) value = new Set(Array.from(value));
 
 		if (value) {
 			for (let element of value) {

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -26,9 +26,7 @@ export class SvelteSet extends Set {
 		super();
 
 		// If the value is invalid then the native exception will fire here
-		if (DEV) {
-			value = new Set(value);
-		}
+		if (DEV) value = new Set(value);
 
 		if (value) {
 			for (let element of value) {

--- a/packages/svelte/tests/runtime-runes/samples/svelte-set-generators/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-set-generators/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	html: `1`
+});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-set-generators/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-set-generators/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { SvelteSet } from 'svelte/reactivity';
+
+	function *generator() {
+		yield 1;
+	}
+
+	let gen = new SvelteSet(generator());
+</script>
+
+{#each gen as item}
+	{item}
+{/each}
+


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14094. Turns out that passing the value to a Set/Map in DEV causes the generator to close and yield before we get a chance to iterate over it. So if we do the logic in DEV to create a Set/Map from the value then we should probably use that instead to iterate over.