### PR TITLE
fix: remove scoping for most `:not` selectors 

### DIFF
--- a/.changeset/quick-eels-occur.md
+++ b/.changeset/quick-eels-occur.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove scoping for `:not` selectors

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -50,9 +50,9 @@ function migrate_css(state) {
 	while (code) {
 		if (
 			code.startsWith(':has') ||
-			code.startsWith(':not') ||
 			code.startsWith(':is') ||
-			code.startsWith(':where')
+			code.startsWith(':where') ||
+			code.startsWith(':not')
 		) {
 			let start = code.indexOf('(') + 1;
 			let is_global = false;
@@ -74,7 +74,7 @@ function migrate_css(state) {
 				char = code[end];
 			}
 			if (start && end) {
-				if (!is_global) {
+				if (!is_global && !code.startsWith(':not')) {
 					str.prependLeft(starting + start, ':global(');
 					str.appendRight(starting + end - 1, ')');
 				}

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -355,18 +355,8 @@ const visitors = {
 		context.state.specificity.bumped = before_bumped;
 	},
 	PseudoClassSelector(node, context) {
-		if (node.name === 'is' || node.name === 'where' || node.name === 'has') {
+		if (node.name === 'is' || node.name === 'where' || node.name === 'has' || node.name === 'not') {
 			context.next();
-		}
-		if (node.name === 'not' && node.args) {
-			for (const complex_selector of node.args.children) {
-				for (const relative_selector of complex_selector.children) {
-					if (relative_selector.metadata.is_global) {
-						const global = /** @type {Css.PseudoClassSelector} */ (relative_selector.selectors[0]);
-						remove_global_pseudo_class(global, relative_selector.combinator, context.state);
-					}
-				}
-			}
 		}
 	}
 };

--- a/packages/svelte/tests/css/samples/not-selector-global/_config.js
+++ b/packages/svelte/tests/css/samples/not-selector-global/_config.js
@@ -1,20 +1,5 @@
 import { test } from '../../test';
 
 export default test({
-	warnings: [
-		{
-			code: 'css_unused_selector',
-			message: 'Unused CSS selector ":global(.x) :not(p)"',
-			start: {
-				line: 14,
-				column: 1,
-				character: 197
-			},
-			end: {
-				line: 14,
-				column: 20,
-				character: 216
-			}
-		}
-	]
+	warnings: []
 });

--- a/packages/svelte/tests/css/samples/not-selector-global/expected.css
+++ b/packages/svelte/tests/css/samples/not-selector-global/expected.css
@@ -9,11 +9,21 @@
 		color: green;
 	}
 	.x .svelte-xyz:not(p) {
-		color: red; /* TODO would be nice to prune this one day */
+		color: green;
 	}
 	.x:not(p) {
-		color: red; /* TODO would be nice to prune this one day */
+		color: green;
 	}
 	.x .svelte-xyz:not(.unused) {
+		color: green;
+	}
+
+	span:not(p.svelte-xyz span:where(.svelte-xyz)) {
+		color: green;
+	}
+	span.svelte-xyz:not(p span) {
+		color: green;
+	}
+	span:not(p span) {
 		color: green;
 	}

--- a/packages/svelte/tests/css/samples/not-selector-global/expected.css
+++ b/packages/svelte/tests/css/samples/not-selector-global/expected.css
@@ -2,18 +2,18 @@
 	.svelte-xyz:not(.foo) {
 		color: green;
 	}
-	.svelte-xyz:not(.foo:where(.svelte-xyz)):not(.unused) {
+	.svelte-xyz:not(.foo):not(.unused) {
 		color: green;
 	}
-	.x:not(.foo.svelte-xyz) {
+	.x:not(.foo) {
 		color: green;
 	}
-	/* (unused) :global(.x) :not(p) {
-		color: red;
-	}*/
-	.x:not(p.svelte-xyz) {
+	.x .svelte-xyz:not(p) {
 		color: red; /* TODO would be nice to prune this one day */
 	}
-	.x .svelte-xyz:not(.unused:where(.svelte-xyz)) {
+	.x:not(p) {
+		color: red; /* TODO would be nice to prune this one day */
+	}
+	.x .svelte-xyz:not(.unused) {
 		color: green;
 	}

--- a/packages/svelte/tests/css/samples/not-selector-global/expected.html
+++ b/packages/svelte/tests/css/samples/not-selector-global/expected.html
@@ -1,1 +1,3 @@
-<p class="foo svelte-xyz">foo</p> <p class="bar svelte-xyz">bar</p>
+<p class="foo svelte-xyz">foo</p>
+<p class="bar svelte-xyz">bar <span class="svelte-xyz">baz</span></p>
+<span class="svelte-xyz">buzz</span>

--- a/packages/svelte/tests/css/samples/not-selector-global/input.svelte
+++ b/packages/svelte/tests/css/samples/not-selector-global/input.svelte
@@ -12,7 +12,7 @@
 		color: green;
 	}
 	:global(.x) :not(p) {
-		color: red;
+		color: red; /* TODO would be nice to prune this one day */
 	}
 	:global(.x):not(p) {
 		color: red; /* TODO would be nice to prune this one day */

--- a/packages/svelte/tests/css/samples/not-selector-global/input.svelte
+++ b/packages/svelte/tests/css/samples/not-selector-global/input.svelte
@@ -1,5 +1,9 @@
 <p class="foo">foo</p>
-<p class="bar">bar</p>
+<p class="bar">
+	bar
+	<span>baz</span>
+</p>
+<span>buzz</span>
 
 <style>
 	:not(:global(.foo)) {
@@ -12,12 +16,22 @@
 		color: green;
 	}
 	:global(.x) :not(p) {
-		color: red; /* TODO would be nice to prune this one day */
+		color: green;
 	}
 	:global(.x):not(p) {
-		color: red; /* TODO would be nice to prune this one day */
+		color: green;
 	}
 	:global(.x) :not(.unused) {
+		color: green;
+	}
+
+	:global(span):not(p span) {
+		color: green;
+	}
+	span:not(:global(p span)) {
+		color: green;
+	}
+	:global(span:not(p span)) {
 		color: green;
 	}
 </style>

--- a/packages/svelte/tests/css/samples/not-selector-hash-on-right-elements/_config.js
+++ b/packages/svelte/tests/css/samples/not-selector-hash-on-right-elements/_config.js
@@ -1,5 +1,0 @@
-import { test } from '../../test';
-
-export default test({
-	warnings: []
-});

--- a/packages/svelte/tests/css/samples/not-selector-hash-on-right-elements/expected.css
+++ b/packages/svelte/tests/css/samples/not-selector-hash-on-right-elements/expected.css
@@ -1,4 +1,0 @@
-
-	.svelte-xyz:not(.bar:where(.svelte-xyz)) {
-		color: green;
-	}

--- a/packages/svelte/tests/css/samples/not-selector-hash-on-right-elements/expected.html
+++ b/packages/svelte/tests/css/samples/not-selector-hash-on-right-elements/expected.html
@@ -1,1 +1,0 @@
-<p class="foo svelte-xyz">foo</p> <p class="bar">bar</p>

--- a/packages/svelte/tests/css/samples/not-selector-hash-on-right-elements/input.svelte
+++ b/packages/svelte/tests/css/samples/not-selector-hash-on-right-elements/input.svelte
@@ -1,8 +1,0 @@
-<p class="foo">foo</p>
-<p class="bar">bar</p>
-
-<style>
-	:not(.bar) {
-		color: green;
-	}
-</style>

--- a/packages/svelte/tests/css/samples/not-selector/_config.js
+++ b/packages/svelte/tests/css/samples/not-selector/_config.js
@@ -4,30 +4,16 @@ export default test({
 	warnings: [
 		{
 			code: 'css_unused_selector',
-			message: 'Unused CSS selector ":not(p)"',
-			start: {
-				line: 11,
-				column: 1,
-				character: 125
-			},
-			end: {
-				line: 11,
-				column: 8,
-				character: 132
-			}
-		},
-		{
-			code: 'css_unused_selector',
 			message: 'Unused CSS selector "p :not(.foo)"',
 			start: {
 				line: 22,
 				column: 1,
-				character: 235
+				character: 291
 			},
 			end: {
 				line: 22,
 				column: 13,
-				character: 247
+				character: 303
 			}
 		},
 		{
@@ -36,12 +22,12 @@ export default test({
 			start: {
 				line: 25,
 				column: 1,
-				character: 268
+				character: 324
 			},
 			end: {
 				line: 25,
 				column: 16,
-				character: 283
+				character: 339
 			}
 		}
 	]

--- a/packages/svelte/tests/css/samples/not-selector/_config.js
+++ b/packages/svelte/tests/css/samples/not-selector/_config.js
@@ -4,30 +4,30 @@ export default test({
 	warnings: [
 		{
 			code: 'css_unused_selector',
-			message: 'Unused CSS selector "p :not(.foo)"',
+			message: 'Unused CSS selector "span :not(.foo)"',
 			start: {
-				line: 22,
+				line: 26,
 				column: 1,
-				character: 291
+				character: 276
 			},
 			end: {
-				line: 22,
-				column: 13,
-				character: 303
+				line: 26,
+				column: 16,
+				character: 291
 			}
 		},
 		{
 			code: 'css_unused_selector',
-			message: 'Unused CSS selector "p :not(.unused)"',
+			message: 'Unused CSS selector "span :not(.unused)"',
 			start: {
-				line: 25,
+				line: 29,
 				column: 1,
-				character: 324
+				character: 312
 			},
 			end: {
-				line: 25,
-				column: 16,
-				character: 339
+				line: 29,
+				column: 19,
+				character: 330
 			}
 		}
 	]

--- a/packages/svelte/tests/css/samples/not-selector/expected.css
+++ b/packages/svelte/tests/css/samples/not-selector/expected.css
@@ -26,3 +26,6 @@
 	span.svelte-xyz:not(p:where(.svelte-xyz) span:where(.svelte-xyz)) {
 		color: green;
 	}
+	span.svelte-xyz:not(:focus) {
+		color: green;
+	}

--- a/packages/svelte/tests/css/samples/not-selector/expected.css
+++ b/packages/svelte/tests/css/samples/not-selector/expected.css
@@ -6,7 +6,7 @@
 		color: green;
 	}
 	.svelte-xyz:not(p) {
-		color: red; /* TODO would be nice to mark this as unused someday */
+		color: green;
 	}
 
 	.svelte-xyz:not(.foo):not(.unused) {
@@ -16,9 +16,13 @@
 	p.svelte-xyz:not(.foo) {
 		color: green;
 	}
-	/* (unused) p :not(.foo) {
+	/* (unused) span :not(.foo) {
 		color: red;
 	}*/
-	/* (unused) p :not(.unused) {
+	/* (unused) span :not(.unused) {
 		color: red;
 	}*/
+
+	span.svelte-xyz:not(p:where(.svelte-xyz) span:where(.svelte-xyz)) {
+		color: green;
+	}

--- a/packages/svelte/tests/css/samples/not-selector/expected.css
+++ b/packages/svelte/tests/css/samples/not-selector/expected.css
@@ -1,19 +1,19 @@
 
-	.svelte-xyz:not(.foo:where(.svelte-xyz)) {
+	.svelte-xyz:not(.foo) {
 		color: green;
 	}
-	.svelte-xyz:not(.unused:where(.svelte-xyz)) {
+	.svelte-xyz:not(.unused) {
 		color: green;
 	}
-	/* (unused) :not(p) {
-		color: red;
-	}*/
-
-	.svelte-xyz:not(.foo:where(.svelte-xyz)):not(.unused:where(.svelte-xyz)) {
-		color: green;
+	.svelte-xyz:not(p) {
+		color: red; /* TODO would be nice to mark this as unused someday */
 	}
 
-	p.svelte-xyz:not(.foo:where(.svelte-xyz)) {
+	.svelte-xyz:not(.foo):not(.unused) {
+		color: green;
+	}
+
+	p.svelte-xyz:not(.foo) {
 		color: green;
 	}
 	/* (unused) p :not(.foo) {

--- a/packages/svelte/tests/css/samples/not-selector/expected.html
+++ b/packages/svelte/tests/css/samples/not-selector/expected.html
@@ -1,1 +1,3 @@
-<p class="foo svelte-xyz">foo</p> <p class="bar svelte-xyz">bar</p>
+<p class="foo svelte-xyz">foo</p>
+<p class="bar svelte-xyz">bar <span class="svelte-xyz">baz</span></p>
+<span class="svelte-xyz">buzz</span>

--- a/packages/svelte/tests/css/samples/not-selector/input.svelte
+++ b/packages/svelte/tests/css/samples/not-selector/input.svelte
@@ -1,5 +1,9 @@
 <p class="foo">foo</p>
-<p class="bar">bar</p>
+<p class="bar">
+	bar
+	<span>baz</span>
+</p>
+<span>buzz</span>
 
 <style>
 	:not(.foo) {
@@ -9,7 +13,7 @@
 		color: green;
 	}
 	:not(p) {
-		color: red; /* TODO would be nice to mark this as unused someday */
+		color: green;
 	}
 
 	:not(.foo):not(.unused) {
@@ -19,10 +23,14 @@
 	p:not(.foo) {
 		color: green;
 	}
-	p :not(.foo) {
+	span :not(.foo) {
 		color: red;
 	}
-	p :not(.unused) {
+	span :not(.unused) {
 		color: red;
+	}
+
+	span:not(p span) {
+		color: green;
 	}
 </style>

--- a/packages/svelte/tests/css/samples/not-selector/input.svelte
+++ b/packages/svelte/tests/css/samples/not-selector/input.svelte
@@ -33,4 +33,7 @@
 	span:not(p span) {
 		color: green;
 	}
+	span:not(:focus) {
+		color: green;
+	}
 </style>

--- a/packages/svelte/tests/css/samples/not-selector/input.svelte
+++ b/packages/svelte/tests/css/samples/not-selector/input.svelte
@@ -9,7 +9,7 @@
 		color: green;
 	}
 	:not(p) {
-		color: red;
+		color: red; /* TODO would be nice to mark this as unused someday */
 	}
 
 	:not(.foo):not(.unused) {

--- a/packages/svelte/tests/css/test.ts
+++ b/packages/svelte/tests/css/test.ts
@@ -32,30 +32,17 @@ const { test, run } = suite<CssTest>(async (config, cwd) => {
 	await compile_directory(cwd, 'client', { cssHash: () => 'svelte-xyz', ...config.compileOptions });
 	await compile_directory(cwd, 'server', { cssHash: () => 'svelte-xyz', ...config.compileOptions });
 
-	const dom_css = fs.readFileSync(`${cwd}/_output/client/input.svelte.css`, 'utf-8').trim();
-	const ssr_css = fs.readFileSync(`${cwd}/_output/server/input.svelte.css`, 'utf-8').trim();
-
-	assert.equal(dom_css, ssr_css);
-
-	const dom_warnings = load_warnings(`${cwd}/_output/client/input.svelte.warnings.json`);
-	const ssr_warnings = load_warnings(`${cwd}/_output/server/input.svelte.warnings.json`);
-	const expected_warnings = (config.warnings || []).map(normalize_warning);
-	assert.deepEqual(dom_warnings, ssr_warnings);
-	assert.deepEqual(dom_warnings.map(normalize_warning), expected_warnings);
-
 	const expected = {
 		html: try_read_file(`${cwd}/expected.html`),
 		css: try_read_file(`${cwd}/expected.css`)
 	};
-
-	assert.equal(dom_css.trim().replace(/\r\n/g, '\n'), (expected.css ?? '').trim());
 
 	// we do this here, rather than in the expected.html !== null
 	// block, to verify that valid code was generated
 	const ClientComponent = (await import(`${cwd}/_output/client/input.svelte.js`)).default;
 	const ServerComponent = (await import(`${cwd}/_output/server/input.svelte.js`)).default;
 
-	// verify that the right elements have scoping selectors
+	// verify that the right elements have scoping selectors (do this first to ensure all actual files are written to disk)
 	if (expected.html !== null) {
 		const target = window.document.createElement('main');
 
@@ -75,6 +62,19 @@ const { test, run } = suite<CssTest>(async (config, cwd) => {
 		// const actual_ssr = ServerComponent.render(config.props).html;
 		// assert_html_equal(actual_ssr, expected.html);
 	}
+
+	const dom_css = fs.readFileSync(`${cwd}/_output/client/input.svelte.css`, 'utf-8').trim();
+	const ssr_css = fs.readFileSync(`${cwd}/_output/server/input.svelte.css`, 'utf-8').trim();
+
+	assert.equal(dom_css, ssr_css);
+
+	const dom_warnings = load_warnings(`${cwd}/_output/client/input.svelte.warnings.json`);
+	const ssr_warnings = load_warnings(`${cwd}/_output/server/input.svelte.warnings.json`);
+	const expected_warnings = (config.warnings || []).map(normalize_warning);
+	assert.deepEqual(dom_warnings, ssr_warnings);
+	assert.deepEqual(dom_warnings.map(normalize_warning), expected_warnings);
+
+	assert.equal(dom_css.trim().replace(/\r\n/g, '\n'), (expected.css ?? '').trim());
 });
 
 export { test };

--- a/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
+++ b/packages/svelte/tests/migrate/samples/is-not-where-has/output.svelte
@@ -21,22 +21,22 @@ what if i'm talking about `:has()` in my blog?
 
 <style lang="postcss">
 	div:has(:global(span)){}
-	div > :not(:global(span)){}
+	div > :not(span){}
 	div > :is(:global(span)){}
 	div > :where(:global(span)){}
 
 	div:has(:global(:is(span))){}
-	div > :not(:global(:is(span))){}
+	div > :not(:is(span)){}
 	div > :is(:global(:is(span))){}
 	div > :where(:global(:is(span))){}
 
 	div:has(:global(.class:is(span))){}
-	div > :not(:global(.class:is(span))){}
+	div > :not(.class:is(span)){}
 	div > :is(:global(.class:is(span))){}
 	div > :where(:global(.class:is(span))){}
 
 	div :has(:global(.class:is(span:where(:focus)))){}
-	div :not(:global(.class:is(span:where(:focus-within)))){}
+	div :not(.class:is(span:where(:focus-within))){}
 	div :is(:global(.class:is(span:is(:hover)))){}
 	div :where(:global(.class:is(span:has(* > *)))){}
 	div :is(:global(.class:is(span:is(:hover)), .x)){}
@@ -51,7 +51,7 @@ what if i'm talking about `:has()` in my blog?
 		p:has(:global(&)){
 
 		}
-		:not(:global(span > *)){
+		:not(span > *){
 			:where(:global(form)){}
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/sveltejs/svelte/issues/14168

This mostly reverts the whole "selectors inside `:not` are scoped" logic. Scoping is done so that styles don't bleed. But within `:not`,everything is reversed, which means scoping the selectors now means they are more likely to bleed. That is the opposite of what we want to achieve, therefore we should just leave those selectors alone.

The exception are `:not` selectors with descendant selectors, as that means "look up the tree" and we need to scope all ancestor elements in that case.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
