### PR TITLE
fix: Make Tween work with continuous target changes

### DIFF
--- a/.changeset/violet-cows-reply.md
+++ b/.changeset/violet-cows-reply.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make Tween work with continuous target changes

--- a/packages/svelte/src/motion/tweened.js
+++ b/packages/svelte/src/motion/tweened.js
@@ -230,7 +230,6 @@ export class Tween {
 	set(value, options) {
 		set(this.#target, value);
 
-		let previous_value = this.#current;
 		let previous_task = this.#task;
 
 		let started = false;
@@ -254,10 +253,12 @@ export class Tween {
 			if (!started) {
 				started = true;
 
-				fn = interpolate(/** @type {any} */ (previous_value.v), value);
+				const prev = this.#current.v;
+
+				fn = interpolate(prev, value);
 
 				if (typeof duration === 'function') {
-					duration = duration(/** @type {any} */ (previous_value.v), value);
+					duration = duration(prev, value);
 				}
 
 				previous_task?.abort();

--- a/packages/svelte/src/motion/tweened.js
+++ b/packages/svelte/src/motion/tweened.js
@@ -230,7 +230,7 @@ export class Tween {
 	set(value, options) {
 		set(this.#target, value);
 
-		let previous_value = this.#current.v;
+		let previous_value = this.#current;
 		let previous_task = this.#task;
 
 		let started = false;
@@ -254,10 +254,10 @@ export class Tween {
 			if (!started) {
 				started = true;
 
-				fn = interpolate(/** @type {any} */ (previous_value), value);
+				fn = interpolate(/** @type {any} */ (previous_value.v), value);
 
 				if (typeof duration === 'function') {
-					duration = duration(/** @type {any} */ (previous_value), value);
+					duration = duration(/** @type {any} */ (previous_value.v), value);
 				}
 
 				previous_task?.abort();


### PR DESCRIPTION
## Description
Fixes #14849 by adjusting when `this.#current.v` is read in `Tween.set`, getting the behavior more in line with the (now deprecated) `tweened`. See the issue for demos illustrating the problem.

I couldn't think of an appropriate test for this. As this is my first PR for Svelte, any help or feedback would be greatly appreciated!

## Checks
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
