### PR TITLE
fix: avoid double deriveds in component props

### DIFF
--- a/.changeset/tasty-pigs-greet.md
+++ b/.changeset/tasty-pigs-greet.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid double deriveds in component props

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -270,41 +270,6 @@ export function should_proxy(node, scope) {
 }
 
 /**
- * @param {Pattern} node
- * @param {import('zimmerframe').Context<AST.SvelteNode, ComponentClientTransformState>} context
- * @returns {{ id: Pattern, declarations: null | Statement[] }}
- */
-export function create_derived_block_argument(node, context) {
-	if (node.type === 'Identifier') {
-		context.state.transform[node.name] = { read: get_value };
-		return { id: node, declarations: null };
-	}
-
-	const pattern = /** @type {Pattern} */ (context.visit(node));
-	const identifiers = extract_identifiers(node);
-
-	const id = b.id('$$source');
-	const value = b.id('$$value');
-
-	const block = b.block([
-		b.var(pattern, b.call('$.get', id)),
-		b.return(b.object(identifiers.map((identifier) => b.prop('init', identifier, identifier))))
-	]);
-
-	const declarations = [b.var(value, create_derived(context.state, b.thunk(block)))];
-
-	for (const id of identifiers) {
-		context.state.transform[id.name] = { read: get_value };
-
-		declarations.push(
-			b.var(id, create_derived(context.state, b.thunk(b.member(b.call('$.get', value), id))))
-		);
-	}
-
-	return { id, declarations };
-}
-
-/**
  * Svelte legacy mode should use safe equals in most places, runes mode shouldn't
  * @param {ComponentClientTransformState} state
  * @param {Expression} arg

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitBlock.js
@@ -1,8 +1,10 @@
 /** @import { BlockStatement, Expression, Pattern, Statement } from 'estree' */
 /** @import { AST } from '#compiler' */
-/** @import { ComponentContext } from '../types' */
+/** @import { ComponentClientTransformState, ComponentContext } from '../types' */
+import { extract_identifiers } from '../../../../utils/ast.js';
 import * as b from '../../../../utils/builders.js';
