### PR TITLE
fix: omit unnecessary nullish coallescing in template expressions

### DIFF
--- a/.changeset/cuddly-walls-pretend.md
+++ b/.changeset/cuddly-walls-pretend.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: omit unnecessary nullish coallescing in template expressions

--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_config.js
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/client/index.svelte.js
@@ -1,0 +1,34 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var on_click = (_, count) => $.update(count);
+var root = $.template(`<h1></h1> <b></b> <button> </button> <h1></h1>`, 1);
+
+export default function Nullish_coallescence_omittance($$anchor) {
+	let name = 'world';
+	let count = $.state(0);
+	var fragment = root();
+	var h1 = $.first_child(fragment);
+
+	h1.textContent = `Hello, ${name ?? ''}!`;
+
+	var b = $.sibling(h1, 2);
+
+	b.textContent = `${1 ?? 'stuff'}${2 ?? 'more stuff'}${3 ?? 'even more stuff'}`;
+
+	var button = $.sibling(b, 2);
+
+	button.__click = [on_click, count];
+
+	var text = $.child(button);
+
+	$.reset(button);
+
+	var h1_1 = $.sibling(button, 2);
+
+	h1_1.textContent = `Hello, ${name ?? 'earth' ?? ''}`;
+	$.template_effect(() => $.set_text(text, `Count is ${$.get(count) ?? ''}`));
+	$.append($$anchor, fragment);
+}
+
+$.delegate(['click']);

--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/server/index.svelte.js
@@ -1,0 +1,8 @@
+import * as $ from 'svelte/internal/server';
+
+export default function Nullish_coallescence_omittance($$payload) {
+	let name = 'world';
+	let count = 0;
+
+	$$payload.out += `<h1>Hello, ${$.escape(name)}!</h1> <b>${$.escape(1 ?? 'stuff')}${$.escape(2 ?? 'more stuff')}${$.escape(3 ?? 'even more stuff')}</b> <button>Count is ${$.escape(count)}</button> <h1>Hello, ${$.escape(name ?? 'earth' ?? null)}</h1>`;
+}

--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/index.svelte
@@ -1,0 +1,8 @@
+<script>
+    let name = 'world';
+    let count = $state(0);
+</script>
+<h1>Hello, {null}{name}!</h1>
+<b>{1 ?? 'stuff'}{2 ?? 'more stuff'}{3 ?? 'even more stuff'}</b>
+<button onclick={()=>count++}>Count is {count}</button>
+<h1>Hello, {name ?? 'earth' ?? null}</h1>


### PR DESCRIPTION
Currently, Svelte will almost always append a nullish coallescence statement (`maybeNullish ?? alternate`) to any interpolations in a template expression, regardless of whether there already is one. This changes that, so that nullish coallescence to a non-null literal will stay the same, and in `stuff ?? null` cases, `null` is replaced with an empty string. 
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
