### PR TITLE
fix: expand boolean attribute support

### DIFF
--- a/.changeset/strange-hairs-trade.md
+++ b/.changeset/strange-hairs-trade.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: expand boolean attribute support

--- a/packages/svelte/src/utils.js
+++ b/packages/svelte/src/utils.js
@@ -170,7 +170,10 @@ const DOM_BOOLEAN_ATTRIBUTES = [
 	'reversed',
 	'seamless',
 	'selected',
-	'webkitdirectory'
+	'webkitdirectory',
+	'defer',
+	'disablepictureinpicture',
+	'disableremoteplayback'
 ];
 
 /**
@@ -197,7 +200,10 @@ const ATTRIBUTE_ALIASES = {
 	defaultvalue: 'defaultValue',
 	defaultchecked: 'defaultChecked',
 	srcobject: 'srcObject',
-	novalidate: 'noValidate'
+	novalidate: 'noValidate',
+	allowfullscreen: 'allowFullscreen',
+	disablepictureinpicture: 'disablePictureInPicture',
+	disableremoteplayback: 'disableRemotePlayback'
 };
 
 /**
@@ -219,7 +225,11 @@ const DOM_PROPERTIES = [
 	'volume',
 	'defaultValue',
 	'defaultChecked',
-	'srcObject'
+	'srcObject',
+	'noValidate',
+	'allowFullscreen',
+	'disablePictureInPicture',
+	'disableRemotePlayback'
 ];
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/attribute-boolean-case-insensitivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/attribute-boolean-case-insensitivity/_config.js
@@ -1,0 +1,50 @@
+import { test } from '../../test';
+
+export default test({
+	html: `
+	<script nomodule async defer></script>
+	<form novalidate></form>
+	<input readonly required checked webkitdirectory>
+	<select multiple disabled></select>
+	<button formnovalidate></button>
+	<img ismap>
+	<video autoplay controls loop muted playsinline disablepictureinpicture disableremoteplayback></video>
+	<audio disableremoteplayback></audio>
+	<track default>
+	<iframe allowfullscreen></iframe>
+	<details open></details>
+	<ol reversed></ol>
+	<div autofocus></div>
+	<span inert></span>
+
+	<script nomodule async defer></script>
+	<form novalidate></form>
+	<input readonly required checked webkitdirectory>
+	<select multiple disabled></select>
+	<button formnovalidate></button>
+	<img ismap>
+	<video autoplay controls loop muted playsinline disablepictureinpicture disableremoteplayback></video>
+	<audio disableremoteplayback></audio>
+	<track default>
+	<iframe allowfullscreen></iframe>
+	<details open></details>
+	<ol reversed></ol>
+	<div autofocus></div>
+	<span inert></span>
+
+	<script></script>
+	<form></form>
+	<input>
+	<select></select>
+	<button></button>
+	<img>
+	<video></video>
+	<audio></audio>
+	<track>
+	<iframe></iframe>
+	<details></details>
+	<ol></ol>
+	<div></div>
+	<span></span>
+`
+});

--- a/packages/svelte/tests/runtime-runes/samples/attribute-boolean-case-insensitivity/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/attribute-boolean-case-insensitivity/_config.js
@@ -1,6 +1,16 @@
 import { test } from '../../test';
 
 export default test({
+	// JSDOM lacks support for some of these attributes, so we'll skip it for now.
+	//
+	// See:
+	//  - `async`: https://github.com/jsdom/jsdom/issues/1564
+	//  - `nomodule`: https://github.com/jsdom/jsdom/issues/2475
+	//  - `autofocus`: https://github.com/jsdom/jsdom/issues/3041
+	//  - `inert`: https://github.com/jsdom/jsdom/issues/3605
+	//  - etc...: https://github.com/jestjs/jest/issues/139#issuecomment-592673550
+	skip_mode: ['client'],
+
 	html: `
 	<script nomodule async defer></script>
 	<form novalidate></form>

--- a/packages/svelte/tests/runtime-runes/samples/attribute-boolean-case-insensitivity/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/attribute-boolean-case-insensitivity/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	let runesMode = $state('using a rune so that we trigger runes mode');
+
+	const attributeValues = [true, 'test', false];
+</script>
+
+{#each attributeValues as val}
+	<script NOMODULE={val} ASYNC={val} DEFER={val}></script>
+	<form NOVALIDATE={val}></form>
+	<input READONLY={val} REQUIRED={val} CHECKED={val} WEBKITDIRECTORY={val} />
+	<select MULTIPLE={val} DISABLED={val}></select>
+	<button FORMNOVALIDATE={val}></button>
+	<img ISMAP={val} />
+	<video AUTOPLAY={val} CONTROLS={val} LOOP={val} MUTED={val} PLAYSINLINE={val} DISABLEPICTUREINPICTURE={val} DISABLEREMOTEPLAYBACK={val}></video>
+	<audio DISABLEREMOTEPLAYBACK={val}></audio>
+	<track DEFAULT={val} />
+	<iframe ALLOWFULLSCREEN={val}></iframe>
+	<details OPEN={val}></details>
+	<ol REVERSED={val}></ol>
+	<div AUTOFOCUS={val}></div>
+	<span INERT={val}></span>
+{/each}


### PR DESCRIPTION
This PR is a follow-up to #15083, in an attempt to further correct the issue in #15082, by expanding HTML element boolean attribute support, especially when the HTML attributes casing don't match the DOM property (IDL attribute) casing.

The following attribute support has been added:

 - [`defer`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#defer)
 - [`disablepictureinpicture`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#disablepictureinpicture)
 - [`disableremoteplayback`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#disableremoteplayback)

... and the following attribute support has been improved (case mapping):

 - [`allowfullscreen`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allowfullscreen)
 - [`novalidate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#novalidate) (as a direct follow-up to #15083)