### PR TITLE
docs: clarify default prop values, attribute behavior and text expressions

### DIFF
--- a/documentation/docs/01-introduction/xx-props.md
+++ b/documentation/docs/01-introduction/xx-props.md
@@ -43,49 +43,9 @@ You can specify a fallback value for a prop. It will be used if the component's 
 
 <Nested answer={42} /> <!-- answer is set to 42 -->
 <Nested answer={null} /> <!-- answer is set to null (default value is not used)-->
-<Nested /> <!-- answer is set 3 (default value) -->
-<Nested answer={undefined}/> <!-- answer is set 3 (default value) -->
+<Nested /> <!-- answer is set to 3 (default value) -->
+<Nested answer={undefined}/> <!-- answer is set to 3 (default value) -->
 
-```
-
-Deep nesting refers to having components nested within other components across multiple levels. In this setup, props can be passed from parent to child components through several layers.
-
-```svelte
-<script>
-	let count = 3;
-</script>
-
-<!-- App.svelte -->
-<First {count} />
-```
-
-```svelte
-<script>
-	export let count;
-</script>
-
-<!-- First.svelte -->
-<p>First: {count}</p>
-<Second {count} />
-```
-
-```svelte
-<script>
-	export let count;
-</script>
-
-<!-- Second.svelte -->
-<p>Second: {count}</p>
-<Third {count} />
-```
-
-```svelte
-<script>
-	export let count;
-</script>
-
-<!-- Third.svelte -->
-<p>Third: {count}</p>
 ```
 
 To get all properties, use rest syntax:

--- a/documentation/docs/01-introduction/xx-props.md
+++ b/documentation/docs/01-introduction/xx-props.md
@@ -43,9 +43,49 @@ You can specify a fallback value for a prop. It will be used if the component's 
 
 <Nested answer={42} /> <!-- answer is set to 42 -->
 <Nested answer={null} /> <!-- answer is set to null (default value is not used)-->
-<Nested /> <!-- answer is set to default value -->
-<Nested answer={undefined}/> <!-- answer is set to default value -->
+<Nested /> <!-- answer is set 3 (default value) -->
+<Nested answer={undefined}/> <!-- answer is set 3 (default value) -->
 
+```
+
+Deep nesting refers to having components nested within other components across multiple levels. In this setup, props can be passed from parent to child components through several layers.
+
+```svelte
+<script>
+	let count = 3;
+</script>
+
+<!-- App.svelte -->
+<First {count} />
+```
+
+```svelte
+<script>
+	export let count;
+</script>
+
+<!-- First.svelte -->
+<p>First: {count}</p>
+<Second {count} />
+```
+
+```svelte
+<script>
+	export let count;
+</script>
+
+<!-- Second.svelte -->
+<p>Second: {count}</p>
+<Third {count} />
+```
+
+```svelte
+<script>
+	export let count;
+</script>
+
+<!-- Third.svelte -->
+<p>Third: {count}</p>
 ```
 
 To get all properties, use rest syntax:

--- a/documentation/docs/01-introduction/xx-props.md
+++ b/documentation/docs/01-introduction/xx-props.md
@@ -26,6 +26,28 @@ You can specify a fallback value for a prop. It will be used if the component's 
 </script>
 ```
 
+> [!NOTE] If a prop is explicitly passed as null, the default value will not be used, and null will be assigned instead. However, if the prop is undefined or not provided at all, the default value will be used.
+
+```svelte
+<script>
+	let { answer = 3 } = $props();
+</script>
+
+<p>The answer is {answer}</p>
+```
+
+```svelte
+<script>
+	import Nested from './Nested.svelte';
+</script>
+
+<Nested answer={42} /> <!-- answer is set to 42 -->
+<Nested answer={null} /> <!-- answer is set to null (default value is not used)-->
+<Nested /> <!-- answer is set to default value -->
+<Nested answer={undefined}/> <!-- answer is set to default value -->
+
+```
+
 To get all properties, use rest syntax:
 
 ```svelte

--- a/documentation/docs/03-template-syntax/01-basic-markup.md
+++ b/documentation/docs/03-template-syntax/01-basic-markup.md
@@ -177,24 +177,30 @@ A JavaScript expression can be included as text by surrounding it with curly bra
 {expression}
 ```
 
-When using {expression} inside markup, Svelte automatically converts the value to a string before rendering it. The conversion follows JavaScript's standard behavior:
+When using {expression} inside markup, Svelte automatically converts the value to a string before rendering it and makes the expression reactive (similar to wrapping it in $derived). The conversion follows JavaScript's standard behavior:
 
 - Primitive values (number, boolean, string) are directly converted to strings.
 - Objects call their .toString() method (if not overridden, it defaults to [object Object]).
-- undefined and null are treated as empty strings ("").
+- Undefined and null are treated as empty strings ("").
+- Expressions using runes ($state, $derived, etc.) maintain their specific reactive behavior.
 
 ```svelte
-<script>
+	let emptyStr = "";
 	let num = 1;
 	let bool = false;
 	let obj = { key: "value" };
+	let objToStr = obj.toString();
 	let empty = undefined;
-</script>
+	let nul = null;
 
+
+<p>{emptyStr}</p> <!-- Renders as: <p></p> -->
 <p>{num}</p>   <!-- Renders as: <p>1</p> -->
 <p>{bool}</p>  <!-- Renders as: <p>false</p> -->
 <p>{obj}</p>   <!-- Renders as: <p>[object Object]</p> -->
