### PR TITLE
feat: warn on using `slide` transition with invalid `display` styles

### DIFF
--- a/.changeset/silver-humans-yawn.md
+++ b/.changeset/silver-humans-yawn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: warn on using `slide` transition with table elements

--- a/documentation/docs/98-reference/.generated/client-warnings.md
+++ b/documentation/docs/98-reference/.generated/client-warnings.md
@@ -226,7 +226,7 @@ To resolve this, ensure you're comparing values where both values were created w
 ### transition_slide_display
 
 ```
-The `slide` transition does not work correctly with elements with `display: %value%`
+The `slide` transition does not work correctly for elements with `display: %value%`
 ```
 
 The [slide](/docs/svelte/svelte-transition#slide) transition works by animating the `height` of the element, which requires a `display` style like `block`, `flex` or `grid`. It does not work for:

--- a/documentation/docs/98-reference/.generated/client-warnings.md
+++ b/documentation/docs/98-reference/.generated/client-warnings.md
@@ -223,12 +223,14 @@ Reactive `$state(...)` proxies and the values they proxy have different identiti
 
 To resolve this, ensure you're comparing values where both values were created with `$state(...)`, or neither were. Note that `$state.raw(...)` will _not_ create a state proxy.
 
-### transition_slide_display_table
+### transition_slide_display
 
 ```
 The `slide` transition does not work correctly with elements with `display: %value%`
 ```
 
-The [slide](/docs/svelte/svelte-transition#slide) transition works by animating the `height` of the element. Setting `height` to a value smaller than the element's natural height has no effect if the element's [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display) style starts with `table` (which is the default state of table elements such as `<tr>`).
+The [slide](/docs/svelte/svelte-transition#slide) transition works by animating the `height` of the element, which requires a `display` style like `block`, `flex` or `grid`. It does not work for:
 
-Consider using a `flex` or `grid` layout instead.
+- `display: inline` (which is the default for elements like `<span>`), and its variants like `inline-block`, `inline-flex` and `inline-grid`
+- `display: table` and `table-[name]`, which are the defaults for elements like `<table>` and `<tr>`
+- `display: contents`

--- a/documentation/docs/98-reference/.generated/client-warnings.md
+++ b/documentation/docs/98-reference/.generated/client-warnings.md
@@ -222,3 +222,13 @@ Reactive `$state(...)` proxies and the values they proxy have different identiti
 ```
 
 To resolve this, ensure you're comparing values where both values were created with `$state(...)`, or neither were. Note that `$state.raw(...)` will _not_ create a state proxy.
+
+### transition_slide_display_table
+
+```
+The `slide` transition does not work correctly with elements with `display: %value%`
+```
+
+The [slide](/docs/svelte/svelte-transition#slide) transition works by animating the `height` of the element. Setting `height` to a value smaller than the element's natural height has no effect if the element's [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display) style starts with `table` (which is the default state of table elements such as `<tr>`).
+
+Consider using a `flex` or `grid` layout instead.

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -186,3 +186,11 @@ To fix it, either create callback props to communicate changes, or mark `person`
 ```
 
 To resolve this, ensure you're comparing values where both values were created with `$state(...)`, or neither were. Note that `$state.raw(...)` will _not_ create a state proxy.
+
+## transition_slide_display_table
+
+> The `slide` transition does not work correctly with elements with `display: %value%`
+
+The [slide](/docs/svelte/svelte-transition#slide) transition works by animating the `height` of the element. Setting `height` to a value smaller than the element's natural height has no effect if the element's [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display) style starts with `table` (which is the default state of table elements such as `<tr>`).
+
+Consider using a `flex` or `grid` layout instead.

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -187,10 +187,12 @@ To fix it, either create callback props to communicate changes, or mark `person`
 
 To resolve this, ensure you're comparing values where both values were created with `$state(...)`, or neither were. Note that `$state.raw(...)` will _not_ create a state proxy.
 
-## transition_slide_display_table
+## transition_slide_display
 
 > The `slide` transition does not work correctly with elements with `display: %value%`
 
-The [slide](/docs/svelte/svelte-transition#slide) transition works by animating the `height` of the element. Setting `height` to a value smaller than the element's natural height has no effect if the element's [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display) style starts with `table` (which is the default state of table elements such as `<tr>`).
+The [slide](/docs/svelte/svelte-transition#slide) transition works by animating the `height` of the element, which requires a `display` style like `block`, `flex` or `grid`. It does not work for:
 
-Consider using a `flex` or `grid` layout instead.
+- `display: inline` (which is the default for elements like `<span>`), and its variants like `inline-block`, `inline-flex` and `inline-grid`
+- `display: table` and `table-[name]`, which are the defaults for elements like `<table>` and `<tr>`
+- `display: contents`

--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -189,7 +189,7 @@ To resolve this, ensure you're comparing values where both values were created w
 
 ## transition_slide_display
 
-> The `slide` transition does not work correctly with elements with `display: %value%`
+> The `slide` transition does not work correctly for elements with `display: %value%`
 
 The [slide](/docs/svelte/svelte-transition#slide) transition works by animating the `height` of the element, which requires a `display` style like `block`, `flex` or `grid`. It does not work for:
 

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -171,10 +171,10 @@ export function state_proxy_equality_mismatch(operator) {
  * The `slide` transition does not work correctly with elements with `display: %value%`
  * @param {string} value
  */
-export function transition_slide_display_table(value) {
+export function transition_slide_display(value) {
 	if (DEV) {
-		console.warn(`%c[svelte] transition_slide_display_table\n%cThe \`slide\` transition does not work correctly with elements with \`display: ${value}\`\nhttps://svelte.dev/e/transition_slide_display_table`, bold, normal);
+		console.warn(`%c[svelte] transition_slide_display\n%cThe \`slide\` transition does not work correctly with elements with \`display: ${value}\`\nhttps://svelte.dev/e/transition_slide_display`, bold, normal);
 	} else {
-		console.warn(`https://svelte.dev/e/transition_slide_display_table`);
+		console.warn(`https://svelte.dev/e/transition_slide_display`);
 	}
 }

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -168,12 +168,12 @@ export function state_proxy_equality_mismatch(operator) {
 }
 
 /**
- * The `slide` transition does not work correctly with elements with `display: %value%`
+ * The `slide` transition does not work correctly for elements with `display: %value%`
  * @param {string} value
  */
 export function transition_slide_display(value) {
 	if (DEV) {
-		console.warn(`%c[svelte] transition_slide_display\n%cThe \`slide\` transition does not work correctly with elements with \`display: ${value}\`\nhttps://svelte.dev/e/transition_slide_display`, bold, normal);
+		console.warn(`%c[svelte] transition_slide_display\n%cThe \`slide\` transition does not work correctly for elements with \`display: ${value}\`\nhttps://svelte.dev/e/transition_slide_display`, bold, normal);
 	} else {
 		console.warn(`https://svelte.dev/e/transition_slide_display`);
 	}

--- a/packages/svelte/src/internal/client/warnings.js
+++ b/packages/svelte/src/internal/client/warnings.js
@@ -166,3 +166,15 @@ export function state_proxy_equality_mismatch(operator) {
 		console.warn(`https://svelte.dev/e/state_proxy_equality_mismatch`);
 	}
 }
+
+/**
+ * The `slide` transition does not work correctly with elements with `display: %value%`
+ * @param {string} value
+ */
+export function transition_slide_display_table(value) {
+	if (DEV) {
+		console.warn(`%c[svelte] transition_slide_display_table\n%cThe \`slide\` transition does not work correctly with elements with \`display: ${value}\`\nhttps://svelte.dev/e/transition_slide_display_table`, bold, normal);
+	} else {
+		console.warn(`https://svelte.dev/e/transition_slide_display_table`);
+	}
+}

--- a/packages/svelte/src/transition/index.js
+++ b/packages/svelte/src/transition/index.js
@@ -108,13 +108,7 @@ var slide_warning = false;
 export function slide(node, { delay = 0, duration = 400, easing = cubic_out, axis = 'y' } = {}) {
 	const style = getComputedStyle(node);
 
-	if (
-		DEV &&
-		!slide_warning &&
-		(style.display.includes('table') ||
-			style.display.includes('inline') ||
-			style.display === 'contents')
-	) {
+	if (DEV && !slide_warning && /(contents|inline|table)/.test(style.display)) {
 		slide_warning = true;
 		Promise.resolve().then(() => (slide_warning = false));
 		w.transition_slide_display(style.display);

--- a/packages/svelte/src/transition/index.js
+++ b/packages/svelte/src/transition/index.js
@@ -108,10 +108,16 @@ var slide_warning = false;
 export function slide(node, { delay = 0, duration = 400, easing = cubic_out, axis = 'y' } = {}) {
 	const style = getComputedStyle(node);
 
-	if (DEV && style.display.startsWith('table-') && !slide_warning) {
+	if (
+		DEV &&
+		!slide_warning &&
+		(style.display.includes('table') ||
+			style.display.includes('inline') ||
+			style.display === 'contents')
+	) {
 		slide_warning = true;
 		Promise.resolve().then(() => (slide_warning = false));
-		w.transition_slide_display_table(style.display);
+		w.transition_slide_display(style.display);
 	}
 
 	const opacity = +style.opacity;

--- a/packages/svelte/src/transition/index.js
+++ b/packages/svelte/src/transition/index.js
@@ -1,4 +1,8 @@
 /** @import { BlurParams, CrossfadeParams, DrawParams, FadeParams, FlyParams, ScaleParams, SlideParams, TransitionConfig } from './public' */
+
+import { DEV } from 'esm-env';
+import * as w from '../internal/client/warnings.js';
+
 /** @param {number} x */
 const linear = (x) => x;
 
@@ -92,6 +96,8 @@ export function fly(
 	};
 }
 
+var slide_warning = false;
+
 /**
  * Slides an element in and out.
  *
@@ -101,6 +107,13 @@ export function fly(
  */
 export function slide(node, { delay = 0, duration = 400, easing = cubic_out, axis = 'y' } = {}) {
 	const style = getComputedStyle(node);
+
+	if (DEV && style.display.startsWith('table-') && !slide_warning) {
+		slide_warning = true;
+		Promise.resolve().then(() => (slide_warning = false));
+		w.transition_slide_display_table(style.display);
+	}
+
 	const opacity = +style.opacity;
 	const primary_property = axis === 'y' ? 'height' : 'width';
 	const primary_property_value = parseFloat(style[primary_property]);


### PR DESCRIPTION
Alternative to #5922, closes #4948. We can't just set `display` to `block` or something else because in many cases that will result in broken styles — the best we can do is encourage people to use flex/grid layouts instead.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
