### PR TITLE
fix: ensure SvelteDate cached methods have correct reactive context

### DIFF
--- a/.changeset/wicked-zebras-exist.md
+++ b/.changeset/wicked-zebras-exist.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure SvelteDate cached methods have correct reactive context

--- a/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
@@ -34,6 +34,7 @@ export function listen(target, events, handler, call_handler_immediately = true)
 /**
  * @template T
  * @param {() => T} fn
+ * @returns {T}
  */
 export function without_reactive_context(fn) {
 	var previous_reaction = active_reaction;

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -1,7 +1,8 @@
 /** @import { Source } from '#client' */
+import { without_reactive_context } from '../internal/client/dom/elements/bindings/shared.js';
 import { derived } from '../internal/client/index.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
-import { get, untrack } from '../internal/client/runtime.js';
+import { get } from '../internal/client/runtime.js';
 
 var inited = false;
 
@@ -46,7 +47,7 @@ export class SvelteDate extends Date {
 						// We don't want to associate the derived with the current
 						// reactive context, as that means the derived will get destroyed
 						// each time it re-fires
-						d = untrack(() =>
+						d = without_reactive_context(() =>
 							derived(() => {
 								get(this.#time);
 								// @ts-ignore

--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -642,3 +642,33 @@ test('Date methods invoked for the first time in a derived', () => {
 
 	cleanup();
 });
+
+test('Date methods shared between deriveds', () => {
+	const date = new SvelteDate(initial_date);
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		const year = derived(() => {
+			return date.getFullYear();
+		});
+		const year2 = derived(() => {
+			return (date.getTime(), date.getFullYear())
+		});
+
+		render_effect(() => {
+			log.push(get(year) + '/' + get(year2).toString());
+		});
+
+		flushSync(() => {
+			date.setFullYear(date.getFullYear() + 1);
+		});
+
+		flushSync(() => {
+			date.setFullYear(date.getFullYear() + 1);
+		});
+	});
+
+	assert.deepEqual(log, ['2023/2023', '2024/2024', '2025/2025']);
+
+	cleanup();
+});

--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -652,7 +652,7 @@ test('Date methods shared between deriveds', () => {
 			return date.getFullYear();
 		});
 		const year2 = derived(() => {
-			return (date.getTime(), date.getFullYear())
+			return date.getTime(), date.getFullYear();
 		});
 
 		render_effect(() => {


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14506. Because the date prototype methods lazily create deriveds – that also means that it matters what the reactive context is when they're created. If they're created inside another derived then each time the derived runs, the method's deriveds will be destroyed and re-created. This is problematic because if they've already been read in another derived, then they won't be correctly shared.

Instead, we need to ensure we set the reactive context to the nearest parent effect. Deriveds created here are safe because deriveds are only added to parent effects if the derived is read in a non-reactive context.