### PR TITLE
fix: add migration task when there's a variable named that would conflict with a rune

### DIFF
--- a/.changeset/chatty-gorillas-poke.md
+++ b/.changeset/chatty-gorillas-poke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add migration task when there's a variable named that would conflict with a rune

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -246,7 +246,7 @@ export function migrate(source, { filename, use_ts } = {}) {
 			const has_rune_binding = !!state.scope.get(rune);
 			if (has_rune_binding) {
 				throw new MigrationError(
-					`migrating this component would require adding a \`$${rune}\` but there's already a variable named ${rune}`
+					`migrating this component would require adding a \`$${rune}\` rune but there's already a variable named ${rune}.\n     Rename the variable and try again or migrate by hand.`
 				);
 			}
 		}
@@ -670,14 +670,13 @@ const instance_script = {
 			}
 
 			/**
-			 *
 			 * @param {"state"|"derived"} rune
 			 */
 			function check_rune_binding(rune) {
 				const has_rune_binding = !!state.scope.get(rune);
 				if (has_rune_binding) {
 					throw new MigrationError(
-						`can't migrate \`${state.str.original.substring(/** @type {number} */ (node.start), node.end)}\` to \`$${rune}\` because there's a variable named ${rune}`
+						`can't migrate \`${state.str.original.substring(/** @type {number} */ (node.start), node.end)}\` to \`$${rune}\` because there's a variable named ${rune}.\n     Rename the variable and try again or migrate by hand.`
 					);
 				}
 			}
