### PR TITLE
fix: don't run each array expression more often than necessary

### DIFF
--- a/.changeset/tidy-months-rush.md
+++ b/.changeset/tidy-months-rush.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't run each array expression more often than necessary


### PR DESCRIPTION
closes #14991 - at least to the extent possible

Also adjusts a comment which a) did not hint at why it's needed in the first place (was added in #14967) b) sounded like we could change that in the future, but we can't, because people will always have the ability to trigger reactivity through other means without changing the array reference

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
