### PR TITLE
fix: ensure unowned deriveds correctly get re-linked to the graph

### DIFF
--- a/.changeset/chatty-dolphins-complain.md
+++ b/.changeset/chatty-dolphins-complain.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure unowned deriveds correctly get re-linked to the graph

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -219,18 +219,16 @@ export function check_dirtiness(reaction) {
 				// If we are working with an unowned signal as part of an effect (due to !skip_reaction)
 				// and the version hasn't changed, we still need to check that this reaction
 				// is linked to the dependency source – otherwise future updates will not be caught.
-				if (
-					is_unowned &&
-					active_effect !== null &&
-					!skip_reaction &&
-					!dependency?.reactions?.includes(reaction)
-				) {
-					(dependency.reactions ??= []).push(reaction);
+				if (is_unowned && active_effect !== null && !skip_reaction) {
+					if (!dependency?.reactions?.includes(reaction)) {
+						(dependency.reactions ??= []).push(reaction);
+					}
+
 					if (version_mismatch) {
 						unowned_dirty = true;
 					}
 				} else if (version_mismatch) {
-					return true
+					return true;
 				}
 			}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -205,10 +205,12 @@ export function check_dirtiness(reaction) {
 				reaction.f ^= DISCONNECTED;
 			}
 
+			var dirty = false;
+
 			for (i = 0; i < dependencies.length; i++) {
 				var dependency = dependencies[i];
 
-				if (check_dirtiness(/** @type {Derived} */ (dependency))) {
+				if (!dirty && check_dirtiness(/** @type {Derived} */ (dependency))) {
 					update_derived(/** @type {Derived} */ (dependency));
 				}
 
@@ -225,8 +227,14 @@ export function check_dirtiness(reaction) {
 				}
 
 				if (dependency.version > reaction.version) {
-					return true;
+					// We can't just return here as we might have other dependencies that are unowned
+					// ad need to be linked to the reaction again
+					dirty = true;
 				}
+			}
+
+			if (dirty) {
+				return true;
 			}
 		}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -198,12 +198,11 @@ export function check_dirtiness(reaction) {
 			var i;
 			var dependency;
 			var is_disconnected = (flags & DISCONNECTED) !== 0;
-			var depedency_needs_linking =
-				is_disconnected || (is_unowned && active_effect !== null && !skip_reaction);
+			var is_unowned_connected = is_unowned && active_effect !== null && !skip_reaction;
 
-			// If we are working with a disconnected or an unowned signal as part of an effect (due to !skip_reaction)
+			// If we are working with a disconnected or an unowned signal that is now connected (due to an active effect)
 			// then we need to re-connect the reaction to the dependency
-			if (depedency_needs_linking) {
+			if (is_disconnected || is_unowned_connected) {
 				for (i = 0; i < dependencies.length; i++) {
 					dependency = dependencies[i];
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -199,11 +199,12 @@ export function check_dirtiness(reaction) {
 			var dependency;
 			var is_disconnected = (flags & DISCONNECTED) !== 0;
 			var is_unowned_connected = is_unowned && active_effect !== null && !skip_reaction;
+			var length = dependencies.length;
 
 			// If we are working with a disconnected or an unowned signal that is now connected (due to an active effect)
 			// then we need to re-connect the reaction to the dependency
 			if (is_disconnected || is_unowned_connected) {
-				for (i = 0; i < dependencies.length; i++) {
+				for (i = 0; i < length; i++) {
 					dependency = dependencies[i];
 
 					if (!dependency?.reactions?.includes(reaction)) {
@@ -216,7 +217,7 @@ export function check_dirtiness(reaction) {
 				}
 			}
 
-			for (i = 0; i < dependencies.length; i++) {
+			for (i = 0; i < length; i++) {
 				dependency = dependencies[i];
 
 				if (check_dirtiness(/** @type {Derived} */ (dependency))) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -197,8 +197,9 @@ export function check_dirtiness(reaction) {
 		if (dependencies !== null) {
 			var i;
 			var dependency;
+			var is_disconnected = (flags & DISCONNECTED) !== 0;
 			var depedency_needs_linking =
-				(flags & DISCONNECTED) !== 0 || (is_unowned && active_effect !== null && !skip_reaction);
+				is_disconnected || (is_unowned && active_effect !== null && !skip_reaction);
 
 			// If we are working with a disconnected or an unowned signal as part of an effect (due to !skip_reaction)
 			// then we need to re-connect the reaction to the dependency
@@ -211,7 +212,9 @@ export function check_dirtiness(reaction) {
 					}
 				}
 
-				reaction.f ^= DISCONNECTED;
+				if (is_disconnected) {
+					reaction.f ^= DISCONNECTED;
+				}
 			}
 
 			for (i = 0; i < dependencies.length; i++) {

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -790,7 +790,7 @@ describe('signals', () => {
 			const b = state(0);
 			const c = derived(() => {
 				$.get(a);
-				return $.get(b)
+				return $.get(b);
 			});
 
 			$.get(c);

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -781,4 +781,37 @@ describe('signals', () => {
 			assert.equal($.get(count), 0n);
 		};
 	});
+
+	test('unowned deriveds correctly re-attach to their source', () => {
+		const log: any[] = [];
+
+		return () => {
+			const a = state(0);
+			const b = state(0);
+			const c = derived(() => {
+				$.get(a);
+				return $.get(b)
+			});
+
+			$.get(c);
+
+			set(a, 1);
+
+			const destroy = effect_root(() => {
+				render_effect(() => {
+					log.push($.get(c));
+				});
+			});
+
+			assert.deepEqual(log, [0]);
+
+			set(b, 1);
+
+			flushSync();
+
+			assert.deepEqual(log, [0, 1]);
+
+			destroy();
+		};
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14846. This ensures that we properly attach unowned deriveds to their dependencies. Previously, we might only attach one of the dependencies if that dependency was also a mismatched version – which meant we skipped all the other dependencies. 