### PR TITLE
fix: skip `log_if_contains_state` if only logging literals

### DIFF
--- a/.changeset/hungry-monkeys-fly.md
+++ b/.changeset/hungry-monkeys-fly.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip `log_if_contains_state` if only logging literals

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/CallExpression.js
@@ -44,7 +44,8 @@ export function CallExpression(node, context) {
 		node.callee.property.type === 'Identifier' &&
 		['debug', 'dir', 'error', 'group', 'groupCollapsed', 'info', 'log', 'trace', 'warn'].includes(
 			node.callee.property.name
-		)
+		) &&
+		node.arguments.some((arg) => arg.type !== 'Literal') // TODO more cases?
 	) {
 		return b.call(
 			node.callee,


### PR DESCRIPTION
To make `console.log(some_state)` more useful, we transform it to this, which prints a snapshot of the state along with instructions on how to do it yourself:

```js
console.log(...$.log_if_contains_state('log', some_state));
```

There's no need to do this if you're just doing `console.log('HERE')` or `console.log('WHY WONT THIS WORK')` or whatever. There are doubtless other cases we could similarly optimise but literals are the obvious place to start

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
