### PR TITLE
fix: prevent false-positive ownership validations due to hot reload

### DIFF
--- a/.changeset/ten-cougars-look.md
+++ b/.changeset/ten-cougars-look.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent false-positive ownership validations due to hot reload

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -216,6 +216,10 @@ function has_owner(metadata, component) {
 
 	return (
 		metadata.owners.has(component) ||
+		// This helps avoid false positives when using HMR, where the component function is replaced
+		[...metadata.owners].some(
+			(owner) => /** @type {any} */ (owner)[FILENAME] === /** @type {any} */ (component)?.[FILENAME]
+		) ||
 		(metadata.parent !== null && has_owner(metadata.parent, component))
 	);
 }


### PR DESCRIPTION
The component identity could change due to HMR, so we fall back to checking the filenames as well

No test because this requires HMR and changes to a file being made.

fixes #14746

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
