### PR TITLE
fix: hydrate `href` that is part of spread attributes

### DIFF
--- a/.changeset/wicked-apes-sin.md
+++ b/.changeset/wicked-apes-sin.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: hydrate `href` that is part of spread attributes

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -419,11 +419,7 @@ export function set_attributes(
 				// @ts-ignore
 				element[name] = value;
 			} else if (typeof value !== 'function') {
-				if (hydrating && (name === 'src' || name === 'href' || name === 'srcset')) {
-					if (!skip_warning) check_src_in_dev_hydration(element, name, value ?? '');
-				} else {
-					set_attribute(element, name, value);
-				}
+				set_attribute(element, name, value);
 			}
 		}
 		if (key === 'style' && '__styles' in element) {

--- a/packages/svelte/tests/hydration/samples/repair-mismatched-a-href/_expected.html
+++ b/packages/svelte/tests/hydration/samples/repair-mismatched-a-href/_expected.html
@@ -1,1 +1,1 @@
-<!--[--><a href="/foo">foo</a><!--]-->
+<!--[--><a href="/foo">foo</a> <a href="/foo">foo</a><!--]-->

--- a/packages/svelte/tests/hydration/samples/repair-mismatched-a-href/main.svelte
+++ b/packages/svelte/tests/hydration/samples/repair-mismatched-a-href/main.svelte
@@ -3,3 +3,4 @@
 </script>
 
 <a href={browser ? '/foo' : '/bar'}>foo</a>
+<a {...{href: browser ? '/foo' : '/bar'}}>foo</a>


### PR DESCRIPTION
We had some duplicated and buggy code, removing it fixes #15120

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
