### PR TITLE
fix: allow `$.state` and `$.derived` to be treeshaken

### DIFF
--- a/.changeset/clever-news-enjoy.md
+++ b/.changeset/clever-news-enjoy.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow `$.state` and `$.derived` to be treeshaken

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -67,6 +67,7 @@ export function derived(fn) {
  * @param {() => V} fn
  * @returns {Derived<V>}
  */
+/*#__NO_SIDE_EFFECTS__*/
 export function user_derived(fn) {
 	const d = derived(fn);
 

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -78,6 +78,7 @@ export function source(v, stack) {
  * @param {V} v
  * @param {Error | null} [stack]
  */
+/*#__NO_SIDE_EFFECTS__*/
 export function state(v, stack) {
 	const s = source(v, stack);
 


### PR DESCRIPTION
closes #15529 (see https://github.com/sveltejs/svelte/pull/15529#issuecomment-2729138326)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
