### PR TITLE
fix: update `state_referenced_locally` message

### DIFF
--- a/.changeset/stale-gorillas-judge.md
+++ b/.changeset/stale-gorillas-judge.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: update `state_referenced_locally` message

--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -823,15 +823,16 @@ See [the migration guide](v5-migration-guide#Snippets-instead-of-slots) for more
 ### state_referenced_locally
 
 ```
-State referenced in its own scope will never update. Did you mean to reference it inside a closure?
+Referencing state in its own scope will cause reactivity loss. Did you mean to reference `%name%` inside a %type% instead?
 ```
 
 This warning is thrown when the compiler detects the following:
-- A reactive variable is declared
-- the variable is reassigned
-- the variable is referenced inside the same scope it is declared and it is a non-reactive context
 
-In this case, the state reassignment will not be noticed by whatever you passed it to. For example, if you pass the state to a function, that function will not notice the updates:
+- A reactive variable is declared
+- ...and later reassigned...
+- ...and referenced in the same scope
+
+This 'breaks the link' to the original state declaration. For example, if you pass the state to a function, the function loses access to the state once it is reassigned:
 
 ```svelte
 <!--- file: Parent.svelte --->

--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -823,7 +823,7 @@ See [the migration guide](v5-migration-guide#Snippets-instead-of-slots) for more
 ### state_referenced_locally
 
 ```
-Referencing state in its own scope will cause reactivity loss. Did you mean to reference `%name%` inside a %type% instead?
+This reference only captures the initial value of `%name%`. Did you mean to reference it inside a %type% instead?
 ```
 
 This warning is thrown when the compiler detects the following:

--- a/packages/svelte/messages/compile-warnings/script.md
+++ b/packages/svelte/messages/compile-warnings/script.md
@@ -54,14 +54,15 @@ To fix this, wrap your variable declaration with `$state`.
 
 ## state_referenced_locally
 
-> State referenced in its own scope will never update. Did you mean to reference it inside a closure?
+> Referencing state in its own scope will cause reactivity loss. Did you mean to reference `%name%` inside a %type% instead?
 
 This warning is thrown when the compiler detects the following:
-- A reactive variable is declared
-- the variable is reassigned
-- the variable is referenced inside the same scope it is declared and it is a non-reactive context
 
-In this case, the state reassignment will not be noticed by whatever you passed it to. For example, if you pass the state to a function, that function will not notice the updates:
+- A reactive variable is declared
+- ...and later reassigned...
+- ...and referenced in the same scope
+
+This 'breaks the link' to the original state declaration. For example, if you pass the state to a function, the function loses access to the state once it is reassigned:
 
 ```svelte
 <!--- file: Parent.svelte --->

--- a/packages/svelte/messages/compile-warnings/script.md
+++ b/packages/svelte/messages/compile-warnings/script.md
@@ -54,7 +54,7 @@ To fix this, wrap your variable declaration with `$state`.
 
 ## state_referenced_locally
 
-> Referencing state in its own scope will cause reactivity loss. Did you mean to reference `%name%` inside a %type% instead?
+> This reference only captures the initial value of `%name%`. Did you mean to reference it inside a %type% instead?
 
 This warning is thrown when the compiler detects the following:
 

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -641,13 +641,13 @@ export function reactive_declaration_module_script_dependency(node) {
 }
 
 /**
- * Referencing state in its own scope will cause reactivity loss. Did you mean to reference `%name%` inside a %type% instead?
+ * This reference only captures the initial value of `%name%`. Did you mean to reference it inside a %type% instead?
  * @param {null | NodeLike} node
  * @param {string} name
  * @param {string} type
  */
 export function state_referenced_locally(node, name, type) {
-	w(node, 'state_referenced_locally', `Referencing state in its own scope will cause reactivity loss. Did you mean to reference \`${name}\` inside a ${type} instead?\nhttps://svelte.dev/e/state_referenced_locally`);
+	w(node, 'state_referenced_locally', `This reference only captures the initial value of \`${name}\`. Did you mean to reference it inside a ${type} instead?\nhttps://svelte.dev/e/state_referenced_locally`);
 }
 
 /**

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -641,11 +641,13 @@ export function reactive_declaration_module_script_dependency(node) {
 }
 
 /**
- * State referenced in its own scope will never update. Did you mean to reference it inside a closure?
+ * Referencing state in its own scope will cause reactivity loss. Did you mean to reference `%name%` inside a %type% instead?
  * @param {null | NodeLike} node
+ * @param {string} name
+ * @param {string} type
  */
-export function state_referenced_locally(node) {
-	w(node, 'state_referenced_locally', `State referenced in its own scope will never update. Did you mean to reference it inside a closure?\nhttps://svelte.dev/e/state_referenced_locally`);
+export function state_referenced_locally(node, name, type) {
+	w(node, 'state_referenced_locally', `Referencing state in its own scope will cause reactivity loss. Did you mean to reference \`${name}\` inside a ${type} instead?\nhttps://svelte.dev/e/state_referenced_locally`);
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/static-state-reference/input.svelte
+++ b/packages/svelte/tests/validator/samples/static-state-reference/input.svelte
@@ -2,6 +2,7 @@
 	let obj = $state({ a: 0 });
 	let count = $state(0);
 	let doubled = $derived(count * 2);
+	let tripled = $state(count * 3);
 
 	console.log(obj);
 	console.log(count);

--- a/packages/svelte/tests/validator/samples/static-state-reference/warnings.json
+++ b/packages/svelte/tests/validator/samples/static-state-reference/warnings.json
@@ -1,26 +1,38 @@
 [
 	{
 		"code": "state_referenced_locally",
-		"message": "State referenced in its own scope will never update. Did you mean to reference it inside a closure?",
+		"message": "Referencing state in its own scope will cause reactivity loss. Did you mean to reference `count` inside a derived instead?",
 		"start": {
-			"column": 13,
-			"line": 7
+			"column": 22,
+			"line": 5
 		},
 		"end": {
-			"column": 18,
-			"line": 7
+			"column": 27,
+			"line": 5
 		}
 	},
 	{
 		"code": "state_referenced_locally",
-		"message": "State referenced in its own scope will never update. Did you mean to reference it inside a closure?",
+		"message": "Referencing state in its own scope will cause reactivity loss. Did you mean to reference `count` inside a closure instead?",
 		"start": {
 			"column": 13,
 			"line": 8
 		},
 		"end": {
-			"column": 20,
+			"column": 18,
 			"line": 8
+		}
+	},
+	{
+		"code": "state_referenced_locally",
+		"message": "Referencing state in its own scope will cause reactivity loss. Did you mean to reference `doubled` inside a closure instead?",
+		"start": {
+			"column": 13,
+			"line": 9
+		},
+		"end": {
+			"column": 20,
+			"line": 9
 		}
 	}
 ]

--- a/packages/svelte/tests/validator/samples/static-state-reference/warnings.json
+++ b/packages/svelte/tests/validator/samples/static-state-reference/warnings.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "state_referenced_locally",
-		"message": "Referencing state in its own scope will cause reactivity loss. Did you mean to reference `count` inside a derived instead?",
+		"message": "This reference only captures the initial value of `count`. Did you mean to reference it inside a derived instead?",
 		"start": {
 			"column": 22,
 			"line": 5
@@ -13,7 +13,7 @@
 	},
 	{
 		"code": "state_referenced_locally",
-		"message": "Referencing state in its own scope will cause reactivity loss. Did you mean to reference `count` inside a closure instead?",
+		"message": "This reference only captures the initial value of `count`. Did you mean to reference it inside a closure instead?",
 		"start": {
 			"column": 13,
 			"line": 8
@@ -25,7 +25,7 @@
 	},
 	{
 		"code": "state_referenced_locally",
-		"message": "Referencing state in its own scope will cause reactivity loss. Did you mean to reference `doubled` inside a closure instead?",
+		"message": "This reference only captures the initial value of `doubled`. Did you mean to reference it inside a closure instead?",
 		"start": {
 			"column": 13,
 			"line": 9


### PR DESCRIPTION
alternative to #15171. closes #11883, closes #13079.

In addition to tweaking the message (and suggesting a derived instead of a closure when the reference is inside a `$state` declaration, per https://github.com/sveltejs/svelte/pull/15171#issuecomment-2672302931) it tweaks the detailed description the message links to.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
