### PR TITLE
fix: spreading style is not consistent with attribute

### DIFF
--- a/.changeset/real-cameras-attack.md
+++ b/.changeset/real-cameras-attack.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: spreading style is not consistent with attribute

--- a/.changeset/real-cameras-attack.md
+++ b/.changeset/real-cameras-attack.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: spreading style is not consistent with attribute
+fix: always use `setAttribute` when setting `style`

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -378,6 +378,7 @@ export function set_attributes(
 				element[`__${event_name}`] = undefined;
 			}
 		} else if (key === 'style') {
+			// avoid using the setter
 			set_attribute(element, key, value);
 		} else if (key === 'autofocus') {
 			autofocus(/** @type {HTMLElement} */ (element), Boolean(value));

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -213,6 +213,7 @@ export function set_custom_element_data(node, prop, value) {
 	// or effect
 	var previous_reaction = active_reaction;
 	var previous_effect = active_effect;
+
 	// If we're hydrating but the custom element is from Svelte, and it already scaffolded,
 	// then it might run block logic in hydration mode, which we have to prevent.
 	let was_hydrating = hydrating;
@@ -222,9 +223,10 @@ export function set_custom_element_data(node, prop, value) {
 
 	set_active_reaction(null);
 	set_active_effect(null);
+
 	try {
 		if (
-			// style need set_attribute()
+			// `style` should use `set_attribute` rather than the setter
 			prop !== 'style' &&
 			// Don't compute setters for custom elements while they aren't registered yet,
 			// because during their upgrade/instantiation they might add more setters.

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -428,10 +428,6 @@ export function set_attributes(
 				set_attribute(element, name, value);
 			}
 		}
-		if (key === 'style' && '__styles' in element) {
-			// reset styles to force style: directive to update
-			element.__styles = {};
-		}
 	}
 
 	if (is_hydrating_custom_element) {

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -224,15 +224,17 @@ export function set_custom_element_data(node, prop, value) {
 	set_active_effect(null);
 	try {
 		if (
+			// style need set_attribute()
+			prop !== 'style' &&
 			// Don't compute setters for custom elements while they aren't registered yet,
 			// because during their upgrade/instantiation they might add more setters.
 			// Instead, fall back to a simple "an object, then set as property" heuristic.
-			setters_cache.has(node.nodeName) ||
+			(setters_cache.has(node.nodeName) ||
 			// customElements may not be available in browser extension contexts
 			!customElements ||
 			customElements.get(node.tagName.toLowerCase())
 				? get_setters(node).includes(prop)
-				: value && typeof value === 'object'
+				: value && typeof value === 'object')
 		) {
 			// @ts-expect-error
 			node[prop] = value;
@@ -375,8 +377,8 @@ export function set_attributes(
 				// @ts-ignore
 				element[`__${event_name}`] = undefined;
 			}
-		} else if (key === 'style' && value != null) {
-			element.style.cssText = value + '';
+		} else if (key === 'style') {
+			set_attribute(element, key, value);
 		} else if (key === 'autofocus') {
 			autofocus(/** @type {HTMLElement} */ (element), Boolean(value));
 		} else if (!is_custom_element && (key === '__value' || (key === 'value' && value != null))) {

--- a/packages/svelte/tests/runtime-runes/samples/style-update/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/style-update/_config.js
@@ -1,0 +1,36 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+const style_1 = 'invalid-key:0; margin:4px;;color: green ;color:blue ';
+const style_2 = ' other-key : 0 ; padding:2px; COLOR:green; color: blue';
+
+// https://github.com/sveltejs/svelte/issues/15309
+export default test({
+	props: {
+		style: style_1
+	},
+
+	html: `
+		<div style="${style_1}"></div>
+		<div style="${style_1}"></div>
+
+		<custom-element style="${style_1}"></custom-element>
+		<custom-element style="${style_1}"></custom-element>
+	`,
+
+	async test({ assert, target, component }) {
+		component.style = style_2;
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<div style="${style_2}"></div>
+			<div style="${style_2}"></div>
+
+			<custom-element style="${style_2}"></custom-element>
+			<custom-element style="${style_2}"></custom-element>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/style-update/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/style-update/_config.js
@@ -32,5 +32,33 @@ export default test({
 			<custom-element style="${style_2}"></custom-element>
 			`
 		);
+
+		component.style = '';
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<div style=""></div>
+			<div style=""></div>
+
+			<custom-element style=""></custom-element>
+			<custom-element style=""></custom-element>
+			`
+		);
+
+		component.style = null;
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<div></div>
+			<div></div>
+
+			<custom-element></custom-element>
+			<custom-element></custom-element>
+			`
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/style-update/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/style-update/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let { style } = $props();
+</script>
+
+<div {style}></div>
+<div {...{style}}></div>
+
+<custom-element {style}></custom-element>
+<custom-element {...{style}}></custom-element>


### PR DESCRIPTION
* Closes #15309

When we pass the style value directly, `set_attribute()` is used.
But with spreading, it was set by an assign on `element.style.cssText` (or `node[prop]` for custom-element).

This cause the text to be parsed/corrected by the browser, and the value of the attribute will be different.

With this fix, spreading also use `set_attribute()` for style.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
