### PR TITLE
fix: null and warnings for local handlers

### DIFF
--- a/.changeset/shy-mirrors-remain.md
+++ b/.changeset/shy-mirrors-remain.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: null and warnings for local handlers

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/events.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/events.js
@@ -46,8 +46,12 @@ export function visit_event_attribute(node, context) {
 
 			// When we hoist a function we assign an array with the function and all
 			// hoisted closure params.
-			const args = [handler, ...hoisted_params];
-			delegated_assignment = b.array(args);
+			if (hoisted_params) {
+				const args = [handler, ...hoisted_params];
+				delegated_assignment = b.array(args);
+			} else {
+				delegated_assignment = handler;
+			}
 		} else {
 			delegated_assignment = handler;
 		}
@@ -123,11 +127,17 @@ export function build_event_handler(node, metadata, context) {
 	}
 
 	// function declared in the script
-	if (
-		handler.type === 'Identifier' &&
-		context.state.scope.get(handler.name)?.declaration_kind !== 'import'
-	) {
-		return handler;
+	if (handler.type === 'Identifier') {
+		const kind = context.state.scope.get(handler.name)?.declaration_kind;
+		if (kind === 'function') {
+			return handler;
+		}
+		// local variable can be assigned directly
+		// except in dev mode where when need $.apply()
+		// in order to handle warnings.
+		if (!dev && kind !== 'import') {
+			return handler;
+		}
 	}
 
 	if (metadata.has_call) {

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -238,7 +238,7 @@ export function handle_event_propagation(event) {
 				var delegated = current_target['__' + event_name];
 
 				if (
-					delegated !== undefined &&
+					delegated != null &&
 					(!(/** @type {any} */ (current_target).disabled) ||
 						// DOM could've been updated already by the time this is reached, so we check this as well
 						// -> the target could not have been disabled because it emits the event in the first place
@@ -311,13 +311,11 @@ export function apply(
 		error = e;
 	}
 
-	if (typeof handler === 'function') {
-		handler.apply(element, args);
-	} else if (has_side_effects || handler != null || error) {
+	if (typeof handler !== 'function' && (has_side_effects || handler != null || error)) {
 		const filename = component?.[FILENAME];
 		const location = loc ? ` at ${filename}:${loc[0]}:${loc[1]}` : ` in ${filename}`;
-
-		const event_name = args[0].type;
+		const phase = args[0]?.eventPhase < Event.BUBBLING_PHASE ? 'capture' : '';
+		const event_name = args[0]?.type + phase;
 		const description = `\`${event_name}\` handler${location}`;
 		const suggestion = remove_parens ? 'remove the trailing `()`' : 'add a leading `() =>`';
 
@@ -327,4 +325,5 @@ export function apply(
 			throw error;
 		}
 	}
+	handler?.apply(element, args);
 }

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-invalid-values/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-invalid-values/_config.js
@@ -1,0 +1,48 @@
+import { assertType } from 'vitest';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, warnings, logs }) {
+		/** @type {any} */
+		let error = null;
+
+		const handler = (/** @type {any} */ e) => {
+			error = e.error;
+			e.stopImmediatePropagation();
+		};
+
+		window.addEventListener('error', handler, true);
+
+		const [b1, b2, b3] = target.querySelectorAll('button');
+
+		b1.click();
+		assert.deepEqual(logs, []);
+		assert.equal(error, null);
+
+		error = null;
+		logs.length = 0;
+
+		b2.click();
+		assert.deepEqual(logs, ['clicked']);
+		assert.equal(error, null);
+
+		error = null;
+		logs.length = 0;
+
+		b3.click();
+		assert.deepEqual(logs, []);
+		assert.deepEqual(warnings, [
+			'`click` handler at main.svelte:10:17 should be a function. Did you mean to add a leading `() =>`?'
+		]);
+		assert.isNotNull(error);
+		assert.match(error.message, /is not a function/);
+
+		window.removeEventListener('error', handler, true);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-invalid-values/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-invalid-values/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let ignore = null;
+	let handler = () => console.log("clicked");
+	let bad = "invalid";
+	
+</script>
+
+<button onclick={ignore}>click</button>
+<button onclick={handler}>click</button>
+<button onclick={bad}>click</button>


### PR DESCRIPTION
* Closes https://github.com/sveltejs/svelte/issues/15411

Fix some problems with event-handlers declared as local variables :
* Delegated events ignore the **null** value.
* The *event_handler_invalid* is not printed for invalid handlers.

And some little fix for all event-handlers :
* The *event_handler_invalid* will print the correct name for capture event (ex: `onclickcapture` instead of `onclick`).
* The *event_handler_invalid* warning will not hide the TypeError "xxx is not a function"
* Do no use "hoisted function" when the function do no have hoisted_params.


### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
