### PR TITLE
fix: add setter to `$derived` class fields

### DIFF
--- a/.changeset/pink-lamps-leave.md
+++ b/.changeset/pink-lamps-leave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add setters to `$derived` class properties

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/ClassBody.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/ClassBody.js
@@ -142,30 +142,17 @@ export function ClassBody(node, context) {
 					// get foo() { return this.#foo; }
 					body.push(b.method('get', definition.key, [], [b.return(b.call('$.get', member))]));
 
-					if (field.kind === 'state' || field.kind === 'raw_state') {
-						// set foo(value) { this.#foo = value; }
-						const value = b.id('value');
+					// set foo(value) { this.#foo = value; }
+					const val = b.id('value');
 
-						body.push(
-							b.method(
-								'set',
-								definition.key,
-								[value],
-								[b.stmt(b.call('$.set', member, value, field.kind === 'state' && b.true))]
-							)
-						);
-					}
-
-					if (dev && (field.kind === 'derived' || field.kind === 'derived_by')) {
-						body.push(
-							b.method(
-								'set',
-								definition.key,
-								[b.id('_')],
-								[b.throw_error(`Cannot update a derived property ('${name}')`)]
-							)
-						);
-					}
+					body.push(
+						b.method(
+							'set',
+							definition.key,
+							[val],
+							[b.stmt(b.call('$.set', member, val, field.kind === 'state' && b.true))]
+						)
+					);
 				}
 				continue;
 			}


### PR DESCRIPTION
Fixes #15621 by adding a setter to `$derived` class fields. 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
