### PR TITLE
chore: rewrite set_style() to handle directives

### DIFF
--- a/.changeset/strange-planes-shout.md
+++ b/.changeset/strange-planes-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: rewrite set_style() to handle directives

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -769,23 +769,45 @@ export function analyze_component(root, source, options) {
 		}
 
 		let has_class = false;
+		let has_style = false;
 		let has_spread = false;
 		let has_class_directive = false;
+		let has_style_directive = false;
 
 		for (const attribute of node.attributes) {
 			// The spread method appends the hash to the end of the class attribute on its own
 			if (attribute.type === 'SpreadAttribute') {
 				has_spread = true;
 				break;
+			} else if (attribute.type === 'Attribute') {
+				has_class ||= attribute.name.toLowerCase() === 'class';
+				has_style ||= attribute.name.toLowerCase() === 'style';
+			} else if (attribute.type === 'ClassDirective') {
+				has_class_directive = true;
+			} else if (attribute.type === 'StyleDirective') {
+				has_style_directive = true;
 			}
-			has_class_directive ||= attribute.type === 'ClassDirective';
-			has_class ||= attribute.type === 'Attribute' && attribute.name.toLowerCase() === 'class';
 		}
 
 		// We need an empty class to generate the set_class() or class="" correctly
 		if (!has_spread && !has_class && (node.metadata.scoped || has_class_directive)) {
 			node.attributes.push(
 				create_attribute('class', -1, -1, [
+					{
+						type: 'Text',
+						data: '',
+						raw: '',
+						start: -1,
+						end: -1
+					}
+				])
+			);
+		}
+
+		// We need an empty style to generate the set_style() correctly
+		if (!has_spread && !has_style && has_style_directive) {
+			node.attributes.push(
+				create_attribute('style', -1, -1, [
 					{
 						type: 'Text',
 						data: '',

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
@@ -5,12 +5,7 @@ import { dev, locator } from '../../../../state.js';
 import { is_text_attribute } from '../../../../utils/ast.js';
 import * as b from '../../../../utils/builders.js';
 import { determine_namespace_for_children } from '../../utils.js';
-import {
-	build_attribute_value,
-	build_set_attributes,
-	build_set_class,
-	build_style_directives
-} from './shared/element.js';
+import { build_attribute_value, build_set_attributes, build_set_class } from './shared/element.js';
 import { build_render_statement, get_expression_id } from './shared/utils.js';
 
 /**
@@ -77,9 +72,6 @@ export function SvelteElement(node, context) {
 	// Let bindings first, they can be used on attributes
 	context.state.init.push(...lets); // create computeds in the outer context; the dynamic element is the single child of this slot
 
-	// Then do attributes
-	let is_attributes_reactive = false;
-
 	if (
 		attributes.length === 1 &&
 		attributes[0].type === 'Attribute' &&
@@ -93,7 +85,7 @@ export function SvelteElement(node, context) {
 			(value, metadata) => (metadata.has_call ? get_expression_id(context.state, value) : value)
 		);
 
-		is_attributes_reactive = build_set_class(
+		build_set_class(
 			node,
 			element_id,
 			attributes[0],
@@ -108,9 +100,10 @@ export function SvelteElement(node, context) {
 
 		// Always use spread because we don't know whether the element is a custom element or not,
 		// therefore we need to do the "how to set an attribute" logic at runtime.
-		is_attributes_reactive = build_set_attributes(
+		build_set_attributes(
 			attributes,
 			class_directives,
+			style_directives,
 			inner_context,
 			node,
 			element_id,
@@ -119,9 +112,6 @@ export function SvelteElement(node, context) {
 			b.call(b.member(b.member(element_id, 'nodeName'), 'includes'), b.literal('-'))
 		);
 	}
-
-	// style directives must be applied last since they could override class/style attributes
-	build_style_directives(style_directives, element_id, inner_context, is_attributes_reactive);
 
 	const get_tag = b.thunk(/** @type {Expression} */ (context.visit(node.tag)));
 

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -15,6 +15,7 @@ import {
 } from '../../runtime.js';
 import { clsx } from '../../../shared/attributes.js';
 import { set_class } from './class.js';
+import { set_style } from './style.js';
 
 export const CLASS = Symbol('class');
 export const STYLE = Symbol('style');
@@ -176,11 +177,6 @@ export function set_attribute(element, attribute, value, skip_warning) {
 
 	if (attributes[attribute] === (attributes[attribute] = value)) return;
 
-	if (attribute === 'style' && '__styles' in element) {
-		// reset styles to force style: directive to update
-		element.__styles = {};
-	}
-
 	if (attribute === 'loading') {
 		// @ts-expect-error
 		element[LOADING_ATTR_SYMBOL] = value;
@@ -297,6 +293,10 @@ export function set_attributes(
 		next.class = null; /* force call to set_class() */
 	}
 
+	if (next[STYLE]) {
+		next.style ??= null; /* force call to set_style() */
+	}
+
 	var setters = get_setters(element);
 
 	// @ts-expect-error
@@ -331,6 +331,13 @@ export function set_attributes(
 			set_class(element, is_html, value, css_hash, prev?.[CLASS], next[CLASS]);
 			current[key] = value;
 			current[CLASS] = next[CLASS];
+			continue;
+		}
+
+		if (key === 'style') {
+			set_style(element, value, prev?.[STYLE], next[STYLE]);
+			current[key] = value;
+			current[STYLE] = next[STYLE];
 			continue;
 		}
 
@@ -385,8 +392,6 @@ export function set_attributes(
 				// @ts-ignore
 				element[`__${event_name}`] = undefined;
 			}
-		} else if (key === 'style' && value != null) {
-			element.style.cssText = value + '';
 		} else if (key === 'autofocus') {
 			autofocus(/** @type {HTMLElement} */ (element), Boolean(value));
 		} else if (!is_custom_element && (key === '__value' || (key === 'value' && value != null))) {
@@ -434,10 +439,6 @@ export function set_attributes(
 			} else if (typeof value !== 'function') {
 				set_attribute(element, name, value);
 			}
-		}
-		if (key === 'style' && '__styles' in element) {
-			// reset styles to force style: directive to update
-			element.__styles = {};
 		}
 	}
 

--- a/packages/svelte/src/internal/client/dom/elements/style.js
+++ b/packages/svelte/src/internal/client/dom/elements/style.js
@@ -35,7 +35,7 @@ export function set_style(dom, value, prev_styles, next_styles) {
 			if (next_style_attr == null) {
 				dom.removeAttribute('style');
 			} else {
-				dom.setAttribute('style', next_style_attr);
+				dom.style.cssText = next_style_attr;
 			}
 		}
 		// @ts-expect-error

--- a/packages/svelte/src/internal/client/dom/elements/style.js
+++ b/packages/svelte/src/internal/client/dom/elements/style.js
@@ -1,22 +1,52 @@
+import { to_style } from '../../../shared/attributes.js';
+import { hydrating } from '../hydration.js';
+
 /**
- * @param {HTMLElement} dom
- * @param {string} key
- * @param {string} value
- * @param {boolean} [important]
+ * @param {Element & ElementCSSInlineStyle} dom
+ * @param {Record<string,any>} prev
+ * @param {Record<string,any>} next
+ * @param {string} important
  */
-export function set_style(dom, key, value, important) {
+function update_styles(dom, prev = {}, next, important) {
+	for (const key in next) {
+		const value = next[key];
+		if (prev[key] !== value) {
+			if (next[key] == null) {
+				dom.style.removeProperty(key);
+			} else {
+				dom.style.setProperty(key, value, important);
+			}
+		}
+	}
+}
+
+/**
+ * @param {Element & ElementCSSInlineStyle} dom
+ * @param {string|null} value
+ * @param {Record<string,any>|[Record<string,any>,Record<string,any>]} [prev_styles]
+ * @param {Record<string,any>|[Record<string,any>,Record<string,any>]} [next_styles]
+ */
+export function set_style(dom, value, prev_styles, next_styles) {
 	// @ts-expect-error
-	var styles = (dom.__styles ??= {});
-
-	if (styles[key] === value) {
-		return;
+	var prev = dom.__style;
+	if (hydrating || prev !== value) {
+		var next_style_attr = to_style(value, next_styles);
+		if (!hydrating || next_style_attr !== dom.getAttribute('style')) {
+			if (next_style_attr == null) {
+				dom.removeAttribute('style');
+			} else {
+				dom.setAttribute('style', next_style_attr);
+			}
+		}
+		// @ts-expect-error
+		dom.__style = value;
+	} else if (next_styles) {
+		if (Array.isArray(next_styles)) {
+			update_styles(dom, prev_styles?.[0], next_styles[0], '');
+			update_styles(dom, prev_styles?.[1], next_styles[1], '');
+		} else {
+			update_styles(dom, prev_styles, next_styles, '');
+		}
 	}
-
-	styles[key] = value;
-
-	if (value == null) {
-		dom.style.removeProperty(key);
-	} else {
-		dom.style.setProperty(key, value, important ? 'important' : '');
-	}
+	return next_styles;
 }

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -48,7 +48,7 @@ export function init_operations() {
 	// @ts-expect-error
 	element_prototype.__attributes = null;
 	// @ts-expect-error
-	element_prototype.__styles = null;
+	element_prototype.__style = undefined;
 	// @ts-expect-error
 	element_prototype.__e = undefined;
 

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -2,7 +2,7 @@
 /** @import { Component, Payload, RenderOutput } from '#server' */
 /** @import { Store } from '#shared' */
 export { FILENAME, HMR } from '../../constants.js';
-import { attr, clsx, to_class } from '../shared/attributes.js';
+import { attr, clsx, to_class, to_style } from '../shared/attributes.js';
 import { is_promise, noop } from '../shared/utils.js';
 import { subscribe_to_store } from '../../store/utils.js';
 import {
@@ -205,9 +205,7 @@ export function css_props(payload, is_html, props, component, dynamic = false) {
  */
 export function spread_attributes(attrs, css_hash, classes, styles, flags = 0) {
 	if (styles) {
-		attrs.style = attrs.style
-			? style_object_to_string(merge_styles(/** @type {string} */ (attrs.style), styles))
-			: style_object_to_string(styles);
+		attrs.style = to_style(attrs.style, styles);
 	}
 
 	if (attrs.class) {
@@ -281,35 +279,29 @@ function style_object_to_string(style_object) {
 		.join(' ');
 }
 
-/** @param {Record<string, string>} style_object */
-export function add_styles(style_object) {
-	const styles = style_object_to_string(style_object);
-	return styles ? ` style="${styles}"` : '';
+/**
+ * @param {any} value
+ * @param {string | null} [hash]
+ * @param {Record<string, boolean>} [directives]
+ */
+export function attr_class(value, hash, directives) {
+	var result = to_class(value, hash, directives);
+	if (result) {
+		return ` class="${escape_html(result, true)}"`;
+	}
+	return '';
 }
 
 /**
- * @param {string} attribute
- * @param {Record<string, string>} styles
+ * @param {any} value
+ * @param {Record<string,any>|[Record<string,any>,Record<string,any>]} [directives]
  */
-export function merge_styles(attribute, styles) {
-	/** @type {Record<string, string>} */
-	var merged = {};
-
-	if (attribute) {
-		for (var declaration of attribute.split(';')) {
-			var i = declaration.indexOf(':');
-			var name = declaration.slice(0, i).trim();
-			var value = declaration.slice(i + 1).trim();
-
-			if (name !== '') merged[name] = value;
-		}
+export function attr_style(value, directives) {
+	var result = to_style(value, directives);
+	if (result) {
+		return ` style="${escape_html(result, true)}"`;
 	}
-
-	for (name in styles) {
-		merged[name] = styles[name];
-	}
-
-	return merged;
+	return '';
 }
 
 /**
@@ -544,7 +536,7 @@ export function props_id(payload) {
 	return uid;
 }
 
-export { attr, clsx, to_class };
+export { attr, clsx };
 
 export { html } from './blocks/html.js';
 

--- a/packages/svelte/tests/runtime-legacy/samples/inline-style-directive-spread-and-attr-empty/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/inline-style-directive-spread-and-attr-empty/_config.js
@@ -2,6 +2,6 @@ import { test } from '../../test';
 
 export default test({
 	html: `
-		<p style=""></p>
+		<p></p>
 	`
 });

--- a/packages/svelte/tests/runtime-runes/samples/style-directive-mutations/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/style-directive-mutations/_config.js
@@ -2,7 +2,7 @@ import { flushSync, tick } from 'svelte';
 import { test } from '../../test';
 
 // This test counts mutations on hydration
-// set_class() should not mutate class on hydration, except if mismatch
+// set_style() should not mutate style on hydration, except if mismatch
 export default test({
 	mode: ['server', 'hydrate'],
 
@@ -14,8 +14,22 @@ export default test({
 		browser: true
 	},
 
+	ssrHtml: `
+		<main id="main" style="color: black;">
+			<div style="color: red; font-size: 18px !important;"></div>
+			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
+			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
+			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
+			<div style="background:blue; background: linear-gradient(0, white 0%, red 100%); color: red; font-size: 18px !important;"></div>
+			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
+			<div style="background: url(https://placehold.co/100x100?text=;&font=roboto); color: red; font-size: 18px !important;"></div>
+			<div style="background: url(&quot;https://placehold.co/100x100?text=;&font=roboto&quot;); color: red; font-size: 18px !important;"></div>
+			<div style="background: url('https://placehold.co/100x100?text=;&font=roboto'); color: red; font-size: 18px !important;"></div>
+		</main>
+	`,
+
 	html: `
-		<main id="main">
+		<main id="main" style="color: white;">
 			<div style="color: red; font-size: 18px !important;"></div>
 			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
 			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
@@ -31,82 +45,51 @@ export default test({
 	async test({ target, assert, component, instance }) {
 		flushSync();
 		tick();
-		assert.deepEqual(instance.get_and_clear_mutations(), []);
+		assert.deepEqual(instance.get_and_clear_mutations(), ['MAIN']);
 
-		// component.foo = false;
-		// flushSync();
-		// tick();
-		// assert.deepEqual(
-		// 	instance.get_and_clear_mutations(),
-		// 	['DIV', 'SPAN', 'B', 'I', 'DIV', 'SPAN', 'B', 'I'],
-		// 	'first mutation'
-		// );
+		let divs = target.querySelectorAll('div');
 
-		// assert.htmlEqual(
-		// 	target.innerHTML,
-		// 	`
-		// 	<main id="main" class="browser">
-		// 		<div class="custom svelte-1cjqok6 bar" title="a title"></div>
-		// 		<span class="svelte-1cjqok6 bar"></span>
-		// 		<b class="custom bar"></b>
-		// 		<i class="bar"></i>
+		// Note : we cannot compare HTML because set_style() use dom.style.cssText
+		// which can alter the format of the attribute...
 
-		// 		<div class="custom svelte-1cjqok6 bar" title="a title"></div>
-		// 		<span class="svelte-1cjqok6 bar"></span>
-		// 		<b class="custom bar"></b>
-		// 		<i class="bar"></i>
-		// 	</main>
-		// 	`
-		// );
+		divs.forEach((d) => assert.equal(d.style.margin, ''));
+		divs.forEach((d) => assert.equal(d.style.color, 'red'));
+		divs.forEach((d) => assert.equal(d.style.fontSize, '18px'));
 
-		// component.foo = true;
-		// flushSync();
-		// assert.deepEqual(
-		// 	instance.get_and_clear_mutations(),
-		// 	['DIV', 'SPAN', 'B', 'I', 'DIV', 'SPAN', 'B', 'I'],
-		// 	'second mutation'
-		// );
+		component.margin = '1px';
+		flushSync();
+		assert.deepEqual(
+			instance.get_and_clear_mutations(),
+			['DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV'],
+			'margin'
+		);
+		divs.forEach((d) => assert.equal(d.style.margin, '1px'));
 
-		// assert.htmlEqual(
-		// 	target.innerHTML,
-		// 	`
-		// 	<main id="main" class="browser">
-		// 		<div class="custom svelte-1cjqok6 bar foo" title="a title"></div>
-		// 		<span class="svelte-1cjqok6 bar foo"></span>
-		// 		<b class="custom bar foo"></b>
-		// 		<i class="bar foo"></i>
+		component.color = 'yellow';
+		flushSync();
+		assert.deepEqual(
+			instance.get_and_clear_mutations(),
+			['DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV'],
+			'color'
+		);
+		divs.forEach((d) => assert.equal(d.style.color, 'yellow'));
 
-		// 		<div class="custom svelte-1cjqok6 bar foo" title="a title"></div>
-		// 		<span class="svelte-1cjqok6 bar foo"></span>
-		// 		<b class="custom bar foo"></b>
-		// 		<i class="bar foo"></i>
-		// 	</main>
-		// 	`
-		// );
+		component.fontSize = '10px';
+		flushSync();
+		assert.deepEqual(
+			instance.get_and_clear_mutations(),
+			['DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV'],
+			'fontSize'
+		);
+		divs.forEach((d) => assert.equal(d.style.fontSize, '10px'));
 
-		// component.classname = 'another';
-		// flushSync();
-		// assert.deepEqual(
-		// 	instance.get_and_clear_mutations(),
-		// 	['DIV', 'B', 'DIV', 'B'],
-		// 	'class mutation'
-		// );
-
-		// assert.htmlEqual(
-		// 	target.innerHTML,
-		// 	`
-		// 	<main id="main" class="browser">
-		// 		<div class="another svelte-1cjqok6 foo bar" title="a title"></div>
-		// 		<span class="svelte-1cjqok6 bar foo"></span>
-		// 		<b class="another foo bar"></b>
-		// 		<i class="bar foo"></i>
-
-		// 		<div class="another svelte-1cjqok6 foo bar" title="a title"></div>
-		// 		<span class="svelte-1cjqok6 bar foo"></span>
-		// 		<b class="another foo bar"></b>
-		// 		<i class="bar foo"></i>
-		// 	</main>
-		// 	`
-		// );
+		component.fontSize = null;
+		flushSync();
+		assert.deepEqual(
+			instance.get_and_clear_mutations(),
+			['DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV', 'DIV'],
+			'fontSize'
+		);
+		divs.forEach((d) => assert.equal(d.style.fontSize, ''));
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/style-directive-mutations/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/style-directive-mutations/_config.js
@@ -1,0 +1,112 @@
+import { flushSync, tick } from 'svelte';
+import { test } from '../../test';
+
+// This test counts mutations on hydration
+// set_class() should not mutate class on hydration, except if mismatch
+export default test({
+	mode: ['server', 'hydrate'],
+
+	server_props: {
+		browser: false
+	},
+
+	props: {
+		browser: true
+	},
+
+	html: `
+		<main id="main">
+			<div style="color: red; font-size: 18px !important;"></div>
+			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
+			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
+			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
+			<div style="background:blue; background: linear-gradient(0, white 0%, red 100%); color: red; font-size: 18px !important;"></div>
+			<div style="border: 1px solid; color: red; font-size: 18px !important;"></div>
+			<div style="background: url(https://placehold.co/100x100?text=;&font=roboto); color: red; font-size: 18px !important;"></div>
+			<div style="background: url(&quot;https://placehold.co/100x100?text=;&font=roboto&quot;); color: red; font-size: 18px !important;"></div>
+			<div style="background: url('https://placehold.co/100x100?text=;&font=roboto'); color: red; font-size: 18px !important;"></div>
+		</main>
+	`,
+
+	async test({ target, assert, component, instance }) {
+		flushSync();
+		tick();
+		assert.deepEqual(instance.get_and_clear_mutations(), []);
+
+		// component.foo = false;
+		// flushSync();
+		// tick();
+		// assert.deepEqual(
+		// 	instance.get_and_clear_mutations(),
+		// 	['DIV', 'SPAN', 'B', 'I', 'DIV', 'SPAN', 'B', 'I'],
+		// 	'first mutation'
+		// );
+
+		// assert.htmlEqual(
+		// 	target.innerHTML,
+		// 	`
+		// 	<main id="main" class="browser">
+		// 		<div class="custom svelte-1cjqok6 bar" title="a title"></div>
+		// 		<span class="svelte-1cjqok6 bar"></span>
+		// 		<b class="custom bar"></b>
+		// 		<i class="bar"></i>
+
+		// 		<div class="custom svelte-1cjqok6 bar" title="a title"></div>
+		// 		<span class="svelte-1cjqok6 bar"></span>
+		// 		<b class="custom bar"></b>
+		// 		<i class="bar"></i>
+		// 	</main>
+		// 	`
+		// );
+
+		// component.foo = true;
+		// flushSync();
+		// assert.deepEqual(
+		// 	instance.get_and_clear_mutations(),
+		// 	['DIV', 'SPAN', 'B', 'I', 'DIV', 'SPAN', 'B', 'I'],
+		// 	'second mutation'
+		// );
+
+		// assert.htmlEqual(
+		// 	target.innerHTML,
+		// 	`
+		// 	<main id="main" class="browser">
+		// 		<div class="custom svelte-1cjqok6 bar foo" title="a title"></div>
+		// 		<span class="svelte-1cjqok6 bar foo"></span>
+		// 		<b class="custom bar foo"></b>
+		// 		<i class="bar foo"></i>
+
+		// 		<div class="custom svelte-1cjqok6 bar foo" title="a title"></div>
+		// 		<span class="svelte-1cjqok6 bar foo"></span>
+		// 		<b class="custom bar foo"></b>
+		// 		<i class="bar foo"></i>
+		// 	</main>
+		// 	`
+		// );
+
+		// component.classname = 'another';
+		// flushSync();
+		// assert.deepEqual(
+		// 	instance.get_and_clear_mutations(),
+		// 	['DIV', 'B', 'DIV', 'B'],
+		// 	'class mutation'
+		// );
+
+		// assert.htmlEqual(
+		// 	target.innerHTML,
+		// 	`
+		// 	<main id="main" class="browser">
+		// 		<div class="another svelte-1cjqok6 foo bar" title="a title"></div>
+		// 		<span class="svelte-1cjqok6 bar foo"></span>
+		// 		<b class="another foo bar"></b>
+		// 		<i class="bar foo"></i>
+
+		// 		<div class="another svelte-1cjqok6 foo bar" title="a title"></div>
+		// 		<span class="svelte-1cjqok6 bar foo"></span>
+		// 		<b class="another foo bar"></b>
+		// 		<i class="bar foo"></i>
+		// 	</main>
+		// 	`
+		// );
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/style-directive-mutations/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/style-directive-mutations/main.svelte
@@ -1,0 +1,54 @@
+<script>
+	let {
+		margin = null,
+		color = 'red',
+		fontSize = '18px',
+		style1 = 'border: 1px solid',
+		style2 = 'border: 1px solid; margin: 1em',
+		style3 = 'color:blue; border: 1px solid; color: green;',
+		style4 = 'background:blue; background: linear-gradient(0, white 0%, red 100%)',
+		style5 = 'border: 1px solid; /* width: 100px; height: 100%; color: green */',
+		style6 = 'background: url(https://placehold.co/100x100?text=;&font=roboto);',
+		style7 = 'background: url("https://placehold.co/100x100?text=;&font=roboto");',
+		style8 = "background: url('https://placehold.co/100x100?text=;&font=roboto');",
+		
+		browser
+	} = $props();
+
+	let mutations = [];
+	let observer;
+
+	if (browser) {
+		observer = new MutationObserver(update_mutation_records);
+		observer.observe(document.querySelector('#main'), { attributes: true, subtree: true });
+
+		$effect(() => {
+			return () => observer.disconnect();
+		});
+	}
+
+	function update_mutation_records(results) {
+		for (const r of results) {
+			mutations.push(r.target.nodeName);
+		}
+	}
+
+	export function get_and_clear_mutations() {
+		update_mutation_records(observer.takeRecords());
+		const result = mutations;
+		mutations = [];
+		return result;
+	}
+</script>
+
+<main id="main">
+	<div style:margin style:color style:font-size|important={fontSize}></div>
+	<div style={style1} style:margin style:color style:font-size|important={fontSize}></div>
+	<div style={style2} style:margin style:color style:font-size|important={fontSize}></div>
+	<div style={style3} style:margin style:color style:font-size|important={fontSize}></div>
+	<div style={style4} style:margin style:color style:font-size|important={fontSize}></div>
+	<div style={style5} style:margin style:color style:font-size|important={fontSize}></div>
+	<div style={style6} style:margin style:color style:font-size|important={fontSize}></div>
+	<div style={style7} style:margin style:color style:font-size|important={fontSize}></div>
+	<div style={style8} style:margin style:color style:font-size|important={fontSize}></div>
+</main>

--- a/packages/svelte/tests/runtime-runes/samples/style-directive-mutations/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/style-directive-mutations/main.svelte
@@ -41,7 +41,7 @@
 	}
 </script>
 
-<main id="main">
+<main id="main" style:color={browser?'white':'black'}>
 	<div style:margin style:color style:font-size|important={fontSize}></div>
 	<div style={style1} style:margin style:color style:font-size|important={fontSize}></div>
 	<div style={style2} style:margin style:color style:font-size|important={fontSize}></div>


### PR DESCRIPTION
This is the #15352 counterpart for `style:directive`

Currently the `style:xxx` directives are managed separately from the `style` attribute.
This is a PoC for rewriting `set_style()` in order to includes `class:` directives.

* Closes #15309 
* Closes #15416 
* Avoid unnecessary mutations during hydration


Note that I edited a test, for removing an empty attribute
Basically :
```diff
-	<p style=""></p>
+	<p></p>
```

I haven't had time to do a test for this yet.
I'll do it this week...

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
