### PR TITLE
chore: await toMatchFileSnapshot()

### DIFF
--- a/packages/svelte/tests/preprocess/test.ts
+++ b/packages/svelte/tests/preprocess/test.ts
@@ -25,7 +25,7 @@ const { test, run } = suite<PreprocessTest>(async (config, cwd) => {
 		fs.writeFileSync(`${cwd}/_actual.html.map`, JSON.stringify(result.map, null, 2));
 	}
 
-	expect(result.code).toMatchFileSnapshot(`${cwd}/output.svelte`);
+	await expect(result.code).toMatchFileSnapshot(`${cwd}/output.svelte`);
 
 	expect(result.dependencies).toEqual(config.dependencies || []);
 


### PR DESCRIPTION
When running tests, I got warnings like that on the preprocess tests :

> Promise returned by `expect(actual).toMatchFileSnapshot(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at C:/projects/svelte/packages/svelte/tests/preprocess/test.ts:28:22


So I just added the `await` to `toMatchFileSnapshot()`

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
