### PR TITLE
docs: add clarification on static template expressions

### DIFF
--- a/documentation/docs/03-template-syntax/01-basic-markup.md
+++ b/documentation/docs/03-template-syntax/01-basic-markup.md
@@ -158,6 +158,25 @@ Curly braces can be included in a Svelte template by using their [HTML entity](h
 
 If you're using a regular expression (`RegExp`) [literal notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#literal_notation_and_constructor), you'll need to wrap it in parentheses.
 
+> [!NOTE] Svelte statically analyzes your code to determine what is actually reactive. As a result, if a text or attribute expression does not contain:
+>	- An object property
+>	- A function call
+>	- A reference to a reactive variable
+>
+> Then Svelte will treat it as a static expression that does not require updates. This means that this sort of statement would be treated as static, and would never update:
+> ```svelte
+> <script>
+> 	let count = $state(0);
+> 	let thing = {
+> 		toString() {
+> 			return count;
+> 		}
+> 	};
+> </script>
+> <button onclick={() => count++}>Count is {thing}</button>
+> ``` 
+> In the above case, if you wanted the statement to be reactive, you would have to append `.toString()` to the expression (to turn `{thing}` into `{thing.toString()}`). 
+
 <!-- prettier-ignore -->
 ```svelte
 <h1>Hello {name}!</h1>


### PR DESCRIPTION
As mentioned in #15289, #14854, #14803, #13525, #13054, #9860 #11012 and #10629, there is a bit of confusion on what expressions are reactive in your template. This adds some clarification to the docs. 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
