### PR TITLE
fix: improved warning message for legacy non-reactive properties

### DIFF
--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -729,7 +729,7 @@ Reassignments of module-level declarations will not cause reactive statements to
 ### reactive_declaration_non_reactive_property
 
 ```
-Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
+Arrays and object properties are only reactive in runes mode. This may be unexpected if referencing an imported runes-based object and the behavior of this statement will change when migrating to runes mode.
 ```
 
 ### script_context_deprecated

--- a/packages/svelte/messages/compile-warnings/script.md
+++ b/packages/svelte/messages/compile-warnings/script.md
@@ -28,7 +28,7 @@
 
 ## reactive_declaration_non_reactive_property
 
-> Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
+> Arrays and object properties are only reactive in runes mode. This may be unexpected if referencing an imported runes-based object and the behavior of this statement will change when migrating to runes mode.
 
 ## state_referenced_locally
 

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -642,11 +642,11 @@ export function reactive_declaration_module_script_dependency(node) {
 }
 
 /**
- * Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
+ * Arrays and object properties are only reactive in runes mode. This may be unexpected if referencing an imported runes-based object and the behavior of this statement will change when migrating to runes mode.
  * @param {null | NodeLike} node
  */
 export function reactive_declaration_non_reactive_property(node) {
-	w(node, "reactive_declaration_non_reactive_property", "Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update");
+	w(node, "reactive_declaration_non_reactive_property", "Arrays and object properties are only reactive in runes mode. This may be unexpected if referencing an imported runes-based object and the behavior of this statement will change when migrating to runes mode.");
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/reactive-statement-non-reactive-import-statement/warnings.json
+++ b/packages/svelte/tests/validator/samples/reactive-statement-non-reactive-import-statement/warnings.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "reactive_declaration_non_reactive_property",
-		"message": "Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update",
+		"message": "Arrays and object properties are only reactive in runes mode. This may be unexpected if referencing an imported runes-based object and the behavior of this statement will change when migrating to runes mode.",
 		"start": {
 			"line": 4,
 			"column": 11


### PR DESCRIPTION
This does make it a bit on the long side. However, previously the second sentence was just a restatement of the first and didn't tell you what to watch out for leading to confusion around the need for the message

closes https://github.com/sveltejs/svelte/pull/14111
closes https://github.com/sveltejs/svelte/issues/13811
closes https://github.com/sveltejs/svelte/issues/14034