### PR TITLE
chore: remove reactive_statements from state

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -270,8 +270,7 @@ export function analyze_module(ast, options) {
 			instance_scope: /** @type {any} */ (null),
 			options: /** @type {ValidatedCompileOptions} */ (options),
 			parent_element: null,
-			reactive_statement: null,
-			reactive_statements: new Map()
+			reactive_statement: null
 		},
 		visitors
 	);
@@ -621,8 +620,7 @@ export function analyze_component(root, source, options) {
 				derived_state: [],
 				function_depth: scope.function_depth,
 				instance_scope: instance.scope,
-				reactive_statement: null,
-				reactive_statements: new Map()
+				reactive_statement: null
 			};
 
 			walk(/** @type {AST.SvelteNode} */ (ast), state, visitors);
@@ -686,7 +684,6 @@ export function analyze_component(root, source, options) {
 				ast_type: ast === instance.ast ? 'instance' : ast === template.ast ? 'template' : 'module',
 				instance_scope: instance.scope,
 				reactive_statement: null,
-				reactive_statements: analysis.reactive_statements,
 				component_slots: new Set(),
 				expression: null,
 				derived_state: [],

--- a/packages/svelte/src/compiler/phases/2-analyze/types.d.ts
+++ b/packages/svelte/src/compiler/phases/2-analyze/types.d.ts
@@ -1,7 +1,6 @@
 import type { Scope } from '../scope.js';
 import type { ComponentAnalysis, ReactiveStatement } from '../types.js';
 import type { AST, ExpressionMetadata, ValidatedCompileOptions } from '#compiler';
-import type { LabeledStatement } from 'estree';
 
 export interface AnalysisState {
 	scope: Scope;
@@ -25,7 +24,6 @@ export interface AnalysisState {
 	// legacy stuff
 	instance_scope: Scope;
 	reactive_statement: null | ReactiveStatement;
-	reactive_statements: Map<LabeledStatement, ReactiveStatement>;
 }
 
 export type Context<State extends AnalysisState = AnalysisState> = import('zimmerframe').Context<

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/LabeledStatement.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/LabeledStatement.js
@@ -64,7 +64,7 @@ export function LabeledStatement(node, context) {
 				}
 			}
 
-			context.state.reactive_statements.set(node, reactive_statement);
+			context.state.analysis.reactive_statements.set(node, reactive_statement);
 
 			if (
 				node.body.type === 'ExpressionStatement' &&


### PR DESCRIPTION
there's no reason for this to be on `state`, it belongs to `state.analysis`