### PR TITLE
fix: ignore text and expressions outside the template when validating HTML

### DIFF
--- a/.changeset/brave-keys-rescue.md
+++ b/.changeset/brave-keys-rescue.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ignore text and expressions outside the template when validating HTML

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExpressionTag.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExpressionTag.js
@@ -9,9 +9,9 @@ import { mark_subtree_dynamic } from './shared/fragment.js';
  * @param {Context} context
  */
 export function ExpressionTag(node, context) {
-	const in_attribute = context.path.at(-1)?.type === 'Attribute';
+	const in_template = context.path.at(-1)?.type === 'Fragment';
 
-	if (!in_attribute && context.state.parent_element) {
+	if (in_template && context.state.parent_element) {
 		if (!is_tag_valid_with_parent('#text', context.state.parent_element)) {
 			e.node_invalid_placement(node, '`{expression}`', context.state.parent_element);
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Text.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Text.js
@@ -9,9 +9,9 @@ import * as e from '../../../errors.js';
  * @param {Context} context
  */
 export function Text(node, context) {
-	const in_attribute = context.path.at(-1)?.type === 'Attribute';
+	const in_template = context.path.at(-1)?.type === 'Fragment';
 
-	if (!in_attribute && context.state.parent_element && regex_not_whitespace.test(node.data)) {
+	if (in_template && context.state.parent_element && regex_not_whitespace.test(node.data)) {
 		if (!is_tag_valid_with_parent('#text', context.state.parent_element)) {
 			e.node_invalid_placement(node, 'Text node', context.state.parent_element);
 		}

--- a/packages/svelte/tests/validator/samples/invalid-node-placement-8/errors.json
+++ b/packages/svelte/tests/validator/samples/invalid-node-placement-8/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "node_invalid_placement",
+		"message": "Text node is invalid inside `<tbody>`",
+		"start": {
+			"line": 3,
+			"column": 8
+		},
+		"end": {
+			"line": 3,
+			"column": 13
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/invalid-node-placement-8/input.svelte
+++ b/packages/svelte/tests/validator/samples/invalid-node-placement-8/input.svelte
@@ -1,0 +1,4 @@
+
+<table attr={value} style:x={y} class="I'm not {counted} as text in the table">
+	<tbody>I am {bad}</tbody>
+</table>


### PR DESCRIPTION
fixes #14466

The logic introduced in #14395 was flawed - not every text or expression outside the template is the child of an attribute. This turns it around: We know that every child of a fragment is inside the template, so we ignore all text/expression tags that are not child of a fragment

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
