### PR TITLE
fix: optimise || expressions in template

### DIFF
--- a/.changeset/large-islands-cover.md
+++ b/.changeset/large-islands-cover.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: optimise || expressions in template

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -118,22 +118,22 @@ export function build_template_chunk(
 				// extra work in the template_effect (instead we do the work in set_text).
 				return { value, has_state };
 			} else {
-				let expression = value;
-				// only add nullish coallescence if it hasn't been added already
-				if (value.type === 'LogicalExpression' && value.operator === '??') {
-					const { right } = value;
-					// `undefined` isn't a Literal (due to pre-ES5 shenanigans), so the only nullish literal is `null`
-					// however, you _can_ make a variable called `undefined` in a Svelte component, so we can't just treat it the same way
-					if (right.type !== 'Literal') {
-						expression = b.logical('??', value, b.literal(''));
-					} else if (right.value === null) {
-						// if they do something weird like `stuff ?? null`, replace `null` with empty string
-						value.right = b.literal('');
+				// add `?? ''` where necessary (TODO optimise more cases)
+				if (
+					value.type === 'LogicalExpression' &&
+					value.right.type === 'Literal' &&
+					(value.operator === '??' || value.operator === '||')
+				) {
+					// `foo ?? null` -=> `foo ?? ''`
+					// otherwise leave the expression untouched
+					if (value.right.value === null) {
+						value = { ...value, right: b.literal('') };
 					}
 				} else {
-					expression = b.logical('??', value, b.literal(''));
+					value = b.logical('??', value, b.literal(''));
 				}
-				expressions.push(expression);
+
+				expressions.push(value);
 			}
 
 			quasi = b.quasi('', i + 1 === values.length);


### PR DESCRIPTION
small follow-up to #15056 — we can simplify the logic a tiny bit (and avoid mutating the AST node), but more to the point we can apply the same optimisation to `||` expressions. ultimately it would be nice to extend this to more cases (variables with a known set of possible values, ternaries, etc) but for now just picking the lowest-hanging fruit

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
