### PR TITLE
docs: avoid using "lame" as a synonym for uncool

### DIFF
--- a/documentation/docs/03-template-syntax/18-class.md
+++ b/documentation/docs/03-template-syntax/18-class.md
@@ -27,8 +27,8 @@ If the value is an object, the truthy keys are added:
 </script>
 
 <!-- results in `class="cool"` if `cool` is truthy,
-     `class="lame"` otherwise -->
-<div class={{ cool, lame: !cool }}>...</div>
+     `class="uncool"` otherwise -->
+<div class={{ cool, uncool: !cool }}>...</div>
 ```
 
 If the value is an array, the truthy values are combined:
@@ -77,14 +77,14 @@ Prior to Svelte 5.16, the `class:` directive was the most convenient way to set 
 
 ```svelte
 <!-- These are equivalent -->
-<div class={{ cool, lame: !cool }}>...</div>
-<div class:cool={cool} class:lame={!cool}>...</div>
+<div class={{ cool, uncool: !cool }}>...</div>
+<div class:cool={cool} class:uncool={!cool}>...</div>
 ```
 
 As with other directives, we can use a shorthand when the name of the class coincides with the value:
 
 ```svelte
-<div class:cool class:lame={!cool}>...</div>
+<div class:cool class:uncool={!cool}>...</div>
 ```
 
 > [!NOTE] Unless you're using an older version of Svelte, consider avoiding `class:`, since the attribute is more powerful and composable.


### PR DESCRIPTION
Using "lame" as synonym for uncool is an example of ableist language. It can come across as offensive, especially to people in disability communities. It would be nice to use more inclusive language throughout. Based on the context I suggested replacing with "uncool", but am open to other alternatives.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
