### PR TITLE
docs: rewrite context docs

### DIFF
--- a/documentation/docs/06-runtime/02-context.md
+++ b/documentation/docs/06-runtime/02-context.md
@@ -86,6 +86,7 @@ Svelte will warn you if you get it wrong.
 A useful pattern is to wrap the calls to `setContext` and `getContext` inside helper functions that let you preserve type safety:
 
 ```js
+/// file: context.js
 // @filename: ambient.d.ts
 interface User {}
 


### PR DESCRIPTION
Noticed while reviewing #15533 — our context docs are really rather strange:

- they talk exclusively about state, when oftentimes context doesn't involve state at all (see the [tutorial](https://svelte.dev/tutorial/svelte/context-api) for example)
- it doesn't even talk about context until you get below the fold (and inexplicably puts the first mention inside backticks). Instead it talks awkwardly about global state and talks vaguely about 'drawbacks' without illustrating what the supposed danger is
- 'slotted content'
- it doesn't explain how reassigning context breaks the link, which is the main thing people have run into

In short it needed a complete rewrite