### PR TITLE
feat: add `onFrame` lifecycle function

### DIFF
--- a/.changeset/tasty-kangaroos-greet.md
+++ b/.changeset/tasty-kangaroos-greet.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: add `onFrame` lifecycle function

--- a/packages/svelte/src/index-client.js
+++ b/packages/svelte/src/index-client.js
@@ -162,6 +162,32 @@ export function afterUpdate(fn) {
 }
 
 /**
+ * The `onFrame` function schedules a callback to run on `requestAnimationFrame`. It must be called inside an effect (e.g. during component initialisation).
+ *
+ * `onFrame` does not run inside [server-side components](https://svelte.dev/docs/svelte/svelte-server#render).
+ *
+ * @template T
+ * @param {() => NotFunction<T> | Promise<NotFunction<T>> | (() => any)} fn
+ * @returns {void}
+ */
+export function onFrame(fn) {
+	onMount(() => {
+		let frame = -1;
+
+		function next() {
+			frame = requestAnimationFrame(next);
+			fn();
+		}
+
+		next();
+
+		return () => {
+			cancelAnimationFrame(frame);
+		};
+	});
+}
+
+/**
  * Legacy-mode: Init callbacks object for onMount/beforeUpdate/afterUpdate
  * @param {ComponentContext} context
  */

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -409,6 +409,13 @@ declare module 'svelte' {
 	 * */
 	export function afterUpdate(fn: () => void): void;
 	/**
+	 * The `onFrame` function schedules a callback to run on `requestAnimationFrame`. It must be called inside an effect (e.g. during component initialisation).
+	 *
+	 * `onFrame` does not run inside [server-side components](https://svelte.dev/docs/svelte/svelte-server#render).
+	 *
+	 * */
+	export function onFrame<T>(fn: () => NotFunction<T> | Promise<NotFunction<T>> | (() => any)): void;
+	/**
 	 * Synchronously flushes any pending state changes and those that result from it.
 	 * */
 	export function flushSync(fn?: (() => void) | undefined): void;
@@ -1671,6 +1678,7 @@ declare module 'svelte/motion' {
 	 * <input type="range" bind:value={spring.target} />
 	 * <input type="range" bind:value={spring.current} disabled />
 	 * ```
+	 * @since 5.8.0
 	 */
 	export class Spring<T> {
 		constructor(value: T, options?: SpringOpts);


### PR DESCRIPTION
Just an idle thought I had while washing the dishes: should we have an `onFrame` function? It would mean for example that [this demo](https://svelte.dev/tutorial/svelte/bind-this) could be written [like this](https://svelte.dev/playground/467340d7f998401a992f1f256db98292?version=commit-63cdd29166014c6109e4d77dca8d8fd64260cc9e):

```js
$effect(() => {
  const context = canvas.getContext('2d');

  onFrame(() => {
    paint(context, Date.now());
  });
});
```

Alternatively we might want to have some sort of reactive time primitive (other than `SvelteDate`) so that it could be used in deriveds too. Either way not wedded to it, just an idle thought that I thought was worth a PR

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
