### PR TITLE
fix: apply `overflow: hidden` style when transitioning elements, where necessary

### DIFF
--- a/.changeset/sixty-paws-compete.md
+++ b/.changeset/sixty-paws-compete.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: apply `overflow: hidden` style when transitioning elements, where necessary

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -192,6 +192,11 @@ export function transition(flags, element, get_fn, get_params) {
 
 	var inert = element.inert;
 
+	/**
+	 * The default overflow style, stashed so we can revert changes during the transition
+	 * that are necessary to work around a Safari <18 bug
+	 * TODO 6.0 remove this, if older versions of Safari have died out enough
+	 */
 	var overflow = element.style.overflow;
 
 	/** @type {Animation | undefined} */
@@ -386,6 +391,11 @@ function animate(element, options, counterpart, t2, on_finish) {
 		var keyframes = [];
 
 		if (duration > 0) {
+			/**
+			 * Whether or not the CSS includes `overflow: hidden`, in which case we need to
+			 * add it as an inline style to work around a Safari <18 bug
+			 * TODO 6.0 remove this, if possible
+			 */
 			var needs_overflow_hidden = false;
 
 			if (css) {


### PR DESCRIPTION
This is a slightly hacky fix for #4712. It works by adding `style="overflow: hidden"` on transitioning elements, if the transition includes `overflow: hidden` (which is the case for `slide`, for example).

We _could_ argue that we shouldn't bother with this, since it's fixed in Safari 18. I just wanted to see how easy the fix would be.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
