### PR TITLE
fix: do not treat reassigned synthetic binds as state in runes mode

### DIFF
--- a/.changeset/bright-papayas-sneeze.md
+++ b/.changeset/bright-papayas-sneeze.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: do not treat reassigned synthetic binds as state in runes mode

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -355,15 +355,15 @@ export function analyze_component(root, source, options) {
 
 			// we push to the array because at this moment in time we can't be sure if we are in legacy
 			// mode yet because we are still changing the module scope
-			synthetic_stores_legacy_check.push((/** @type {boolean} */ runes) => {
+			synthetic_stores_legacy_check.push(() => {
 				// if we are creating a synthetic binding for a let declaration we should also declare
-				// the declaration as state in case it's reassigned and we are not in runes mode
+				// the declaration as state in case it's reassigned and we are not in runes mode (the function will
+				// not be called if we are not in runes mode, that's why there's no !runes check here)
 				if (
 					declaration !== null &&
 					declaration.kind === 'normal' &&
 					declaration.declaration_kind === 'let' &&
-					declaration.reassigned &&
-					!runes
+					declaration.reassigned
 				) {
 					declaration.kind = 'state';
 				}
@@ -380,8 +380,10 @@ export function analyze_component(root, source, options) {
 
 	const runes = options.runes ?? Array.from(module.scope.references.keys()).some(is_rune);
 
-	for (let check of synthetic_stores_legacy_check) {
-		check(runes);
+	if (!runes) {
+		for (let check of synthetic_stores_legacy_check) {
+			check();
+		}
 	}
 
 	if (runes && root.module) {

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -276,6 +276,8 @@ export function analyze_component(root, source, options) {
 	/** @type {Template} */
 	const template = { ast: root.fragment, scope, scopes };
 
+	let synthetic_stores_legacy_check = [];
+
 	// create synthetic bindings for store subscriptions
 	for (const [name, references] of module.scope.references) {
 		if (name[0] !== '$' || RESERVED.includes(name)) continue;
@@ -351,16 +353,21 @@ export function analyze_component(root, source, options) {
 				}
 			}
 
-			// if we are creating a synthetic binding for a let declaration we should also declare
-			// the declaration as state in case it's reassigned
-			if (
-				declaration !== null &&
-				declaration.kind === 'normal' &&
-				declaration.declaration_kind === 'let' &&
-				declaration.reassigned
-			) {
-				declaration.kind = 'state';
-			}
+			// we push to the array because at this moment in time we can't be sure if we are in legacy
+			// mode yet because we are still changing the module scope
+			synthetic_stores_legacy_check.push((/** @type {boolean} */ runes) => {
+				// if we are creating a synthetic binding for a let declaration we should also declare
+				// the declaration as state in case it's reassigned and we are not in runes mode
+				if (
+					declaration !== null &&
+					declaration.kind === 'normal' &&
+					declaration.declaration_kind === 'let' &&
+					declaration.reassigned &&
+					!runes
+				) {
+					declaration.kind = 'state';
+				}
+			});
 
 			const binding = instance.scope.declare(b.id(name), 'store_sub', 'synthetic');
 			binding.references = references;
@@ -372,6 +379,10 @@ export function analyze_component(root, source, options) {
 	const component_name = get_component_name(options.filename);
 
 	const runes = options.runes ?? Array.from(module.scope.references.keys()).some(is_rune);
+
+	for (let check of synthetic_stores_legacy_check) {
+		check(runes);
+	}
 
 	if (runes && root.module) {
 		const context = root.module.attributes.find((attribute) => attribute.name === 'context');

--- a/packages/svelte/tests/runtime-runes/samples/reassigned-store-not-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/reassigned-store-not-state/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ logs, assert }) {
+		assert.deepEqual(logs, ['world']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/reassigned-store-not-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/reassigned-store-not-state/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	let style = writable('world');
+	
+	$effect(() => {
+	  console.log($style);
+	});
+
+	function init(){
+		style = writable('svelte');
+	}
+</script>


### PR DESCRIPTION
Closes #14233

The fix was slightly more involved because at that state we still can't have full certainty if we are in rune mode because we are still modifying the module scope.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
