### PR TITLE
fix: ignore generic type arguments while creating AST

### DIFF
--- a/.changeset/happy-snakes-pump.md
+++ b/.changeset/happy-snakes-pump.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ignore generic type arguments while creating AST

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -156,7 +156,7 @@
     "axobject-query": "^4.1.0",
     "clsx": "^2.1.1",
     "esm-env": "^1.2.1",
-    "esrap": "^1.4.3",
+    "esrap": "^1.4.6",
     "is-reference": "^3.0.3",
     "locate-character": "^3.0.0",
     "magic-string": "^0.30.11",

--- a/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
+++ b/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
@@ -24,6 +24,7 @@ const visitors = {
 		// until that day comes, we just delete them so they don't confuse esrap
 		delete n.typeAnnotation;
 		delete n.typeParameters;
+		delete n.typeArguments;
 		delete n.returnType;
 		delete n.accessibility;
 	},

--- a/packages/svelte/tests/runtime-runes/samples/typescript/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/typescript/main.svelte
@@ -8,7 +8,7 @@
 		console.log(this);
 	}
 
-	function foo(): string {
+	function foo<T>(): string {
 		return ""!;
 	}
 
@@ -46,6 +46,7 @@
 
 	const TypedFoo = Foo<true>;
 	const typeAssertion = <boolean>true;
+	const x = foo<true>();
 </script>
 
 <script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       esrap:
-        specifier: ^1.4.3
-        version: 1.4.3
+        specifier: ^1.4.6
+        version: 1.4.6
       is-reference:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1261,8 +1261,8 @@ packages:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
 
-  esrap@1.4.3:
-    resolution: {integrity: sha512-Xddc1RsoFJ4z9nR7W7BFaEPIp4UXoeQ0+077UdWLxbafMQFyU79sQJMk7kxNgRwQ9/aVgaKacCHC2pUACGwmYw==}
+  esrap@1.4.6:
+    resolution: {integrity: sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -3617,7 +3617,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@1.4.3:
+  esrap@1.4.6:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 


### PR DESCRIPTION
bumps esrap and fixes a resulting error: because esrap now uses a more compliant TSESTree AST, it has `typeArguments` instead of `typeParameters` in some places - those were not deleted while stripping types, which caused an error.
