### PR TITLE
fix(migration): named slots with reserved keywords

### DIFF
--- a/.changeset/mean-worms-fetch.md
+++ b/.changeset/mean-worms-fetch.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix(migration): named slots with reserved keyword
+fix: bail on named slots with that have reserved keywords during migration

--- a/.changeset/mean-worms-fetch.md
+++ b/.changeset/mean-worms-fetch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix(migration): named slots with reserved keyword

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -17,7 +17,7 @@ import {
 } from '../utils/ast.js';
 import { migrate_svelte_ignore } from '../utils/extract_svelte_ignore.js';
 import { validate_component_options } from '../validate-options.js';
-import { is_svg, is_void } from '../../utils.js';
+import { is_reserved, is_svg, is_void } from '../../utils.js';
 import { regex_is_valid_identifier } from '../phases/patterns.js';
 
 const regex_style_tags = /(<style[^>]+>)([\S\s]*?)(<\/style>)/g;
@@ -1440,7 +1440,7 @@ function migrate_slot_usage(node, path, state) {
 			if (snippet_name === 'default') {
 				snippet_name = 'children';
 			}
-			if (!regex_is_valid_identifier.test(snippet_name)) {
+			if (!regex_is_valid_identifier.test(snippet_name) || is_reserved(snippet_name)) {
 				has_migration_task = true;
 				state.str.appendLeft(
 					node.start,

--- a/packages/svelte/tests/migrate/samples/slot-non-identifier/input.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-non-identifier/input.svelte
@@ -15,6 +15,12 @@
 </Comp>
 
 <Comp>
+	<div slot="new">
+		reserved keyword
+	</div>
+</Comp>
+
+<Comp>
 	<div slot="stuff">
 		cool
 	</div>

--- a/packages/svelte/tests/migrate/samples/slot-non-identifier/output.svelte
+++ b/packages/svelte/tests/migrate/samples/slot-non-identifier/output.svelte
@@ -17,6 +17,13 @@
 </Comp>
 
 <Comp>
+	<!-- @migration-task: migrate this slot by hand, `new` is an invalid identifier -->
+	<div slot="new">
+		reserved keyword
+	</div>
+</Comp>
+
+<Comp>
 	{#snippet stuff()}
 		<div >
 			cool


### PR DESCRIPTION
Fixes named slots with a reserved keyword not working anymore after migration. Re-uses the `@migration-task` logic for invalid identifiers.

Fixes #14277 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
