### PR TITLE
fix: avoid relying on Node specifics within compiler

### DIFF
--- a/.changeset/strange-adults-visit.md
+++ b/.changeset/strange-adults-visit.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid relying on Node specifics within compiler

--- a/packages/svelte/src/compiler/validate-options.js
+++ b/packages/svelte/src/compiler/validate-options.js
@@ -1,5 +1,3 @@
-import process from 'node:process';
-
 /** @import { ModuleCompileOptions, ValidatedModuleCompileOptions, CompileOptions, ValidatedCompileOptions } from '#compiler' */
 import * as e from './errors.js';
 import * as w from './warnings.js';
@@ -13,9 +11,19 @@ import * as w from './warnings.js';
 const common = {
 	filename: string('(unknown)'),
 
-	// default to process.cwd() where it exists to replicate svelte4 behavior
+	// default to process.cwd() where it exists to replicate svelte4 behavior (and make Deno work with this as well)
 	// see https://github.com/sveltejs/svelte/blob/b62fc8c8fd2640c9b99168f01b9d958cb2f7574f/packages/svelte/src/compiler/compile/Component.js#L211
-	rootDir: string(typeof process !== 'undefined' ? process.cwd?.() : undefined),
+	/* eslint-disable */
+	rootDir: string(
+		typeof process !== 'undefined'
+			? process.cwd()
+			: // @ts-expect-error
+				typeof Deno !== 'undefined'
+				? // @ts-expect-error
+					Deno.cwd()
+				: undefined
+	),
+	/* eslint-enable */
 
 	dev: boolean(false),
 

--- a/packages/svelte/src/compiler/validate-options.js
+++ b/packages/svelte/src/compiler/validate-options.js
@@ -16,7 +16,7 @@ const common = {
 	/* eslint-disable */
 	rootDir: string(
 		typeof process !== 'undefined'
-			? process.cwd()
+			? process.cwd?.()
 			: // @ts-expect-error
 				typeof Deno !== 'undefined'
 				? // @ts-expect-error


### PR DESCRIPTION
fixes #14294
