### PR TITLE
fix: Allow global-like pseudo-selectors refinement

### DIFF
--- a/.changeset/gold-hairs-jog.md
+++ b/.changeset/gold-hairs-jog.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow global-like pseudo-selectors refinement

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -133,7 +133,7 @@ const css_visitors = {
 
 		node.metadata.is_global = node.selectors.length >= 1 && is_global(node);
 
-		if (node.selectors.length === 1) {
+		if (node.selectors.length >= 1) {
 			const first = node.selectors[0];
 			node.metadata.is_global_like ||=
 				(first.type === 'PseudoClassSelector' && first.name === 'host') ||

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -133,7 +133,13 @@ const css_visitors = {
 
 		node.metadata.is_global = node.selectors.length >= 1 && is_global(node);
 
-		if (node.selectors.length >= 1) {
+		if (
+			node.selectors.length >= 1 &&
+			node.selectors.every(
+				(selector) =>
+					selector.type === 'PseudoClassSelector' || selector.type === 'PseudoElementSelector'
+			)
+		) {
 			const first = node.selectors[0];
 			node.metadata.is_global_like ||=
 				(first.type === 'PseudoClassSelector' && first.name === 'host') ||

--- a/packages/svelte/tests/css/samples/view-transition/expected.css
+++ b/packages/svelte/tests/css/samples/view-transition/expected.css
@@ -8,7 +8,13 @@
 	::view-transition-old {
 		animation-duration: 0.5s;
 	}
+	::view-transition-old:only-child {
+		animation-duration: 0.5s;
+	}
 	::view-transition-new {
+		animation-duration: 0.5s;
+	}
+	::view-transition-new:only-child {
 		animation-duration: 0.5s;
 	}
 	::view-transition-image-pair {

--- a/packages/svelte/tests/css/samples/view-transition/input.svelte
+++ b/packages/svelte/tests/css/samples/view-transition/input.svelte
@@ -8,7 +8,13 @@
 	::view-transition-old {
 		animation-duration: 0.5s;
 	}
+	::view-transition-old:only-child {
+		animation-duration: 0.5s;
+	}
 	::view-transition-new {
+		animation-duration: 0.5s;
+	}
+	::view-transition-new:only-child {
 		animation-duration: 0.5s;
 	}
 	::view-transition-image-pair {


### PR DESCRIPTION
For instance, specifying a tree-structural pseudo-class to `::view-transition-new` should still constitute a valid global-like selector.

Fixes #15312

---

This PR tweaked some tests, which wouldn't pass before but do now; however they're far from being exhaustive, as I'm sure this needs a little bit of thinking.

Secondly, this PR introduced a fix that's certainly way too broad in scope, additionally and "accidentally" allowing `:host` as well to be re-specified. Frankly, there may be quite a bit to discuss there.  
Or we can start by having a specific exception for `:only-child` only, and solely for `::view-transition-new()` and `::view-transition-old()`, as at least these combinations seem to be legitimate.

`pnpm test` went fine; the linting one failed to run... but it's nearly midnight and I'm fairly confident my changes so far would pass.

---

Please don't hesitate to engage in the discussion, I'll happily tweak this preliminary commit and am well aware that it certainly isn't just right as of now :)