### PR TITLE
fix: convert input value to number on hydration

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -45,7 +45,7 @@ export function bind_value(input, get, set = get) {
 		// If we are hydrating and the value has since changed, then use the update value
 		// from the input instead.
 		if (hydrating && input.defaultValue !== input.value) {
-			set(input.value);
+			set(is_numberlike_input(input) ? to_number(input.value) : input.value);
 			return;
 		}
 


### PR DESCRIPTION
further fixes #1755 when input is of type "number", currently the binding is set to a string if the default doesn't match.

this gets triggered frequently on Firefox, as it restores input values immediately after a refresh, before the content gets hydrated.