### PR TITLE
chore: remove svelte.dev section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ You may view [our roadmap](https://svelte.dev/roadmap) if you'd like to see what
 
 Please see the [Contributing Guide](CONTRIBUTING.md) and the [`svelte`](packages/svelte) package for information on contributing to Svelte.
 
-### svelte.dev
-
-The source code for https://svelte.dev lives in the [svelte.dev](https://github.com/sveltejs/svelte.dev/tree/main/apps/svelte.dev) repository, with all the documentation right [here](https://github.com/sveltejs/svelte.dev/tree/main/apps/svelte.dev/content/docs/svelte). The site is built with [SvelteKit](https://svelte.dev/docs/kit/introduction).
-
 ## Is svelte.dev down?
 
 Probably not, but it's possible. If you can't seem to access any `.dev` sites, check out [this SuperUser question and answer](https://superuser.com/q/1413402).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please see the [Contributing Guide](CONTRIBUTING.md) and the [`svelte`](packages
 
 ### svelte.dev
 
-The source code for https://svelte.dev lives in the [sites](https://github.com/sveltejs/svelte/tree/master/sites/svelte.dev) folder, with all the documentation right [here](https://github.com/sveltejs/svelte/tree/master/documentation). The site is built with [SvelteKit](https://svelte.dev/docs/kit).
+The source code for https://svelte.dev lives in the [svelte.dev](https://github.com/sveltejs/svelte.dev/tree/main/apps/svelte.dev) repository, with all the documentation right [here](https://github.com/sveltejs/svelte.dev/tree/main/apps/svelte.dev/content/docs/svelte). The site is built with [SvelteKit](https://svelte.dev/docs/kit/introduction).
 
 ## Is svelte.dev down?
 


### PR DESCRIPTION
Content in the svelte.dev section was outdated. So just updated the links and wording. 