### PR TITLE
fix: addresses memory leak when creating deriveds inside untrack

### DIFF
--- a/.changeset/great-crabs-rhyme.md
+++ b/.changeset/great-crabs-rhyme.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: addresses memory leak when creating deriveds inside untrack
+fix: prevent memory leak when creating deriveds inside untrack

--- a/.changeset/great-crabs-rhyme.md
+++ b/.changeset/great-crabs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: addresses memory leak when creating deriveds inside untrack

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -42,6 +42,11 @@ export function derived(fn) {
 		active_effect.f |= EFFECT_HAS_DERIVED;
 	}
 
+	var parent_derived =
+		active_reaction !== null && (active_reaction.f & DERIVED) !== 0
+			? /** @type {Derived} */ (active_reaction)
+			: null;
+
 	/** @type {Derived<V>} */
 	const signal = {
 		children: null,
@@ -53,12 +58,11 @@ export function derived(fn) {
 		reactions: null,
 		v: /** @type {V} */ (null),
 		version: 0,
-		parent: active_effect
+		parent: parent_derived || active_effect
 	};
 
-	if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
-		var derived = /** @type {Derived} */ (active_reaction);
-		(derived.children ??= []).push(signal);
+	if (parent_derived !== null) {
+		(parent_derived.children ??= []).push(signal);
 	}
 
 	return signal;
@@ -105,6 +109,21 @@ function destroy_derived_children(derived) {
 let stack = [];
 
 /**
+ * @param {Derived} derived
+ * @returns {Effect | null}
+ */
+export function get_derived_parent_effect(derived) {
+	var parent = derived.parent;
+	if (parent !== null) {
+		if ((parent.f & DERIVED) === 0) {
+			return /** @type {Effect} */ (parent);
+		}
+		parent = parent.parent;
+	}
+	return null;
+}
+
+/**
  * @template T
  * @param {Derived} derived
  * @returns {T}
@@ -113,7 +132,7 @@ export function execute_derived(derived) {
 	var value;
 	var prev_active_effect = active_effect;
 
-	set_active_effect(derived.parent);
+	set_active_effect(get_derived_parent_effect(derived));
 
 	if (DEV) {
 		let prev_inspect_effects = inspect_effects;
@@ -162,14 +181,13 @@ export function update_derived(derived) {
 }
 
 /**
- * @param {Derived} signal
+ * @param {Derived} derived
  * @returns {void}
  */
-export function destroy_derived(signal) {
-	destroy_derived_children(signal);
-	remove_reactions(signal, 0);
-	set_signal_status(signal, DESTROYED);
+export function destroy_derived(derived) {
+	destroy_derived_children(derived);
+	remove_reactions(derived, 0);
+	set_signal_status(derived, DESTROYED);
 
-	// TODO we need to ensure we remove the derived from any parent derives
-	signal.v = signal.children = signal.deps = signal.ctx = signal.reactions = null;
+	derived.v = derived.children = derived.deps = derived.ctx = derived.reactions = null;
 }

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -112,7 +112,7 @@ let stack = [];
  * @param {Derived} derived
  * @returns {Effect | null}
  */
-export function get_derived_parent_effect(derived) {
+function get_derived_parent_effect(derived) {
 	var parent = derived.parent;
 	while (parent !== null) {
 		if ((parent.f & DERIVED) === 0) {

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -114,7 +114,7 @@ let stack = [];
  */
 export function get_derived_parent_effect(derived) {
 	var parent = derived.parent;
-	if (parent !== null) {
+	while (parent !== null) {
 		if ((parent.f & DERIVED) === 0) {
 			return /** @type {Effect} */ (parent);
 		}

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -58,7 +58,7 @@ export function derived(fn) {
 		reactions: null,
 		v: /** @type {V} */ (null),
 		version: 0,
-		parent: parent_derived || active_effect
+		parent: parent_derived ?? active_effect
 	};
 
 	if (parent_derived !== null) {

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -23,7 +23,6 @@ export interface Reaction extends Signal {
 	fn: null | Function;
 	/** Signals that this signal reads from */
 	deps: null | Value[];
-	parent: Effect | null;
 }
 
 export interface Derived<V = unknown> extends Value<V>, Reaction {
@@ -31,6 +30,8 @@ export interface Derived<V = unknown> extends Value<V>, Reaction {
 	fn: () => V;
 	/** Reactions created inside this signal */
 	children: null | Reaction[];
+	/** Parent effect or derived */
+	parent: Effect | Derived | null;
 }
 
 export interface Effect extends Reaction {
@@ -58,6 +59,8 @@ export interface Effect extends Reaction {
 	first: null | Effect;
 	/** Last child effect created inside this signal */
 	last: null | Effect;
+	/** Parent effect */
+	parent: Effect | null;
 	/** Dev only */
 	component_function?: any;
 }

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -771,11 +771,14 @@ export function get(signal) {
 
 		while (parent !== null) {
 			if ((parent.f & DERIVED) !== 0) {
-				target = /** @type {Derived} */ (parent);
-				parent = /** @type {Derived} */ (parent.parent);
+				var parent_derived = /** @type {Derived} */ (parent);
+
+				target = parent_derived;
+				parent = parent_derived.parent;
 			} else {
-				if (!(/** @type {Effect} */ (parent).deriveds?.includes(target))) {
-					var parent_effect = /** @type {Effect} */ (parent);
+				var parent_effect = /** @type {Effect} */ (parent);
+
+				if (!parent_effect.deriveds?.includes(target)) {
 					(parent_effect.deriveds ??= []).push(target);
 				}
 				break;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -770,6 +770,8 @@ export function get(signal) {
 		var target = derived;
 
 		while (parent !== null) {
+			// Attach the derived to the nearest parent effect, if there are deriveds
+			// in between then we also need to attach them too
 			if ((parent.f & DERIVED) !== 0) {
 				var parent_derived = /** @type {Derived} */ (parent);
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -29,12 +29,7 @@ import {
 import { flush_tasks } from './dom/task.js';
 import { add_owner } from './dev/ownership.js';
 import { mutate, set, source } from './reactivity/sources.js';
-import {
-	destroy_derived,
-	execute_derived,
-	get_derived_parent_effect,
-	update_derived
-} from './reactivity/deriveds.js';
+import { destroy_derived, execute_derived, update_derived } from './reactivity/deriveds.js';
 import * as e from './errors.js';
 import { lifecycle_outside_component } from '../shared/errors.js';
 import { FILENAME } from '../../constants.js';
@@ -771,9 +766,14 @@ export function get(signal) {
 		}
 	} else if (is_derived && /** @type {Derived} */ (signal).deps === null) {
 		var derived = /** @type {Derived} */ (signal);
-		var parent_effect = get_derived_parent_effect(derived);
+		var parent = derived.parent;
 
-		if (parent_effect !== null && !parent_effect.deriveds?.includes(derived)) {
+		if (
+			parent !== null &&
+			(parent.f & DERIVED) === 0 &&
+			!(/** @type {Effect} */ (parent).deriveds?.includes(derived))
+		) {
+			var parent_effect = /** @type {Effect} */ (parent);
 			(parent_effect.deriveds ??= []).push(derived);
 		}
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -767,14 +767,19 @@ export function get(signal) {
 	} else if (is_derived && /** @type {Derived} */ (signal).deps === null) {
 		var derived = /** @type {Derived} */ (signal);
 		var parent = derived.parent;
+		var target = derived;
 
-		if (
-			parent !== null &&
-			(parent.f & DERIVED) === 0 &&
-			!(/** @type {Effect} */ (parent).deriveds?.includes(derived))
-		) {
-			var parent_effect = /** @type {Effect} */ (parent);
-			(parent_effect.deriveds ??= []).push(derived);
+		while (parent !== null) {
+			if ((parent.f & DERIVED) !== 0) {
+				target = /** @type {Derived} */ (parent);
+				parent = /** @type {Derived} */ (parent.parent);
+			} else {
+				if (!(/** @type {Effect} */ (parent).deriveds?.includes(target))) {
+					var parent_effect = /** @type {Effect} */ (parent);
+					(parent_effect.deriveds ??= []).push(target);
+				}
+				break;
+			}
 		}
 	}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -29,7 +29,12 @@ import {
 import { flush_tasks } from './dom/task.js';
 import { add_owner } from './dev/ownership.js';
 import { mutate, set, source } from './reactivity/sources.js';
-import { destroy_derived, execute_derived, update_derived } from './reactivity/deriveds.js';
+import {
+	destroy_derived,
+	execute_derived,
+	get_derived_parent_effect,
+	update_derived
+} from './reactivity/deriveds.js';
 import * as e from './errors.js';
 import { lifecycle_outside_component } from '../shared/errors.js';
 import { FILENAME } from '../../constants.js';
@@ -766,10 +771,10 @@ export function get(signal) {
 		}
 	} else if (is_derived && /** @type {Derived} */ (signal).deps === null) {
 		var derived = /** @type {Derived} */ (signal);
-		var parent = derived.parent;
+		var parent_effect = get_derived_parent_effect(derived);
 
-		if (parent !== null && !parent.deriveds?.includes(derived)) {
-			(parent.deriveds ??= []).push(derived);
+		if (parent_effect !== null && !parent_effect.deriveds?.includes(derived)) {
+			(parent_effect.deriveds ??= []).push(derived);
 		}
 	}
 

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -740,7 +740,7 @@ describe('signals', () => {
 		};
 	});
 
-	test('nested deriveds clean up the releationships when used with untrack', () => {
+	test('nested deriveds clean up the relationships when used with untrack', () => {
 		return () => {
 			let a = render_effect(() => {});
 

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -740,7 +740,7 @@ describe('signals', () => {
 		};
 	});
 
-	test.only('nested deriveds clean up the releationships when used with untrack', () => {
+	test('nested deriveds clean up the releationships when used with untrack', () => {
 		return () => {
 			let a = render_effect(() => {});
 

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -739,4 +739,30 @@ describe('signals', () => {
 			assert.deepEqual(a.reactions, null);
 		};
 	});
+
+	test.only('nested deriveds clean up the releationships when used with untrack', () => {
+		return () => {
+			let a = render_effect(() => {});
+
+			const destroy = effect_root(() => {
+				a = render_effect(() => {
+					$.untrack(() => {
+						const b = derived(() => {
+							const c = derived(() => {});
+							$.untrack(() => {
+								$.get(c);
+							});
+						});
+						$.get(b);
+					});
+				});
+			});
+
+			assert.deepEqual(a.deriveds?.length, 1);
+
+			destroy();
+
+			assert.deepEqual(a.deriveds, null);
+		};
+	});
 });


### PR DESCRIPTION
This was an odd memory leak that I've been tracking for weeks. I made the discovery today whilst looking into another issue that it was to do with `untrack`. Specifically, we only attach a derived to the parent effect when we're in a non tracking context – however, because nested deriveds only recorded their parent as effect, it meant that nested deriveds were incorrectly being added to the same effect after each run.

Rather than have the awkwardly deal with removing a derived from the parent each time, and know that deriveds can only be created where they are declared, we can instead just make the parent of a derived by that of an effect or another derived.