### PR TITLE
fix: tighten up `export default` validation

### DIFF
--- a/.changeset/new-houses-roll.md
+++ b/.changeset/new-houses-roll.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: tighten up `export default` validation

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportDefaultDeclaration.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportDefaultDeclaration.js
@@ -1,13 +1,18 @@
-/** @import { ExportDefaultDeclaration, Node } from 'estree' */
+/** @import { ExportDefaultDeclaration } from 'estree' */
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
+import { validate_export } from './shared/utils.js';
 
 /**
  * @param {ExportDefaultDeclaration} node
  * @param {Context} context
  */
 export function ExportDefaultDeclaration(node, context) {
-	if (context.state.ast_type === 'instance') {
+	if (!context.state.ast_type /* .svelte.js module */) {
+		if (node.declaration.type === 'Identifier') {
+			validate_export(node, context.state.scope, node.declaration.name);
+		}
+	} else {
 		e.module_illegal_default_export(node);
 	}
 

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportSpecifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportSpecifier.js
@@ -1,8 +1,6 @@
-/** @import { ExportSpecifier, Node } from 'estree' */
-/** @import { Binding } from '#compiler' */
+/** @import { ExportSpecifier } from 'estree' */
 /** @import { Context } from '../types' */
-/** @import { Scope } from '../../scope' */
-import * as e from '../../../errors.js';
+import { validate_export } from './shared/utils.js';
 
 /**
  * @param {ExportSpecifier} node
@@ -28,24 +26,5 @@ export function ExportSpecifier(node, context) {
 		}
 	} else {
 		validate_export(node, context.state.scope, local_name);
-	}
-}
-
-/**
- *
- * @param {Node} node
- * @param {Scope} scope
- * @param {string} name
- */
-function validate_export(node, scope, name) {
-	const binding = scope.get(name);
-	if (!binding) return;
-
-	if (binding.kind === 'derived') {
-		e.derived_invalid_export(node);
-	}
-
-	if ((binding.kind === 'state' || binding.kind === 'raw_state') && binding.reassigned) {
-		e.state_invalid_export(node);
 	}
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
@@ -1,4 +1,4 @@
-/** @import { AssignmentExpression, Expression, Literal, Pattern, PrivateIdentifier, Super, UpdateExpression, VariableDeclarator } from 'estree' */
+/** @import { AssignmentExpression, Expression, Literal, Node, Pattern, PrivateIdentifier, Super, UpdateExpression, VariableDeclarator } from 'estree' */
 /** @import { AST, Binding } from '#compiler' */
 /** @import { AnalysisState, Context } from '../../types' */
 /** @import { Scope } from '../../../scope' */
@@ -261,5 +261,24 @@ export function validate_identifier_name(binding, function_depth) {
 		) {
 			e.dollar_prefix_invalid(node);
 		}
+	}
+}
+
+/**
+ * Checks that the exported name is not a derived or reassigned state variable.
+ * @param {Node} node
+ * @param {Scope} scope
+ * @param {string} name
+ */
+export function validate_export(node, scope, name) {
+	const binding = scope.get(name);
+	if (!binding) return;
+
+	if (binding.kind === 'derived') {
+		e.derived_invalid_export(node);
+	}
+
+	if ((binding.kind === 'state' || binding.kind === 'raw_state') && binding.reassigned) {
+		e.state_invalid_export(node);
 	}
 }

--- a/packages/svelte/tests/compiler-errors/samples/export-default-derived-state-indirect/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/export-default-derived-state-indirect/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'derived_invalid_export',
+		message:
+			'Cannot export derived state from a module. To expose the current derived value, export a function returning its value',
+		position: [61, 83]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/export-default-derived-state-indirect/main.svelte.js
+++ b/packages/svelte/tests/compiler-errors/samples/export-default-derived-state-indirect/main.svelte.js
@@ -1,0 +1,5 @@
+let count = $state(0);
+
+const double = $derived(count * 2);
+
+export default double;

--- a/packages/svelte/tests/compiler-errors/samples/export-default-state-indirect/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/export-default-state-indirect/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'state_invalid_export',
+		message:
+			"Cannot export state from a module if it is reassigned. Either export a function returning the state value or only mutate the state value's properties",
+		position: [93, 118]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/export-default-state-indirect/main.svelte.js
+++ b/packages/svelte/tests/compiler-errors/samples/export-default-state-indirect/main.svelte.js
@@ -1,0 +1,7 @@
+let primitive = $state('nope');
+
+export function update_primitive() {
+	primitive = 'yep';
+}
+
+export default primitive;

--- a/packages/svelte/tests/validator/samples/default-export-module/errors.json
+++ b/packages/svelte/tests/validator/samples/default-export-module/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "module_illegal_default_export",
+		"message": "A component cannot have a default export",
+		"start": {
+			"line": 2,
+			"column": 1
+		},
+		"end": {
+			"line": 2,
+			"column": 19
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/default-export-module/input.svelte
+++ b/packages/svelte/tests/validator/samples/default-export-module/input.svelte
@@ -1,0 +1,3 @@
+<script module>
+	export default 42;
+</script>


### PR DESCRIPTION
through #14363 I noticed our `export default` validation wasn't quite right:
- missed checking for derived/state exports
- the "cannot have a default export" error was only thrown if you did `export default` from the instance script, but it shouldn't matter from which component part you export it; it's never ok

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
