### PR TITLE
fix: ensure props passed to components via mount are updateable

### DIFF
--- a/.changeset/fresh-pigs-divide.md
+++ b/.changeset/fresh-pigs-divide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure props passed to components via mount are updateable

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -22,4 +22,5 @@ export const EFFECT_HAS_DERIVED = 1 << 19;
 
 export const STATE_SYMBOL = Symbol('$state');
 export const STATE_SYMBOL_METADATA = Symbol('$state metadata');
+export const LEGACY_PROPS = Symbol('legacy props');
 export const LOADING_ATTR_SYMBOL = Symbol('');

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -296,7 +296,8 @@ export function prop(props, key, flags, fallback) {
 	var is_entry_props = STATE_SYMBOL in props || LEGACY_PROPS in props;
 
 	var setter =
-		get_descriptor(props, key)?.set ?? (is_entry_props ? (v) => (props[key] = v) : undefined);
+		get_descriptor(props, key)?.set ??
+		(is_entry_props && bindable ? (v) => (props[key] = v) : undefined);
 
 	var fallback_value = /** @type {V} */ (fallback);
 	var fallback_dirty = true;
@@ -322,7 +323,7 @@ export function prop(props, key, flags, fallback) {
 		}
 
 		prop_value = get_fallback();
-		if (setter && (!is_entry_props || bindable)) setter(prop_value);
+		if (setter) setter(prop_value);
 	}
 
 	/** @type {() => V} */

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -20,7 +20,7 @@ import {
 } from '../runtime.js';
 import { safe_equals } from './equality.js';
 import * as e from '../errors.js';
-import { BRANCH_EFFECT, LEGACY_DERIVED_PROP, ROOT_EFFECT } from '../constants.js';
+import { BRANCH_EFFECT, LEGACY_DERIVED_PROP, ROOT_EFFECT, STATE_SYMBOL } from '../constants.js';
 import { proxy } from '../proxy.js';
 import { capture_store_binding } from './store.js';
 import { legacy_mode_flag } from '../../flags/index.js';
@@ -282,7 +282,11 @@ export function prop(props, key, flags, fallback) {
 	} else {
 		prop_value = /** @type {V} */ (props[key]);
 	}
