### PR TITLE
fix: throw rune_invalid_arguments_length when $state.raw() is used with more than 1 arg

### DIFF
--- a/.changeset/two-spies-lie.md
+++ b/.changeset/two-spies-lie.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: throw rune_invalid_arguments_length when $state.raw() is used with more than 1 arg

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -117,7 +117,7 @@ export function CallExpression(node, context) {
 
 			if ((rune === '$derived' || rune === '$derived.by') && node.arguments.length !== 1) {
 				e.rune_invalid_arguments_length(node, rune, 'exactly one argument');
-			} else if (rune === '$state' && node.arguments.length > 1) {
+			} else if (node.arguments.length > 1) {
 				e.rune_invalid_arguments_length(node, rune, 'zero or one arguments');
 			}
 

--- a/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-raw-args/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-raw-args/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'rune_invalid_arguments_length',
+		message: '`$state.raw` must be called with zero or one arguments'
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-raw-args/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-raw-args/main.svelte
@@ -1,0 +1,3 @@
+<script>
+	const foo = $state.raw(1, 2, 3);
+</script>

--- a/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-raw-args/main.svelte.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-raw-args/main.svelte.js
@@ -1,0 +1,1 @@
+const foo = $state.raw(1, 2, 3);


### PR DESCRIPTION
Simple fix : I just found that the compiler don't check the arguments count on `$state.raw()`.

```svelte
<script>
    let value = $state.raw(1, 2); // No compiler error
</script>
```


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
