### PR TITLE
chore: improve compiler dependency resolution

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
@@ -64,6 +64,9 @@ export function Attribute(node, context) {
 
 			node.metadata.expression.has_state ||= chunk.metadata.expression.has_state;
 			node.metadata.expression.has_call ||= chunk.metadata.expression.has_call;
+			chunk.metadata.expression.dependencies.forEach((dependency) =>
+				node.metadata.expression.dependencies.add(dependency)
+			);
 		}
 
 		if (is_event_attribute(node)) {


### PR DESCRIPTION
This means that we pass the `dependencies` through to the `Attribute`, otherwise it's always empty and useless.