### PR TITLE
fix: Keep inlined JSDoc comments in property conversion of svelte-migrate

### DIFF
--- a/.changeset/happy-cameras-bow.md
+++ b/.changeset/happy-cameras-bow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Keep inlined trailing JSDoc comments of properties when running svelte-migrate

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1592,7 +1592,6 @@ function extract_type_and_comment(declarator, state, path) {
 	const comment_start = /** @type {any} */ (comment_node)?.start;
 	const comment_end = /** @type {any} */ (comment_node)?.end;
 	let comment = comment_node && str.original.substring(comment_start, comment_end);
-
 	if (comment_node) {
 		str.update(comment_start, comment_end, '');
 	}
@@ -1673,6 +1672,11 @@ function extract_type_and_comment(declarator, state, path) {
 		state.has_type_or_fallback = true;
 		const match = /@type {(.+)}/.exec(comment_node.value);
 		if (match) {
+			// try to find JSDoc comments after a hyphen `-`
+			const jsdocComment = /@type {.+} (?:\w+|\[.*?\]) - (.+)/.exec(comment_node.value);
+			if (jsdocComment) {
+				cleaned_comment += jsdocComment[1]?.trim();
+			}
 			return {
 				type: match[1],
 				comment: cleaned_comment,
@@ -1693,7 +1697,6 @@ function extract_type_and_comment(declarator, state, path) {
 			};
 		}
 	}
-
 	return {
 		type: 'any',
 		comment: state.uses_ts ? comment : cleaned_comment,

--- a/packages/svelte/tests/migrate/samples/jsdoc-with-comments/input.svelte
+++ b/packages/svelte/tests/migrate/samples/jsdoc-with-comments/input.svelte
@@ -40,4 +40,10 @@
 	export let inline_multiline_trailing_comment = 'world'; /*
 	* this is a same-line trailing multiline comment
 	**/
+
+	/** @type {number} [default_value=1] */
+	export let default_value = 1;
+
+	/** @type {number} [comment_default_value=1] - This has a comment and an optional value. */
+	export let comment_default_value = 1;
 </script>

--- a/packages/svelte/tests/migrate/samples/jsdoc-with-comments/input.svelte
+++ b/packages/svelte/tests/migrate/samples/jsdoc-with-comments/input.svelte
@@ -21,6 +21,9 @@
 	 */
 	export let type_no_comment;
 
+	/** @type {boolean} type_with_comment - One-line declaration with comment */
+	export let type_with_comment;
+
 	/**
 	 * This is optional
 	 */

--- a/packages/svelte/tests/migrate/samples/jsdoc-with-comments/output.svelte
+++ b/packages/svelte/tests/migrate/samples/jsdoc-with-comments/output.svelte
@@ -9,12 +9,18 @@
 	
 
 	
+
+	
 	
 
 	
 
 	
 
+
+	
+
+	
 	/**
 	 * @typedef {Object} Props
 	 * @property {string} comment - My wonderful comment
@@ -22,13 +28,14 @@
 	 * @property {any} one_line - one line comment
 	 * @property {any} no_comment
 	 * @property {boolean} type_no_comment
+	 * @property {boolean} type_with_comment - One-line declaration with comment
 	 * @property {any} [optional] - This is optional
 	 * @property {any} inline_commented - this should stay a comment
 	 * @property {any} inline_commented_merged - This comment should be merged - with this inline comment
 	 * @property {string} [inline_multiline_leading_comment] - this is a same-line leading multiline comment
 	 * @property {string} [inline_multiline_trailing_comment] - this is a same-line trailing multiline comment
-	 * @property {number} [default_value=1]
-	 * @property {number} [comment_default_value=1] - This has a comment and an optional value.
+	 * @property {number} [default_value]
+	 * @property {number} [comment_default_value] - This has a comment and an optional value.
 	 */
 
 	/** @type {Props} */
@@ -38,6 +45,7 @@
 		one_line,
 		no_comment,
 		type_no_comment,
+		type_with_comment,
 		optional = {stuff: true},
 		inline_commented,
 		inline_commented_merged,

--- a/packages/svelte/tests/migrate/samples/jsdoc-with-comments/output.svelte
+++ b/packages/svelte/tests/migrate/samples/jsdoc-with-comments/output.svelte
@@ -27,6 +27,8 @@
 	 * @property {any} inline_commented_merged - This comment should be merged - with this inline comment
 	 * @property {string} [inline_multiline_leading_comment] - this is a same-line leading multiline comment
 	 * @property {string} [inline_multiline_trailing_comment] - this is a same-line trailing multiline comment
+	 * @property {number} [default_value=1]
+	 * @property {number} [comment_default_value=1] - This has a comment and an optional value.
 	 */
 
 	/** @type {Props} */
@@ -40,6 +42,8 @@
 		inline_commented,
 		inline_commented_merged,
 		inline_multiline_leading_comment = 'world',
-		inline_multiline_trailing_comment = 'world'
+		inline_multiline_trailing_comment = 'world',
+		default_value = 1,
+		comment_default_value = 1
 	} = $props();
 </script>


### PR DESCRIPTION
This addresses trailing inlined JSDoc property descriptions being deleted by svelte-migrate, see #15530.

Previously:
```js
/** @type {number} [comment_default_value=1] - This has a comment and a default value. */
export let comment_default_value = 1;```
```

The comment would be removed in the migrated version:
```js
/**
* @typedef {Object} Props
* @property {number} [comment_default_value].
*/

/** @type {Props} */
let { comment_default_value = 1 } = $props();
```

With the change in this PR it becomes the following:
```js
/**
* @typedef {Object} Props
* @property {number} [comment_default_value] - This has a comment and a default value.
*/

/** @type {Props} */
let { comment_default_value = 1 } = $props();
```

The default value description in the JSDoc is still removed, but that's probably ok, as the default value is still in the declaration below.

Happy to change this if you can guide me to a different solution. The regex used here could also potentially be improved to handle more cases of (multiple) whitespace, but wanted to start a discussion first.

The style of JSDoc comments is used in [Layer Cake](https://layercake.graphics/). The components are vendored in other projects so there are lots of repos out there who use this kind of comment (e.g. GitHub search for [AxisX.svelte](https://github.com/search?q=path%3A**%2FAxisX.svelte+layercake&type=code&p=5))   
