### PR TITLE
fix: switch to our fork acorn typescript plugin

### DIFF
--- a/.changeset/selfish-cougars-allow.md
+++ b/.changeset/selfish-cougars-allow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: switch acorn-typescript plugin

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -150,7 +150,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.0",
     "@types/estree": "^1.0.5",
     "acorn": "^8.12.1",
-    "@sveltejs/acorn-typescript": "^1.0.3",
+    "@sveltejs/acorn-typescript": "^1.0.4",
     "aria-query": "^5.3.1",
     "axobject-query": "^4.1.0",
     "clsx": "^2.1.1",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -150,7 +150,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.0",
     "@types/estree": "^1.0.5",
     "acorn": "^8.12.1",
-    "@sveltejs/acorn-typescript": "^1.0.1",
+    "@sveltejs/acorn-typescript": "^1.0.2",
     "aria-query": "^5.3.1",
     "axobject-query": "^4.1.0",
     "clsx": "^2.1.1",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -150,7 +150,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.0",
     "@types/estree": "^1.0.5",
     "acorn": "^8.12.1",
-    "@sveltejs/acorn-typescript": "^1.0.0",
+    "@sveltejs/acorn-typescript": "^1.0.1",
     "aria-query": "^5.3.1",
     "axobject-query": "^4.1.0",
     "clsx": "^2.1.1",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -150,7 +150,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.0",
     "@types/estree": "^1.0.5",
     "acorn": "^8.12.1",
-    "@sveltejs/acorn-typescript": "^1.0.4",
+    "@sveltejs/acorn-typescript": "^1.0.5",
     "aria-query": "^5.3.1",
     "axobject-query": "^4.1.0",
     "clsx": "^2.1.1",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -150,7 +150,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.0",
     "@types/estree": "^1.0.5",
     "acorn": "^8.12.1",
-    "@sveltejs/acorn-typescript": "^1.0.2",
+    "@sveltejs/acorn-typescript": "^1.0.3",
     "aria-query": "^5.3.1",
     "axobject-query": "^4.1.0",
     "clsx": "^2.1.1",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -150,7 +150,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.0",
     "@types/estree": "^1.0.5",
     "acorn": "^8.12.1",
-    "acorn-typescript": "^1.4.13",
+    "@sveltejs/acorn-typescript": "^1.0.0",
     "aria-query": "^5.3.1",
     "axobject-query": "^4.1.0",
     "clsx": "^2.1.1",

--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -2,7 +2,7 @@
 /** @import { Node } from 'acorn' */
 import * as acorn from 'acorn';
 import { walk } from 'zimmerframe';
-import { tsPlugin } from 'acorn-typescript';
+import { tsPlugin } from '@sveltejs/acorn-typescript';
 import { locator } from '../../state.js';
 
 const ParserWithTS = acorn.Parser.extend(tsPlugin({ allowSatisfies: true }));

--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -1,11 +1,9 @@
 /** @import { Comment, Program } from 'estree' */
-/** @import { Node } from 'acorn' */
 import * as acorn from 'acorn';
 import { walk } from 'zimmerframe';
 import { tsPlugin } from '@sveltejs/acorn-typescript';
-import { locator } from '../../state.js';
 
-const ParserWithTS = acorn.Parser.extend(tsPlugin({ allowSatisfies: true }));
+const ParserWithTS = acorn.Parser.extend(tsPlugin());
 
 /**
  * @param {string} source
@@ -48,7 +46,6 @@ export function parse(source, typescript, is_script) {
 		}
 	}
 
-	if (typescript) amend(source, ast);
 	add_comments(ast);
 
 	return /** @type {Program} */ (ast);
@@ -71,7 +68,6 @@ export function parse_expression_at(source, typescript, index) {
 		locations: true
 	});
 
-	if (typescript) amend(source, ast);
 	add_comments(ast);
 
 	return ast;
@@ -172,43 +168,4 @@ function get_comment_handlers(source) {
 			}
 		}
 	};
