### PR TITLE
fix: recurse into `$derived` for ownership validation

### DIFF
--- a/.changeset/thick-carrots-arrive.md
+++ b/.changeset/thick-carrots-arrive.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: recurse into `$derived` for ownership validation

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/ClassBody.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/ClassBody.js
@@ -190,22 +190,21 @@ export function ClassBody(node, context) {
 				'method',
 				b.id('$.ADD_OWNER'),
 				[b.id('owner')],
-				Array.from(public_state)
-					// Only run ownership addition on $state fields.
-					// Theoretically someone could create a `$state` while creating `$state.raw` or inside a `$derived.by`,
-					// but that feels so much of an edge case that it doesn't warrant a perf hit for the common case.
-					.filter(([_, { kind }]) => kind === 'state')
-					.map(([name]) =>
-						b.stmt(
-							b.call(
-								'$.add_owner',
-								b.call('$.get', b.member(b.this, b.private_id(name))),
-								b.id('owner'),
-								b.literal(false),
-								is_ignored(node, 'ownership_invalid_binding') && b.true
-							)
+				[
+					b.stmt(
+						b.call(
+							'$.add_owner_to_class',
+							b.this,
+							b.id('owner'),
+							b.array(
+								Array.from(public_state).map(([name]) =>
+									b.thunk(b.call('$.get', b.member(b.this, b.private_id(name))))
+								)
+							),
+							is_ignored(node, 'ownership_invalid_binding') && b.true
 						)
-					),
+					)
+				],
 				true
 			)
 		);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -180,37 +180,18 @@ export function build_component(node, component_name, context, anchor = context.
 			const expression = /** @type {Expression} */ (context.visit(attribute.expression));
 
 			if (dev && attribute.name !== 'this') {
-				let should_add_owner = true;
-
-				if (attribute.expression.type !== 'SequenceExpression') {
-					const left = object(attribute.expression);
-
-					if (left?.type === 'Identifier') {
-						const binding = context.state.scope.get(left.name);
-
-						// Only run ownership addition on $state fields.
-						// Theoretically someone could create a `$state` while creating `$state.raw` or inside a `$derived.by`,
-						// but that feels so much of an edge case that it doesn't warrant a perf hit for the common case.
-						if (binding?.kind === 'derived' || binding?.kind === 'raw_state') {
-							should_add_owner = false;
-						}
-					}
-				}
-
-				if (should_add_owner) {
-					binding_initializers.push(
-						b.stmt(
-							b.call(
-								b.id('$.add_owner_effect'),
-								expression.type === 'SequenceExpression'
-									? expression.expressions[0]
-									: b.thunk(expression),
-								b.id(component_name),
-								is_ignored(node, 'ownership_invalid_binding') && b.true
-							)
+				binding_initializers.push(
+					b.stmt(
+						b.call(
+							b.id('$.add_owner_effect'),
+							expression.type === 'SequenceExpression'
+								? expression.expressions[0]
+								: b.thunk(expression),
+							b.id(component_name),
+							is_ignored(node, 'ownership_invalid_binding') && b.true
 						)
-					);
-				}
+					)
+				);
 			}
 
 			if (expression.type === 'SequenceExpression') {

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -10,6 +10,7 @@ export {
 	mark_module_start,
 	mark_module_end,
 	add_owner_effect,
+	add_owner_to_class,
 	skip_ownership_validation
 } from './dev/ownership.js';
 export { check_target, legacy_api } from './dev/legacy.js';

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/CounterBinding.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/CounterBinding.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { linked3 = $bindable(), linked4 = $bindable() } = $props();
+</script>
+
+<p>Binding</p>
+<button onclick={() => linked3.count++}>Increment Linked 1 ({linked3.count})</button>
+<button onclick={() => linked4.count++}>Increment Linked 2 ({linked4.count})</button>

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/CounterContext.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/CounterContext.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { getContext } from 'svelte';
+	const linked1 = getContext('linked1');
+	const linked2 = getContext('linked2');
+</script>
+
+<p>Context</p>
+<button onclick={() => linked1.linked.current.count++}
+	>Increment Linked 1 ({linked1.linked.current.count})</button
+>
+<button onclick={() => linked2.linked.current.count++}
+	>Increment Linked 2 ({linked2.linked.current.count})</button
+>

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/_config.js
@@ -1,0 +1,34 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+// Tests that ownership is widened with $derived (on class or on its own) that contains $state
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, warnings }) {
+		const [root, counter_context1, counter_context2, counter_binding1, counter_binding2] =
+			target.querySelectorAll('button');
+
+		counter_context1.click();
+		counter_context2.click();
+		counter_binding1.click();
+		counter_binding2.click();
+		flushSync();
+
+		assert.equal(warnings.length, 0);
+
+		root.click();
+		flushSync();
+		counter_context1.click();
+		counter_context2.click();
+		counter_binding1.click();
+		counter_binding2.click();
+		flushSync();
+
+		assert.equal(warnings.length, 0);
+	},
+
+	warnings: []
+});

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/main.svelte
@@ -1,0 +1,82 @@
+<script>
+	import CounterBinding from './CounterBinding.svelte';
+	import CounterContext from './CounterContext.svelte';
+	import { setContext } from 'svelte';
+
+	let counter = $state({ count: 0 });
+
+	class Linked {
+		#getter;
+		linked = $derived.by(() => {
+			const state = $state({ current: $state.snapshot(this.#getter()) });
+			return state;
+		});
+
+		constructor(fn) {
+			this.#getter = fn;
+		}
+	}
+
+	const linked1 = $derived.by(() => {
+		const state = $state({ current: $state.snapshot(counter) });
+		return state;
+	});
+	const linked2 = new Linked(() => counter);
+
+	setContext('linked1', {
+		get linked() {
+			return linked1;
+		}
+	});
+	setContext('linked2', linked2);
+
+	const linked3 = $derived.by(() => {
+		const state = $state({ current: $state.snapshot(counter) });
+		return state;
+	});
+	const linked4 = new Linked(() => counter);
+</script>
+
+<p>Parent</p>
+<button onclick={() => counter.count++}>
+	Increment Original ({counter.count})
+</button>
+
+<CounterContext />
+<CounterBinding bind:linked3={linked3.current} bind:linked4={linked4.linked.current} />
+
+<!-- <script>
+    import { createPortalKey } from 'svelte';
+    let x = createPortalKey();
+    let count = $state(0);
+    let root = $state();
+
+    $effect(() => {
+        root = document.querySelector('#root');
+    })
+</script>
+
+<div>
+    <svelte:portal for={x}></svelte:portal>
+</div>
+
+<button onclick={() => count++}>increment</button>
+
+<svelte:portal target={x}>
+    hello {count}
+</svelte:portal>
+
+{#if count < 5}
+    <svelte:portal target={x}>
+        <span>hello2 {count}</span>
+    </svelte:portal>
+{/if}
+
+<p></p>
+
+<svelte:portal target="{root}">
+    I'm rendered in the
+    <button onclick={() => root = document.querySelector('p')}>
+        {root === document.querySelector('#root') ? 'root' : 'p'}
+    </button>
+</svelte:portal> -->

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-with-binding-8/main.svelte
@@ -44,39 +44,3 @@
 
 <CounterContext />
 <CounterBinding bind:linked3={linked3.current} bind:linked4={linked4.linked.current} />
-
-<!-- <script>
-    import { createPortalKey } from 'svelte';
-    let x = createPortalKey();
-    let count = $state(0);
-    let root = $state();
-
-    $effect(() => {
-        root = document.querySelector('#root');
-    })
-</script>
-
-<div>
-    <svelte:portal for={x}></svelte:portal>
-</div>
-
-<button onclick={() => count++}>increment</button>
-
-<svelte:portal target={x}>
-    hello {count}
-</svelte:portal>
-
-{#if count < 5}
-    <svelte:portal target={x}>
-        <span>hello2 {count}</span>
-    </svelte:portal>
-{/if}
-
-<p></p>
-
-<svelte:portal target="{root}">
-    I'm rendered in the
-    <button onclick={() => root = document.querySelector('p')}>
-        {root === document.querySelector('#root') ? 'root' : 'p'}
-    </button>
-</svelte:portal> -->


### PR DESCRIPTION
- `$derived` can contain `$state` declarations so we cannot ignore them, so this reverts #14533
- instead, we add equality checks to not do this expensive work unnecessarily
- this also adds a render effect similar to the class ownership addition when it detects a getter on a POJO during ownership addition

fixes #15164

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
