### PR TITLE
fix: ensure tracking returns true, even if in unowned

### DIFF
--- a/.changeset/long-moles-join.md
+++ b/.changeset/long-moles-join.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure tracking returns true, even if in unowned

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -170,7 +170,7 @@ export function effect_tracking() {
 
 	// If it's skipped, that's because we're inside an unowned
 	// that is not being tracked by another reaction
-	return !skip_reaction;
+	return true;
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -164,13 +164,7 @@ function create_effect(type, fn, sync, push = true) {
  * @returns {boolean}
  */
 export function effect_tracking() {
-	if (active_reaction === null || untracking) {
-		return false;
-	}
-
-	// If it's skipped, that's because we're inside an unowned
-	// that is not being tracked by another reaction
-	return true;
+	return active_reaction !== null && !untracking;
 }
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-unowned/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-unowned/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const b1 = target.querySelector('button');
+
+		b1?.click();
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`<o>Store: new</o><p>Text: new message</p><button>Change Store</button>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-unowned/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-unowned/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { writable, fromStore, toStore } from "svelte/store";
+
+	const store = writable("previous");
+	let text = $derived(fromStore(store).current + " message");
+
+	const textStore = toStore(() => text);
+</script>
+
+<o>Store: {$store}</o>
+<p>Text: {text}</p>
+<button onclick={() => { store.set("new"); }}>Change Store</button>

--- a/packages/svelte/tests/runtime-runes/samples/effect-tracking-unowned/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-tracking-unowned/main.svelte
@@ -4,7 +4,7 @@
 	const store = writable("previous");
 	let text = $derived(fromStore(store).current + " message");
 
-	const textStore = toStore(() => text);
+	text; // read derived in a non-tracking context
 </script>
 
 <o>Store: {$store}</o>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/15212

I should have changed this in https://github.com/sveltejs/svelte/pull/15137. As deriveds are now technically not owned and we have a dedicated `untracked` flag, we can remove this heuristic entirely. You can still track things inside an unowned derived, because that derived is still technically reactive. We had to do this with https://github.com/sveltejs/svelte/pull/14005 because deriveds were just broken.