### PR TITLE
docs: Update 01-basic-markup.md with new svelte-ignore syntax

### DIFF
--- a/documentation/docs/03-template-syntax/01-basic-markup.md
+++ b/documentation/docs/03-template-syntax/01-basic-markup.md
@@ -185,7 +185,7 @@ You can use HTML comments inside components.
 Comments beginning with `svelte-ignore` disable warnings for the next block of markup. Usually, these are accessibility warnings; make sure that you're disabling them for a good reason.
 
 ```svelte
-<!-- svelte-ignore a11y-autofocus -->
+<!-- svelte-ignore a11y_autofocus -->
 <input bind:value={name} autofocus />
 ```
 


### PR DESCRIPTION
`01-basic-markup.md` was using an old svelte-ignore syntax with dashed rule names (`a11y-autofocus`). I fixed it with a underscored one (`a11y_autofocus`).

There is no old-syntaxed `svelte-ignore` in the docs anymore.