### PR TITLE
chore: add test for binding event reactive context

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -1,6 +1,6 @@
 import { DEV } from 'esm-env';
 import { render_effect, teardown } from '../../../reactivity/effects.js';
-import { listen_to_event_and_reset_event, without_reactive_context } from './shared.js';
+import { listen_to_event_and_reset_event } from './shared.js';
 import * as e from '../../../errors.js';
 import { is } from '../../../proxy.js';
 import { queue_micro_task } from '../../task.js';

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-binding-set/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-binding-set/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	test({ target, assert, logs }) {
+		const input = /** @type {HTMLInputElement} */ (target.querySelector('input'));
+		input.value = 'everybody';
+		input.dispatchEvent(new window.Event('input'));
+
+		assert.deepEqual(logs, [false]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-binding-set/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-binding-set/_config.js
@@ -1,11 +1,7 @@
 import { test } from '../../test';
 
 export default test({
-	test({ target, assert, logs }) {
-		const input = /** @type {HTMLInputElement} */ (target.querySelector('input'));
-		input.value = 'everybody';
-		input.dispatchEvent(new window.Event('input'));
-
+	test({ assert, logs }) {
 		assert.deepEqual(logs, [false]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-binding-set/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-binding-set/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	let bar = $state('');
+
+	const foo = {
+		set bar(v) {
+
+			console.log($effect.tracking());
+
+			bar = v;
+		},
+		get bar() {
+			return bar;
+		}
+	}
+</script>
+
+<input type="text" bind:value={foo.bar}>

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-binding-set/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-binding-set/main.svelte
@@ -12,6 +12,13 @@
 			return bar;
 		}
 	}
+
+	let input;
+
+	$effect(() => {
+		input.value = 'everybody';
+		input.dispatchEvent(new window.Event('input'));
+	})
 </script>
 
-<input type="text" bind:value={foo.bar}>
+<input type="text" bind:value={foo.bar} bind:this={input}>


### PR DESCRIPTION
Added a test to show why we need bindings events to have no reactive context, as per requested in https://github.com/sveltejs/svelte/pull/14511