### PR TITLE
fix: export private legacy ComponentType (#14256)

### DIFF
--- a/.changeset/lovely-mayflies-sing.md
+++ b/.changeset/lovely-mayflies-sing.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: export private legacy ComponentType
+fix: provide temporary `LegacyComponentType`

--- a/.changeset/lovely-mayflies-sing.md
+++ b/.changeset/lovely-mayflies-sing.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: export private legacy ComponentType

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -1,20 +1,9 @@
-declare module 'svelte/transitionary' {
-	import { SvelteComponent, Component, type ComponentConstructorOptions } from 'svelte';
-	// Support using the component as both a class and function during the transition period
-	// prettier-ignore
-	export interface TransitionaryComponentType {
-        (
-            ...args: Parameters<Component<Record<string, any>>>
-        ): ReturnType<Component<Record<string, any>, Record<string, any>>>
-        new (o: ComponentConstructorOptions): SvelteComponent
-    }
-}
 declare module '*.svelte' {
 	// use prettier-ignore for a while because of https://github.com/sveltejs/language-tools/commit/026111228b5814a9109cc4d779d37fb02955fb8b
 	// prettier-ignore
 	import { SvelteComponent } from 'svelte'
-	import { TransitionaryComponentType } from 'svelte/transitionary';
-	const Comp: TransitionaryComponentType;
+	import { LegacyComponentType } from 'svelte/legacy';
+	const Comp: LegacyComponentType;
 	type Comp = SvelteComponent;
 	export default Comp;
 }

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -5,7 +5,7 @@ declare module '*.svelte' {
 
 	// Support using the component as both a class and function during the transition period
 	// prettier-ignore
-	interface ComponentType {
+	export interface ComponentType {
 		(
 			...args: Parameters<Component<Record<string, any>>>
 		): ReturnType<Component<Record<string, any>, Record<string, any>>>

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -1,17 +1,20 @@
+declare module 'svelte/transitionary' {
+	import { SvelteComponent, Component, type ComponentConstructorOptions } from 'svelte';
+	// Support using the component as both a class and function during the transition period
+	// prettier-ignore
+	export interface TransitionaryComponentType {
+        (
+            ...args: Parameters<Component<Record<string, any>>>
+        ): ReturnType<Component<Record<string, any>, Record<string, any>>>
+        new (o: ComponentConstructorOptions): SvelteComponent
+    }
+}
 declare module '*.svelte' {
 	// use prettier-ignore for a while because of https://github.com/sveltejs/language-tools/commit/026111228b5814a9109cc4d779d37fb02955fb8b
 	// prettier-ignore
-	import { SvelteComponent, Component, type ComponentConstructorOptions } from 'svelte'
-
-	// Support using the component as both a class and function during the transition period
-	// prettier-ignore
-	export interface ComponentType {
-		(
-			...args: Parameters<Component<Record<string, any>>>
-		): ReturnType<Component<Record<string, any>, Record<string, any>>>
-		new (o: ComponentConstructorOptions): SvelteComponent
-	}
-	const Comp: ComponentType;
+	import { SvelteComponent } from 'svelte'
+	import { TransitionaryComponentType } from 'svelte/transitionary';
+	const Comp: TransitionaryComponentType;
 	type Comp = SvelteComponent;
 	export default Comp;
 }

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -63,6 +63,11 @@ export function asClassComponent(component) {
 	};
 }
 
+/**
+ * Support using the component as both a class and function during the transition period
+ * @typedef  {{new: (o: ComponentConstructorOptions) => SvelteComponent} & ((...args: Parameters<Component<Record<string, any>>>) => ReturnType<Component<Record<string, any>, Record<string, any>>>)} LegacyComponentType
+ */
+
 class Svelte4Component {
 	/** @type {any} */
 	#events;

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -65,7 +65,7 @@ export function asClassComponent(component) {
 
 /**
  * Support using the component as both a class and function during the transition period
- * @typedef  {{new: (o: ComponentConstructorOptions) => SvelteComponent} & ((...args: Parameters<Component<Record<string, any>>>) => ReturnType<Component<Record<string, any>, Record<string, any>>>)} LegacyComponentType
+ * @typedef  {{new (o: ComponentConstructorOptions): SvelteComponent;(...args: Parameters<Component<Record<string, any>>>): ReturnType<Component<Record<string, any>, Record<string, any>>>;}} LegacyComponentType
  */
 
 class Svelte4Component {

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2305,20 +2305,23 @@ declare module 'svelte/types/compiler/interfaces' {
 	};
 
 	export {};
-}declare module '*.svelte' {
-	// use prettier-ignore for a while because of https://github.com/sveltejs/language-tools/commit/026111228b5814a9109cc4d779d37fb02955fb8b
-	// prettier-ignore
-	import { SvelteComponent, Component, type ComponentConstructorOptions } from 'svelte'
-
+}declare module 'svelte/transitionary' {
+	import { SvelteComponent, Component, type ComponentConstructorOptions } from 'svelte';
 	// Support using the component as both a class and function during the transition period
 	// prettier-ignore
-	export interface ComponentType {
-		(
-			...args: Parameters<Component<Record<string, any>>>
-		): ReturnType<Component<Record<string, any>, Record<string, any>>>
-		new (o: ComponentConstructorOptions): SvelteComponent
-	}
-	const Comp: ComponentType;
+	export interface TransitionaryComponentType {
+        (
+            ...args: Parameters<Component<Record<string, any>>>
+        ): ReturnType<Component<Record<string, any>, Record<string, any>>>
+        new (o: ComponentConstructorOptions): SvelteComponent
+    }
+}
+declare module '*.svelte' {
+	// use prettier-ignore for a while because of https://github.com/sveltejs/language-tools/commit/026111228b5814a9109cc4d779d37fb02955fb8b
+	// prettier-ignore
+	import { SvelteComponent } from 'svelte'
+	import { TransitionaryComponentType } from 'svelte/transitionary';
+	const Comp: TransitionaryComponentType;
 	type Comp = SvelteComponent;
 	export default Comp;
 }

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2312,7 +2312,7 @@ declare module 'svelte/types/compiler/interfaces' {
 
 	// Support using the component as both a class and function during the transition period
 	// prettier-ignore
-	interface ComponentType {
+	export interface ComponentType {
 		(
 			...args: Parameters<Component<Record<string, any>>>
 		): ReturnType<Component<Record<string, any>, Record<string, any>>>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1582,8 +1582,9 @@ declare module 'svelte/legacy' {
 	 * Support using the component as both a class and function during the transition period
 	 */
 	export type LegacyComponentType = {
-		new: (o: ComponentConstructorOptions) => SvelteComponent;
-	} & ((...args: Parameters<Component<Record<string, any>>>) => ReturnType<Component<Record<string, any>, Record<string, any>>>);
+		new (o: ComponentConstructorOptions): SvelteComponent;
+		(...args: Parameters<Component<Record<string, any>>>): ReturnType<Component<Record<string, any>, Record<string, any>>>;
+	};
 	/**
 	 * Substitute for the `trusted` event modifier
 	 * @deprecated

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1579,6 +1579,12 @@ declare module 'svelte/legacy' {
 	 */
 	export function createBubbler(): (type: string) => (event: Event) => boolean;
 	/**
+	 * Support using the component as both a class and function during the transition period
+	 */
+	export type LegacyComponentType = {
+		new: (o: ComponentConstructorOptions) => SvelteComponent;
+	} & ((...args: Parameters<Component<Record<string, any>>>) => ReturnType<Component<Record<string, any>, Record<string, any>>>);
+	/**
 	 * Substitute for the `trusted` event modifier
 	 * @deprecated
 	 * */
@@ -2305,23 +2311,12 @@ declare module 'svelte/types/compiler/interfaces' {
 	};
 
 	export {};
-}declare module 'svelte/transitionary' {
-	import { SvelteComponent, Component, type ComponentConstructorOptions } from 'svelte';
-	// Support using the component as both a class and function during the transition period
-	// prettier-ignore
-	export interface TransitionaryComponentType {
-        (
-            ...args: Parameters<Component<Record<string, any>>>
-        ): ReturnType<Component<Record<string, any>, Record<string, any>>>
-        new (o: ComponentConstructorOptions): SvelteComponent
-    }
-}
-declare module '*.svelte' {
+}declare module '*.svelte' {
 	// use prettier-ignore for a while because of https://github.com/sveltejs/language-tools/commit/026111228b5814a9109cc4d779d37fb02955fb8b
 	// prettier-ignore
 	import { SvelteComponent } from 'svelte'
-	import { TransitionaryComponentType } from 'svelte/transitionary';
-	const Comp: TransitionaryComponentType;
+	import { LegacyComponentType } from 'svelte/legacy';
+	const Comp: LegacyComponentType;
 	type Comp = SvelteComponent;
 	export default Comp;
 }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

The transitionary interface `ComponentType` not being exported from the `*.svelte` module declaration causes issues when running `tsc` with `"declaration": true`: `error TS4082: Default export of the module has or is using private name 'ComponentType'.`

Exporting the interface from the  solves this problem in my reproduction (see: #14256)

## Fixed Reproduction

> pnpm add https://pkg.pr.new/svelte@14257

holy smokes, `pkg.pr.new` is cool:
[Broken reproduction with svelte@5.1.9](https://stackblitz.com/edit/vitejs-vite-fgmgkx?file=src%2Findex.ts)
↓
[Fixed reproduction with svelte@https://pkg.pr.new/svelte@14257](https://stackblitz.com/edit/vitejs-vite-2hpal5?file=src%2Findex.ts)

### Question:

~since `packages/svelte/src/ambient.d.ts` is included in `packages/svelte/types/index.d.ts` when building I wasn't sure if I should commit both files into this branch?~
the ci lint job told me what to do