### PR TITLE
fix: account for parent scale when animating elements

### DIFF
--- a/.changeset/long-weeks-brush.md
+++ b/.changeset/long-weeks-brush.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: account for parent scale when animating elements

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -11,26 +11,36 @@ import { cubicOut } from '../easing/index.js';
  * @returns {AnimationConfig}
  */
 export function flip(node, { from, to }, params = {}) {
-	var style = getComputedStyle(node);
-	var zoom = get_zoom(node); // https://drafts.csswg.org/css-viewport/#effective-zoom
+	var { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
 
+	var style = getComputedStyle(node);
+
+	// find the transform origin, expressed as a pair of values between 0 and 1
 	var transform = style.transform === 'none' ? '' : style.transform;
 	var [ox, oy] = style.transformOrigin.split(' ').map(parseFloat);
-	var dsx = from.width / to.width;
-	var dsy = from.height / to.height;
-
 	ox /= node.clientWidth;
 	oy /= node.clientHeight;
 
-	var fromx = from.left + from.width * ox;
-	var tox = to.left + to.width * ox;
+	// calculate effect of parent transforms and zoom
+	var zoom = get_zoom(node); // https://drafts.csswg.org/css-viewport/#effective-zoom
+	var sx = node.clientWidth / to.width / zoom;
+	var sy = node.clientHeight / to.height / zoom;
 
-	var fromy = from.top + from.height * oy;
-	var toy = to.top + to.height * oy;
+	// find the starting position of the transform origin
+	var fx = from.left + from.width * ox;
+	var fy = from.top + from.height * oy;
 
-	var dx = ((fromx - tox) * (node.clientWidth / to.width)) / zoom;
-	var dy = ((fromy - toy) * (node.clientHeight / to.height)) / zoom;
-	var { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
+	// find the ending position of the transform origin
+	var tx = to.left + to.width * ox;
+	var ty = to.top + to.height * oy;
+
+	// find the translation at the start of the transform
+	var dx = (fx - tx) * sx;
+	var dy = (fy - ty) * sy;
+
+	// find the relative scale at the start of the transform
+	var dsx = from.width / to.width;
+	var dsy = from.height / to.height;
 
 	return {
 		delay,

--- a/packages/svelte/src/animate/index.js
+++ b/packages/svelte/src/animate/index.js
@@ -19,8 +19,17 @@ export function flip(node, { from, to }, params = {}) {
 	var dsx = from.width / to.width;
 	var dsy = from.height / to.height;
 
-	var dx = (from.left + dsx * ox - (to.left + ox)) / zoom;
-	var dy = (from.top + dsy * oy - (to.top + oy)) / zoom;
+	ox /= node.clientWidth;
+	oy /= node.clientHeight;
+
+	var fromx = from.left + from.width * ox;
+	var tox = to.left + to.width * ox;
+
+	var fromy = from.top + from.height * oy;
+	var toy = to.top + to.height * oy;
+
+	var dx = ((fromx - tox) * (node.clientWidth / to.width)) / zoom;
+	var dy = ((fromy - toy) * (node.clientHeight / to.height)) / zoom;
 	var { delay = 0, duration = (d) => Math.sqrt(d) * 120, easing = cubicOut } = params;
 
 	return {
@@ -32,7 +41,8 @@ export function flip(node, { from, to }, params = {}) {
 			var y = u * dy;
 			var sx = t + u * dsx;
 			var sy = t + u * dsy;
-			return `transform: ${transform} scale(${sx}, ${sy}) translate(${x}px, ${y}px);`;
+
+			return `transform: ${transform} translate(${x}px, ${y}px) scale(${sx}, ${sy});`;
 		}
 	};
 }


### PR DESCRIPTION
Supersedes #7207, closes #7205, and attempts to make the logic slightly easier to follow (this damn near broke my brain)

- [5.17.0](https://svelte.dev/playground/d6d27cd6b789451085fe894fb15f9ef1?version=5.17.0)
- [this PR](https://svelte.dev/playground/d6d27cd6b789451085fe894fb15f9ef1?version=pr-14957)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
