### PR TITLE
docs: Refer to SvelteKit instead of Svelte

### DIFF
--- a/documentation/docs/01-introduction/02-getting-started.md
+++ b/documentation/docs/01-introduction/02-getting-started.md
@@ -11,7 +11,7 @@ npm install
 npm run dev
 ```
 
-Don't worry if you don't know Svelte yet! You can ignore all the nice features SvelteKit brings on top for now and dive into it later.
+Don't worry if you don't know SvelteKit yet! You can ignore all the nice features SvelteKit brings on top for now and dive into it later.
 
 ## Alternatives to SvelteKit
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Changed mention of Svelte to SvelteKit where it was suggesting beginners to not be afraid to use sveltekit for a svelte project even if they haven't used it before.
