### PR TITLE
feat: enable `animate:` directive for snippets

### DIFF
--- a/.changeset/sixty-grapes-dream.md
+++ b/.changeset/sixty-grapes-dream.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: enable `animate:` directive for snippets

--- a/documentation/docs/98-reference/.generated/compile-errors.md
+++ b/documentation/docs/98-reference/.generated/compile-errors.md
@@ -9,7 +9,7 @@ An element can only have one 'animate' directive
 ### animation_invalid_placement
 
 ```
-An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block
+An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block, or an only child of a snippet
 ```
 
 ### animation_missing_key

--- a/packages/svelte/messages/compile-errors/template.md
+++ b/packages/svelte/messages/compile-errors/template.md
@@ -4,7 +4,7 @@
 
 ## animation_invalid_placement
 
-> An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block
+> An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block, or an only child of a snippet
 
 ## animation_missing_key
 

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -625,12 +625,12 @@ export function animation_duplicate(node) {
 }
 
 /**
- * An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block
+ * An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block, or an only child of a snippet
  * @param {null | number | NodeLike} node
  * @returns {never}
  */
 export function animation_invalid_placement(node) {
-	e(node, "animation_invalid_placement", `An element that uses the \`animate:\` directive must be the only child of a keyed \`{#each ...}\` block\nhttps://svelte.dev/e/animation_invalid_placement`);
+	e(node, "animation_invalid_placement", `An element that uses the \`animate:\` directive must be the only child of a keyed \`{#each ...}\` block, or an only child of a snippet\nhttps://svelte.dev/e/animation_invalid_placement`);
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/element.js
@@ -91,9 +91,9 @@ export function validate_element(node, context) {
 			validate_attribute_name(attribute);
 		} else if (attribute.type === 'AnimateDirective') {
 			const parent = context.path.at(-2);
-			if (parent?.type !== 'EachBlock') {
+			if (parent?.type !== 'EachBlock' && parent?.type !== 'SnippetBlock') {
 				e.animation_invalid_placement(attribute);
-			} else if (!parent.key) {
+			} else if (parent.type === 'EachBlock' && !parent.key) {
 				e.animation_missing_key(attribute);
 			} else if (
 				parent.body.nodes.filter(

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -276,13 +276,14 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
  * @returns {void}
  */
 function reconcile(array, state, anchor, render_fn, flags, is_inert, get_key, get_collection) {
-	var is_animated = (flags & EACH_IS_ANIMATED) !== 0;
 	var should_update = (flags & (EACH_ITEM_REACTIVE | EACH_INDEX_REACTIVE)) !== 0;
 
 	var length = array.length;
 	var items = state.items;
 	var first = state.first;
 	var current = first;
+
+	var is_animated = items.get(get_key(array[0], 0))?.a !== null;
 
 	/** @type {undefined | Set<EachItem>} */
 	var seen;

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -276,15 +276,14 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
  * @returns {void}
  */
 function reconcile(array, state, anchor, render_fn, flags, is_inert, get_key, get_collection) {
+	var is_animated = (flags & EACH_IS_ANIMATED) !== 0;
 	var should_update = (flags & (EACH_ITEM_REACTIVE | EACH_INDEX_REACTIVE)) !== 0;
 
 	var length = array.length;
 	var items = state.items;
 	var first = state.first;
 	var current = first;
-
-	var is_animated = items.get(get_key(array[0], 0))?.a !== null;
-
+	
 	/** @type {undefined | Set<EachItem>} */
 	var seen;
 

--- a/packages/svelte/tests/validator/samples/animation-not-in-each/errors.json
+++ b/packages/svelte/tests/validator/samples/animation-not-in-each/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "animation_invalid_placement",
-		"message": "An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block",
+		"message": "An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block, or an only child of a snippet",
 		"start": {
 			"line": 5,
 			"column": 5

--- a/packages/svelte/tests/validator/samples/animation-siblings/errors.json
+++ b/packages/svelte/tests/validator/samples/animation-siblings/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "animation_invalid_placement",
-		"message": "An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block",
+		"message": "An element that uses the `animate:` directive must be the only child of a keyed `{#each ...}` block, or an only child of a snippet",
 		"start": {
 			"line": 6,
 			"column": 6


### PR DESCRIPTION
This would solve [#14792](https://github.com/sveltejs/svelte/issues/14792) which still needs to be discussed. I'm opening this PR as an initiative.

It might be considered a feature or a bug (?).

This feature allows the use of the `animate:` directive within snippets:

```ts
{#snippet example(item)}
    <div animate:flip={{ duration: 200 }}>{item}</div>
{/snippet}

{#each items as item (item)}
    {@render example(item)}
{/each}
```

I still need to create a test for it, and provide error-feedback: If you try to render a snippet with `animate:` directive and the `each`-block isn't keyed, or the `each`-block have multiple children, with an animated snippet.

------

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
