### PR TITLE
fix: improve internal_set versioning mechanic

### DIFF
--- a/.changeset/pretty-planes-visit.md
+++ b/.changeset/pretty-planes-visit.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improve internal_set versioning mechanic

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -162,7 +162,6 @@ export function internal_set(source, value) {
 		}
 
 		source.v = value;
-		source.wv = increment_write_version();
 
 		if (DEV && tracing_mode_flag) {
 			source.updated = get_stack('UpdatedAt');
@@ -179,6 +178,8 @@ export function internal_set(source, value) {
 			}
 			set_signal_status(source, (source.f & UNOWNED) === 0 ? CLEAN : MAYBE_DIRTY);
 		}
+
+		source.wv = increment_write_version();
 
 		mark_reactions(source, DIRTY);
 

--- a/packages/svelte/tests/runtime-runes/samples/writable-derived-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/writable-derived-2/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	html: `true true`,
+
+	test({ assert, target, window }) {}
+});

--- a/packages/svelte/tests/runtime-runes/samples/writable-derived-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/writable-derived-2/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { expect2, createAppState } from "./util.svelte.js"
+
+  const result = createAppState({ source: () => "wrong" });
+  result.onChange("right");
+  const expect1 = result.value === "right";
+</script>
+
+{expect1} {expect2}

--- a/packages/svelte/tests/runtime-runes/samples/writable-derived-2/util.svelte.js
+++ b/packages/svelte/tests/runtime-runes/samples/writable-derived-2/util.svelte.js
@@ -1,0 +1,17 @@
+export const createAppState = (options) => {
+	const source = $derived(options.source());
+	let value = $derived(source);
+
+	return {
+		get value() {
+			return value;
+		},
+		onChange(nextValue) {
+			value = nextValue;
+		}
+	};
+};
+
+const result = createAppState({ source: () => 'wrong' });
+result.onChange('right');
+export const expect2 = result.value === 'right';


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/15721. We needed to increment the version after we execute the derived.