### PR TITLE
feat: migrate reassigned deriveds to `$derived`

### DIFF
--- a/.changeset/forty-snakes-lay.md
+++ b/.changeset/forty-snakes-lay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+feat: migrate reassigned deriveds to `$derived`

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -19,6 +19,7 @@ import { migrate_svelte_ignore } from '../utils/extract_svelte_ignore.js';
 import { validate_component_options } from '../validate-options.js';
 import { is_reserved, is_svg, is_void } from '../../utils.js';
 import { regex_is_valid_identifier } from '../phases/patterns.js';
+import { VERSION } from 'svelte/compiler';
 
 const regex_style_tags = /(<style[^>]+>)([\S\s]*?)(<\/style>)/g;
 const style_placeholder = '/*$$__STYLE_CONTENT__$$*/';
@@ -112,6 +113,16 @@ function find_closing_parenthesis(start, code) {
 	}
 	return end;
 }
+
+function check_support_writable_deriveds() {
+	const [major, minor, patch] = VERSION.split('.');
+
+	if (+major < 5) return false;
+	if (+minor < 25) return false;
+	return true;
+}
+
+const support_writable_derived = check_support_writable_deriveds();
 
 /**
  * Does a best-effort migration of Svelte code towards using runes, event attributes and render tags.
@@ -952,7 +963,11 @@ const instance_script = {
 			const reassigned_bindings = bindings.filter((b) => b?.reassigned);
 
 			if (
-				reassigned_bindings.length === 0 &&
+				// on version 5.25.0 deriveds are writable so we can use them even if
+				// reassigned (but if the right side is a literal we want to use `$state`)
+				(support_writable_derived
+					? node.body.expression.right.type !== 'Literal'
+					: reassigned_bindings.length === 0) &&
 				!bindings.some((b) => b?.kind === 'store_sub') &&
 				node.body.expression.left.type !== 'MemberExpression'
 			) {

--- a/packages/svelte/tests/migrate/samples/reassigned-deriveds/input.svelte
+++ b/packages/svelte/tests/migrate/samples/reassigned-deriveds/input.svelte
@@ -1,0 +1,10 @@
+<script>
+	let name = 'world';
+
+	$: upper = name.toUpperCase();
+</script>
+
+<input bind:value={name} />
+<input bind:value={upper} />
+
+{upper}

--- a/packages/svelte/tests/migrate/samples/reassigned-deriveds/output.svelte
+++ b/packages/svelte/tests/migrate/samples/reassigned-deriveds/output.svelte
@@ -1,0 +1,10 @@
+<script>
+	let name = $state('world');
+
+	let upper = $derived(name.toUpperCase());
+</script>
+
+<input bind:value={name} />
+<input bind:value={upper} />
+
+{upper}


### PR DESCRIPTION
Since now deriveds are writable we can properly migrate even reassigned labeled statements...i did add a check for the version so that in older versions we migrate to compatible code but maybe that's unnecessary?

Also i still migrate this

```ts
$: something = 43;
```
to state because it's better.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
