### PR TITLE
serialize bigint AST, albeit incorrectly

### DIFF
--- a/playgrounds/sandbox/run.js
+++ b/playgrounds/sandbox/run.js
@@ -46,7 +46,14 @@ for (const generate of /** @type {const} */ (['client', 'server'])) {
 				modern: true
 			});
 
-			fs.writeFileSync(`${cwd}/output/${file}.json`, JSON.stringify(ast, null, '\t'));
+			fs.writeFileSync(
+				`${cwd}/output/${file}.json`,
+				JSON.stringify(
+					ast,
+					(key, value) => (typeof value === 'bigint' ? ['BigInt', value.toString()] : value),
+					'\t'
+				)
+			);
 
 			try {
 				const migrated = migrate(source);


### PR DESCRIPTION
`playgrounds/sandbox/run.js` doesn't work for components containing bigints, because they can't be serialized to JSON. There isn't really a great fix for this issue but this at least allows the sandbox to run