### PR TITLE
chore: use moveBefore on supported browsers

### DIFF
--- a/.changeset/eight-onions-melt.md
+++ b/.changeset/eight-onions-melt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: use moveBefore on supported browsers

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -20,7 +20,8 @@ import {
 	clear_text_content,
 	create_text,
 	get_first_child,
-	get_next_sibling
+	get_next_sibling,
+	move_before
 } from '../operations.js';
 import {
 	block,
@@ -584,7 +585,7 @@ function move(item, next, anchor) {
 
 	while (node !== end) {
 		var next_node = /** @type {TemplateNode} */ (get_next_sibling(node));
-		dest.before(node);
+		move_before(dest, node);
 		node = next_node;
 	}
 }

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -42,10 +42,7 @@ export function init_operations() {
 	// @ts-ignore
 	next_sibling_getter = get_descriptor(node_prototype, 'nextSibling').get;
 	// @ts-ignore
-	move_before_func = (
-		get_descriptor(element_prototype, 'moveBefore') ??
-		get_descriptor(node_prototype, 'insertBefore')
-	).value;
+	move_before_func = element_prototype.moveBefore ?? element_prototype.insertBefore;
 
 	// the following assignments improve perf of lookups on DOM nodes
 	// @ts-expect-error

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -18,6 +18,8 @@ export var is_firefox;
 var first_child_getter;
 /** @type {() => Node | null} */
 var next_sibling_getter;
+/** @type {(new_node: Node, reference_node: Node) => void} */
+var move_before_func;
 
 /**
  * Initialize these lazily to avoid issues when using the runtime in a server context
@@ -39,6 +41,11 @@ export function init_operations() {
 	first_child_getter = get_descriptor(node_prototype, 'firstChild').get;
 	// @ts-ignore
 	next_sibling_getter = get_descriptor(node_prototype, 'nextSibling').get;
+	// @ts-ignore
+	move_before_func = (
+		get_descriptor(element_prototype, 'moveBefore') ??
+		get_descriptor(node_prototype, 'insertBefore')
+	).value;
 
 	// the following assignments improve perf of lookups on DOM nodes
 	// @ts-expect-error
@@ -89,6 +96,15 @@ export function get_first_child(node) {
 /*@__NO_SIDE_EFFECTS__*/
 export function get_next_sibling(node) {
 	return next_sibling_getter.call(node);
+}
+
+/**
+ * @template {Node} N
+ * @param {N} node
+ * @param {N} new_node
+ */
+export function move_before(node, new_node) {
+	move_before_func.call(node.parentElement, new_node, node);
 }
 
 /**


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

* Closes #13543 

The PR change the API used in `{#each}` block to move existing node.

Currently it use `before()`. Now it use the new API `moveBefore()` when the browser support it, or fallback to `insertBefore()`.

`moveBefore()` allow to move a node without losing state.
The feature is stiff experimental but I don't think there a problem using it (with a fallback)


Sources :
* [Chrome for Developers Blog](https://developer.chrome.com/blog/movebefore-api)
* Whatwg https://github.com/whatwg/dom/pull/1307


Notes : 

* I don't know how to create a test for this !
* Some functions in operations.js are annotated with `/*@__NO_SIDE_EFFECTS__*/`.
I don't know what this does exactly or if I should put it on the function I added


---


- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
