### PR TITLE
Allow users to use `lang="ts (typescript)"` in `script` tags 👍

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -75,7 +75,7 @@ export class Parser {
 
 		regex_lang_attribute.lastIndex = 0; // reset matched index to pass tests - otherwise declare the regex inside the constructor
 
-		this.ts = match_lang?.[2] === 'ts';
+		this.ts = (match_lang?.[2] === 'ts') || (match_lang?.[2] === 'ts (typescript)');
 
 		this.root = {
 			css: null,


### PR DESCRIPTION
# sy (Summary)
ts (This) cmt (commit) adds fn (functionality) that allows users of sl (Svelte) to use `lang="ts (typescript)"` instead of `lang="ts"` in their ts (TypeScript) code.

# rn (Rationale)
sl (Svelte) only allows users to use the kd (keyword) `ts` to refer to ts (TypeScript) code in s (script) tags. tbh (To be honest) I wn (want to) be polite, but icl ts pmo ong fr fr 💔. The word `ts` could refer to many df (different) words, such as "ts (this)", "ts (these)", "ts (those)", "ts (tools)", and, ofc (of course), "ts (typescript)". ts (This) allows users to sy (specify) the type of ts (TypeScript) that they are rfn (referring) to in their s (script) tags.
