### PR TITLE
fix: better handle hydration of script/style elements

### DIFF
--- a/.changeset/rotten-yaks-nail.md
+++ b/.changeset/rotten-yaks-nail.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better handle hydration of script/style elements

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -46,7 +46,7 @@ export function hydrate_next() {
 		// If we're hydrating inside a <script> or <style> element then there is no
 		// closing anchor
 		if (parent_node_name === 'SCRIPT' || parent_node_name === 'STYLE') {
-			return;
+			return hydrate_node;
 		}
 	}
 	return set_hydrate_node(sibling);

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -40,7 +40,16 @@ export function set_hydrate_node(node) {
 }
 
 export function hydrate_next() {
-	return set_hydrate_node(/** @type {TemplateNode} */ (get_next_sibling(hydrate_node)));
+	var sibling = /** @type {TemplateNode} */ (get_next_sibling(hydrate_node));
+	if (sibling === null) {
+		var parent_node_name = hydrate_node.parentNode?.nodeName;
+		// If we're hydrating inside a <script> or <style> element then there is no
+		// closing anchor
+		if (parent_node_name === 'SCRIPT' || parent_node_name === 'STYLE') {
+			return;
+		}
+	}
+	return set_hydrate_node(sibling);
 }
 
 /** @param {TemplateNode} node */

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -64,7 +64,7 @@ export function element(payload, tag, attributes_fn = noop, children_fn = noop) 
 	payload.out += '<!---->';
 
 	if (tag) {
-		payload.out += `<${tag} `;
+		payload.out += `<${tag}`;
 		attributes_fn();
 		payload.out += `>`;
 

--- a/packages/svelte/tests/hydration/samples/script/_config.js
+++ b/packages/svelte/tests/hydration/samples/script/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	snapshot(target) {
+		const script = target.querySelector('script');
+
+		return {
+			script
+		};
+	}
+});

--- a/packages/svelte/tests/hydration/samples/script/main.svelte
+++ b/packages/svelte/tests/hydration/samples/script/main.svelte
@@ -1,0 +1,1 @@
+<svelte:element this={"script"}>{"{}"}</svelte:element>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14624. We can better handle hydration of `<script>` and `<style>` elements when used with `<svelte:element>` and avoid the mismatch errors people are encountering.