### PR TITLE
fix: fire delegated events on target even it was disabled in the meantime

### DIFF
--- a/.changeset/wicked-apples-yawn.md
+++ b/.changeset/wicked-apples-yawn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: fire delegated events on target even it was disabled in the meantime

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -237,7 +237,13 @@ export function handle_event_propagation(event) {
 				// @ts-expect-error
 				var delegated = current_target['__' + event_name];
 
-				if (delegated !== undefined && !(/** @type {any} */ (current_target).disabled)) {
+				if (
+					delegated !== undefined &&
+					(!(/** @type {any} */ (current_target).disabled) ||
+						// DOM could've been updated already by the time this is reached, so we check this as well
+						// -> the target could not have been disabled because it emits the event in the first place
+						event.target === current_target)
+				) {
 					if (is_array(delegated)) {
 						var [fn, ...data] = delegated;
 						fn.apply(current_target, [event, ...data]);


### PR DESCRIPTION
The DOM could've been updated already by the time the event bubbling logic is reached, so the target element itself could not be notified of the event because it is marked as disabled. But the target could not have been disabled because it emits the event in the first place, so we emit regardless.

No test because not reproducible in jsdom environment.

Fixes #15256

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
