### PR TITLE
chore: add missing permissions for `pkg.pr.new-comment`

### DIFF
--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -6,6 +6,9 @@ on:
     types:
       - completed
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     name: 'Update comment'


### PR DESCRIPTION
I noticed this job fail on one of my PRs

https://github.com/sveltejs/svelte/actions/runs/13740490010