### PR TITLE
fix: create fewer deriveds for concatenated strings

### DIFF
--- a/.changeset/rich-donkeys-wink.md
+++ b/.changeset/rich-donkeys-wink.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: create fewer deriveds for concatenated strings

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -48,7 +48,7 @@ export function build_template_chunk(values, visit, state) {
 			}
 		} else {
 			if (node.metadata.expression.has_call && contains_multiple_call_expression) {
-				const id = b.id(state.scope.generate('stringified_text'));
+				const id = b.id(state.scope.generate('expression'));
 				state.init.push(
 					b.const(
 						id,

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -47,7 +47,7 @@ export function build_template_chunk(values, visit, state) {
 				quasi.value.cooked += node.expression.value + '';
 			}
 		} else {
-			if (contains_multiple_call_expression) {
+			if (node.metadata.expression.has_call && contains_multiple_call_expression) {
 				const id = b.id(state.scope.generate('stringified_text'));
 				state.init.push(
 					b.const(

--- a/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/client/index.svelte.js
@@ -16,11 +16,11 @@ export default function Text_nodes_deriveds($$anchor) {
 	}
 
 	var p = root();
-	const stringified_text = $.derived(() => text1() ?? '');
-	const stringified_text_1 = $.derived(() => text2() ?? '');
+	const expression = $.derived(() => text1() ?? '');
+	const expression_1 = $.derived(() => text2() ?? '');
 	var text = $.child(p);
 
-	$.template_effect(() => $.set_text(text, `${$.get(stringified_text)}${$.get(stringified_text_1)}`));
+	$.template_effect(() => $.set_text(text, `${$.get(expression)}${$.get(expression_1)}`));
 	$.reset(p);
 	$.append($$anchor, p);
 }


### PR DESCRIPTION
When dealing with things like this, where a text node's value involves multiple expressions involving function calls...

```svelte
<p>{one()} + {two()} + {three} = {one() + two() + three}</p>
```

...we create deriveds for the expressions to avoid (for example) recalculating `{two()}` when only `one` changed.

But we take it a bit too far — we also create an unnecessary derived for `{three}`. This fixes it. It also renames the very strange 'stringified_text' (what next, a numberfied number?) to 'expression'