### PR TITLE
fix: ensure SvelteDate cached methods have correct reactive context

### DIFF
--- a/.changeset/wicked-zebras-exist.md
+++ b/.changeset/wicked-zebras-exist.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure SvelteDate cached methods have correct reactive context
+fix: use correct reaction when lazily creating deriveds inside `SvelteDate`

--- a/.changeset/wicked-zebras-exist.md
+++ b/.changeset/wicked-zebras-exist.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure SvelteDate cached methods have correct reactive context

--- a/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
@@ -34,7 +34,6 @@ export function listen(target, events, handler, call_handler_immediately = true)
 /**
  * @template T
  * @param {() => T} fn
- * @returns {T}
  */
 export function without_reactive_context(fn) {
 	var previous_reaction = active_reaction;

--- a/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/shared.js
@@ -34,6 +34,7 @@ export function listen(target, events, handler, call_handler_immediately = true)
 /**
  * @template T
  * @param {() => T} fn
+ * @returns {T}
  */
 export function without_reactive_context(fn) {
 	var previous_reaction = active_reaction;

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -1,7 +1,8 @@
 /** @import { Source } from '#client' */
+import { without_reactive_context } from '../internal/client/dom/elements/bindings/shared.js';
 import { derived } from '../internal/client/index.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
-import { get, untrack } from '../internal/client/runtime.js';
+import { get } from '../internal/client/runtime.js';
 
 var inited = false;
 
@@ -46,7 +47,7 @@ export class SvelteDate extends Date {
 						// We don't want to associate the derived with the current
 						// reactive context, as that means the derived will get destroyed
 						// each time it re-fires
-						d = untrack(() =>
+						d = without_reactive_context(() =>
 							derived(() => {
 								get(this.#time);
 								// @ts-ignore

--- a/packages/svelte/src/reactivity/date.js
+++ b/packages/svelte/src/reactivity/date.js
@@ -1,40 +1,17 @@
-/** @import { Source, Derived, Effect } from '#client' */
-import { DERIVED } from '../internal/client/constants.js';
+/** @import { Source } from '#client' */
 import { derived } from '../internal/client/index.js';
 import { source, set } from '../internal/client/reactivity/sources.js';
 import { active_reaction, get, set_active_reaction } from '../internal/client/runtime.js';
 
 var inited = false;
 
-/**
- * @template T
- * @param {() => T} fn
- * @returns {T}
- */
-function with_parent_effect(fn) {
-	var previous_reaction = active_reaction;
-	var parent_reaction = active_reaction;
-
-	while (parent_reaction !== null) {
-		if ((parent_reaction.f & DERIVED) === 0) {
-			break;
-		}
-		parent_reaction = /** @type {Derived | Effect} */ (parent_reaction).parent;
-	}
-
-	set_active_reaction(parent_reaction);
-	try {
-		return fn();
-	} finally {
-		set_active_reaction(previous_reaction);
-	}
-}
-
 export class SvelteDate extends Date {
 	#time = source(super.getTime());
 
 	/** @type {Map<keyof Date, Source<unknown>>} */
 	#deriveds = new Map();
+
+	#reaction = active_reaction;
 
 	/** @param {any[]} params */
 	constructor(...params) {
@@ -68,18 +45,20 @@ export class SvelteDate extends Date {
 					var d = this.#deriveds.get(method);
 
 					if (d === undefined) {
-						// Ensure we create the derived inside the nearest parent effect if
-						// we're inside a derived, otherwise the derived will be destroyed each
-						// time it re-runs
-						d = with_parent_effect(() =>
-							derived(() => {
-								get(this.#time);
-								// @ts-ignore
-								return date_proto[method].apply(this, args);
-							})
-						);
+						// lazily create the derived, but as though it were being
+						// created at the same time as the class instance
+						const reaction = active_reaction;
+						set_active_reaction(this.#reaction);
+
+						d = derived(() => {
+							get(this.#time);
+							// @ts-ignore
+							return date_proto[method].apply(this, args);
+						});
 
 						this.#deriveds.set(method, d);
+
+						set_active_reaction(reaction);
 					}
 
 					return get(d);

--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -642,3 +642,33 @@ test('Date methods invoked for the first time in a derived', () => {
 
 	cleanup();
 });
+
+test('Date methods shared between deriveds', () => {
+	const date = new SvelteDate(initial_date);
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		const year = derived(() => {
+			return date.getFullYear();
+		});
+		const year2 = derived(() => {
+			return (date.getTime(), date.getFullYear())
+		});
+
+		render_effect(() => {
+			log.push(get(year) + '/' + get(year2).toString());
+		});
+
+		flushSync(() => {
+			date.setFullYear(date.getFullYear() + 1);
+		});
+
+		flushSync(() => {
+			date.setFullYear(date.getFullYear() + 1);
+		});
+	});
+
+	assert.deepEqual(log, ['2023/2023', '2024/2024', '2025/2025']);
+
+	cleanup();
+});

--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -652,7 +652,7 @@ test('Date methods shared between deriveds', () => {
 			return date.getFullYear();
 		});
 		const year2 = derived(() => {
-			return (date.getTime(), date.getFullYear())
+			return date.getTime(), date.getFullYear();
 		});
 
 		render_effect(() => {


### PR DESCRIPTION
alternative to #14512 — instead of using the nearest parent effect, we use whichever reaction was active when the instance was created

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
