### PR TITLE
Add return value to dialog

### DIFF
--- a/.changeset/weak-ligers-hunt.md
+++ b/.changeset/weak-ligers-hunt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add `returnValue` to HTMLDialogAttributes

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -958,6 +958,8 @@ export interface HTMLDelAttributes extends HTMLAttributes<HTMLModElement> {
 export interface HTMLDialogAttributes extends HTMLAttributes<HTMLDialogElement> {
 	open?: boolean | undefined | null;
 	closedby?: 'any' | 'closerequest' | 'none' | undefined | null;
+	/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/returnValue) */
+	returnValue?: string | undefined | null;
 }
 
 export interface HTMLEmbedAttributes extends HTMLAttributes<HTMLEmbedElement> {


### PR DESCRIPTION
The property `returnValue` that can be set manually or by the closing functions of a dialog (`close` or `requestClose`) seems to be missing from the [HTMLDialogAttribute](https://github.com/sveltejs/svelte/blob/a1257c17f5ba93bdbf7c470a5720ff9a69a224dc/packages/svelte/elements.d.ts#L958-L961) typing.

Aside from typing It would be ideal to also have bidings for `open` and `returnValue` IMO, as it can both be set externally or by interactions (`close`, `requestClose`, `show`, `showModal`, etc.).

Not sure how to go about it though 🤔 

see [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue)