### PR TITLE
Correct create svelte 4 project command

### DIFF
--- a/documentation/docs/01-getting-started/01-introduction.md
+++ b/documentation/docs/01-getting-started/01-introduction.md
@@ -11,7 +11,7 @@ If that's not you (yet), you may prefer to visit the [interactive tutorial](/tut
 We recommend using [SvelteKit](https://kit.svelte.dev/), the official application framework from the Svelte team:
 
 ```
-npm create svelte@latest myapp
+npm create svelte@6.4.0 myapp
 cd myapp
 npm install
 npm run dev


### PR DESCRIPTION
People visiting v4.svelte.dev are interested in pre-5 svelte. Latest version of `create-svelte` package provides no functionality to create a project (it's a notice to use v5).  Provided materials created for v4 and earlier need not be simply thrown away, creating a pre-v5 project should still be possible. `6.4.0` seems to be the last version of `create-svelte` package that can be used to create a v4 svelte project.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
