### PR TITLE
fix: ensure svg namespace for `<a>` elements is correct

### DIFF
--- a/.changeset/nine-buses-own.md
+++ b/.changeset/nine-buses-own.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure svg namespace persists from parent of if blocks

--- a/.changeset/nine-buses-own.md
+++ b/.changeset/nine-buses-own.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure svg namespace persists from parent of if blocks
+fix: ensure svg namespace for `<a>`  elements is correct

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/RegularElement.js
@@ -86,7 +86,10 @@ export function RegularElement(node, context) {
 		(attribute) => attribute.type === 'SpreadAttribute'
 	);
 
-	node.metadata.svg = is_svg(node.name);
+	node.metadata.svg =
+		is_svg(node.name) ||
+		(node.name === 'a' &&
+			context.path.some((n) => n.type === 'RegularElement' && n.name === 'svg'));
 	node.metadata.mathml = is_mathml(node.name);
 
 	if (is_custom_element_node(node) && node.attributes.length > 0) {

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/RegularElement.js
@@ -86,10 +86,23 @@ export function RegularElement(node, context) {
 		(attribute) => attribute.type === 'SpreadAttribute'
 	);
 
-	node.metadata.svg =
-		is_svg(node.name) ||
-		(node.name === 'a' &&
-			context.path.some((n) => n.type === 'RegularElement' && n.name === 'svg'));
+	const is_svg_element = () => {
+		if (is_svg(node.name)) {
+			return true;
+		}
+		if (node.name === 'a') {
+			for (let i = context.path.length - 1; i >= 0; i--) {
+				const ancestor = context.path[i];
+				if (ancestor.type === 'RegularElement') {
+					return ancestor.metadata.svg;
+				}
+			}
+		}
+
+		return false;
+	};
+
+	node.metadata.svg = is_svg_element();
 	node.metadata.mathml = is_mathml(node.name);
 
 	if (is_custom_element_node(node) && node.attributes.length > 0) {

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -347,6 +347,11 @@ export function infer_namespace(namespace, parent, nodes) {
 		}
 	}
 
+	// If we're already in a non-html namespace, continue using that
+	if (namespace !== 'html') {
+		return namespace;
+	}
+
 	/** @type {Namespace | null} */
 	let new_namespace = null;
 

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -347,11 +347,6 @@ export function infer_namespace(namespace, parent, nodes) {
 		}
 	}
 
-	// If we're already in a non-html namespace, continue using that
-	if (namespace !== 'html') {
-		return namespace;
-	}
-
 	/** @type {Namespace | null} */
 	let new_namespace = null;
 

--- a/packages/svelte/tests/runtime-runes/samples/svg-namespace-if-block-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svg-namespace-if-block-2/_config.js
@@ -1,0 +1,11 @@
+import { test, ok } from '../../test';
+
+export default test({
+	html: `<svg><a href="/docs"><text class="small" x="20" y="40"></text></a></svg>`,
+	test({ assert, target }) {
+		const a = target.querySelector('a');
+		ok(a);
+
+		assert.equal(a.namespaceURI, 'http://www.w3.org/2000/svg');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svg-namespace-if-block-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svg-namespace-if-block-2/main.svelte
@@ -1,0 +1,7 @@
+<svg>
+	{#if true}
+		<a href="/docs">
+			<text x="20" y="40" class="small">{name}</text>
+		</a>
+	{/if}
+</svg>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14723 and fixes https://github.com/sveltejs/svelte/issues/14751.