### PR TITLE
feat: loose parser mode

### DIFF
--- a/.changeset/twelve-hairs-marry.md
+++ b/.changeset/twelve-hairs-marry.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: provide loose parser mode

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -14,7 +14,7 @@ class InternalCompileError extends Error {
 	 */
 	constructor(code, message, position) {
 		super(message);
-		// this.stack = ''; // avoid unnecessary noise; don't set it as a class property or it becomes enumerable
+		this.stack = ''; // avoid unnecessary noise; don't set it as a class property or it becomes enumerable
 		// We want to extend from Error so that various bundler plugins properly handle it.
 		// But we also want to share the same object shape with that of warnings, therefore
 		// we create an instance of the shared class an copy over its properties.

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -14,7 +14,7 @@ class InternalCompileError extends Error {
 	 */
 	constructor(code, message, position) {
 		super(message);
-		this.stack = ''; // avoid unnecessary noise; don't set it as a class property or it becomes enumerable
+		// this.stack = ''; // avoid unnecessary noise; don't set it as a class property or it becomes enumerable
 		// We want to extend from Error so that various bundler plugins properly handle it.
 		// But we also want to share the same object shape with that of warnings, therefore
 		// we create an instance of the shared class an copy over its properties.

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -99,15 +99,15 @@ export function compileModule(source, options) {
  * `modern` will become `true` by default in Svelte 6, and the option will be removed in Svelte 7.
  *
  * @param {string} source
- * @param {{ filename?: string; rootDir?: string; modern?: boolean }} [options]
+ * @param {{ filename?: string; rootDir?: string; modern?: boolean; loose?: boolean }} [options]
  * @returns {AST.Root | LegacyRoot}
  */
-export function parse(source, { filename, rootDir, modern } = {}) {
+export function parse(source, { filename, rootDir, modern, loose } = {}) {
 	source = remove_bom(source);
 	state.reset_warning_filter(() => false);
 	state.reset(source, { filename: filename ?? '(unknown)', rootDir });
 
-	const ast = _parse(source);
+	const ast = _parse(source, loose);
 	return to_public_ast(source, ast, modern);
 }
 

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -76,7 +76,7 @@ export function compileModule(source, options) {
  *
  * @overload
  * @param {string} source
- * @param {{ filename?: string; modern: true }} options
+ * @param {{ filename?: string; modern: true; loose?: boolean }} options
  * @returns {AST.Root}
  */
 
@@ -88,7 +88,7 @@ export function compileModule(source, options) {
  *
  * @overload
  * @param {string} source
- * @param {{ filename?: string; modern?: false }} [options]
+ * @param {{ filename?: string; modern?: false; loose?: boolean }} [options]
  * @returns {Record<string, any>}
  */
 

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -22,6 +22,13 @@ export class Parser {
 	 */
 	template;
 
+	/**
+	 * Whether or not we're in loose parsing mode, in which
+	 * case we try to continue parsing as much as possible
+	 * @type {boolean}
+	 */
+	loose;
+
 	/** */
 	index = 0;
 
@@ -43,12 +50,16 @@ export class Parser {
 	/** @type {LastAutoClosedTag | undefined} */
 	last_auto_closed_tag;
 
-	/** @param {string} template */
-	constructor(template) {
+	/**
+	 * @param {string} template
+	 * @param {boolean} loose
+	 */
+	constructor(template, loose) {
 		if (typeof template !== 'string') {
 			throw new TypeError('Template must be a string');
 		}
 
+		this.loose = loose;
 		this.template = template.trimEnd();
 
 		let match_lang;
@@ -274,10 +285,11 @@ export class Parser {
 
 /**
  * @param {string} template
+ * @param {boolean} [loose]
  * @returns {AST.Root}
  */
-export function parse(template) {
-	const parser = new Parser(template);
+export function parse(template, loose = false) {
+	const parser = new Parser(template, loose);
 	return parser.root;
 }
 

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -247,6 +247,7 @@ export class Parser {
 	/** @param {RegExp} pattern */
 	read_until(pattern) {
 		if (this.index >= this.template.length) {
+			if (this.loose) return '';
 			e.unexpected_eof(this.template.length);
 		}
 

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -164,14 +164,15 @@ export class Parser {
 	/**
 	 * @param {string} str
 	 * @param {boolean} required
+	 * @param {boolean} required_in_loose
 	 */
-	eat(str, required = false) {
+	eat(str, required = false, required_in_loose = true) {
 		if (this.match(str)) {
 			this.index += str.length;
 			return true;
 		}
 
-		if (required) {
+		if (required && (!this.loose || required_in_loose)) {
 			e.expected_token(this.index, str);
 		}
 

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -99,7 +99,9 @@ export class Parser {
 		if (this.stack.length > 1) {
 			const current = this.current();
 
-			if (current.type === 'RegularElement') {
+			if (this.loose) {
+				current.end = this.template.length;
+			} else if (current.type === 'RegularElement') {
 				current.end = current.start + 1;
 				e.element_unclosed(current, current.name);
 			} else {

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -23,6 +23,12 @@ export class Parser {
 	template;
 
 	/**
+	 * @readonly
+	 * @type {string}
+	 */
+	template_untrimmed;
+
+	/**
 	 * Whether or not we're in loose parsing mode, in which
 	 * case we try to continue parsing as much as possible
 	 * @type {boolean}
@@ -60,6 +66,7 @@ export class Parser {
 		}
 
 		this.loose = loose;
+		this.template_untrimmed = template;
 		this.template = template.trimEnd();
 
 		let match_lang;

--- a/packages/svelte/src/compiler/phases/1-parse/read/expression.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/expression.js
@@ -3,6 +3,7 @@
 import { parse_expression_at } from '../acorn.js';
 import { regex_whitespace } from '../../patterns.js';
 import * as e from '../../../errors.js';
+import { find_matching_bracket } from '../utils/bracket.js';
 
 /**
  * @param {Parser} parser
@@ -41,33 +42,17 @@ export default function read_expression(parser) {
 	} catch (err) {
 		if (parser.loose) {
 			// Find the next } and treat it as the end of the expression
-			let index = parser.index;
-			let num_braces = 0;
-			while (index < parser.template.length) {
-				const char = parser.template[index];
-				if (char === '{') num_braces += 1;
-				if (char === '}') {
-					if (num_braces === 0) {
-						// We assume that there's some kind of whitespace or the start of the closing tag after the closing brace,
-						// else this hints at a wrong counting of braces (e.g. in the case of foo={'hi}'})
-						if (!/[\s>/]/.test(parser.template[index + 1])) {
-							num_braces += 1;
-							continue;
-						}
-
-						const start = parser.index;
-						parser.index = index;
-						// We don't know what the expression is and signal this by returning an empty identifier
-						return {
-							type: 'Identifier',
-							start,
-							end: index,
-							name: ''
-						};
-					}
-					num_braces -= 1;
-				}
-				index += 1;
+			const end = find_matching_bracket(parser.template, parser.index, '{');
+			if (end) {
+				const start = parser.index;
+				parser.index = end;
+				// We don't know what the expression is and signal this by returning an empty identifier
+				return {
+					type: 'Identifier',
+					start,
+					end,
+					name: ''
+				};
 			}
 		}
 

--- a/packages/svelte/src/compiler/phases/1-parse/read/expression.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/expression.js
@@ -39,6 +39,38 @@ export default function read_expression(parser) {
 
 		return /** @type {Expression} */ (node);
 	} catch (err) {
+		if (parser.loose) {
+			// Find the next } and treat it as the end of the expression
+			let index = parser.index;
+			let num_braces = 0;
+			while (index < parser.template.length) {
+				const char = parser.template[index];
+				if (char === '{') num_braces += 1;
+				if (char === '}') {
+					if (num_braces === 0) {
+						// We assume that there's some kind of whitespace or the start of the closing tag after the closing brace,
+						// else this hints at a wrong counting of braces (e.g. in the case of foo={'hi}'})
+						if (!/[\s>/]/.test(parser.template[index + 1])) {
+							num_braces += 1;
+							continue;
+						}
+
+						const start = parser.index;
+						parser.index = index;
+						// We don't know what the expression is and signal this by returning an empty identifier
+						return {
+							type: 'Identifier',
+							start,
+							end: index,
+							name: ''
+						};
+					}
+					num_braces -= 1;
+				}
+				index += 1;
+			}
+		}
+
 		parser.acorn_error(err);
 	}
 }

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -481,7 +481,7 @@ function read_attribute(parser) {
 			return spread;
 		} else {
 			const value_start = parser.index;
-			const name = parser.read_identifier();
+			let name = parser.read_identifier();
 
 			if (name === null) {
 				if (
@@ -491,8 +491,12 @@ function read_attribute(parser) {
 					// We're likely in an unclosed opening tag and did read part of a block.
 					// Return null to not crash the parser so it can continue with closing the tag.
 					return null;
+				} else if (parser.loose && parser.match('}')) {
+					// Likely in the middle of typing, just created the shorthand
+					name = '';
+				} else {
+					e.attribute_empty_shorthand(start);
 				}
-				e.attribute_empty_shorthand(start);
 			}
 
 			parser.allow_whitespace();

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -80,7 +80,7 @@ export default function element(parser) {
 
 		// close any elements that don't have their own closing tags, e.g. <div><p></div>
 		while (/** @type {AST.RegularElement} */ (parent).name !== name) {
-			if (parent.type !== 'RegularElement') {
+			if (parent.type !== 'RegularElement' && !parser.loose) {
 				if (parser.last_auto_closed_tag && parser.last_auto_closed_tag.tag === name) {
 					e.element_invalid_closing_tag_autoclosed(start, name, parser.last_auto_closed_tag.reason);
 				} else {

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -336,7 +336,7 @@ export default function element(parser) {
 
 	// Loose parsing mode
 	if (!closed) {
-		// We may have eaten an opening `<` of the next element and treated is as an attribute...
+		// We may have eaten an opening `<` of the next element and treated it as an attribute...
 		const last = element.attributes.at(-1);
 		if (last?.type === 'Attribute' && last.name === '<') {
 			parser.index = last.start;

--- a/packages/svelte/src/compiler/phases/1-parse/utils/bracket.js
+++ b/packages/svelte/src/compiler/phases/1-parse/utils/bracket.js
@@ -1,3 +1,5 @@
+import full_char_code_at from './full_char_code_at.js';
+
 const SQUARE_BRACKET_OPEN = '['.charCodeAt(0);
 const SQUARE_BRACKET_CLOSE = ']'.charCodeAt(0);
 const CURLY_BRACKET_OPEN = '{'.charCodeAt(0);
@@ -32,4 +34,138 @@ export function get_bracket_close(open) {
 	if (open === CURLY_BRACKET_OPEN) {
 		return CURLY_BRACKET_CLOSE;
 	}
+}
+
+/**
+ * @param {number} num
+ * @returns {number} Infinity if {@link num} is negative, else {@link num}.
+ */
+function infinity_if_negative(num) {
+	if (num < 0) {
+		return Infinity;
+	}
+	return num;
+}
+
+/**
+ * @param {string} string The string to search.
+ * @param {number} search_start_index The index to start searching at.
+ * @param {"'" | '"' | '`'} string_start_char The character that started this string.
+ * @returns {number} The index of the end of this string expression, or `Infinity` if not found.
+ */
+function find_string_end(string, search_start_index, string_start_char) {
+	let string_to_search;
+	if (string_start_char === '`') {
+		string_to_search = string;
+	} else {
+		// we could slice at the search start index, but this way the index remains valid
+		string_to_search = string.slice(
+			0,
+			infinity_if_negative(string.indexOf('\n', search_start_index))
+		);
+	}
+
+	return find_unescaped_char(string_to_search, search_start_index, string_start_char);
+}
+
+/**
+ * @param {string} string The string to search.
+ * @param {number} search_start_index The index to start searching at.
+ * @returns {number} The index of the end of this regex expression, or `Infinity` if not found.
+ */
+function find_regex_end(string, search_start_index) {
+	return find_unescaped_char(string, search_start_index, '/');
+}
+
+/**
+ *
+ * @param {string} string The string to search.
+ * @param {number} search_start_index The index to begin the search at.
+ * @param {string} char The character to search for.
+ * @returns {number} The index of the first unescaped instance of {@link char}, or `Infinity` if not found.
+ */
+function find_unescaped_char(string, search_start_index, char) {
+	let i = search_start_index;
+	while (true) {
+		const found_index = string.indexOf(char, i);
+		if (found_index === -1) {
+			return Infinity;
+		}
+		if (count_leading_backslashes(string, found_index - 1) % 2 === 0) {
+			return found_index;
+		}
+		i = found_index + 1;
+	}
+}
+
+/**
+ * Count consecutive leading backslashes before {@link search_start_index}.
+ *
+ * @example
+ * ```js
+ * count_leading_backslashes('\\\\\\foo', 2); // 3 (the backslashes have to be escaped in the string literal, there are three in reality)
+ * ```
+ *
+ * @param {string} string The string to search.
+ * @param {number} search_start_index The index to begin the search at.
+ */
+function count_leading_backslashes(string, search_start_index) {
+	let i = search_start_index;
+	let count = 0;
+	while (string[i] === '\\') {
+		count++;
+		i--;
+	}
+	return count;
+}
+
+/**
+ * Finds the corresponding closing bracket, ignoring brackets found inside comments, strings, or regex expressions.
+ * @param {string} template The string to search.
+ * @param {number} index The index to begin the search at.
+ * @param {string} open The opening bracket (ex: `'{'` will search for `'}'`).
+ * @returns {number | undefined} The index of the closing bracket, or undefined if not found.
+ */
+export function find_matching_bracket(template, index, open) {
+	const open_code = full_char_code_at(open, 0);
+	const close_code = get_bracket_close(open_code);
+	let brackets = 1;
+	let i = index;
+	while (brackets > 0 && i < template.length) {
+		const char = template[i];
+		switch (char) {
+			case "'":
+			case '"':
+			case '`':
+				i = find_string_end(template, i + 1, char) + 1;
+				continue;
+			case '/': {
+				const next_char = template[i + 1];
+				if (!next_char) continue;
+				if (next_char === '/') {
+					i = infinity_if_negative(template.indexOf('\n', i + 1)) + '\n'.length;
+					continue;
+				}
+				if (next_char === '*') {
+					i = infinity_if_negative(template.indexOf('*/', i + 1)) + '*/'.length;
+					continue;
+				}
+				i = find_regex_end(template, i + 1) + '/'.length;
+				continue;
+			}
+			default: {
+				const code = full_char_code_at(template, i);
+				if (code === open_code) {
+					brackets++;
+				} else if (code === close_code) {
+					brackets--;
+				}
+				if (brackets === 0) {
+					return i;
+				}
+				i++;
+			}
+		}
+	}
+	return undefined;
 }

--- a/packages/svelte/tests/parser-legacy/samples/loose-invalid-block/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/loose-invalid-block/input.svelte
@@ -1,0 +1,13 @@
+{#if }
+{:else if }
+{:else }
+{/if}
+
+{#each }
+{/each}
+
+{#snippet }
+{/snippet}
+
+{#snippet foo}
+{/snippet}

--- a/packages/svelte/tests/parser-legacy/samples/loose-invalid-block/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/loose-invalid-block/output.json
@@ -1,0 +1,107 @@
+{
+	"html": {
+		"type": "Fragment",
+		"start": 0,
+		"end": 102,
+		"children": [
+			{
+				"type": "IfBlock",
+				"start": 0,
+				"end": 33,
+				"expression": {
+					"type": "Identifier",
+					"start": 5,
+					"end": 5,
+					"name": ""
+				},
+				"children": [],
+				"else": {
+					"type": "ElseBlock",
+					"start": 18,
+					"end": 28,
+					"children": [
+						{
+							"type": "IfBlock",
+							"start": 18,
+							"end": 33,
+							"expression": {
+								"type": "Identifier",
+								"start": 17,
+								"end": 17,
+								"name": ""
+							},
+							"children": [],
+							"else": {
+								"type": "ElseBlock",
+								"start": 27,
+								"end": 28,
+								"children": []
+							},
+							"elseif": true
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 33,
+				"end": 35,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "EachBlock",
+				"start": 35,
+				"end": 51,
+				"children": [],
+				"context": null,
+				"expression": {
+					"type": "Identifier",
+					"start": 42,
+					"end": 42,
+					"name": ""
+				}
+			},
+			{
+				"type": "Text",
+				"start": 51,
+				"end": 53,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "SnippetBlock",
+				"start": 53,
+				"end": 75,
+				"expression": {
+					"type": "Identifier",
+					"start": 63,
+					"end": 63,
+					"name": ""
+				},
+				"parameters": [],
+				"children": []
+			},
+			{
+				"type": "Text",
+				"start": 75,
+				"end": 77,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "SnippetBlock",
+				"start": 77,
+				"end": 102,
+				"expression": {
+					"type": "Identifier",
+					"start": 87,
+					"end": 90,
+					"name": "foo"
+				},
+				"parameters": [],
+				"children": []
+			}
+		]
+	}
+}

--- a/packages/svelte/tests/parser-legacy/samples/loose-invalid-expression/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/loose-invalid-expression/input.svelte
@@ -1,0 +1,8 @@
+<div {}></div>
+<div foo={}></div>
+
+<div foo={a.}></div>
+<div foo={'hi}'.}></div>
+<Component onclick={() => x.} />
+
+<input bind:value={a.} />

--- a/packages/svelte/tests/parser-legacy/samples/loose-invalid-expression/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/loose-invalid-expression/input.svelte
@@ -6,3 +6,6 @@
 <Component onclick={() => x.} />
 
 <input bind:value={a.} />
+
+asd{a.}asd
+{foo[bar.]}

--- a/packages/svelte/tests/parser-legacy/samples/loose-invalid-expression/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/loose-invalid-expression/output.json
@@ -2,7 +2,7 @@
 	"html": {
 		"type": "Fragment",
 		"start": 0,
-		"end": 140,
+		"end": 164,
 		"children": [
 			{
 				"type": "Element",
@@ -200,6 +200,42 @@
 					}
 				],
 				"children": []
+			},
+			{
+				"type": "Text",
+				"start": 140,
+				"end": 145,
+				"raw": "\n\nasd",
+				"data": "\n\nasd"
+			},
+			{
+				"type": "MustacheTag",
+				"start": 145,
+				"end": 149,
+				"expression": {
+					"type": "Identifier",
+					"start": 146,
+					"end": 148,
+					"name": ""
+				}
+			},
+			{
+				"type": "Text",
+				"start": 149,
+				"end": 153,
+				"raw": "asd\n",
+				"data": "asd\n"
+			},
+			{
+				"type": "MustacheTag",
+				"start": 153,
+				"end": 164,
+				"expression": {
+					"type": "Identifier",
+					"start": 154,
+					"end": 163,
+					"name": ""
+				}
 			}
 		]
 	}

--- a/packages/svelte/tests/parser-legacy/samples/loose-invalid-expression/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/loose-invalid-expression/output.json
@@ -1,0 +1,206 @@
+{
+	"html": {
+		"type": "Fragment",
+		"start": 0,
+		"end": 140,
+		"children": [
+			{
+				"type": "Element",
+				"start": 0,
+				"end": 14,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 5,
+						"end": 7,
+						"name": "",
+						"value": [
+							{
+								"type": "AttributeShorthand",
+								"start": 6,
+								"end": 6,
+								"expression": {
+									"start": 6,
+									"end": 6,
+									"type": "Identifier",
+									"name": ""
+								}
+							}
+						]
+					}
+				],
+				"children": []
+			},
+			{
+				"type": "Text",
+				"start": 14,
+				"end": 15,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "Element",
+				"start": 15,
+				"end": 33,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 20,
+						"end": 26,
+						"name": "foo",
+						"value": [
+							{
+								"type": "MustacheTag",
+								"start": 24,
+								"end": 26,
+								"expression": {
+									"type": "Identifier",
+									"start": 25,
+									"end": 25,
+									"name": ""
+								}
+							}
+						]
+					}
+				],
+				"children": []
+			},
+			{
+				"type": "Text",
+				"start": 33,
+				"end": 35,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 35,
+				"end": 55,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 40,
+						"end": 48,
+						"name": "foo",
+						"value": [
+							{
+								"type": "MustacheTag",
+								"start": 44,
+								"end": 48,
+								"expression": {
+									"type": "Identifier",
+									"start": 45,
+									"end": 47,
+									"name": ""
+								}
+							}
+						]
+					}
+				],
+				"children": []
+			},
+			{
+				"type": "Text",
+				"start": 55,
+				"end": 56,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "Element",
+				"start": 56,
+				"end": 80,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 61,
+						"end": 73,
+						"name": "foo",
+						"value": [
+							{
+								"type": "MustacheTag",
+								"start": 65,
+								"end": 73,
+								"expression": {
+									"type": "Identifier",
+									"start": 66,
+									"end": 72,
+									"name": ""
+								}
+							}
+						]
+					}
+				],
+				"children": []
+			},
+			{
+				"type": "Text",
+				"start": 80,
+				"end": 81,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "InlineComponent",
+				"start": 81,
+				"end": 113,
+				"name": "Component",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 92,
+						"end": 110,
+						"name": "onclick",
+						"value": [
+							{
+								"type": "MustacheTag",
+								"start": 100,
+								"end": 110,
+								"expression": {
+									"type": "Identifier",
+									"start": 101,
+									"end": 109,
+									"name": ""
+								}
+							}
+						]
+					}
+				],
+				"children": []
+			},
+			{
+				"type": "Text",
+				"start": 113,
+				"end": 115,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 115,
+				"end": 140,
+				"name": "input",
+				"attributes": [
+					{
+						"start": 122,
+						"end": 137,
+						"type": "Binding",
+						"name": "value",
+						"expression": {
+							"type": "Identifier",
+							"start": 134,
+							"end": 136,
+							"name": ""
+						},
+						"modifiers": []
+					}
+				],
+				"children": []
+			}
+		]
+	}
+}

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-block/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-block/input.svelte
@@ -1,0 +1,20 @@
+<div>
+	{#if foo}
+</div>
+
+<Comp>
+	{#key bar}
+</Comp>
+
+<div>
+	{#if foo}
+		{#if bar}
+	{/if}
+</div>
+
+{#if foo}
+	{#key bar}
+{/if}
+
+{#each x as y}
+<p>hi</p>

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-block/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-block/output.json
@@ -1,0 +1,276 @@
+{
+	"html": {
+		"type": "Fragment",
+		"start": 0,
+		"end": 150,
+		"children": [
+			{
+				"type": "Element",
+				"start": 0,
+				"end": 23,
+				"name": "div",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 5,
+						"end": 7,
+						"raw": "\n\t",
+						"data": "\n\t"
+					},
+					{
+						"type": "IfBlock",
+						"start": 7,
+						"end": 17,
+						"expression": {
+							"type": "Identifier",
+							"start": 12,
+							"end": 15,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 6
+								},
+								"end": {
+									"line": 2,
+									"column": 9
+								}
+							},
+							"name": "foo"
+						},
+						"children": []
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 23,
+				"end": 25,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "InlineComponent",
+				"start": 25,
+				"end": 51,
+				"name": "Comp",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 31,
+						"end": 33,
+						"raw": "\n\t",
+						"data": "\n\t"
+					},
+					{
+						"type": "KeyBlock",
+						"start": 33,
+						"end": 44,
+						"expression": {
+							"type": "Identifier",
+							"start": 39,
+							"end": 42,
+							"loc": {
+								"start": {
+									"line": 6,
+									"column": 7
+								},
+								"end": {
+									"line": 6,
+									"column": 10
+								}
+							},
+							"name": "bar"
+						},
+						"children": []
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 51,
+				"end": 53,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 53,
+				"end": 95,
+				"name": "div",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 58,
+						"end": 60,
+						"raw": "\n\t",
+						"data": "\n\t"
+					},
+					{
+						"type": "IfBlock",
+						"start": 60,
+						"end": 89,
+						"expression": {
+							"type": "Identifier",
+							"start": 65,
+							"end": 68,
+							"loc": {
+								"start": {
+									"line": 10,
+									"column": 6
+								},
+								"end": {
+									"line": 10,
+									"column": 9
+								}
+							},
+							"name": "foo"
+						},
+						"children": [
+							{
+								"type": "IfBlock",
+								"start": 72,
+								"end": 88,
+								"expression": {
+									"type": "Identifier",
+									"start": 77,
+									"end": 80,
+									"loc": {
+										"start": {
+											"line": 11,
+											"column": 7
+										},
+										"end": {
+											"line": 11,
+											"column": 10
+										}
+									},
+									"name": "bar"
+								},
+								"children": []
+							}
+						]
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 95,
+				"end": 97,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "IfBlock",
+				"start": 97,
+				"end": 124,
+				"expression": {
+					"type": "Identifier",
+					"start": 102,
+					"end": 105,
+					"loc": {
+						"start": {
+							"line": 15,
+							"column": 5
+						},
+						"end": {
+							"line": 15,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"children": [
+					{
+						"type": "KeyBlock",
+						"start": 108,
+						"end": 119,
+						"expression": {
+							"type": "Identifier",
+							"start": 114,
+							"end": 117,
+							"loc": {
+								"start": {
+									"line": 16,
+									"column": 7
+								},
+								"end": {
+									"line": 16,
+									"column": 10
+								}
+							},
+							"name": "bar"
+						},
+						"children": []
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 124,
+				"end": 126,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "EachBlock",
+				"start": 126,
+				"end": 150,
+				"children": [
+					{
+						"type": "Element",
+						"start": 141,
+						"end": 150,
+						"name": "p",
+						"attributes": [],
+						"children": [
+							{
+								"type": "Text",
+								"start": 144,
+								"end": 146,
+								"raw": "hi",
+								"data": "hi"
+							}
+						]
+					}
+				],
+				"context": {
+					"type": "Identifier",
+					"name": "y",
+					"start": 138,
+					"loc": {
+						"start": {
+							"line": 19,
+							"column": 12,
+							"character": 138
+						},
+						"end": {
+							"line": 19,
+							"column": 13,
+							"character": 139
+						}
+					},
+					"end": 139
+				},
+				"expression": {
+					"type": "Identifier",
+					"start": 133,
+					"end": 134,
+					"loc": {
+						"start": {
+							"line": 19,
+							"column": 7
+						},
+						"end": {
+							"line": 19,
+							"column": 8
+						}
+					},
+					"name": "x"
+				}
+			}
+		]
+	}
+}

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-open-tag/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-open-tag/input.svelte
@@ -1,0 +1,20 @@
+<div>
+	<Comp foo={bar}
+</div>
+
+<div>
+	<span foo={bar}
+</div>
+
+{#if foo}
+	<Comp foo={bar}
+{/if}
+
+{#if foo}
+	<Comp foo={bar}
+	{#if bar}
+		{bar}
+	{/if}
+{/if}
+
+<div foo={bar}

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-open-tag/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-open-tag/output.json
@@ -1,0 +1,349 @@
+{
+	"html": {
+		"type": "Fragment",
+		"start": 0,
+		"end": 170,
+		"children": [
+			{
+				"type": "Element",
+				"start": 0,
+				"end": 29,
+				"name": "div",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 5,
+						"end": 7,
+						"raw": "\n\t",
+						"data": "\n\t"
+					},
+					{
+						"type": "InlineComponent",
+						"start": 7,
+						"end": 23,
+						"name": "Comp",
+						"attributes": [
+							{
+								"type": "Attribute",
+								"start": 13,
+								"end": 22,
+								"name": "foo",
+								"value": [
+									{
+										"type": "MustacheTag",
+										"start": 17,
+										"end": 22,
+										"expression": {
+											"type": "Identifier",
+											"start": 18,
+											"end": 21,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 12
+												},
+												"end": {
+													"line": 2,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								]
+							}
+						],
+						"children": []
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 29,
+				"end": 31,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 31,
+				"end": 60,
+				"name": "div",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 36,
+						"end": 38,
+						"raw": "\n\t",
+						"data": "\n\t"
+					},
+					{
+						"type": "Element",
+						"start": 38,
+						"end": 54,
+						"name": "span",
+						"attributes": [
+							{
+								"type": "Attribute",
+								"start": 44,
+								"end": 53,
+								"name": "foo",
+								"value": [
+									{
+										"type": "MustacheTag",
+										"start": 48,
+										"end": 53,
+										"expression": {
+											"type": "Identifier",
+											"start": 49,
+											"end": 52,
+											"loc": {
+												"start": {
+													"line": 6,
+													"column": 12
+												},
+												"end": {
+													"line": 6,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								]
+							}
+						],
+						"children": []
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 60,
+				"end": 62,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "IfBlock",
+				"start": 62,
+				"end": 94,
+				"expression": {
+					"type": "Identifier",
+					"start": 67,
+					"end": 70,
+					"loc": {
+						"start": {
+							"line": 9,
+							"column": 5
+						},
+						"end": {
+							"line": 9,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"children": [
+					{
+						"type": "InlineComponent",
+						"start": 73,
+						"end": 89,
+						"name": "Comp",
+						"attributes": [
+							{
+								"type": "Attribute",
+								"start": 79,
+								"end": 88,
+								"name": "foo",
+								"value": [
+									{
+										"type": "MustacheTag",
+										"start": 83,
+										"end": 88,
+										"expression": {
+											"type": "Identifier",
+											"start": 84,
+											"end": 87,
+											"loc": {
+												"start": {
+													"line": 10,
+													"column": 12
+												},
+												"end": {
+													"line": 10,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								]
+							}
+						],
+						"children": []
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 94,
+				"end": 96,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "IfBlock",
+				"start": 96,
+				"end": 154,
+				"expression": {
+					"type": "Identifier",
+					"start": 101,
+					"end": 104,
+					"loc": {
+						"start": {
+							"line": 13,
+							"column": 5
+						},
+						"end": {
+							"line": 13,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"children": [
+					{
+						"type": "InlineComponent",
+						"start": 107,
+						"end": 124,
+						"name": "Comp",
+						"attributes": [
+							{
+								"type": "Attribute",
+								"start": 113,
+								"end": 122,
+								"name": "foo",
+								"value": [
+									{
+										"type": "MustacheTag",
+										"start": 117,
+										"end": 122,
+										"expression": {
+											"type": "Identifier",
+											"start": 118,
+											"end": 121,
+											"loc": {
+												"start": {
+													"line": 14,
+													"column": 12
+												},
+												"end": {
+													"line": 14,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								]
+							}
+						],
+						"children": []
+					},
+					{
+						"type": "IfBlock",
+						"start": 124,
+						"end": 148,
+						"expression": {
+							"type": "Identifier",
+							"start": 129,
+							"end": 132,
+							"loc": {
+								"start": {
+									"line": 15,
+									"column": 6
+								},
+								"end": {
+									"line": 15,
+									"column": 9
+								}
+							},
+							"name": "bar"
+						},
+						"children": [
+							{
+								"type": "MustacheTag",
+								"start": 136,
+								"end": 141,
+								"expression": {
+									"type": "Identifier",
+									"start": 137,
+									"end": 140,
+									"loc": {
+										"start": {
+											"line": 16,
+											"column": 3
+										},
+										"end": {
+											"line": 16,
+											"column": 6
+										}
+									},
+									"name": "bar"
+								}
+							}
+						]
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 154,
+				"end": 156,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 156,
+				"end": 170,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 161,
+						"end": 170,
+						"name": "foo",
+						"value": [
+							{
+								"type": "MustacheTag",
+								"start": 165,
+								"end": 170,
+								"expression": {
+									"type": "Identifier",
+									"start": 166,
+									"end": 169,
+									"loc": {
+										"start": {
+											"line": 20,
+											"column": 10
+										},
+										"end": {
+											"line": 20,
+											"column": 13
+										}
+									},
+									"name": "bar"
+								}
+							}
+						]
+					}
+				],
+				"children": []
+			}
+		]
+	}
+}

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/input.svelte
@@ -3,12 +3,22 @@
 </div>
 
 <div>
-	<span>
+	<Comp foo={bar}
+</div>
+
+<div>
+	<span
 </div>
 
 {#if foo}
 	<div>
 {/if}
 
+{#if foo}
+	<Comp foo={bar}
+{/if}
+
 <div>
 <p>hi</p>
+
+<open-ended

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/input.svelte
@@ -6,5 +6,9 @@
 	<span>
 </div>
 
+{#if foo}
+	<div>
+{/if}
+
 <div>
 <p>hi</p>

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/input.svelte
@@ -1,0 +1,10 @@
+<div>
+	<Comp>
+</div>
+
+<div>
+	<span>
+</div>
+
+<div>
+<p>hi</p>

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/output.json
@@ -1,0 +1,119 @@
+{
+	"html": {
+		"type": "Fragment",
+		"start": 0,
+		"end": 59,
+		"children": [
+			{
+				"type": "Element",
+				"start": 0,
+				"end": 20,
+				"name": "div",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 5,
+						"end": 7,
+						"raw": "\n\t",
+						"data": "\n\t"
+					},
+					{
+						"type": "InlineComponent",
+						"start": 7,
+						"end": 14,
+						"name": "Comp",
+						"attributes": [],
+						"children": [
+							{
+								"type": "Text",
+								"start": 13,
+								"end": 14,
+								"raw": "\n",
+								"data": "\n"
+							}
+						]
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 20,
+				"end": 22,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 22,
+				"end": 42,
+				"name": "div",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 27,
+						"end": 29,
+						"raw": "\n\t",
+						"data": "\n\t"
+					},
+					{
+						"type": "Element",
+						"start": 29,
+						"end": 36,
+						"name": "span",
+						"attributes": [],
+						"children": [
+							{
+								"type": "Text",
+								"start": 35,
+								"end": 36,
+								"raw": "\n",
+								"data": "\n"
+							}
+						]
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 42,
+				"end": 44,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 44,
+				"end": 59,
+				"name": "div",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 49,
+						"end": 50,
+						"raw": "\n",
+						"data": "\n"
+					},
+					{
+						"type": "Element",
+						"start": 50,
+						"end": 59,
+						"name": "p",
+						"attributes": [],
+						"children": [
+							{
+								"type": "Text",
+								"start": 53,
+								"end": 55,
+								"raw": "hi",
+								"data": "hi"
+							}
+						]
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/output.json
@@ -2,7 +2,7 @@
 	"html": {
 		"type": "Fragment",
 		"start": 0,
-		"end": 59,
+		"end": 83,
 		"children": [
 			{
 				"type": "Element",
@@ -83,30 +83,76 @@
 				"data": "\n\n"
 			},
 			{
-				"type": "Element",
+				"type": "IfBlock",
 				"start": 44,
-				"end": 59,
+				"end": 66,
+				"expression": {
+					"type": "Identifier",
+					"start": 49,
+					"end": 52,
+					"loc": {
+						"start": {
+							"line": 9,
+							"column": 5
+						},
+						"end": {
+							"line": 9,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"children": [
+					{
+						"type": "Element",
+						"start": 55,
+						"end": 61,
+						"name": "div",
+						"attributes": [],
+						"children": [
+							{
+								"type": "Text",
+								"start": 60,
+								"end": 61,
+								"raw": "\n",
+								"data": "\n"
+							}
+						]
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 66,
+				"end": 68,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 68,
+				"end": 83,
 				"name": "div",
 				"attributes": [],
 				"children": [
 					{
 						"type": "Text",
-						"start": 49,
-						"end": 50,
+						"start": 73,
+						"end": 74,
 						"raw": "\n",
 						"data": "\n"
 					},
 					{
 						"type": "Element",
-						"start": 50,
-						"end": 59,
+						"start": 74,
+						"end": 83,
 						"name": "p",
 						"attributes": [],
 						"children": [
 							{
 								"type": "Text",
-								"start": 53,
-								"end": 55,
+								"start": 77,
+								"end": 79,
 								"raw": "hi",
 								"data": "hi"
 							}

--- a/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/loose-unclosed-tag/output.json
@@ -2,7 +2,7 @@
 	"html": {
 		"type": "Fragment",
 		"start": 0,
-		"end": 83,
+		"end": 160,
 		"children": [
 			{
 				"type": "Element",
@@ -46,7 +46,7 @@
 			{
 				"type": "Element",
 				"start": 22,
-				"end": 42,
+				"end": 51,
 				"name": "div",
 				"attributes": [],
 				"children": [
@@ -58,45 +58,98 @@
 						"data": "\n\t"
 					},
 					{
-						"type": "Element",
+						"type": "InlineComponent",
 						"start": 29,
-						"end": 36,
-						"name": "span",
-						"attributes": [],
-						"children": [
+						"end": 45,
+						"name": "Comp",
+						"attributes": [
 							{
-								"type": "Text",
+								"type": "Attribute",
 								"start": 35,
-								"end": 36,
-								"raw": "\n",
-								"data": "\n"
+								"end": 44,
+								"name": "foo",
+								"value": [
+									{
+										"type": "MustacheTag",
+										"start": 39,
+										"end": 44,
+										"expression": {
+											"type": "Identifier",
+											"start": 40,
+											"end": 43,
+											"loc": {
+												"start": {
+													"line": 6,
+													"column": 12
+												},
+												"end": {
+													"line": 6,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								]
 							}
-						]
+						],
+						"children": []
 					}
 				]
 			},
 			{
 				"type": "Text",
-				"start": 42,
-				"end": 44,
+				"start": 51,
+				"end": 53,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "Element",
+				"start": 53,
+				"end": 72,
+				"name": "div",
+				"attributes": [],
+				"children": [
+					{
+						"type": "Text",
+						"start": 58,
+						"end": 60,
+						"raw": "\n\t",
+						"data": "\n\t"
+					},
+					{
+						"type": "Element",
+						"start": 60,
+						"end": 66,
+						"name": "span",
+						"attributes": [],
+						"children": []
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 72,
+				"end": 74,
 				"raw": "\n\n",
 				"data": "\n\n"
 			},
 			{
 				"type": "IfBlock",
-				"start": 44,
-				"end": 66,
+				"start": 74,
+				"end": 96,
 				"expression": {
 					"type": "Identifier",
-					"start": 49,
-					"end": 52,
+					"start": 79,
+					"end": 82,
 					"loc": {
 						"start": {
-							"line": 9,
+							"line": 13,
 							"column": 5
 						},
 						"end": {
-							"line": 9,
+							"line": 13,
 							"column": 8
 						}
 					},
@@ -105,15 +158,15 @@
 				"children": [
 					{
 						"type": "Element",
-						"start": 55,
-						"end": 61,
+						"start": 85,
+						"end": 91,
 						"name": "div",
 						"attributes": [],
 						"children": [
 							{
 								"type": "Text",
-								"start": 60,
-								"end": 61,
+								"start": 90,
+								"end": 91,
 								"raw": "\n",
 								"data": "\n"
 							}
@@ -123,40 +176,123 @@
 			},
 			{
 				"type": "Text",
-				"start": 66,
-				"end": 68,
+				"start": 96,
+				"end": 98,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "IfBlock",
+				"start": 98,
+				"end": 130,
+				"expression": {
+					"type": "Identifier",
+					"start": 103,
+					"end": 106,
+					"loc": {
+						"start": {
+							"line": 17,
+							"column": 5
+						},
+						"end": {
+							"line": 17,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"children": [
+					{
+						"type": "InlineComponent",
+						"start": 109,
+						"end": 125,
+						"name": "Comp",
+						"attributes": [
+							{
+								"type": "Attribute",
+								"start": 115,
+								"end": 124,
+								"name": "foo",
+								"value": [
+									{
+										"type": "MustacheTag",
+										"start": 119,
+										"end": 124,
+										"expression": {
+											"type": "Identifier",
+											"start": 120,
+											"end": 123,
+											"loc": {
+												"start": {
+													"line": 18,
+													"column": 12
+												},
+												"end": {
+													"line": 18,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								]
+							}
+						],
+						"children": []
+					}
+				]
+			},
+			{
+				"type": "Text",
+				"start": 130,
+				"end": 132,
 				"raw": "\n\n",
 				"data": "\n\n"
 			},
 			{
 				"type": "Element",
-				"start": 68,
-				"end": 83,
+				"start": 132,
+				"end": 160,
 				"name": "div",
 				"attributes": [],
 				"children": [
 					{
 						"type": "Text",
-						"start": 73,
-						"end": 74,
+						"start": 137,
+						"end": 138,
 						"raw": "\n",
 						"data": "\n"
 					},
 					{
 						"type": "Element",
-						"start": 74,
-						"end": 83,
+						"start": 138,
+						"end": 147,
 						"name": "p",
 						"attributes": [],
 						"children": [
 							{
 								"type": "Text",
-								"start": 77,
-								"end": 79,
+								"start": 141,
+								"end": 143,
 								"raw": "hi",
 								"data": "hi"
 							}
 						]
+					},
+					{
+						"type": "Text",
+						"start": 147,
+						"end": 149,
+						"raw": "\n\n",
+						"data": "\n\n"
+					},
+					{
+						"type": "Element",
+						"start": 149,
+						"end": 160,
+						"name": "open-ended",
+						"attributes": [],
+						"children": []
 					}
 				]
 			}

--- a/packages/svelte/tests/parser-legacy/test.ts
+++ b/packages/svelte/tests/parser-legacy/test.ts
@@ -12,7 +12,9 @@ const { test, run } = suite<ParserTest>(async (config, cwd) => {
 		.replace(/\s+$/, '')
 		.replace(/\r/g, '');
 
-	const actual = JSON.parse(JSON.stringify(parse(input)));
+	const actual = JSON.parse(
+		JSON.stringify(parse(input, { loose: cwd.split('/').pop()!.startsWith('loose-') }))
+	);
 
 	// run `UPDATE_SNAPSHOTS=true pnpm test parser` to update parser tests
 	if (process.env.UPDATE_SNAPSHOTS) {

--- a/packages/svelte/tests/parser-modern/samples/loose-invalid-block/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/loose-invalid-block/input.svelte
@@ -1,0 +1,13 @@
+{#if }
+{:else if }
+{:else }
+{/if}
+
+{#each }
+{/each}
+
+{#snippet }
+{/snippet}
+
+{#snippet foo}
+{/snippet}

--- a/packages/svelte/tests/parser-modern/samples/loose-invalid-block/output.json
+++ b/packages/svelte/tests/parser-modern/samples/loose-invalid-block/output.json
@@ -1,0 +1,171 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 102,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 0,
+				"end": 33,
+				"test": {
+					"type": "Identifier",
+					"start": 5,
+					"end": 5,
+					"name": ""
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 6,
+							"end": 7,
+							"raw": "\n",
+							"data": "\n"
+						}
+					]
+				},
+				"alternate": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"start": 7,
+							"end": 33,
+							"type": "IfBlock",
+							"elseif": true,
+							"test": {
+								"type": "Identifier",
+								"start": 17,
+								"end": 17,
+								"name": ""
+							},
+							"consequent": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 18,
+										"end": 19,
+										"raw": "\n",
+										"data": "\n"
+									}
+								]
+							},
+							"alternate": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 27,
+										"end": 28,
+										"raw": "\n",
+										"data": "\n"
+									}
+								]
+							}
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 33,
+				"end": 35,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "EachBlock",
+				"start": 35,
+				"end": 51,
+				"expression": {
+					"type": "Identifier",
+					"start": 42,
+					"end": 42,
+					"name": ""
+				},
+				"body": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 43,
+							"end": 44,
+							"raw": "\n",
+							"data": "\n"
+						}
+					]
+				},
+				"context": null
+			},
+			{
+				"type": "Text",
+				"start": 51,
+				"end": 53,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "SnippetBlock",
+				"start": 53,
+				"end": 75,
+				"expression": {
+					"type": "Identifier",
+					"start": 63,
+					"end": 63,
+					"name": ""
+				},
+				"parameters": [],
+				"body": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 64,
+							"end": 65,
+							"raw": "\n",
+							"data": "\n"
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 75,
+				"end": 77,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "SnippetBlock",
+				"start": 77,
+				"end": 102,
+				"expression": {
+					"type": "Identifier",
+					"start": 87,
+					"end": 90,
+					"name": "foo"
+				},
+				"parameters": [],
+				"body": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 91,
+							"end": 92,
+							"raw": "\n",
+							"data": "\n"
+						}
+					]
+				}
+			}
+		]
+	},
+	"options": null
+}

--- a/packages/svelte/tests/parser-modern/samples/loose-invalid-expression/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/loose-invalid-expression/input.svelte
@@ -1,0 +1,8 @@
+<div {}></div>
+<div foo={}></div>
+
+<div foo={a.}></div>
+<div foo={'hi}'.}></div>
+<Component onclick={() => x.} />
+
+<input bind:value={a.} />

--- a/packages/svelte/tests/parser-modern/samples/loose-invalid-expression/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/loose-invalid-expression/input.svelte
@@ -6,3 +6,6 @@
 <Component onclick={() => x.} />
 
 <input bind:value={a.} />
+
+asd{a.}asd
+{foo[bar.]}

--- a/packages/svelte/tests/parser-modern/samples/loose-invalid-expression/output.json
+++ b/packages/svelte/tests/parser-modern/samples/loose-invalid-expression/output.json
@@ -1,0 +1,218 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 140,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "RegularElement",
+				"start": 0,
+				"end": 14,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 5,
+						"end": 7,
+						"name": "",
+						"value": {
+							"type": "ExpressionTag",
+							"start": 6,
+							"end": 6,
+							"expression": {
+								"start": 6,
+								"end": 6,
+								"type": "Identifier",
+								"name": ""
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 14,
+				"end": 15,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 15,
+				"end": 33,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 20,
+						"end": 26,
+						"name": "foo",
+						"value": {
+							"type": "ExpressionTag",
+							"start": 24,
+							"end": 26,
+							"expression": {
+								"type": "Identifier",
+								"start": 25,
+								"end": 25,
+								"name": ""
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 33,
+				"end": 35,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 35,
+				"end": 55,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 40,
+						"end": 48,
+						"name": "foo",
+						"value": {
+							"type": "ExpressionTag",
+							"start": 44,
+							"end": 48,
+							"expression": {
+								"type": "Identifier",
+								"start": 45,
+								"end": 47,
+								"name": ""
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 55,
+				"end": 56,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 56,
+				"end": 80,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 61,
+						"end": 73,
+						"name": "foo",
+						"value": {
+							"type": "ExpressionTag",
+							"start": 65,
+							"end": 73,
+							"expression": {
+								"type": "Identifier",
+								"start": 66,
+								"end": 72,
+								"name": ""
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 80,
+				"end": 81,
+				"raw": "\n",
+				"data": "\n"
+			},
+			{
+				"type": "Component",
+				"start": 81,
+				"end": 113,
+				"name": "Component",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 92,
+						"end": 110,
+						"name": "onclick",
+						"value": {
+							"type": "ExpressionTag",
+							"start": 100,
+							"end": 110,
+							"expression": {
+								"type": "Identifier",
+								"start": 101,
+								"end": 109,
+								"name": ""
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 113,
+				"end": 115,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 115,
+				"end": 140,
+				"name": "input",
+				"attributes": [
+					{
+						"start": 122,
+						"end": 137,
+						"type": "BindDirective",
+						"name": "value",
+						"expression": {
+							"type": "Identifier",
+							"start": 134,
+							"end": 136,
+							"name": ""
+						},
+						"modifiers": []
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			}
+		]
+	},
+	"options": null
+}

--- a/packages/svelte/tests/parser-modern/samples/loose-invalid-expression/output.json
+++ b/packages/svelte/tests/parser-modern/samples/loose-invalid-expression/output.json
@@ -2,7 +2,7 @@
 	"css": null,
 	"js": [],
 	"start": 0,
-	"end": 140,
+	"end": 164,
 	"type": "Root",
 	"fragment": {
 		"type": "Fragment",
@@ -210,6 +210,42 @@
 				"fragment": {
 					"type": "Fragment",
 					"nodes": []
+				}
+			},
+			{
+				"type": "Text",
+				"start": 140,
+				"end": 145,
+				"raw": "\n\nasd",
+				"data": "\n\nasd"
+			},
+			{
+				"type": "ExpressionTag",
+				"start": 145,
+				"end": 149,
+				"expression": {
+					"type": "Identifier",
+					"start": 146,
+					"end": 148,
+					"name": ""
+				}
+			},
+			{
+				"type": "Text",
+				"start": 149,
+				"end": 153,
+				"raw": "asd\n",
+				"data": "asd\n"
+			},
+			{
+				"type": "ExpressionTag",
+				"start": 153,
+				"end": 164,
+				"expression": {
+					"type": "Identifier",
+					"start": 154,
+					"end": 163,
+					"name": ""
 				}
 			}
 		]

--- a/packages/svelte/tests/parser-modern/samples/loose-unclosed-open-tag/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/loose-unclosed-open-tag/input.svelte
@@ -1,0 +1,20 @@
+<div>
+	<Comp foo={bar}
+</div>
+
+<div>
+	<span foo={bar}
+</div>
+
+{#if foo}
+	<Comp foo={bar}
+{/if}
+
+{#if foo}
+	<Comp foo={bar}
+	{#if bar}
+		{bar}
+	{/if}
+{/if}
+
+<div foo={bar}

--- a/packages/svelte/tests/parser-modern/samples/loose-unclosed-open-tag/output.json
+++ b/packages/svelte/tests/parser-modern/samples/loose-unclosed-open-tag/output.json
@@ -1,0 +1,414 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 170,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "RegularElement",
+				"start": 0,
+				"end": 29,
+				"name": "div",
+				"attributes": [],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 5,
+							"end": 7,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "Component",
+							"start": 7,
+							"end": 23,
+							"name": "Comp",
+							"attributes": [
+								{
+									"type": "Attribute",
+									"start": 13,
+									"end": 22,
+									"name": "foo",
+									"value": {
+										"type": "ExpressionTag",
+										"start": 17,
+										"end": 22,
+										"expression": {
+											"type": "Identifier",
+											"start": 18,
+											"end": 21,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 12
+												},
+												"end": {
+													"line": 2,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								}
+							],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": []
+							}
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 29,
+				"end": 31,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 31,
+				"end": 60,
+				"name": "div",
+				"attributes": [],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 36,
+							"end": 38,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "RegularElement",
+							"start": 38,
+							"end": 54,
+							"name": "span",
+							"attributes": [
+								{
+									"type": "Attribute",
+									"start": 44,
+									"end": 53,
+									"name": "foo",
+									"value": {
+										"type": "ExpressionTag",
+										"start": 48,
+										"end": 53,
+										"expression": {
+											"type": "Identifier",
+											"start": 49,
+											"end": 52,
+											"loc": {
+												"start": {
+													"line": 6,
+													"column": 12
+												},
+												"end": {
+													"line": 6,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								}
+							],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": []
+							}
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 60,
+				"end": 62,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 62,
+				"end": 94,
+				"test": {
+					"type": "Identifier",
+					"start": 67,
+					"end": 70,
+					"loc": {
+						"start": {
+							"line": 9,
+							"column": 5
+						},
+						"end": {
+							"line": 9,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 71,
+							"end": 73,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "Component",
+							"start": 73,
+							"end": 89,
+							"name": "Comp",
+							"attributes": [
+								{
+									"type": "Attribute",
+									"start": 79,
+									"end": 88,
+									"name": "foo",
+									"value": {
+										"type": "ExpressionTag",
+										"start": 83,
+										"end": 88,
+										"expression": {
+											"type": "Identifier",
+											"start": 84,
+											"end": 87,
+											"loc": {
+												"start": {
+													"line": 10,
+													"column": 12
+												},
+												"end": {
+													"line": 10,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								}
+							],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": []
+							}
+						}
+					]
+				},
+				"alternate": null
+			},
+			{
+				"type": "Text",
+				"start": 94,
+				"end": 96,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 96,
+				"end": 154,
+				"test": {
+					"type": "Identifier",
+					"start": 101,
+					"end": 104,
+					"loc": {
+						"start": {
+							"line": 13,
+							"column": 5
+						},
+						"end": {
+							"line": 13,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 105,
+							"end": 107,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "Component",
+							"start": 107,
+							"end": 124,
+							"name": "Comp",
+							"attributes": [
+								{
+									"type": "Attribute",
+									"start": 113,
+									"end": 122,
+									"name": "foo",
+									"value": {
+										"type": "ExpressionTag",
+										"start": 117,
+										"end": 122,
+										"expression": {
+											"type": "Identifier",
+											"start": 118,
+											"end": 121,
+											"loc": {
+												"start": {
+													"line": 14,
+													"column": 12
+												},
+												"end": {
+													"line": 14,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								}
+							],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": []
+							}
+						},
+						{
+							"type": "IfBlock",
+							"elseif": false,
+							"start": 124,
+							"end": 148,
+							"test": {
+								"type": "Identifier",
+								"start": 129,
+								"end": 132,
+								"loc": {
+									"start": {
+										"line": 15,
+										"column": 6
+									},
+									"end": {
+										"line": 15,
+										"column": 9
+									}
+								},
+								"name": "bar"
+							},
+							"consequent": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 133,
+										"end": 136,
+										"raw": "\n\t\t",
+										"data": "\n\t\t"
+									},
+									{
+										"type": "ExpressionTag",
+										"start": 136,
+										"end": 141,
+										"expression": {
+											"type": "Identifier",
+											"start": 137,
+											"end": 140,
+											"loc": {
+												"start": {
+													"line": 16,
+													"column": 3
+												},
+												"end": {
+													"line": 16,
+													"column": 6
+												}
+											},
+											"name": "bar"
+										}
+									},
+									{
+										"type": "Text",
+										"start": 141,
+										"end": 143,
+										"raw": "\n\t",
+										"data": "\n\t"
+									}
+								]
+							},
+							"alternate": null
+						},
+						{
+							"type": "Text",
+							"start": 148,
+							"end": 149,
+							"raw": "\n",
+							"data": "\n"
+						}
+					]
+				},
+				"alternate": null
+			},
+			{
+				"type": "Text",
+				"start": 154,
+				"end": 156,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 156,
+				"end": 170,
+				"name": "div",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 161,
+						"end": 170,
+						"name": "foo",
+						"value": {
+							"type": "ExpressionTag",
+							"start": 165,
+							"end": 170,
+							"expression": {
+								"type": "Identifier",
+								"start": 166,
+								"end": 169,
+								"loc": {
+									"start": {
+										"line": 20,
+										"column": 10
+									},
+									"end": {
+										"line": 20,
+										"column": 13
+									}
+								},
+								"name": "bar"
+							}
+						}
+					}
+				],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": []
+				}
+			}
+		]
+	},
+	"options": null
+}

--- a/packages/svelte/tests/parser-modern/samples/loose-unclosed-tag/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/loose-unclosed-tag/input.svelte
@@ -3,8 +3,22 @@
 </div>
 
 <div>
-	<span>
+	<Comp foo={bar}
 </div>
 
 <div>
+	<span
+</div>
+
+{#if foo}
+	<div>
+{/if}
+
+{#if foo}
+	<Comp foo={bar}
+{/if}
+
+<div>
 <p>hi</p>
+
+<open-ended

--- a/packages/svelte/tests/parser-modern/samples/loose-unclosed-tag/input.svelte
+++ b/packages/svelte/tests/parser-modern/samples/loose-unclosed-tag/input.svelte
@@ -1,0 +1,10 @@
+<div>
+	<Comp>
+</div>
+
+<div>
+	<span>
+</div>
+
+<div>
+<p>hi</p>

--- a/packages/svelte/tests/parser-modern/samples/loose-unclosed-tag/output.json
+++ b/packages/svelte/tests/parser-modern/samples/loose-unclosed-tag/output.json
@@ -2,7 +2,7 @@
 	"css": null,
 	"js": [],
 	"start": 0,
-	"end": 59,
+	"end": 160,
 	"type": "Root",
 	"fragment": {
 		"type": "Fragment",
@@ -55,7 +55,7 @@
 			{
 				"type": "RegularElement",
 				"start": 22,
-				"end": 42,
+				"end": 51,
 				"name": "div",
 				"attributes": [],
 				"fragment": {
@@ -69,22 +69,42 @@
 							"data": "\n\t"
 						},
 						{
-							"type": "RegularElement",
+							"type": "Component",
 							"start": 29,
-							"end": 36,
-							"name": "span",
-							"attributes": [],
+							"end": 45,
+							"name": "Comp",
+							"attributes": [
+								{
+									"type": "Attribute",
+									"start": 35,
+									"end": 44,
+									"name": "foo",
+									"value": {
+										"type": "ExpressionTag",
+										"start": 39,
+										"end": 44,
+										"expression": {
+											"type": "Identifier",
+											"start": 40,
+											"end": 43,
+											"loc": {
+												"start": {
+													"line": 6,
+													"column": 12
+												},
+												"end": {
+													"line": 6,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								}
+							],
 							"fragment": {
 								"type": "Fragment",
-								"nodes": [
-									{
-										"type": "Text",
-										"start": 35,
-										"end": 36,
-										"raw": "\n",
-										"data": "\n"
-									}
-								]
+								"nodes": []
 							}
 						}
 					]
@@ -92,15 +112,15 @@
 			},
 			{
 				"type": "Text",
-				"start": 42,
-				"end": 44,
+				"start": 51,
+				"end": 53,
 				"raw": "\n\n",
 				"data": "\n\n"
 			},
 			{
 				"type": "RegularElement",
-				"start": 44,
-				"end": 59,
+				"start": 53,
+				"end": 72,
 				"name": "div",
 				"attributes": [],
 				"fragment": {
@@ -108,15 +128,194 @@
 					"nodes": [
 						{
 							"type": "Text",
-							"start": 49,
-							"end": 50,
+							"start": 58,
+							"end": 60,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "RegularElement",
+							"start": 60,
+							"end": 66,
+							"name": "span",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": []
+							}
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 72,
+				"end": 74,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 74,
+				"end": 96,
+				"test": {
+					"type": "Identifier",
+					"start": 79,
+					"end": 82,
+					"loc": {
+						"start": {
+							"line": 13,
+							"column": 5
+						},
+						"end": {
+							"line": 13,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 83,
+							"end": 85,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "RegularElement",
+							"start": 85,
+							"end": 91,
+							"name": "div",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 90,
+										"end": 91,
+										"raw": "\n",
+										"data": "\n"
+									}
+								]
+							}
+						}
+					]
+				},
+				"alternate": null
+			},
+			{
+				"type": "Text",
+				"start": 96,
+				"end": 98,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "IfBlock",
+				"elseif": false,
+				"start": 98,
+				"end": 130,
+				"test": {
+					"type": "Identifier",
+					"start": 103,
+					"end": 106,
+					"loc": {
+						"start": {
+							"line": 17,
+							"column": 5
+						},
+						"end": {
+							"line": 17,
+							"column": 8
+						}
+					},
+					"name": "foo"
+				},
+				"consequent": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 107,
+							"end": 109,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "Component",
+							"start": 109,
+							"end": 125,
+							"name": "Comp",
+							"attributes": [
+								{
+									"type": "Attribute",
+									"start": 115,
+									"end": 124,
+									"name": "foo",
+									"value": {
+										"type": "ExpressionTag",
+										"start": 119,
+										"end": 124,
+										"expression": {
+											"type": "Identifier",
+											"start": 120,
+											"end": 123,
+											"loc": {
+												"start": {
+													"line": 18,
+													"column": 12
+												},
+												"end": {
+													"line": 18,
+													"column": 15
+												}
+											},
+											"name": "bar"
+										}
+									}
+								}
+							],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": []
+							}
+						}
+					]
+				},
+				"alternate": null
+			},
+			{
+				"type": "Text",
+				"start": 130,
+				"end": 132,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 132,
+				"end": 160,
+				"name": "div",
+				"attributes": [],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 137,
+							"end": 138,
 							"raw": "\n",
 							"data": "\n"
 						},
 						{
 							"type": "RegularElement",
-							"start": 50,
-							"end": 59,
+							"start": 138,
+							"end": 147,
 							"name": "p",
 							"attributes": [],
 							"fragment": {
@@ -124,12 +323,30 @@
 								"nodes": [
 									{
 										"type": "Text",
-										"start": 53,
-										"end": 55,
+										"start": 141,
+										"end": 143,
 										"raw": "hi",
 										"data": "hi"
 									}
 								]
+							}
+						},
+						{
+							"type": "Text",
+							"start": 147,
+							"end": 149,
+							"raw": "\n\n",
+							"data": "\n\n"
+						},
+						{
+							"type": "RegularElement",
+							"start": 149,
+							"end": 160,
+							"name": "open-ended",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": []
 							}
 						}
 					]

--- a/packages/svelte/tests/parser-modern/samples/loose-unclosed-tag/output.json
+++ b/packages/svelte/tests/parser-modern/samples/loose-unclosed-tag/output.json
@@ -1,0 +1,141 @@
+{
+	"css": null,
+	"js": [],
+	"start": 0,
+	"end": 59,
+	"type": "Root",
+	"fragment": {
+		"type": "Fragment",
+		"nodes": [
+			{
+				"type": "RegularElement",
+				"start": 0,
+				"end": 20,
+				"name": "div",
+				"attributes": [],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 5,
+							"end": 7,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "Component",
+							"start": 7,
+							"end": 14,
+							"name": "Comp",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 13,
+										"end": 14,
+										"raw": "\n",
+										"data": "\n"
+									}
+								]
+							}
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 20,
+				"end": 22,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 22,
+				"end": 42,
+				"name": "div",
+				"attributes": [],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 27,
+							"end": 29,
+							"raw": "\n\t",
+							"data": "\n\t"
+						},
+						{
+							"type": "RegularElement",
+							"start": 29,
+							"end": 36,
+							"name": "span",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 35,
+										"end": 36,
+										"raw": "\n",
+										"data": "\n"
+									}
+								]
+							}
+						}
+					]
+				}
+			},
+			{
+				"type": "Text",
+				"start": 42,
+				"end": 44,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "RegularElement",
+				"start": 44,
+				"end": 59,
+				"name": "div",
+				"attributes": [],
+				"fragment": {
+					"type": "Fragment",
+					"nodes": [
+						{
+							"type": "Text",
+							"start": 49,
+							"end": 50,
+							"raw": "\n",
+							"data": "\n"
+						},
+						{
+							"type": "RegularElement",
+							"start": 50,
+							"end": 59,
+							"name": "p",
+							"attributes": [],
+							"fragment": {
+								"type": "Fragment",
+								"nodes": [
+									{
+										"type": "Text",
+										"start": 53,
+										"end": 55,
+										"raw": "hi",
+										"data": "hi"
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		]
+	},
+	"options": null
+}

--- a/packages/svelte/tests/parser-modern/test.ts
+++ b/packages/svelte/tests/parser-modern/test.ts
@@ -15,7 +15,8 @@ const { test, run } = suite<ParserTest>(async (config, cwd) => {
 	const actual = JSON.parse(
 		JSON.stringify(
 			parse(input, {
-				modern: true
+				modern: true,
+				loose: cwd.split('/').pop()!.startsWith('loose-')
 			})
 		)
 	);

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -632,6 +632,7 @@ declare module 'svelte/compiler' {
 	export function parse(source: string, options: {
 		filename?: string;
 		modern: true;
+		loose?: boolean;
 	}): AST.Root;
 	/**
 	 * The parse function parses a component, returning only its abstract syntax tree.
@@ -643,6 +644,7 @@ declare module 'svelte/compiler' {
 	export function parse(source: string, options?: {
 		filename?: string;
 		modern?: false;
+		loose?: boolean;
 	} | undefined): Record<string, any>;
 	/**
 	 * @deprecated Replace this with `import { walk } from 'estree-walker'`


### PR DESCRIPTION
This implements a new option for the parser, `loose`, which means the parser is forgiving with the syntax and tries to continue parsing even if it encounters broken code. It does not parse no matter what, but handles the most common "in the middle of typing" scenarios gracefully.

closes #4818

Our language tools can then make use of this to provide better intellisense in more situations.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
