### PR TITLE
chore: use `pull_request_target` instead of `pull_request` event in workflows

### DIFF
--- a/.github/workflows/docs-preview-create-request.yml
+++ b/.github/workflows/docs-preview-create-request.yml
@@ -2,7 +2,7 @@
 name: Docs preview create request
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 

--- a/.github/workflows/docs-preview-delete-request.yml
+++ b/.github/workflows/docs-preview-delete-request.yml
@@ -2,7 +2,7 @@
 name: Docs preview delete request
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types: [closed]


### PR DESCRIPTION
This should allow preview deployments to be created for PRs from external contributors