### PR TITLE
feat: add `$state.invalidate` rune

### DIFF
--- a/.changeset/breezy-baboons-exercise.md
+++ b/.changeset/breezy-baboons-exercise.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: add `$state.invalidate` rune

--- a/documentation/docs/98-reference/.generated/compile-errors.md
+++ b/documentation/docs/98-reference/.generated/compile-errors.md
@@ -828,6 +828,12 @@ Cannot export state from a module if it is reassigned. Either export a function 
 `%rune%(...)` can only be used as a variable declaration initializer or a class field
 ```
 
+### state_invalidate_nonreactive_argument
+
+```
+`$state.invalidate` only takes a variable declared with `$state` or `$state.raw` as its argument
+```
+
 ### store_invalid_scoped_subscription
 
 ```

--- a/packages/svelte/messages/compile-errors/script.md
+++ b/packages/svelte/messages/compile-errors/script.md
@@ -220,6 +220,10 @@ It's possible to export a snippet from a `<script module>` block, but only if it
 
 > `%rune%(...)` can only be used as a variable declaration initializer or a class field
 
+## state_invalidate_nonreactive_argument
+
+> `$state.invalidate` only takes a variable declared with `$state` or `$state.raw` as its argument
+
 ## store_invalid_scoped_subscription
 
 > Cannot subscribe to stores that are not declared at the top level of the component

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -94,6 +94,30 @@ declare namespace $state {
 						: never;
 
 	/**
+	 * Forces an update on a `$state` or `$state.raw` variable.
+	 * This is primarily meant as an escape hatch to be able to use external or native classes
+	 * with Svelte's reactivity system.
+	 * If you used Svelte 3 or 4, this is the equivalent of `foo = foo`.
+	 * Example:
+	 * ```svelte
+	 * <script>
+	 *   import Counter from 'external-class';
+	 * 
+	 *   let counter = $state(new Counter());
+	 * 
+	 *   function increment() {
+	 *     counter.increment(); 
+	 *     $state.invalidate(counter);
+	 *   }
+	 * </script>
+	 * <button onclick={increment}>
+	 *   Count is {counter.count}
+	 * </button>
+	 * ```
+	 */
+	export function invalidate(source: unknown): void;
+
+	/**
 	 * Declares state that is _not_ made deeply reactive — instead of mutating it,
 	 * you must reassign it.
 	 *

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -481,6 +481,15 @@ export function state_invalid_placement(node, rune) {
 }
 
 /**
+ * `$state.invalidate` only takes a variable declared with `$state` or `$state.raw` as its argument
+ * @param {null | number | NodeLike} node
+ * @returns {never}
+ */
+export function state_invalidate_nonreactive_argument(node) {
+	e(node, 'state_invalidate_nonreactive_argument', `\`$state.invalidate\` only takes a variable declared with \`$state\` or \`$state.raw\` as its argument\nhttps://svelte.dev/e/state_invalidate_nonreactive_argument`);
+}
+
+/**
  * Cannot subscribe to stores that are not declared at the top level of the component
  * @param {null | number | NodeLike} node
  * @returns {never}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -111,6 +111,24 @@ export function CallExpression(node, context) {
 			break;
 		}
 
+		case '$state.invalidate':
+			if (node.arguments.length !== 1) {
+				e.rune_invalid_arguments_length(node, rune, 'exactly one argument');
+			} else {
+				let arg = node.arguments[0];
+				if (arg.type !== 'Identifier') {
+					e.rune_invalid_arguments(node, rune);
+				}
+				let binding = context.state.scope.get(arg.name);
+				if (binding) {
+					if (binding.kind === 'raw_state' || binding.kind === 'state') {
+						binding.reassigned = true;
+						break;
+					}
+				}
+				e.state_invalidate_nonreactive_argument(node);
+			}
+
 		case '$state':
 		case '$state.raw':
 		case '$derived':

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/CallExpression.js
@@ -23,6 +23,8 @@ export function CallExpression(node, context) {
 				/** @type {Expression} */ (context.visit(node.arguments[0])),
 				is_ignored(node, 'state_snapshot_uncloneable') && b.true
 			);
+		case '$state.invalidate':
+			return b.call('$.invalidate', node.arguments[0]);
 
 		case '$effect.root':
 			return b.call(

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -113,7 +113,15 @@ export {
 	user_effect,
 	user_pre_effect
 } from './reactivity/effects.js';
-export { mutable_source, mutate, set, state, update, update_pre } from './reactivity/sources.js';
+export {
+	invalidate,
+	mutable_source,
+	mutate,
+	set,
+	state,
+	update,
+	update_pre
+} from './reactivity/sources.js';
 export {
 	prop,
 	rest_props,

--- a/packages/svelte/src/utils.js
+++ b/packages/svelte/src/utils.js
@@ -430,6 +430,7 @@ export function is_mathml(name) {
 
 const RUNES = /** @type {const} */ ([
 	'$state',
+	'$state.invalidate',
 	'$state.raw',
 	'$state.snapshot',
 	'$props',

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2761,6 +2761,30 @@ declare namespace $state {
 						: never;
 
 	/**
+	 * Forces an update on a `$state` or `$state.raw` variable.
+	 * This is primarily meant as an escape hatch to be able to use external or native classes
+	 * with Svelte's reactivity system.
+	 * If you used Svelte 3 or 4, this is the equivalent of `foo = foo`.
+	 * Example:
+	 * ```svelte
+	 * <script>
+	 *   import Counter from 'external-class';
+	 * 
+	 *   let counter = $state(new Counter());
+	 * 
+	 *   function increment() {
+	 *     counter.increment(); 
+	 *     $state.invalidate(counter);
+	 *   }
+	 * </script>
+	 * <button onclick={increment}>
+	 *   Count is {counter.count}
+	 * </button>
+	 * ```
+	 */
+	export function invalidate(source: unknown): void;
+
+	/**
 	 * Declares state that is _not_ made deeply reactive — instead of mutating it,
 	 * you must reassign it.
 	 *


### PR DESCRIPTION
This adds the `$state.invalidate` rune for forcing updates on a variable declared with `$state` or `$state.raw`, based on [`$state.opaque`](https://github.com/sveltejs/svelte/pull/14639) and closely related to https://github.com/sveltejs/svelte/issues/14520#issuecomment-2514661788. If you have used Svelte 3 or 4, this is the equivalent of `foo = foo`, which currently doesn't have a Svelte 5 equivalent. 
Now, while I don't quite know the exact reasons that `$state.opaque` was rejected (the most info we have is [this](https://github.com/sveltejs/svelte/pull/14639#issuecomment-2687675678)), I have noticed some ergonomic issues, such as:
- A variable that needs a force update has to have its declaration changed to a destructured pattern with `$state.opaque` like so:
```js
//before:
let thing = $state(new Class());
//after:
let [thing, invalidateThing] = $state.opaque(new Class());
```
- There's no good way to name the invalidate function. With similar functions outside of Svelte like React's `useState`, the common convention is `[thing, setThing]`, but with `$state.opaque`, there wasn't a clear non-verbose way to name the invalidator. 

Meanwhile, `$state.invalidate` can be used without these caveats on any `$state` or `$state.raw` variable:
```js
let counter = $state(new Counter()); //imagine `Counter` as being a class from an NPM package or a native class
function increment() {
   counter.increment(); // counter's internal state has changed, but Svelte has no way of knowing that
   $state.invalidate(counter); 
}
$effect(() => console.log(`Count is ${counter.count}`));
```
## Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
