### PR TITLE
docs: typo in ## script_context_deprecated

### DIFF
--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -775,7 +775,7 @@ Reassignments of module-level declarations will not cause reactive statements to
 ```
 
 ```svelte
-<script ---context="module"--- +++context+++>
+<script ---context="module"--- +++module+++>
 	let foo = 'bar';
 </script>
 ```

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -57,7 +57,7 @@ This code will work when the component is rendered on the client (which is why t
 > `context="module"` is deprecated, use the `module` attribute instead
 
 ```svelte
-<script ---context="module"--- +++context+++>
+<script ---context="module"--- +++module+++>
 	let foo = 'bar';
 </script>
 ```


### PR DESCRIPTION
Found a typo in the compiler warnings docs in [script context deprecated](https://svelte.dev/docs/svelte/compiler-warnings#script_context_deprecated)
It said +++context+++ instead of +++module+++