### PR TITLE
fix: issue with implicit public modifier causing undefined properties

### DIFF
--- a/.changeset/four-countries-taste.md
+++ b/.changeset/four-countries-taste.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: issue with implicit public modifier causing undefined properties in classes
+fix: error on TypeScript's `readonly` modifier

--- a/.changeset/four-countries-taste.md
+++ b/.changeset/four-countries-taste.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: issue with implicit public modifier causing undefined properties in classes

--- a/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
+++ b/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
@@ -94,7 +94,7 @@ const visitors = {
 		e.typescript_invalid_feature(node, 'enums');
 	},
 	TSParameterProperty(node, context) {
-		if (node.accessibility && context.path.at(-2)?.kind === 'constructor') {
+		if ((node.readonly || node.accessibility) && context.path.at(-2)?.kind === 'constructor') {
 			e.typescript_invalid_feature(node, 'accessibility modifiers on constructor parameters');
 		}
 		return node.parameter;

--- a/packages/svelte/tests/runtime-runes/samples/typescript/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/typescript/main.svelte
@@ -9,7 +9,10 @@
 	}
 
 	class Foo {
-		constructor(readonly name: string) {}
+		public name: string;
+		constructor(name: string) {
+			this.name = name;
+		}
 	}
 
 	declare const declared_const: number;

--- a/packages/svelte/tests/validator/samples/ts-unsupported-modifier-readonly/errors.json
+++ b/packages/svelte/tests/validator/samples/ts-unsupported-modifier-readonly/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "typescript_invalid_feature",
+		"message": "TypeScript language features like accessibility modifiers on constructor parameters are not natively supported, and their use is generally discouraged. Outside of `<script>` tags, these features are not supported. For use within `<script>` tags, you will need to use a preprocessor to convert it to JavaScript before it gets passed to the Svelte compiler. If you are using `vitePreprocess`, make sure to specifically enable preprocessing script tags (`vitePreprocess({ script: true })`)",
+		"start": {
+			"line": 3,
+			"column": 14
+		},
+		"end": {
+			"line": 3,
+			"column": 32
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/ts-unsupported-modifier-readonly/input.svelte
+++ b/packages/svelte/tests/validator/samples/ts-unsupported-modifier-readonly/input.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	class Foo {
+		constructor(readonly x: number) {}
+	}
+</script>


### PR DESCRIPTION
This PR fixes #14152 where an implicit public access modifier on a constructor parameter prevents the Svelte runtime from correctly generating the class. When the class is instantiated, attempting to log or display the property results in undefined instead of the expected value.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
