### PR TITLE
fix: properly add owners to function bindings

### DIFF
--- a/.changeset/yellow-dodos-smell.md
+++ b/.changeset/yellow-dodos-smell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: properly add owners to function bindings

--- a/packages/svelte/tests/runtime-runes/samples/ownership-function-bindings/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-function-bindings/Child.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { arr = $bindable() } = $props();
+</script>
+
+<button onclick={() => arr.push(arr.length)}></button>

--- a/packages/svelte/tests/runtime-runes/samples/ownership-function-bindings/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-function-bindings/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+	test({ target, warnings, assert }) {
+		const btn = target.querySelector('button');
+		flushSync(() => {
+			btn?.click();
+		});
+		assert.deepEqual(warnings, []);
+
+		flushSync(() => {
+			btn?.click();
+		});
+		assert.deepEqual(warnings, []);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/ownership-function-bindings/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-function-bindings/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Child from './Child.svelte';
+	
+	let arr = $state([]);
+	let arr2 = $state([]);
+
+	let len = $derived(arr.length + arr2.length);
+</script>
+
+<Child bind:arr={() => len % 2 === 0 ? arr : arr2, (v) => {}} />


### PR DESCRIPTION
Closes #14956 

The ownership stuff was specifically guarded against the `SequenceExpression` so i'm not sure if this is has any downside but for the moment let's open the PR so we can eventually discuss. I've added the owner to every stateful identifier in the `get` function only since that's the only part the child component could mutate in some way (i wonder if we should actually just consider the identifiers returned from the function instead of every identifier).

Also also i discovered that we were adding the same identifier multiple times in situations like this

```svelte
<Component bind:arr={arr} bind:arr2={arr} />
```

there were two `add_owner_effect`'s added which is wasteful. I did that fix in a separate commit so if we decide against this change we can always merge revert it and merge the fix for multiple effects separately.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
