### PR TITLE
fix: use cached indexOf array prototype method internally

### DIFF
--- a/.changeset/real-dolphins-return.md
+++ b/.changeset/real-dolphins-return.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: use cached indexOf array prototype method internally

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -1,6 +1,6 @@
 /** @import { ComponentContext, Derived, Effect, Reaction, Signal, Source, Value } from '#client' */
 import { DEV } from 'esm-env';
-import { define_property, get_descriptors, get_prototype_of } from '../shared/utils.js';
+import { define_property, get_descriptors, get_prototype_of, index_of } from '../shared/utils.js';
 import {
 	destroy_block_effect_children,
 	destroy_effect_children,
@@ -448,7 +448,7 @@ export function update_reaction(reaction) {
 function remove_reaction(signal, dependency) {
 	let reactions = dependency.reactions;
 	if (reactions !== null) {
-		var index = reactions.indexOf(signal);
+		var index = index_of.call(reactions, signal);
 		if (index !== -1) {
 			var new_length = reactions.length - 1;
 			if (new_length === 0) {

--- a/packages/svelte/src/internal/shared/utils.js
+++ b/packages/svelte/src/internal/shared/utils.js
@@ -1,6 +1,7 @@
 // Store the references to globals in case someone tries to monkey patch these, causing the below
 // to de-opt (this occurs often when using popular extensions).
 export var is_array = Array.isArray;
+export var index_of = Array.prototype.indexOf;
 export var array_from = Array.from;
 export var object_keys = Object.keys;
 export var define_property = Object.defineProperty;


### PR DESCRIPTION
Instead of using `array.indexOf` we can use the cached prototype method, avoiding any monkey-patching in DEV and also ensuring the IC is always hot in both dev and prod. Should hopefully resolve https://github.com/sveltejs/svelte/issues/14875.