### PR TITLE
fix: ensure signal write invalidation within effects is consistent

### DIFF
--- a/.changeset/tricky-spiders-collect.md
+++ b/.changeset/tricky-spiders-collect.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure signal write invalidation within effects is persistent

--- a/.changeset/tricky-spiders-collect.md
+++ b/.changeset/tricky-spiders-collect.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure signal write invalidation within effects is persistent
+fix: ensure signal write invalidation within effects is consistent

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -29,7 +29,8 @@ import {
 	INSPECT_EFFECT,
 	UNOWNED,
 	MAYBE_DIRTY,
-	BLOCK_EFFECT
+	BLOCK_EFFECT,
+	ROOT_EFFECT
 } from '../constants.js';
 import * as e from '../errors.js';
 import { legacy_mode_flag, tracing_mode_flag } from '../../flags/index.js';
@@ -191,17 +192,13 @@ export function internal_set(source, value) {
 			is_runes() &&
 			active_effect !== null &&
 			(active_effect.f & CLEAN) !== 0 &&
-			(active_effect.f & BRANCH_EFFECT) === 0
+			(active_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0
 		) {
-			if (new_deps !== null && new_deps.includes(source)) {
-				set_signal_status(active_effect, DIRTY);
-				schedule_effect(active_effect);
+
+			if (untracked_writes === null) {
+				set_untracked_writes([source]);
 			} else {
-				if (untracked_writes === null) {
-					set_untracked_writes([source]);
-				} else {
-					untracked_writes.push(source);
-				}
+				untracked_writes.push(source);
 			}
 		}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -383,6 +383,34 @@ export function handle_error(error, effect, previous_effect, component_context) 
 }
 
 /**
+ * @param {Value} signal
+ * @param {Effect} effect
+ * @param {number} [depth]
+ */
+function schedule_possible_effect_self_invalidation(signal, effect, depth = 0) {
+	var reactions = signal.reactions;
+	if (reactions === null) return;
+
+	for (var i = 0; i < reactions.length; i++) {
+		var reaction = reactions[i];
+		if ((reaction.f & DERIVED) !== 0) {
+			schedule_possible_effect_self_invalidation(
+				/** @type {Derived} */ (reaction),
+				effect,
+				depth + 1
+			);
+		} else if (effect === reaction) {
+			if (depth === 0) {
+				set_signal_status(reaction, DIRTY);
+			} else if ((reaction.f & CLEAN) !== 0) {
+				set_signal_status(reaction, MAYBE_DIRTY);
+			}
+			schedule_effect(/** @type {Effect} */ (reaction));
+		}
+	}
+}
+
+/**
  * @template V
  * @param {Reaction} reaction
  * @returns {V}
@@ -432,6 +460,18 @@ export function update_reaction(reaction) {
 		} else if (deps !== null && skipped_deps < deps.length) {
 			remove_reactions(reaction, skipped_deps);
 			deps.length = skipped_deps;
+		}
+
+		// If we're inside an effect and we have untracked writes, then we need to
+		// ensure that if any of those untracked writes result in re-invalidation
+		// of the current effect, then we need to re-schedule the current effect
+		if (untracked_writes !== null && (reaction.f & (DERIVED | MAYBE_DIRTY | DIRTY)) === 0) {
+			for (i = 0; i < /** @type {Source[]} */ (untracked_writes).length; i++) {
+				schedule_possible_effect_self_invalidation(
+					untracked_writes[i],
+					/** @type {Effect} */ (reaction)
+				);
+			}
 		}
 
 		// If we are returning to an previous reaction then
@@ -906,17 +946,6 @@ export function get(signal) {
 				new_deps = [signal];
 			} else {
 				new_deps.push(signal);
-			}
-
-			if (
-				untracked_writes !== null &&
-				active_effect !== null &&
-				(active_effect.f & CLEAN) !== 0 &&
-				(active_effect.f & BRANCH_EFFECT) === 0 &&
-				untracked_writes.includes(signal)
-			) {
-				set_signal_status(active_effect, DIRTY);
-				schedule_effect(active_effect);
 			}
 		}
 	} else if (is_derived && /** @type {Derived} */ (signal).deps === null) {

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -402,6 +402,43 @@ describe('signals', () => {
 		};
 	});
 
+	test('schedules rerun when writing to signal before reading it from derived', (runes) => {
+		if (!runes) return () => {};
+		let log: any[] = [];
+
+		const value = state(1);
+		const double = derived(() => $.get(value) * 2);
+
+		user_effect(() => {
+			set(value, 10);
+			log.push($.get(double));
+			set(value, 10);
+		});
+
+		return () => {
+			flushSync();
+			assert.deepEqual(log, [20]);
+		};
+	});
+
+	test('schedules rerun when writing to signal after reading it from derived', (runes) => {
+		if (!runes) return () => {};
+		let log: any[] = [];
+
+		const value = state(1);
+		const double = derived(() => $.get(value) * 2);
+
+		user_effect(() => {
+			log.push($.get(double));
+			set(value, 10);
+		});
+
+		return () => {
+			flushSync();
+			assert.deepEqual(log, [2, 20]);
+		};
+	});
+
 	test('effect teardown is removed on re-run', () => {
 		const count = state(0);
 		let first = true;


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/14976.

The existing logic for handling writes within effects was a bit ancient before we updated the whole system a while ago. Thus it wasn't always consistent. This PR changes that by ensuring we do the consistent update after the reaction has run for an effect.