### PR TITLE
docs: add note about `@component`

### DIFF
--- a/documentation/docs/03-template-syntax/01-basic-markup.md
+++ b/documentation/docs/03-template-syntax/01-basic-markup.md
@@ -211,3 +211,12 @@ You can add a special comment starting with `@component` that will show up when 
 	</h1>
 </main>
 ````
+
+You can document components with the `@component` tag. These comments will appear when hovering over a component in IDEs with support such as VS Code with [the Svelte VS Code extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
+```svelte
+<!--
+@component this is a component description
+-->
+<h1>Hello world</h1>
+```


### PR DESCRIPTION
closes #14560 (I know the issue talks about having a separate page, but it feels like overkill — I think it's fine to have it here)