### PR TITLE
fix: value/checked not correctly set using spread

### DIFF
--- a/.changeset/fuzzy-zoos-repeat.md
+++ b/.changeset/fuzzy-zoos-repeat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: value/checked not correctly set using spread

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -387,10 +387,14 @@ export function set_attributes(
 						let prev = input.defaultValue;
 						input.removeAttribute(name);
 						input.defaultValue = prev;
+						input.value = '';
+						// @ts-ignore
+						input.__value = null;
 					} else {
 						let prev = input.defaultChecked;
 						input.removeAttribute(name);
 						input.defaultChecked = prev;
+						input.checked = false;
 					}
 				} else {
 					element.removeAttribute(key);

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -382,19 +382,18 @@ export function set_attributes(
 				if (name === 'value' || name === 'checked') {
 					// removing value/checked also removes defaultValue/defaultChecked — preserve
 					let input = /** @type {HTMLInputElement} */ (element);
-
+					const use_default = prev === undefined;
 					if (name === 'value') {
-						let prev = input.defaultValue;
+						let previous = input.defaultValue;
 						input.removeAttribute(name);
-						input.defaultValue = prev;
-						input.value = '';
+						input.defaultValue = previous;
 						// @ts-ignore
-						input.__value = null;
+						input.value = input.__value = use_default ? previous : null;
 					} else {
-						let prev = input.defaultChecked;
+						let previous = input.defaultChecked;
 						input.removeAttribute(name);
-						input.defaultChecked = prev;
-						input.checked = false;
+						input.defaultChecked = previous;
+						input.checked = use_default ? previous : false;
 					}
 				} else {
 					element.removeAttribute(key);

--- a/packages/svelte/tests/runtime-runes/samples/attribute-spread-input/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/attribute-spread-input/_config.js
@@ -1,0 +1,33 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ target, assert }) {
+		// Test for https://github.com/sveltejs/svelte/issues/15237
+		const [setValues, clearValue] = target.querySelectorAll('button');
+		const [text1, text2, check1, check2] = target.querySelectorAll('input');
+
+		assert.equal(text1.value, '');
+		assert.equal(text2.value, '');
+		assert.equal(check1.checked, false);
+		assert.equal(check2.checked, false);
+
+		flushSync(() => {
+			setValues.click();
+		});
+
+		assert.equal(text1.value, 'message');
+		assert.equal(text2.value, 'message');
+		assert.equal(check1.checked, true);
+		assert.equal(check2.checked, true);
+
+		flushSync(() => {
+			clearValue.click();
+		});
+
+		assert.equal(text1.value, '');
+		assert.equal(text2.value, '');
+		assert.equal(check1.checked, false);
+		assert.equal(check2.checked, false);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/attribute-spread-input/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/attribute-spread-input/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	let value = $state();
+	let checked = $state(false);
+
+	function setValues() {
+		value = 'message';
+		checked = true;
+	}
+	function clearValues() {
+		value = null;
+		checked = null;
+	}
+</script>
+
+<button onclick={setValues}>setValues</button>
+<button onclick={clearValues}>clearValues</button>
+
+<input type="text" {value} />
+<input type="text" {value} {...{}} />
+
+<input type="checkbox" {checked} />
+<input type="checkbox" {checked} {...{}} />


### PR DESCRIPTION
Fix issue https://github.com/sveltejs/svelte/issues/15237 : "Using spread syntax '{...rest }' with props doesnt work correctly!"

Note : the issue is about the input input text `value`, but there's the same problem with `checked`.

`set_attributes()` use `removeAttributes()` which removes the attribute without impacting the JS state of `value/checked`, so the result is not constant.
This work only on the initial state, but not when the `value/checked` was previously set by JavaScript.

=> The `value/checked` properties must be set explicitly.


Note : I not launched **lint** and all **test**s because it generates strange errors on my config (before any change in the code).


### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
