### PR TITLE
fix: never deduplicate expressions in templates

### DIFF
--- a/.changeset/five-wolves-swim.md
+++ b/.changeset/five-wolves-swim.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: never deduplicate expressions in templates

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -26,53 +26,7 @@ export function memoize_expression(state, value) {
  * @param {Expression} value
  */
 export function get_expression_id(state, value) {
-	for (let i = 0; i < state.expressions.length; i += 1) {
-		if (compare_expressions(state.expressions[i], value)) {
-			return b.id(`$${i}`);
-		}
-	}
-
 	return b.id(`$${state.expressions.push(value) - 1}`);
-}
-
-/**
- * Returns true of two expressions have an identical AST shape
- * @param {Expression} a
- * @param {Expression} b
- */
-function compare_expressions(a, b) {
-	if (a.type !== b.type) {
-		return false;
-	}
-
-	for (const key in a) {
-		if (key === 'type' || key === 'metadata' || key === 'loc' || key === 'start' || key === 'end') {
-			continue;
-		}
-
-		const va = /** @type {any} */ (a)[key];
-		const vb = /** @type {any} */ (b)[key];
-
-		if ((typeof va === 'object') !== (typeof vb === 'object')) {
-			return false;
-		}
-
-		if (typeof va !== 'object' || va === null || vb === null) {
-			if (va !== vb) return false;
-		} else if (Array.isArray(va)) {
-			if (va.length !== vb.length) {
-				return false;
-			}
-
-			if (va.some((v, i) => !compare_expressions(v, vb[i]))) {
-				return false;
-			}
-		} else if (!compare_expressions(va, vb)) {
-			return false;
-		}
-	}
-
-	return true;
 }
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/random/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/random/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const [p1, p2] = target.querySelectorAll('p');
+		assert.notEqual(p1.textContent, p2.textContent);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/random/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/random/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { m = 1 } = $props();
+</script>
+
+<p>{(Math.random() * m).toFixed(10)}</p>
+<p>{(Math.random() * m).toFixed(10)}</p>

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -21,13 +21,13 @@ export default function Main($$anchor) {
 	$.template_effect(() => $.set_custom_element_data(custom_element_1, 'fooBar', y()));
 
 	$.template_effect(
-		($0) => {
+		($0, $1) => {
 			$.set_attribute(div, 'foobar', x);
 			$.set_attribute(svg, 'viewBox', x);
 			$.set_attribute(div_1, 'foobar', $0);
-			$.set_attribute(svg_1, 'viewBox', $0);
+			$.set_attribute(svg_1, 'viewBox', $1);
 		},
-		[y]
+		[y, y]
 	);
 
 	$.append($$anchor, fragment);


### PR DESCRIPTION
Fixes #15096. A shame to lose this optimisation, but it doesn't make a difference to the vast majority of apps, and correctness comes first.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
