### PR TITLE
[chore] Don't use locale-specific code in test inline-expressions

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/inline-expressions/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inline-expressions/main.svelte
@@ -1,6 +1,6 @@
 <p>Without text expression: 7.36</p>
 <p>With text expression: {7.36}</p>
-<p>With text expression and function call: {(7.36).toLocaleString()}</p>
+<p>With text expression and function call: {(7.36).toString()}</p>
 <p>With text expression and property access: {"test".length}</p>
 <h1>Hello {('name').toUpperCase().toLowerCase()}!</h1>
 <p>{"test".length}</p>


### PR DESCRIPTION
The unit test **runtime-runes/inline-expressions** use `toLocaleString()` on a `number`, which gives different results depending on the user's locale.
Ex : `7.36` will be printed as `7,36` (with a comma) on some locale like french, italien or spanish...


I simply replaced `toLocaleString()`  with `toString()`


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