-}
-
-/**
- * Tidy up some stuff left behind by acorn-typescript
- * @param {string} source
- * @param {Node} node
- */
-function amend(source, node) {
-	return walk(node, null, {
-		_(node, context) {
-			// @ts-expect-error
-			delete node.loc.start.index;
-			// @ts-expect-error
-			delete node.loc.end.index;
-
-			if (typeof node.loc?.end === 'number') {
-				const loc = locator(node.loc.end);
-				if (loc) {
-					node.loc.end = {
-						line: loc.line,
-						column: loc.column
-					};
-				}
-			}
-
-			if (
-				/** @type {any} */ (node).typeAnnotation &&
-				(node.end === undefined || node.end < node.start)
-			) {
-				// i think there might be a bug in acorn-typescript that prevents
-				// `end` from being assigned when there's a type annotation
-				let end = /** @type {any} */ (node).typeAnnotation.start;
-				while (/\s/.test(source[end - 1])) end -= 1;
-				node.end = end;
-			}
-
-			context.next();
-		}
-	});
 }

--- a/packages/svelte/src/compiler/phases/1-parse/ambient.d.ts
+++ b/packages/svelte/src/compiler/phases/1-parse/ambient.d.ts
@@ -1,3 +1,0 @@
-// Silence the acorn typescript errors through this ambient type definition + tsconfig.json path alias
-// That way we can omit `"skipLibCheck": true` and catch other errors in our d.ts files
-declare module 'acorn-typescript';

