### PR TITLE
fix: ensure resuming effects works correctly with unowned dependencies

### DIFF
--- a/.changeset/fuzzy-fans-beg.md
+++ b/.changeset/fuzzy-fans-beg.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: esnure resuming effects works correctly with unowned dependencies
+fix: ensure resuming effects works correctly with unowned dependencies

--- a/.changeset/fuzzy-fans-beg.md
+++ b/.changeset/fuzzy-fans-beg.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: esnure resuming effects works correctly with unowned dependencies

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -598,10 +598,18 @@ function resume_children(effect, local) {
 	}
 
 	// If a dependency of this effect changed while it was paused,
-	// schedule the effect to update
-	if (check_dirtiness(effect)) {
-		set_signal_status(effect, DIRTY);
-		schedule_effect(effect);
+	// schedule the effect to update and ensure we set the effect
+	// to be the active reaction to ensure that unowned deriveds
+	// are correctly tracked because we're resuming the effect
+	var previous_reaction = active_reaction;
+	try {
+		set_active_reaction(effect);
+		if (check_dirtiness(effect)) {
+			set_signal_status(effect, DIRTY);
+			schedule_effect(effect);
+		}
+	} finally {
+		set_active_reaction(previous_reaction);
 	}
 
 	var child = effect.first;

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -16,8 +16,7 @@ import {
 	check_dirtiness,
 	set_is_flushing_effect,
 	is_flushing_effect,
-	untracking,
-	set_active_reaction
+	untracking
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import {
@@ -212,14 +211,8 @@ export function internal_set(source, value) {
 					if ((effect.f & CLEAN) !== 0) {
 						set_signal_status(effect, MAYBE_DIRTY);
 					}
-					var previous_reaction = active_reaction;
-					try {
-						set_active_reaction(effect);
-						if (check_dirtiness(effect)) {
-							update_effect(effect);
-						}
-					} finally {
-						set_active_reaction(previous_reaction);
+					if (check_dirtiness(effect)) {
+						update_effect(effect);
 					}
 				}
 			} finally {

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -16,7 +16,8 @@ import {
 	check_dirtiness,
 	set_is_flushing_effect,
 	is_flushing_effect,
-	untracking
+	untracking,
+	set_active_reaction
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import {
@@ -211,8 +212,14 @@ export function internal_set(source, value) {
 					if ((effect.f & CLEAN) !== 0) {
 						set_signal_status(effect, MAYBE_DIRTY);
 					}
-					if (check_dirtiness(effect)) {
-						update_effect(effect);
+					var previous_reaction = active_reaction;
+					try {
+						set_active_reaction(effect);
+						if (check_dirtiness(effect)) {
+							update_effect(effect);
+						}
+					} finally {
+						set_active_reaction(previous_reaction);
 					}
 				}
 			} finally {


### PR DESCRIPTION
We missed a few more cases where we need to the `active_reaction` when checking dirtiness of effects in https://github.com/sveltejs/svelte/pull/15158.