### PR TITLE
fix: widen ownership when calling setContext

### DIFF
--- a/.changeset/unlucky-gorillas-hunt.md
+++ b/.changeset/unlucky-gorillas-hunt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: widen ownership when calling setContext

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -109,7 +109,7 @@ export function mark_module_end(component) {
 
 /**
  * @param {any} object
- * @param {any} owner
+ * @param {any | null} owner
  * @param {boolean} [global]
  * @param {boolean} [skip_warning]
  */
@@ -120,7 +120,7 @@ export function add_owner(object, owner, global = false, skip_warning = false) {
 		if (metadata && !has_owner(metadata, component)) {
 			let original = get_owner(metadata);
 
-			if (owner[FILENAME] !== component[FILENAME] && !skip_warning) {
+			if (owner && owner[FILENAME] !== component[FILENAME] && !skip_warning) {
 				w.ownership_invalid_binding(component[FILENAME], owner[FILENAME], original[FILENAME]);
 			}
 		}
@@ -165,7 +165,7 @@ export function widen_ownership(from, to) {
 
 /**
  * @param {any} object
- * @param {Function} owner
+ * @param {Function | null} owner If `null`, then the object is globally owned and will not be checked
  * @param {Set<any>} seen
  */
 function add_owner_to_object(object, owner, seen) {
@@ -174,7 +174,11 @@ function add_owner_to_object(object, owner, seen) {
 	if (metadata) {
 		// this is a state proxy, add owner directly, if not globally shared
 		if ('owners' in metadata && metadata.owners != null) {
-			metadata.owners.add(owner);
+			if (owner) {
+				metadata.owners.add(owner);
+			} else {
+				metadata.owners = null;
+			}
 		}
 	} else if (object && typeof object === 'object') {
 		if (seen.has(object)) return;


### PR DESCRIPTION
Instead of doing ownership addition at each `getContext` call site, we do it once as the `setContext` call site and make the state basically global.
- avoids potential false positives in edge cases
- makes the whole thing more performant, especially around things like calling `getContext` inside a list item component
- false negatives are unlikely from this (as shown by no current tests failing)

No new test added because this is mainly about performance.

fixes #15072

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