-import { create_derived_block_argument } from '../utils.js';
+import { create_derived } from '../utils.js';
+import { get_value } from './shared/declarations.js';
 
 /**
  * @param {AST.AwaitBlock} node
@@ -64,4 +66,39 @@ export function AwaitBlock(node, context) {
 			)
 		)
 	);
+}
+
+/**
+ * @param {Pattern} node
+ * @param {import('zimmerframe').Context<AST.SvelteNode, ComponentClientTransformState>} context
+ * @returns {{ id: Pattern, declarations: null | Statement[] }}
+ */
+function create_derived_block_argument(node, context) {
+	if (node.type === 'Identifier') {
+		context.state.transform[node.name] = { read: get_value };
+		return { id: node, declarations: null };
+	}
+
+	const pattern = /** @type {Pattern} */ (context.visit(node));
+	const identifiers = extract_identifiers(node);
+
+	const id = b.id('$$source');
+	const value = b.id('$$value');
+
+	const block = b.block([
+		b.var(pattern, b.call('$.get', id)),
+		b.return(b.object(identifiers.map((identifier) => b.prop('init', identifier, identifier))))
+	]);
+
+	const declarations = [b.var(value, create_derived(context.state, b.thunk(block)))];
+
+	for (const id of identifiers) {
+		context.state.transform[id.name] = { read: get_value };
+
+		declarations.push(
+			b.var(id, create_derived(context.state, b.thunk(b.member(b.call('$.get', value), id))))
+		);
+	}
+
+	return { id, declarations };
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -537,8 +537,8 @@ function build_element_attribute_update_assignment(
 	const is_svg = context.state.metadata.namespace === 'svg' || element.name === 'svg';
 	const is_mathml = context.state.metadata.namespace === 'mathml';
 
-	let { value, has_state } = build_attribute_value(attribute.value, context, (value) =>
-		get_expression_id(state, value)
+	let { value, has_state } = build_attribute_value(attribute.value, context, (value, metadata) =>
+		metadata.has_call ? get_expression_id(state, value) : value
 	);
 
 	if (name === 'autofocus') {
@@ -665,8 +665,8 @@ function build_custom_element_attribute_update_assignment(node_id, attribute, co
  */
 function build_element_special_value_attribute(element, node_id, attribute, context) {
 	const state = context.state;
-	const { value, has_state } = build_attribute_value(attribute.value, context, (value) =>
-		get_expression_id(state, value)
+	const { value, has_state } = build_attribute_value(attribute.value, context, (value, metadata) =>
+		metadata.has_call ? get_expression_id(state, value) : value
 	);
 
 	const inner_assignment = b.assignment(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SlotElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SlotElement.js
@@ -30,8 +30,10 @@ export function SlotElement(node, context) {
 		if (attribute.type === 'SpreadAttribute') {
 			spreads.push(b.thunk(/** @type {Expression} */ (context.visit(attribute))));
 		} else if (attribute.type === 'Attribute') {
-			const { value, has_state } = build_attribute_value(attribute.value, context, (value) =>
-				memoize_expression(context.state, value)
+			const { value, has_state } = build_attribute_value(
+				attribute.value,
+				context,
+				(value, metadata) => (metadata.has_call ? memoize_expression(context.state, value) : value)
 			);
 
 			if (attribute.name === 'name') {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -4,7 +4,6 @@
 import { dev, is_ignored } from '../../../../../state.js';
 import { get_attribute_chunks, object } from '../../../../../utils/ast.js';
 import * as b from '../../../../../utils/builders.js';
-import { create_derived } from '../../utils.js';
 import { build_bind_this, memoize_expression, validate_binding } from '../shared/utils.js';
 import { build_attribute_value } from '../shared/element.js';
 import { build_event_handler } from './events.js';

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
@@ -5,7 +5,7 @@ import { normalize_attribute } from '../../../../../../utils.js';
 import { is_ignored } from '../../../../../state.js';
 import { is_event_attribute } from '../../../../../utils/ast.js';
 import * as b from '../../../../../utils/builders.js';
-import { build_getter, create_derived } from '../../utils.js';
+import { build_getter } from '../../utils.js';
 import { build_template_chunk, get_expression_id } from './utils.js';
 
 /**
@@ -61,10 +61,9 @@ export function build_set_attributes(
 			let value = /** @type {Expression} */ (context.visit(attribute));
 
 			if (attribute.metadata.expression.has_call) {
-				const id = b.id(state.scope.generate('spread_with_call'));
-				state.init.push(b.const(id, create_derived(state, b.thunk(value))));
-				value = b.call('$.get', id);
+				value = get_expression_id(context.state, value);
 			}
+
 			values.push(b.spread(value));
 		}
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -1,5 +1,5 @@
 /** @import { Expression, ExpressionStatement, Identifier, MemberExpression, SequenceExpression, Statement, Super } from 'estree' */
-/** @import { AST } from '#compiler' */
+/** @import { AST, ExpressionMetadata } from '#compiler' */
 /** @import { ComponentClientTransformState } from '../../types' */
 import { walk } from 'zimmerframe';
 import { object } from '../../../../../utils/ast.js';
@@ -79,14 +79,14 @@ function compare_expressions(a, b) {
  * @param {Array<AST.Text | AST.ExpressionTag>} values
  * @param {(node: AST.SvelteNode, state: any) => any} visit
  * @param {ComponentClientTransformState} state
- * @param {(value: Expression) => Expression} memoize
+ * @param {(value: Expression, metadata: ExpressionMetadata) => Expression} memoize
  * @returns {{ value: Expression, has_state: boolean }}
  */
 export function build_template_chunk(
 	values,
 	visit,
 	state,
-	memoize = (value) => get_expression_id(state, value)
+	memoize = (value, metadata) => (metadata.has_call ? get_expression_id(state, value) : value)
 ) {
 	/** @type {Expression[]} */
 	const expressions = [];
@@ -106,13 +106,12 @@ export function build_template_chunk(
 				quasi.value.cooked += node.expression.value + '';
 			}
 		} else {
-			let value = /** @type {Expression} */ (visit(node.expression, state));
+			let value = memoize(
+				/** @type {Expression} */ (visit(node.expression, state)),
+				node.metadata.expression
+			);
 
 			has_state ||= node.metadata.expression.has_state;
-
-			if (node.metadata.expression.has_call) {
-				value = memoize(value);
-			}
 
 			if (values.length === 1) {
 				// If we have a single expression, then pass that in directly to possibly avoid doing


### PR DESCRIPTION
This fixes a small regression introduced in #15050. Prior to that PR, we would handle memoization in different ways throughout the compiler; now, the memoization logic is more explicit and consistent. The decision of _whether_ to memoize happens inside `build_attribute_value` (or `build_template_chunk`), using the passed-in logic — if an expression contains a `CallExpression`, we memoize — but this elides an important distinction between component props and other expressions.

In most cases, an expression like `a + b` doesn't get memoized (it doesn't contain a `CallExpression`). But for component props, we _do_ memoize these expressions, because otherwise we get overfiring in a case like this:

```svelte
<Foo active={i === index} />
```

The result, post-#15050, is that anything containing a `CallExpression` gets memoized _twice_ — once because it's contains a `CallExpression`, and once because it's a 'non-simple' expression (i.e. not an `Identifier` or `MemberExpression`).

The result is that we create two deriveds where one will do — a case like this...

```svelte
<script>
  let { fn } = $props();
</script>

<Foo bar={fn()} />
```

...has this outcome:

```diff
-var bar = $.derived(() => $$props.fn());
+const expression = $.derived(() => $$props.fn());
+var bar = $.derived(() => $.get(expression));

Foo($$anchor, {
  get bar() {
    return $.get(bar);
  }
});
```

This PR fixes it by taking the decision of whether to memoize out of `build_attribute_value` and `build_template_chunk` and into their callers.

It also makes the memoization of spreads-with-call-expressions consistent with other template effects:

```diff
var div = root();
-const spread_with_call = $.derived(() => $$props.foo($$props.a, $$props.b));
let attributes;

-$.template_effect(() => attributes = $.set_attributes(div, attributes, { ...$.get(spread_with_call) }));
+$.template_effect(($0) => attributes = $.set_attributes(div, attributes, { ...$0 }), [() => $$props.foo($$props.a, $$props.b)]);
```

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
