### PR TITLE
fix: prevent infinite loops when pruning CSS

### DIFF
--- a/.changeset/itchy-timers-relax.md
+++ b/.changeset/itchy-timers-relax.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent infinite loops when pruning CSS

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -825,9 +825,10 @@ function get_element_parent(node) {
 /**
  * @param {Compiler.AST.RegularElement | Compiler.AST.SvelteElement | Compiler.AST.RenderTag | Compiler.AST.Component | Compiler.AST.SvelteComponent | Compiler.AST.SvelteSelf} node
  * @param {boolean} adjacent_only
+ * @param {Set<Compiler.AST.SnippetBlock>} seen
  * @returns {Map<Compiler.AST.RegularElement | Compiler.AST.SvelteElement | Compiler.AST.SlotElement | Compiler.AST.RenderTag, NodeExistsValue>}
  */
-function get_possible_element_siblings(node, adjacent_only) {
+function get_possible_element_siblings(node, adjacent_only, seen = new Set()) {
 	/** @type {Map<Compiler.AST.RegularElement | Compiler.AST.SvelteElement | Compiler.AST.SlotElement | Compiler.AST.RenderTag, NodeExistsValue>} */
 	const result = new Map();
 	const path = node.metadata.path;
@@ -886,8 +887,11 @@ function get_possible_element_siblings(node, adjacent_only) {
 		}
 
 		if (current.type === 'SnippetBlock') {
+			if (seen.has(current)) break;
+			seen.add(current);
+
 			for (const site of current.metadata.sites) {
-				const siblings = get_possible_element_siblings(site, adjacent_only);
+				const siblings = get_possible_element_siblings(site, adjacent_only, seen);
 				add_to_map(siblings, result);
 
 				if (adjacent_only && current.metadata.sites.size === 1 && has_definite_elements(siblings)) {

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -44,6 +44,12 @@ const nesting_selector = {
 };
 
 /**
+ * Snippets encountered already (avoids infinite loops)
+ * @type {Set<Compiler.AST.SnippetBlock>}
+ */
+const seen = new Set();
+
+/**
  *
  * @param {Compiler.Css.StyleSheet} stylesheet
  * @param {Compiler.AST.RegularElement | Compiler.AST.SvelteElement} element
@@ -59,6 +65,8 @@ export function prune(stylesheet, element) {
 		},
 		ComplexSelector(node) {
 			const selectors = get_relative_selectors(node);
+
+			seen.clear();
 
 			if (
 				apply_selector(selectors, /** @type {Compiler.Css.Rule} */ (node.metadata.rule), element)
@@ -193,6 +201,9 @@ function apply_combinator(relative_selector, parent_selectors, rule, node) {
 				const parent = path[i];
 
 				if (parent.type === 'SnippetBlock') {
+					if (seen.has(parent)) return true;
+					seen.add(parent);
+
 					for (const site of parent.metadata.sites) {
 						if (apply_combinator(relative_selector, parent_selectors, rule, site)) {
 							return true;

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -346,6 +346,8 @@ function relative_selector_might_apply_to_node(relative_selector, rule, element)
 			descendant_elements.push(element);
 		}
 
+		const seen = new Set();
+
 		/**
 		 * @param {Compiler.SvelteNode} node
 		 * @param {{ is_child: boolean }} state
@@ -366,6 +368,9 @@ function relative_selector_might_apply_to_node(relative_selector, rule, element)
 						}
 					} else if (node.type === 'RenderTag') {
 						for (const snippet of node.metadata.snippets) {
+							if (seen.has(snippet)) continue;
+
+							seen.add(snippet);
 							walk_children(snippet.body, context.state);
 						}
 					} else {
@@ -629,6 +634,8 @@ function get_following_sibling_elements(element, include_self) {
 	// ...then walk them, starting from the node after the one
 	// containing the element in question
 
+	const seen = new Set();
+
 	/** @param {Compiler.SvelteNode} node */
 	function get_siblings(node) {
 		walk(node, null, {
@@ -640,6 +647,9 @@ function get_following_sibling_elements(element, include_self) {
 			},
 			RenderTag(node) {
 				for (const snippet of node.metadata.snippets) {
+					if (seen.has(snippet)) continue;
+
+					seen.add(snippet);
 					get_siblings(snippet.body);
 				}
 			}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/component.js
@@ -51,7 +51,7 @@ export function visit_component(node, context) {
 			if (binding?.initial?.type === 'SnippetBlock') {
 				node.metadata.snippets.add(binding.initial);
 			}
-		} else {
+		} else if (expression.type !== 'Literal') {
 			resolved = false;
 		}
 	}

--- a/packages/svelte/tests/css/samples/render-tag-loop/_config.js
+++ b/packages/svelte/tests/css/samples/render-tag-loop/_config.js
@@ -1,0 +1,20 @@
+import { test } from '../../test';
+
+export default test({
+	warnings: [
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector "div + div"',
+			start: {
+				line: 19,
+				column: 1,
+				character: 185
+			},
+			end: {
+				line: 19,
+				column: 10,
+				character: 194
+			}
+		}
+	]
+});

--- a/packages/svelte/tests/css/samples/render-tag-loop/expected.css
+++ b/packages/svelte/tests/css/samples/render-tag-loop/expected.css
@@ -1,0 +1,4 @@
+
+	div.svelte-xyz div:where(.svelte-xyz) {
+		color: red;
+	}

--- a/packages/svelte/tests/css/samples/render-tag-loop/expected.css
+++ b/packages/svelte/tests/css/samples/render-tag-loop/expected.css
@@ -1,7 +1,10 @@
 
-	div.svelte-xyz div:where(.svelte-xyz) {
+	div div.svelte-xyz {
 		color: green;
 	}
+	/* (unused) div + div {
+		color: red; /* this is marked as unused, but only because we've written an infinite loop - worth fixing? *\/
+	}*/
 	div.svelte-xyz:has(div:where(.svelte-xyz)) {
 		color: green;
 	}

--- a/packages/svelte/tests/css/samples/render-tag-loop/expected.css
+++ b/packages/svelte/tests/css/samples/render-tag-loop/expected.css
@@ -1,4 +1,7 @@
 
 	div.svelte-xyz div:where(.svelte-xyz) {
-		color: red;
+		color: green;
+	}
+	div.svelte-xyz:has(div:where(.svelte-xyz)) {
+		color: green;
 	}

--- a/packages/svelte/tests/css/samples/render-tag-loop/input.svelte
+++ b/packages/svelte/tests/css/samples/render-tag-loop/input.svelte
@@ -1,10 +1,12 @@
 {#snippet a()}
+	{@render b()}
 	<div>
 		{@render b()}
 	</div>
 {/snippet}
 
 {#snippet b()}
+	{@render a()}
 	<div>
 		{@render a()}
 	</div>
@@ -13,6 +15,9 @@
 <style>
 	div div {
 		color: green;
+	}
+	div + div {
+		color: red; /* this is marked as unused, but only because we've written an infinite loop - worth fixing? */
 	}
 	div:has(div) {
 		color: green;

--- a/packages/svelte/tests/css/samples/render-tag-loop/input.svelte
+++ b/packages/svelte/tests/css/samples/render-tag-loop/input.svelte
@@ -12,6 +12,9 @@
 
 <style>
 	div div {
-		color: red;
+		color: green;
+	}
+	div:has(div) {
+		color: green;
 	}
 </style>

--- a/packages/svelte/tests/css/samples/render-tag-loop/input.svelte
+++ b/packages/svelte/tests/css/samples/render-tag-loop/input.svelte
@@ -1,0 +1,17 @@
+{#snippet a()}
+	<div>
+		{@render b()}
+	</div>
+{/snippet}
+
+{#snippet b()}
+	<div>
+		{@render a()}
+	</div>
+{/snippet}
+
+<style>
+	div div {
+		color: red;
+	}
+</style>


### PR DESCRIPTION
fixes #14472, and also makes improves snippet resolution (it was only handling strings and identifiers, not literals, meaning `answer={42}` was interpreted as 'could be any snippet').

There might be other situations that could result in a loop, trying to think of any

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
