### PR TITLE
fix: lazily connect derievds (in deriveds) to their parent

### DIFF
--- a/.changeset/few-beans-bow.md
+++ b/.changeset/few-beans-bow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: lazily connect derievds (in deriveds) to their parent

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -68,10 +68,6 @@ export function derived(fn) {
 		signal.created = get_stack('CreatedAt');
 	}
 
-	if (parent_derived !== null) {
-		(parent_derived.children ??= []).push(signal);
-	}
-
 	return signal;
 }
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -957,26 +957,30 @@ export function get(signal) {
 				new_deps.push(signal);
 			}
 		}
-	} else if (is_derived && /** @type {Derived} */ (signal).deps === null) {
+	}
+
+	if (
+		is_derived &&
+		/** @type {Derived} */ (signal).deps === null &&
+		(active_reaction === null || untracking || (active_reaction.f & DERIVED) !== 0)
+	) {
 		var derived = /** @type {Derived} */ (signal);
 		var parent = derived.parent;
-		var target = derived;
 
-		while (parent !== null) {
-			// Attach the derived to the nearest parent effect, if there are deriveds
-			// in between then we also need to attach them too
+		if (parent !== null) {
+			// Attach the derived to the nearest parent effect or derived
 			if ((parent.f & DERIVED) !== 0) {
 				var parent_derived = /** @type {Derived} */ (parent);
 
-				target = parent_derived;
-				parent = parent_derived.parent;
+				if (!parent_derived.children?.includes(derived)) {
+					(parent_derived.children ??= []).push(derived);
+				}
 			} else {
 				var parent_effect = /** @type {Effect} */ (parent);
 
-				if (!parent_effect.deriveds?.includes(target)) {
-					(parent_effect.deriveds ??= []).push(target);
+				if (!parent_effect.deriveds?.includes(derived)) {
+					(parent_effect.deriveds ??= []).push(derived);
 				}
-				break;
 			}
 		}
 	}

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -803,6 +803,33 @@ describe('signals', () => {
 		};
 	});
 
+	test('nested deriveds do not connect inside parent deriveds if unused', () => {
+		return () => {
+			let a = render_effect(() => {});
+			let b: Derived<void> | undefined;
+
+			const destroy = effect_root(() => {
+				a = render_effect(() => {
+					$.untrack(() => {
+						b = derived(() => {
+							derived(() => {});
+							derived(() => {});
+							derived(() => {});
+						});
+						$.get(b);
+					});
+				});
+			});
+
+			assert.deepEqual(a.deriveds?.length, 1);
+			assert.deepEqual(b?.children, null);
+
+			destroy();
+
+			assert.deepEqual(a.deriveds, null);
+		};
+	});
+
 	test('deriveds containing effects work correctly when used with untrack', () => {
 		return () => {
 			let a = render_effect(() => {});


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/15111. 

We don't need to eagerly connect deriveds to their parents – we don't do this in effects, so we can apply the same heuristic here too. If we lazily do it upon read of the derived from within a parent derived. If no read is done, we skip pushing it into the children. This will avoid the buggy case linked, and also provide a nice performance uplift by avoiding array allocations for cases where don't need to do them.