### PR TITLE
fix: improve unowned derived performance

### DIFF
--- a/.changeset/many-worms-attend.md
+++ b/.changeset/many-worms-attend.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improve unowned derived performance

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -231,8 +231,8 @@ export function check_dirtiness(reaction) {
 		}
 
 		// Unowned signals should never be marked as clean unless they
-		// are used within an active_effect
-		if (!is_unowned || active_effect !== null) {
+		// are used within an active_effect without skip_reaction
+		if (!is_unowned || (active_effect !== null && !skip_reaction)) {
 			set_signal_status(reaction, CLEAN);
 		}
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -230,8 +230,9 @@ export function check_dirtiness(reaction) {
 			}
 		}
 
-		// Unowned signals should never be marked as clean.
-		if (!is_unowned) {
+		// Unowned signals should never be marked as clean unless they
+		// are used within an active_effect
+		if (!is_unowned || active_effect !== null) {
 			set_signal_status(reaction, CLEAN);
 		}
 	}


### PR DESCRIPTION
Fixes some of the performance issues on https://github.com/sveltejs/svelte/issues/14721

If we have an unowned derived that is actively in the graph, we can mark it as CLEAN. It's only if it's not in the graph can we not.