### PR TITLE
chore: better SSR output for <svelte:element>

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/SvelteElement.js
@@ -14,13 +14,14 @@ import { build_template } from './shared/utils.js';
  */
 export function SvelteElement(node, context) {
 	let tag = /** @type {Expression} */ (context.visit(node.tag));
-	if (tag.type !== 'Identifier') {
-		const tag_id = context.state.scope.generate('$$tag');
-		context.state.init.push(b.const(tag_id, tag));
-		tag = b.id(tag_id);
-	}
 
 	if (dev) {
+		if (tag.type !== 'Identifier') {
+			const tag_id = context.state.scope.generate('$$tag');
+			context.state.init.push(b.const(tag_id, tag));
+			tag = b.id(tag_id);
+		}
+
 		if (node.fragment.nodes.length > 0) {
 			context.state.init.push(b.stmt(b.call('$.validate_void_dynamic_element', b.thunk(tag))));
 		}


### PR DESCRIPTION
very minor tweak — avoids creating an unnecessary `$$tag` variable in prod. Won't really make any difference since any minifier would inline the variable anyway, but makes the generated code more readable. Found while looking into #14492