### PR TITLE
chore: add custom comment with link to playground for `pkg.pr.new`

### DIFF
--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -1,0 +1,107 @@
+name: Update pkg.pr.new comment
+
+on:
+  workflow_run:
+    workflows: ['Publish Any Commit']
+    types:
+      - completed
+
+jobs:
+  run:
+    name: 'Update comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: output.json
+          path: output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: 'Post or update comment'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+
+            const bot_comment_identifier = `<!-- pkg.pr.new comment -->`;
+
+            const body = (number) => `${bot_comment_identifier}
+
+            [Playground](https://svelte.dev/playground?version=pr-${number})
+
+            \`\`\`
+            ${output.packages.map((p) => `pnpm add https://pkg.pr.new/${p.name}@${number}`).join('\n')}
+            \`\`\`
+            `;
+
+            async function find_bot_comment(issue_number) {
+              if (!issue_number) return null;
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+              });
+              return comments.data.find((comment) =>
+                comment.body.includes(bot_comment_identifier)
+              );
+            }
+
+            async function create_or_update_comment(issue_number) {
+              if (!issue_number) {
+                console.log('No issue number provided. Cannot post or update comment.');
+                return;
+              }
+
+              const existing_comment = await find_bot_comment(issue_number);
+              if (existing_comment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing_comment.id,
+                  body: body(issue_number),
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: issue_number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body(issue_number),
+                });
+              }
+            }
+
+            async function log_publish_info() {
+              console.log('\n' + '='.repeat(50));
+              console.log('Publish Information');
+              console.log('='.repeat(50));
+              console.log('\nPublished Packages:');
+              console.log(packages);
+              console.log('\nPlayground URL:');
+              console.log(`\nhttps://svelte.dev/playground?version=commit-${output.sha.substring(0, 7)}`)
+              console.log('\n' + '='.repeat(50));
+            }
+
+            if (output.event_name === 'pull_request') {
+              if (context.issue.number) {
+                await create_or_update_comment(context.issue.number);
+              }
+            } else if (output.event_name === 'push') {
+              const pull_requests = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head: `${context.repo.owner}:${output.ref.replace('refs/heads/', '')}`,
+              });
+
+              if (pull_requests.data.length > 0) {
+                await create_or_update_comment(pull_requests.data[0].number);
+              } else {
+                console.log(
+                  'No open pull request found for this push. Logging publish information to console:'
+                );
+                await log_publish_info();
+              }
+            }

--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 jobs:
-  run:
+  build:
     name: 'Update comment'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -22,90 +22,19 @@ jobs:
         run: pnpm build
 
       - run: pnpx pkg-pr-new publish --comment=off --json output.json --compact --no-template './packages/svelte'
-      - name: Post or update comment
+      - name: Add metadata to output
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
-
-            const bot_comment_identifier = `<!-- pkg.pr.new comment -->`;
-
-            const body = (number) => `${bot_comment_identifier}
-
-            [Playground](https://svelte.dev/playground?version=pr-${number})
-
-            \`\`\`
-            ${output.packages.map((p) => `pnpm add https://pkg.pr.new/${p.name}@${number}`).join('\n')}
-            \`\`\`
-            `;
-
-            async function find_bot_comment(issue_number) {
-              if (!issue_number) return null;
-              const comments = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue_number,
-              });
-              return comments.data.find((comment) =>
-                comment.body.includes(bot_comment_identifier)
-              );
-            }
-
-            async function create_or_update_comment(issue_number) {
-              if (!issue_number) {
-                console.log('No issue number provided. Cannot post or update comment.');
-                return;
-              }
-
-              const existing_comment = await find_bot_comment(issue_number);
-              if (existing_comment) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing_comment.id,
-                  body: body(issue_number),
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  issue_number: issue_number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: body(issue_number),
-                });
-              }
-            }
-
-            async function log_publish_info() {
-              console.log('\n' + '='.repeat(50));
-              console.log('Publish Information');
-              console.log('='.repeat(50));
-              console.log('\nPublished Packages:');
-              console.log(packages);
-              console.log('\nPlayground URL:');
-              console.log(`\nhttps://svelte.dev/playground?version=commit-${context.sha.substring(0, 7)}`)
-              console.log('\n' + '='.repeat(50));
-            }
-
-            if (context.eventName === 'pull_request') {
-              if (context.issue.number) {
-                await create_or_update_comment(context.issue.number);
-              }
-            } else if (context.eventName === 'push') {
-              const pull_requests = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                head: `${context.repo.owner}:${context.ref.replace('refs/heads/', '')}`,
-              });
-
-              if (pull_requests.data.length > 0) {
-                await create_or_update_comment(pull_requests.data[0].number);
-              } else {
-                console.log(
-                  'No open pull request found for this push. Logging publish information to console:'
-                );
-                await log_publish_info();
-              }
-            }
+            output.number = context.issue.number;
+            output.event_name = context.eventName;
+            output.ref = context.ref;
+            fs.writeFileSync('output.json', JSON.stringify(output), 'utf8');
+      - name: Upload output
+        uses: actions/upload-artifact@v4
+        with:
+          name: output.json
+          path: output.json

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -27,17 +27,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
 
