### PR TITLE
fix: only make `$state` variables reactive when read

### DIFF
--- a/.changeset/brown-plums-prove.md
+++ b/.changeset/brown-plums-prove.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only make variables reactive if they are read (and reassigned)

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -389,6 +389,10 @@ export function analyze_component(root, source, options) {
 			});
 
 			const binding = instance.scope.declare(b.id(name), 'store_sub', 'synthetic');
+			const store_binding = instance.scope.get(name.slice(1));
+			if (store_binding) {
+				store_binding.has_store_sub = true;
+			}
 			binding.references = references;
 			instance.scope.references.set(name, references);
 			module.scope.references.delete(name);

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -23,7 +23,9 @@ import { get_value } from './visitors/shared/declarations.js';
 export function is_state_source(binding, analysis) {
 	return (
 		(binding.kind === 'state' || binding.kind === 'raw_state') &&
-		(!analysis.immutable || binding.reassigned || analysis.accessors)
+		(!analysis.immutable ||
+			(binding.reassigned && (binding.read || binding.has_store_sub)) ||
+			analysis.accessors)
 	);
 }
 

--- a/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/client/index.svelte.js
@@ -13,4 +13,5 @@ export function update(array) {
 	);
 
 	[c, d] = array;
+	console.log({ a: $.get(a), b: $.get(b) });
 }

--- a/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/server/index.svelte.js
@@ -9,4 +9,5 @@ let d = 4;
 export function update(array) {
 	[a, b] = array;
 	[c, d] = array;
+	console.log({ a, b });
 }

--- a/packages/svelte/tests/snapshot/samples/destructured-assignments/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/destructured-assignments/index.svelte.js
@@ -6,4 +6,5 @@ let d = 4;
 export function update(array) {
 	[a, b] = array;
 	[c, d] = array;
+	console.log({ a, b });
 }


### PR DESCRIPTION
Currently, if a variable is wrapped in `$state`, it will only actually be wrapped in `$.state` if it is reassigned. However, this doesn't account for whether or not the variable is read. This PR fixes this, so that only `$state` variables that are written to *and* read from are perceived as reactive. Here's an example:
```js
let count = $state(0);
function reset() {
    count = 0;
}
```
This code declares a reactive variable and assigns to it, but never reads it, meaning that it wouldn't have to be reactive. Meanwhile this...
```js
let count = $state(0);
function increment() {
    count++;
}
```
*Is* reactive, since to increment count, its previous value has to be accessed. 
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
