### PR TITLE
fix: make dialog element and role interactive

### DIFF
--- a/.changeset/gentle-humans-call.md
+++ b/.changeset/gentle-humans-call.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: make dialog element and role interactive

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y.js
@@ -30,7 +30,7 @@ const non_interactive_roles = non_abstract_roles
 			// 'generic' is meant to have no semantic meaning.
 			// 'cell' is treated as CellRole by the AXObject which is interactive, so we treat 'cell' it as interactive as well.
 			!['toolbar', 'tabpanel', 'generic', 'cell'].includes(name) &&
-			!role?.superClass.some((classes) => classes.includes('widget'))
+			!role?.superClass.some((classes) => classes.includes('widget') || classes.includes('window'))
 		);
 	})
 	.concat(

--- a/packages/svelte/tests/validator/samples/a11y-no-noninteractive-element-interactions/input.svelte
+++ b/packages/svelte/tests/validator/samples/a11y-no-noninteractive-element-interactions/input.svelte
@@ -3,6 +3,7 @@
 <div role="button" tabindex="-1" on:click={() => {}} on:keypress={() => {}}></div>
 <div role="listitem" aria-hidden="true" on:click={() => {}} on:keypress={() => {}}></div>
 <button on:click={() => {}}>click me</button>
+<dialog on:click={() => {}}>alert</dialog>
 <h1 contenteditable="true" on:keydown={() => {}}>Heading</h1>
 <h1>Heading</h1>
 

--- a/packages/svelte/tests/validator/samples/a11y-no-noninteractive-element-interactions/warnings.json
+++ b/packages/svelte/tests/validator/samples/a11y-no-noninteractive-element-interactions/warnings.json
@@ -3,60 +3,60 @@
 		"code": "a11y_no_noninteractive_element_interactions",
 		"end": {
 			"column": 51,
-			"line": 10
+			"line": 11
 		},
 		"message": "Non-interactive element `<div>` should not be assigned mouse or keyboard event listeners",
 		"start": {
 			"column": 0,
-			"line": 10
+			"line": 11
 		}
 	},
 	{
 		"code": "a11y_no_noninteractive_element_interactions",
 		"end": {
 			"column": 58,
-			"line": 11
+			"line": 12
 		},
 		"message": "Non-interactive element `<h1>` should not be assigned mouse or keyboard event listeners",
 		"start": {
 			"column": 0,
-			"line": 11
+			"line": 12
 		}
 	},
 	{
 		"code": "a11y_no_noninteractive_element_interactions",
 		"end": {
 			"column": 50,
-			"line": 12
+			"line": 13
 		},
 		"message": "Non-interactive element `<h1>` should not be assigned mouse or keyboard event listeners",
 		"start": {
 			"column": 0,
-			"line": 12
+			"line": 13
 		}
 	},
 	{
 		"code": "a11y_no_noninteractive_element_interactions",
 		"end": {
 			"column": 30,
-			"line": 13
+			"line": 14
 		},
 		"message": "Non-interactive element `<p>` should not be assigned mouse or keyboard event listeners",
 		"start": {
 			"column": 0,
-			"line": 13
+			"line": 14
 		}
 	},
 	{
 		"code": "a11y_no_noninteractive_element_interactions",
 		"end": {
 			"column": 50,
-			"line": 14
+			"line": 15
 		},
 		"message": "Non-interactive element `<div>` should not be assigned mouse or keyboard event listeners",
 		"start": {
 			"column": 0,
-			"line": 14
+			"line": 15
 		}
 	}
 ]


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/8283

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Motivation

I want to use native `dialog` elements. A common pattern for modal dialogs is dismissing them by clicking on the backdrop pseudo-element. This is achieved by assigning a click event handler to the dialog itself. Svelte is perfect for this task. Except Svelte raises a warning (`a11y_no_noninteractive_element_interactions`) about adding a click event handler to the dialog element, because Svelte treats it as non-interactive. This is what I want to change.

### Solution

Svelte considers elements non-interactive if they don’t have a `widget` superclass and their roles are not `toolbar`, `tabpanel`, `cell`, or `generic`. The dialog-related roles are `dialog` and `alertdialog`, [both of them having a superclass `window`](https://w3c.github.io/aria/#window_roles). Instead of adding the two roles to the exceptions list, I think it makes more sense to also treat the window subclasses as interactive. After all, windows are interactive. If you prefer, however, I could modify the exceptions instead.