### PR TITLE
fix: ensure transient writes to tracked parent effects works as expected

### DIFF
--- a/.changeset/brown-rockets-shake.md
+++ b/.changeset/brown-rockets-shake.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure transient writes to tracked parent effects works as expected
+fix: invalidate parent effects when child effects update parent dependencies

--- a/.changeset/brown-rockets-shake.md
+++ b/.changeset/brown-rockets-shake.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure transient writes to tracked parent effects works as expected

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -460,6 +460,7 @@ export function update_reaction(reaction) {
 		// the same version
 		if (previous_reaction !== null) {
 			read_version++;
+
 			if (untracked_writes !== null) {
 				if (previous_untracked_writes === null) {
 					previous_untracked_writes = untracked_writes;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -460,6 +460,13 @@ export function update_reaction(reaction) {
 		// the same version
 		if (previous_reaction !== null) {
 			read_version++;
+			if (untracked_writes !== null) {
+				if (previous_untracked_writes === null) {
+					previous_untracked_writes = untracked_writes;
+				} else {
+					previous_untracked_writes.push(.../** @type {Source[]} */ (untracked_writes));
+				}
+			}
 		}
 
 		return result;

--- a/packages/svelte/tests/runtime-runes/samples/untracked-write-pre/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/untracked-write-pre/_config.js
@@ -2,6 +2,6 @@ import { test } from '../../test';
 
 export default test({
 	test({ assert, target, logs }) {
-		assert.deepEqual(logs, ["Outer", 'Inner', "Outer", 'Inner']);
+		assert.deepEqual(logs, ['Outer', 'Inner', 'Outer', 'Inner']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/untracked-write-pre/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/untracked-write-pre/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target, logs }) {
+		assert.deepEqual(logs, ["Outer", 'Inner', "Outer", 'Inner']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/untracked-write-pre/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/untracked-write-pre/main.svelte
@@ -1,0 +1,14 @@
+<script>
+
+	let value = $state(0);
+
+	$effect.pre(() => {
+			console.log("Outer");
+			value;
+
+			$effect.pre(() => {
+					console.log("Inner");
+					value = 10;
+			});
+	});
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/untracked-write-pre/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/untracked-write-pre/main.svelte
@@ -1,14 +1,13 @@
 <script>
-
 	let value = $state(0);
 
 	$effect.pre(() => {
-			console.log("Outer");
-			value;
+		console.log("Outer");
+		value;
 
-			$effect.pre(() => {
-					console.log("Inner");
-					value = 10;
-			});
+		$effect.pre(() => {
+			console.log("Inner");
+			value = 10;
+		});
 	});
 </script>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/15499. We need to ensure that if there was a previous active reaction and we have untracked writes, that we propagate those writes to that reaction too.