### PR TITLE
docs: add shared state example for bind:group & add labels

### DIFF
--- a/documentation/docs/03-template-syntax/11-bind.md
+++ b/documentation/docs/03-template-syntax/11-bind.md
@@ -130,18 +130,57 @@ Inputs that work together can use `bind:group`.
 </script>
 
 <!-- grouped radio inputs are mutually exclusive -->
-<input type="radio" bind:group={tortilla} value="Plain" />
-<input type="radio" bind:group={tortilla} value="Whole wheat" />
-<input type="radio" bind:group={tortilla} value="Spinach" />
+<label><input type="radio" bind:group={tortilla} value="Plain" />Plain</label>
+<label><input type="radio" bind:group={tortilla} value="Whole wheat" />Whole wheat</label>
+<label><input type="radio" bind:group={tortilla} value="Spinach" />Spinach</label>
 
 <!-- grouped checkbox inputs populate an array -->
-<input type="checkbox" bind:group={fillings} value="Rice" />
-<input type="checkbox" bind:group={fillings} value="Beans" />
-<input type="checkbox" bind:group={fillings} value="Cheese" />
-<input type="checkbox" bind:group={fillings} value="Guac (extra)" />
+<label><input type="checkbox" bind:group={fillings} value="Rice" /> Rice</label>
+<label><input type="checkbox" bind:group={fillings} value="Beans" />Beans</label>
+<label><input type="checkbox" bind:group={fillings} value="Cheese" /> Cheese</label>
+<label><input type="checkbox" bind:group={fillings} value="Guac (extra)" />Guac</label>
 ```
 
 > [!NOTE] `bind:group` only works if the inputs are in the same Svelte component.
+
+`bind:group` can be used with component props with help of [bind-property](#bind:property-for-components):
+
+```javascript
+// sharedState.svelte.js
+export const tortilla = $state({selectedValue: ""});
+export const fillings = $state({selectedValues: []});
+```
+
+```svelte
+<!-- App.svelte -->
+<script>
+	import { tortilla, fillings } from './sharedState.svelte.js';
+	import Selection from './Selection.svelte';
+</script>
+
+<Selection bind:tortilla={tortilla.selectedValue} bind:fillings={fillings.selectedValues} />
+```
+
+```svelte
+<!-- Selection.svelte -->
+<script>
+	let { tortilla = $bindable(), fillings = $bindable() } = $props();
+</script>
+
+<!-- grouped radio inputs are mutually exclusive -->
+<label><input type="radio" bind:group={tortilla} value="Plain" />Plain</label>
+<label><input type="radio" bind:group={tortilla} value="Whole wheat" />Whole wheat</label>
+<label><input type="radio" bind:group={tortilla} value="Spinach" />Spinach</label>
+
+<!-- grouped checkbox inputs populate an array -->
+<label><input type="checkbox" bind:group={fillings} value="Rice" /> Rice</label>
+<label><input type="checkbox" bind:group={fillings} value="Beans" />Beans</label>
+<label><input type="checkbox" bind:group={fillings} value="Cheese" /> Cheese</label>
+<label><input type="checkbox" bind:group={fillings} value="Guac (extra)" />Guac</label>
+```
+
+> [!NOTE] `bind:group` only works if the inputs are in the same Svelte component, you can't pass down a single $state to multiple components (with different values).
+
 
 ## `<input bind:files>`
 


### PR DESCRIPTION
In the last couple of days I tried to learn the new Svelte v5 $state ([notes](https://dev.to/mandrasch/svelte-5-share-state-between-components-for-dummies-4gd2)). I did some small hobby projects with v4 before.

I mainly stumbled over the lack of examples for `bind:group` with shared state, since object wrapping is needed here when using `export`. My current guess is that other developers will face the same challenge in future when they just check the docs for `bind:group` for v5 and try to use it with shared state on their own (like I did). Took me multiple days and support on Discord/Bluesky to get it right.

**PR changes to [bind-group docs](https://svelte.dev/docs/svelte/bind#input-bind:group):**

- include a small example of shared state to get developers up to speed
- add note that state can't be passed to multiple components with different values 
    - related: https://github.com/sveltejs/svelte/issues/2308
- add `<label>` to the whole example to be a11y-complicant

[REPL for submitted code](https://svelte.dev/playground/8056f77f66f04b68ae94634f0f57b04f?version=5.16.2)

As alternative, a link to a tutorial might help as well.

Keep up the awesome work with Svelte and much success in 2025! 🎉

_PS: I know that there is also the section [bind:property for components](https://svelte.dev/docs/svelte/bind#bind:property-for-components), but I just noticed it afterwards + it's very technical. Wouldn't have helped me.  https://svelte.dev/tutorial/svelte/group-inputs also doesn't cover shared state._

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Couldn't run `pnpm lint` on node v23.5.0 and with `pnpm 9.15.3` 

```bash
Error: Cannot find module '/Users/XXX/webserver/svelte/node_modules/.pnpm/svelte-eslint-parser@0.41.0_svelte@packages+svelte/node_modules/svelte/compiler/index.js'
```
