### PR TITLE
fix: ensure AST analysis on `svelte.js` modules succeeds

### DIFF
--- a/.changeset/good-spiders-own.md
+++ b/.changeset/good-spiders-own.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure AST analysis on `svelte.js` modules succeeds

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -258,8 +258,20 @@ export function analyze_module(ast, options) {
 		{
 			scope,
 			scopes,
-			// @ts-expect-error TODO
-			analysis
+			analysis: /** @type {ComponentAnalysis} */ (analysis),
+			derived_state: [],
+			// TODO the following are not needed for modules, but we have to pass them in order to avoid type error,
+			// and reducing the type would result in a lot of tedious type casts elsewhere - find a good solution one day
+			ast_type: /** @type {any} */ (null),
+			component_slots: new Set(),
+			expression: null,
+			function_depth: 0,
+			has_props_rune: false,
+			instance_scope: /** @type {any} */ (null),
+			options: /** @type {ValidatedCompileOptions} */ (options),
+			parent_element: null,
+			reactive_statement: null,
+			reactive_statements: new Map()
 		},
 		visitors
 	);


### PR DESCRIPTION
This was the result of a `@ts-expect-error` silencing other type errors, which lead to this creeping in. This changes it so that the object is fully set, so we'll get type errors when new properties need to be added

fixes #15284
