### PR TITLE
docs: correct toggle function in lifecycle hooks example

### DIFF
--- a/documentation/docs/06-runtime/03-lifecycle-hooks.md
+++ b/documentation/docs/06-runtime/03-lifecycle-hooks.md
@@ -147,7 +147,7 @@ With runes, we can use `$effect.pre`, which behaves the same as `$effect` but ru
 	}
 
 	function toggle() {
-		toggleValue = !toggleValue;
+		theme = theme === 'dark' ? 'light' : 'dark';
 	}
 </script>
 


### PR DESCRIPTION
This is my first contribution to the Svelte project. 
## Fix toggle function in lifecycle hooks example

### Issue
Fix for [Issue #15404](https://github.com/sveltejs/svelte/issues/15404) where the theme toggle callback function in the lifecycle hooks documentation was using an undefined `toggleValue` variable.

### Changes
- Modified the `toggle()` function to correctly toggle the theme state variable
- Changed from using undefined `toggleValue` to properly using the existing `theme` variable
- Made the implementation match the 'After' playground example code

### Testing
Verified that the modified example code is now consistent with the correct implementation shown in the "After" playground link.

This PR ensures that users following the documentation won't encounter undefined variable errors when implementing dark mode toggling.

Fixes #15404

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
