### PR TITLE
Add same note as in tutorial to documentation for "Dimension bindings"

### DIFF
--- a/documentation/docs/03-template-syntax/11-bind.md
+++ b/documentation/docs/03-template-syntax/11-bind.md
@@ -223,6 +223,8 @@ All visible elements have the following readonly bindings, measured with a `Resi
 </div>
 ```
 
+> [!NOTE] `display: inline` elements do not have a width or height (except for elements with 'intrinsic' dimensions, like `<img>` and `<canvas>`), and cannot be observed with a `ResizeObserver`. You will need to change the `display` style of these elements to something else, such as `inline-block`.
+
 ## bind:this
 
 ```svelte


### PR DESCRIPTION
Since the note from the tutorial is missing from the actual docs, i put the same note into the docs as well. 
Original note: https://svelte.dev/tutorial/svelte/dimensions
