### PR TITLE
docs: Adjust docs for snippet typing to be more explicit

### DIFF
--- a/documentation/docs/03-template-syntax/06-snippet.md
+++ b/documentation/docs/03-template-syntax/06-snippet.md
@@ -228,22 +228,29 @@ Snippets implement the `Snippet` interface imported from `'svelte'`:
 
 With this change, red squigglies will appear if you try and use the component without providing a `data` prop and a `row` snippet. Notice that the type argument provided to `Snippet` is a tuple, since snippets can have multiple parameters.
 
-We can tighten things up further by declaring a generic, so that `data` and `row` refer to the same type:
+We can tighten things up further by declaring a Fruit type, so that `data` and `row` refer to the same type. Now a row snippet will error if the shape is not used.
 
 ```svelte
-<script lang="ts" generics="T">
+<script lang="ts">
 	import type { Snippet } from 'svelte';
+
+  type Fruit = {
+    name: string;
+    qty: number;
+    price: number;
+  }
 
 	let {
 		data,
 		children,
 		row
 	}: {
-		data: T[];
+		data: Fruit[];
 		children: Snippet;
-		row: Snippet<[T]>;
+		row: Snippet<[Fruit]>;
 	} = $props();
 </script>
+
 ```
 
 ## Exporting snippets


### PR DESCRIPTION
I found the Snippet docs a little opaque in regard to typing. I think in this case it's best to be explicit with the typing, rather than use a generic, because the shape of the example is consistent throughout the page.

As an aside, I might even suggest an "Advanced patterns" section with Snippets that shows how snippet parameters can be spread to a render since that is extremely common in Svelte components in practice. I'm happy to construct an example like that if needed in a second PR.

This is only my second PR against the docs, so please let me know if I've made any stylistic or pattern errors.

### Before submitting the PR, please make sure you do the following

- [ ] ~It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs~
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] ~Ideally, include a test that fails without this PR but passes with it.~
- [ ] ~If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).~

### Tests and linting

- [ ] ~Run the tests with `pnpm test` and lint the project with `pnpm lint`~
