### PR TITLE
fix: ensure migrate keeps inline/trailing comments in $props type definition and produces non-broken code

### DIFF
--- a/.changeset/mean-seas-give.md
+++ b/.changeset/mean-seas-give.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure trailing multiline comments on props produce correct code (#14143#issuecomment-2455702689)

--- a/.changeset/purple-owls-hug.md
+++ b/.changeset/purple-owls-hug.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure migrate keeps inline/trailing comments in $props type definition

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1501,7 +1501,8 @@ function extract_type_and_comment(declarator, state, path) {
 	const trailing_comment_node = /** @type {Node} */ (parent)?.trailingComments?.at(0);
 	const trailing_comment_start = /** @type {any} */ (trailing_comment_node)?.start;
 	const trailing_comment_end = /** @type {any} */ (trailing_comment_node)?.end;
-	let trailing_comment = trailing_comment_node && str.original.substring(trailing_comment_start, trailing_comment_end);
+	let trailing_comment =
+		trailing_comment_node && str.original.substring(trailing_comment_start, trailing_comment_end);
 
 	if (trailing_comment_node) {
 		str.update(trailing_comment_start, trailing_comment_end, '');
@@ -1513,7 +1514,11 @@ function extract_type_and_comment(declarator, state, path) {
 		while (str.original[start] === ' ') {
 			start++;
 		}
-		return { type: str.original.substring(start, declarator.id.typeAnnotation.end), comment, trailing_comment };
+		return {
+			type: str.original.substring(start, declarator.id.typeAnnotation.end),
+			comment,
+			trailing_comment
+		};
 	}
 
 	let cleaned_comment_arr = comment
@@ -1535,7 +1540,7 @@ function extract_type_and_comment(declarator, state, path) {
 	let cleaned_comment = cleaned_comment_arr
 		?.slice(0, first_at_comment !== -1 ? first_at_comment : cleaned_comment_arr.length)
 		.join('\n');
-	
+
 	let cleaned_comment_arr_trailing = trailing_comment
 		?.split('\n')
 		.map((line) =>
@@ -1551,9 +1556,16 @@ function extract_type_and_comment(declarator, state, path) {
 				.replace(/^\*\s*/g, '')
 		)
 		.filter(Boolean);
-	const first_at_comment_trailing = cleaned_comment_arr_trailing?.findIndex((line) => line.startsWith('@'));
+	const first_at_comment_trailing = cleaned_comment_arr_trailing?.findIndex((line) =>
+		line.startsWith('@')
+	);
 	let cleaned_comment_trailing = cleaned_comment_arr_trailing
-		?.slice(0, first_at_comment_trailing !== -1 ? first_at_comment_trailing : cleaned_comment_arr_trailing.length)
+		?.slice(
+			0,
+			first_at_comment_trailing !== -1
+				? first_at_comment_trailing
+				: cleaned_comment_arr_trailing.length
+		)
 		.join('\n');
 
 	// try to find a comment with a type annotation, hinting at jsdoc
@@ -1561,7 +1573,11 @@ function extract_type_and_comment(declarator, state, path) {
 		state.has_type_or_fallback = true;
 		const match = /@type {(.+)}/.exec(comment_node.value);
 		if (match) {
-			return { type: match[1], comment: cleaned_comment, trailing_comment: cleaned_comment_trailing };
+			return {
+				type: match[1],
+				comment: cleaned_comment,
+				trailing_comment: cleaned_comment_trailing
+			};
 		}
 	}
 
@@ -1570,11 +1586,19 @@ function extract_type_and_comment(declarator, state, path) {
 		state.has_type_or_fallback = true; // only assume type if it's trivial to infer - else someone would've added a type annotation
 		const type = typeof declarator.init.value;
 		if (type === 'string' || type === 'number' || type === 'boolean') {
-			return { type, comment: state.uses_ts ? comment : cleaned_comment, trailing_comment: state.uses_ts ? trailing_comment : cleaned_comment_trailing };
+			return {
+				type,
+				comment: state.uses_ts ? comment : cleaned_comment,
+				trailing_comment: state.uses_ts ? trailing_comment : cleaned_comment_trailing
+			};
 		}
 	}
 
-	return { type: 'any', comment: state.uses_ts ? comment : cleaned_comment, trailing_comment: state.uses_ts ? trailing_comment : cleaned_comment_trailing };
+	return {
+		type: 'any',
+		comment: state.uses_ts ? comment : cleaned_comment,
+		trailing_comment: state.uses_ts ? trailing_comment : cleaned_comment_trailing
+	};
 }
 
 // Ensure modifiers are applied in the same order as Svelte 4

--- a/packages/svelte/tests/migrate/samples/jsdoc-with-comments/input.svelte
+++ b/packages/svelte/tests/migrate/samples/jsdoc-with-comments/input.svelte
@@ -24,5 +24,12 @@
 	/**
 	 * This is optional
 	 */
-	 export let optional = {stuff: true};
+	export let optional = {stuff: true};
+	
+	export let inline_commented; // this should stay a comment
+
+	/**
+	 * This comment should be merged
+	 */
+	export let inline_commented_merged; // with this inline comment
 </script>

--- a/packages/svelte/tests/migrate/samples/jsdoc-with-comments/input.svelte
+++ b/packages/svelte/tests/migrate/samples/jsdoc-with-comments/input.svelte
@@ -32,4 +32,12 @@
 	 * This comment should be merged
 	 */
 	export let inline_commented_merged; // with this inline comment
+
+	/*
+	* this is a same-line leading multiline comment
+	**/ export let inline_multiline_leading_comment = 'world';
+
+	export let inline_multiline_trailing_comment = 'world'; /*
+	* this is a same-line trailing multiline comment
+	**/
 </script>

--- a/packages/svelte/tests/migrate/samples/jsdoc-with-comments/output.svelte
+++ b/packages/svelte/tests/migrate/samples/jsdoc-with-comments/output.svelte
@@ -9,6 +9,9 @@
 	
 
 	
+	
+
+	
 	/**
 	 * @typedef {Object} Props
 	 * @property {string} comment - My wonderful comment
@@ -17,6 +20,8 @@
 	 * @property {any} no_comment
 	 * @property {boolean} type_no_comment
 	 * @property {any} [optional] - This is optional
+	 * @property {any} inline_commented - this should stay a comment
+	 * @property {any} inline_commented_merged - This comment should be merged - with this inline comment
 	 */
 
 	/** @type {Props} */
@@ -26,6 +31,8 @@
 		one_line,
 		no_comment,
 		type_no_comment,
-		optional = {stuff: true}
+		optional = {stuff: true},
+		inline_commented,
+		inline_commented_merged
 	} = $props();
 </script>

--- a/packages/svelte/tests/migrate/samples/jsdoc-with-comments/output.svelte
+++ b/packages/svelte/tests/migrate/samples/jsdoc-with-comments/output.svelte
@@ -12,6 +12,9 @@
 	
 
 	
+
+	
+
 	/**
 	 * @typedef {Object} Props
 	 * @property {string} comment - My wonderful comment
@@ -22,6 +25,8 @@
 	 * @property {any} [optional] - This is optional
 	 * @property {any} inline_commented - this should stay a comment
 	 * @property {any} inline_commented_merged - This comment should be merged - with this inline comment
+	 * @property {string} [inline_multiline_leading_comment] - this is a same-line leading multiline comment
+	 * @property {string} [inline_multiline_trailing_comment] - this is a same-line trailing multiline comment
 	 */
 
 	/** @type {Props} */
@@ -33,6 +38,8 @@
 		type_no_comment,
 		optional = {stuff: true},
 		inline_commented,
-		inline_commented_merged
+		inline_commented_merged,
+		inline_multiline_leading_comment = 'world',
+		inline_multiline_trailing_comment = 'world'
 	} = $props();
 </script>

--- a/packages/svelte/tests/migrate/samples/props-ts/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/input.svelte
@@ -6,6 +6,8 @@
 	export let bindingOptional: string | undefined = 'bar';
 	/** this should stay a comment */
 	export let no_type_but_comment = 0;
+	export let type_and_inline_comment:number; // this should also stay a comment
+	export let no_type_and_inline_comment = 0;         // this should stay as well
 </script>
 
 {readonly}

--- a/packages/svelte/tests/migrate/samples/props-ts/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/input.svelte
@@ -8,6 +8,14 @@
 	export let no_type_but_comment = 0;
 	export let type_and_inline_comment:number; // this should also stay a comment
 	export let no_type_and_inline_comment = 0;         // this should stay as well
+
+	/*
+	* this is a same-line leading multiline comment
+	**/ export let inline_multiline_leading_comment = 'world';
+
+	export let inline_multiline_trailing_comment = 'world'; /*
+	* this is a same-line trailing multiline comment
+	**/
 </script>
 
 {readonly}

--- a/packages/svelte/tests/migrate/samples/props-ts/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/output.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	
 	
+
+	
+
 	interface Props {
 		/** some comment */
 		readonly: number;
@@ -11,6 +14,13 @@
 		no_type_but_comment?: number;
 		type_and_inline_comment: number; // this should also stay a comment
 		no_type_and_inline_comment?: number; // this should stay as well
+		/*
+	* this is a same-line leading multiline comment
+	**/
+		inline_multiline_leading_comment?: string;
+		inline_multiline_trailing_comment?: string; /*
+	* this is a same-line trailing multiline comment
+	**/
 	}
 
 	let {
@@ -20,7 +30,9 @@
 		bindingOptional = $bindable('bar'),
 		no_type_but_comment = 0,
 		type_and_inline_comment,
-		no_type_and_inline_comment = 0
+		no_type_and_inline_comment = 0,
+		inline_multiline_leading_comment = 'world',
+		inline_multiline_trailing_comment = 'world'
 	}: Props = $props();
 </script>
 

--- a/packages/svelte/tests/migrate/samples/props-ts/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-ts/output.svelte
@@ -9,6 +9,8 @@
 		bindingOptional?: string | undefined;
 		/** this should stay a comment */
 		no_type_but_comment?: number;
+		type_and_inline_comment: number; // this should also stay a comment
+		no_type_and_inline_comment?: number; // this should stay as well
 	}
 
 	let {
@@ -16,7 +18,9 @@
 		optional = 'foo',
 		binding = $bindable(),
 		bindingOptional = $bindable('bar'),
-		no_type_but_comment = 0
+		no_type_but_comment = 0,
+		type_and_inline_comment,
+		no_type_and_inline_comment = 0
 	}: Props = $props();
 </script>
 


### PR DESCRIPTION
Fixes #14140

Keeps inline comments when migrating types, as we already do with other statement types [L783](https://github.com/sveltejs/svelte/blob/551284ca2259d934d34b71a38071d85684bd6d4f/packages/svelte/src/compiler/migrate/index.js#L783C1-L783C43)
```ts
    export let step: number | null = null // In-line comments are now kept
```

```ts
    interface Props {
	step: number | null; // In-line comments are now kept
    }
```

Added tests for Typescript and JSDoc migration. In the latter, the comments are merged with leading comments. See `tests/migrate/jsdoc-with-comments/output.svelte`