### PR TITLE
fix: handle static form values in combination with default values

### DIFF
--- a/.changeset/blue-fans-greet.md
+++ b/.changeset/blue-fans-greet.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: handle static form values in combination with default values

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -104,6 +104,28 @@ export function set_selected(element, selected) {
 }
 
 /**
+ * Applies the default checked property without influencing the current checked property.
+ * @param {HTMLInputElement} element
+ * @param {boolean} checked
+ */
+export function set_default_checked(element, checked) {
+	const existing_value = element.checked;
+	element.defaultChecked = checked;
+	element.checked = existing_value;
+}
+
+/**
+ * Applies the default value property without influencing the current value property.
+ * @param {HTMLInputElement | HTMLTextAreaElement} element
+ * @param {string} value
+ */
+export function set_default_value(element, value) {
+	const existing_value = element.value;
+	element.defaultValue = value;
+	element.value = existing_value;
+}
+
+/**
  * @param {Element} element
  * @param {string} attribute
  * @param {string | null} value

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -35,7 +35,9 @@ export {
 	handle_lazy_img,
 	set_value,
 	set_checked,
-	set_selected
+	set_selected,
+	set_default_checked,
+	set_default_value
 } from './dom/elements/attributes.js';
 export { set_class, set_svg_class, set_mathml_class, toggle_class } from './dom/elements/class.js';
 export { apply, event, delegate, replay_events } from './dom/elements/events.js';

--- a/packages/svelte/tests/runtime-runes/samples/form-default-value/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/form-default-value/_config.js
@@ -37,7 +37,7 @@ export default test({
 		const after_reset = [];
 
 		const reset = /** @type {HTMLInputElement} */ (target.querySelector('input[type=reset]'));
-		const [test1, test2, test3, test4, test5] = target.querySelectorAll('div');
+		const [test1, test2, test3, test4, test5, test12] = target.querySelectorAll('div');
 		const [test6, test7, test8, test9] = target.querySelectorAll('select');
 		const [
 			test1_span,
@@ -198,6 +198,20 @@ export default test({
 			after_reset.push(() => {
 				check_inputs(options, 'selected', [false, true, false]);
 				assert.htmlEqual(test9_span.innerHTML, 'b');
+			});
+		}
+
+		{
+			/** @type {NodeListOf<HTMLInputElement | HTMLTextAreaElement>} */
+			const inputs = test12.querySelectorAll('input, textarea');
+			assert.equal(inputs[0].value, 'x');
+			assert.equal(/** @type {HTMLInputElement} */ (inputs[1]).checked, true);
+			assert.equal(inputs[2].value, 'x');
+
+			after_reset.push(() => {
+				assert.equal(inputs[0].value, 'y');
+				assert.equal(/** @type {HTMLInputElement} */ (inputs[1]).checked, false);
+				assert.equal(inputs[2].value, 'y');
 			});
 		}
 

--- a/packages/svelte/tests/runtime-runes/samples/form-default-value/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/form-default-value/main.svelte
@@ -137,6 +137,13 @@
 		<option value="c">C</option>
 	</select>
 
+	<p>Static values</p>
+	<div class="test-12">
+		<input value="x" defaultValue="y" />
+		<input type="checkbox" checked defaultChecked={false} />
+		<textarea defaultValue="y">x</textarea>
+	</div>
+
 	<input type="reset" value="Reset" />
 </form>
 


### PR DESCRIPTION
When the `value` or `checked` attribute of an input or the contents of a textarea were static, setting the `defaulValue/defaultChecked` property caused the latter to take precedence over the former. This is due to how we transform the code: If the value is static, we put it onto

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
