### PR TITLE
feat: Display directive

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -485,6 +485,25 @@ function read_static_attribute(parser) {
 function read_attribute(parser) {
 	const start = parser.index;
 
+	if (parser.eat('#display={')) {
+		parser.allow_whitespace();
+		const expression = read_expression(parser);
+		parser.allow_whitespace();
+		parser.eat('}', true);
+
+		/** @type {AST.DisplayDirective} */
+		const display = {
+			type: 'DisplayDirective',
+			start,
+			end: parser.index,
+			expression,
+			metadata: {
+				expression: create_expression_metadata()
+			}
+		};
+		return display;
+	}
+
 	if (parser.eat('{')) {
 		parser.allow_whitespace();
 

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/StyleDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/StyleDirective.js
@@ -10,7 +10,12 @@ import { mark_subtree_dynamic } from './shared/fragment.js';
  */
 export function StyleDirective(node, context) {
 	if (node.modifiers.length > 1 || (node.modifiers.length && node.modifiers[0] !== 'important')) {
-		e.style_directive_invalid_modifier(node);
+		if (
+			node.name !== 'display' ||
+			node.modifiers.findIndex((m) => m !== 'important' && m !== 'transition') >= 0
+		) {
+			e.style_directive_invalid_modifier(node);
+		}
 	}
 
 	mark_subtree_dynamic(context.path);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
@@ -217,13 +217,15 @@ export function get_attribute_name(element, attribute) {
 
 /**
  * @param {Identifier} node_id
- * @param {AST.DisplayDirective} display
+ * @param {AST.DisplayDirective | null} display
  * @param {AST.StyleDirective | null} style
  * @param {BlockStatement} block
  * @param {ComponentContext} context
  */
 export function build_display_directive(node_id, display, style, block, context) {
-	const visibility = b.thunk(/** @type {Expression} */ (context.visit(display.expression)));
+	const visibility = display
+		? b.thunk(/** @type {Expression} */ (context.visit(display.expression)))
+		: b.literal(null);
 
 	/** @type {Expression | undefined} */
 	let value = undefined;

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
@@ -448,6 +448,9 @@ function build_style_directives(display_directive, style_directives, style_attri
 			directive.value === true
 				? b.id(directive.name)
 				: build_attribute_value(directive.value, context, true);
+		if (directive.name === 'display' && directive.modifiers.includes('transition')) {
+			value = b.call('$.get_display', value);
+		}
 		if (directive.modifiers.includes('important')) {
 			value = b.binary('+', value, b.literal(' !important'));
 		}

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -240,7 +240,7 @@ export namespace AST {
 		name: string;
 		/** The 'y' in `style:x={y}` */
 		value: true | ExpressionTag | Array<ExpressionTag | Text>;
-		modifiers: Array<'important'>;
+		modifiers: Array<'important' | 'transition'>;
 		/** @internal */
 		metadata: {
 			expression: ExpressionMetadata;

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -494,6 +494,15 @@ export namespace AST {
 		};
 	}
 
+	export interface DisplayDirective extends BaseNode {
+		type: 'DisplayDirective';
+		expression: Expression;
+		/** @internal */
+		metadata: {
+			expression: ExpressionMetadata;
+		};
+	}
+
 	export interface Script extends BaseNode {
 		type: 'Script';
 		context: 'default' | 'module';
@@ -511,7 +520,8 @@ export namespace AST {
 		| AST.OnDirective
 		| AST.StyleDirective
 		| AST.TransitionDirective
-		| AST.UseDirective;
+		| AST.UseDirective
+		| AST.DisplayDirective;
 
 	export type Block =
 		| AST.EachBlock

--- a/packages/svelte/src/internal/client/dom/blocks/display.js
+++ b/packages/svelte/src/internal/client/dom/blocks/display.js
@@ -1,0 +1,80 @@
+import { UNINITIALIZED } from '../../../../constants.js';
+import { block, template_effect } from '../../reactivity/effects.js';
+import { hydrate_next, hydrate_node, hydrating } from '../hydration.js';
+
+/**
+ * @template V
+ * @param {HTMLElement} node
+ * @param {() => any} get_visibility
+ * @param {() => void} render_fn
+ * @param {()=>string|null} [get_value]
+ * @param {boolean} [default_important]
+ * @returns {void}
+ */
+export function display(node, get_visibility, render_fn, get_value, default_important) {
+	if (hydrating) {
+		hydrate_next();
+	}
+
+	var anchor = node;
+
+	/** @type {boolean | typeof UNINITIALIZED} */
+	let prev_visible = UNINITIALIZED;
+	/** @type {string | null | undefined | typeof UNINITIALIZED} */
+	let prev_value = UNINITIALIZED;
+
+	const effect = block(render_fn);
+	template_effect(() => {
+		const visible = !!get_visibility();
+		const value = visible ? get_value?.() : 'none';
+
+		if (visible === prev_visible && value === prev_value) {
+			return;
+		}
+
+		const transitions = effect.transitions;
+		const run_transitions = prev_visible !== UNINITIALIZED && transitions?.length;
+
+		if (visible || !run_transitions) {
+			if (value == null) {
+				anchor.style.removeProperty('display');
+			} else {
+				anchor.style.setProperty(
+					'display',
+					value,
+					!visible || default_important ? 'important' : ''
+				);
+			}
+		}
+
+		if (run_transitions) {
+			if (visible) {
+				// Start show transition
+				for (const transition of transitions) {
+					transition.in();
+				}
+			} else {
+				var remaining = transitions.length;
+				var check = () => {
+					if (--remaining == 0) {
+						// cleanup
+						for (var transition of transitions) {
+							transition.stop();
+						}
+						anchor.style.setProperty('display', 'none', 'important');
+					}
+				};
+				for (var transition of transitions) {
+					transition.out(check);
+				}
+			}
+		}
+
+		prev_visible = visible;
+		prev_value = value;
+	});
+
+	if (hydrating) {
+		anchor = /** @type {HTMLElement} */ (hydrate_node);
+	}
+}

--- a/packages/svelte/src/internal/client/dom/blocks/display.js
+++ b/packages/svelte/src/internal/client/dom/blocks/display.js
@@ -23,6 +23,22 @@ export function display(node, get_visibility, render_fn, get_value, default_impo
 	/** @type {string | null | undefined | typeof UNINITIALIZED} */
 	let prev_value = UNINITIALIZED;
 
+	// special case when style:display is missing
+	// we get the style value from the node :
+	if (get_value === undefined) {
+		/** @type {string | null} */
+		let anchor_display = null;
+		get_value = () => {
+			if (prev_visible !== false) {
+				anchor_display = anchor.style.display || null;
+				if (anchor_display) {
+					default_important = anchor.style.getPropertyPriority('display') === 'important';
+				}
+			}
+			return anchor_display;
+		};
+	}
+
 	const effect = block(render_fn);
 	template_effect(() => {
 		const visible = !!get_visibility();

--- a/packages/svelte/src/internal/client/dom/blocks/display.js
+++ b/packages/svelte/src/internal/client/dom/blocks/display.js
@@ -7,7 +7,7 @@ import { hydrate_next, hydrate_node, hydrating } from '../hydration.js';
  * @param {HTMLElement} node
  * @param {() => any} get_visibility
  * @param {() => void} render_fn
- * @param {()=>string|null} [get_value]
+ * @param {()=>string|boolean|null} [get_value]
  * @param {boolean} [default_important]
  * @returns {void}
  */
@@ -41,8 +41,14 @@ export function display(node, get_visibility, render_fn, get_value, default_impo
 
 	const effect = block(render_fn);
 	template_effect(() => {
-		const visible = !!get_visibility();
-		const value = visible ? get_value?.() : 'none';
+		let display_value = get_value?.();
+		if (display_value === true) {
+			display_value = null;
+		} else if (display_value === false) {
+			display_value = 'none';
+		}
+		const visible = get_visibility !== null ? !!get_visibility() : display_value !== 'none';
+		const value = visible ? display_value : 'none';
 
 		if (visible === prev_visible && value === prev_value) {
 			return;

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -17,6 +17,7 @@ export { inspect } from './dev/inspect.js';
 export { await_block as await } from './dom/blocks/await.js';
 export { if_block as if } from './dom/blocks/if.js';
 export { key_block as key } from './dom/blocks/key.js';
+export { display } from './dom/blocks/display.js';
 export { css_props } from './dom/blocks/css-props.js';
 export { index, each } from './dom/blocks/each.js';
 export { html } from './dom/blocks/html.js';

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -270,6 +270,13 @@ function style_object_to_string(style_object) {
 		.join(' ');
 }
 
+/** @param {string|boolean} value */
+export function get_display(value) {
+	if (value === true) return null;
+	if (value === false) return 'none';
+	return value;
+}
+
 /** @param {Record<string, string>} style_object */
 export function add_styles(style_object) {
 	const styles = style_object_to_string(style_object);

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1269,6 +1269,11 @@ declare module 'svelte/compiler' {
 			expression: Expression;
 		}
 
+		export interface DisplayDirective extends BaseNode {
+			type: 'DisplayDirective';
+			expression: Expression;
+		}
+
 		export interface Script extends BaseNode {
 			type: 'Script';
 			context: 'default' | 'module';
@@ -1286,7 +1291,8 @@ declare module 'svelte/compiler' {
 			| AST.OnDirective
 			| AST.StyleDirective
 			| AST.TransitionDirective
-			| AST.UseDirective;
+			| AST.UseDirective
+			| AST.DisplayDirective;
 
 		export type Block =
 			| AST.EachBlock

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1103,7 +1103,7 @@ declare module 'svelte/compiler' {
 			name: string;
 			/** The 'y' in `style:x={y}` */
 			value: true | ExpressionTag | Array<ExpressionTag | Text>;
-			modifiers: Array<'important'>;
+			modifiers: Array<'important' | 'transition'>;
 		}
 
 		// TODO have separate in/out/transition directives


### PR DESCRIPTION
WIP : Another possible solution for https://github.com/sveltejs/svelte/issues/9976

This add a new **`#display`** directive for DOM elements.
This directive will allow to show/hide an element using the Svelte transition API, without destroying it.

```svelte
<div transition:slide #display={visible}>
   ...
</div>
```
=> When visible is "falsy", the element will be hidden using a `display: none !important`.
Otherwise it will be show either by removing the display style, or setting the value of `style:display`.

Note : I known that `#display={...]` is not usual for directive but I think it's more expressive...
In any case we could replace it with something like `svelte:display={...}`

It's still a work in progress, and need some works that I can do if the syntax of this PR is accepted...



### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
