### PR TITLE
docs: fix 'rune' phonetic spelling

### DIFF
--- a/documentation/docs/02-runes/01-what-are-runes.md
+++ b/documentation/docs/02-runes/01-what-are-runes.md
@@ -2,7 +2,7 @@
 title: What are runes?
 ---
 
-> [!NOTE] **rune** /ro͞on/ _noun_
+> [!NOTE] **rune** /ruːn/ _noun_
 >
 > A letter or mark used as a mystical or magic symbol.
 


### PR DESCRIPTION
The intro docs page for runes includes a flavor-text dictionary entry for "rune".
https://svelte.dev/docs/svelte/what-are-runes

This seems to have some special/invalid character, which is displayed differently in different browsers:

| Browsers |
|--------|
| Chromium <br/><img width="569" alt="Screenshot 2025-03-04 at 8 40 44 PM" src="https://github.com/user-attachments/assets/27d93f9f-df8d-4d48-8575-7a26cc27feed" /> |
| Firefox <br/><img width="569" alt="Screenshot 2025-03-04 at 8 42 52 PM" src="https://github.com/user-attachments/assets/f4b2d2af-b58c-4e96-bf49-020bd834e7fb" /> |
| Safari <br/><img width="569" alt="Screenshot 2025-03-04 at 8 42 59 PM" src="https://github.com/user-attachments/assets/9d36945d-739e-45ca-836f-1d56d0f1190c" /> | 

This should be switched to something that displays normally on all popular browsers.

I opted to use the International Phonetic Alphabet notation from [OED](https://www.oed.com/dictionary/rune_n2?tab=factsheet#24851663), but I'll gladly tweak it to anything that seems sensible and displays well on different browsers.

I didn't test this fix, as I don't have the docs site dev environment setup. Would be happy to set it up if needed, but the `svelte-dev` repo isn't super clear on how to run it against docs changes from this repository?