### PR TITLE
fix: don't hoist snippets with `bind:group`

### DIFF
--- a/.changeset/lazy-carrots-fry.md
+++ b/.changeset/lazy-carrots-fry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't hoist snippets with `bind:group`

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -391,7 +391,7 @@ function open(parser) {
 			parameters: function_expression.params,
 			body: create_fragment(),
 			metadata: {
-				can_hoist: false,
+				can_hoist: undefined,
 				sites: new Set()
 			}
 		});

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/BindDirective.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/BindDirective.js
@@ -199,6 +199,12 @@ export function BindDirective(node, context) {
 			throw new Error('Cannot find declaration for bind:group');
 		}
 
+		const snippet_parent = context.path.find((parent) => parent.type === 'SnippetBlock');
+
+		if (snippet_parent) {
+			snippet_parent.metadata.can_hoist = false;
+		}
+
 		// Traverse the path upwards and find all EachBlocks who are (indirectly) contributing to bind:group,
 		// i.e. one of their declarations is referenced in the binding. This allows group bindings to work
 		// correctly when referencing a variable declared in an EachBlock by using the index of the each block

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SnippetBlock.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SnippetBlock.js
@@ -42,7 +42,8 @@ export function SnippetBlock(node, context) {
 		}
 	}
 
-	node.metadata.can_hoist = can_hoist;
+	node.metadata.can_hoist =
+		node.metadata.can_hoist != null ? node.metadata.can_hoist && can_hoist : can_hoist;
 
 	const { path } = context;
 	const parent = path.at(-2);

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -463,7 +463,7 @@ export namespace AST {
 		body: Fragment;
 		/** @internal */
 		metadata: {
-			can_hoist: boolean;
+			can_hoist?: boolean;
 			/** The set of components/render tags that could render this snippet,
 			 * used for CSS pruning */
 			sites: Set<Component | SvelteComponent | SvelteSelf | RenderTag>;

--- a/packages/svelte/tests/runtime-runes/samples/bind-group-non-hoistable-snippet/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-group-non-hoistable-snippet/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const [radio1, radio2] = target.querySelectorAll('input');
+		const p = target.querySelector('p');
+
+		assert.equal(p?.innerHTML, '');
+		flushSync(() => {
+			radio1.click();
+		});
+		assert.equal(p?.innerHTML, 'cool');
+		flushSync(() => {
+			radio2.click();
+		});
+		assert.equal(p?.innerHTML, 'cooler');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bind-group-non-hoistable-snippet/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-group-non-hoistable-snippet/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let group = $state({ selected: undefined });
+</script>
+
+{#snippet radio(group, value)}
+	<input type="radio" bind:group={group.selected} {value}/>
+{/snippet}
+
+{@render radio(group, "cool")}
+{@render radio(group, "cooler")}
+
+<p>{group.selected}</p>


### PR DESCRIPTION
Closes #15037

This is a bit of weird one...the point is that the snippet was technically not accessing anything from the instance so it was hoisted but it was using `bind:group` so it needed the `binding_group`...i tried to think it it make sense to export a snippet with a bind group but i don't think it does (especially since we specify in the docs that for `bind:group` to work inputs needs to be in the same component) and i don't even think we could do it because even if we would accept the `binding_group` as an argument for the snippet a component that renders that snippet should know that it needs a `binding_group` in some way and i don't think it's doable.

However while trying to come up with various situations where the snippet could've been exported i noticed that we can technically "kinda" export snippets by passing them as prop. So a user could do something like this

`App.svelte`
```svelte
<script>
    import Component from "./Component.svelte";
</script>

{#snippet radio(group, value)}
    <input type="radio", bind:group={group.selected} {value} />
{/snippet}

<Component {radio} />
<Component {radio} />
```

`Component.svelte`
```svelte
<script>
    let { radio } = $props();
    let group = $state({ selected: undefined });
</script>

{@render radio(group, "A")}
{@render radio(group, "B")}
```

this is a bit weird because now `App` has the `binding_group` array but the `state` is inside `Component`. So i was wondering...should we disallow `bind:group` in snippets all togheter? Technically we can't do it now since it would be a breaking change but i wonder if we should do something about this weirdness.
 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`