### PR TITLE
fix: when re-connecting unowned deriveds, remove their unowned flag

### DIFF
--- a/.changeset/nasty-pigs-lay.md
+++ b/.changeset/nasty-pigs-lay.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: when an unowned derived is tracked again, remove unowned flag
+fix: alter heuristic for reading data eagerly in props handling

--- a/.changeset/nasty-pigs-lay.md
+++ b/.changeset/nasty-pigs-lay.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: alter heuristic for reading data eagerly in props handling
+fix: when re-connecting unowned deriveds, remove their unowned flag

--- a/.changeset/nasty-pigs-lay.md
+++ b/.changeset/nasty-pigs-lay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: when an unowned derived is tracked again, remove unowned flag

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -3,7 +3,6 @@ import { DEV } from 'esm-env';
 import {
 	CLEAN,
 	DERIVED,
-	DESTROYED,
 	DIRTY,
 	EFFECT_HAS_DERIVED,
 	MAYBE_DIRTY,
@@ -12,7 +11,6 @@ import {
 import {
 	active_reaction,
 	active_effect,
-	remove_reactions,
 	set_signal_status,
 	skip_reaction,
 	update_reaction,

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -1,13 +1,6 @@
 /** @import { Derived, Effect } from '#client' */
 import { DEV } from 'esm-env';
-import {
-	CLEAN,
-	DERIVED,
-	DIRTY,
-	EFFECT_HAS_DERIVED,
-	MAYBE_DIRTY,
-	UNOWNED
-} from '../constants.js';
+import { CLEAN, DERIVED, DIRTY, EFFECT_HAS_DERIVED, MAYBE_DIRTY, UNOWNED } from '../constants.js';
 import {
 	active_reaction,
 	active_effect,

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -242,26 +242,6 @@ export function spread_props(...props) {
 }
 
 /**
- * @template T
- * @param {() => T} fn
- * @returns {T}
- */
-function with_parent_branch(fn) {
-	var effect = active_effect;
-	var previous_effect = active_effect;
-
-	while (effect !== null && (effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
-		effect = effect.parent;
-	}
-	try {
-		set_active_effect(effect);
-		return fn();
-	} finally {
-		set_active_effect(previous_effect);
-	}
-}
-
-/**
  * This function is responsible for synchronizing a possibly bound prop with the inner component state.
  * It is used whenever the compiler sees that the component writes to the prop, or when it has a default prop_value.
  * @template V
@@ -335,8 +315,8 @@ export function prop(props, key, flags, fallback) {
 	} else {
 		// Svelte 4 did not trigger updates when a primitive value was updated to the same value.
 		// Replicate that behavior through using a derived
-		var derived_getter = with_parent_branch(() =>
-			(immutable ? derived : derived_safe_equal)(() => /** @type {V} */ (props[key]))
+		var derived_getter = (immutable ? derived : derived_safe_equal)(
+			() => /** @type {V} */ (props[key])
 		);
 		derived_getter.f |= LEGACY_DERIVED_PROP;
 		getter = () => {
@@ -380,21 +360,19 @@ export function prop(props, key, flags, fallback) {
 	// The derived returns the current value. The underlying mutable
 	// source is written to from various places to persist this value.
 	var inner_current_value = mutable_source(prop_value);
-	var current_value = with_parent_branch(() =>
-		derived(() => {
-			var parent_value = getter();
-			var child_value = get(inner_current_value);
+	var current_value = derived(() => {
+		var parent_value = getter();
+		var child_value = get(inner_current_value);
 
-			if (from_child) {
-				from_child = false;
-				was_from_child = true;
-				return child_value;
-			}
+		if (from_child) {
+			from_child = false;
+			was_from_child = true;
+			return child_value;
+		}
 
-			was_from_child = false;
-			return (inner_current_value.v = parent_value);
-		})
-	);
+		was_from_child = false;
+		return (inner_current_value.v = parent_value);
+	});
 
 	if (!immutable) current_value.equals = safe_equals;
 

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -254,7 +254,7 @@ export function spread_props(...props) {
  * @param {() => T} fn
  * @returns {T}
  */
-function with_parent_branch(fn) {
+function with_parent_tracking_context(fn) {
 	var effect = active_effect;
 	var previous_effect = active_effect;
 	var previous_reaction = active_reaction;
@@ -290,7 +290,7 @@ export function prop(props, key, flags, fallback) {
 	var is_store_sub = false;
 	var prop_value;
 
-	with_parent_branch(() => {
+	with_parent_tracking_context(() => {
 		if (bindable) {
 			[prop_value, is_store_sub] = capture_store_binding(() => /** @type {V} */ (props[key]));
 		} else {
@@ -331,7 +331,7 @@ export function prop(props, key, flags, fallback) {
 			e.props_invalid_value(key);
 		}
 
-		prop_value = get_fallback();
+		prop_value = with_parent_tracking_context(get_fallback);
 		if (setter) setter(prop_value);
 	}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -185,6 +185,7 @@ export function check_dirtiness(reaction) {
 			// then we need to re-connect the reaction to the dependency
 			if (is_disconnected || is_unowned_connected) {
 				var derived = /** @type {Derived} */ (reaction);
+				var parent = derived.parent;
 
 				for (i = 0; i < length; i++) {
 					dependency = dependencies[i];
@@ -200,16 +201,10 @@ export function check_dirtiness(reaction) {
 				if (is_disconnected) {
 					derived.f ^= DISCONNECTED;
 				}
-				var parent = derived.parent;
-				// If the unowned derived is now fully connected to the graph again (it has reactions, has a parent and
-				// the parent is not unowned), then we can mark it as connected again, removing the need for the unowned
+				// If the unowned derived is now fully connected to the graph again (it unowned and reconnected, has a parent
+				// and the parent is not unowned), then we can mark it as connected again, removing the need for the unowned
 				// flag
-				if (
-					is_unowned_connected &&
-					derived.reactions !== null &&
-					parent !== null &&
-					(parent.f & UNOWNED) === 0
-				) {
+				if (is_unowned_connected && parent !== null && (parent.f & UNOWNED) === 0) {
 					derived.f ^= UNOWNED;
 				}
 			}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -184,19 +184,29 @@ export function check_dirtiness(reaction) {
 			// If we are working with a disconnected or an unowned signal that is now connected (due to an active effect)
 			// then we need to re-connect the reaction to the dependency
 			if (is_disconnected || is_unowned_connected) {
+				var derived = /** @type {Derived} */ (reaction);
+
 				for (i = 0; i < length; i++) {
 					dependency = dependencies[i];
 
 					// We always re-add all reactions (even duplicates) if the derived was
 					// previously disconnected, however we don't if it was unowned as we
 					// de-duplicate dependencies in that case
-					if (is_disconnected || !dependency?.reactions?.includes(reaction)) {
-						(dependency.reactions ??= []).push(reaction);
+					if (is_disconnected || !dependency?.reactions?.includes(derived)) {
+						(dependency.reactions ??= []).push(derived);
 					}
 				}
 
 				if (is_disconnected) {
-					reaction.f ^= DISCONNECTED;
+					derived.f ^= DISCONNECTED;
+				}
+				var parent = derived.parent;
+
+				if (is_unowned_connected && parent !== null && (parent.f & UNOWNED) === 0) {
+					// If the derived is owned by another derived then mark it as owned agaub
+					// as the derived value might have been referenced in a different context
+					// and now has a reacive context managing it
+					derived.f ^= UNOWNED;
 				}
 			}
 
@@ -408,6 +418,10 @@ export function update_reaction(reaction) {
 	skip_reaction =
 		(flags & UNOWNED) !== 0 &&
 		(!is_flushing_effect || previous_reaction === null || previous_untracking);
+
+	if (skip_reaction) {
+		// debugger
+	}
 
 	derived_sources = null;
 	set_component_context(reaction.ctx);

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -206,7 +206,7 @@ export function check_dirtiness(reaction) {
 					// If the derived is owned by another derived then mark it as owned agaub
 					// as the derived value might have been referenced in a different context
 					// and now has a reacive context managing it
-					derived.f ^= UNOWNED;
+					// derived.f ^= UNOWNED;
 				}
 			}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -201,7 +201,7 @@ export function check_dirtiness(reaction) {
 				if (is_disconnected) {
 					derived.f ^= DISCONNECTED;
 				}
-				// If the unowned derived is now fully connected to the graph again (it unowned and reconnected, has a parent
+				// If the unowned derived is now fully connected to the graph again (it's unowned and reconnected, has a parent
 				// and the parent is not unowned), then we can mark it as connected again, removing the need for the unowned
 				// flag
 				if (is_unowned_connected && parent !== null && (parent.f & UNOWNED) === 0) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -419,10 +419,6 @@ export function update_reaction(reaction) {
 		(flags & UNOWNED) !== 0 &&
 		(!is_flushing_effect || previous_reaction === null || previous_untracking);
 
-	if (skip_reaction) {
-		// debugger
-	}
-
 	derived_sources = null;
 	set_component_context(reaction.ctx);
 	untracking = false;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -184,19 +184,33 @@ export function check_dirtiness(reaction) {
 			// If we are working with a disconnected or an unowned signal that is now connected (due to an active effect)
 			// then we need to re-connect the reaction to the dependency
 			if (is_disconnected || is_unowned_connected) {
+				var derived = /** @type {Derived} */ (reaction);
+
 				for (i = 0; i < length; i++) {
 					dependency = dependencies[i];
 
 					// We always re-add all reactions (even duplicates) if the derived was
 					// previously disconnected, however we don't if it was unowned as we
 					// de-duplicate dependencies in that case
-					if (is_disconnected || !dependency?.reactions?.includes(reaction)) {
-						(dependency.reactions ??= []).push(reaction);
+					if (is_disconnected || !dependency?.reactions?.includes(derived)) {
+						(dependency.reactions ??= []).push(derived);
 					}
 				}
 
 				if (is_disconnected) {
-					reaction.f ^= DISCONNECTED;
+					derived.f ^= DISCONNECTED;
+				}
+				var parent = derived.parent;
+				// If the unowned derived is now fully connected to the graph again (it has reactions, has a parent and
+				// the parent is not unowned), then we can mark it as connected again, removing the need for the unowned
+				// flag
+				if (
+					is_unowned_connected &&
+					derived.reactions !== null &&
+					parent !== null &&
+					(parent.f & UNOWNED) === 0
+				) {
+					derived.f ^= UNOWNED;
 				}
 			}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -184,29 +184,19 @@ export function check_dirtiness(reaction) {
 			// If we are working with a disconnected or an unowned signal that is now connected (due to an active effect)
 			// then we need to re-connect the reaction to the dependency
 			if (is_disconnected || is_unowned_connected) {
-				var derived = /** @type {Derived} */ (reaction);
-
 				for (i = 0; i < length; i++) {
 					dependency = dependencies[i];
 
 					// We always re-add all reactions (even duplicates) if the derived was
 					// previously disconnected, however we don't if it was unowned as we
 					// de-duplicate dependencies in that case
-					if (is_disconnected || !dependency?.reactions?.includes(derived)) {
-						(dependency.reactions ??= []).push(derived);
+					if (is_disconnected || !dependency?.reactions?.includes(reaction)) {
+						(dependency.reactions ??= []).push(reaction);
 					}
 				}
 
 				if (is_disconnected) {
-					derived.f ^= DISCONNECTED;
-				}
-				var parent = derived.parent;
-
-				if (is_unowned_connected && parent !== null && (parent.f & UNOWNED) === 0) {
-					// If the derived is owned by another derived then mark it as owned agaub
-					// as the derived value might have been referenced in a different context
-					// and now has a reacive context managing it
-					// derived.f ^= UNOWNED;
+					reaction.f ^= DISCONNECTED;
 				}
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-12/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-12/_config.js
@@ -1,0 +1,25 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		let [btn1, btn2] = target.querySelectorAll('button');
+
+		btn1?.click();
+		flushSync();
+
+		btn2?.click();
+		flushSync();
+
+		btn1?.click();
+		flushSync();
+
+		btn1?.click();
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>linked.current</button>\n3\n<button>count</button>\n1`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-12/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-12/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	import { untrack } from 'svelte';
+
+	let count = $state(0);
+	let state = $state({current: count});
+
+	let linked = $derived.by(() => {
+		count;
+
+		untrack(() => state.current = count);
+	  return untrack(() => state);
+	});
+
+	linked.current++;
+</script>
+
+<button onclick={() => linked.current++}>linked.current</button> {linked.current}
+<button onclick={() => count++}>count</button> {count}

--- a/packages/svelte/tests/runtime-runes/samples/derived-unowned-12/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-unowned-12/main.svelte
@@ -8,7 +8,7 @@
 		count;
 
 		untrack(() => state.current = count);
-	  return untrack(() => state);
+		return untrack(() => state);
 	});
 
 	linked.current++;

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -440,7 +440,7 @@ describe('signals', () => {
 
 			assert.deepEqual(log, [[{}], [{}], [{}], [{}], [{}]]);
 
-			log.length = 0
+			log.length = 0;
 
 			const destroy3 = effect_root(() => {
 				render_effect(() => {

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -224,20 +224,75 @@ describe('signals', () => {
 		};
 	});
 
+	test('https://perf.js.hyoo.ru/#!bench=9h2as6_u0mfnn #2', () => {
+		let res: number[] = [];
+
+		const numbers = Array.from({ length: 2 }, (_, i) => i);
+		const fib = (n: number): number => (n < 2 ? 1 : fib(n - 1) + fib(n - 2));
+		const hard = (n: number, l: string) => n + fib(16);
+
+		const A = state(0);
+		const B = state(0);
+
+		return () => {
+			const C = derived(() => ($.get(A) % 2) + ($.get(B) % 2));
+			const D = derived(() => numbers.map((i) => i + ($.get(A) % 2) - ($.get(B) % 2)));
+			const E = derived(() => hard($.get(C) + $.get(A) + $.get(D)[0]!, 'E'));
+			const F = derived(() => hard($.get(D)[0]! && $.get(B), 'F'));
+			const G = derived(() => $.get(C) + ($.get(C) || $.get(E) % 2) + $.get(D)[0]! + $.get(F));
+
+			const destroy = effect_root(() => {
+				effect(() => {
+					res.push(hard($.get(G), 'H'));
+				});
+				effect(() => {
+					res.push($.get(G));
+				});
+				effect(() => {
+					res.push(hard($.get(F), 'J'));
+				});
+			});
+
+			flushSync();
+
+			let i = 2;
+			while (--i) {
+				res.length = 0;
+				set(B, 1);
+				set(A, 1 + i * 2);
+				flushSync();
+
+				set(A, 2 + i * 2);
+				set(B, 2);
+				flushSync();
+
+				assert.equal(res.length, 4);
+				assert.deepEqual(res, [3198, 1601, 3195, 1598]);
+			}
+
+			destroy();
+			assert(A.reactions === null);
+			assert(B.reactions === null);
+		};
+	});
+
 	test('effects correctly handle unowned derived values that do not change', () => {
 		const log: number[] = [];
 
-		let count = state(0);
-		const read = () => {
-			const x = derived(() => ({ count: $.get(count) }));
-			return $.get(x);
-		};
-		const derivedCount = derived(() => read().count);
-		user_effect(() => {
-			log.push($.get(derivedCount));
-		});
-
 		return () => {
+			let count = state(0);
+			const read = () => {
+				const x = derived(() => ({ count: $.get(count) }));
+				return $.get(x);
+			};
+			const derivedCount = derived(() => read().count);
+
+			const destroy = effect_root(() => {
+				user_effect(() => {
+					log.push($.get(derivedCount));
+				});
+			});
+
 			flushSync(() => set(count, 1));
 			// Ensure we're not leaking consumers
 			assert.deepEqual(count.reactions?.length, 1);
@@ -248,6 +303,8 @@ describe('signals', () => {
 			// Ensure we're not leaking consumers
 			assert.deepEqual(count.reactions?.length, 1);
 			assert.deepEqual(log, [0, 1, 2, 3]);
+
+			destroy();
 		};
 	});
 
@@ -343,25 +400,69 @@ describe('signals', () => {
 		};
 	});
 
-	let some_state = state({});
-	let some_deps = derived(() => {
-		return [$.get(some_state)];
-	});
-
 	test('two effects with an unowned derived that has some dependencies', () => {
 		const log: Array<Array<any>> = [];
 
-		render_effect(() => {
-			log.push($.get(some_deps));
-		});
-
-		render_effect(() => {
-			log.push($.get(some_deps));
-		});
-
 		return () => {
+			let some_state = state({});
+			let some_deps = derived(() => {
+				return [$.get(some_state)];
+			});
+			let destroy2: any;
+
+			const destroy = effect_root(() => {
+				render_effect(() => {
+					$.untrack(() => {
+						log.push($.get(some_deps));
+					});
+				});
+
+				destroy2 = effect_root(() => {
+					render_effect(() => {
+						log.push($.get(some_deps));
+					});
+
+					render_effect(() => {
+						log.push($.get(some_deps));
+					});
+				});
+			});
+
+			set(some_state, {});
 			flushSync();
-			assert.deepEqual(log, [[{}], [{}]]);
+
+			assert.deepEqual(log, [[{}], [{}], [{}], [{}], [{}]]);
+
+			destroy2();
+
+			set(some_state, {});
+			flushSync();
+
+			assert.deepEqual(log, [[{}], [{}], [{}], [{}], [{}]]);
+
+			log.length = 0
+
+			const destroy3 = effect_root(() => {
+				render_effect(() => {
+					$.untrack(() => {
+						log.push($.get(some_deps));
+					});
+					log.push($.get(some_deps));
+				});
+			});
+
+			set(some_state, {});
+			flushSync();
+
+			assert.deepEqual(log, [[{}], [{}], [{}], [{}]]);
+
+			destroy3();
+
+			assert(some_state.reactions === null);
+
+			destroy();
+
+			assert(some_state.reactions === null);
 		};
 	});
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/15229. 
Fixes https://github.com/sveltejs/svelte/issues/15180.

Where we know that an unowned that was temporarily made unowned, and has definitely become owned again, we can remove the unowned flag entirely. This is the inverse of the logic that makes the derived temporarily unowned to begin with.