### PR TITLE
docs: Link to migration guide from <svelte:component> documentation

### DIFF
--- a/documentation/docs/99-legacy/30-legacy-svelte-component.md
+++ b/documentation/docs/99-legacy/30-legacy-svelte-component.md
@@ -2,7 +2,7 @@
 title: <svelte:component>
 ---
 
-In runes mode, `<MyComponent>` will re-render if the value of `MyComponent` changes.
+In runes mode, `<MyComponent>` will re-render if the value of `MyComponent` changes. See the [Svelte 5 migration guide](/docs/svelte/v5-migration-guide#Breaking-changes-in-runes-mode-svelte:component-is-no-longer-necessary) for an example.
 
 In legacy mode, it won't — we must use `<svelte:component>`, which destroys and recreates the component instance when the value of its `this` expression changes:
 


### PR DESCRIPTION
It's not obvious how to create dynamically rendered components in Svelte 5.

If you come from Svelte 4 and search for `svelte:component`, you'll most likely end up on [this page](https://svelte.dev/docs/svelte/legacy-svelte-component), which only gives a cursory explanation for runes mode. The [migration guide's section on `<svelte:component>`](https://svelte.dev/docs/svelte/v5-migration-guide#Breaking-changes-in-runes-mode-svelte:component-is-no-longer-necessary) has a great example that clears things up. Adding a link to that would be very helpful.