### PR TITLE
fix: throw runtime error when template returns different html

### DIFF
--- a/.changeset/fluffy-eggs-do.md
+++ b/.changeset/fluffy-eggs-do.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: throw runtime error when template returns different html

--- a/documentation/docs/98-reference/.generated/client-errors.md
+++ b/documentation/docs/98-reference/.generated/client-errors.md
@@ -80,6 +80,12 @@ Maximum update depth exceeded. This can happen when a reactive block or effect r
 Failed to hydrate the application
 ```
 
+### invalid_html_structure
+
+```
+This html structure `%html_input%` would be corrected like this `%html_output%` by the browser making this component impossible to hydrate properly
+```
+
 ### invalid_snippet
 
 ```

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -52,6 +52,10 @@ See the [migration guide](/docs/svelte/v5-migration-guide#Components-are-no-long
 
 > Failed to hydrate the application
 
+## invalid_html_structure
+
+> This html structure `%html_input%` would be corrected like this `%html_output%` by the browser making this component impossible to hydrate properly
+
 ## invalid_snippet
 
 > Could not `{@render}` snippet due to the expression being `null` or `undefined`. Consider using optional chaining `{@render snippet?.()}`

--- a/packages/svelte/src/internal/client/dom/blocks/html.js
+++ b/packages/svelte/src/internal/client/dom/blocks/html.js
@@ -99,7 +99,7 @@ export function html(node, get_value, svg, mathml, skip_warning) {
 			// Don't use create_fragment_with_script_from_html here because that would mean script tags are executed.
 			// @html is basically `.innerHTML = ...` and that doesn't execute scripts either due to security reasons.
 			/** @type {DocumentFragment | Element} */
-			var node = create_fragment_from_html(html);
+			var node = create_fragment_from_html(html, false);
 
 			if (svg || mathml) {
 				node = /** @type {Element} */ (get_first_child(node));

--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -1,6 +1,29 @@
-/** @param {string} html */
-export function create_fragment_from_html(html) {
+import { DEV } from 'esm-env';
+import * as e from '../errors.js';
+
+/**
+ *  @param {string} html
+ *  @param {boolean} [check_structure]
+ */
+export function create_fragment_from_html(html, check_structure = true) {
 	var elem = document.createElement('template');
 	elem.innerHTML = html;
+	if (DEV && check_structure) {
+		let replace_comments = html.replaceAll('<!>', '<!---->');
+		let remove_attributes_and_text_input = replace_comments
+			// we remove every attribute since the template automatically adds ="" after boolean attributes
+			.replace(/<([a-z0-9]+)(\s+[^>]+?)?>/g, '<$1>')
+			// we remove the text within the elements because the template change & to &amp; (and similar)
+			.replace(/>([^<>]*)/g, '>');
+		let remove_attributes_and_text_output = elem.innerHTML
+			// we remove every attribute since the template automatically adds ="" after boolean attributes
+			.replace(/<([a-z0-9]+)(\s+[^>]+?)?>/g, '<$1>')
+			// we remove the text within the elements because the template change & to &amp; (and similar)
+			.replace(/>([^<>]*)/g, '>');
+		if (remove_attributes_and_text_input !== remove_attributes_and_text_output) {
+			e.invalid_html_structure(remove_attributes_and_text_input, remove_attributes_and_text_output);
+		}
+	}
+
 	return elem.content;
 }

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -199,6 +199,23 @@ export function hydration_failed() {
 }
 
 /**
+ * This html structure `%html_input%` would be corrected like this `%html_output%` by the browser making this component impossible to hydrate properly
+ * @param {string} html_input
+ * @param {string} html_output
+ * @returns {never}
+ */
+export function invalid_html_structure(html_input, html_output) {
+	if (DEV) {
+		const error = new Error(`invalid_html_structure\nThis html structure \`${html_input}\` would be corrected like this \`${html_output}\` by the browser making this component impossible to hydrate properly\nhttps://svelte.dev/e/invalid_html_structure`);
+
+		error.name = 'Svelte error';
+		throw error;
+	} else {
+		throw new Error(`https://svelte.dev/e/invalid_html_structure`);
+	}
+}
+
+/**
  * Could not `{@render}` snippet due to the expression being `null` or `undefined`. Consider using optional chaining `{@render snippet?.()}`
  * @returns {never}
  */

--- a/packages/svelte/tests/runtime-runes/samples/invalid-html-structure/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/invalid-html-structure/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	mode: ['client', 'hydrate'],
+	recover: true,
+	runtime_error: 'invalid_html_structure'
+});

--- a/packages/svelte/tests/runtime-runes/samples/invalid-html-structure/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/invalid-html-structure/main.svelte
@@ -1,0 +1,3 @@
+<svelte:options runes />
+<p></p>
+<tr></tr>


### PR DESCRIPTION
Closes #15502

I've added a runtime error that checks if the html generated by the `template` is the same structure as the passed in string. This should prevent more obscure errors because if the structure is different our marching of the dom will still fail at runtime.

To properly check i had to transform both the innerHTML and the incoming structure to remove inner texts (that get's converted in html entities) and attributes (because boolean attributes get `=""` appended automatically.

Also i don't do this check in `{@html}` because you could technically pass invalid html there but that doesn't affect the marching algorithm.

Another idea I had (might still open a PR as an alternative) is to add a `validate_element` call after every `next` or `child`...basically like this

```ts
import 'svelte/internal/disclose-version';
import 'svelte/internal/flags/legacy';
import * as $ from 'svelte/internal/client';

var root = $.template(`<p></p> <tr><td></td></tr>`, 1);

export default function App($$anchor) {
	let name = 'world';
	var fragment = root();
	var tr = $.sibling($.first_child(fragment), 2);
	$.validate_element(tr, 'tr');
	var td = $.child(tr);
	$.validate_element(td, 'td');
	td.textContent = name;
	$.reset(tr);
	$.append($$anchor, fragment);
}
```
but i think this would be more unreliable.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`