### PR TITLE
fix: correctly prune CSS for elements inside snippets

### DIFF
--- a/.changeset/popular-dogs-exist.md
+++ b/.changeset/popular-dogs-exist.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly prune CSS for elements inside snippets

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -201,16 +201,19 @@ function apply_combinator(relative_selector, parent_selectors, rule, node) {
 				const parent = path[i];
 
 				if (parent.type === 'SnippetBlock') {
-					if (seen.has(parent)) return true;
-					seen.add(parent);
+					if (seen.has(parent)) {
+						parent_matched = true;
+					} else {
+						seen.add(parent);
 
-					for (const site of parent.metadata.sites) {
-						if (apply_combinator(relative_selector, parent_selectors, rule, site)) {
-							return true;
+						for (const site of parent.metadata.sites) {
+							if (apply_combinator(relative_selector, parent_selectors, rule, site)) {
+								parent_matched = true;
+							}
 						}
 					}
 
-					return false;
+					break;
 				}
 
 				if (parent.type === 'RegularElement' || parent.type === 'SvelteElement') {

--- a/packages/svelte/tests/css/samples/render-tag-loop/expected.css
+++ b/packages/svelte/tests/css/samples/render-tag-loop/expected.css
@@ -1,5 +1,5 @@
 
-	div div.svelte-xyz {
+	div.svelte-xyz div:where(.svelte-xyz) {
 		color: green;
 	}
 	/* (unused) div + div {

--- a/packages/svelte/tests/css/samples/snippets-elements/expected.css
+++ b/packages/svelte/tests/css/samples/snippets-elements/expected.css
@@ -1,0 +1,4 @@
+
+	x.svelte-xyz y:where(.svelte-xyz) {
+		color: green;
+	}

--- a/packages/svelte/tests/css/samples/snippets-elements/input.svelte
+++ b/packages/svelte/tests/css/samples/snippets-elements/input.svelte
@@ -1,0 +1,13 @@
+{#snippet foo()}
+	<x>
+		<y></y>
+	</x>
+{/snippet}
+
+{@render foo()}
+
+<style>
+	x y {
+		color: green;
+	}
+</style>


### PR DESCRIPTION
fixes #14483 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
