### PR TITLE
feat: add partial evaluation

### DIFF
--- a/.changeset/selfish-onions-begin.md
+++ b/.changeset/selfish-onions-begin.md
@@ -2,4 +2,4 @@
 'svelte': minor
 ---
 
-feat: partial evaluation
+feat: partially evaluate certain expressions

--- a/.changeset/selfish-onions-begin.md
+++ b/.changeset/selfish-onions-begin.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: partial evaluation

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -686,7 +686,6 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 	);
 
 	const evaluated = context.state.scope.evaluate(value);
-
 	const assignment = b.assignment('=', b.member(node_id, '__value'), value);
 
 	const inner_assignment = b.assignment(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -686,16 +686,14 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 			: value
 	);
 
-	const values = context.state.scope.evaluate(value);
+	const evaluated = context.state.scope.evaluate(value);
 
 	const assignment = b.assignment('=', b.member(node_id, '__value'), value);
 
 	const inner_assignment = b.assignment(
 		'=',
 		b.member(node_id, 'value'),
-		values.has(UNKNOWN) || values.has(null) || values.has(undefined)
-			? b.logical('??', assignment, b.literal(''))
-			: assignment
+		evaluated.is_defined ? assignment : b.logical('??', assignment, b.literal(''))
 	);
 
 	const update = b.stmt(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -33,7 +33,6 @@ import {
 	memoize_expression
 } from './shared/utils.js';
 import { visit_event_attribute } from './shared/events.js';
-import { UNKNOWN } from '../../../scope.js';
 
 /**
  * @param {AST.RegularElement} node

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -89,13 +89,9 @@ export function build_template_chunk(
 				}
 			}
 
-			const is_defined =
-				value.type === 'BinaryExpression' ||
-				(value.type === 'UnaryExpression' && value.operator !== 'void') ||
-				(value.type === 'LogicalExpression' && value.right.type === 'Literal') ||
-				(value.type === 'Identifier' && value.name === state.analysis.props_id?.name);
+			const evaluated = state.scope.evaluate(value);
 
-			if (!is_defined) {
+			if (!evaluated.is_defined) {
 				// add `?? ''` where necessary (TODO optimise more cases)
 				value = b.logical('??', value, b.literal(''));
 			}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -91,15 +91,19 @@ export function build_template_chunk(
 
 			const evaluated = state.scope.evaluate(value);
 
-			if (!evaluated.is_defined) {
-				// add `?? ''` where necessary (TODO optimise more cases)
-				value = b.logical('??', value, b.literal(''));
+			if (evaluated.is_known) {
+				quasi.value.cooked += evaluated.value + '';
+			} else {
+				if (!evaluated.is_defined) {
+					// add `?? ''` where necessary (TODO optimise more cases)
+					value = b.logical('??', value, b.literal(''));
+				}
+
+				expressions.push(value);
+
+				quasi = b.quasi('', i + 1 === values.length);
+				quasis.push(quasi);
 			}
-
-			expressions.push(value);
-
-			quasi = b.quasi('', i + 1 === values.length);
-			quasis.push(quasi);
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -95,7 +95,7 @@ export function build_template_chunk(
 				quasi.value.cooked += evaluated.value + '';
 			} else {
 				if (!evaluated.is_defined) {
-					// add `?? ''` where necessary (TODO optimise more cases)
+					// add `?? ''` where necessary
 					value = b.logical('??', value, b.literal(''));
 				}
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
@@ -44,15 +44,17 @@ export function process_children(nodes, { visit, state }) {
 			if (node.type === 'Text' || node.type === 'Comment') {
 				quasi.value.cooked +=
 					node.type === 'Comment' ? `<!--${node.data}-->` : escape_html(node.data);
-			} else if (node.type === 'ExpressionTag' && node.expression.type === 'Literal') {
-				if (node.expression.value != null) {
-					quasi.value.cooked += escape_html(node.expression.value + '');
-				}
 			} else {
-				expressions.push(b.call('$.escape', /** @type {Expression} */ (visit(node.expression))));
+				const evaluated = state.scope.evaluate(node.expression);
 
