### PR TITLE
fix: correctly handle `novalidate` attribute casing

### DIFF
--- a/.changeset/pink-wolves-search.md
+++ b/.changeset/pink-wolves-search.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly handle `novalidate` attribute casing

--- a/packages/svelte/src/utils.js
+++ b/packages/svelte/src/utils.js
@@ -196,7 +196,8 @@ const ATTRIBUTE_ALIASES = {
 	readonly: 'readOnly',
 	defaultvalue: 'defaultValue',
 	defaultchecked: 'defaultChecked',
-	srcobject: 'srcObject'
+	srcobject: 'srcObject',
+	novalidate: 'noValidate'
 };
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/form-novalidate-casing/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/form-novalidate-casing/_config.js
@@ -1,7 +1,7 @@
 import { test } from '../../test';
 
 export default test({
-  html: `
+	html: `
 		<form novalidate></form>
 		<form novalidate></form>
 `

--- a/packages/svelte/tests/runtime-runes/samples/form-novalidate-casing/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/form-novalidate-casing/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+  html: `
+		<form novalidate></form>
+		<form novalidate></form>
+`
+});

--- a/packages/svelte/tests/runtime-runes/samples/form-novalidate-casing/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/form-novalidate-casing/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let noValidate = $state(true);
+</script>
+
+<form novalidate={true}></form>
+<form {noValidate}></form>


### PR DESCRIPTION
This PR fixes #15082 by correctly handling the HTML element `novalidate` attribute casing through `noValidate` DOM property mapping.
