### PR TITLE
fix: legacy `$:´ causes an fatal error on 3rd party libs

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -268,8 +268,7 @@ export function legacy_pre_effect(deps, fn) {
 	/** @type {{ effect: null | Effect, ran: boolean }} */
 	var token = { effect: null, ran: false };
 
-	if(context.l !=null){
-
+	if(context.l !=null && context.l.r1 != null){
 		context.l.r1.push(token);
 	}
 
@@ -281,7 +280,10 @@ export function legacy_pre_effect(deps, fn) {
 		if (token.ran) return;
 
 		token.ran = true;
-		set(context.l.r2, true);
+
+		if(context.l!=null && context.l.r2 != null){
+			set(context.l.r2, true);
+		}
 		untrack(fn);
 	});
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -267,7 +267,11 @@ export function legacy_pre_effect(deps, fn) {
 
 	/** @type {{ effect: null | Effect, ran: boolean }} */
 	var token = { effect: null, ran: false };
-	context.l.r1.push(token);
+
+	if(context.l !=null){
+
+		context.l.r1.push(token);
+	}
 
 	token.effect = render_effect(() => {
 		deps();


### PR DESCRIPTION
- [Issue 14296 ] [https://github.com/sveltejs/svelte/issues/14296]

Some libs ran into the issue that the array is `null`. Reading from it therefore causes an error


### Tests and linting

I didn't wrote a test. Appreciate some help here to build a valid scenario!

Edit: _Fix some typos_
