### PR TITLE
[docs] update warning message for `state_referenced_locally`

### DIFF
--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -645,7 +645,7 @@ export function reactive_declaration_module_script_dependency(node) {
  * @param {null | NodeLike} node
  */
 export function state_referenced_locally(node) {
-	w(node, 'state_referenced_locally', `State referenced in its own scope will never update. Did you mean to reference it inside a closure?\nhttps://svelte.dev/e/state_referenced_locally`);
+	w(node, 'state_referenced_locally', `This state is not reactive. Did you mean to reference it inside a closure?\nhttps://svelte.dev/e/state_referenced_locally`);
 }
 
 /**


### PR DESCRIPTION
closes #11883 #13079

I believe there should be better examples for closures. The current example only covers `setContext('count', () => count);`. But there is more than 1 way to create a closure and more than 1 place this warning can appear. For example:

```svelte
<script>
  const items = 5
  let itemsPerPage = $state(5)
  let pages = $state(items / itemsPerPage)
</script>
```
[REPL
](https://svelte.dev/playground/hello-world?version=5.19.6#H4sIAAAAAAAACm3NPwvCMBAF8K9yHA4tFDt1CVVwc-xuHWJ7lkCahNz5j9LvLhGrDq6_9x5vQqdHQoV7stbDzUfbQ0a9EepzLPBsLDGqw4TyCKmXAItltQthzVeykuykmf55552QE0aFNXfRBNm2DqDzjgWM0MiwgSqRpTc0FBs9EGxgxaKFsipf8qAH4m_wqpe_o7x1dfn5wQKF7oJK4oXm4_wE-RQkc_EAAAA=)
### Before submitting the PR, please make sure you do the following

If there is interest. I can create a separate issue for the above.

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
