### PR TITLE
fix: remove leading newline from `<pre>` contents

### DIFF
--- a/.changeset/tricky-radios-vanish.md
+++ b/.changeset/tricky-radios-vanish.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove leading newline from `<pre>` contents

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -270,6 +270,22 @@ export function clean_nodes(
 
 	var first = trimmed[0];
 
+	// initial newline inside a `<pre>` is disregarded
+	if (
+		parent.type === 'RegularElement' &&
+		parent.name === 'pre' &&
+		first.type === 'Text' &&
+		first.data[0] === '\n'
+	) {
+		first.data = first.data.slice(1);
+		first.raw = first.raw.slice(1);
+
+		if (first.data === '') {
+			trimmed.shift();
+			first = trimmed[0];
+		}
+	}
+
 	// Special case: Add a comment if this is a lone script tag. This ensures that our run_scripts logic in template.js
 	// will always be able to call node.replaceWith() on the script tag in order to make it run. If we don't add this
 	// and would still call node.replaceWith() on the script tag, it would be a no-op because the script tag has no parent.

--- a/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/_config.js
+++ b/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/_expected.html
+++ b/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/_expected.html
@@ -1,0 +1,2 @@
+<!--[--><pre><div><span></span></div>
+</pre><!--]-->

--- a/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/main.svelte
+++ b/packages/svelte/tests/hydration/samples/pre-first-node-backslash-n/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let name = $state('');
+</script>
+
+<pre>
+<div><span>{name}</span></div>
+</pre>

--- a/packages/svelte/tests/runtime-legacy/samples/pre-tag/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/pre-tag/_config.js
@@ -31,9 +31,7 @@ function get_html(ssr) {
     </span>
     E
     F
-  </pre></div> <div id="pre-with-leading-newline"><pre>leading newline</pre> <pre>  leading newline and spaces</pre> <pre>
-leading newlines</pre></div> <div id="pre-without-leading-newline"><pre>without spaces</pre> <pre>  with spaces  </pre> <pre>${' '}
+  </pre></div> <div id="pre-with-leading-newline"><pre>leading newline</pre> <pre>  leading newline and spaces</pre> <pre>leading newlines</pre></div> <div id="pre-without-leading-newline"><pre>without spaces</pre> <pre>  with spaces  </pre> <pre>${' '}
 newline after leading space</pre></div> <pre id="pre-with-multiple-leading-newlines">
-
 multiple leading newlines</pre>${ssr ? '<!--]-->' : ''}`;
 }


### PR DESCRIPTION
Alternative to #14783. All we need to do, as far as I can tell, is disregard a `\n` that immediately follows a `<pre>` tag

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
