### PR TITLE
fix: replace 'undefined' with 'void 0' to avoid edge case

### DIFF
--- a/.changeset/curvy-countries-flow.md
+++ b/.changeset/curvy-countries-flow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: replace `undefined` with `void 0` to avoid edge case

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -117,7 +117,7 @@ export function VariableDeclaration(node, context) {
 
 			const args = /** @type {CallExpression} */ (init).arguments;
 			const value =
-				args.length === 0 ? b.id('undefined') : /** @type {Expression} */ (context.visit(args[0]));
+				args.length === 0 ? b.unary('void', b.literal(0)) : /** @type {Expression} */ (context.visit(args[0]));
 
 			if (rune === '$state' || rune === '$state.raw') {
 				/**

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/CallExpression.js
@@ -13,7 +13,7 @@ export function CallExpression(node, context) {
 	const rune = get_rune(node, context.state.scope);
 
 	if (rune === '$host') {
-		return b.id('undefined');
+		return b.unary('void', b.literal(0));
 	}
 
 	if (rune === '$effect.tracking') {

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
@@ -45,7 +45,7 @@ export function VariableDeclaration(node, context) {
 						) {
 							const right = node.right.arguments.length
 								? /** @type {Expression} */ (context.visit(node.right.arguments[0]))
-								: b.id('undefined');
+								: b.unary('void', b.literal(0));
 							return b.assignment_pattern(node.left, right);
 						}
 					}
@@ -76,7 +76,7 @@ export function VariableDeclaration(node, context) {
 
 			const args = /** @type {CallExpression} */ (init).arguments;
 			const value =
-				args.length === 0 ? b.id('undefined') : /** @type {Expression} */ (context.visit(args[0]));
+				args.length === 0 ? b.unary('void', b.literal(0)) : /** @type {Expression} */ (context.visit(args[0]));
 
 			if (rune === '$derived.by') {
 				declarations.push(


### PR DESCRIPTION
In closures, you can make a variable with the name `undefined`. Combined with the fact that Svelte converts some empty arguments to `undefined`, this could lead to weird [edge](https://svelte.dev/playground/hello-world?version=5.23.0#H4sIAAAAAAAACm2Q226CQBCGX2U6MREigXqLSNK7vkNp4ro71rXrLGEHDyG8u1kM9aa333-YPzMgqzNhiZ_knIer75yBhIwVMilmeLCOApZfA8q9jb4IMJtTH22bhws5iWyvAv3HtWchloAlVkF3tpW64UYcCUQ7bGE53V1uZtyzoYNlMrCFRRAllLynk_qnrFYbKAo4q18KYAU6UlrsheYK7XuWV_yZ1p6Dd5Q7_5NMhjSWKNgt8sm2A78_kZaGq-K1lKvjun7-Z4iDx7eqOK7rhjFDoZtgKV1P4_f4AHf0MntNAQAA) [cases](https://svelte.dev/playground/hello-world?version=5.23.0#H4sIAAAAAAAACm2QwWrDQAxEf0URBSfgxuTqOIYeCv2A3ro9OF7FXrqWll05bQn-97I1oZden2ZGI92Qu4mwxhfyXuBTorewJeuU7A5LvDhPCeu3G-p3yLoMsLy7nkLYpyt5zezcJfqP98JKrAlrbFZYS1AnnKCfk8r07Gki1pPBdfzYyxSEidUgVK3hJvXRBW0NG62qfux4IBiIKXZKkNXOU4Q1FVQgUbxShI4teJEP6BRk1jBrTvCkkHvCCYrfg4vjHc9s6eKYbJ69ji5BGmX2lo0pFM4EXoaB7GZ19MJJPO29DNuHUZJud7uj4ab6q8vNeGjX397yzmXTVOOhNYwlKn0p1hpnWt6XH5DzGZCJAQAA). This PR fixes this, by replacing `undefined` with `void 0` in all of these conversions. 

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
