### PR TITLE
fix: ensure clearing of old values happens independent of root flushes

### DIFF
--- a/.changeset/kind-elephants-behave.md
+++ b/.changeset/kind-elephants-behave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure clearing of old values happens indepedent of root flushes

--- a/.changeset/kind-elephants-behave.md
+++ b/.changeset/kind-elephants-behave.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: ensure clearing of old values happens indepedent of root flushes
+fix: ensure clearing of old values happens independent of root flushes

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -692,6 +692,7 @@ function flush_queued_root_effects() {
 				var collected_effects = process_effects(root_effects[i]);
 				flush_queued_effects(collected_effects);
 			}
+			old_values.clear();
 		}
 	} finally {
 		is_flushing = false;
@@ -701,7 +702,6 @@ function flush_queued_root_effects() {
 		if (DEV) {
 			dev_effect_stack = [];
 		}
-		old_values.clear();
 	}
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/onmount-prop-access/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/onmount-prop-access/Component.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { onMount } from 'svelte'
+
+	let thing = $state(0)
+
+	onMount(() => {
+		thing = 1;
+		return () => {
+			console.log(thing);
+		}
+	})
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/onmount-prop-access/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/onmount-prop-access/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, logs }) {
+		assert.deepEqual(logs, [1]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/onmount-prop-access/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/onmount-prop-access/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { onMount } from "svelte"
+	import Component from './Component.svelte';
+
+	let key = $state(0);
+
+	onMount(() => {
+		key = 1;
+	})
+</script>
+
+{#key key}
+	<Component />
+{/key}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/15606. We were calling `old_values.clear()` in the wrong place!