### PR TITLE
fix: better scope `:global()` with nesting selector `&`

### DIFF
--- a/.changeset/stupid-vans-draw.md
+++ b/.changeset/stupid-vans-draw.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better scope `:global()` with nesting selector `&`

--- a/packages/svelte/tests/css/samples/global-with-nesting/expected.css
+++ b/packages/svelte/tests/css/samples/global-with-nesting/expected.css
@@ -1,5 +1,10 @@
 	div.svelte-xyz {
 		&.class{
-			color: red;
+			color: green;
+		}
+	}
+	* {
+		&:hover .class.svelte-xyz {
+			color: green;
 		}
 	}

--- a/packages/svelte/tests/css/samples/global-with-nesting/input.svelte
+++ b/packages/svelte/tests/css/samples/global-with-nesting/input.svelte
@@ -1,7 +1,12 @@
 <style>
 	div {
 		&:global(.class){
-			color: red;
+			color: green;
+		}
+	}
+	:global(*) {
+		&:hover .class {
+			color: green;
 		}
 	}
 </style>


### PR DESCRIPTION
Fixes #14616

Personal though: I think RelativeSelector with `:global()` must contain nothing else (exceptions are `:not()` and `:has()`) because it is ambiguous whether the part outside `:global()` should be scoped, and if yes, what is the point of `:global()` then. But it will be a breaking change.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
