### PR TITLE
chore: make if blocks tree-shakable

### DIFF
--- a/.changeset/beige-windows-happen.md
+++ b/.changeset/beige-windows-happen.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-chore: make if blocks dead code eliminable
+chore: make if blocks tree-shakable

--- a/.changeset/beige-windows-happen.md
+++ b/.changeset/beige-windows-happen.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: make if blocks dead code eliminable

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
@@ -32,12 +32,7 @@ export function IfBlock(node, context) {
 			b.block([
 				b.if(
 					/** @type {Expression} */ (context.visit(node.test)),
-					b.stmt(
-						b.call(
-							b.id('$$render'),
-							b.id(consequent_id)
-						)
-					),
+					b.stmt(b.call(b.id('$$render'), b.id(consequent_id))),
 					alternate_id
 						? b.stmt(
 								b.call(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
@@ -35,8 +35,7 @@ export function IfBlock(node, context) {
 					b.stmt(
 						b.call(
 							b.id('$$render'),
-							b.id(consequent_id),
-							node.alternate ? b.literal(true) : undefined
+							b.id(consequent_id)
 						)
 					),
 					alternate_id

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -13,13 +13,11 @@ import { HYDRATION_START_ELSE } from '../../../../constants.js';
 
 /**
  * @param {TemplateNode} node
- * @param {() => boolean} get_condition
- * @param {(anchor: Node) => void} consequent_fn
- * @param {null | ((anchor: Node) => void)} [alternate_fn]
+ * @param {(branch: (flag: 0 | 1, fn: (anchor: Node) => void) => void) => void} fn
  * @param {boolean} [elseif] True if this is an `{:else if ...}` block rather than an `{#if ...}`, as that affects which transitions are considered 'local'
  * @returns {void}
  */
-export function if_block(node, get_condition, consequent_fn, alternate_fn = null, elseif = false) {
+export function if_block(node, fn, elseif = false) {
 	if (hydrating) {
 		hydrate_next();
 	}
@@ -37,8 +35,18 @@ export function if_block(node, get_condition, consequent_fn, alternate_fn = null
 
 	var flags = elseif ? EFFECT_TRANSPARENT : 0;
 
-	block(() => {
-		if (condition === (condition = !!get_condition())) return;
+	var has_branch = false;
+
+	const set_branch = (/** @type {0 | 1} */ flag, /** @type {(anchor: Node) => void} */ fn) => {
+		has_branch = true;
+		update_branch(flag === 0, fn);
+	};
+
+	const update_branch = (
+		/** @type {boolean | null} */ new_condition,
+		/** @type {null | ((anchor: Node) => void)} */ fn
+	) => {
+		if (condition === (condition = new_condition)) return;
 
 		/** Whether or not there was a hydration mismatch. Needs to be a `let` or else it isn't treeshaken out */
 		let mismatch = false;
@@ -60,8 +68,8 @@ export function if_block(node, get_condition, consequent_fn, alternate_fn = null
 		if (condition) {
 			if (consequent_effect) {
 				resume_effect(consequent_effect);
-			} else {
-				consequent_effect = branch(() => consequent_fn(anchor));
+			} else if (fn) {
+				consequent_effect = branch(() => fn(anchor));
 			}
 
 			if (alternate_effect) {
@@ -72,8 +80,8 @@ export function if_block(node, get_condition, consequent_fn, alternate_fn = null
 		} else {
 			if (alternate_effect) {
 				resume_effect(alternate_effect);
-			} else if (alternate_fn) {
-				alternate_effect = branch(() => alternate_fn(anchor));
+			} else if (fn) {
+				alternate_effect = branch(() => fn(anchor));
 			}
 
 			if (consequent_effect) {
@@ -86,6 +94,14 @@ export function if_block(node, get_condition, consequent_fn, alternate_fn = null
 		if (mismatch) {
 			// continue in hydration mode
 			set_hydrating(true);
+		}
+	};
+
+	block(() => {
+		has_branch = false;
+		fn(set_branch);
+		if (!has_branch) {
+			update_branch(null, null);
 		}
 	}, flags);
 

--- a/packages/svelte/src/internal/client/dom/blocks/if.js
+++ b/packages/svelte/src/internal/client/dom/blocks/if.js
@@ -13,7 +13,7 @@ import { HYDRATION_START_ELSE } from '../../../../constants.js';
 
 /**
  * @param {TemplateNode} node
- * @param {(branch: (flag: 0 | 1, fn: (anchor: Node) => void) => void) => void} fn
+ * @param {(branch: (fn: (anchor: Node) => void, flag?: boolean) => void) => void} fn
  * @param {boolean} [elseif] True if this is an `{:else if ...}` block rather than an `{#if ...}`, as that affects which transitions are considered 'local'
  * @returns {void}
  */
@@ -37,9 +37,9 @@ export function if_block(node, fn, elseif = false) {
 
 	var has_branch = false;
 
-	const set_branch = (/** @type {0 | 1} */ flag, /** @type {(anchor: Node) => void} */ fn) => {
+	const set_branch = (/** @type {(anchor: Node) => void} */ fn, flag = true) => {
 		has_branch = true;
-		update_branch(flag === 0, fn);
+		update_branch(flag, fn);
 	};
 
 	const update_branch = (

--- a/packages/svelte/tests/runtime-runes/samples/bind-this-no-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-this-no-state/main.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { tick } from 'svelte';
-	
+
 	let selected = $state(-1);
 	let current = $state();
 

--- a/packages/svelte/tests/runtime-runes/samples/bind-this-no-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-this-no-state/main.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { tick } from 'svelte';
-
+	
 	let selected = $state(-1);
 	let current = $state();
 


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/12833.

Thanks to @adiguba for the idea as shown in https://github.com/sveltejs/svelte/discussions/13313. This PR aims to make `{#if}` blocks tree-shakable without any runtime performance regressions.

The principle is very similar to https://github.com/sveltejs/svelte/discussions/13313, but executed very differently to ensure that the following remain true:

- We don't have to change any existing tests and there should be no observable behaviour difference or breaking changes
- We don't cause runtime overhead and too much code size explosion
- We allow tree-shaking of if block conditions

The result of these things, means that this PR compiles this:

```svelte
{#if false}
	Hello world
{:else}
	LOL!
{/if}
```

In to this:

```js
var consequent = ($$anchor) => {
  var text = $.text("Hello world");

  $.append($$anchor, text);
};

var alternate = ($$anchor) => {
  var text_1 = $.text("LOL!");

  $.append($$anchor, text_1);
};

$.if(node, ($$render) => {
  if (false) $$render(consequent); else $$render(alternate, false);
});
```

You'll notice that we now have a simple if block inside the `$.if` that can easily be tree-shaken. Furthermore, unlike https://github.com/sveltejs/svelte/discussions/13313, we don't return an array with the path index and a closure, but instead invoke `$$render` which does a similar thing. Explained in more detail:

- Invoking the function with the index rather than returning an array is significantly faster in my testing and results in quite a few bytes less code in the minified output.
- We hoist out the closure rather than have it inline, as in my testing, this had a noticeable impact on performance – which makes sense, given that the closure from the `$.if` block will be invoked even if the condition hasn't changed – so creating a new closure each time is just utterly wasteful.
- If there is no branch for something, or a branch gets treeshaken out, then the runtime understands this and fallsback to the default use-case, ensuring things work as expected, including on hydration.

Another difference to https://github.com/sveltejs/svelte/discussions/13313 is that we keep the same heuristics as we have now when it comes to "else if" cases, and nest them on the else case, rather than as flattened else if cases within the same `$.if` block as shown in https://github.com/sveltejs/svelte/discussions/13313. Flattening causes tests to fail and also had the side-effect of adding a significant amount of complexity to the codebase.

The nice thing about this PR is that very little changes. However, we can revisit this in the future if we decide it's worth it. In many ways, doing these two workloads separately might actually make more sense to happen in different PRs anyway, as it will be easier to review and revert if something goes wrong that isn't covered by tests.
