### PR TITLE
fix: wrap each block expression in derived to encapsulte effects

### DIFF
--- a/.changeset/tender-apples-scream.md
+++ b/.changeset/tender-apples-scream.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: wrap each block expression in derived to encapsulte effects

--- a/.changeset/tender-apples-scream.md
+++ b/.changeset/tender-apples-scream.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: wrap each block expression in derived to encapsulte effects
+fix: wrap each block expression in derived to encapsulate effects

--- a/packages/svelte/tests/runtime-runes/samples/each-updates-9/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-updates-9/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn1] = target.querySelectorAll('button');
+
+		btn1.click();
+		flushSync();
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.deepEqual(logs, ['cleanup']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-updates-9/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-updates-9/main.svelte
@@ -1,0 +1,46 @@
+<script>
+	import { createSubscriber } from 'svelte/reactivity';
+
+	class MyStore {
+		#subscribe;
+		#data = $state([
+			['a', [1, 2]],
+			['b', [3, 4]]
+		]);
+		#id;
+
+		constructor(options) {
+			options?.someBoolean;
+			this.#id = options?.id;
+			this.#subscribe = createSubscriber(() => {
+				debugger
+				return () => {
+					console.log('cleanup');
+				};
+			});
+		}
+
+		get data() {
+			this.#subscribe();
+			return this.#data;
+		}
+		set data(v) {
+			this.#data = v;
+		}
+	}
+
+	let storeOptions = $state({
+		someBoolean: false,
+		id: 0
+	});
+
+	let myStore = $derived(new MyStore(storeOptions));
+</script>
+
+<button
+	onclick={() => {
+		storeOptions.someBoolean = !storeOptions.someBoolean;
+	}}>+</button
+>
+
+{#each myStore.data as _}{/each}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14961. 

[We have logic in the each block today](https://github.com/sveltejs/svelte/blob/main/packages/svelte/src/internal/client/dom/blocks/each.js#L478-L479) that assumes that the child effects of an each block effect are always the entries of the each block. This is not correct – as the expression used to get the collection for the each block might also create its own effects. Previously, we'd override the effects created from `get_collection` and it would cause a bunch of issues.

To avoid this, we can wrap the collection expression in a derived that enables us to instead put the effects associated with that collection with the derived rather than the each block effect.