### PR TITLE
fix: treeshake `$inspect.trace` code if unused in modules

### DIFF
--- a/.changeset/modern-colts-drive.md
+++ b/.changeset/modern-colts-drive.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: treeshake `$inspect.trace` code if unused in modules

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -243,13 +243,15 @@ export function analyze_module(ast, options) {
 		}
 	}
 
+	const analysis = { runes: true, tracing: false };
+
 	walk(
 		/** @type {Node} */ (ast),
 		{
 			scope,
 			scopes,
 			// @ts-expect-error TODO
-			analysis: { runes: true }
+			analysis
 		},
 		visitors
 	);
@@ -259,7 +261,8 @@ export function analyze_module(ast, options) {
 		name: options.filename,
 		accessors: false,
 		runes: true,
-		immutable: true
+		immutable: true,
+		tracing: analysis.tracing
 	};
 }
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -671,9 +671,15 @@ export function client_module(analysis, options) {
 		walk(/** @type {AST.SvelteNode} */ (analysis.module.ast), state, visitors)
 	);
 
+	const body = [b.import_all('$', 'svelte/internal/client')];
+
+	if (analysis.tracing) {
+		body.push(b.imports([], 'svelte/internal/flags/tracing'));
+	}
+
 	return {
 		type: 'Program',
 		sourceType: 'module',
-		body: [b.import_all('$', 'svelte/internal/client'), ...module.body]
+		body: [...body, ...module.body]
 	};
 }

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -27,6 +27,7 @@ export interface Analysis {
 	name: string; // TODO should this be filename? it's used in `compileModule` as well as `compile`
 	runes: boolean;
 	immutable: boolean;
+	tracing: boolean;
 
 	// TODO figure out if we can move this to ComponentAnalysis
 	accessors: boolean;


### PR DESCRIPTION
Follow up to https://github.com/sveltejs/svelte/pull/14770. I missed the call-site for handling serialisation in Svelte modules.