### PR TITLE
docs: where the hell did this come from?

### DIFF
--- a/documentation/docs/03-template-syntax/03-each.md
+++ b/documentation/docs/03-template-syntax/03-each.md
@@ -23,8 +23,6 @@ Iterating over values can be done with an each block. The values in question can
 </ul>
 ```
 
-You can use each blocks to iterate over any array or array-like value — that is, any object with a `length` property.
-
 An each block can also specify an _index_, equivalent to the second argument in an `array.map(...)` callback:
 
 ```svelte


### PR DESCRIPTION
i don't understand how this text suddenly reappeared, it's not on the production deploy of svelte.dev nor should it be (since it's duplicative). and yet it's in the `03-each.md` file? wtf