### PR TITLE
 fix: correctly visit elements that may match :has() during pruning

### DIFF
--- a/.changeset/cuddly-turtles-work.md
+++ b/.changeset/cuddly-turtles-work.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly visit elements that may match :has() during pruning

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -158,7 +158,7 @@ function truncate(node) {
 }
 
 /**
- * @param {Compiler.AST.CSS.RelativeSelector[]} relative_selectors
+ * @param {ExtendedRelativeSelector[]} relative_selectors
  * @param {Compiler.AST.CSS.Rule} rule
  * @param {Compiler.AST.RegularElement | Compiler.AST.SvelteElement} element
  * @returns {boolean}
@@ -173,7 +173,7 @@ function apply_selector(relative_selectors, rule, element) {
 		apply_combinator(relative_selector, parent_selectors, rule, element);
 
 	if (matched) {
-		if (!is_outer_global(relative_selector)) {
+		if (!is_outer_global(/** @type {Compiler.AST.CSS.RelativeSelector} */ (relative_selector))) {
 			relative_selector.metadata.scoped = true;
 		}
 
@@ -184,8 +184,8 @@ function apply_selector(relative_selectors, rule, element) {
 }
 
 /**
- * @param {Compiler.AST.CSS.RelativeSelector} relative_selector
- * @param {Compiler.AST.CSS.RelativeSelector[]} parent_selectors
+ * @param {ExtendedRelativeSelector} relative_selector
+ * @param {ExtendedRelativeSelector[]} parent_selectors
  * @param {Compiler.AST.CSS.Rule} rule
  * @param {Compiler.AST.RegularElement | Compiler.AST.SvelteElement | Compiler.AST.RenderTag | Compiler.AST.Component | Compiler.AST.SvelteComponent | Compiler.AST.SvelteSelf} node
  * @returns {boolean}
@@ -269,7 +269,7 @@ function apply_combinator(relative_selector, parent_selectors, rule, node) {
  * it's a `:global(...)` or unscopeable selector, or
  * is an `:is(...)` or `:where(...)` selector that contains
  * a global selector
- * @param {Compiler.AST.CSS.RelativeSelector} selector
+ * @param {ExtendedRelativeSelector} selector
  * @param {Compiler.AST.CSS.Rule} rule
  */
 function is_global(selector, rule) {
@@ -403,11 +403,7 @@ function relative_selector_might_apply_to_node(relative_selector, rule, element)
 					if (
 						selectors.length === 0 /* is :global(...) */ ||
 						(element.metadata.scoped && selector_matched) ||
-						apply_selector(
-							/** @type {Compiler.AST.CSS.RelativeSelector[]} */ (selectors),
-							rule,
-							element
-						)
+						apply_selector(selectors, rule, element)
 					) {
 						complex_selector.metadata.used = true;
 						selector_matched = matched = true;

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -694,7 +694,7 @@ function get_descendant_elements(element, include_self) {
 					seen.add(snippet);
 					walk_children(snippet.body);
 				}
-			},
+			}
 		});
 	}
 

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js
@@ -369,12 +369,14 @@ function relative_selector_might_apply_to_node(relative_selector, rule, element)
 			}
 
 			sibling_elements ??= get_following_sibling_elements(element, include_self);
-			if (selectors.some(s => s.combinator?.name === ' ' || s.combinator?.name === '>')) {
-				sibling_descendant_elements ??= sibling_elements.flatMap(el => get_descendant_elements(el, false));
+			if (selectors.some((s) => s.combinator?.name === ' ' || s.combinator?.name === '>')) {
+				sibling_descendant_elements ??= sibling_elements.flatMap((el) =>
+					get_descendant_elements(el, false)
+				);
 				return sibling_descendant_elements;
 			}
 			return sibling_elements;
-		}
+		};
 
 		// :has(...) is special in that it means "look downwards in the CSS tree". Since our matching algorithm goes
 		// upwards and back-to-front, we need to first check the selectors inside :has(...), then check the rest of the
