### PR TITLE
fix: `src` and `loading` in lazy loaded images returns right value immediately

### DIFF
--- a/.changeset/friendly-crews-sin.md
+++ b/.changeset/friendly-crews-sin.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: `src` and `loading` in lazy loaded images returns right value immediately


### PR DESCRIPTION
Because of a weird Firefox+`cloneNode` bug nowadays if there's a lazy loaded image we remove the `loading` and `src` attributes and we reinstate them in the next animation frame (this will trick Firefox in doing it's job).

However this is problematic if the user access those attributes on mount or in an action. For example a case [like this](https://svelte.dev/playground/dfb509276d78417f80ffacae017787a0?version=5.19.5)

```svelte
<script>
	function check(node){
		console.log(node.loading);
		console.log(node.getAttribute("loading"));
		console.log(node.src);
		console.log(node.getAttribute("src"));
	}
</script>


<img 
	use:check
	loading="lazy"
	src="https://unsplash.it/300"
	alt="cool"
/>
```

because as you can see from the logs the values are completely unexpected.

I found a solution to this problem but it might have other implications that i'm not aware of...basically when we `handle_lazy_img` after removing the attributes i also define two properties on the element to handle `loading` and `src` "manually" (the same is true for `getAttribute`). This keeps the attribute "not there" for Firefox while also allowing the user to access it in JS if needed.

Do you think it's a reasonable solution?

P.s. i was not able to add a test for this because jsdom acts a bit weird with `loading` and it's always `undefined` so it never actually enters in the if inside `handle_lazy_img`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
