### PR TITLE
fix: on teardown, use the last known value for the signal before the set

### DIFF
--- a/.changeset/sharp-elephants-invite.md
+++ b/.changeset/sharp-elephants-invite.md
@@ -1,5 +1,5 @@
 ---
-'svelte': patch
+'svelte': minor
 ---
 
 fix: on teardown, use the last known value for the signal before the set

--- a/.changeset/sharp-elephants-invite.md
+++ b/.changeset/sharp-elephants-invite.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: on teardown, use the last known value for the signal before the set

--- a/.changeset/sharp-elephants-invite.md
+++ b/.changeset/sharp-elephants-invite.md
@@ -2,4 +2,4 @@
 'svelte': minor
 ---
 
-fix: on teardown, use the last known value for the signal before the set
+fix: make values consistent between effects and their cleanup functions

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -42,6 +42,9 @@ export function CallExpression(node, context) {
 				e.bindable_invalid_location(node);
 			}
 
+			// We need context in case the bound prop is stale
+			context.state.analysis.needs_context = true;
+
 			break;
 
 		case '$host':

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -11,7 +11,7 @@ import {
 	set_active_reaction,
 	untrack
 } from './runtime.js';
-import { effect } from './reactivity/effects.js';
+import { effect, teardown } from './reactivity/effects.js';
 import { legacy_mode_flag } from '../flags/index.js';
 
 /** @type {ComponentContext | null} */