-				quasi = b.quasi('', i + 1 === sequence.length);
-				quasis.push(quasi);
+				if (evaluated.is_known) {
+					quasi.value.cooked += escape_html((evaluated.value ?? '') + '');
+				} else {
+					expressions.push(b.call('$.escape', /** @type {Expression} */ (visit(node.expression))));
+
+					quasi = b.quasi('', i + 1 === sequence.length);
+					quasis.push(quasi);
+				}
 			}
 		}
 

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -298,7 +298,7 @@ export class Scope {
 			case 'Identifier':
 				const binding = this.get(expression.name);
 				if (binding && !binding.updated && binding.initial !== null) {
-					this.evaluate(/** @type {Expression} */ (binding.initial), values);
+					binding.scope.evaluate(/** @type {Expression} */ (binding.initial), values);
 					break;
 				}
 

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -113,7 +113,7 @@ class Evaluation {
 	 * @readonly
 	 * @type {boolean}
 	 */
-	is_known = false;
+	is_known = true;
 
 	/**
 	 * True if the value is known to not be null/undefined
@@ -165,7 +165,12 @@ class Evaluation {
 						break;
 					}
 
-					if (!binding.updated && binding.initial !== null) {
+					const is_prop =
+						binding.kind === 'prop' ||
+						binding.kind === 'rest_prop' ||
+						binding.kind === 'bindable_prop';
+
+					if (!binding.updated && binding.initial !== null && !is_prop) {
 						const evaluation = binding.scope.evaluate(/** @type {Expression} */ (binding.initial));
 						for (const value of evaluation.values) {
 							this.values.add(value);
@@ -293,7 +298,7 @@ class Evaluation {
 				break;
 
 			case 'UnaryExpression':
-				const argument = scope.evaluate(expression.argument);
+				var argument = scope.evaluate(expression.argument);
 
 				if (argument.is_known) {
 					this.values.add(unary[expression.operator](argument.value));
@@ -326,6 +331,7 @@ class Evaluation {
 						// TypeScript getting confused
 						throw new Error(`Unknown operator ${expression.operator}`);
 				}
+				break;
 
 			default:
 				this.values.add(UNKNOWN);
@@ -347,7 +353,9 @@ class Evaluation {
 			}
 		}
 
-		this.is_known = this.values.size === 1 && typeof this.value !== 'symbol';
+		if (this.values.size > 1 || typeof this.value === 'symbol') {
+			this.is_known = false;
+		}
 	}
 }
 

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -172,6 +172,8 @@ class Evaluation {
 						}
 						break;
 					}
+
+					// TODO each index is always defined
 				}
 
 				// TODO glean what we can from reassignments

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -238,9 +238,7 @@ class Evaluation {
 						break;
 
 					default:
-						// @ts-expect-error we can't guard against future operators without
-						// TypeScript getting confused
-						throw new Error(`Unknown operator ${expression.operator}`);
+						this.values.add(UNKNOWN);
 				}
 				break;
 
