### PR TITLE
fix: remove 'implements' from class declaration

### DIFF
--- a/.changeset/calm-maps-cover.md
+++ b/.changeset/calm-maps-cover.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove implements from class declarations

--- a/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
+++ b/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
@@ -115,6 +115,7 @@ const visitors = {
 		if (node.declare) {
 			return b.empty;
 		}
+		delete node.implements;
 		return context.next();
 	},
 	VariableDeclaration(node, context) {

--- a/packages/svelte/tests/runtime-browser/samples/typescript-class-and-interface/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/typescript-class-and-interface/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../assert';
+
+export default test({});

--- a/packages/svelte/tests/runtime-browser/samples/typescript-class-and-interface/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/typescript-class-and-interface/main.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // TypeScript syntax should not cause compilation failure
+  interface MyInterface {}
+  class MyClass implements MyInterface {}
+</script>


### PR DESCRIPTION
related: #14743 #14744 @Rich-Harris 

This PR fixes a build issue that occurs when esrap 1.3.0 or later is used.

When compiling the following component:

```svelte
<script lang="ts">
  interface MyInterface {}
  class MyClass implements MyInterface {}
</script>

<p>hello</p>
```

The following error occurs:

```
error during build:
src/routes/Component.svelte (4:26): Expected '{', got 'implements' (Note that you need plugins to import files that are not JavaScript)
file: /path/to/project/src/routes/Component.svelte:4:26

2:   interface MyInterface {}
3: 
4:   class MyClass implements MyInterface {}
```


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
