### PR TITLE
fix: ignore typescript abstract methods during code transformation

### DIFF
--- a/.changeset/short-fireants-talk.md
+++ b/.changeset/short-fireants-talk.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: removing typescript abstract methods
+fix: ignore typescript abstract methods

--- a/.changeset/short-fireants-talk.md
+++ b/.changeset/short-fireants-talk.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: removing typescript abstract methods

--- a/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
+++ b/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
@@ -118,6 +118,12 @@ const visitors = {
 		delete node.implements;
 		return context.next();
 	},
+	MethodDefinition(node, context) {
+		if (node.abstract) {
+			return b.empty;
+		}
+		return context.next();
+	},
 	VariableDeclaration(node, context) {
 		if (node.declare) {
 			return b.empty;

--- a/packages/svelte/tests/runtime-runes/samples/typescript/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/typescript/main.svelte
@@ -22,6 +22,11 @@
 
 	class MyClass implements Hello {}
 
+	abstract class MyAbstractClass {
+		abstract x(): void;
+		y() {}
+	}
+
 	declare const declared_const: number;
 	declare function declared_fn(): void;
 	declare class declared_class {


### PR DESCRIPTION
### Problem

When transforming TypeScript code, abstract methods were incorrectly included in the generated JavaScript output. Given the following TypeScript code:

```ts
abstract class MyClass {
    abstract myMethod(): void;
}
```

The transformation produced invalid JavaScript:

```js
class MyClass {
    myMethod()
}
```
This resulted in a syntax error in the browser.

### Solution

This PR ensures that abstract methods are removed during transformation, so the output JavaScript becomes:
```js
class MyClass {}
```

Resolves #15260 

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
