### PR TITLE
fix: ensure resume effects are scheduled in topological order

### DIFF
--- a/.changeset/lemon-llamas-reflect.md
+++ b/.changeset/lemon-llamas-reflect.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure resume effects are scheduled in topological order

--- a/packages/svelte/tests/runtime-runes/samples/transition-each-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/transition-each-4/_config.js
@@ -1,0 +1,35 @@
+import { flushSync } from '../../../../src/index-client.js';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, raf, target, logs }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>Toggle</button><div><div>1</div><div>2</div><div>3</div></div>'
+		);
+
+		const btn1 = target.querySelector('button');
+		btn1?.click();
+		flushSync();
+		raf.tick(250);
+
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>Toggle</button><div style="opacity: 0.5;"><div>1</div><div>2</div><div>3</div></div>'
+		);
+
+		logs.length = 0;
+
+		await Promise.resolve();
+
+		flushSync();
+		raf.tick(500);
+
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>Toggle</button><div style=""><div>3</div><div>4</div></div>'
+		);
+
+		assert.deepEqual(logs, ['$effect.pre', '$effect.pre', '$effect', '$effect'])
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/transition-each-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/transition-each-4/_config.js
@@ -30,6 +30,6 @@ export default test({
 			'<button>Toggle</button><div style=""><div>3</div><div>4</div></div>'
 		);
 
-		assert.deepEqual(logs, ['$effect.pre', '$effect.pre', '$effect', '$effect'])
+		assert.deepEqual(logs, ['$effect.pre', '$effect.pre', '$effect', '$effect']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/transition-each-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/transition-each-4/main.svelte
@@ -1,0 +1,39 @@
+<script>
+	function fade(_) {
+		return {
+			duration: 500,
+			css: t => `opacity: ${t}`,
+		}
+	}
+
+	let toggle = $state(true);
+	let items = $state([ 1, 2, 3 ]);
+
+	const handle_toggle = async () => {
+		toggle = false;
+		await Promise.resolve();
+		items = [3, 4];
+		toggle = true;
+	};
+</script>
+
+<button onclick={handle_toggle}>Toggle</button>
+
+{#if toggle}
+	<div transition:fade>
+		{#each items as item (item)}
+		{(() => {
+			$effect(() => {
+				items;
+				console.log('$effect');
+			});
+
+			$effect.pre(() => {
+				items;
+				console.log('$effect.pre');
+			});
+		})()}
+			<div>{item}</div>
+		{/each}
+	</div>
+{/if}


### PR DESCRIPTION
This has been on my radar for a while now, and the fix became obvious today. When we resume children on an effect tree, we need to execute any of the stale effects that are dirty. We should be scheduling effects rather than just running them sync – otherwise we don't the correct topological ordering.