-	var setter = get_descriptor(props, key)?.set;
+
+	var setter =
+		get_descriptor(props, key)?.set ??
+		// Can be the case when someone does `mount(Component, props)` with `let props = $state({...})`
+		(STATE_SYMBOL in props ? (v) => (props[key] = v) : undefined);
 
 	var fallback_value = /** @type {V} */ (fallback);
 	var fallback_dirty = true;

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -215,7 +215,8 @@ const spread_props_handler = {
 		}
 	},
 	has(target, key) {
-		if (key === STATE_SYMBOL) return false;
+		// To prevent a false positive `is_entry_props` in the `prop` function
+		if (key === STATE_SYMBOL || key === LEGACY_PROPS) return false;
 
 		for (let p of target.props) {
 			if (is_function(p)) p = p();
@@ -297,7 +298,7 @@ export function prop(props, key, flags, fallback) {
 
 	var setter =
 		get_descriptor(props, key)?.set ??
-		(is_entry_props && bindable ? (v) => (props[key] = v) : undefined);
+		(is_entry_props && bindable && key in props ? (v) => (props[key] = v) : undefined);
 
 	var fallback_value = /** @type {V} */ (fallback);
 	var fallback_dirty = true;
@@ -318,7 +319,7 @@ export function prop(props, key, flags, fallback) {
 	};
 
 	if (prop_value === undefined && fallback !== undefined) {
-		if (setter && runes && !is_entry_props) {
+		if (setter && runes) {
 			e.props_invalid_value(key);
 		}
 

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -215,6 +215,8 @@ const spread_props_handler = {
 		}
 	},
 	has(target, key) {
+		if (key === STATE_SYMBOL) return false;
+
 		for (let p of target.props) {
 			if (is_function(p)) p = p();
 			if (p != null && key in p) return true;
@@ -320,7 +322,7 @@ export function prop(props, key, flags, fallback) {
 		}
 
 		prop_value = get_fallback();
-		if (setter) setter(prop_value);
+		if (setter && (!is_entry_props || bindable)) setter(prop_value);
 	}
 
 	/** @type {() => V} */

--- a/packages/svelte/src/internal/client/validate.js
+++ b/packages/svelte/src/internal/client/validate.js
@@ -1,19 +1,10 @@
-import { dev_current_component_function, untrack } from './runtime.js';
+import { dev_current_component_function } from './runtime.js';
 import { get_descriptor, is_array } from '../shared/utils.js';
 import * as e from './errors.js';
 import { FILENAME } from '../../constants.js';
 import { render_effect } from './reactivity/effects.js';
 import * as w from './warnings.js';
 import { capture_store_binding } from './reactivity/store.js';
-
-/** regex of all html void element names */
-const void_element_names =
-	/^(?:area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/;
-
-/** @param {string} tag */
-function is_void(tag) {
-	return void_element_names.test(tag) || tag.toLowerCase() === '!doctype';
-}
 
 /**
  * @param {() => any} collection

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -1,5 +1,5 @@
 /** @import { ComponentConstructorOptions, ComponentType, SvelteComponent, Component } from 'svelte' */
-import { DIRTY, MAYBE_DIRTY } from '../internal/client/constants.js';
+import { DIRTY, LEGACY_PROPS, MAYBE_DIRTY } from '../internal/client/constants.js';
 import { user_pre_effect } from '../internal/client/reactivity/effects.js';
 import { mutable_source, set } from '../internal/client/reactivity/sources.js';
 import { hydrate, mount, unmount } from '../internal/client/render.js';
@@ -89,7 +89,7 @@ class Svelte4Component {
 		};
 
 		// Replicate coarse-grained props through a proxy that has a version source for
-		// each property, which is increment on updates to the property itself. Do not
+		// each property, which is incremented on updates to the property itself. Do not
 		// use our $state proxy because that one has fine-grained reactivity.
 		const props = new Proxy(
 			{ ...(options.props || {}), $$events: {} },
@@ -98,26 +98,15 @@ class Svelte4Component {
 					return get(sources.get(prop) ?? add_source(prop, Reflect.get(target, prop)));
 				},
 				has(target, prop) {
+					// Necessary to not throw "invalid binding" validation errors on the component side
+					if (prop === LEGACY_PROPS) return true;
+
 					get(sources.get(prop) ?? add_source(prop, Reflect.get(target, prop)));
 					return Reflect.has(target, prop);
 				},
 				set(target, prop, value) {
 					set(sources.get(prop) ?? add_source(prop, value), value);
 					return Reflect.set(target, prop, value);
-				},
-				getOwnPropertyDescriptor(target, prop) {
-					// TODO this throws "invalid binding" errors on the component side
-					const desc = Reflect.getOwnPropertyDescriptor(target, prop);
-					if (!desc?.configurable) return desc;
-					return {
-						get: () => get(sources.get(prop) ?? add_source(prop, Reflect.get(target, prop))),
-						set: (value) => {
-							set(sources.get(prop) ?? add_source(prop, value), value);
-							return Reflect.set(target, prop, value);
-						},
-						enumerable: desc.enumerable,
-						configurable: desc.configurable
-					};
 				}
 			}
 		);

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -104,6 +104,20 @@ class Svelte4Component {
 				set(target, prop, value) {
 					set(sources.get(prop) ?? add_source(prop, value), value);
 					return Reflect.set(target, prop, value);
+				},
+				getOwnPropertyDescriptor(target, prop) {
+					// TODO this throws "invalid binding" errors on the component side
+					const desc = Reflect.getOwnPropertyDescriptor(target, prop);
+					if (!desc?.configurable) return desc;
+					return {
+						get: () => get(sources.get(prop) ?? add_source(prop, Reflect.get(target, prop))),
+						set: (value) => {
+							set(sources.get(prop) ?? add_source(prop, value), value);
+							return Reflect.set(target, prop, value);
+						},
+						enumerable: desc.enumerable,
+						configurable: desc.configurable
+					};
 				}
 			}
 		);

--- a/packages/svelte/tests/runtime-runes/samples/mount-props-updates/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/mount-props-updates/_config.js
@@ -5,8 +5,9 @@ export default test({
 	test({ assert, target }) {
 		assert.htmlEqual(
 			target.innerHTML,
+			// Even thought we're in runes mode, the buz fallback propagates back up in this case
 			`
-			<button>reset</button>
+			<button>reset</button> foo baz buz
 			<div><button>update</button> foo bar baz buz</div>
 			<div><button>update</button> foo bar baz buz</div>
 			`
@@ -19,8 +20,9 @@ export default test({
 		flushSync();
 		assert.htmlEqual(
 			target.innerHTML,
+			// bar is not set in the parent because it's a readonly property
 			`
-			<button>reset</button>
+			<button>reset</button> foo 3 4
 			<div><button>update</button> 1 2 3 4</div>
 			<div><button>update</button> 1 2 3 4</div>
 			`
@@ -30,10 +32,13 @@ export default test({
 		flushSync();
 		assert.htmlEqual(
 			target.innerHTML,
+			// Because foo is a readonly property, component.svelte diverges locally from it,
+			// and the passed in property keeps the initial value of foo. This is why it stays
+			// at 1, because foo is not updated to a different value.
 			`
-				<button>reset</button>
-			<div><button>update</button> foo bar baz buz</div>
-			<div><button>update</button> foo bar baz buz</div>
+				<button>reset</button> foo bar baz buz
+			<div><button>update</button> 1 bar baz buz</div>
+			<div><button>update</button> 1 bar baz buz</div>
 				`
 		);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/mount-props-updates/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/mount-props-updates/_config.js
@@ -1,0 +1,40 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>reset</button>
+			<div><button>update</button> foo bar baz buz</div>
+			<div><button>update</button> foo bar baz buz</div>
+			`
+		);
+
+		const [btn1, btn2, btn3] = target.querySelectorAll('button');
+
+		btn2.click();
+		btn3.click();
+		flushSync();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>reset</button>
+			<div><button>update</button> 1 2 3 4</div>
+			<div><button>update</button> 1 2 3 4</div>
+			`
+		);
+
+		btn1.click();
+		flushSync();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>reset</button>
+			<div><button>update</button> foo bar baz buz</div>
+			<div><button>update</button> foo bar baz buz</div>
+				`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/mount-props-updates/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/mount-props-updates/_config.js
@@ -5,9 +5,9 @@ export default test({
 	test({ assert, target }) {
 		assert.htmlEqual(
 			target.innerHTML,
-			// Even thought we're in runes mode, the buz fallback propagates back up in this case
+			// The buz fallback does not propagate back up
 			`
-			<button>reset</button> foo baz buz
+			<button>reset</button> foo baz
 			<div><button>update</button> foo bar baz buz</div>
 			<div><button>update</button> foo bar baz buz</div>
 			`
@@ -21,8 +21,10 @@ export default test({
 		assert.htmlEqual(
 			target.innerHTML,
 			// bar is not set in the parent because it's a readonly property
+			// baz is not set in the parent because while it's a bindable property,
+			// it wasn't set initially so it's treated as a readonly proeprty
 			`
-			<button>reset</button> foo 3 4
+			<button>reset</button> foo 3
 			<div><button>update</button> 1 2 3 4</div>
 			<div><button>update</button> 1 2 3 4</div>
 			`

--- a/packages/svelte/tests/runtime-runes/samples/mount-props-updates/component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/mount-props-updates/component.svelte
@@ -1,0 +1,17 @@
+<script>
+	let { foo, bar = 'bar', baz = $bindable(), buz = $bindable('buz') } = $props();
+</script>
+
+<button
+	onclick={() => {
+		foo = '1';
+		bar = '2';
+		baz = '3';
+		buz = '4';
+	}}>update</button
+>
+
+{foo}
+{bar}
+{baz}
+{buz}

--- a/packages/svelte/tests/runtime-runes/samples/mount-props-updates/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/mount-props-updates/main.svelte
@@ -1,0 +1,30 @@
+<script>
+	import { createClassComponent } from 'svelte/legacy';
+	import Component from './component.svelte';
+	import { mount, onMount } from 'svelte';
+
+	let div1, div2;
+	let legacy;
+	const props = $state({ foo: 'foo', baz: 'baz' });
+
+	onMount(() => {
+		legacy = createClassComponent({
+			component: Component,
+			target: div1,
+			props: { foo: 'foo', baz: 'baz' }
+		});
+		mount(Component, { target: div2, props });
+	});
+</script>
+
+<button
+	onclick={() => {
+		legacy.$set({ foo: 'foo', bar: 'bar', baz: 'baz', buz: 'buz' });
+		props.foo = 'foo';
+		props.bar = 'bar';
+		props.baz = 'baz';
+		props.buz = 'buz';
+	}}>reset</button
+>
+<div bind:this={div1}></div>
+<div bind:this={div2}></div>

--- a/packages/svelte/tests/runtime-runes/samples/mount-props-updates/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/mount-props-updates/main.svelte
@@ -25,6 +25,6 @@
 		props.baz = 'baz';
 		props.buz = 'buz';
 	}}>reset</button
->
+> {props.foo} {props.bar} {props.baz} {props.buz}
 <div bind:this={div1}></div>
 <div bind:this={div2}></div>


### PR DESCRIPTION
The detection whether or not props are writable is buggy; it doesn't take into account the case when instantiating components via `mount` or legacy-`new`

Fixes #14161

This posed an interesting question: What to do about (non-)`bind:`able properties? The answer I arrived on was: Treat it as if everything that _can_ be bound _is_ treated as bound, and everything else as readonly. In other words, if you're reassigning a prop, it will diverge from the passed in props if it's not bindable or not set in the parent, otherwise it will mutate the passed in props. I think that makes the most sense, given that you can't control this behavior from the outside.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