-            const packages = output.packages
-              .map((t) => `\`\`\`
-              pnpm add ${t.url}
-              \`\`\``)
-              .join('\n');
 
             const body = (number)=>`## \`pkg.pr.new\` for ${context.sha.substring(0, 7)}
-            ${packages}
+            \`\`\`
+            pnpm add https://pkg.pr.new/svelte@${number}
+            \`\`\`
 
             [Open Playground](https://svelte.dev/playground?version=pr-${number})
             `;
@@ -87,7 +82,7 @@ jobs:
               console.log('\nPublished Packages:');
               console.log(packages);
               console.log('\nPlayground URL:');
-              console.log(`\nhttps://svelte.dev/playground?version=commit-${context.sha}`)
+              console.log(`\nhttps://svelte.dev/playground?version=commit-${context.sha.substring(0, 7)}`)
               console.log('\n' + '='.repeat(50));
             }
 

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -27,17 +27,22 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const fs = require('fs');
+            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
 
+            const body = (number)=>`## \`pkg.pr.new\`
 
-            const body = (number)=>`## \`pkg.pr.new\` for ${context.sha.substring(0, 7)}
+            ${output.packages
+              .map((p) => `
+            ### ${p.name}
             \`\`\`
-            pnpm add https://pkg.pr.new/svelte@${number}
-            \`\`\`
+            pnpm add https://pkg.pr.new/${p.name}@${number}
+            \`\`\``).join('\n')}
 
             [Open Playground](https://svelte.dev/playground?version=pr-${number})
             `;
 
-            const bot_comment_identifier = `## \`pkg.pr.new\` for ${context.sha.substring(0, 7)}`;
+            const bot_comment_identifier = `## \`pkg.pr.new\``;
 
             async function find_bot_comment(issue_number) {
               if (!issue_number) return null;

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -30,19 +30,16 @@ jobs:
             const fs = require('fs');
             const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
 
-            const body = (number)=>`## \`pkg.pr.new\`
+            const bot_comment_identifier = `<!-- pkg.pr.new comment -->`;
 
-            ${output.packages
-              .map((p) => `
-            ### ${p.name}
+            const body = (number) => `${bot_comment_identifier}
+
+            [Playground](https://svelte.dev/playground?version=pr-${number})
+
             \`\`\`
-            pnpm add https://pkg.pr.new/${p.name}@${number}
-            \`\`\``).join('\n')}
-
-            [Open Playground](https://svelte.dev/playground?version=pr-${number})
+            ${output.packages.map((p) => `pnpm add https://pkg.pr.new/${p.name}@${number}`).join('\n')}
+            \`\`\`
             `;
-
-            const bot_comment_identifier = `## \`pkg.pr.new\``;
 
             async function find_bot_comment(issue_number) {
               if (!issue_number) return null;

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -21,4 +21,94 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - run: pnpx pkg-pr-new publish --compact --no-template './packages/svelte'
+      - run: pnpx pkg-pr-new publish --comment=off --json output.json --compact --no-template './packages/svelte'
+      - name: Post or update comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+
+            const packages = output.packages
+              .map((t) => `\`\`\`
+              pnpm add ${t.url}
+              \`\`\``)
+              .join('\n');
+
+            const body = (number)=>`## \`pkg.pr.new\` for ${context.sha.substring(0, 7)}
+            ${packages}
+
+            [Open Playground](https://svelte.dev/playground?version=pr-${number})
+            `;
+
+            const bot_comment_identifier = `## \`pkg.pr.new\` for ${context.sha.substring(0, 7)}`;
+
+            async function find_bot_comment(issue_number) {
+              if (!issue_number) return null;
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+              });
+              return comments.data.find((comment) =>
+                comment.body.includes(bot_comment_identifier)
+              );
+            }
+
+            async function create_or_update_comment(issue_number) {
+              if (!issue_number) {
+                console.log('No issue number provided. Cannot post or update comment.');
+                return;
+              }
+
+              const existing_comment = await find_bot_comment(issue_number);
+              if (existing_comment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing_comment.id,
+                  body: body(issue_number),
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: issue_number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body(issue_number),
+                });
+              }
+            }
+
+            async function log_publish_info() {
+              console.log('\n' + '='.repeat(50));
+              console.log('Publish Information');
+              console.log('='.repeat(50));
+              console.log('\nPublished Packages:');
+              console.log(packages);
+              console.log('\nPlayground URL:');
+              console.log(`\nhttps://svelte.dev/playground?version=commit-${context.sha}`)
+              console.log('\n' + '='.repeat(50));
+            }
+
+            if (context.eventName === 'pull_request') {
+              if (context.issue.number) {
+                await create_or_update_comment(context.issue.number);
+              }
+            } else if (context.eventName === 'push') {
+              const pull_requests = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head: `${context.repo.owner}:${context.ref.replace('refs/heads/', '')}`,
+              });
+
+              if (pull_requests.data.length > 0) {
+                await create_or_update_comment(pull_requests.data[0].number);
+              } else {
+                console.log(
+                  'No open pull request found for this push. Logging publish information to console:'
+                );
+                await log_publish_info();
+              }
+            }


### PR DESCRIPTION
After we merge https://github.com/sveltejs/svelte.dev/pull/745 it could be cool to have the link to the playground directly in the comment.

This is following pkg.pr.new recommendation to add a custom comment with some modification on my part to make it more useful for us. I'm not entirely sure what would happen on merge but i guess we can always iterate.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
