### PR TITLE
fix: only call `onchange` once for array mutations

### DIFF
--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -170,13 +170,13 @@ export function proxy(value, options, parent = null, prev) {
 				return v === UNINITIALIZED ? undefined : v;
 			}
 
-			const value = Reflect.get(target, prop, receiver);
+			v = Reflect.get(target, prop, receiver);
 
 			if (is_proxied_array && array_methods.includes(/** @type {string} */ (prop))) {
-				return batch_onchange(value);
+				return batch_onchange(v);
 			}
 
-			return value;
+			return v;
 		},
 
 		getOwnPropertyDescriptor(target, prop) {

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -9,7 +9,7 @@ import {
 	object_prototype
 } from '../shared/utils.js';
 import { check_ownership, widen_ownership } from './dev/ownership.js';
-import { source, set, state, set_call_onchange } from './reactivity/sources.js';
+import { source, set, state, batch_onchange } from './reactivity/sources.js';
 import { STATE_SYMBOL, STATE_SYMBOL_METADATA } from './constants.js';
 import { UNINITIALIZED } from '../../constants.js';
 import * as e from './errors.js';
@@ -173,16 +173,7 @@ export function proxy(value, options, parent = null, prev) {
 			const value = Reflect.get(target, prop, receiver);
 
 			if (is_proxied_array && array_methods.includes(/** @type {string} */ (prop))) {
-				// @ts-expect-error
-				return (...args) => {
-					set_call_onchange(false);
-					const result = value.apply(receiver, args);
-					set_call_onchange(true);
-
-					options?.onchange?.();
-
-					return result;
-				};
+				return batch_onchange(value);
 			}
 
 			return value;

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -45,6 +45,13 @@ export function set_inspect_effects(v) {
 	inspect_effects = v;
 }
 
+let call_onchange = true;
+
+/** @param {boolean} v */
+export function set_call_onchange(v) {
+	call_onchange = v;
+}
+
 /**
  * @template V
  * @param {V} v
@@ -191,7 +198,10 @@ export function internal_set(source, value) {
 		var old_value = source.v;
 		source.v = value;
 		source.wv = increment_write_version();
-		untrack(() => source.o?.onchange?.());
+
+		if (call_onchange) {
+			untrack(() => source.o?.onchange?.());
+		}
 
 		if (DEV && tracing_mode_flag) {
 			source.updated = get_stack('UpdatedAt');


### PR DESCRIPTION
small addition to #15069 — only call `onchange` once for array mutations

- [#15069](https://svelte.dev/playground/hello-world?version=pr-15069#H4sIAAAAAAAAE41RS07DMBC9ymAh1VaTtAFWJUnFjju0XbjptDEYO7InBRTl7thNKlggxMrW-_l5pmdGviFbsWfU2sK7dfoAHA-K8CBYwo5Ko2erTc_os426CAR8cj21bebPqClie-nxN7y2htBQiGGFr51qqdqaLWkkqBtpTuihhFtPkpAvxWPkrrx07pvbLBPIE7hL4D6Bh10C_UVK1owxXEzAlsKT3mrMtD3x0Z15I1vfWOIhU0yvROXUYF5CPoFDPIYoKRbffU1xk6aAsm7AHoEa9Aghrwvzcug7TaAMSPDKnDROH4M0DdZi31EoCaGnVvVr2XMBZRX_lrWdb3hslEniaS5gvYalgDnkYqgiWSxG898xvlFH4sFyufzP4_CMzuPFZd1PU7C1VR81L1YZPktgJoZi0VYjMU1suC4vMmHLhB_EVuQ6HHbDF_eYNblXAgAA)
- [this PR](https://svelte.dev/playground/hello-world?version=pr-15073#H4sIAAAAAAAAE41RS07DMBC9ymAh1VaTtAFWJUnFjju0XbjptDEYO7InBRTl7thNKlggxMrW-_l5pmdGviFbsWfU2sK7dfoAHA-K8CBYwo5Ko2erTc_os426CAR8cj21bebPqClie-nxN7y2htBQiGGFr51qqdqaLWkkqBtpTuihhFtPkpAvxWPkrrx07pvbLBPIE7hL4D6Bh10C_UVK1owxXEzAlsKT3mrMtD3x0Z15I1vfWOIhU0yvROXUYF5CPoFDPIYoKRbffU1xk6aAsm7AHoEa9Aghrwvzcug7TaAMSPDKnDROH4M0DdZi31EoCaGnVvVr2XMBZRX_lrWdb3hslEniaS5gvYalgDnkYqgiWSxG898xvlFH4sFyufzP4_CMzuPFZd1PU7C1VR81L1YZPktgJoZi0VYjMU1suC4vMmHLhB_EVuQ6HHbDF_eYNblXAgAA)

This isn't just about avoiding unnecessary work — it's about correctness. Without something like this, the callback will fire when the array mutation is incomplete, which could lead to all sorts of bad things.

I _thought_ we were already doing something like this in the context of `$inspect`, but it turns out we weren't. Perhaps we should?