### PR TITLE
fix: restore input binding selection position

### DIFF
--- a/.changeset/cyan-ducks-train.md
+++ b/.changeset/cyan-ducks-train.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: restore input binding selection position

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -30,8 +30,17 @@ export function bind_value(input, get, set = get) {
 		// In runes mode, respect any validation in accessors (doesn't apply in legacy mode,
 		// because we use mutable state which ensures the render effect always runs)
 		if (runes && value !== (value = get())) {
+			var start = input.selectionStart;
+			var end = input.selectionEnd;
+
 			// the value is coerced on assignment
 			input.value = value ?? '';
+
+			// Restore selection
+			if (end !== null) {
+				input.selectionStart = start;
+				input.selectionEnd = Math.min(end, input.value.length);
+			}
 		}
 	});
 


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/14630.

We can actually restore selection on an input that has `bind:value` and the input differs because of a function binding accessor. In fact, we can re-use the restoration logic [implementation from React](https://github.com/facebook/react/blob/372ec00c0384cd2089651154ea7c67693ee3f2a5/packages/react-dom-bindings/src/client/ReactInputSelection.js#L194-L195).

Unfortunately, JSDOM doesn't seem to emulate selection changes when the value changes, so I didn't come up with a test.