### PR TITLE
chore: reuse expression nodes

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -596,7 +596,7 @@ export function client_component(analysis, options) {
 				/** @type {ESTree.Property[]} */ (
 					[
 						prop_def.attribute ? b.init('attribute', b.literal(prop_def.attribute)) : undefined,
-						prop_def.reflect ? b.init('reflect', b.literal(true)) : undefined,
+						prop_def.reflect ? b.init('reflect', b.true) : undefined,
 						prop_def.type ? b.init('type', b.literal(prop_def.type)) : undefined
 					].filter(Boolean)
 				)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AnimateDirective.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AnimateDirective.js
@@ -11,7 +11,7 @@ import { parse_directive_name } from './shared/utils.js';
 export function AnimateDirective(node, context) {
 	const expression =
 		node.expression === null
-			? b.literal(null)
+			? b.null
 			: b.thunk(/** @type {Expression} */ (context.visit(node.expression)));
 
 	// in after_update to ensure it always happens after bind:this

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitBlock.js
@@ -60,7 +60,7 @@ export function AwaitBlock(node, context) {
 				expression,
 				node.pending
 					? b.arrow([b.id('$$anchor')], /** @type {BlockStatement} */ (context.visit(node.pending)))
-					: b.literal(null),
+					: b.null,
 				then_block,
 				catch_block
 			)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BinaryExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BinaryExpression.js
@@ -16,7 +16,7 @@ export function BinaryExpression(node, context) {
 				'$.strict_equals',
 				/** @type {Expression} */ (context.visit(node.left)),
 				/** @type {Expression} */ (context.visit(node.right)),
-				operator === '!==' && b.literal(false)
+				operator === '!==' && b.false
 			);
 		}
 
@@ -25,7 +25,7 @@ export function BinaryExpression(node, context) {
 				'$.equals',
 				/** @type {Expression} */ (context.visit(node.left)),
 				/** @type {Expression} */ (context.visit(node.right)),
-				operator === '!=' && b.literal(false)
+				operator === '!=' && b.false
 			);
 		}
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
@@ -40,9 +40,7 @@ export function IfBlock(node, context) {
 				b.if(
 					/** @type {Expression} */ (context.visit(node.test)),
 					b.stmt(b.call(b.id('$$render'), b.id(consequent_id))),
-					alternate_id
-						? b.stmt(b.call(b.id('$$render'), b.id(alternate_id), b.literal(false)))
-						: undefined
+					alternate_id ? b.stmt(b.call(b.id('$$render'), b.id(alternate_id), b.false)) : undefined
 				)
 			])
 		)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -689,7 +689,7 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 		'=',
 		b.member(node_id, 'value'),
 		b.conditional(
-			b.binary('==', b.literal(null), b.assignment('=', b.member(node_id, '__value'), value)),
+			b.binary('==', b.null, b.assignment('=', b.member(node_id, '__value'), value)),
 			b.literal(''), // render null/undefined values as empty string to support placeholder options
 			value
 		)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SlotElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SlotElement.js
@@ -59,7 +59,7 @@ export function SlotElement(node, context) {
 
 	const fallback =
 		node.fragment.nodes.length === 0
-			? b.literal(null)
+			? b.null
 			: b.arrow([b.id('$$anchor')], /** @type {BlockStatement} */ (context.visit(node.fragment)));
 
 	const slot = b.call(

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/element.js
@@ -95,7 +95,7 @@ export function build_set_attributes(
 	const call = b.call(
 		'$.set_attributes',
 		element_id,
-		is_dynamic ? attributes_id : b.literal(null),
+		is_dynamic ? attributes_id : b.null,
 		b.object(values),
 		element.metadata.scoped &&
 			context.state.analysis.css.hash !== '' &&
@@ -120,7 +120,7 @@ export function build_set_attributes(
  */
 export function build_attribute_value(value, context, memoize = (value) => value) {
 	if (value === true) {
-		return { value: b.literal(true), has_state: false };
+		return { value: b.true, has_state: false };
 	}
 
 	if (!Array.isArray(value) || value.length === 1) {

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/SlotElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/SlotElement.js
@@ -38,7 +38,7 @@ export function SlotElement(node, context) {
 
 	const fallback =
 		node.fragment.nodes.length === 0
-			? b.literal(null)
+			? b.null
 			: b.thunk(/** @type {BlockStatement} */ (context.visit(node.fragment)));
 
 	const slot = b.call(

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -485,7 +485,7 @@ export function do_while(test, body) {
 
 const true_instance = literal(true);
 const false_instance = literal(false);
-const null_instane = literal(null);
+const null_instance = literal(null);
 
 /** @type {ESTree.DebuggerStatement} */
 const debugger_builder = {
@@ -647,7 +647,7 @@ export {
 	return_builder as return,
 	if_builder as if,
 	this_instance as this,
-	null_instane as null,
+	null_instance as null,
 	debugger_builder as debugger
 };
 


### PR DESCRIPTION
noticed a few places where we're recreating expression nodes unnecessarily