### PR TITLE
chore: create `binding.updated` getter

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -566,7 +566,7 @@ export function analyze_component(root, source, options) {
 										binding.declaration_kind !== 'import'
 									) {
 										binding.kind = 'state';
-										binding.mutated = binding.updated = true;
+										binding.mutated = true;
 									}
 								}
 							}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportSpecifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportSpecifier.js
@@ -22,7 +22,7 @@ export function ExportSpecifier(node, context) {
 			});
 
 			const binding = context.state.scope.get(local_name);
-			if (binding) binding.reassigned = binding.updated = true;
+			if (binding) binding.reassigned = true;
 		}
 	} else {
 		validate_export(node, context.state.scope, local_name);

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -60,7 +60,6 @@ export class Binding {
 	is_called = false;
 	mutated = false;
 	reassigned = false;
-	updated = false;
 
 	/**
 	 *
@@ -76,6 +75,10 @@ export class Binding {
 		this.initial = initial;
 		this.kind = kind;
 		this.declaration_kind = declaration_kind;
+	}
+
+	get updated() {
+		return this.mutated || this.reassigned;
 	}
 }
 
@@ -738,8 +741,6 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			const binding = left && scope.get(left.name);
 
 			if (binding !== null && left !== binding.node) {
-				binding.updated = true;
-
 				if (left === expression) {
 					binding.reassigned = true;
 				} else {


### PR DESCRIPTION
This makes the definition of `binding.updated` clearer, and makes it impossible for it to be out of sync with `binding.mutated` and `binding.reassigned`, even if we reassign/mutate in more places in future

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
