### PR TITLE
fix: prevent state runes from being called with spread

### DIFF
--- a/.changeset/nice-pianos-punch.md
+++ b/.changeset/nice-pianos-punch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent state runes from being called with spread

--- a/documentation/docs/98-reference/.generated/compile-errors.md
+++ b/documentation/docs/98-reference/.generated/compile-errors.md
@@ -660,6 +660,12 @@ Cannot access a computed property of a rune
 `%name%` is not a valid rune
 ```
 
+### rune_invalid_spread
+
+```
+`%rune%` cannot be called with a spread argument
+```
+
 ### rune_invalid_usage
 
 ```

--- a/packages/svelte/messages/compile-errors/script.md
+++ b/packages/svelte/messages/compile-errors/script.md
@@ -162,6 +162,10 @@ This turned out to be buggy and unpredictable, particularly when working with de
 
 > `%name%` is not a valid rune
 
+## rune_invalid_spread
+
+> `%rune%` cannot be called with a spread argument
+
 ## rune_invalid_usage
 
 > Cannot use `%rune%` rune in non-runes mode

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -384,6 +384,16 @@ export function rune_invalid_name(node, name) {
 }
 
 /**
+ * `%rune%` cannot be called with a spread argument
+ * @param {null | number | NodeLike} node
+ * @param {string} rune
+ * @returns {never}
+ */
+export function rune_invalid_spread(node, rune) {
+	e(node, 'rune_invalid_spread', `\`${rune}\` cannot be called with a spread argument\nhttps://svelte.dev/e/rune_invalid_spread`);
+}
+
+/**
  * Cannot use `%rune%` rune in non-runes mode
  * @param {null | number | NodeLike} node
  * @param {string} rune

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -17,6 +17,14 @@ export function CallExpression(node, context) {
 
 	const rune = get_rune(node, context.state.scope);
 
+	if (rune && rune !== '$inspect') {
+		for (const arg of node.arguments) {
+			if (arg.type === 'SpreadElement') {
+				e.rune_invalid_spread(node, rune);
+			}
+		}
+	}
+
 	switch (rune) {
 		case null:
 			if (!is_safe_identifier(node.callee, context.state.scope)) {
@@ -113,10 +121,6 @@ export function CallExpression(node, context) {
 				!(parent.type === 'PropertyDefinition' && !parent.static && !parent.computed)
 			) {
 				e.state_invalid_placement(node, rune);
-			}
-
-			if (node.arguments.some((arg) => arg.type === 'SpreadElement')) {
-				e.rune_invalid_spread(node, rune);
 			}
 
 			if ((rune === '$derived' || rune === '$derived.by') && node.arguments.length !== 1) {

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -115,6 +115,10 @@ export function CallExpression(node, context) {
 				e.state_invalid_placement(node, rune);
 			}
 
+			if (node.arguments.some((arg) => arg.type === 'SpreadElement')) {
+				e.rune_invalid_spread(node, rune);
+			}
+
 			if ((rune === '$derived' || rune === '$derived.by') && node.arguments.length !== 1) {
 				e.rune_invalid_arguments_length(node, rune, 'exactly one argument');
 			} else if (node.arguments.length > 1) {

--- a/packages/svelte/tests/validator/samples/rune-invalid-spread-derived-by/errors.json
+++ b/packages/svelte/tests/validator/samples/rune-invalid-spread-derived-by/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "rune_invalid_spread",
+		"end": {
+			"column": 35,
+			"line": 3
+		},
+		"message": "`$derived.by` cannot be called with a spread argument",
+		"start": {
+			"column": 15,
+			"line": 3
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/rune-invalid-spread-derived-by/input.svelte
+++ b/packages/svelte/tests/validator/samples/rune-invalid-spread-derived-by/input.svelte
@@ -1,0 +1,4 @@
+<script>
+	const args = [0];
+	const count = $derived.by(...args);
+</script>

--- a/packages/svelte/tests/validator/samples/rune-invalid-spread-derived/errors.json
+++ b/packages/svelte/tests/validator/samples/rune-invalid-spread-derived/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "rune_invalid_spread",
+		"end": {
+			"column": 32,
+			"line": 3
+		},
+		"message": "`$derived` cannot be called with a spread argument",
+		"start": {
+			"column": 15,
+			"line": 3
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/rune-invalid-spread-derived/input.svelte
+++ b/packages/svelte/tests/validator/samples/rune-invalid-spread-derived/input.svelte
@@ -1,0 +1,4 @@
+<script>
+	const args = [0];
+	const count = $derived(...args);
+</script>

--- a/packages/svelte/tests/validator/samples/rune-invalid-spread-state-raw/errors.json
+++ b/packages/svelte/tests/validator/samples/rune-invalid-spread-state-raw/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "rune_invalid_spread",
+		"end": {
+			"column": 34,
+			"line": 3
+		},
+		"message": "`$state.raw` cannot be called with a spread argument",
+		"start": {
+			"column": 15,
+			"line": 3
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/rune-invalid-spread-state-raw/input.svelte
+++ b/packages/svelte/tests/validator/samples/rune-invalid-spread-state-raw/input.svelte
@@ -1,0 +1,4 @@
+<script>
+	const args = [0];
+	const count = $state.raw(...args);
+</script>

--- a/packages/svelte/tests/validator/samples/rune-invalid-spread-state/errors.json
+++ b/packages/svelte/tests/validator/samples/rune-invalid-spread-state/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "rune_invalid_spread",
+		"end": {
+			"column": 30,
+			"line": 3
+		},
+		"message": "`$state` cannot be called with a spread argument",
+		"start": {
+			"column": 15,
+			"line": 3
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/rune-invalid-spread-state/input.svelte
+++ b/packages/svelte/tests/validator/samples/rune-invalid-spread-state/input.svelte
@@ -1,0 +1,4 @@
+<script>
+	const args = [0];
+	const count = $state(...args);
+</script>


### PR DESCRIPTION
This will make #15579 safer...is technically a breaking but we are probably safe from this.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