@@ -112,15 +112,16 @@ export function getAllContexts() {
  * @returns {void}
  */
 export function push(props, runes = false, fn) {
-	component_context = {
+	var ctx = (component_context = {
 		p: component_context,
 		c: null,
+		d: false,
 		e: null,
 		m: false,
 		s: props,
 		x: null,
 		l: null
-	};
+	});
 
 	if (legacy_mode_flag && !runes) {
 		component_context.l = {
@@ -130,6 +131,10 @@ export function push(props, runes = false, fn) {
 			r2: source(false)
 		};
 	}
+
+	teardown(() => {
+		/** @type {ComponentContext} */ (ctx).d = true;
+	});
 
 	if (DEV) {
 		// component function

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -424,7 +424,7 @@ export function prop(props, key, flags, fallback) {
 			return value;
 		}
 
-		if (has_destoyed_component_ctx(current_value)) {
+		if (has_destroyed_component_ctx(current_value)) {
 			return current_value.v;
 		}
 

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -10,11 +10,7 @@ import {
 import { get_descriptor, is_function } from '../../shared/utils.js';
 import { mutable_source, set, source, update } from './sources.js';
 import { derived, derived_safe_equal } from './deriveds.js';
-import {
-	get,
-	captured_signals,
-	untrack,
-} from '../runtime.js';
+import { get, captured_signals, untrack } from '../runtime.js';
 import { safe_equals } from './equality.js';
 import * as e from '../errors.js';
 import { LEGACY_DERIVED_PROP, LEGACY_PROPS, STATE_SYMBOL } from '../constants.js';

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -245,7 +245,7 @@ export function spread_props(...props) {
  * @param {Derived} current_value
  * @returns {boolean}
  */
-function has_destoyed_component_ctx(current_value) {
+function has_destroyed_component_ctx(current_value) {
 	return current_value.ctx?.d ?? false;
 }
 

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -1,4 +1,4 @@
-/** @import { Source } from './types.js' */
+/** @import { Derived, Source } from './types.js' */
 import { DEV } from 'esm-env';
 import {
 	PROPS_IS_BINDABLE,
@@ -10,7 +10,11 @@ import {
 import { get_descriptor, is_function } from '../../shared/utils.js';
 import { mutable_source, set, source, update } from './sources.js';
 import { derived, derived_safe_equal } from './deriveds.js';
-import { get, captured_signals, untrack } from '../runtime.js';
+import {
+	get,
+	captured_signals,
+	untrack,
+} from '../runtime.js';
 import { safe_equals } from './equality.js';
 import * as e from '../errors.js';
 import { LEGACY_DERIVED_PROP, LEGACY_PROPS, STATE_SYMBOL } from '../constants.js';

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -1,4 +1,4 @@
-/** @import { Derived, Source } from './types.js' */
+/** @import { Source } from './types.js' */
 import { DEV } from 'esm-env';
 import {
 	PROPS_IS_BINDABLE,
@@ -10,13 +10,7 @@ import {
 import { get_descriptor, is_function } from '../../shared/utils.js';
 import { mutable_source, set, source, update } from './sources.js';
 import { derived, derived_safe_equal } from './deriveds.js';
-import {
-	get,
-	captured_signals,
-	untrack,
-	set_is_destroying_effect,
-	is_destroying_effect
-} from '../runtime.js';
+import { get, captured_signals, untrack } from '../runtime.js';
 import { safe_equals } from './equality.js';
 import * as e from '../errors.js';
 import { LEGACY_DERIVED_PROP, LEGACY_PROPS, STATE_SYMBOL } from '../constants.js';

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -414,7 +414,7 @@ export function prop(props, key, flags, fallback) {
 					fallback_value = new_value;
 				}
 
-				if (has_destoyed_component_ctx(current_value)) {
+				if (has_destroyed_component_ctx(current_value)) {
 					return value;
 				}
 

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -15,7 +15,6 @@ import {
 	set_derived_sources,
 	check_dirtiness,
 	untracking,
-	old_values,
 	is_destroying_effect
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
@@ -36,6 +35,7 @@ import { get_stack } from '../dev/tracing.js';
 import { component_context, is_runes } from '../context.js';
 
 export let inspect_effects = new Set();
+export const old_values = new Map();
 
 /**
  * @param {Set<any>} v

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -34,7 +34,6 @@ import * as e from '../errors.js';
 import { legacy_mode_flag, tracing_mode_flag } from '../../flags/index.js';
 import { get_stack } from '../dev/tracing.js';
 import { component_context, is_runes } from '../context.js';
-import { queue_micro_task } from '../dom/task.js';
 
 export let inspect_effects = new Set();
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -24,7 +24,7 @@ import {
 	DISCONNECTED,
 	BOUNDARY_EFFECT
 } from './constants.js';
-import { flush_tasks, queue_micro_task } from './dom/task.js';
+import { flush_tasks } from './dom/task.js';
 import { internal_set } from './reactivity/sources.js';
 import { destroy_derived_effects, update_derived } from './reactivity/deriveds.js';
 import * as e from './errors.js';

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -25,7 +25,7 @@ import {
 	BOUNDARY_EFFECT
 } from './constants.js';
 import { flush_tasks } from './dom/task.js';
-import { internal_set } from './reactivity/sources.js';
+import { internal_set, old_values } from './reactivity/sources.js';
 import { destroy_derived_effects, update_derived } from './reactivity/deriveds.js';
 import * as e from './errors.js';
 import { FILENAME } from '../../constants.js';
@@ -39,8 +39,6 @@ import {
 	set_dev_current_component_function
 } from './context.js';
 import { is_firefox } from './dom/operations.js';
-
-export const old_values = new Map();
 
 // Used for DEV time error handling
 /** @param {WeakSet<Error>} value */

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -14,6 +14,8 @@ export type ComponentContext = {
 	p: null | ComponentContext;
 	/** context */
 	c: null | Map<unknown, unknown>;
+	/** destroyed */
+	d: boolean;
 	/** deferred effects */
 	e: null | Array<{
 		fn: () => void | (() => void);

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-2/Component.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-2/Component.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { onDestroy } from 'svelte';
+
+	export let my_prop;
+
+	onDestroy(() => {
+		console.log(my_prop.foo);
+	});
+</script>
+
+{my_prop.foo}

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-2/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-2/_config.js
@@ -1,0 +1,14 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn1] = target.querySelectorAll('button');
+
+		flushSync(() => {
+			btn1.click();
+		});
+
+		assert.deepEqual(logs, ['bar']);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-2/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-2/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	import Component from './Component.svelte';
+
+	let value = { foo: 'bar' };
+</script>
+
+<button
+	onclick={() => {
+		value = undefined;
+	}}>Reset value</button
+>
+
+{#if value !== undefined}
+	<Component my_prop={value} />
+{/if}

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-3/Component.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-3/Component.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	export let ref;
+</script>
+
+<input bind:this={ref} />

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-3/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-3/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	async test({ target }) {
+		const [btn1] = target.querySelectorAll('button');
+
+		btn1.click();
+		flushSync();
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-3/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access-3/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	import Component from './Component.svelte';
+	let state = { title: 'foo' };
+</script>
+
+{#if state}
+	{@const attributes = { title: state.title }}
+	<Component {...attributes} />
+{/if}
+<button
+	onclick={() => {
+		state = undefined;
+	}}
+>
+	Del
+</button>

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access/Component.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access/Component.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { onDestroy } from "svelte";
+	export let checked;
+	export let count;
+	onDestroy(() => {
+		console.log(count, checked);
+	});
+</script>
+
+<p>{count}</p>
+
+<button onclick={()=> count-- }></button>

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access/_config.js
@@ -1,0 +1,68 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn1, btn2, btn3] = target.querySelectorAll('button');
+		let ps = [...target.querySelectorAll('p')];
+
+		for (const p of ps) {
+			assert.equal(p.innerHTML, '0');
+		}
+
+		flushSync(() => {
+			btn1.click();
+		});
+
+		// prop update normally if we are not unmounting
+		for (const p of ps) {
+			assert.equal(p.innerHTML, '1');
+		}
+
+		flushSync(() => {
+			btn3.click();
+		});
+
+		// binding still works and update the value correctly
+		for (const p of ps) {
+			assert.equal(p.innerHTML, '0');
+		}
+
+		flushSync(() => {
+			btn1.click();
+		});
+
+		flushSync(() => {
+			btn1.click();
+		});
+
+		console.warn(logs);
+
+		// the five components guarded by `count < 2` unmount and log
+		assert.deepEqual(logs, [1, true, 1, true, 1, true, 1, true, 1, true]);
+
+		flushSync(() => {
+			btn2.click();
+		});
+
+		// the three components guarded by `show` unmount and log
+		assert.deepEqual(logs, [
+			1,
+			true,
+			1,
+			true,
+			1,
+			true,
+			1,
+			true,
+			1,
+			true,
+			2,
+			true,
+			2,
+			true,
+			2,
+			true
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/ondestroy-prop-access/main.svelte
@@ -1,0 +1,41 @@
+<script>
+	import Component from "./Component.svelte";
+	let show = true;
+	let count = 0;
+	$: spread = { checked: show, count };
+</script>
+
+<button onclick={()=> count++ }></button>
+<button onclick={()=> show = !show }></button>
+
+<!-- count with bind -->
+{#if count < 2}
+	<Component bind:count bind:checked={show} />
+{/if}
+
+<!-- spread syntax -->
+{#if count < 2}
+	<Component {...spread} />
+{/if}
+
+<!-- normal prop -->
+{#if count < 2}
+	<Component {count} checked={show} />
+{/if}
+
+<!-- prop only accessed in destroy -->
+{#if show}
+	<Component {count} checked={show} />
+{/if}
+
+<!-- dynamic component -->
+<svelte:component this={count < 2 ? Component : undefined} {count} checked={show} />
+
+<!-- dynamic component spread -->
+<svelte:component this={count < 2 ? Component : undefined} {...spread} />
+
+<!-- dynamic component with prop only accessed on destroy -->
+<svelte:component this={show ? Component : undefined} {count} checked={show} />
+
+<!-- dynamic component with prop only accessed on destroy spread -->
+<svelte:component this={show ? Component : undefined} {...spread} />

--- a/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/nested-effect-conflict/_config.js
@@ -10,14 +10,6 @@ export default test({
 		});
 
 		await Promise.resolve();
-		assert.deepEqual(logs, [
-			'top level',
-			'inner',
-			0,
-			'destroy inner',
-			undefined,
-			'destroy outer',
-			undefined
-		]);
+		assert.deepEqual(logs, ['top level', 'inner', 0, 'destroy inner', 0, 'destroy outer', 0]);
 	}
 });


### PR DESCRIPTION
# PSA: we are changing how effect teardowns work!

Today, if you read some state inside a teardown function, you get the _latest_ state:

```js
$effect(() => {
  const prev = value;
  return () => {
    // could be `true` but is usually `false`, depending on
    // whether the teardown is running because the effect
    // is about to re-run (because `value` changed) or
    // because it's being destroyed (because the
    // component unmounted, for example)
    console.log(prev === value); 
  };
});
```

This is counter-intuitive to many people, especially those coming from React, since this is perhaps the one place where stale closures _don't_ make things more confusing:

```js
const [value, setValue] = useState(...);

useEffect(() => {
  const prev = value;
  return () => {
    console.log(prev === value);
  };
});
```

On one level, this is just how signals work. The same behaviour occurs with other signal-based frameworks like Solid.

But on another, it's irksome behaviour, and can easily lead to frustrating bugs — if you have something like this...

```svelte
{#if chat}
  <Chat {chat} />
{/if}
```

...and `Chat.svelte` reads `chat` inside an effect teardown function...

```svelte
<script>
  import { open, close } from '$lib/chat';

  let { chat } = $props();

  $effect(() => {
    open(chat.id);
    return () => close(chat.id);
  });
</script>
```

...then `chat` will be undefined by the time it runs. You can work around it by storing a reference inside the effect, but that's weird and annoying. It's so annoying in fact that it inspired a widely-shared post called [Svelte 5 is not JavaScript](https://hodlbod.npub.pro/post/1739830562159/). We're always grateful for this sort of detailed feedback!

So here's the plan: when a state change occurs that could lead to an effect re-running, we capture the previous value. If that state is read inside a teardown function that runs _as a consequence of the state change_, we provide the previous value instead of the current value. As you can see from the PR, this is relatively straightforward and carries very little overhead.

This is technically a breaking change! But the strong consensus among maintainers is that it qualifies as a bugfix, and as such doesn't require a semver major release. If this decision is likely to cause you headaches, **now is the time to let us know**.

Thank you for your attention! — _Rich_

Original PR message follows:

---

An alternative to https://github.com/sveltejs/svelte/pull/15400. Fixes https://github.com/sveltejs/svelte/issues/14725.

As [Rich suggested yesterday](https://github.com/sveltejs/svelte/pull/15400#issuecomment-2704060044), we can store the old value in a `Map` and then use that during the teardown phase. Additionally, we also need to do some work around the logic in how `props.js` works which we can extract from https://github.com/sveltejs/svelte/pull/15400 in a simpler form as we don't need to rest of the logic.