### PR TITLE
feat: allow non-numeric values to be tweened by snapping immediately to new value

### DIFF
--- a/.changeset/cool-apples-report.md
+++ b/.changeset/cool-apples-report.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: allow non-numeric values to be tweened by snapping immediately to new value

--- a/packages/svelte/src/motion/tweened.js
+++ b/packages/svelte/src/motion/tweened.js
@@ -72,7 +72,8 @@ function get_interpolator(a, b) {
 		return (t) => a + t * delta;
 	}
 
-	throw new Error(`Cannot interpolate ${type} values`);
+	// for non-numeric values, snap to the final value immediately
+	return () => b;
 }
 
 /**

--- a/packages/svelte/tests/motion/test.ts
+++ b/packages/svelte/tests/motion/test.ts
@@ -3,6 +3,7 @@ import '../helpers.js'; // for the matchMedia polyfill
 import { describe, it, assert } from 'vitest';
 import { get } from 'svelte/store';
 import { spring, tweened, Tween } from 'svelte/motion';
+import { raf } from '../animation-helpers.js';
 
 describe('motion', () => {
 	describe('spring', () => {
@@ -38,6 +39,16 @@ describe('motion', () => {
 			size.update((v) => v + 10);
 			assert.equal(get(size), 20);
 		});
+
+		it('updates non-numeric values immediately', () => {
+			raf.reset();
+			const boolean = tweened(false);
+
+			boolean.set(true, { duration: 100 });
+
+			raf.tick(1);
+			assert.equal(get(boolean), true);
+		});
 	});
 
 	describe('Tween', () => {
@@ -46,6 +57,16 @@ describe('motion', () => {
 
 			size.set(100, { duration: 0 });
 			assert.equal(size.current, 100);
+		});
+
+		it('updates non-numeric values immediately', () => {
+			raf.reset();
+			const boolean = new Tween(false);
+
+			boolean.set(true, { duration: 100 });
+
+			raf.tick(1);
+			assert.equal(boolean.current, true);
 		});
 	});
 


### PR DESCRIPTION
Right now, non-numeric values cause interpolation in `tweened` or `Tween` to fail unless you provide a custom interpolator. It would probably be more useful if they just snapped to their new value instead — if you need some slightly different behaviour (e.g. flipping at the halfway mark) then you can continue to provide your own interpolator, but with this PR it's no longer required.

Supersedes #8678, closes #7543.

[Demo](https://svelte.dev/playground/hello-world?version=pr-14941#H4sIAAAAAAAAE22SwXLbIBCGX2WHi-wZR3Yy04ssudNbb730VvWAYK0wQaCBVdxUw7sXgdzWTi5C_Pst-7PszAwfkFXsK2pt4WKdlrBBqQjllu3YWWn0rPoxM3obF24Ror5mfRnH0r-ipkXruMePdGENoaF4DKu9cGqkU2taUsNoHcEMYuqU-DYRBDg7O0CRM_fIvTJ9cbyBv18QzT05WFLWJDKysZ4noAQ2YPCSkzZLrKU5Ly159RsreNxd98Jq6yooOj1hkcWwu8vJlqq_lldsWbaxer3_dz9TdxORTY48vWlsWuYF17HmnLyVYnIu9qVcjIQjdFy89M5ORr4jkrXQsuUsa4RW4qWZN1toTrBayzxx1yPFS99d8v9oKgdN08AjfIYn-KAFN3jSEp87E5MK67jp4-9dt9JLhXBKBmHAen9tQW6IVK-ner980zZ1JY1Cxq6uz3FeKlDmGZ2iY9ZWZ5fnOJirRNGEP1s3PFinemUqOMBhjXXWSYy8sQZvpAfHpZp8ZMsnHNbQyKVMz3ooP61iSI-5GowzTPiLWEVuwvAz_AEI9HInNQMAAA==) — without this PR, it chokes on the `color` change (yes, this effect could obviously be done with just CSS but you get the idea)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
