### PR TITLE
fix: overwrite #last_value when Spring is `.set()` with `{instant: true}`

### DIFF
--- a/.changeset/shy-carpets-rescue.md
+++ b/.changeset/shy-carpets-rescue.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Overwrite Spring.#last_value when using .set() with {instant: true}

--- a/packages/svelte/src/motion/spring.js
+++ b/packages/svelte/src/motion/spring.js
@@ -282,6 +282,7 @@ export class Spring {
 			this.#task?.abort();
 			this.#task = null;
 			set(this.#current, set(this.#target, value));
+			this.#last_value = value;
 			return Promise.resolve();
 		}
 


### PR DESCRIPTION
Issue: https://github.com/sveltejs/svelte/issues/14645

After using the `{instant: true}` option with `Spring.set()`, a subsequent (non-instant) `.set()` sometimes displayed unexpected behavior. See Issue link for reproduction, .gif of example, and more details.

This PR overwrites the Spring's #last_value after updating instantly so that no data/context from before the `instant` `.set()` lingers to interfere with future `.set()`s. After building this modified version of svelte and linking it to a sveltekit project, I no longer see the glitchy behavior described in the Issue linked above.

I saw no tests in the `/svelte/tests/` directory that use the newly created Spring class and don't feel currently knowledgeable enough to write a full suite myself. I'm also unsure how I would test the private #last_value property. If tests are necessary, please let me know and I will do my best to provide them.


### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
