### PR TITLE
docs: rephrase copyright holder

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2025 [these people](https://github.com/sveltejs/svelte/graphs/contributors)
+Copyright (c) 2016-2025 [Svelte Contributors](https://github.com/sveltejs/svelte/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

This PR updates the copyright holder in the `LICENSE.md` file from "these people" to "Svelte Contributors". This change is considered more formal and follows common best practices seen in most open-source repos.

However, there are other alternatives worth mentioning:
- Acknowledging Rich Harris for creating Svelte: "Rich Harris and Svelte Contributors" (similar to how the Vue repo uses "Yuxi (Evan) You and Vue contributors").

- Acknowledging the Svelte Team for maintaining the project: "Svelte Team" (similar to how Nuxt uses "Nuxt Team"). This can also be combined with contributors: "Svelte Team and Contributors"

The capitalisation of "Contributors" is intended to show respect and to indicate it as a defined term, similar to how "You" is treated in the Apache 2.0 license.