### PR TITLE
docs: fix description

### DIFF
--- a/packages/svelte/src/compiler/types/index.d.ts
+++ b/packages/svelte/src/compiler/types/index.d.ts
@@ -110,7 +110,7 @@ export interface CompileOptions extends ModuleCompileOptions {
 	 */
 	cssHash?: CssHashGetter;
 	/**
-	 * If `true`, your HTML comments will be preserved during server-side rendering. By default, they are stripped out.
+	 * If `true`, your HTML comments will be preserved in the output. By default, they are stripped out.
 	 *
 	 * @default false
 	 */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -812,7 +812,7 @@ declare module 'svelte/compiler' {
 		 */
 		cssHash?: CssHashGetter;
 		/**
-		 * If `true`, your HTML comments will be preserved during server-side rendering. By default, they are stripped out.
+		 * If `true`, your HTML comments will be preserved in the output. By default, they are stripped out.
 		 *
 		 * @default false
 		 */
@@ -2183,7 +2183,7 @@ declare module 'svelte/types/compiler/interfaces' {
 		 */
 		cssHash?: CssHashGetter;
 		/**
-		 * If `true`, your HTML comments will be preserved during server-side rendering. By default, they are stripped out.
+		 * If `true`, your HTML comments will be preserved in the output. By default, they are stripped out.
 		 *
 		 * @default false
 		 */


### PR DESCRIPTION
Since Svelte 5, comments are also preserved on the client

Noticed this while closing #6805
