### PR TITLE
fix: improve derived connection to ownership graph

### DIFF
--- a/.changeset/blue-rocks-play.md
+++ b/.changeset/blue-rocks-play.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improve derived connection to ownership graph

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -87,7 +87,7 @@ export function derived_safe_equal(fn) {
  * @param {Derived} derived
  * @returns {void}
  */
-function destroy_derived_children(derived) {
+export function destroy_derived_children(derived) {
 	var children = derived.children;
 
 	if (children !== null) {

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -99,7 +99,6 @@ function create_effect(type, fn, sync, push = true) {
 	var effect = {
 		ctx: component_context,
 		deps: null,
-		deriveds: null,
 		nodes_start: null,
 		nodes_end: null,
 		f: type | DIRTY,
@@ -397,22 +396,6 @@ export function execute_effect_teardown(effect) {
 
 /**
  * @param {Effect} signal
- * @returns {void}
- */
-export function destroy_effect_deriveds(signal) {
-	var deriveds = signal.deriveds;
-
-	if (deriveds !== null) {
-		signal.deriveds = null;
-
-		for (var i = 0; i < deriveds.length; i += 1) {
-			destroy_derived(deriveds[i]);
-		}
-	}
-}
-
-/**
- * @param {Effect} signal
  * @param {boolean} remove_dom
  * @returns {void}
  */
@@ -468,7 +451,6 @@ export function destroy_effect(effect, remove_dom = true) {
 	}
 
 	destroy_effect_children(effect, remove_dom && !removed);
-	destroy_effect_deriveds(effect);
 	remove_reactions(effect, 0);
 	set_signal_status(effect, DESTROYED);
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -53,7 +53,7 @@ export function validate_effect(rune) {
 		e.effect_orphan(rune);
 	}
 
-	if (active_reaction !== null && (active_reaction.f & UNOWNED) !== 0) {
+	if (active_reaction !== null && (active_reaction.f & UNOWNED) !== 0 && active_effect === null) {
 		e.effect_in_unowned_derived();
 	}
 
@@ -153,7 +153,7 @@ function create_effect(type, fn, sync, push = true) {
 		// if we're in a derived, add the effect there too
 		if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
 			var derived = /** @type {Derived} */ (active_reaction);
-			(derived.children ??= []).push(effect);
+			(derived.effects ??= []).push(effect);
 		}
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -36,8 +36,8 @@ export interface Reaction extends Signal {
 export interface Derived<V = unknown> extends Value<V>, Reaction {
 	/** The derived function */
 	fn: () => V;
-	/** Reactions created inside this signal */
-	children: null | Reaction[];
+	/** Effects created inside this signal */
+	effects: null | Effect[];
 	/** Parent effect or derived */
 	parent: Effect | Derived | null;
 }

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -51,8 +51,6 @@ export interface Effect extends Reaction {
 	 */
 	nodes_start: null | TemplateNode;
 	nodes_end: null | TemplateNode;
-	/** Reactions created inside this signal */
-	deriveds: null | Derived[];
 	/** The effect function */
 	fn: null | (() => void | (() => void));
 	/** The teardown function returned from the effect function */

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -216,6 +216,9 @@ export function check_dirtiness(reaction) {
 				}
 
 				if (dependency.wv > reaction.wv) {
+					if (is_unowned) {
+						reaction.wv = dependency.wv;
+					}
 					return true;
 				}
 			}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -959,9 +959,6 @@ export function get(signal) {
 		var parent = derived.parent;
 
 		if (parent !== null) {
-			// if ((parent.f & UNOWNED) === 0) {
-			// 	derived.f ^= UNOWNED;
-			// }
 			// If the derived is owned by another derived then mark it as unowned
 			// as the derived value might have been referenced in a different context
 			// since and thus its parent might not be its true owner anymore

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -418,8 +418,12 @@ export function update_reaction(reaction) {
 	skip_reaction =
 		(flags & UNOWNED) !== 0 &&
 		(!is_flushing_effect ||
+			// If we were previously not in a reactive context and we're reading an unowned derived
+			// that was created inside another derived, then we don't fully know the real owner and thus
+			// we need to skip adding any reactions for this unowned
+				((previous_reaction === null || previous_untracking) &&
 				(/** @type {Derived} */ (reaction).parent !== null &&
-				(/** @type {Derived} */ (reaction).parent.f & DERIVED) !== 0));
+				(/** @type {Derived} */ (reaction).parent.f & DERIVED) !== 0)));
 
 	derived_sources = null;
 	set_component_context(reaction.ctx);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -953,10 +953,9 @@ export function get(signal) {
 
 		if (parent !== null) {
 			// If the derived is owned by another derived then mark it as unowned
-			// as the derived value might have been shared and thus we cannot determine
-			// a true
+			// as the derived value might have been referenced in a different context
+			// since and thus its parent might not be its true owner anymore
 			if ((parent.f & DERIVED) !== 0 && (parent.f & UNOWNED) === 0) {
-				debugger;
 				derived.f ^= UNOWNED;
 			} else {
 				// Otherwise we can attach the derieved to the parent effect

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -4,7 +4,6 @@ import { define_property, get_descriptors, get_prototype_of, index_of } from '..
 import {
 	destroy_block_effect_children,
 	destroy_effect_children,
-	destroy_effect_deriveds,
 	execute_effect_teardown,
 	unlink_effect
 } from './reactivity/effects.js';
@@ -580,7 +579,6 @@ export function update_effect(effect) {
 		} else {
 			destroy_effect_children(effect);
 		}
-		destroy_effect_deriveds(effect);
 
 		execute_effect_teardown(effect);
 		var teardown = update_reaction(effect);
@@ -962,15 +960,8 @@ export function get(signal) {
 			// If the derived is owned by another derived then mark it as unowned
 			// as the derived value might have been referenced in a different context
 			// since and thus its parent might not be its true owner anymore
-			if ((parent.f & DERIVED) !== 0 && (parent.f & UNOWNED) === 0) {
+			if ((parent.f & UNOWNED) === 0) {
 				derived.f ^= UNOWNED;
-			} else {
-				// Otherwise we can attach the derieved to the parent effect
-				var parent_effect = /** @type {Effect} */ (parent);
-
-				if (!parent_effect.deriveds?.includes(derived)) {
-					(parent_effect.deriveds ??= []).push(derived);
-				}
 			}
 		}
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -216,9 +216,6 @@ export function check_dirtiness(reaction) {
 				}
 
 				if (dependency.wv > reaction.wv) {
-					if (is_unowned) {
-						reaction.wv = dependency.wv;
-					}
 					return true;
 				}
 			}

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-7/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-7/_config.js
@@ -9,15 +9,6 @@ export default test({
 			btn1.click();
 		});
 
-		assert.deepEqual(logs, [
-			'computing C',
-			'computing B',
-			'a',
-			'foo',
-			'computing B',
-			'aaa',
-			'computing C'
-			'foo'
-		]);
+		assert.deepEqual(logs, ['computing C', 'computing B', 'a', 'foo', 'computing B', 'aaa', 'foo']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-7/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-7/_config.js
@@ -9,6 +9,15 @@ export default test({
 			btn1.click();
 		});
 
-		assert.deepEqual(logs, ['computing C', 'computing B', 'a', 'foo', 'computing B', 'aaa', 'foo']);
+		assert.deepEqual(logs, [
+			'computing C',
+			'computing B',
+			'a',
+			'foo',
+			'computing B',
+			'aaa',
+			'computing C'
+			'foo'
+		]);
 	}
 });

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -538,6 +538,64 @@ describe('signals', () => {
 		};
 	});
 
+	test('mixed nested deriveds correctly cleanup when no longer connected to graph #1', () => {
+		let a: Derived<unknown>;
+		let b: Derived<unknown>;
+		let s = state(0);
+
+		const destroy = effect_root(() => {
+			render_effect(() => {
+				a = derived(() => {
+					b = derived(() => {
+						$.get(s);
+					});
+					$.untrack(() => {
+						$.get(b);
+					});
+					$.get(s);
+				});
+				$.get(a);
+			});
+		});
+
+		return () => {
+			flushSync();
+			assert.equal(a?.deps?.length, 1);
+			assert.equal(s?.reactions?.length, 1);
+			destroy();
+			assert.equal(s?.reactions, null);
+		};
+	});
+
+	test('mixed nested deriveds correctly cleanup when no longer connected to graph #2', () => {
+		let a: Derived<unknown>;
+		let b: Derived<unknown>;
+		let s = state(0);
+
+		const destroy = effect_root(() => {
+			render_effect(() => {
+				a = derived(() => {
+					b = derived(() => {
+						$.get(s);
+					});
+					effect_root(() => {
+						$.get(b);
+					});
+					$.get(s);
+				});
+				$.get(a);
+			});
+		});
+
+		return () => {
+			flushSync();
+			assert.equal(a?.deps?.length, 1);
+			assert.equal(s?.reactions?.length, 1);
+			destroy();
+			assert.equal(s?.reactions, null);
+		};
+	});
+
 	test('deriveds update upon reconnection #1', () => {
 		let a = state(false);
 		let b = state(false);

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -481,6 +481,7 @@ describe('signals', () => {
 					effect(() => {
 						log.push('inner', $.get(inner));
 					});
+					return $.get(outer);
 				});
 			});
 		});

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -507,7 +507,7 @@ describe('signals', () => {
 				set(inner, 2);
 				$.get(a);
 			});
-			assert.deepEqual(log, ['outer', 1, 'inner', 2]);
+			assert.deepEqual(log, ['inner', 2]);
 			destroy();
 		};
 	});

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -612,7 +612,6 @@ describe('signals', () => {
 						$.get(b);
 					});
 					render_effect(() => {
-						debugger
 						logs.push($.get(b));
 					});
 					$.get(s);

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -928,7 +928,7 @@ describe('signals', () => {
 			});
 
 			assert.deepEqual(a.deriveds?.length, 1);
-			assert.deepEqual(b?.children, null);
+			assert.deepEqual(b?.effects, null);
 
 			destroy();
 
@@ -957,14 +957,14 @@ describe('signals', () => {
 				});
 			});
 
-			assert.equal(c!.children?.length, 1);
+			assert.equal(c!.effects?.length, 1);
 			assert.equal(a.first, a.last);
 
 			set(b, 1);
 
 			flushSync();
 
-			assert.equal(c!.children?.length, 1);
+			assert.equal(c!.effects?.length, 1);
 			assert.equal(a.first, a.last);
 
 			destroy();
@@ -1001,14 +1001,14 @@ describe('signals', () => {
 				});
 			});
 
-			assert.equal(c!.children?.length, 1);
+			assert.equal(c!.effects?.length, 1);
 			assert.equal(a.first, a.last);
 
 			set(b, 1);
 
 			flushSync();
 
-			assert.equal(c!.children?.length, 1);
+			assert.equal(c!.effects?.length, 1);
 			assert.equal(a.first, a.last);
 
 			destroy();


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/15111 fully.

This is a follow up to https://github.com/sveltejs/svelte/pull/15129. If a derived is disconnected from the reactivity graph, then it should destroy any child effects/deriveds that it has. Furthermore, instead of blindly attaching a derived to it's original parent derived – we mark it as unowned, as the derived value might have been passed around to other owners since and thus not be associated anymore. For example if you create a class instance (that has derived properties) inside a derived and then pass that elsewhere, it's not technically owner by the original derived anymore.