--- a/packages/svelte/tests/parser-modern/samples/comment-before-script/output.json
+++ b/packages/svelte/tests/parser-modern/samples/comment-before-script/output.json
@@ -75,7 +75,7 @@
 							"id": {
 								"type": "Identifier",
 								"start": 52,
-								"end": 57,
+								"end": 65,
 								"loc": {
 									"start": {
 										"line": 3,

--- a/packages/svelte/tests/parser-modern/samples/snippets/output.json
+++ b/packages/svelte/tests/parser-modern/samples/snippets/output.json
@@ -28,7 +28,7 @@
 					{
 						"type": "Identifier",
 						"start": 43,
-						"end": 46,
+						"end": 54,
 						"loc": {
 							"start": {
 								"line": 3,

--- a/packages/svelte/tests/parser-modern/samples/typescript-in-event-handler/output.json
+++ b/packages/svelte/tests/parser-modern/samples/typescript-in-event-handler/output.json
@@ -25,7 +25,6 @@
 						"end": 147,
 						"type": "OnDirective",
 						"name": "click",
-						"modifiers": [],
 						"expression": {
 							"type": "ArrowFunctionExpression",
 							"start": 73,
@@ -48,7 +47,7 @@
 								{
 									"type": "Identifier",
 									"start": 74,
-									"end": 75,
+									"end": 87,
 									"loc": {
 										"start": {
 											"line": 6,
@@ -155,7 +154,7 @@
 												"id": {
 													"type": "Identifier",
 													"start": 102,
-													"end": 106,
+													"end": 114,
 													"loc": {
 														"start": {
 															"line": 7,
@@ -316,7 +315,8 @@
 									}
 								]
 							}
-						}
+						},
+						"modifiers": []
 					}
 				],
 				"fragment": {

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -15,7 +15,6 @@
 		"allowJs": true,
 		"checkJs": true,
 		"paths": {
-			"acorn-typescript": ["./src/compiler/phases/1-parse/ambient.d.ts"],
 			"svelte": ["./src/index.d.ts"],
 			"svelte/action": ["./src/action/public.d.ts"],
 			"svelte/compiler": ["./src/compiler/public.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@sveltejs/acorn-typescript':
-        specifier: ^1.0.3
-        version: 1.0.3(acorn@8.14.0)
+        specifier: ^1.0.4
+        version: 1.0.4(acorn@8.14.0)
       '@types/estree':
         specifier: ^1.0.5
         version: 1.0.6
@@ -626,8 +626,8 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  '@sveltejs/acorn-typescript@1.0.3':
-    resolution: {integrity: sha512-vHZ4ogoVUXHiPrZfHxcukqVhrENf76jlejs6XYmAUzOJCH5DlPDF1yvh+L4ZVXTAWLZAFxucr3fcbrNPcQDzvQ==}
+  '@sveltejs/acorn-typescript@1.0.4':
+    resolution: {integrity: sha512-nPVrutUss4Xt1EOeO19nDICo9rN6NqqCyNyg+SoUQPbHsc5N0avH0f+RWqOjUrI8vWsaIGBC84T0nHkN9pE1gw==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -2720,7 +2720,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
 
-  '@sveltejs/acorn-typescript@1.0.3(acorn@8.14.0)':
+  '@sveltejs/acorn-typescript@1.0.4(acorn@8.14.0)':
     dependencies:
       acorn: 8.14.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@sveltejs/acorn-typescript':
-        specifier: ^1.0.2
-        version: 1.0.2(acorn@8.14.0)
+        specifier: ^1.0.3
+        version: 1.0.3(acorn@8.14.0)
       '@types/estree':
         specifier: ^1.0.5
         version: 1.0.6
@@ -626,8 +626,8 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  '@sveltejs/acorn-typescript@1.0.2':
-    resolution: {integrity: sha512-38Pff7qkxTQnWDHSaesgXGllvZoX5sc5A7sITVnCn56OZhDmMwD8kOr1fXTNAPjulB4mFNQMhUktkfsLHxWH2Q==}
+  '@sveltejs/acorn-typescript@1.0.3':
+    resolution: {integrity: sha512-vHZ4ogoVUXHiPrZfHxcukqVhrENf76jlejs6XYmAUzOJCH5DlPDF1yvh+L4ZVXTAWLZAFxucr3fcbrNPcQDzvQ==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -2720,7 +2720,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
 
-  '@sveltejs/acorn-typescript@1.0.2(acorn@8.14.0)':
+  '@sveltejs/acorn-typescript@1.0.3(acorn@8.14.0)':
     dependencies:
       acorn: 8.14.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,15 +65,15 @@ importers:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.5.0
         version: 1.5.0
+      '@sveltejs/acorn-typescript':
+        specifier: ^1.0.0
+        version: 1.0.1(acorn@8.14.0)
       '@types/estree':
         specifier: ^1.0.5
         version: 1.0.6
       acorn:
         specifier: ^8.12.1
         version: 8.14.0
-      acorn-typescript:
-        specifier: ^1.4.13
-        version: 1.4.13(acorn@8.14.0)
       aria-query:
         specifier: ^5.3.1
         version: 5.3.1
@@ -626,6 +626,11 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
+  '@sveltejs/acorn-typescript@1.0.1':
+    resolution: {integrity: sha512-MPvOVpdeRE5pA7hNPmPJwbVxoMC7dQWsIsn0PBJsfXlWyJJtwas4qSMNyArbLkpiNsMzlkyNU1k5Asckp57Srg==}
+    peerDependencies:
+      acorn: '>=8.9.0'
+
   '@sveltejs/eslint-config@8.1.0':
     resolution: {integrity: sha512-cfgp4lPREYBjNd4ZzaP/jA85ufm7vfXiaV7h9vILXNogne80IbZRNhRCQ8XoOqTAOY/pChIzWTBuR8aDNMbAEA==}
     peerDependencies:
@@ -778,11 +783,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn-typescript@1.4.13:
-    resolution: {integrity: sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==}
-    peerDependencies:
-      acorn: '>=8.9.0'
 
   acorn@8.14.0:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
@@ -2720,6 +2720,10 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
 
+  '@sveltejs/acorn-typescript@1.0.1(acorn@8.14.0)':
+    dependencies:
+      acorn: 8.14.0
+
   '@sveltejs/eslint-config@8.1.0(@stylistic/eslint-plugin-js@1.8.0(eslint@9.9.1))(eslint-config-prettier@9.1.0(eslint@9.9.1))(eslint-plugin-n@17.9.0(eslint@9.9.1))(eslint-plugin-svelte@2.38.0(eslint@9.9.1)(svelte@packages+svelte))(eslint@9.9.1)(typescript-eslint@8.2.0(eslint@9.9.1)(typescript@5.5.4))(typescript@5.5.4)':
     dependencies:
       '@stylistic/eslint-plugin-js': 1.8.0(eslint@9.9.1)
@@ -2923,10 +2927,6 @@ snapshots:
       tinyrainbow: 1.2.0
 
   acorn-jsx@5.3.2(acorn@8.14.0):
-    dependencies:
-      acorn: 8.14.0
-
-  acorn-typescript@1.4.13(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@sveltejs/acorn-typescript':
-        specifier: ^1.0.4
-        version: 1.0.4(acorn@8.14.0)
+        specifier: ^1.0.5
+        version: 1.0.5(acorn@8.14.0)
       '@types/estree':
         specifier: ^1.0.5
         version: 1.0.6
@@ -626,8 +626,8 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  '@sveltejs/acorn-typescript@1.0.4':
-    resolution: {integrity: sha512-nPVrutUss4Xt1EOeO19nDICo9rN6NqqCyNyg+SoUQPbHsc5N0avH0f+RWqOjUrI8vWsaIGBC84T0nHkN9pE1gw==}
+  '@sveltejs/acorn-typescript@1.0.5':
+    resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -2720,7 +2720,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
 
-  '@sveltejs/acorn-typescript@1.0.4(acorn@8.14.0)':
+  '@sveltejs/acorn-typescript@1.0.5(acorn@8.14.0)':
     dependencies:
       acorn: 8.14.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@sveltejs/acorn-typescript':
-        specifier: ^1.0.0
+        specifier: ^1.0.1
         version: 1.0.1(acorn@8.14.0)
       '@types/estree':
         specifier: ^1.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@sveltejs/acorn-typescript':
-        specifier: ^1.0.1
-        version: 1.0.1(acorn@8.14.0)
+        specifier: ^1.0.2
+        version: 1.0.2(acorn@8.14.0)
       '@types/estree':
         specifier: ^1.0.5
         version: 1.0.6
@@ -626,10 +626,10 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  '@sveltejs/acorn-typescript@1.0.1':
-    resolution: {integrity: sha512-MPvOVpdeRE5pA7hNPmPJwbVxoMC7dQWsIsn0PBJsfXlWyJJtwas4qSMNyArbLkpiNsMzlkyNU1k5Asckp57Srg==}
+  '@sveltejs/acorn-typescript@1.0.2':
+    resolution: {integrity: sha512-38Pff7qkxTQnWDHSaesgXGllvZoX5sc5A7sITVnCn56OZhDmMwD8kOr1fXTNAPjulB4mFNQMhUktkfsLHxWH2Q==}
     peerDependencies:
-      acorn: '>=8.9.0'
+      acorn: ^8.9.0
 
   '@sveltejs/eslint-config@8.1.0':
     resolution: {integrity: sha512-cfgp4lPREYBjNd4ZzaP/jA85ufm7vfXiaV7h9vILXNogne80IbZRNhRCQ8XoOqTAOY/pChIzWTBuR8aDNMbAEA==}
@@ -2720,7 +2720,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
 
-  '@sveltejs/acorn-typescript@1.0.1(acorn@8.14.0)':
+  '@sveltejs/acorn-typescript@1.0.2(acorn@8.14.0)':
     dependencies:
       acorn: 8.14.0
 


### PR DESCRIPTION
Since the original library is abandoned, we had to fork it and continue maintenance there.

This PR switches out the package to https://github.com/sveltejs/acorn-typescript

The two notable changes from this are:
- no more "fix the TS AST afterwards" walk, might speed up things a tiny bit
- the `end` of a `Pattern` now also includes the type annotation, i.e. `const msg: boolean = true` will not have `end: 9` but `end: 18`
