### PR TITLE
fix: disallow invalid attributes for `<svelte:window>` and `<svelte:document>`

### DIFF
--- a/.changeset/fast-ligers-repeat.md
+++ b/.changeset/fast-ligers-repeat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: disallow invalid attributes for `<svelte:window>` and `<svelte:document>`

--- a/documentation/docs/98-reference/.generated/compile-errors.md
+++ b/documentation/docs/98-reference/.generated/compile-errors.md
@@ -412,6 +412,12 @@ Expected whitespace
 `$host()` can only be used inside custom element component instances
 ```
 
+### illegal_element_attribute
+
+```
+`<%name%>` does not support non-event attributes or spread attributes
+```
+
 ### import_svelte_internal_forbidden
 
 ```

--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -172,6 +172,10 @@
 
 > Expected whitespace
 
+## illegal_element_attribute
+
+> `<%name%>` does not support non-event attributes or spread attributes
+
 ## js_parse_error
 
 > %message%

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -985,6 +985,16 @@ export function expected_whitespace(node) {
 }
 
 /**
+ * `<%name%>` does not support non-event attributes or spread attributes
+ * @param {null | number | NodeLike} node
+ * @param {string} name
+ * @returns {never}
+ */
+export function illegal_element_attribute(node, name) {
+	e(node, "illegal_element_attribute", `\`<${name}>\` does not support non-event attributes or spread attributes`);
+}
+
+/**
  * %message%
  * @param {null | number | NodeLike} node
  * @param {string} message

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteDocument.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteDocument.js
@@ -1,6 +1,8 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
 import { disallow_children } from './shared/special-element.js';
+import * as e from '../../../errors.js';
+import { is_event_attribute } from '../../../utils/ast.js';
 
 /**
  * @param {AST.SvelteDocument} node
@@ -8,5 +10,15 @@ import { disallow_children } from './shared/special-element.js';
  */
 export function SvelteDocument(node, context) {
 	disallow_children(node);
+
+	for (const attribute of node.attributes) {
+		if (
+			attribute.type === 'SpreadAttribute' ||
+			(attribute.type === 'Attribute' && !is_event_attribute(attribute))
+		) {
+			e.illegal_element_attribute(attribute, 'svelte:document');
+		}
+	}
+
 	context.next();
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteWindow.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteWindow.js
@@ -1,6 +1,8 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
 import { disallow_children } from './shared/special-element.js';
+import * as e from '../../../errors.js';
+import { is_event_attribute } from '../../../utils/ast.js';
 
 /**
  * @param {AST.SvelteWindow} node
@@ -8,5 +10,15 @@ import { disallow_children } from './shared/special-element.js';
  */
 export function SvelteWindow(node, context) {
 	disallow_children(node);
+
+	for (const attribute of node.attributes) {
+		if (
+			attribute.type === 'SpreadAttribute' ||
+			(attribute.type === 'Attribute' && !is_event_attribute(attribute))
+		) {
+			e.illegal_element_attribute(attribute, 'svelte:window');
+		}
+	}
+
 	context.next();
 }

--- a/packages/svelte/tests/validator/samples/illegal_spread_element-document/errors.json
+++ b/packages/svelte/tests/validator/samples/illegal_spread_element-document/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "illegal_element_attribute",
+		"message": "`<svelte:document>` does not support non-event attributes or spread attributes",
+		"start": {
+			"line": 4,
+			"column": 17
+		},
+		"end": {
+			"line": 4,
+			"column": 23
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/illegal_spread_element-document/input.svelte
+++ b/packages/svelte/tests/validator/samples/illegal_spread_element-document/input.svelte
@@ -1,0 +1,4 @@
+<script>
+	let a = {};
+</script>
+<svelte:document {...a}></svelte:document>

--- a/packages/svelte/tests/validator/samples/illegal_spread_element-window/errors.json
+++ b/packages/svelte/tests/validator/samples/illegal_spread_element-window/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "illegal_element_attribute",
+		"message": "`<svelte:window>` does not support non-event attributes or spread attributes",
+		"start": {
+			"line": 4,
+			"column": 15
+		},
+		"end": {
+			"line": 4,
+			"column": 21
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/illegal_spread_element-window/input.svelte
+++ b/packages/svelte/tests/validator/samples/illegal_spread_element-window/input.svelte
@@ -1,0 +1,4 @@
+<script>
+	let a = {};
+</script>
+<svelte:window {...a}></svelte:window>


### PR DESCRIPTION
Seems like we missed this validation for these special Svelte elements, but have it on the others.