### PR TITLE
fix: don't error on slot prop inside block inside other component

### DIFF
--- a/.changeset/good-rocks-talk.md
+++ b/.changeset/good-rocks-talk.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't error on slot prop inside block inside other component

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/attribute.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/attribute.js
@@ -80,40 +80,42 @@ export function validate_slot_attribute(context, attribute, is_component = false
 	}
 
 	if (owner) {
-		if (!is_text_attribute(attribute)) {
-			e.slot_attribute_invalid(attribute);
-		}
-
 		if (
 			owner.type === 'Component' ||
 			owner.type === 'SvelteComponent' ||
 			owner.type === 'SvelteSelf'
 		) {
 			if (owner !== parent) {
-				e.slot_attribute_invalid_placement(attribute);
-			}
+				if (!is_component) {
+					e.slot_attribute_invalid_placement(attribute);
+				}
+			} else {
+				if (!is_text_attribute(attribute)) {
+					e.slot_attribute_invalid(attribute);
+				}
 
-			const name = attribute.value[0].data;
+				const name = attribute.value[0].data;
 
-			if (context.state.component_slots.has(name)) {
-				e.slot_attribute_duplicate(attribute, name, owner.name);
-			}
+				if (context.state.component_slots.has(name)) {
+					e.slot_attribute_duplicate(attribute, name, owner.name);
+				}
 
-			context.state.component_slots.add(name);
+				context.state.component_slots.add(name);
 
-			if (name === 'default') {
-				for (const node of owner.fragment.nodes) {
-					if (node.type === 'Text' && regex_only_whitespaces.test(node.data)) {
-						continue;
-					}
-
-					if (node.type === 'RegularElement' || node.type === 'SvelteFragment') {
-						if (node.attributes.some((a) => a.type === 'Attribute' && a.name === 'slot')) {
+				if (name === 'default') {
+					for (const node of owner.fragment.nodes) {
+						if (node.type === 'Text' && regex_only_whitespaces.test(node.data)) {
 							continue;
 						}
-					}
 
-					e.slot_default_duplicate(node);
+						if (node.type === 'RegularElement' || node.type === 'SvelteFragment') {
+							if (node.attributes.some((a) => a.type === 'Attribute' && a.name === 'slot')) {
+								continue;
+							}
+						}
+
+						e.slot_default_duplicate(node);
+					}
 				}
 			}
 		}

--- a/packages/svelte/tests/validator/samples/slot-attribute-component/input.svelte
+++ b/packages/svelte/tests/validator/samples/slot-attribute-component/input.svelte
@@ -1,2 +1,8 @@
 <Foo slot="foo">valid</Foo>
 <Foo slot={foo}>valid</Foo>
+<Foo>
+    {#if true}
+        <Foo slot="foo">valid</Foo>
+        <Foo slot={foo}>valid</Foo>
+    {/if}
+</Foo>


### PR DESCRIPTION
`slot` is treated as a regular prop if it is not used directly inside another component, but we were running validations on such regular props that should only be run on real slots.

Fixes #15125

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
