### PR TITLE
fix: don't depend on deriveds created inside the current reaction

### DIFF
--- a/.changeset/young-poets-wait.md
+++ b/.changeset/young-poets-wait.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't depend on deriveds created inside the current reaction

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -113,14 +113,7 @@ export {
 	user_effect,
 	user_pre_effect
 } from './reactivity/effects.js';
-export {
-	mutable_source,
-	mutate,
-	set,
-	source as state,
-	update,
-	update_pre
-} from './reactivity/sources.js';
+export { mutable_source, mutate, set, state, update, update_pre } from './reactivity/sources.js';
 export {
 	prop,
 	rest_props,

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -101,7 +101,7 @@ export {
 	text,
 	props_id
 } from './dom/template.js';
-export { derived, derived_safe_equal } from './reactivity/deriveds.js';
+export { user_derived as derived, derived_safe_equal } from './reactivity/deriveds.js';
 export {
 	effect_tracking,
 	effect_root,

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -10,7 +10,7 @@ import {
 	object_prototype
 } from '../shared/utils.js';
 import { check_ownership, widen_ownership } from './dev/ownership.js';
-import { source, set } from './reactivity/sources.js';
+import { state as source, set } from './reactivity/sources.js';
 import { STATE_SYMBOL, STATE_SYMBOL_METADATA } from './constants.js';
 import { UNINITIALIZED } from '../../constants.js';
 import * as e from './errors.js';

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -8,7 +8,8 @@ import {
 	skip_reaction,
 	update_reaction,
 	increment_write_version,
-	set_active_effect
+	set_active_effect,
+	push_reaction_value
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import * as e from '../errors.js';
@@ -53,6 +54,8 @@ export function derived(fn) {
 		wv: 0,
 		parent: parent_derived ?? active_effect
 	};
+
+	push_reaction_value(signal);
 
 	if (DEV && tracing_mode_flag) {
 		signal.created = get_stack('CreatedAt');

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -55,13 +55,24 @@ export function derived(fn) {
 		parent: parent_derived ?? active_effect
 	};
 
-	push_reaction_value(signal);
-
 	if (DEV && tracing_mode_flag) {
 		signal.created = get_stack('CreatedAt');
 	}
 
 	return signal;
+}
+
+/**
+ * @template V
+ * @param {() => V} fn
+ * @returns {Derived<V>}
+ */
+export function user_derived(fn) {
+	const d = derived(fn);
+
+	push_reaction_value(d);
+
+	return d;
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -15,7 +15,8 @@ import {
 	set_reaction_sources,
 	check_dirtiness,
 	untracking,
-	is_destroying_effect
+	is_destroying_effect,
+	push_reaction_value
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import {
@@ -64,20 +65,24 @@ export function source(v, stack) {
 		wv: 0
 	};
 
-	if (active_reaction !== null && active_reaction.f & EFFECT_IS_UPDATING) {
-		if (reaction_sources === null) {
-			set_reaction_sources([signal]);
-		} else {
-			reaction_sources.push(signal);
-		}
-	}
-
 	if (DEV && tracing_mode_flag) {
 		signal.created = stack ?? get_stack('CreatedAt');
 		signal.debug = null;
 	}
 
 	return signal;
+}
+
+/**
+ * @template V
+ * @param {V} v
+ */
+export function state(v) {
+	const s = source(v);
+
+	push_reaction_value(s);
+
+	return s;
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -76,9 +76,10 @@ export function source(v, stack) {
 /**
  * @template V
  * @param {V} v
+ * @param {Error | null} [stack]
  */
-export function state(v) {
-	const s = source(v);
+export function state(v, stack) {
+	const s = source(v, stack);
 
 	push_reaction_value(s);
 

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
@@ -10,6 +10,6 @@ export default test({
 		flushSync(() => {
 			b1.click();
 		});
-		assert.deepEqual(logs, ['init 0', 'cleanup 2', null, 'init 2', 'cleanup 4', null, 'init 4']);
+		assert.deepEqual(logs, ['init 0', 'cleanup 4', null]);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-cleanup/_config.js
@@ -10,6 +10,6 @@ export default test({
 		flushSync(() => {
 			b1.click();
 		});
-		assert.deepEqual(logs, ['init 0', 'cleanup 4', null]);
+		assert.deepEqual(logs, ['init 0']);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/untrack-own-deriveds/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/untrack-own-deriveds/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target, logs }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<p>1/2</p
+			`
+		);
+
+		assert.deepEqual(logs, [0, 0]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/untrack-own-deriveds/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/untrack-own-deriveds/main.svelte
@@ -1,0 +1,26 @@
+<script>
+	class Foo {
+		value = $state(0);
+		double = $derived(this.value * 2);
+
+		constructor() {
+			console.log(this.value, this.double);
+		}
+
+		increment() {
+			this.value++;
+		}
+	}
+
+	let foo = $state();
+
+	$effect(() => {
+		foo = new Foo();
+	});
+</script>
+
+<button onclick={() => foo.increment()}>increment</button>
+
+{#if foo}
+	<p>{foo.value}/{foo.double}</p>
+{/if}

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -8,12 +8,7 @@ import {
 	render_effect,
 	user_effect
 } from '../../src/internal/client/reactivity/effects';
-import {
-	source as state,
-	set,
-	update,
-	update_pre
-} from '../../src/internal/client/reactivity/sources';
+import { state, set, update, update_pre } from '../../src/internal/client/reactivity/sources';
 import type { Derived, Effect, Value } from '../../src/internal/client/types';
 import { proxy } from '../../src/internal/client/proxy';
 import { derived } from '../../src/internal/client/reactivity/deriveds';


### PR DESCRIPTION
Follow-up to #15553 which fixes [this case](https://github.com/sveltejs/svelte/pull/15300#issuecomment-2660814372).

Unfortunately it changes the behaviour of effects in a way that could be considered breaking — in a case like this, where a derived that's local to an effect depends on state _outside_ the effect...

```js
let count = $state(0);

$effect(() => {
  let double = $derived(count * 2)

  console.log('init ' + double);

  return function() {
    console.log('cleanup ' + double);
    console.log(this);
  };
});
```

...today the effect will re-run when `count` changes, but in this PR it won't. I'm not sure there's a way to have that behaviour _and_ have effects not depend on deriveds that depend entirely on local state. I _think_ this is the right trade-off, but I'd love to hear from other maintainers.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
