### PR TITLE
chore: simplify process_effects

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -679,10 +679,7 @@ function flush_queued_root_effects(root_effects) {
 				effect.f ^= CLEAN;
 			}
 
-			/** @type {Effect[]} */
-			var collected_effects = [];
-
-			process_effects(effect, collected_effects);
+			var collected_effects = process_effects(effect);
 			flush_queued_effects(collected_effects);
 		}
 	} finally {
@@ -783,10 +780,12 @@ export function schedule_effect(signal) {
  * effects to be flushed.
  *
  * @param {Effect} effect
- * @param {Effect[]} collected_effects
- * @returns {void}
+ * @returns {Effect[]}
  */
-function process_effects(effect, collected_effects) {
+function process_effects(effect) {
+	/** @type {Effect[]} */
+	var effects = [];
+
 	var current_effect = effect.first;
 
 	main_loop: while (current_effect !== null) {
@@ -797,7 +796,7 @@ function process_effects(effect, collected_effects) {
 
 		if (!is_skippable_branch && (flags & INERT) === 0) {
 			if ((flags & EFFECT) !== 0) {
-				collected_effects.push(current_effect);
+				effects.push(current_effect);
 			} else if (is_branch) {
 				current_effect.f ^= CLEAN;
 			} else {
@@ -843,6 +842,8 @@ function process_effects(effect, collected_effects) {
 
 		current_effect = sibling;
 	}
+
+	return effects;
 }
 
 /**

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -788,7 +788,6 @@ export function schedule_effect(signal) {
  */
 function process_effects(effect, collected_effects) {
 	var current_effect = effect.first;
-	var effects = [];
 
 	main_loop: while (current_effect !== null) {
 		var flags = current_effect.f;
@@ -797,34 +796,32 @@ function process_effects(effect, collected_effects) {
 		var sibling = current_effect.next;
 
 		if (!is_skippable_branch && (flags & INERT) === 0) {
-			if ((flags & RENDER_EFFECT) !== 0) {
-				if (is_branch) {
-					current_effect.f ^= CLEAN;
-				} else {
-					// Ensure we set the effect to be the active reaction
-					// to ensure that unowned deriveds are correctly tracked
-					// because we're flushing the current effect
-					var previous_active_reaction = active_reaction;
-					try {
-						active_reaction = current_effect;
-						if (check_dirtiness(current_effect)) {
-							update_effect(current_effect);
-						}
-					} catch (error) {
-						handle_error(error, current_effect, null, current_effect.ctx);
-					} finally {
-						active_reaction = previous_active_reaction;
+			if ((flags & EFFECT) !== 0) {
+				collected_effects.push(current_effect);
+			} else if (is_branch) {
+				current_effect.f ^= CLEAN;
+			} else {
+				// Ensure we set the effect to be the active reaction
+				// to ensure that unowned deriveds are correctly tracked
+				// because we're flushing the current effect
+				var previous_active_reaction = active_reaction;
+				try {
+					active_reaction = current_effect;
+					if (check_dirtiness(current_effect)) {
+						update_effect(current_effect);
 					}
+				} catch (error) {
+					handle_error(error, current_effect, null, current_effect.ctx);
+				} finally {
+					active_reaction = previous_active_reaction;
 				}
+			}
 
-				var child = current_effect.first;
+			var child = current_effect.first;
 
-				if (child !== null) {
-					current_effect = child;
-					continue;
-				}
-			} else if ((flags & EFFECT) !== 0) {
-				effects.push(current_effect);
+			if (child !== null) {
+				current_effect = child;
+				continue;
 			}
 		}
 
@@ -845,14 +842,6 @@ function process_effects(effect, collected_effects) {
 		}
 
 		current_effect = sibling;
-	}
-
-	// We might be dealing with many effects here, far more than can be spread into
-	// an array push call (callstack overflow). So let's deal with each effect in a loop.
-	for (var i = 0; i < effects.length; i++) {
-		child = effects[i];
-		collected_effects.push(child);
-		process_effects(child, collected_effects);
 	}
 }
 


### PR DESCRIPTION
I might be missing some subtlety relating to effect ordering, but it seems we can simplify `process_effects`, making it non-recursive and removing some indirection. Is there any behaviour that would change with this PR? Avoiding the array allocation and for loop seems like a nice performance win, on top of the simpler code.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
