### PR TITLE
fix: ensure reactions are correctly attached for unowned deriveds

### DIFF
--- a/.changeset/loud-cars-scream.md
+++ b/.changeset/loud-cars-scream.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure reactions are correctly attached for unowned deriveds

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -802,12 +802,19 @@ function process_effects(effect, collected_effects) {
 				if (is_branch) {
 					current_effect.f ^= CLEAN;
 				} else {
+					// Ensure we set the effect to be the active reaction
+					// to ensure that unowned deriveds are correctly tracked
+					// because we're flushing the current effect
+					var previous_active_reaction = active_reaction;
 					try {
+						active_reaction = current_effect;
 						if (check_dirtiness(current_effect)) {
 							update_effect(current_effect);
 						}
 					} catch (error) {
 						handle_error(error, current_effect, null, current_effect.ctx);
+					} finally {
+						active_reaction = previous_active_reaction;
 					}
 				}
 

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-11/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-11/Child.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { value = $bindable() } = $props()
+</script>
+
+<button onclick={() => value = 'a'}>change</button>

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-11/Child2.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-11/Child2.svelte
@@ -1,0 +1,5 @@
+<script>
+	let {disabled = false} = $props()
+</script>
+
+{disabled}

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-11/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-11/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		let [btn1, btn2] = target.querySelectorAll('button');
+
+		btn1?.click();
+		flushSync();
+
+		btn2?.click();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, `<button>change</button><button>change</button>\nfalse`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-11/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-11/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import Child2 from './Child2.svelte'
+	import Child from './Child.svelte'
+	let loginname = $state('')
+	let password = $state('')
+</script>
+
+<Child bind:value={loginname} />
+<Child bind:value={password} />
+<Child2 disabled={!loginname || !password} />
+


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/15149. We weren't setting the `active_reaction` when processing effects and checking if they were dirty, which mean the `skip_reaction` logic was not treating unowned deriveds as connected even though they should as we're flushing effects at this stage of reconcilation.