### PR TITLE
fix: mark pseudo classes nested inside `:not` as used

### DIFF
--- a/.changeset/chatty-singers-sin.md
+++ b/.changeset/chatty-singers-sin.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: mark pseudo classes nested inside `:not` as used

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -150,8 +150,9 @@ const css_visitors = {
 			// So that nested selectors like `:root:not(.x)` are not marked as unused
 			for (const child of node.selectors) {
 				walk(/** @type {Css.Node} */ (child), null, {
-					ComplexSelector(node) {
+					ComplexSelector(node, context) {
 						node.metadata.used = true;
+						context.next();
 					}
 				});
 			}

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -531,7 +531,12 @@ function relative_selector_might_apply_to_node(relative_selector, rule, element,
 				// with descendants, in which case we scope them all.
 				if (name === 'not' && selector.args) {
 					for (const complex_selector of selector.args.children) {
-						complex_selector.metadata.used = true;
+						walk(complex_selector, null, {
+							ComplexSelector(node, context) {
+								node.metadata.used = true;
+								context.next();
+							}
+						});
 						const relative = truncate(complex_selector);
 
 						if (complex_selector.children.length > 1) {

--- a/packages/svelte/tests/css/samples/not-selector/expected.css
+++ b/packages/svelte/tests/css/samples/not-selector/expected.css
@@ -29,3 +29,7 @@
 	span.svelte-xyz:not(:focus) {
 		color: green;
 	}
+
+	p.svelte-xyz:not(:has(span)) {
+		color: green;
+	}

--- a/packages/svelte/tests/css/samples/not-selector/input.svelte
+++ b/packages/svelte/tests/css/samples/not-selector/input.svelte
@@ -36,4 +36,8 @@
 	span:not(:focus) {
 		color: green;
 	}
+
+	p:not(:has(span)) {
+		color: green;
+	}
 </style>


### PR DESCRIPTION
fixes the css bug part of #14299

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