@@ -401,7 +403,11 @@ function relative_selector_might_apply_to_node(relative_selector, rule, element)
 					if (
 						selectors.length === 0 /* is :global(...) */ ||
 						(element.metadata.scoped && selector_matched) ||
-						apply_selector(/** @type {Compiler.AST.CSS.RelativeSelector[]} */ (selectors), rule, element)
+						apply_selector(
+							/** @type {Compiler.AST.CSS.RelativeSelector[]} */ (selectors),
+							rule,
+							element
+						)
 					) {
 						complex_selector.metadata.used = true;
 						selector_matched = matched = true;
@@ -1097,19 +1103,21 @@ function is_block(node) {
 function make_element_selector(element) {
 	return {
 		type: 'RelativeSelector',
-		selectors: [{
-			type: 'ElementSelector',
-			element,
-			start: -1,
-			end: -1,
-		}],
+		selectors: [
+			{
+				type: 'ElementSelector',
+				element,
+				start: -1,
+				end: -1
+			}
+		],
 		combinator: null,
 		metadata: {
 			is_global: false,
 			is_global_like: false,
-			scoped: false,
+			scoped: false
 		},
 		start: -1,
-		end: -1,
+		end: -1
 	};
 }

--- a/packages/svelte/tests/css/samples/has/_config.js
+++ b/packages/svelte/tests/css/samples/has/_config.js
@@ -6,210 +6,224 @@ export default test({
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused:has(y)"',
 			start: {
-				line: 33,
+				line: 41,
 				column: 1,
-				character: 330
+				character: 378
 			},
 			end: {
-				line: 33,
+				line: 41,
 				column: 15,
-				character: 344
+				character: 392
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused:has(:global(y))"',
 			start: {
-				line: 36,
+				line: 44,
 				column: 1,
-				character: 365
+				character: 413
 			},
 			end: {
-				line: 36,
+				line: 44,
 				column: 24,
-				character: 388
+				character: 436
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "x:has(.unused)"',
 			start: {
-				line: 39,
+				line: 47,
 				column: 1,
-				character: 409
+				character: 457
 			},
 			end: {
-				line: 39,
+				line: 47,
 				column: 15,
-				character: 423
+				character: 471
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ":global(.foo):has(.unused)"',
 			start: {
-				line: 42,
+				line: 50,
 				column: 1,
-				character: 444
+				character: 492
 			},
 			end: {
-				line: 42,
+				line: 50,
 				column: 27,
-				character: 470
+				character: 518
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "x:has(y):has(.unused)"',
 			start: {
-				line: 52,
+				line: 60,
 				column: 1,
-				character: 578
+				character: 626
 			},
 			end: {
-				line: 52,
+				line: 60,
 				column: 22,
-				character: 599
+				character: 647
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused"',
 			start: {
-				line: 71,
+				line: 79,
 				column: 2,
-				character: 804
+				character: 852
 			},
 			end: {
-				line: 71,
+				line: 79,
 				column: 9,
-				character: 811
+				character: 859
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused x:has(y)"',
 			start: {
-				line: 87,
+				line: 95,
 				column: 1,
-				character: 958
+				character: 1006
 			},
 			end: {
-				line: 87,
+				line: 95,
 				column: 17,
-				character: 974
+				character: 1022
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ".unused:has(.unused)"',
 			start: {
-				line: 90,
+				line: 98,
 				column: 1,
-				character: 995
+				character: 1043
 			},
 			end: {
-				line: 90,
+				line: 98,
 				column: 21,
-				character: 1015
+				character: 1063
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "x:has(> z)"',
 			start: {
-				line: 100,
+				line: 108,
 				column: 1,
-				character: 1115
+				character: 1163
 			},
 			end: {
-				line: 100,
+				line: 108,
 				column: 11,
-				character: 1125
+				character: 1173
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "x:has(> d)"',
 			start: {
-				line: 103,
+				line: 111,
 				column: 1,
-				character: 1146
+				character: 1194
 			},
 			end: {
-				line: 103,
+				line: 111,
 				column: 11,
-				character: 1156
+				character: 1204
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "x:has(~ y)"',
 			start: {
-				line: 123,
+				line: 131,
 				column: 1,
-				character: 1348
+				character: 1396
 			},
 			end: {
-				line: 123,
+				line: 131,
 				column: 11,
-				character: 1358
+				character: 1406
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "f:has(~ d)"',
 			start: {
-				line: 133,
+				line: 141,
 				column: 1,
-				character: 1446
+				character: 1494
 			},
 			end: {
-				line: 133,
+				line: 141,
 				column: 11,
-				character: 1456
+				character: 1504
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ":has(.unused)"',
 			start: {
-				line: 141,
+				line: 149,
 				column: 2,
-				character: 1529
+				character: 1577
 			},
 			end: {
-				line: 141,
+				line: 149,
 				column: 15,
-				character: 1542
+				character: 1590
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector "&:has(.unused)"',
 			start: {
-				line: 147,
+				line: 155,
 				column: 2,
-				character: 1600
+				character: 1648
 			},
 			end: {
-				line: 147,
+				line: 155,
 				column: 16,
-				character: 1614
+				character: 1662
 			}
 		},
 		{
 			code: 'css_unused_selector',
 			message: 'Unused CSS selector ":global(.foo):has(.unused)"',
 			start: {
-				line: 155,
+				line: 163,
 				column: 1,
-				character: 1684
+				character: 1732
 			},
 			end: {
-				line: 155,
+				line: 163,
 				column: 27,
-				character: 1710
+				character: 1758
+			}
+		},
+		{
+			code: 'css_unused_selector',
+			message: 'Unused CSS selector "h:has(> h > i)"',
+			start: {
+				line: 170,
+				column: 1,
+				character: 1817
+			},
+			end: {
+				line: 170,
+				column: 15,
+				character: 1831
 			}
 		}
 	]

--- a/packages/svelte/tests/css/samples/has/expected.css
+++ b/packages/svelte/tests/css/samples/has/expected.css
@@ -143,3 +143,13 @@
 	/* (unused) :global(.foo):has(.unused) {
 		color: red;
 	}*/
+
+	g.svelte-xyz:has(> h:where(.svelte-xyz) > i:where(.svelte-xyz)) {
+		color: green;
+	}
+	/* (unused) h:has(> h > i) {
+		color: red;
+	}*/
+	g.svelte-xyz:has(+ j:where(.svelte-xyz) > k:where(.svelte-xyz)) {
+		color: green;
+	}

--- a/packages/svelte/tests/css/samples/has/input.svelte
+++ b/packages/svelte/tests/css/samples/has/input.svelte
@@ -9,6 +9,14 @@
 	</y>
 </x>
 <c></c>
+<g>
+	<h>
+		<i></i>
+	</h>
+</g>
+<j>
+	<k></k>
+</j>
 
 <style>
 	x:has(y) {
@@ -154,5 +162,15 @@
 	}
 	:global(.foo):has(.unused) {
 		color: red;
+	}
+
+	g:has(> h > i) {
+		color: green;
+	}
+	h:has(> h > i) {
+		color: red;
+	}
+	g:has(+ j > k) {
+		color: green;
 	}
 </style>


### PR DESCRIPTION
Fixes #14072 

`:has()` was matching only against descendants or siblings, but not sibling's descendants.

Also, in a case like `:has(> .foo > .bar)` it was matching against children instead of descendants, so I had to drop the `>` optimization. But, to ensure that in case like `:has(> .foo)` it matches only the direct children, the inner selector is prepended with a selector of new type that matches only certain element.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
