### PR TITLE
chore: add download/hash scripts for sandbox

### DIFF
--- a/playgrounds/sandbox/index.html
+++ b/playgrounds/sandbox/index.html
@@ -12,7 +12,7 @@
 
 		<script type="module">
 			import { mount, hydrate, unmount } from 'svelte';
-			import App from '/src/main.svelte';
+			import App from '/src/App.svelte';
 
 			const root = document.getElementById('root');
 			const render = root.firstChild?.nextSibling ? hydrate : mount;

--- a/playgrounds/sandbox/package.json
+++ b/playgrounds/sandbox/package.json
@@ -9,7 +9,9 @@
     "ssr": "node --conditions=development ./ssr-dev.js",
     "build": "vite build --outDir dist/client && vite build --outDir dist/server --ssr ssr-prod.js",
     "prod": "npm run build && node dist/server/ssr-prod",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "download": "node scripts/download.js",
+    "hash": "node scripts/hash.js | pbcopy && echo \"copied URL to clipboard\""
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",

--- a/playgrounds/sandbox/scripts/download.js
+++ b/playgrounds/sandbox/scripts/download.js
@@ -29,8 +29,6 @@ if (url.hash.length > 1) {
 	const stream = new Blob([u8]).stream().pipeThrough(new DecompressionStream('gzip'));
 	const json = await new Response(stream).text();
 
-	console.log(JSON.parse(json));
-
 	files = JSON.parse(json).files;
 } else {
 	const id = url.pathname.split('/')[2];

--- a/playgrounds/sandbox/scripts/download.js
+++ b/playgrounds/sandbox/scripts/download.js
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+
+const arg = process.argv[2];
+
+/** @type {URL} */
+let url;
+
+try {
+	url = new URL(arg);
+} catch (e) {
+	console.error(`${arg} is not a URL`);
+	process.exit(1);
+}
+
+if (url.origin !== 'https://svelte.dev' || !url.pathname.startsWith('/playground/')) {
+	console.error(`${arg} is not a Svelte playground URL`);
+	process.exit(1);
+}
+
+let files;
+
+if (url.hash.length > 1) {
+	const decoded = atob(url.hash.slice(1).replaceAll('-', '+').replaceAll('_', '/'));
+	// putting it directly into the blob gives a corrupted file
+	const u8 = new Uint8Array(decoded.length);
+	for (let i = 0; i < decoded.length; i++) {
+		u8[i] = decoded.charCodeAt(i);
+	}
+	const stream = new Blob([u8]).stream().pipeThrough(new DecompressionStream('gzip'));
+	const json = await new Response(stream).text();
+
+	console.log(JSON.parse(json));
+
+	files = JSON.parse(json).files;
+} else {
+	const id = url.pathname.split('/')[2];
+	const response = await fetch(`https://svelte.dev/playground/api/${id}.json`);
+
+	files = (await response.json()).components.map((data) => {
+		const basename = `${data.name}.${data.type}`;
+
+		return {
+			type: 'file',
+			name: basename,
+			basename,
+			contents: data.source,
+			text: true
+		};
+	});
+}
+
+for (const file of files) {
+	fs.writeFileSync(`src/${file.name}`, file.contents);
+}

--- a/playgrounds/sandbox/scripts/hash.js
+++ b/playgrounds/sandbox/scripts/hash.js
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+
+const files = [];
+
+for (const basename of fs.readdirSync('src')) {
+	if (fs.statSync(`src/${basename}`).isDirectory()) continue;
+
+	files.push({
+		type: 'file',
+		name: basename,
+		basename,
+		contents: fs.readFileSync(`src/${basename}`, 'utf-8'),
+		text: true // TODO might not be
+	});
+}
+
+const payload = JSON.stringify({
+	name: 'sandbox',
+	files
+});
+
+async function compress(payload) {
+	const reader = new Blob([payload])
+		.stream()
+		.pipeThrough(new CompressionStream('gzip'))
+		.getReader();
+
+	let buffer = '';
+	for (;;) {
+		const { done, value } = await reader.read();
+
+		if (done) {
+			reader.releaseLock();
+			return btoa(buffer).replaceAll('+', '-').replaceAll('/', '_');
+		} else {
+			for (let i = 0; i < value.length; i++) {
+				// decoding as utf-8 will make btoa reject the string
+				buffer += String.fromCharCode(value[i]);
+			}
+		}
+	}
+}
+
+const hash = await compress(payload);
+console.log(`https://svelte.dev/playground/untitled#${hash}`);

--- a/playgrounds/sandbox/ssr-dev.js
+++ b/playgrounds/sandbox/ssr-dev.js
@@ -22,7 +22,7 @@ polka()
 	.use(async (req, res) => {
 		const template = fs.readFileSync(path.resolve(__dirname, 'index.html'), 'utf-8');
 		const transformed_template = await vite.transformIndexHtml(req.url, template);
-		const { default: App } = await vite.ssrLoadModule('/src/main.svelte');
+		const { default: App } = await vite.ssrLoadModule('/src/App.svelte');
 		const { head, body } = render(App);
 
 		const html = transformed_template

--- a/playgrounds/sandbox/ssr-prod.js
+++ b/playgrounds/sandbox/ssr-prod.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import polka from 'polka';
 import { render } from 'svelte/server';
-import App from './src/main.svelte';
+import App from './src/App.svelte';
 
 const { head, body } = render(App);
 


### PR DESCRIPTION
Copying playgrounds to the sandbox in this repo, for local debugging, is currently a bit of a chore, as is the reverse operation. This PR adds two new scripts. The first one downloads a playground to `playgrounds/sandbox/src` (it will use the hash, if present, and if not get the data from `svelte.dev/playground/api`):

```bash
pnpm download https://svelte.dev/playground/8a021b2ec2064230bde4a10b08464876?version=5.19.7
```

The second hashes the current contents of `playgrounds/sandbox/src` and copies a URL to the clipboard:

```bash
pnpm hash
```