### PR TITLE
docs: Switch typing of Action<Parameter> from null to undefined in 12-use.md

### DIFF
--- a/documentation/docs/03-template-syntax/12-use.md
+++ b/documentation/docs/03-template-syntax/12-use.md
@@ -58,7 +58,8 @@ The `Action` interface receives three optional type arguments — a node type (w
 	 * 		onswiperight: (e: CustomEvent) => void;
 	 * 		onswipeleft: (e: CustomEvent) => void;
 	 * 		// ...
-	 * }>}
+	 * 	}
+	 * >}
 	 */
 	function gestures(node) {
 		$effect(() => {

--- a/documentation/docs/03-template-syntax/12-use.md
+++ b/documentation/docs/03-template-syntax/12-use.md
@@ -55,7 +55,7 @@ The `Action` interface receives three optional type arguments — a node type (w
 	/**
 	 * @type {import('svelte/action').Action<
 	 * 	HTMLDivElement,
-	 * 	null,
+	 * 	undefined,
 	 * 	{
 	 * 		onswiperight: (e: CustomEvent) => void;
 	 * 		onswipeleft: (e: CustomEvent) => void;

--- a/documentation/docs/03-template-syntax/12-use.md
+++ b/documentation/docs/03-template-syntax/12-use.md
@@ -50,8 +50,6 @@ The `Action` interface receives three optional type arguments — a node type (w
 ```svelte
 <!--- file: App.svelte --->
 <script>
-	import { on } from 'svelte/events';
-
 	/**
 	 * @type {import('svelte/action').Action<
 	 * 	HTMLDivElement,


### PR DESCRIPTION
Currently, the docs for `use:` give an example of using the `Action` interface to type an action. In it, `null` is specified as the optional type argument for the parameter. Unfortunately, this means the example leads to the following type error in practice, on the line where `use:gestures` is contained: `Expected 2 arguments, but got 1.`

The solution is to switch the type argument for the parameter to `undefined`. This gets rid of the type error, accomplishes the intended behaviour, and matches the default value for the generic to begin with.

No testing required as it is a documentation change. To recreate the type error simply copy and paste the example into any svelte project. I couldn't figure out how to get the playground compiler to do type-checking in svelte files to show it directly, or if it's even possible.