### PR TITLE
chore: remove unnecessary `binding.is_called` property

### DIFF
--- a/.changeset/green-geckos-tickle.md
+++ b/.changeset/green-geckos-tickle.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: remove unnecessary `binding.is_called` property

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
@@ -162,7 +162,7 @@ function get_delegated_event(event_name, handler, context) {
 			return unhoisted;
 		}
 
-		if (binding !== null && binding.initial !== null && !binding.updated && !binding.is_called) {
+		if (binding !== null && binding.initial !== null && !binding.updated) {
 			const binding_type = binding.initial.type;
 
 			if (

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -213,14 +213,6 @@ export function CallExpression(node, context) {
 			break;
 	}
 
-	if (node.callee.type === 'Identifier') {
-		const binding = context.state.scope.get(node.callee.name);
-
-		if (binding !== null) {
-			binding.is_called = true;
-		}
-	}
-
 	// `$inspect(foo)` or `$derived(foo) should not trigger the `static-state-reference` warning
 	if (rune === '$inspect' || rune === '$derived') {
 		context.next({ ...context.state, function_depth: context.state.function_depth + 1 });

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/TaggedTemplateExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/TaggedTemplateExpression.js
@@ -1,4 +1,4 @@
-/** @import { TaggedTemplateExpression, VariableDeclarator } from 'estree' */
+/** @import { TaggedTemplateExpression } from 'estree' */
 /** @import { Context } from '../types' */
 import { is_pure } from './shared/utils.js';
 
@@ -12,12 +12,5 @@ export function TaggedTemplateExpression(node, context) {
 		context.state.expression.has_state = true;
 	}
 
-	if (node.tag.type === 'Identifier') {
-		const binding = context.state.scope.get(node.tag.name);
-
-		if (binding !== null) {
-			binding.is_called = true;
-		}
-	}
 	context.next();
 }

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -57,7 +57,6 @@ export class Binding {
 	 */
 	metadata = null;
 
-	is_called = false;
 	mutated = false;
 	reassigned = false;
 	updated = false;


### PR DESCRIPTION
Ostensibly, this property exists to prevent event handlers being incorrectly used for delegation (since that changes their signature, meaning the original call would no longer be valid). But that's already taken care of by this check:

https://github.com/sveltejs/svelte/blob/3c4a8d425b8192dc11ea2af256d531c51c37ba5d/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js#L154-L156

It's therefore not doing anything useful and can be removed

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
