### PR TITLE
fix: Allow unquoted slash in attributes

### DIFF
--- a/.changeset/long-boxes-flow.md
+++ b/.changeset/long-boxes-flow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Allow unquoted slash in attributes

--- a/.changeset/long-boxes-flow.md
+++ b/.changeset/long-boxes-flow.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Allow unquoted slash in attributes
+fix: allow unquoted slash in attributes

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -504,8 +504,24 @@ function read_attribute(parser) {
 	let value = true;
 	if (parser.eat('=')) {
 		parser.allow_whitespace();
-		value = read_attribute_value(parser);
-		end = parser.index;
+
+		if (parser.template[parser.index] === '/') {
+			const char_start = parser.index;
+			parser.index++; // consume '/'
+			value = [
+				{
+					start: char_start,
+					end: char_start + 1,
+					type: 'Text',
+					raw: '/',
+					data: '/'
+				}
+			];
+			end = parser.index;
+		} else {
+			value = read_attribute_value(parser);
+			end = parser.index;
+		}
 	} else if (parser.match_regex(regex_starts_with_quote_characters)) {
 		e.expected_token(parser.index, '=');
 	}

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -505,7 +505,7 @@ function read_attribute(parser) {
 	if (parser.eat('=')) {
 		parser.allow_whitespace();
 
-		if (parser.template[parser.index] === '/') {
+		if (parser.template[parser.index] === '/' && parser.template[parser.index + 1] === '>') {
 			const char_start = parser.index;
 			parser.index++; // consume '/'
 			value = [

--- a/packages/svelte/tests/parser-legacy/samples/attribute-unquoted/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/attribute-unquoted/input.svelte
@@ -1,1 +1,2 @@
 <div class=foo></div>
+<a href=/>home</a>

--- a/packages/svelte/tests/parser-legacy/samples/attribute-unquoted/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/attribute-unquoted/input.svelte
@@ -1,2 +1,3 @@
 <div class=foo></div>
 <a href=/>home</a>
+<a href=/foo>home</a>

--- a/packages/svelte/tests/parser-legacy/samples/attribute-unquoted/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/attribute-unquoted/output.json
@@ -2,7 +2,7 @@
 	"html": {
 		"type": "Fragment",
 		"start": 0,
-		"end": 21,
+		"end": 40,
 		"children": [
 			{
 				"type": "Element",
@@ -27,6 +27,45 @@
 					}
 				],
 				"children": []
+			},
+			{
+				"type": "Text",
+				"start": 21,
+				"end": 22,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "Element",
+				"start": 22,
+				"end": 40,
+				"name": "a",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 25,
+						"end": 31,
+						"name": "href",
+						"value": [
+							{
+								"start": 30,
+								"end": 31,
+								"type": "Text",
+								"raw": "/",
+								"data": "/"
+							}
+						]
+					}
+				],
+				"children": [
+					{
+						"type": "Text",
+						"start": 32,
+						"end": 36,
+						"raw": "home",
+						"data": "home"
+					}
+				]
 			}
 		]
 	}

--- a/packages/svelte/tests/parser-legacy/samples/attribute-unquoted/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/attribute-unquoted/output.json
@@ -2,7 +2,7 @@
 	"html": {
 		"type": "Fragment",
 		"start": 0,
-		"end": 40,
+		"end": 62,
 		"children": [
 			{
 				"type": "Element",
@@ -62,6 +62,45 @@
 						"type": "Text",
 						"start": 32,
 						"end": 36,
+						"raw": "home",
+						"data": "home"
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 40,
+				"end": 41,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "Element",
+				"start": 41,
+				"end": 62,
+				"name": "a",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 44,
+						"end": 53,
+						"name": "href",
+						"value": [
+							{
+								"start": 49,
+								"end": 53,
+								"type": "Text",
+								"raw": "/foo",
+								"data": "/foo"
+							}
+						]
+					}
+				],
+				"children": [
+					{
+						"type": "Text",
+						"start": 54,
+						"end": 58,
 						"raw": "home",
 						"data": "home"
 					}


### PR DESCRIPTION
This pull request introduces the ability to allow unquoted slashes in attributes within the Svelte compiler. The key changes include modifications to the parser to handle unquoted slashes, as well as updates to the test cases to ensure this new feature is properly validated.

**Changes to the Svelte compiler**:

* [`packages/svelte/src/compiler/phases/1-parse/state/element.js`](diffhunk://#diff-7b392039dd08109dbbe1b76e614dc5fa1801f49a3a626cb229534af1263f3d46R507-R524): Modified the `read_attribute` function to handle unquoted slashes in attribute values. When it's an unquoted slash, parser will handle it as a quoted slash. 

**Updates to test cases**:

* [`packages/svelte/tests/parser-legacy/samples/attribute-unquoted/input.svelte`](diffhunk://#diff-3db67cd7f70fc4bdb0773f8f19690eccd3404005ad084e3c03751ecb98b152d6R2): Added a new test case for an anchor tag with an unquoted slash in the `href` attribute.
* [`packages/svelte/tests/parser-legacy/samples/attribute-unquoted/output.json`](diffhunk://#diff-298557312eb396b4e0e0e8823624da2e696306433294e7de0595880732c51861L5-R5): Updated the expected output JSON to reflect the new test case and ensure the parser correctly handles the unquoted slash. [[1]](diffhunk://#diff-298557312eb396b4e0e0e8823624da2e696306433294e7de0595880732c51861L5-R5) [[2]](diffhunk://#diff-298557312eb396b4e0e0e8823624da2e696306433294e7de0595880732c51861R30-R68)

**Documentation**:

* [`.changeset/long-boxes-flow.md`](diffhunk://#diff-ba82939feed855f2ab79e0e535d287137aa27c16257b760008fa7448e84b5356R1-R5): Added a changeset entry to document the new feature allowing unquoted slashes in attributes.

**Issues Related**: 
#7782 
