### PR TITLE
fix: reset title element to previous value on removal

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/TitleElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/TitleElement.js
@@ -14,11 +14,10 @@ export function TitleElement(node, context) {
 		context.state
 	);
 
-	const statement = b.stmt(b.assignment('=', b.id('$.document.title'), value));
+	context.state.init.push(b.stmt(b.call('$.title', value)));
 
 	if (has_state) {
+		const statement = b.stmt(b.assignment('=', b.id('$.document.title'), value));
 		context.state.update.push(statement);
-	} else {
-		context.state.init.push(statement);
 	}
 }

--- a/packages/svelte/src/internal/client/dom/elements/misc.js
+++ b/packages/svelte/src/internal/client/dom/elements/misc.js
@@ -1,3 +1,4 @@
+import { teardown } from '../../reactivity/effects.js';
 import { hydrating } from '../hydration.js';
 import { clear_text_content, get_first_child } from '../operations.js';
 import { queue_micro_task } from '../task.js';
@@ -55,4 +56,15 @@ export function add_form_reset_listener() {
 			{ capture: true }
 		);
 	}
+}
+
+/**
+ * @param {string} text
+ */
+export function title(text) {
+	const previous = document.title;
+	document.title = text;
+	teardown(() => {
+		document.title = previous;
+	});
 }


### PR DESCRIPTION
The started as an attempt to fix #7656, but I now ran into some questions where I'm not sure what's the best answer, to I'm pushing this up as a WIP

The questions:
- is resetting the title to the previous value the correct move? or should we reset it to the empty string?
- assuming we reset it to the previous value, what does happen if you have multiple `title` elements at the same time in different components, and the parent title is set to `A`, then the child title is set to `B`, then the parent title updates its title to `A2`. Upon removal, with this PR, it would go back too `A`. Is that fine?

