### PR TITLE
docs: note before/afterUpdate breaking change

### DIFF
--- a/documentation/docs/07-misc/07-v5-migration-guide.md
+++ b/documentation/docs/07-misc/07-v5-migration-guide.md
@@ -823,6 +823,8 @@ The `foreign` namespace was only useful for Svelte Native, which we're planning 
 
 `afterUpdate` callbacks in a parent component will now run after `afterUpdate` callbacks in any child components.
 
+`beforeUpdate/afterUpdate` no longer run when the component contains a `<slot>` and its content is updated.
+
 Both functions are disallowed in runes mode — use `$effect.pre(...)` and `$effect(...)` instead.
 
 ### `contenteditable` behavior change


### PR DESCRIPTION
...about slotted content behavior
Related to #14564