+<p>{objToStr}</p> <!-- Renders as: <p>[object Object]</p> -->
 <p>{empty}</p> <!-- Renders as: <p></p> (empty string) -->
+<p>{nul}</p> <!-- Renders as: <p></p> -->
 ```
 
 Curly braces can be included in a Svelte template by using their [HTML entity](https://developer.mozilla.org/docs/Glossary/Entity) strings: `&lbrace;`, `&lcub;`, or `&#123;` for `{` and `&rbrace;`, `&rcub;`, or `&#125;` for `}`.

--- a/documentation/docs/03-template-syntax/01-basic-markup.md
+++ b/documentation/docs/03-template-syntax/01-basic-markup.md
@@ -182,10 +182,10 @@ When using {expression} inside markup, Svelte automatically converts the value t
 - Primitive values (numbers, booleans, strings) are directly converted to strings.
 - Objects are converted based on JavaScript’s type coercion rules:
 
-  - If an object defines a [Symbol.toPrimitive](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) method, it takes precedence and determines how the object is converted.
+  - If an object defines a [Symbol.toPrimitive()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) method, it takes precedence and determines how the object is converted.
   - Otherwise, if a [toString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString) method is present, it is called. If not overridden, it defaults to "[object Object]".
   - If toString() is not available or does not return a primitive, JavaScript may fall back to [valueOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf), which may be used if it returns a primitive value.
-  - Additionally, an object with a [Symbol.toStringTag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property affects how it is represented when coerced to a string.
+  - Additionally, an object with a [Symbol.toStringTag()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property affects how it is represented when coerced to a string.
 
 - undefined and null are treated as empty strings ("").
 - Expressions using runes ($state, $derived, etc.) maintain their specific reactive behavior.

--- a/documentation/docs/03-template-syntax/01-basic-markup.md
+++ b/documentation/docs/03-template-syntax/01-basic-markup.md
@@ -72,6 +72,29 @@ When the attribute name and value match (`name={name}`), they can be replaced wi
 -->
 ```
 
+When passing null or undefined to an attribute, the attribute is omitted from the rendered HTML.
+
+```svelte
+<script>
+	let someId = undefined;
+	let someClass = null;
+</script>
+
+<div id={someId} class={someClass}>Attributes are not included.</div>
+<!-- The 'id' and 'class' attributes won't be included in the rendered HTML -->
+```
+
+If an empty string ("") is assigned to an attribute, the attribute remains in the HTML but with an empty value.
+
+```svelte
+<script>
+	let emptyClass = ""
+</script>
+
+<div class={emptyClass}>Hello</div>
+<!-- This will render as: <div class="">Hello</div> -->
+```
+
 ## Component props
 
 By convention, values passed to components are referred to as _properties_ or _props_ rather than _attributes_, which are a feature of the DOM.
@@ -152,6 +175,26 @@ A JavaScript expression can be included as text by surrounding it with curly bra
 
 ```svelte
 {expression}
+```
+
+When using {expression} inside markup, Svelte automatically converts the value to a string before rendering it. The conversion follows JavaScript's standard behavior:
+
+- Primitive values (number, boolean, string) are directly converted to strings.
+- Objects call their .toString() method (if not overridden, it defaults to [object Object]).
+- undefined and null are treated as empty strings ("").
+
+```svelte
+<script>
+	let num = 1;
+	let bool = false;
+	let obj = { key: "value" };
+	let empty = undefined;
+</script>
+
+<p>{num}</p>   <!-- Renders as: <p>1</p> -->
+<p>{bool}</p>  <!-- Renders as: <p>false</p> -->
+<p>{obj}</p>   <!-- Renders as: <p>[object Object]</p> -->
+<p>{empty}</p> <!-- Renders as: <p></p> (empty string) -->
 ```
 
 Curly braces can be included in a Svelte template by using their [HTML entity](https://developer.mozilla.org/docs/Glossary/Entity) strings: `&lbrace;`, `&lcub;`, or `&#123;` for `{` and `&rbrace;`, `&rcub;`, or `&#125;` for `}`.

--- a/documentation/docs/03-template-syntax/01-basic-markup.md
+++ b/documentation/docs/03-template-syntax/01-basic-markup.md
@@ -188,17 +188,16 @@ When using {expression} inside markup, Svelte automatically converts the value t
 	let emptyStr = "";
 	let num = 1;
 	let bool = false;
-	let obj = { key: "value" };
-	let objToStr = obj.toString();
+	let obj1 = { key: "value" };
+	let obj2 = { toString: () => "str" };
 	let empty = undefined;
 	let nul = null;
-
 
 <p>{emptyStr}</p> <!-- Renders as: <p></p> -->
 <p>{num}</p>   <!-- Renders as: <p>1</p> -->
 <p>{bool}</p>  <!-- Renders as: <p>false</p> -->
-<p>{obj}</p>   <!-- Renders as: <p>[object Object]</p> -->
-<p>{objToStr}</p> <!-- Renders as: <p>[object Object]</p> -->
+<p>{obj1}</p>   <!-- Renders as: <p>[object Object]</p> -->
+<p>{obj2}</p> <!-- Renders as: <p>str</p> -->
 <p>{empty}</p> <!-- Renders as: <p></p> (empty string) -->
 <p>{nul}</p> <!-- Renders as: <p></p> -->
 ```


### PR DESCRIPTION
### What does this PR do?
- Clarifies the behavior of default prop values.
- Explains how `null` and `undefined` affect attributes and text expressions in markup.

### Issue Reference
Closes #14716 

### Additional Information
- Tests have passed successfully ✅ 
- Linting have passed successfully ✅ 