### PR TITLE
fix: render attributes during SSR regardless of case

### DIFF
--- a/.changeset/proud-crews-itch.md
+++ b/.changeset/proud-crews-itch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: render attributes during SSR regardless of case

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -222,11 +222,13 @@ export function spread_attributes(attrs, classes, styles, flags = 0) {
 		if (name[0] === '$' && name[1] === '$') continue; // faster than name.startsWith('$$')
 		if (INVALID_ATTR_NAME_CHAR_REGEX.test(name)) continue;
 
+		var value = attrs[name];
+
 		if (lowercase) {
 			name = name.toLowerCase();
 		}
 
-		attr_str += attr(name, attrs[name], is_html && is_boolean_attribute(name));
+		attr_str += attr(name, value, is_html && is_boolean_attribute(name));
 	}
 
 	return attr_str;

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-element-svg/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-element-svg/_config.js
@@ -1,0 +1,20 @@
+import { test } from '../../test';
+
+export default test({
+	mode: ['hydrate'],
+
+	test({ assert, target, hydrate }) {
+		const svg = target.querySelector('svg');
+		const circle = target.querySelector('circle');
+
+		assert.equal(svg?.getAttribute('viewBox'), '0 0 1000 1000');
+		assert.equal(svg?.namespaceURI, 'http://www.w3.org/2000/svg');
+		assert.equal(circle?.namespaceURI, 'http://www.w3.org/2000/svg');
+
+		hydrate();
+
+		assert.equal(svg?.getAttribute('viewBox'), '0 0 1000 1000');
+		assert.equal(svg?.namespaceURI, 'http://www.w3.org/2000/svg');
+		assert.equal(circle?.namespaceURI, 'http://www.w3.org/2000/svg');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-element-svg/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-element-svg/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	let props = {
+		height: '100px',
+		width: '100px',
+		viewBox: '0 0 1000 1000'
+	};
+</script>
+
+<svelte:element this={'svg'} {...props}>
+	<circle cx="500" cy="500" r="500"></circle>
+</svelte:element>


### PR DESCRIPTION
This fixes part of #14479 — attributes like `viewBox` were failing because the name was being lowercased and _then_ used to look up the value, creating a mismatch.

It doesn't fix the client-side error though, which happens because the contents of the `<svelte:element>` have an HTML template when they need an SVG one. Not yet sure what a good solution to that looks like.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
