### PR TITLE
chore: reuse is_function helper

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
@@ -162,16 +162,8 @@ function get_delegated_event(event_name, handler, context) {
 			return unhoisted;
 		}
 
-		if (binding !== null && binding.initial !== null && !binding.updated) {
-			const binding_type = binding.initial.type;
-
-			if (
-				binding_type === 'ArrowFunctionExpression' ||
-				binding_type === 'FunctionDeclaration' ||
-				binding_type === 'FunctionExpression'
-			) {
-				target_function = binding.initial;
-			}
+		if (binding?.is_function()) {
+			target_function = binding.initial;
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -1,4 +1,4 @@
-/** @import { ClassDeclaration, Expression, FunctionDeclaration, Identifier, ImportDeclaration, MemberExpression, Node, Pattern, VariableDeclarator } from 'estree' */
+/** @import { ArrowFunctionExpression, ClassDeclaration, Expression, FunctionDeclaration, FunctionExpression, Identifier, ImportDeclaration, MemberExpression, Node, Pattern, VariableDeclarator } from 'estree' */
 /** @import { Context, Visitor } from 'zimmerframe' */
 /** @import { AST, BindingKind, DeclarationKind } from '#compiler' */
 import is_reference from 'is-reference';
@@ -80,19 +80,23 @@ export class Binding {
 		return this.mutated || this.reassigned;
 	}
 
+	/**
+	 * @returns {this is Binding & { initial: ArrowFunctionExpression | FunctionDeclaration | FunctionExpression }}
+	 */
 	is_function() {
-		if (this.reassigned) {
+		if (this.updated) {
 			// even if it's reassigned to another function,
 			// we can't use it directly as e.g. an event handler
 			return false;
 		}
 
-		if (this.declaration_kind === 'function') {
-			return true;
-		}
-
 		const type = this.initial?.type;
-		return type === 'ArrowFunctionExpression' || type === 'FunctionExpression';
+
+		return (
+			type === 'ArrowFunctionExpression' ||
+			type === 'FunctionExpression' ||
+			type === 'FunctionDeclaration'
+		);
 	}
 }
 


### PR DESCRIPTION
I added an `is_function` method on `Binding` in #15460. Turns out there's at least one more place we can use it. I also added some TypeScript trickery ([thanks for the assist, v0](https://v0.dev/chat/type-narrowing-in-type-script-XmHkOfWgYwx)) so that you can type narrowing when you use it