### PR TITLE
chore: fix `$props.id` tests

### DIFF
--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -252,6 +252,10 @@ export function append(anchor, dom) {
 
 let uid = 1;
 
+export function reset_props_id() {
+	uid = 1;
+}
+
 /**
  * Create (or hydrate) an unique UID for the component instance.
  */

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -11,6 +11,7 @@ import { setup_html_equal } from '../html_equal.js';
 import { raf } from '../animation-helpers.js';
 import type { CompileOptions } from '#compiler';
 import { suite_with_variants, type BaseTest } from '../suite.js';
+import { reset_props_id } from '../../src/internal/client/dom/template.js';
 
 type Assert = typeof import('vitest').assert & {
 	htmlEqual(a: string, b: string, description?: string): void;
@@ -345,6 +346,7 @@ async function run_test_variant(
 
 			if (runes) {
 				props = proxy({ ...(config.props || {}) });
+				reset_props_id();
 				if (manual_hydrate) {
 					hydrate_fn = () => {
 						instance = hydrate(mod.default, {

--- a/packages/svelte/tests/runtime-runes/samples/props-id/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-id/_config.js
@@ -3,25 +3,57 @@ import { test } from '../../test';
 
 export default test({
 	test({ assert, target, variant }) {
-		const ps = [...target.querySelectorAll('p')].map((p) => p.innerHTML);
-		const unique = new Set(ps);
-		assert.equal(ps.length, unique.size);
-
-		if (variant === 'hydrate') {
-			const start = ps.map((p) => p.substring(0, 1));
-			assert.deepEqual(start, ['s', 's', 's', 's']);
+		if (variant === 'dom') {
+			assert.htmlEqual(
+				target.innerHTML,
+				`
+					<button>toggle</button>
+					<h1>c1</h1>
+					<p>c2</p>
+					<p>c3</p>
+					<p>c4</p>
+				`
+			);
+		} else {
+			assert.htmlEqual(
+				target.innerHTML,
+				`
+					<button>toggle</button>
+					<h1>s1</h1>
+					<p>s2</p>
+					<p>s3</p>
+					<p>s4</p>
+				`
+			);
 		}
 
 		let button = target.querySelector('button');
 		flushSync(() => button?.click());
 
-		const ps_after = [...target.querySelectorAll('p')].map((p) => p.innerHTML);
-		const unique_after = new Set(ps_after);
-		assert.equal(ps_after.length, unique_after.size);
-
-		if (variant === 'hydrate') {
-			const start = ps_after.map((p) => p.substring(0, 1));
-			assert.deepEqual(start, ['s', 's', 's', 's', 'c']);
+		if (variant === 'dom') {
+			assert.htmlEqual(
+				target.innerHTML,
+				`
+					<button>toggle</button>
+					<h1>c1</h1>
+					<p>c2</p>
+					<p>c3</p>
+					<p>c4</p>
+					<p>c5</p>
+				`
+			);
+		} else {
+			assert.htmlEqual(
+				target.innerHTML,
+				`
+					<button>toggle</button>
+					<h1>s1</h1>
+					<p>s2</p>
+					<p>s3</p>
+					<p>s4</p>
+					<p>c1</p>
+				`
+			);
 		}
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/props-id/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-id/_config.js
@@ -3,59 +3,25 @@ import { test } from '../../test';
 
 export default test({
 	test({ assert, target, variant }) {
-		if (variant === 'dom') {
-			assert.htmlEqual(
-				target.innerHTML,
-				`
-					<button>toggle</button>
-					<h1>c1</h1>
-					<p>c2</p>
-					<p>c3</p>
-					<p>c4</p>
-				`
-			);
-		} else {
-			assert.htmlEqual(
-				target.innerHTML,
-				`
-					<button>toggle</button>
-					<h1>s1</h1>
-					<p>s2</p>
-					<p>s3</p>
-					<p>s4</p>
-				`
-			);
+		const ps = [...target.querySelectorAll('p')].map((p) => p.innerHTML);
+		const unique = new Set(ps);
+		assert.equal(ps.length, unique.size);
+
+		if (variant === 'hydrate') {
+			const start = ps.map((p) => p.substring(0, 1));
+			assert.deepEqual(start, ['s', 's', 's', 's']);
 		}
 
 		let button = target.querySelector('button');
 		flushSync(() => button?.click());
 
-		if (variant === 'dom') {
-			assert.htmlEqual(
-				target.innerHTML,
-				`
-					<button>toggle</button>
-					<h1>c1</h1>
-					<p>c2</p>
-					<p>c3</p>
-					<p>c4</p>
-					<p>c5</p>
-				`
-			);
-		} else {
-			// `c6` because this runs after the `dom` tests
-			// (slightly brittle but good enough for now)
-			assert.htmlEqual(
-				target.innerHTML,
-				`
-					<button>toggle</button>
-					<h1>s1</h1>
-					<p>s2</p>
-					<p>s3</p>
-					<p>s4</p>
-					<p>c6</p>
-				`
-			);
+		const ps_after = [...target.querySelectorAll('p')].map((p) => p.innerHTML);
+		const unique_after = new Set(ps_after);
+		assert.equal(ps_after.length, unique_after.size);
+
+		if (variant === 'hydrate') {
+			const start = ps_after.map((p) => p.substring(0, 1));
+			assert.deepEqual(start, ['s', 's', 's', 's', 'c']);
 		}
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/props-id/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-id/main.svelte
@@ -8,7 +8,7 @@
 
 <button onclick={() => show = !show}>toggle</button>
 
-<h1>{id}</h1>
+<p>{id}</p>
 
 <Child />
 <Child />

--- a/packages/svelte/tests/runtime-runes/samples/props-id/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-id/main.svelte
@@ -8,7 +8,7 @@
 
 <button onclick={() => show = !show}>toggle</button>
 
-<p>{id}</p>
+<h1>{id}</h1>
 
 <Child />
 <Child />


### PR DESCRIPTION
Currently tests for `$props.id` are a bit brittle because the id will be shared between all tests...this means that if we add a new test that uses `$props.id` before the current test the old test will fail for apparently no reason. This can be very confusing so we definitely need to fix this.

I changed the test to make sure that all the ids are different and in hydrate mode i've also cut the numbers out and checked that the first ones starts with `s` meaning they are the same as the server. I don't know if this is the right approach but it's the only one i could think of to actually test that the values comes from the server.

cc @adiguba maybe is worth for you to take a look at this.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
