### PR TITLE
docs: Fixes swapped logic for readonly function bindings

### DIFF
--- a/documentation/docs/03-template-syntax/11-bind.md
+++ b/documentation/docs/03-template-syntax/11-bind.md
@@ -28,12 +28,12 @@ You can also use `bind:property={get, set}`, where `get` and `set` are functions
 />
 ```
 
-In the case of readonly bindings like [dimension bindings](#Dimensions), the `get` value should be `null`:
+In the case of readonly bindings like [dimension bindings](#Dimensions), the `set` value should be `null`:
 
 ```svelte
 <div
-	bind:clientWidth={null, redraw}
-	bind:clientHeight={null, redraw}
+	bind:clientWidth={redraw, null}
+	bind:clientHeight={redraw, null}
 >...</div>
 ```
 


### PR DESCRIPTION
Read-only bindings should have the SET value assigned to null, not the GET.

e.g. this:
`<input type="checkbox" bind:indeterminate={null, () => true} />`

...fails, while this:

`<input type="checkbox" bind:indeterminate={() => true, null} />`

...works as expected.
(note: ts doesn't love this, prefers: `<input type="checkbox" bind:indeterminate={() => true, () => null} />`)

**Question**: should I also add explicit wording for bind:indeterminate since it no longer works without explicitly defining a getter/setter: 

```
let status = 'pending'
<input type="checkbox" bind:indeterminate={(staus === 'pending')} />`
// or
<input type="checkbox" bind:indeterminate={(satus === 'pending') ? true : false} />
```

Fail. Rather:

`<input type="checkbox" bind:indeterminate={() => true, null} />`

...appears to be the only way this binding currently works in Svelte5.

Alternatively, should support for indeterminate={true} be a feat: ticket?


Repl (duplicated below): 
https://svelte.dev/playground/1e48fd6b1c8a46b8aba20a37545a0cd8?version=5.19.6



(edits:clarity and repl inclusion)


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
