### PR TITLE
fix: disregard TypeScript nodes when pruning CSS

### DIFF
--- a/.changeset/tender-balloons-relate.md
+++ b/.changeset/tender-balloons-relate.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: disregard TypeScript nodes when pruning CSS

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -895,7 +895,7 @@ function get_possible_element_siblings(element, adjacent_only) {
 	let i = path.length;
 
 	while (i--) {
-		let current = node;
+		let fragment = /** @type {Compiler.AST.Fragment} */ (path[i--]);
 
 		// @ts-expect-error
 		while ((node = node.prev)) {
@@ -928,20 +928,14 @@ function get_possible_element_siblings(element, adjacent_only) {
 			}
 		}
 
-		let parent = path[i];
+		node = path[i];
 
-		if (parent.type === 'Fragment') {
-			parent = path[--i];
-		}
+		if (!node || !is_block(node)) break;
 
-		if (!parent || !is_block(parent)) break;
-
-		if (parent.type === 'EachBlock' && !parent.fallback?.nodes.includes(current)) {
+		if (node.type === 'EachBlock' && fragment === node.body) {
 			// `{#each ...}<a /><b />{/each}` — `<b>` can be previous sibling of `<a />`
-			add_to_map(get_possible_last_child(parent, adjacent_only), result);
+			add_to_map(get_possible_last_child(node, adjacent_only), result);
 		}
-
-		node = parent;
 	}
 
 	return result;

--- a/packages/svelte/tests/css/samples/unused-ts-as-expression/_config.js
+++ b/packages/svelte/tests/css/samples/unused-ts-as-expression/_config.js
@@ -1,0 +1,20 @@
+import { test } from '../../test';
+
+export default test({
+	warnings: [
+		{
+			code: 'css_unused_selector',
+			end: {
+				character: 127,
+				column: 28,
+				line: 10
+			},
+			message: 'Unused CSS selector "[data-active=\'true\'] > span"',
+			start: {
+				character: 100,
+				column: 1,
+				line: 10
+			}
+		}
+	]
+});

--- a/packages/svelte/tests/css/samples/unused-ts-as-expression/expected.css
+++ b/packages/svelte/tests/css/samples/unused-ts-as-expression/expected.css
@@ -1,0 +1,4 @@
+
+	/* (unused) [data-active='true'] > span {
+		background-color: red;
+	}*/

--- a/packages/svelte/tests/css/samples/unused-ts-as-expression/input.svelte
+++ b/packages/svelte/tests/css/samples/unused-ts-as-expression/input.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	//
+</script>
+
+<div data-active={false as true}>
+	<span></span>
+</div>
+
+<style>
+	[data-active='true'] > span {
+		background-color: red;
+	}
+</style>


### PR DESCRIPTION
Fixes #14204 — this refactors `get_possible_element_siblings` to make it non-recursive, and use `context.path` and `fragment.nodes` rather than `node.parent` and `node.prev`. We should now be able to get rid of all references to those properties, but I'll do that in a separate PR.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
