### PR TITLE
fix: always use set for private identifiers

### DIFF
--- a/.changeset/tiny-trainers-sleep.md
+++ b/.changeset/tiny-trainers-sleep.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: always use set for private identifiers

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
@@ -46,6 +46,8 @@ function build_assignment(operator, left, right, context) {
 			}
 
 			if (context.state.in_constructor) {
+				// inside the constructor, we can assign to `this.#foo.v` rather than using `$.set`,
+				// since nothing is tracking the signal at this point
 				return b.assignment(operator, /** @type {Pattern} */ (context.visit(left)), value);
 			}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
@@ -37,24 +37,19 @@ function build_assignment(operator, left, right, context) {
 		const private_state = context.state.private_state.get(left.property.name);
 
 		if (private_state !== undefined) {
-			let transformed = false;
 			let value = /** @type {Expression} */ (
 				context.visit(build_assignment_value(operator, left, right))
 			);
 
-			if (should_proxy(value, context.state.scope)) {
-				transformed = true;
-				value =
-					private_state.kind === 'raw_state'
-						? value
-						: build_proxy_reassignment(value, b.member(b.this, private_state.id));
+			if (private_state.kind !== 'raw_state' && should_proxy(value, context.state.scope)) {
+				value = build_proxy_reassignment(value, b.member(b.this, private_state.id));
 			}
 
-			if (!context.state.in_constructor) {
-				return b.call('$.set', left, value);
-			} else if (transformed) {
+			if (context.state.in_constructor) {
 				return b.assignment(operator, /** @type {Pattern} */ (context.visit(left)), value);
 			}
+
+			return b.call('$.set', left, value);
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
@@ -32,30 +32,28 @@ function build_assignment(operator, left, right, context) {
 	if (
 		context.state.analysis.runes &&
 		left.type === 'MemberExpression' &&
-		left.object.type === 'ThisExpression'
+		left.property.type === 'PrivateIdentifier'
 	) {
-		if (left.property.type === 'PrivateIdentifier') {
-			const private_state = context.state.private_state.get(left.property.name);
+		const private_state = context.state.private_state.get(left.property.name);
 
-			if (private_state !== undefined) {
-				let transformed = false;
-				let value = /** @type {Expression} */ (
-					context.visit(build_assignment_value(operator, left, right))
-				);
+		if (private_state !== undefined) {
+			let transformed = false;
+			let value = /** @type {Expression} */ (
+				context.visit(build_assignment_value(operator, left, right))
+			);
 
-				if (should_proxy(value, context.state.scope)) {
-					transformed = true;
-					value =
-						private_state.kind === 'raw_state'
-							? value
-							: build_proxy_reassignment(value, b.member(b.this, private_state.id));
-				}
+			if (should_proxy(value, context.state.scope)) {
+				transformed = true;
+				value =
+					private_state.kind === 'raw_state'
+						? value
+						: build_proxy_reassignment(value, b.member(b.this, private_state.id));
+			}
 
-				if (!context.state.in_constructor) {
-					return b.call('$.set', left, value);
-				} else if (transformed) {
-					return b.assignment(operator, /** @type {Pattern} */ (context.visit(left)), value);
-				}
+			if (!context.state.in_constructor) {
+				return b.call('$.set', left, value);
+			} else if (transformed) {
+				return b.assignment(operator, /** @type {Pattern} */ (context.visit(left)), value);
 			}
 		}
 	}

--- a/packages/svelte/tests/runtime-runes/samples/private-identifiers-not-this/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/private-identifiers-not-this/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: `<p>42</p><p>1337</p><button></button>`,
+	async test({ assert, target, instance }) {
+		const [a, b] = target.querySelectorAll('p');
+		const btn = target.querySelector('button');
+
+		flushSync(() => {
+			btn?.click();
+		});
+
+		assert.equal(a.textContent, '1337');
+		assert.equal(b.textContent, '42');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/private-identifiers-not-this/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/private-identifiers-not-this/main.svelte
@@ -1,0 +1,26 @@
+<script>
+	class Box {
+		#value = $state(0);
+
+		get value(){
+			return this.#value;
+		}
+		
+		constructor(num){
+			this.#value = num;
+		}
+		
+		swap(other) {
+			const value = this.#value;
+			this.#value = other.value;
+			other.#value = value;
+		}
+	}
+
+	const a = new Box(42);
+	const b = new Box(1337);
+</script>
+
+<p>{a.value}</p>
+<p>{b.value}</p>
+<button onclick={()=>{a.swap(b)}}></button>


### PR DESCRIPTION
Closes #13965

Unless i'm missing something obvious there's no reason to not always transform PrivateIdentifiers that are also inside the class private state so no need to check for the left object to be `this`. JS will stop them to modify a private identifier which is not of the same class and if it is from the same class it's fine to use `set` to set it.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
