### PR TITLE
docs: remove duplicate `onDestroy` description

### DIFF
--- a/documentation/docs/06-runtime/03-lifecycle-hooks.md
+++ b/documentation/docs/06-runtime/03-lifecycle-hooks.md
@@ -45,8 +45,6 @@ If a function is returned from `onMount`, it will be called when the component i
 
 ## `onDestroy`
 
-> EXPORT_SNIPPET: svelte#onDestroy
-
 Schedules a callback to run immediately before the component is unmounted.
 
 Out of `onMount`, `beforeUpdate`, `afterUpdate` and `onDestroy`, this is the only one that runs inside a server-side component.


### PR DESCRIPTION
The same description is defined in both the docs and type definition:

https://github.com/sveltejs/svelte/blob/a3e49b611094559a2c4f3830dec2cc75680140ab/documentation/docs/06-runtime/03-lifecycle-hooks.md?plain=1#L50-L52

https://github.com/sveltejs/svelte/blob/a3e49b611094559a2c4f3830dec2cc75680140ab/packages/svelte/types/index.d.ts#L361-L368

Since the docs also import the type definition, it resulted in the same content shown twice:

<img width="781" alt="Screenshot 2025-02-12 at 2 17 22 PM" src="https://github.com/user-attachments/assets/49091d03-84a4-421c-9919-7657136d8b56" />