### PR TITLE
fix: make Tween with duration 0 set current to target immediately

### DIFF
--- a/.changeset/cold-cups-act.md
+++ b/.changeset/cold-cups-act.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: Make Tween duration 0 set current to target immediately

--- a/packages/svelte/src/motion/tweened.js
+++ b/packages/svelte/src/motion/tweened.js
@@ -240,6 +240,15 @@ export class Tween {
 			interpolate = get_interpolator
 		} = { ...this.#defaults, ...options };
 
+		if (duration === 0) {
+			if (previous_task) {
+				previous_task.abort();
+				previous_task = null;
+			}
+			set(this.#current, value);
+			return Promise.resolve();
+		}
+
 		const start = raf.now() + delay;
 
 		/** @type {(t: number) => T} */

--- a/packages/svelte/tests/motion/test.ts
+++ b/packages/svelte/tests/motion/test.ts
@@ -2,7 +2,7 @@
 import '../helpers.js'; // for the matchMedia polyfill
 import { describe, it, assert } from 'vitest';
 import { get } from 'svelte/store';
-import { spring, tweened } from 'svelte/motion';
+import { spring, tweened, Tween } from 'svelte/motion';
 
 describe('motion', () => {
 	describe('spring', () => {
@@ -38,5 +38,21 @@ describe('motion', () => {
 			size.update((v) => v + 10);
 			assert.equal(get(size), 20);
 		});
+	});
+
+	describe('Tween', () => {
+		it('sets immediately when duration is 0', () => {
+			const size = new Tween(0);
+
+			size.set(100, { duration: 0 });
+			assert.equal(size.current, 100);
+		})
+	});
+
+	it('updates correctly when initialized with a `null`-ish value', () => {
+		const size = new Tween(undefined as unknown as number, { duration: 0 });
+
+		size.set(10);
+		assert.equal(size.current, 10);
 	});
 });


### PR DESCRIPTION
Fixes #14897, where setting a Tween with `{ duration: 0 }` would first evaluate tot `NaN` before becoming the target value.

## Checks
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
