### PR TITLE
chore: don't distribute unused types definitions

### DIFF
--- a/.changeset/hungry-dancers-tap.md
+++ b/.changeset/hungry-dancers-tap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: don't distribute unused types definitions

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -9,12 +9,12 @@
     "node": ">=18"
   },
   "files": [
+    "*.d.ts",
     "src",
     "!src/**/*.test.*",
     "!src/**/*.d.ts",
+    "types",
     "compiler",
-    "types/index.d.ts",
-    "elements.d.ts",
     "README.md"
   ],
   "module": "src/index-client.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -11,9 +11,10 @@
   "files": [
     "src",
     "!src/**/*.test.*",
-    "types",
+    "!src/**/*.d.ts",
     "compiler",
-    "*.d.ts",
+    "types/index.d.ts",
+    "elements.d.ts",
     "README.md"
   ],
   "module": "src/index-client.js",


### PR DESCRIPTION
results in a smaller package. don't need to distribute unused files

this may close (or not, we'll see) https://github.com/sveltejs/svelte/issues/15182