### PR TITLE
fix: show `:then` block for `null` value

### DIFF
--- a/.changeset/breezy-insects-live.md
+++ b/.changeset/breezy-insects-live.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: show `:then` block for `null` value
+fix: show `:then` block for `null/undefined` value

--- a/.changeset/breezy-insects-live.md
+++ b/.changeset/breezy-insects-live.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: show `:then` block for `null` value

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -14,6 +14,7 @@ import {
 } from '../../runtime.js';
 import { hydrate_next, hydrate_node, hydrating } from '../hydration.js';
 import { queue_micro_task } from '../task.js';
+import { UNINITIALIZED } from '../../../../constants.js';
 
 const PENDING = 0;
 const THEN = 1;
@@ -40,7 +41,7 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 	/** @type {any} */
 	var component_function = DEV ? component_context?.function : null;
 
-	/** @type {V | Promise<V> | null} */
+	/** @type {V | Promise<V> | typeof UNINITIALIZED} */
 	var input;
 
 	/** @type {Effect | null} */
@@ -156,8 +157,8 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 			update(THEN, false);
 		}
 
-		// Set the input to null, in order to disable the promise callbacks
-		return () => (input = null);
+		// Set the input to something else, in order to disable the promise callbacks
+		return () => (input = UNINITIALIZED);
 	});
 
 	if (hydrating) {

--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -42,7 +42,7 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 	var component_function = DEV ? component_context?.function : null;
 
 	/** @type {V | Promise<V> | typeof UNINITIALIZED} */
-	var input;
+	var input = UNINITIALIZED;
 
 	/** @type {Effect | null} */
 	var pending_effect;

--- a/packages/svelte/tests/runtime-runes/samples/await-non-promise/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-non-promise/_config.js
@@ -1,9 +1,28 @@
 import { flushSync } from 'svelte';
-import { test } from '../../test';
+import { ok, test } from '../../test';
 
 export default test({
+	solo: true,
 	compileOptions: {
 		dev: true
 	},
-	test() {}
+	test({ assert, target }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+		const p = target.querySelector('p');
+		ok(p);
+
+		assert.htmlEqual(p.outerHTML, `<p>0</p>`);
+
+		btn1.click();
+		flushSync();
+		assert.htmlEqual(p.outerHTML, `<p>1</p>`);
+
+		btn2.click();
+		flushSync();
+		assert.htmlEqual(p.outerHTML, `<p></p>`);
+
+		btn1.click();
+		flushSync();
+		assert.htmlEqual(p.outerHTML, `<p>1</p>`);
+	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/await-non-promise/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-non-promise/_config.js
@@ -2,7 +2,6 @@ import { flushSync } from 'svelte';
 import { ok, test } from '../../test';
 
 export default test({
-	solo: true,
 	compileOptions: {
 		dev: true
 	},
@@ -11,7 +10,7 @@ export default test({
 		const p = target.querySelector('p');
 		ok(p);
 
-		assert.htmlEqual(p.outerHTML, `<p>0</p>`);
+		assert.htmlEqual(p.outerHTML, `<p></p>`);
 
 		btn1.click();
 		flushSync();

--- a/packages/svelte/tests/runtime-runes/samples/await-non-promise/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-non-promise/main.svelte
@@ -1,5 +1,5 @@
 <script>
-	let count = $state(0);
+	let count = $state();
 </script>
 
 <button onclick={() => count += 1}>increment</button>

--- a/packages/svelte/tests/runtime-runes/samples/await-non-promise/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-non-promise/main.svelte
@@ -2,7 +2,7 @@
 	let count = $state();
 </script>
 
-<button onclick={() => count += 1}>increment</button>
+<button onclick={() => count = 1}>number</button>
 <button onclick={() => count = null}>nullify</button>
 
 <p>

--- a/packages/svelte/tests/runtime-runes/samples/await-non-promise/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/await-non-promise/main.svelte
@@ -1,9 +1,14 @@
 <script>
-	let count = $state(43);
+	let count = $state(0);
 </script>
 
-{#await count}
-	loading
-{:then count}
-	{count}
-{/await}
+<button onclick={() => count += 1}>increment</button>
+<button onclick={() => count = null}>nullify</button>
+
+<p>
+	{#await count}
+		loading
+	{:then count}
+		{count}
+	{/await}
+</p>


### PR DESCRIPTION
fixes #14439

This bug was introduced in #13642 because setting the input to `null` means the equality check ("is the input different") fails if you set the value to `null`

Also fixes #14441 - this bug was present for a long time, and the reason is the same as for the other bug: The equality check always returns "yes this is the same" if the value is `undefined` initially. The fix is similar; we need to initialize the input to something that can never be equal to whatever value is passed

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
