### PR TITLE
fix: store access on component destroy

### DIFF
--- a/.changeset/hot-kings-shout.md
+++ b/.changeset/hot-kings-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: store access on component destroy

--- a/packages/svelte/tests/runtime-runes/samples/store-update-on-destroy/Test.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-update-on-destroy/Test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	const { store } = $props();
+
+	$effect(() => {
+		$store;
+		return () => {
+			console.log($store);
+			$store++;
+			console.log($store);
+		};
+	});
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/store-update-on-destroy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/store-update-on-destroy/_config.js
@@ -1,0 +1,12 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const input = target.querySelector('input');
+		flushSync(() => {
+			input?.click();
+		});
+		assert.deepEqual(logs, [0, 1]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/store-update-on-destroy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/store-update-on-destroy/main.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { writable } from 'svelte/store';
+
+	import Test from './Test.svelte';
+
+	let store = writable(0);
+
+	let checked = $state(true);
+</script>
+
+<input type="checkbox" bind:checked />
+
+{#if checked}
+	<Test {store} />
+{/if}


### PR DESCRIPTION
Closes #14950 

While working on this initially with @oscard0m i actually found out of a separate bug, a memory leak: basically if you did something like this

```svelte
<script>
    let { store } = $props();

    $effect(()=>{
        return ()=>{
            $store;
        }
    });
</script>
```
the store was accessed for the first time after the teardown of the stores executed. So a new subscription was created for the store that generally would've been cleaned up by the teardown but since it already ran it was stuck in memory.

This was even worse for stuff that was accessed on component destroy asynchronously.

This solution does two things:

1. the `setup_stores` function doesn't register the `teardown` immediately but returns a function that does that. This function is called after `pop` so that register even after every user effect.
2. now that we know that the teardown will be executed last, on teardown uses the `stores` variable as a way of communication...it register a symbol on it so that inside `get_store` we can check if the component was already unmounted and, in that case, it prevents the creation of a subscription in the store while at the same time accessing the store with `get` from `svelte/store`, less efficient but more consistent (the bug we are closing was about the consistency of the read) and not leaky. Furthermore this will only really happen when someone is accessing stuff after the component unmounts so should not be a problem.

I didn't found a way to test the memory leak but if you have ideas it could be good to add.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
