### PR TITLE
docs: Don't use "lame" in documentation

### DIFF
--- a/documentation/docs/03-template-syntax/07-@render.md
+++ b/documentation/docs/03-template-syntax/07-@render.md
@@ -17,7 +17,7 @@ To render a [snippet](snippet), use a `{@render ...}` tag.
 The expression can be an identifier like `sum`, or an arbitrary JavaScript expression:
 
 ```svelte
-{@render (cool ? coolSnippet : lameSnippet)()}
+{@render (cool ? coolSnippet : boringSnippet)()}
 ```
 
 ## Optional snippets

--- a/documentation/docs/03-template-syntax/18-class.md
+++ b/documentation/docs/03-template-syntax/18-class.md
@@ -27,8 +27,8 @@ If the value is an object, the truthy keys are added:
 </script>
 
 <!-- results in `class="cool"` if `cool` is truthy,
-     `class="lame"` otherwise -->
-<div class={{ cool, lame: !cool }}>...</div>
+     `class="boring"` otherwise -->
+<div class={{ cool, boring: !cool }}>...</div>
 ```
 
 If the value is an array, the truthy values are combined:
@@ -77,14 +77,14 @@ Prior to Svelte 5.16, the `class:` directive was the most convenient way to set 
 
 ```svelte
 <!-- These are equivalent -->
-<div class={{ cool, lame: !cool }}>...</div>
-<div class:cool={cool} class:lame={!cool}>...</div>
+<div class={{ cool, boring: !cool }}>...</div>
+<div class:cool={cool} class:boring={!cool}>...</div>
 ```
 
 As with other directives, we can use a shorthand when the name of the class coincides with the value:
 
 ```svelte
-<div class:cool class:lame={!cool}>...</div>
+<div class:cool class:boring={!cool}>...</div>
 ```
 
 > [!NOTE] Unless you're using an older version of Svelte, consider avoiding `class:`, since the attribute is more powerful and composable.

--- a/packages/svelte/src/compiler/legacy.js
+++ b/packages/svelte/src/compiler/legacy.js
@@ -591,7 +591,7 @@ export function convert(source, ast) {
 			Text(node, { path }) {
 				const parent = path.at(-1);
 				if (parent?.type === 'RegularElement' && parent.name === 'style') {
-					// these text nodes are missing `raw` for some dumb reason
+					// these text nodes are missing `raw` for some reason
 					return /** @type {AST.Text} */ ({
 						type: 'Text',
 						start: node.start,

--- a/packages/svelte/tests/runtime-legacy/samples/window-event-context/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/window-event-context/_config.js
@@ -8,7 +8,7 @@ export default test({
 
 	html: 'true',
 
-	skip: /^v4/.test(process.version), // node 4 apparently does some dumb stuff
+	skip: /^v4/.test(process.version), // node 4 apparently does some weird stuff
 
 	async test({ assert, component, target, window }) {
 		const event = new window.Event('click');


### PR DESCRIPTION
I noticed that the docs for the new `class` features use `cool/lame` as an example. The usage of the word "lame" feels a bit unnecessary in this case and some people (including me) consider it ableist. For example, Merriam-Webster say:

> Lame is no longer applied to people in medical contexts, and the disparaging uses, as in "a lame excuse," "he's so lame," "a lame party," and "lame jokes," are occasionally considered to be offensive as well.

(via https://www.merriam-webster.com/dictionary/lame)

My suggestion is to replace the wanted contrast with `cool/boring` and be done with it. I also quickly checked for other ableist words in examples but couldn't find any. (There were two "dumb"s in code comments, and I changed them as well, but they are not user-facing.)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] ~Ideally, include a test that fails without this PR but passes with it.~
- [x] ~If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).~

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
