### PR TITLE
feat: add "worker" exports condition

### DIFF
--- a/.changeset/calm-shrimps-remain.md
+++ b/.changeset/calm-shrimps-remain.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: add "worker" exports condition to better support bundling for worker-based environments

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -21,6 +21,7 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
+      "worker": "./src/index-server.js",
       "browser": "./src/index-client.js",
       "default": "./src/index-server.js"
     },
@@ -64,6 +65,7 @@
     },
     "./legacy": {
       "types": "./types/index.d.ts",
+      "worker": "./src/legacy/legacy-server.js",
       "browser": "./src/legacy/legacy-client.js",
       "default": "./src/legacy/legacy-server.js"
     },
@@ -73,6 +75,7 @@
     },
     "./reactivity": {
       "types": "./types/index.d.ts",
+      "worker": "./src/reactivity/index-server.js",
       "browser": "./src/reactivity/index-client.js",
       "default": "./src/reactivity/index-server.js"
     },
@@ -86,6 +89,7 @@
     },
     "./store": {
       "types": "./types/index.d.ts",
+      "worker": "./src/store/index-server.js",
       "browser": "./src/store/index-client.js",
       "default": "./src/store/index-server.js"
     },


### PR DESCRIPTION
This PR adds the `worker` condition for entrypoints that exports dual browser/non-browser files, so that `worker` resolves to the non-browser file.

### Reason

In Svelte 5, there has been issues using it in Astro and Cloudflare (https://github.com/withastro/adapters/issues/485). The cloudflare integration configures Vite with `ssr.target: 'webworker'`, which also changes the resolve conditions to `browser`, `development|production`, etc.

<details>
<summary>Additional info: about why `browser` condition is used</summary>

Usually if a library have either `browser` or `node` conditions, it's more likely for `browser` to work in those worker-based environments, like Cloudflare's workerd or Vercel edge since they don't support node-based APIs. Though today these environments do have some form of node-based compat APIs, the decision to prefer `browser` was made before that.

</details>

However, using the `browser` condition in Svelte seem to interfere with the runtime lifecycle, and causes runtime issues (linked issue above). Using the non-`browser` condition (usually `default` in the exports) works. This PR adds the `worker` condition to route to the `default` file.

<details>
<summary>Additional info: about why `worker` condition is used</summary>

The `worker` condition had been the usual way (afaict) to refer to "all edge environments". Otherwise you'd have to manually specify `workerd`, `edge-light`, [any specific runtimes](https://runtime-keys.proposal.wintercg.org) etc. It was touched on at https://github.com/vitejs/vite/issues/6401, and supported in Astro ([1](https://github.com/withastro/adapters/blob/f487c91f0b59ca6adb22a12de85fc6bbf67cd843/packages/vercel/src/serverless/middleware.ts#L48), [2](https://github.com/withastro/adapters/blob/f487c91f0b59ca6adb22a12de85fc6bbf67cd843/packages/cloudflare/src/index.ts#L227)) and [Solid](https://github.com/solidjs/solid/blob/4d824b08d8534d2a079f9ca4c1ea980684c05582/packages/solid/package.json#L47) too.

</details>

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

I also tested this change in Astro and it fixes the issue.
