### PR TITLE
docs: tweak links

### DIFF
--- a/packages/svelte/scripts/generate-version.js
+++ b/packages/svelte/scripts/generate-version.js
@@ -8,8 +8,6 @@ fs.writeFileSync(
 
 /**
  * The current version, as set in package.json.
- *
- * https://svelte.dev/docs/svelte-compiler#svelte-version
  * @type {string}
  */
 export const VERSION = '${pkg.version}';

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -278,7 +278,7 @@ declare const SnippetReturn: unique symbol;
  * ```
  * You can only call a snippet through the `{@render ...}` tag.
  *
- * https://svelte.dev/docs/svelte/snippet
+ * See the [snippet documentation](https://svelte.dev/docs/svelte/snippet) for more info.
  *
  * @template Parameters the parameters that the snippet expects (if any) as a tuple.
  */

--- a/packages/svelte/src/version.js
+++ b/packages/svelte/src/version.js
@@ -2,8 +2,6 @@
 
 /**
  * The current version, as set in package.json.
- *
- * https://svelte.dev/docs/svelte-compiler#svelte-version
  * @type {string}
  */
 export const VERSION = '5.16.2';

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -275,7 +275,7 @@ declare module 'svelte' {
 	 * ```
 	 * You can only call a snippet through the `{@render ...}` tag.
 	 *
-	 * https://svelte.dev/docs/svelte/snippet
+	 * See the [snippet documentation](https://svelte.dev/docs/svelte/snippet) for more info.
 	 *
 	 * @template Parameters the parameters that the snippet expects (if any) as a tuple.
 	 */
@@ -1339,8 +1339,6 @@ declare module 'svelte/compiler' {
 	} | undefined): Promise<Processed>;
 	/**
 	 * The current version, as set in package.json.
-	 *
-	 * https://svelte.dev/docs/svelte-compiler#svelte-version
 	 * */
 	export const VERSION: string;
 	/**


### PR DESCRIPTION
Remove one that is unnecessary, and make another one appear nice in markdown.
closes #14850