### PR TITLE
fix: allow get_proxied_value to return original value when error

### DIFF
--- a/.changeset/afraid-penguins-battle.md
+++ b/.changeset/afraid-penguins-battle.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent dev server from throwing errors when attempting to retrieve the proxied value of an iframe's contentWindow

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -327,8 +327,18 @@ function update_version(signal, d = 1) {
  * @param {any} value
  */
 export function get_proxied_value(value) {
-	if (value !== null && typeof value === 'object' && STATE_SYMBOL in value) {
-		return value[STATE_SYMBOL];
+	try {
+		if (value !== null && typeof value === 'object' && STATE_SYMBOL in value) {
+			return value[STATE_SYMBOL];
+		}
+	} catch (err) {
+		// the above if check can throw an error if the value in question
+		// is the contentWindow of an iframe on another domain, in which
+		// case we want to just return the value (because it's definitely
+		// not a proxied value) so we don't break any JavaScript interacting
+		// with that iframe (such as various payment companies client side
+		// JavaScript libraries interacting with their iframes on the same
+		// domain)
 	}
 
 	return value;

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -331,7 +331,7 @@ export function get_proxied_value(value) {
 		if (value !== null && typeof value === 'object' && STATE_SYMBOL in value) {
 			return value[STATE_SYMBOL];
 		}
-	} catch (err) {
+	} catch {
 		// the above if check can throw an error if the value in question
 		// is the contentWindow of an iframe on another domain, in which
 		// case we want to just return the value (because it's definitely


### PR DESCRIPTION
closes #15546

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

More details in the connected issue, but the TL;DNR version is that when running the dev server, the `init_array_prototype_warnings` function causes problems with the iframe/JavaScript interactions for 3rd party integrations, such as with Recurly and other payment providers. This is caused because the check for a proxied value involves passing the `value` to check if it exists within. 

By simply wrapping the `get_proxied_value` function in a `try/catch`, we avoid the problem of halting the JS run by the 3rd party script on the iframe it controls.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

I intended to write a test for this function, but it appears that the existing proxy test file only runs tests against the `proxy` function. I can still do that, but it seemed out of keeping with the patterns I see in the code base already.
