### PR TITLE
fix: Add files and group properties to HTMLInputAttributes

### DIFF
--- a/.changeset/plenty-bats-lay.md
+++ b/.changeset/plenty-bats-lay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add `files` and `group` to HTMLInputAttributes in elements.d.ts

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1076,6 +1076,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	checked?: boolean | undefined | null;
 	dirname?: string | undefined | null;
 	disabled?: boolean | undefined | null;
+	files?: FileList | undefined | null;
 	form?: string | undefined | null;
 	formaction?: string | undefined | null;
 	formenctype?:
@@ -1087,6 +1088,7 @@ export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
 	formmethod?: 'dialog' | 'get' | 'post' | 'DIALOG' | 'GET' | 'POST' | undefined | null;
 	formnovalidate?: boolean | undefined | null;
 	formtarget?: string | undefined | null;
+	group?: any | undefined | null;
 	height?: number | string | undefined | null;
 	indeterminate?: boolean | undefined | null;
 	list?: string | undefined | null;


### PR DESCRIPTION
This adds missing `files` and `group` properties to match the respective `bind:files` and `bind:group`.

Unless I'm mistaken, it seems that the `files` and `group` attributes are missing from the HTMLInputAttributes type in [element.d.ts](https://github.com/sveltejs/svelte/blob/dbd4617ac42a4bf5e97af05f2d5bc6a0517e24b2/packages/svelte/elements.d.ts#L1069-L1124).

The typings for the binding 'bind:group' and 'bind:files' are present (as [seen here](https://github.com/sveltejs/svelte/blob/main/packages/svelte/elements.d.ts#L1119-L1121)) but the individual properties aren't.

Note that the bindings exists on [the deprecated ](https://github.com/sveltejs/language-tools/blob/02db54de1f2fc44d958d67113a9d0fb41a8f6fe7/packages/svelte2tsx/svelte-jsx.d.ts#L1192-L1196) `SvelteInputProps`, so maybe this is intentional somehow ?

Closes issue [#14579](https://github.com/sveltejs/svelte/issues/14579)
