### PR TITLE
fix: respect the unidirectional nature of time

### DIFF
--- a/.changeset/sixty-tables-fold.md
+++ b/.changeset/sixty-tables-fold.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: respect the unidirectional nature of time

--- a/packages/svelte/src/internal/client/loop.js
+++ b/packages/svelte/src/internal/client/loop.js
@@ -7,6 +7,8 @@ import { raf } from './timing.js';
  * @returns {void}
  */
 function run_tasks() {
+	// use `raf.now()` instead of the `requestAnimationFrame` callback argument, because
+	// otherwise things can get wonky https://github.com/sveltejs/svelte/pull/14541
 	const now = raf.now();
 
 	raf.tasks.forEach((task) => {

--- a/packages/svelte/src/internal/client/loop.js
+++ b/packages/svelte/src/internal/client/loop.js
@@ -4,10 +4,11 @@ import { raf } from './timing.js';
 // TODO move this into timing.js where it probably belongs
 
 /**
- * @param {number} now
  * @returns {void}
  */
-function run_tasks(now) {
+function run_tasks() {
+	const now = raf.now();
+
 	raf.tasks.forEach((task) => {
 		if (!task.c(now)) {
 			raf.tasks.delete(task);


### PR DESCRIPTION
supersedes #4531, fixes #4468. It turns out that `performance.now()` uses a different clock to `requestAnimationFrame`, or at least they behave as though that were true. You can see if yourself by doing this:

```js
function go() {
  const then = performance.now();

  requestAnimationFrame((now) => {
    if (now < then) {
      console.error('oops! rift detected in spacetime continuum');
    }
  });
}
```

If you call `go()` enough times, you'll likely see the error, especially in Chrome.

#4531 offers one fix, but I think this one is probably more future-proof, and means that the first frame of a spring loop 'does' something which likely isn't true with the alternative.

No test because I have no idea how.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
