### PR TITLE
fix: ensure spread attribute events are attached synchronously

### DIFF
--- a/.changeset/rich-worms-burn.md
+++ b/.changeset/rich-worms-burn.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure spread attribute events are attached synchronously
+fix: attach spread attribute events synchronously

--- a/.changeset/rich-worms-burn.md
+++ b/.changeset/rich-worms-burn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure spread attribute events are attached synchronously

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -13,6 +13,7 @@ import {
 	set_active_effect,
 	set_active_reaction
 } from '../../runtime.js';
+import { destroy_effect, effect } from '../../reactivity/effects.js';
 
 /**
  * The value/checked attribute in the template actually corresponds to the defaultValue property, so we need
@@ -325,17 +326,10 @@ export function set_attributes(
 		}
 	}
 
-	// On the first run, ensure that events are added after bindings so
-	// that their listeners fire after the binding listeners
-	if (!prev) {
-		queue_micro_task(() => {
-			if (!element.isConnected) return;
-			for (const [key, value, evt] of events) {
-				if (current[key] === value) {
-					evt();
-				}
-			}
-		});
+	for (const [key, value, evt] of events) {
+		if (current[key] === value) {
+			evt();
+		}
 	}
 
 	return current;

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -5,7 +5,7 @@ import { create_event, delegate } from './events.js';
 import { add_form_reset_listener, autofocus } from './misc.js';
 import * as w from '../../warnings.js';
 import { LOADING_ATTR_SYMBOL } from '../../constants.js';
-import { queue_idle_task, queue_micro_task } from '../task.js';
+import { queue_idle_task } from '../task.js';
 import { is_capture_event, is_delegated, normalize_attribute } from '../../../../utils.js';
 import {
 	active_effect,
@@ -13,7 +13,6 @@ import {
 	set_active_effect,
 	set_active_reaction
 } from '../../runtime.js';
-import { destroy_effect, effect } from '../../reactivity/effects.js';
 
 /**
  * The value/checked attribute in the template actually corresponds to the defaultValue property, so we need

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -209,8 +209,6 @@ export function set_attributes(
 
 	// @ts-expect-error
 	var attributes = /** @type {Record<string, unknown>} **/ (element.__attributes ??= {});
-	/** @type {Array<[string, any, () => void]>} */
-	var events = [];
 
 	// since key is captured we use const
 	for (const key in next) {
@@ -277,15 +275,7 @@ export function set_attributes(
 						current[key].call(this, evt);
 					}
 
-					if (!prev) {
-						events.push([
-							key,
-							value,
-							() => (current[event_handle_key] = create_event(event_name, element, handle, opts))
-						]);
-					} else {
-						current[event_handle_key] = create_event(event_name, element, handle, opts);
-					}
+					current[event_handle_key] = create_event(event_name, element, handle, opts);
 				} else {
 					// @ts-ignore
 					element[`__${event_name}`] = value;
@@ -322,12 +312,6 @@ export function set_attributes(
 		if (key === 'style' && '__styles' in element) {
 			// reset styles to force style: directive to update
 			element.__styles = {};
-		}
-	}
-
-	for (const [key, value, evt] of events) {
-		if (current[key] === value) {
-			evt();
 		}
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/event-spread-timing/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-spread-timing/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	test({ assert, logs }) {
+		assert.deepEqual(logs, ['onfocus']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-spread-timing/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-spread-timing/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	const focus = (input) => {
+		input.focus();
+	};
+</script>
+
+<input {...({})} onfocus={() => console.log("onfocus")} use:focus />


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14385. Interestingly, it seems the tests in https://github.com/sveltejs/svelte/pull/11230 still pass here so I assume that we've fixed this issue through some other changes in the codebase since.