### PR TITLE
feat: Add `closedby` to `HTMLDialogAttributes` (dialog element)

### DIFF
--- a/.changeset/metal-spoons-scream.md
+++ b/.changeset/metal-spoons-scream.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: Add `closedby` property to HTMLDialogAttributes type

--- a/.changeset/metal-spoons-scream.md
+++ b/.changeset/metal-spoons-scream.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-feat: Add `closedby` property to HTMLDialogAttributes type
+fix: Add `closedby` property to HTMLDialogAttributes type

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -957,6 +957,7 @@ export interface HTMLDelAttributes extends HTMLAttributes<HTMLModElement> {
 
 export interface HTMLDialogAttributes extends HTMLAttributes<HTMLDialogElement> {
 	open?: boolean | undefined | null;
+	closedby?: 'any' | 'closerequest' | 'none' | undefined | null;
 }
 
 export interface HTMLEmbedAttributes extends HTMLAttributes<HTMLEmbedElement> {


### PR DESCRIPTION
This PR adds support for the new `closedby` attribute to the `dialog` element, by adding definitions for it and it's enumerated values in the element types (`HTMLDialogAttributes`).

Spec: https://html.spec.whatwg.org/#attr-dialog-closedby