### PR TITLE
fix: correctly set custom element props

### DIFF
--- a/.changeset/sharp-shoes-look.md
+++ b/.changeset/sharp-shoes-look.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: take into account registration state when setting custom element props

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -323,11 +323,21 @@ var setters_cache = new Map();
 
 /** @param {Element} element */
 function get_setters(element) {
-	var setters = setters_cache.get(element.nodeName);
+	var name = element.nodeName;
+	var setters = setters_cache.get(name);
+
 	if (setters) return setters;
-	setters_cache.set(element.nodeName, (setters = []));
+
+	setters = [];
+
+	// Don't cache the result for custom elements while they aren't connected yet,
+	// because during their upgrade they might add more setters
+	if (!name.includes('-') || element.isConnected) {
+		setters_cache.set(name, setters);
+	}
+
 	var descriptors;
-	var proto = get_prototype_of(element);
+	var proto = element;
 	var element_proto = Element.prototype;
 
 	// Stop at Element, from there on there's only unnecessary setters we're not interested in

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -335,6 +335,7 @@ var setters_cache = new Map();
 /** @param {Element} element */
 function get_setters(element) {
 	var setters = setters_cache.get(element.nodeName);
+	if (setters) return setters;
 	setters_cache.set(element.nodeName, (setters = []));
 
 	var descriptors;

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/late-ce-mount/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/late-ce-mount/_config.js
@@ -1,0 +1,25 @@
+import { flushSync } from 'svelte';
+import { test } from '../../assert';
+
+const tick = () => Promise.resolve();
+
+// Check that rendering a custom element and setting a property before it is registered
+// does not break the "when to set this as a property" logic
+export default test({
+	async test({ assert, target }) {
+		target.innerHTML = '<custom-element></custom-element>';
+		await tick();
+		await tick();
+
+		const ce_root = target.querySelector('custom-element').shadowRoot;
+
+		ce_root.querySelector('button')?.click();
+		flushSync();
+		await tick();
+		await tick();
+
+		const inner_ce_root = ce_root.querySelectorAll('set-property-before-mounted');
+		assert.htmlEqual(inner_ce_root[0].shadowRoot.innerHTML, 'object|{"foo":"bar"}');
+		assert.htmlEqual(inner_ce_root[1].shadowRoot.innerHTML, 'object|{"foo":"bar"}');
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/late-ce-mount/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/late-ce-mount/main.svelte
@@ -1,0 +1,31 @@
+<svelte:options customElement="custom-element" />
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	class CustomElement extends HTMLElement {
+		constructor() {
+			super();
+			this.attachShadow({ mode: 'open' });
+			Object.defineProperty(this, 'property', {
+				set: (value) => {
+					this.shadowRoot.innerHTML = typeof value + '|' + JSON.stringify(value);
+				}
+			});
+		}
+	}
+
+	onMount(async () => {
+		customElements.define('set-property-before-mounted', CustomElement);
+	});
+
+	let property = $state();
+</script>
+
+<button onclick={() => (property = { foo: 'bar' })}>Update</button>
+<!-- one that's there before it's registered -->
+<set-property-before-mounted {property}></set-property-before-mounted>
+<!-- and one that's after registration but sets property to an object right away -->
+{#if property}
+	<set-property-before-mounted {property}></set-property-before-mounted>
+{/if}


### PR DESCRIPTION
fixes #14391

In #13337 the "when to set as a property" logic for custom elements was adjusted. A bug was introduced during this, and it consists of several parts, of which the latter I'm not sure what's the best solution, hence opening this to discuss.

The problem is that during `set_custom_element_data`, `get_setters` is the only check done to differentiate between setting the value as a prop (has a setter) or as an attribute (doesn't have a setter).

The solution is to take into account whether or not the custom element is already registered, and defer getting (and caching) its setters until then. Instead, fall back to a "an object is always set as a prop" heuristic.

### Old description

Part 1 of the bug is that this only checks the setters of the prototype, but you can also add setters to the instance type. Furthermore, custom elements may not have instantiated yet when we come across them to set the property, which means the setters may not have been added yet. That's why we can cache the setters only once `element.isConnected` is `true`.
This part is fixed in this PR.

But part 2 of the bug is not fixed through that yet: What if you set an object to the custom element while it is not instantiated yet / there is no such setter yet? Then the fix will be useless. Example:

```svelte
<script lang="ts">
	import { onMount } from 'svelte';

	class CustomElement extends HTMLElement {
		constructor() {
			super();
			this.attachShadow({ mode: 'open' });
		}

		connectedCallback() {
			console.log('b#m');
			Object.defineProperty(this, 'image', {
				set: (value) => {
					this.shadowRoot.innerHTML = typeof value + '|' + JSON.stringify(value);
				}
			});
		}
	}

	onMount(async () => {
		customElements.define('wc-image', CustomElement);
	});

	let image = $state({ foo: 'bar' });
</script>

<wc-image {image}></wc-image>
```

`image` is set too soon and therefore set as an attribute. Even if we had handling inside the web component to pick up a prop from before the element was upgraded it would fail.

I therefore think we need to revisit the logic change from #13337 and either for custom elements set this as a property if it's not a string even without a setter, or go back to what it was before completely.

Thoughts?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
