### PR TITLE
fix: `pre` tag with single `\n` incorrect hydration

### DIFF
--- a/.changeset/unlucky-nails-stare.md
+++ b/.changeset/unlucky-nails-stare.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: `pre` tag with single `\n` incorrect hydration

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -393,13 +393,21 @@ export function RegularElement(node, context) {
 			arg = b.member(arg, 'content');
 		}
 
-		process_children(trimmed, (is_text) => b.call('$.child', arg, is_text && b.true), true, {
-			...context,
-			state: child_state
-		});
+		process_children(
+			trimmed,
+			(is_text) => b.call('$.child', arg, is_text && b.true),
+			true,
+			{
+				...context,
+				state: child_state
+			},
+			node.name === 'pre'
+		);
 
 		if (needs_reset) {
-			child_state.init.push(b.stmt(b.call('$.reset', context.state.node)));
+			child_state.init.push(
+				b.stmt(b.call('$.reset', context.state.node, node.name === 'pre' ? b.true : undefined))
+			);
 		}
 	}
 

--- a/packages/svelte/src/internal/client/dom/hydration.js
+++ b/packages/svelte/src/internal/client/dom/hydration.js
@@ -43,12 +43,24 @@ export function hydrate_next() {
 	return set_hydrate_node(/** @type {TemplateNode} */ (get_next_sibling(hydrate_node)));
 }
 
-/** @param {TemplateNode} node */
-export function reset(node) {
+/**
+ *  @param {TemplateNode} node
+ * @param {boolean} [is_pre]
+ */
+export function reset(node, is_pre = false) {
 	if (!hydrating) return;
 
+	let sibling = get_next_sibling(hydrate_node);
+	// if the first text child of a pre tag is a single \n
+	// we don't skip to the sibling (for some reason if the firstChild
+	// of a pre tag is a single \n text node it's skipped by the browser)
+	// it might happen that the at this point there's still a \n sibling
+	// in that case is fine to get the next sibling and check for that
+	if (is_pre && sibling) {
+		sibling = get_next_sibling(sibling);
+	}
 	// If the node has remaining siblings, something has gone wrong
-	if (get_next_sibling(hydrate_node) !== null) {
+	if (sibling !== null) {
 		w.hydration_mismatch();
 		throw HYDRATION_ERROR;
 	}

--- a/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/_config.js
+++ b/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/_expected.html
+++ b/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/_expected.html
@@ -1,0 +1,2 @@
+<!--[--><pre><div><span></span></div>
+</pre><!--]-->

--- a/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/main.svelte
+++ b/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let name = $state('');
+</script>
+
+<pre>
+<div><span>{name}</span></div>
+</pre>


### PR DESCRIPTION
Closes #14767

This is a super weird one...basically calling `firstChild` on a `pre` tag where the first text node is a single `\n` skips the `\n` completely. This meant that a code like this

```svelte
<script>
	let name = $state('');
</script>

<pre>
<div><span>{name}</span></div>
</pre>
```
was incorrectly compiled to have 
```ts
var pre = root();
var div = $.sibling($.child(pre));
```
but `$.child` was already returning the `div`.

This is not something we do, the browser does this as you can see in this [codepen](https://codepen.io/paoloricciuti/pen/VYZpVXY) so we have to special case it. However this meant that the check for hydration mismatch on reset was wrong to so i had to compensate there too.

Finally for an extra bit of weirdness, the `\n` is literally removed from `innerHTML` too (also tested in the codepen) so in the test i had to specify an `_expected.html`.

All of this feels very weird and kinda brittle to me but i don't know if there's a better solution. WDYT?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
