### PR TITLE
chore: tweak render tag logic

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -706,7 +706,7 @@ function special(parser) {
 			expression: /** @type {AST.RenderTag['expression']} */ (expression),
 			metadata: {
 				dynamic: false,
-				args_with_call_expression: new Set(),
+				arguments: [],
 				path: [],
 				snippets: new Set()
 			}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -605,7 +605,6 @@ export function analyze_component(root, source, options) {
 				has_props_rune: false,
 				component_slots: new Set(),
 				expression: null,
-				render_tag: null,
 				private_derived_state: [],
 				function_depth: scope.function_depth,
 				instance_scope: instance.scope,
@@ -677,7 +676,6 @@ export function analyze_component(root, source, options) {
 				reactive_statements: analysis.reactive_statements,
 				component_slots: new Set(),
 				expression: null,
-				render_tag: null,
 				private_derived_state: [],
 				function_depth: scope.function_depth
 			};

--- a/packages/svelte/src/compiler/phases/2-analyze/types.d.ts
+++ b/packages/svelte/src/compiler/phases/2-analyze/types.d.ts
@@ -19,8 +19,6 @@ export interface AnalysisState {
 	component_slots: Set<string>;
 	/** Information about the current expression/directive/block value */
 	expression: ExpressionMetadata | null;
-	/** The current {@render ...} tag, if any */
-	render_tag: null | AST.RenderTag;
 	private_derived_state: string[];
 	function_depth: number;
 

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -186,18 +186,6 @@ export function CallExpression(node, context) {
 			break;
 	}
 
-	if (context.state.render_tag) {
-		// Find out which of the render tag arguments contains this call expression
-		const arg_idx = unwrap_optional(context.state.render_tag.expression).arguments.findIndex(
-			(arg) => arg === node || context.path.includes(arg)
-		);
-
-		// -1 if this is the call expression of the render tag itself
-		if (arg_idx !== -1) {
-			context.state.render_tag.metadata.args_with_call_expression.add(arg_idx);
-		}
-	}
-
 	if (node.callee.type === 'Identifier') {
 		const binding = context.state.scope.get(node.callee.name);
 

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -166,7 +166,7 @@ export namespace AST {
 		/** @internal */
 		metadata: {
 			dynamic: boolean;
-			args_with_call_expression: Set<number>;
+			arguments: ExpressionMetadata[];
 			path: SvelteNode[];
 			/** The set of locally-defined snippets that this render tag could correspond to,
 			 * used for CSS pruning purposes */


### PR DESCRIPTION
another harmless tweak a la #15108, which reduces the size of an upcoming PR diff. It's also more efficient (less traversal) and more self-contained, since the logic now resides in the `RenderTag` analysis and transformation visitors instead of also polluting the `CallExpression` visitor