### PR TITLE
docs: note what the value of `this` can be on `svelte:element`

### DIFF
--- a/documentation/docs/05-special-elements/05-svelte-element.md
+++ b/documentation/docs/05-special-elements/05-svelte-element.md
@@ -29,3 +29,5 @@ Svelte tries its best to infer the correct namespace from the element's surround
 ```svelte
 <svelte:element this={tag} xmlns="http://www.w3.org/2000/svg" />
 ```
+
+`this` needs to be a valid DOM element tag, things like `#text` or `svelte:head` will not work.


### PR DESCRIPTION
closes #7575
