### PR TITLE
chore: remove without_reactive_context

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -1,6 +1,6 @@
 import { DEV } from 'esm-env';
 import { render_effect, teardown } from '../../../reactivity/effects.js';
-import { listen_to_event_and_reset_event, without_reactive_context } from './shared.js';
+import { listen_to_event_and_reset_event } from './shared.js';
 import * as e from '../../../errors.js';
 import { is } from '../../../proxy.js';
 import { queue_micro_task } from '../../task.js';

--- a/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
@@ -32,23 +32,6 @@ export function listen(target, events, handler, call_handler_immediately = true)
 }
 
 /**
- * @template T
- * @param {() => T} fn
- */
-export function without_reactive_context(fn) {
-	var previous_reaction = active_reaction;
-	var previous_effect = active_effect;
-	set_active_reaction(null);
-	set_active_effect(null);
-	try {
-		return fn();
-	} finally {
-		set_active_reaction(previous_reaction);
-		set_active_effect(previous_effect);
-	}
-}
-
-/**
  * Listen to the given event, and then instantiate a global form reset listener if not already done,
  * to notify all bindings when the form is reset
  * @param {HTMLElement} element
@@ -57,7 +40,7 @@ export function without_reactive_context(fn) {
  * @param {() => void} [on_reset]
  */
 export function listen_to_event_and_reset_event(element, event, handler, on_reset = handler) {
-	element.addEventListener(event, () => without_reactive_context(handler));
+	element.addEventListener(event, handler);
 	// @ts-expect-error
 	const prev = element.__on_r;
 	if (prev) {

--- a/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
@@ -1,10 +1,4 @@
 import { teardown } from '../../../reactivity/effects.js';
-import {
-	active_effect,
-	active_reaction,
-	set_active_effect,
-	set_active_reaction
-} from '../../../runtime.js';
 import { add_form_reset_listener } from '../misc.js';
 
 /**

--- a/packages/svelte/src/internal/client/dom/elements/bindings/window.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/window.js
@@ -1,5 +1,5 @@
 import { effect, render_effect, teardown } from '../../../reactivity/effects.js';
-import { listen, without_reactive_context } from './shared.js';
+import { listen } from './shared.js';
 
 /**
  * @param {'x' | 'y'} type
@@ -10,14 +10,13 @@ import { listen, without_reactive_context } from './shared.js';
 export function bind_window_scroll(type, get, set = get) {
 	var is_scrolling_x = type === 'x';
 
-	var target_handler = () =>
-		without_reactive_context(() => {
-			scrolling = true;
-			clearTimeout(timeout);
-			timeout = setTimeout(clear, 100); // TODO use scrollend event if supported (or when supported everywhere?)
+	var target_handler = () => {
+		scrolling = true;
+		clearTimeout(timeout);
+		timeout = setTimeout(clear, 100); // TODO use scrollend event if supported (or when supported everywhere?)
 
-			set(window[is_scrolling_x ? 'scrollX' : 'scrollY']);
-		});
+		set(window[is_scrolling_x ? 'scrollX' : 'scrollY']);
+	};
 
 	addEventListener('scroll', target_handler, {
 		passive: true
@@ -62,5 +61,5 @@ export function bind_window_scroll(type, get, set = get) {
  * @param {(size: number) => void} set
  */
 export function bind_window_size(type, set) {
-	listen(window, ['resize'], () => without_reactive_context(() => set(window[type])));
+	listen(window, ['resize'], () => set(window[type]));
 }

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -11,7 +11,6 @@ import {
 	set_active_effect,
 	set_active_reaction
 } from '../../runtime.js';
-import { without_reactive_context } from './bindings/shared.js';
 
 /** @type {Set<string>} */
 export const all_registered_events = new Set();
@@ -62,9 +61,7 @@ export function create_event(event_name, dom, handler, options) {
 			handle_event_propagation.call(dom, event);
 		}
 		if (!event.cancelBubble) {
-			return without_reactive_context(() => {
-				return handler.call(this, event);
-			});
+			return handler.call(this, event);
 		}
 	}
 


### PR DESCRIPTION
This was added in #14194 but I have no idea why — there are no tests, no comments, and I can't discern any difference in the behaviour of the repro in #14186 without it. There _is_ a difference between [5.1.11](https://svelte.dev/playground/6fbbf69c47894154bfa37c9fb83e7ac0?version=5.1.11) and [latest](https://svelte.dev/playground/6fbbf69c47894154bfa37c9fb83e7ac0), but removing this stuff doesn't seem to cause a regression, at least not locally (we'll see what happens when the playground link is added here).

What is it for @trueadm?