### PR TITLE
chore: remove some unused code

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
@@ -57,23 +57,5 @@ export function ExportNamedDeclaration(node, context) {
 				}
 			}
 		}
-
-		if (!context.state.ast_type /* .svelte.js module */ || context.state.ast_type === 'module') {
-			for (const specified of node.specifiers) {
-				if (specified.local.type !== 'Identifier') continue;
-
-				const binding = context.state.scope.get(specified.local.name);
-
-				if (!binding) continue;
-
-				if (binding.kind === 'derived') {
-					e.derived_invalid_export(node);
-				}
-
-				if ((binding.kind === 'state' || binding.kind === 'raw_state') && binding.reassigned) {
-					e.state_invalid_export(node);
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
this is unnecessary — the same logic exists in the `ExportSpecifier` visitor