@@ -901,7 +900,7 @@ const instance_script = {
 			const has_rune_binding = state.scope.get(rune);
 			if (has_rune_binding) {
 				throw new MigrationError(
-					`can't migrate \`$: ${state.str.original.substring(/** @type {number} */ (node.body.start), node.body.end)}\` to \`$${rune}\` because there's a variable named ${rune}`
+					`can't migrate \`$: ${state.str.original.substring(/** @type {number} */ (node.body.start), node.body.end)}\` to \`$${rune}\` because there's a variable named ${rune}.\n     Rename the variable and try again or migrate by hand.`
 				);
 			}
 		}

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -239,6 +239,18 @@ export function migrate(source, { filename, use_ts } = {}) {
 
 		insertion_point = state.props_insertion_point;
 
+		/**
+		 * @param {"derived"|"props"|"bindable"} rune
+		 */
+		function check_rune_binding(rune) {
+			const has_rune_binding = !!state.scope.get(rune);
+			if (has_rune_binding) {
+				throw new MigrationError(
+					`migrating this component would require adding a \`$${rune}\` but there's already a variable named ${rune}`
+				);
+			}
+		}
+
 		if (state.props.length > 0 || analysis.uses_rest_props || analysis.uses_props) {
 			const has_many_props = state.props.length > 3;
 			const newline_separator = `\n${indent}${indent}`;
@@ -253,6 +265,7 @@ export function migrate(source, { filename, use_ts } = {}) {
 						let prop_str =
 							prop.local === prop.exported ? prop.local : `${prop.exported}: ${prop.local}`;
 						if (prop.bindable) {
+							check_rune_binding('bindable');
 							prop_str += ` = $bindable(${prop.init})`;
 						} else if (prop.init) {
 							prop_str += ` = ${prop.init}`;
@@ -300,11 +313,13 @@ export function migrate(source, { filename, use_ts } = {}) {
 					if (type) {
 						props_declaration = `${type}\n\n${indent}${props_declaration}`;
 					}
+					check_rune_binding('props');
 					props_declaration = `${props_declaration}${type ? `: ${type_name}` : ''} = $props();`;
 				} else {
 					if (type) {
 						props_declaration = `${state.props.length > 0 ? `${type}\n\n${indent}` : ''}/** @type {${state.props.length > 0 ? type_name : ''}${analysis.uses_props || analysis.uses_rest_props ? `${state.props.length > 0 ? ' & ' : ''}{ [key: string]: any }` : ''}} */\n${indent}${props_declaration}`;
 					}
+					check_rune_binding('props');
 					props_declaration = `${props_declaration} = $props();`;
 				}
 
@@ -361,6 +376,7 @@ export function migrate(source, { filename, use_ts } = {}) {
 			: insertion_point;
 
 		if (state.derived_components.size > 0) {
+			check_rune_binding('derived');
 			str.appendRight(
 				insertion_point,
 				`\n${indent}${[...state.derived_components.entries()].map(([init, name]) => `const ${name} = $derived(${init});`).join(`\n${indent}`)}\n`
@@ -368,6 +384,7 @@ export function migrate(source, { filename, use_ts } = {}) {
 		}
 
 		if (state.derived_conflicting_slots.size > 0) {
+			check_rune_binding('derived');
 			str.appendRight(
 				insertion_point,
 				`\n${indent}${[...state.derived_conflicting_slots.entries()].map(([name, init]) => `const ${name} = $derived(${init});`).join(`\n${indent}`)}\n`
@@ -652,6 +669,19 @@ const instance_script = {
 				continue;
 			}
 
+			/**
+			 *
+			 * @param {"state"|"derived"} rune
+			 */
+			function check_rune_binding(rune) {
+				const has_rune_binding = !!state.scope.get(rune);
+				if (has_rune_binding) {
+					throw new MigrationError(
+						`can't migrate \`${state.str.original.substring(/** @type {number} */ (node.start), node.end)}\` to \`$${rune}\` because there's a variable named ${rune}`
+					);
+				}
+			}
+
 			// state
 			if (declarator.init) {
 				let { start, end } = /** @type {{ start: number, end: number }} */ (declarator.init);
@@ -660,6 +690,8 @@ const instance_script = {
 					while (state.str.original[start] !== '(') start -= 1;
 					while (state.str.original[end - 1] !== ')') end += 1;
 				}
+
+				check_rune_binding('state');
 
 				state.str.prependLeft(start, '$state(');
 				state.str.appendRight(end, ')');
@@ -755,6 +787,8 @@ const instance_script = {
 						}
 					}
 
+					check_rune_binding('derived');
+
 					// Someone wrote a `$: { ... }` statement which we can turn into a `$derived`
 					state.str.appendRight(
 						/** @type {number} */ (declarator.id.typeAnnotation?.end ?? declarator.id.end),
@@ -795,6 +829,8 @@ const instance_script = {
 						}
 					}
 				} else {
+					check_rune_binding('state');
+
 					state.str.prependLeft(
 						/** @type {number} */ (declarator.id.typeAnnotation?.end ?? declarator.id.end),
 						' = $state('
@@ -858,6 +894,18 @@ const instance_script = {
 
 		next();
 
+		/**
+		 * @param {"state"|"derived"} rune
+		 */
+		function check_rune_binding(rune) {
+			const has_rune_binding = state.scope.get(rune);
+			if (has_rune_binding) {
+				throw new MigrationError(
+					`can't migrate \`$: ${state.str.original.substring(/** @type {number} */ (node.body.start), node.body.end)}\` to \`$${rune}\` because there's a variable named ${rune}`
+				);
+			}
+		}
+
 		if (
 			node.body.type === 'ExpressionStatement' &&
 			node.body.expression.type === 'AssignmentExpression'
@@ -877,6 +925,8 @@ const instance_script = {
 				let { start, end } = /** @type {{ start: number, end: number }} */ (
 					node.body.expression.right
 				);
+
+				check_rune_binding('derived');
 
 				// $derived
 				state.str.update(
@@ -902,6 +952,7 @@ const instance_script = {
 			} else {
 				for (const binding of reassigned_bindings) {
 					if (binding && (ids.includes(binding.node) || expression_ids.length === 0)) {
+						check_rune_binding('state');
 						const init =
 							binding.kind === 'state'
 								? ' = $state()'

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$bindable-bindable-var-1/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$bindable-bindable-var-1/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$bindable-bindable-var-1/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$bindable-bindable-var-1/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let bindable;
+	export let something;
+</script>
+
+<input bind:value={something} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$bindable-bindable-var-1/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$bindable-bindable-var-1/output.svelte
@@ -1,4 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$bindable` but there's already a variable named bindable -->
+<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$bindable` rune but there's already a variable named bindable.
+     Rename the variable and try again or migrate by hand. -->
 <script>
 	let bindable;
 	export let something;

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$bindable-bindable-var-1/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$bindable-bindable-var-1/output.svelte
@@ -1,0 +1,7 @@
+<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$bindable` but there's already a variable named bindable -->
+<script>
+	let bindable;
+	export let something;
+</script>
+
+<input bind:value={something} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-1/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-1/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-1/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-1/input.svelte
@@ -1,0 +1,9 @@
+<script>
+	let name = 'world';
+
+	let derived;
+
+	$: other = name;
+</script>
+
+<input bind:value={name} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-1/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-1/output.svelte
@@ -1,4 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: can't migrate `$: other = name;` to `$derived` because there's a variable named derived -->
+<!-- @migration-task Error while migrating Svelte code: can't migrate `$: other = name;` to `$derived` because there's a variable named derived.
+     Rename the variable and try again or migrate by hand. -->
 <script>
 	let name = 'world';
 

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-1/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-1/output.svelte
@@ -1,0 +1,10 @@
+<!-- @migration-task Error while migrating Svelte code: can't migrate `$: other = name;` to `$derived` because there's a variable named derived -->
+<script>
+	let name = 'world';
+
+	let derived;
+
+	$: other = name;
+</script>
+
+<input bind:value={name} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-2/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-2/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-2/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-2/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	let derived;
+</script>
+
+<svelte:component this={derived} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-2/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-2/output.svelte
@@ -1,4 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$derived` but there's already a variable named derived -->
+<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$derived` rune but there's already a variable named derived.
+     Rename the variable and try again or migrate by hand. -->
 <script>
 	let derived;
 </script>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-2/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-2/output.svelte
@@ -1,0 +1,6 @@
+<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$derived` but there's already a variable named derived -->
+<script>
+	let derived;
+</script>
+
+<svelte:component this={derived} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-3/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-3/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-3/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-3/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let derived;
+</script>
+<Component>
+	<slot name="derived" slot="derived" />
+</Component>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-3/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-3/output.svelte
@@ -1,0 +1,7 @@
+<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot making the component unusable -->
+<script>
+	let derived;
+</script>
+<Component>
+	<slot name="derived" slot="derived" />
+</Component>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-4/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-4/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-4/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-4/input.svelte
@@ -1,0 +1,10 @@
+<script>
+	let name = 'world';
+
+	let derived;
+
+	let other;
+	$: other = name;
+</script>
+
+<input bind:value={name} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-4/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-4/output.svelte
@@ -1,0 +1,11 @@
+<!-- @migration-task Error while migrating Svelte code: can't migrate `let other;` to `$derived` because there's a variable named derived -->
+<script>
+	let name = 'world';
+
+	let derived;
+
+	let other;
+	$: other = name;
+</script>
+
+<input bind:value={name} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-4/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-4/output.svelte
@@ -1,4 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: can't migrate `let other;` to `$derived` because there's a variable named derived -->
+<!-- @migration-task Error while migrating Svelte code: can't migrate `let other;` to `$derived` because there's a variable named derived.
+     Rename the variable and try again or migrate by hand. -->
 <script>
 	let name = 'world';
 

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$props-props-var-1/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$props-props-var-1/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$props-props-var-1/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$props-props-var-1/input.svelte
@@ -1,0 +1,4 @@
+<script>
+	let props;
+	export let something;
+</script>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$props-props-var-1/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$props-props-var-1/output.svelte
@@ -1,4 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$props` but there's already a variable named props -->
+<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$props` rune but there's already a variable named props.
+     Rename the variable and try again or migrate by hand. -->
 <script>
 	let props;
 	export let something;

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$props-props-var-1/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$props-props-var-1/output.svelte
@@ -1,0 +1,5 @@
+<!-- @migration-task Error while migrating Svelte code: migrating this component would require adding a `$props` but there's already a variable named props -->
+<script>
+	let props;
+	export let something;
+</script>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-1/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-1/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-1/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-1/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	let state = 'world';
+
+	let other;
+</script>
+
+<input bind:value={other} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-1/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-1/output.svelte
@@ -1,4 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: can't migrate `let other;` to `$state` because there's a variable named state -->
+<!-- @migration-task Error while migrating Svelte code: can't migrate `let other;` to `$state` because there's a variable named state.
+     Rename the variable and try again or migrate by hand. -->
 <script>
 	let state = 'world';
 

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-1/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-1/output.svelte
@@ -1,0 +1,8 @@
+<!-- @migration-task Error while migrating Svelte code: can't migrate `let other;` to `$state` because there's a variable named state -->
+<script>
+	let state = 'world';
+
+	let other;
+</script>
+
+<input bind:value={other} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-2/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-2/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-2/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-2/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	let state = 'world';
+
+	let other = 42;
+</script>
+
+<input bind:value={other} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-2/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-2/output.svelte
@@ -1,0 +1,8 @@
+<!-- @migration-task Error while migrating Svelte code: can't migrate `let other = 42;` to `$state` because there's a variable named state -->
+<script>
+	let state = 'world';
+
+	let other = 42;
+</script>
+
+<input bind:value={other} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-2/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-2/output.svelte
@@ -1,4 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: can't migrate `let other = 42;` to `$state` because there's a variable named state -->
+<!-- @migration-task Error while migrating Svelte code: can't migrate `let other = 42;` to `$state` because there's a variable named state.
+     Rename the variable and try again or migrate by hand. -->
 <script>
 	let state = 'world';
 

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-3/_config.js
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-3/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	logs: [
+		'One or more `@migration-task` comments were added to `output.svelte`, please check them and complete the migration manually.'
+	],
+	errors: []
+});

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-3/input.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-3/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	let state = 'world';
+
+	$: other = 42;
+</script>
+
+<input bind:value={other} />

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-3/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-3/output.svelte
@@ -1,4 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: can't migrate `$: other = 42;` to `$state` because there's a variable named state -->
+<!-- @migration-task Error while migrating Svelte code: can't migrate `$: other = 42;` to `$state` because there's a variable named state.
+     Rename the variable and try again or migrate by hand. -->
 <script>
 	let state = 'world';
 

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-3/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$state-state-var-3/output.svelte
@@ -1,0 +1,8 @@
+<!-- @migration-task Error while migrating Svelte code: can't migrate `$: other = 42;` to `$state` because there's a variable named state -->
+<script>
+	let state = 'world';
+
+	$: other = 42;
+</script>
+
+<input bind:value={other} />


### PR DESCRIPTION
Closes #14215

As usual with the migration script you start simple and then you realise new edge cases. This started simply with a `state` variable erroring when migrating to `$state`. Then i realised the same could be true for `$derived` and `$props` and `$bindable`.

There are some false negative here: technically this is migratable

```svelte
<script>
    export let props;
</script>
```
because
```svelte
<script>
    let { props } = $props();
</script>
```
is valid but while with props is probably fine trying to migrate when the binding is in the expression that we are migrating is a lot more complex for `derived` for example (because we create some new derived in some cases and we don't have a node for that. But i would say this is still good enough and better have some false negative for an edge case than migrate something that can break imho.

There are a lot of tests but that's because i couldn't test multiple things in the same test :(

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
