### PR TITLE
fix: ensure tree-shaken if blocks correctly hydrate

### DIFF
--- a/.changeset/fast-eyes-hear.md
+++ b/.changeset/fast-eyes-hear.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure tree-shaken if blocks correctly hydrate

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -17,7 +17,7 @@ import {
 	hydrate_node,
 	hydrating,
 	next,
-	remove_nodes,
+	traverse_nodes,
 	set_hydrate_node
 } from '../hydration.js';
 import { queue_micro_task } from '../task.js';
@@ -92,7 +92,7 @@ export function boundary(node, props, boundary_fn) {
 			} else if (hydrating) {
 				set_hydrate_node(hydrate_open);
 				next();
-				set_hydrate_node(remove_nodes());
+				set_hydrate_node(traverse_nodes(true));
 			}
 
 			if (failed) {

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -12,7 +12,7 @@ import {
 	hydrate_next,
 	hydrate_node,
 	hydrating,
-	remove_nodes,
+	traverse_nodes,
 	set_hydrate_node,
 	set_hydrating
 } from '../hydration.js';
@@ -160,7 +160,7 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 
 			if (is_else !== (length === 0)) {
 				// hydration mismatch — remove the server-rendered DOM and start over
-				anchor = remove_nodes();
+				anchor = traverse_nodes(true);
 
 				set_hydrate_node(anchor);
 				set_hydrating(false);
@@ -199,7 +199,7 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 
 			// remove excess nodes
 			if (length > 0) {
-				set_hydrate_node(remove_nodes());
+				set_hydrate_node(traverse_nodes(true));
 			}
 		}
 

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -81,6 +81,7 @@ export function next(count = 1) {
 
 /**
  * Removes all nodes starting at `hydrate_node` up until the next hydration end comment
+ * @param {boolean} [remove]
  */
 export function traverse_nodes(remove = false) {
 	var depth = 0;

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -82,7 +82,7 @@ export function next(count = 1) {
 /**
  * Removes all nodes starting at `hydrate_node` up until the next hydration end comment
  */
-export function remove_nodes() {
+export function traverse_nodes(remove = false) {
 	var depth = 0;
 	var node = hydrate_node;
 
@@ -99,7 +99,9 @@ export function remove_nodes() {
 		}
 
 		var next = /** @type {TemplateNode} */ (get_next_sibling(node));
-		node.remove();
+		if (remove) {
+			node.remove();
+		}
 		node = next;
 	}
 }

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1671,6 +1671,7 @@ declare module 'svelte/motion' {
 	 * <input type="range" bind:value={spring.target} />
 	 * <input type="range" bind:value={spring.current} disabled />
 	 * ```
+	 * @since 5.8.0
 	 */
 	export class Spring<T> {
 		constructor(value: T, options?: SpringOpts);


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14588. We need to ensure we move the hydration node when the `if` block basically all gets tree-shaken away. Unfortunately, I found no way to test this as this relies on Rollup treeshaking away parts of the bundle and runtime.