### PR TITLE
fix: prevent ownership warnings if the fallback of a bindable is used

### DIFF
--- a/.changeset/wise-turkeys-yell.md
+++ b/.changeset/wise-turkeys-yell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent ownership warnings if the fallback of a bindable is used

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -348,6 +348,7 @@ export function validate_mutation(node, context, expression) {
 		b.literal(binding.prop_alias),
 		b.array(path),
 		expression,
+		binding.prop_alias != null && b.id(binding.prop_alias),
 		loc && b.literal(loc.line),
 		loc && b.literal(loc.column)
 	);

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -23,5 +23,6 @@ export const EFFECT_HAS_DERIVED = 1 << 20;
 export const EFFECT_IS_UPDATING = 1 << 21;
 
 export const STATE_SYMBOL = Symbol('$state');
+export const BINDABLE_FALLBACK_SYMBOL = Symbol('bindable fallback');
 export const LEGACY_PROPS = Symbol('legacy props');
 export const LOADING_ATTR_SYMBOL = Symbol('');

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -9,7 +9,7 @@ import {
 	object_prototype
 } from '../shared/utils.js';
 import { state as source, set } from './reactivity/sources.js';
-import { STATE_SYMBOL } from './constants.js';
+import { BINDABLE_FALLBACK_SYMBOL, STATE_SYMBOL } from './constants.js';
 import { UNINITIALIZED } from '../../constants.js';
 import * as e from './errors.js';
 import { get_stack } from './dev/tracing.js';
@@ -64,10 +64,13 @@ export function proxy(value) {
 	return new Proxy(/** @type {any} */ (value), {
 		defineProperty(_, prop, descriptor) {
 			if (
-				!('value' in descriptor) ||
-				descriptor.configurable === false ||
-				descriptor.enumerable === false ||
-				descriptor.writable === false
+				// we allow non enumerable/writable defines if the prop being set is our own symbol
+				// this should be fine for the invariants since the user can't get a handle to the symbol
+				(!DEV || prop !== BINDABLE_FALLBACK_SYMBOL) &&
+				(!('value' in descriptor) ||
+					descriptor.configurable === false ||
+					descriptor.enumerable === false ||
+					descriptor.writable === false)
 			) {
 				// we disallow non-basic descriptors, because unless they are applied to the
 				// target object — which we avoid, so that state can be forked — we will run

--- a/packages/svelte/tests/runtime-runes/samples/ownership-invalid-binding-bindable-fallback/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-invalid-binding-bindable-fallback/Child.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { test = $bindable() } = $props();
+</script>
+
+{test}

--- a/packages/svelte/tests/runtime-runes/samples/ownership-invalid-binding-bindable-fallback/Parent.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-invalid-binding-bindable-fallback/Parent.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Child from './Child.svelte';
+
+	let { test = $bindable({}) } = $props();
+</script>
+
+<Child bind:test />

--- a/packages/svelte/tests/runtime-runes/samples/ownership-invalid-binding-bindable-fallback/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-invalid-binding-bindable-fallback/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	compileOptions: {
+		dev: true
+	},
+	async test({ warnings, assert }) {
+		assert.deepEqual(warnings, []);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/ownership-invalid-binding-bindable-fallback/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-invalid-binding-bindable-fallback/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Parent from './Parent.svelte';
+</script>
+
+<Parent />

--- a/packages/svelte/tests/runtime-runes/samples/ownership-invalid-mutation-bindable-fallback/Parent.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-invalid-mutation-bindable-fallback/Parent.svelte
@@ -1,0 +1,8 @@
+<script>
+	let { test = $bindable({}) } = $props();
+</script>
+
+<button onclick={()=>test = {}}></button>
+<button onclick={()=>test.test = {}}></button>
+
+{test}

--- a/packages/svelte/tests/runtime-runes/samples/ownership-invalid-mutation-bindable-fallback/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-invalid-mutation-bindable-fallback/_config.js
@@ -1,0 +1,23 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	compileOptions: {
+		dev: true
+	},
+	async test({ warnings, assert, target }) {
+		const [btn, btn2] = target.querySelectorAll('button');
+		flushSync(() => {
+			btn2.click();
+		});
+		assert.deepEqual(warnings, []);
+		flushSync(() => {
+			btn.click();
+		});
+		flushSync(() => {
+			btn2.click();
+		});
+		assert.deepEqual(warnings, []);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/ownership-invalid-mutation-bindable-fallback/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/ownership-invalid-mutation-bindable-fallback/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Parent from './Parent.svelte';
+</script>
+
+<Parent />


### PR DESCRIPTION
Closes #15717

I wonder if there's a better way to do this but i couldn't find one. This seems to work however and I'm not to worried about the weirdness because it's in dev only. WDYT?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`