@@ -328,9 +326,7 @@ class Evaluation {
 						break;
 
 					default:
-						// @ts-expect-error we can't guard against future operators without
-						// TypeScript getting confused
-						throw new Error(`Unknown operator ${expression.operator}`);
+						this.values.add(UNKNOWN);
 				}
 				break;
 

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -150,12 +150,13 @@ class Evaluation {
 	 */
 	constructor(scope, expression) {
 		switch (expression.type) {
-			case 'Literal':
+			case 'Literal': {
 				this.values.add(expression.value);
 				break;
+			}
 
-			case 'Identifier':
-				var binding = scope.get(expression.name);
+			case 'Identifier': {
+				const binding = scope.get(expression.name);
 
 				if (binding) {
 					if (
@@ -187,10 +188,11 @@ class Evaluation {
 
 				this.values.add(UNKNOWN);
 				break;
+			}
 
-			case 'BinaryExpression':
-				var a = scope.evaluate(/** @type {Expression} */ (expression.left)); // `left` cannot be `PrivateIdentifier` unless operator is `in`
-				var b = scope.evaluate(expression.right);
+			case 'BinaryExpression': {
+				const a = scope.evaluate(/** @type {Expression} */ (expression.left)); // `left` cannot be `PrivateIdentifier` unless operator is `in`
+				const b = scope.evaluate(expression.right);
 
 				if (a.is_known && b.is_known) {
 					this.values.add(binary[expression.operator](a.value, b.value));
@@ -241,11 +243,12 @@ class Evaluation {
 						this.values.add(UNKNOWN);
 				}
 				break;
+			}
 
-			case 'ConditionalExpression':
-				var test = scope.evaluate(expression.test);
-				var consequent = scope.evaluate(expression.consequent);
-				var alternate = scope.evaluate(expression.alternate);
+			case 'ConditionalExpression': {
+				const test = scope.evaluate(expression.test);
+				const consequent = scope.evaluate(expression.consequent);
+				const alternate = scope.evaluate(expression.alternate);
 
 				if (test.is_known) {
 					for (const value of (test.value ? consequent : alternate).values) {
@@ -261,10 +264,11 @@ class Evaluation {
 					}
 				}
 				break;
+			}
 
-			case 'LogicalExpression':
-				a = scope.evaluate(expression.left);
-				b = scope.evaluate(expression.right);
+			case 'LogicalExpression': {
+				const a = scope.evaluate(expression.left);
+				const b = scope.evaluate(expression.right);
 
 				if (a.is_known) {
 					if (b.is_known) {
@@ -295,9 +299,10 @@ class Evaluation {
 					this.values.add(value);
 				}
 				break;
+			}
 
-			case 'UnaryExpression':
-				var argument = scope.evaluate(expression.argument);
+			case 'UnaryExpression': {
+				const argument = scope.evaluate(expression.argument);
 
 				if (argument.is_known) {
 					this.values.add(unary[expression.operator](argument.value));
@@ -329,9 +334,11 @@ class Evaluation {
 						this.values.add(UNKNOWN);
 				}
 				break;
+			}
 
-			default:
+			default: {
 				this.values.add(UNKNOWN);
+			}
 		}
 
 		for (const value of this.values) {

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -17,7 +17,8 @@ import { determine_slot } from '../utils/slot.js';
 import { validate_identifier_name } from './2-analyze/visitors/shared/utils.js';
 
 export const UNKNOWN = Symbol('unknown');
-export const NUMBER = Symbol('number'); // includes BigInt
+/** Includes `BigInt` */
+export const NUMBER = Symbol('number');
 export const STRING = Symbol('string');
 
 export class Binding {
@@ -540,7 +541,9 @@ export class Scope {
 	}
 
 	/**
-	 *
+	 * Does partial evaluation to find an exact value or at least the rough type of the expression.
+	 * Only call this once scope has been fully generated in a first pass,
+	 * else this evaluates on incomplete data and may yield wrong results.
 	 * @param {Expression} expression
 	 * @param {Set<any>} values
 	 */

--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/client/index.svelte.js
@@ -10,7 +10,7 @@ export default function Nullish_coallescence_omittance($$anchor) {
 	var fragment = root();
 	var h1 = $.first_child(fragment);
 
-	h1.textContent = `Hello, ${name ?? ''}!`;
+	h1.textContent = `Hello, ${name}!`;
 
 	var b = $.sibling(h1, 2);
 

--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/client/index.svelte.js
@@ -10,11 +10,11 @@ export default function Nullish_coallescence_omittance($$anchor) {
 	var fragment = root();
 	var h1 = $.first_child(fragment);
 
-	h1.textContent = `Hello, ${name}!`;
+	h1.textContent = 'Hello, world!';
 
 	var b = $.sibling(h1, 2);
 
-	b.textContent = `${1 ?? 'stuff'}${2 ?? 'more stuff'}${3 ?? 'even more stuff'}`;
+	b.textContent = '123';
 
 	var button = $.sibling(b, 2);
 
@@ -26,7 +26,7 @@ export default function Nullish_coallescence_omittance($$anchor) {
 
 	var h1_1 = $.sibling(button, 2);
 
-	h1_1.textContent = `Hello, ${name ?? 'earth' ?? ''}`;
+	h1_1.textContent = 'Hello, world';
 	$.template_effect(() => $.set_text(text, `Count is ${$.get(count) ?? ''}`));
 	$.append($$anchor, fragment);
 }

--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/server/index.svelte.js
@@ -4,5 +4,5 @@ export default function Nullish_coallescence_omittance($$payload) {
 	let name = 'world';
 	let count = 0;
 
-	$$payload.out += `<h1>Hello, ${$.escape(name)}!</h1> <b>${$.escape(1 ?? 'stuff')}${$.escape(2 ?? 'more stuff')}${$.escape(3 ?? 'even more stuff')}</b> <button>Count is ${$.escape(count)}</button> <h1>Hello, ${$.escape(name ?? 'earth' ?? null)}</h1>`;
+	$$payload.out += `<h1>Hello, world!</h1> <b>123</b> <button>Count is ${$.escape(count)}</button> <h1>Hello, world</h1>`;
 }

--- a/packages/svelte/tests/snapshot/samples/skip-static-subtree/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/skip-static-subtree/_expected/client/index.svelte.js
@@ -38,7 +38,7 @@ export default function Skip_static_subtree($$anchor, $$props) {
 	var select = $.sibling(div_1, 2);
 	var option = $.child(select);
 
-	option.value = null == (option.__value = 'a') ? '' : 'a';
+	option.value = option.__value = 'a';
 	$.reset(select);
 
 	var img = $.sibling(select, 2);

--- a/packages/svelte/tests/sourcemaps/samples/attached-sourcemap/input.svelte
+++ b/packages/svelte/tests/sourcemaps/samples/attached-sourcemap/input.svelte
@@ -8,4 +8,4 @@
 		replace_me_script = 'hello'
 	;
 </script>
-<h1 class="done_replace_style_2">{done_replace_script_2}</h1>
+<h1 class="done_replace_style_2">{Math.random() < 1 && done_replace_script_2}</h1>


### PR DESCRIPTION
Noticed while looking into something unrelated that this input...

```svelte
<script>
  let choice = $state('one');
</script>

<input type="radio" bind:group={choice} value="one" />
<input type="radio" bind:group={choice} value="two" />
<input type="radio" bind:group={choice} value="three" />

<p>{choice}</p>
```

...yields this output:

```js
input.value = null == (input.__value = 'one') ? '' : 'one';
```

At minimum, it should be this instead:

```js
input.value = input.__value = 'one' ?? '';
```

But we can go much further. Something I've been meaning to get round to for a while is to add some simple partial evaluation, which would make it possible to avoid the `?? ''` stuff in a lot more cases. @Ocean-OS made some progress on this front in #15374 but I'd like it to be able to accommodate bindings as well (in other words, knowing that `message` is always a string and `count` is always a number). I think it makes sense to implement this as an `evaluate` method on the `Scope` class.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
