### PR TITLE
[docs] remove duplicate `paused` prop in `<audio>`

### DIFF
--- a/documentation/docs/03-template-syntax/11-bind.md
+++ b/documentation/docs/03-template-syntax/11-bind.md
@@ -219,11 +219,10 @@ You can give the `<select>` a default value by adding a `selected` attribute to 
 - [`volume`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/volume)
 - [`muted`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/muted)
 
-...and seven readonly ones:
+...and six readonly ones:
 
 - [`duration`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/duration)
 - [`buffered`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/buffered)
-- [`paused`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/paused)
 - [`seekable`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seekable)
 - [`seeking`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seeking_event)
 - [`ended`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/ended)


### PR DESCRIPTION
closes #13976 

Use this [REPL](https://svelte.dev/playground/93652d40f09a416d9fc177a4ac89b32b?version=5.19.6#H4sIAAAAAAAACm2OwUrEMBBAf6UOHnah26z1FtqCHyB4FeMhTUc3mCahM7Eupf8usUUvnjK8eczLAl6PCBIe0mBD8eT0FSco4c06JJAvC_A15n0GUP7aMVb0iY4z6zXhf9wEz-iZQEJDZrKRO-UVO-Qi6kQ4FG1xS6wZD0flG_Hn-Ebn72S7t36Qu54PTsFR5jSZVsGFOZIUYp7nylwCWVOZMIo5nva4SNEFPZCoz3Utznfi0RJZ_356Dqka470C5btG_OS2cp-Ygy-CN86aj3Y5HNtu67c327t2yz40YrM7KIHxi0HylHB9Xb8Bd5iOJ1cBAAA=) to verify.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
