### PR TITLE
chore: add missing await in tests

### DIFF
--- a/packages/svelte/tests/preprocess/test.ts
+++ b/packages/svelte/tests/preprocess/test.ts
@@ -25,7 +25,7 @@ const { test, run } = suite<PreprocessTest>(async (config, cwd) => {
 		fs.writeFileSync(`${cwd}/_actual.html.map`, JSON.stringify(result.map, null, 2));
 	}
 
-	expect(result.code).toMatchFileSnapshot(`${cwd}/output.svelte`);
+	await expect(result.code).toMatchFileSnapshot(`${cwd}/output.svelte`);
 
 	expect(result.dependencies).toEqual(config.dependencies || []);
 


### PR DESCRIPTION
The tests are spitting out lots of warnings that this line will error with vitest 3