### PR TITLE
fix: ensure custom element updates don't run in hydration mode

### DIFF
--- a/.changeset/light-ligers-switch.md
+++ b/.changeset/light-ligers-switch.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure custom element updates don't run in hydration mode


### PR DESCRIPTION
When a custom element is created before Svelte hydration kicks in, it will scaffold itself, using the properties given via attributes. Now when a custom element property is set during Svelte's hydration, the Svelte custom element component could run logic like updating an each block. Without turning off hydration mode during that time, the update would try to pick up existing element nodes (because it thinks they must be there because of hydration mode), and crash.

No test because it would require a setup where we can ensure the element is scaffolded before hydration runs.

Fixes #15213

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
