### PR TITLE
fix: correctly validate `undefined` snippet params with default value

### DIFF
--- a/.changeset/angry-mayflies-matter.md
+++ b/.changeset/angry-mayflies-matter.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly validate `undefined` snippet params with default value

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SnippetBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SnippetBlock.js
@@ -34,12 +34,7 @@ export function SnippetBlock(node, context) {
 		if (!argument) continue;
 
 		if (argument.type === 'Identifier') {
-			args.push({
-				type: 'AssignmentPattern',
-				left: argument,
-				right: b.id('$.noop')
-			});
-
+			args.push(b.assignment_pattern(argument, b.id('$.noop')));
 			transform[argument.name] = { read: b.call };
 
 			continue;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SnippetBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SnippetBlock.js
@@ -28,8 +28,6 @@ export function SnippetBlock(node, context) {
 	const transform = { ...context.state.transform };
 	const child_state = { ...context.state, transform };
 
-	let fallback_arr = [];
-
 	for (let i = 0; i < node.parameters.length; i++) {
 		const argument = node.parameters[i];
 
@@ -55,9 +53,6 @@ export function SnippetBlock(node, context) {
 		for (const path of paths) {
 			const name = /** @type {Identifier} */ (path.node).name;
 			const needs_derived = path.has_default_value; // to ensure that default value is only called once
-			if (needs_derived) {
-				fallback_arr.push(i);
-			}
 			const fn = b.thunk(
 				/** @type {Expression} */ (context.visit(path.expression?.(b.maybe_call(b.id(arg_alias)))))
 			);
@@ -75,6 +70,7 @@ export function SnippetBlock(node, context) {
 			}
 		}
 	}
+
 	body = b.block([
 		...declarations,
 		.../** @type {BlockStatement} */ (context.visit(node.body, child_state)).body

--- a/packages/svelte/src/internal/client/dev/validation.js
+++ b/packages/svelte/src/internal/client/dev/validation.js
@@ -1,16 +1,14 @@
 import { invalid_snippet_arguments } from '../../shared/errors.js';
 /**
  * @param {Node} anchor
- * @param {number[]} with_fallback_idx
  * @param {...(()=>any)[]} args
  */
-export function validate_snippet_args(anchor, with_fallback_idx, ...args) {
+export function validate_snippet_args(anchor, ...args) {
 	if (typeof anchor !== 'object' || !(anchor instanceof Node)) {
 		invalid_snippet_arguments();
 	}
-	for (let i = 0; i < args.length; i++) {
-		const arg = args[i];
-		if (typeof arg !== 'function' && !(with_fallback_idx.includes(i) && arg === undefined)) {
+	for (let arg of args) {
+		if (typeof arg !== 'function') {
 			invalid_snippet_arguments();
 		}
 	}

--- a/packages/svelte/src/internal/client/dev/validation.js
+++ b/packages/svelte/src/internal/client/dev/validation.js
@@ -1,14 +1,16 @@
 import { invalid_snippet_arguments } from '../../shared/errors.js';
 /**
  * @param {Node} anchor
+ * @param {number[]} with_fallback_idx
  * @param {...(()=>any)[]} args
  */
-export function validate_snippet_args(anchor, ...args) {
+export function validate_snippet_args(anchor, with_fallback_idx, ...args) {
 	if (typeof anchor !== 'object' || !(anchor instanceof Node)) {
 		invalid_snippet_arguments();
 	}
-	for (let arg of args) {
-		if (typeof arg !== 'function') {
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (typeof arg !== 'function' && !(with_fallback_idx.includes(i) && arg === undefined)) {
 			invalid_snippet_arguments();
 		}
 	}

--- a/packages/svelte/tests/runtime-runes/samples/validate-undefined-snippet-default-arg/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/validate-undefined-snippet-default-arg/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<p>default</p>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/validate-undefined-snippet-default-arg/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/validate-undefined-snippet-default-arg/main.svelte
@@ -1,0 +1,5 @@
+{#snippet test(param = "default")}
+    <p>{param}</p>
+{/snippet}
+
+{@render test()}


### PR DESCRIPTION
Closes #15749

Technically we could've avoid all the fallback_idx conundrum and just allow undefined too but this should be more correct most of the times and it's not really a problem since it's mostly in dev. I also thought of using a `Set` instead of an array but it's not really worth it since there will never be a lot of params anyway.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`