### PR TITLE
fix: guard against `customElements` being unavailable in browser extension contexts

### DIFF
--- a/.changeset/forty-books-taste.md
+++ b/.changeset/forty-books-taste.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: guard against `customElements` being unavailable in browser extension contexts

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -221,7 +221,10 @@ export function set_custom_element_data(node, prop, value) {
 			// Don't compute setters for custom elements while they aren't registered yet,
 			// because during their upgrade/instantiation they might add more setters.
 			// Instead, fall back to a simple "an object, then set as property" heuristic.
-			setters_cache.has(node.nodeName) || customElements.get(node.tagName.toLowerCase())
+			setters_cache.has(node.nodeName) ||
+			// customElements may not be available in browser extension contexts
+			!customElements ||
+			customElements.get(node.tagName.toLowerCase())
 				? get_setters(node).includes(prop)
 				: value && typeof value === 'object'
 		) {


### PR DESCRIPTION
No test because no way to do that

fixes #14739

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
