### PR TITLE
chore: memoize clsx()

### DIFF
--- a/.changeset/tame-trees-deliver.md
+++ b/.changeset/tame-trees-deliver.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+chore: memoize `clsx` calls

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -573,14 +573,17 @@ function build_element_attribute_update_assignment(
 
 	const is_autofocus = name === 'autofocus';
 
-	let { value, has_state } = build_attribute_value(attribute.value, context, (value, metadata) =>
-		metadata.has_call
-			? // if it's autofocus we will not add this to a template effect so we don't want to get the expression id
-				// but separately memoize the expression
-				is_autofocus
-				? memoize_expression(state, value)
-				: get_expression_id(state, value)
-			: value
+	let { value, has_state, has_call } = build_attribute_value(
+		attribute.value,
+		context,
+		(value, metadata) =>
+			metadata.has_call
+				? // if it's autofocus we will not add this to a template effect so we don't want to get the expression id
+					// but separately memoize the expression
+					is_autofocus
+					? memoize_expression(state, value)
+					: get_expression_id(state, value)
+				: value
 	);
 
 	if (is_autofocus) {
@@ -608,6 +611,7 @@ function build_element_attribute_update_assignment(
 			attribute,
 			value,
 			has_state,
+			has_call,
 			class_directives,
 			context,
 			!is_svg && !is_mathml

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
@@ -87,7 +87,7 @@ export function SvelteElement(node, context) {
 		is_text_attribute(attributes[0])
 	) {
 		// special case when there only a class attribute, without call expression
-		let { value, has_state } = build_attribute_value(
+		let { value, has_state, has_call } = build_attribute_value(
 			attributes[0].value,
 			context,
 			(value, metadata) => (metadata.has_call ? get_expression_id(context.state, value) : value)
@@ -99,6 +99,7 @@ export function SvelteElement(node, context) {
 			attributes[0],
 			value,
 			has_state,
+			has_call,
 			class_directives,
 			inner_context,
 			false

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -80,7 +80,7 @@ function compare_expressions(a, b) {
  * @param {(node: AST.SvelteNode, state: any) => any} visit
  * @param {ComponentClientTransformState} state
  * @param {(value: Expression, metadata: ExpressionMetadata) => Expression} memoize
- * @returns {{ value: Expression, has_state: boolean }}
+ * @returns {{ value: Expression, has_state: boolean, has_call: boolean }}
  */
 export function build_template_chunk(
 	values,
@@ -95,6 +95,7 @@ export function build_template_chunk(
 	const quasis = [quasi];
 
 	let has_state = false;
+	let has_call = false;
 
 	for (let i = 0; i < values.length; i++) {
 		const node = values[i];
@@ -116,11 +117,12 @@ export function build_template_chunk(
 			);
 
 			has_state ||= node.metadata.expression.has_state;
+			has_call ||= node.metadata.expression.has_call;
 
 			if (values.length === 1) {
 				// If we have a single expression, then pass that in directly to possibly avoid doing
 				// extra work in the template_effect (instead we do the work in set_text).
-				return { value, has_state };
+				return { value, has_state, has_call };
 			}
 
 			if (
@@ -162,7 +164,7 @@ export function build_template_chunk(
 			? b.template(quasis, expressions)
 			: b.literal(/** @type {string} */ (quasi.value.cooked));
 
-	return { value, has_state };
+	return { value, has_state, has_call };
 }
 
 /**


### PR DESCRIPTION
Just a little improvement on **clsx()**.

Function call in the template are memoized in order to be executed only on state changes.
But this is not the case for `$.clsx()` which is added by the compiler.

Currently, a code like that :
```svelte
<script>
	let { class: className } = $props();
</script>

<div class={className}>
	... stuff
</div>
```

is compiled into something like that : 
```js
	$.template_effect(() => {
		$.set_class(div, 1, $.clsx($$props.class));
		// ... stuff
	});
```
So, every time the template is updated, `$.clsx($$props.class)` is re-evaluated.


With this PR, the `$.clsx($$props.class)` will be memoized on the `template_effect()`, and executed only when necessary :
```js
	$.template_effect(($0) => {
		$.set_class(div, 1, $0);
		// ... stuff
	}, [() => $.clsx($$props.class)]);
```

Note that this is only done when the value of `$.clsx()` is not already memoized (I think this is a rare case which would be more complex to treat).


I don't have a test for that (I don't known how to check that), but all the current test are OK.


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
