### PR TITLE
fix: correctly validate head snippets on the server

### DIFF
--- a/.changeset/dirty-zebras-do.md
+++ b/.changeset/dirty-zebras-do.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly validate head snippets on the server

--- a/packages/svelte/src/internal/server/dev.js
+++ b/packages/svelte/src/internal/server/dev.js
@@ -6,7 +6,7 @@ import {
 } from '../../html-tree-validation.js';
 import { current_component } from './context.js';
 import { invalid_snippet_arguments } from '../shared/errors.js';
-import { Payload } from './payload.js';
+import { HeadPayload, Payload } from './payload.js';
 
 /**
  * @typedef {{
@@ -105,7 +105,11 @@ export function pop_element() {
  * @param {Payload} payload
  */
 export function validate_snippet_args(payload) {
-	if (typeof payload !== 'object' || !(payload instanceof Payload)) {
+	if (
+		typeof payload !== 'object' ||
+		// for some reason typescript consider the type of payload as never after the first instanceof
+		!(payload instanceof Payload || /** @type {any} */ (payload) instanceof HeadPayload)
+	) {
 		invalid_snippet_arguments();
 	}
 }

--- a/packages/svelte/src/internal/server/payload.js
+++ b/packages/svelte/src/internal/server/payload.js
@@ -11,17 +11,6 @@ export class HeadPayload {
 		this.title = title;
 		this.uid = uid;
 	}
-
-	clone() {
-		const payload = new HeadPayload();
-
-		payload.out = this.out;
-		payload.css = new Set(this.css);
-		payload.title = this.title;
-		payload.uid = this.uid;
-
-		return payload;
-	}
 }
 
 export class Payload {
@@ -50,7 +39,11 @@ export function copy_payload({ out, css, head, uid }) {
 	payload.css = new Set(css);
 	payload.uid = uid;
 
-	payload.head = head.clone();
+	payload.head = new HeadPayload();
+	payload.head.out = head.out;
+	payload.head.css = new Set(head.css);
+	payload.head.title = head.title;
+	payload.head.uid = head.uid;
 
 	return payload;
 }

--- a/packages/svelte/src/internal/server/payload.js
+++ b/packages/svelte/src/internal/server/payload.js
@@ -1,16 +1,36 @@
+export class HeadPayload {
+	/** @type {Set<{ hash: string; code: string }>} */
+	css = new Set();
+	out = '';
+	uid = () => '';
+	title = '';
+
+	constructor(css = new Set(), out = '', title = '', uid = () => '') {
+		this.css = css;
+		this.out = out;
+		this.title = title;
+		this.uid = uid;
+	}
+
+	clone() {
+		const payload = new HeadPayload();
+
+		payload.out = this.out;
+		payload.css = new Set(this.css);
+		payload.title = this.title;
+		payload.uid = this.uid;
+
+		return payload;
+	}
+}
+
 export class Payload {
 	/** @type {Set<{ hash: string; code: string }>} */
 	css = new Set();
 	out = '';
 	uid = () => '';
 
-	head = {
-		/** @type {Set<{ hash: string; code: string }>} */
-		css: new Set(),
-		title: '',
-		out: '',
-		uid: () => ''
-	};
+	head = new HeadPayload();
 
 	constructor(id_prefix = '') {
 		this.uid = props_id_generator(id_prefix);
@@ -30,12 +50,7 @@ export function copy_payload({ out, css, head, uid }) {
 	payload.css = new Set(css);
 	payload.uid = uid;
 
-	payload.head = {
-		title: head.title,
-		out: head.out,
-		css: new Set(head.css),
-		uid: head.uid
-	};
+	payload.head = head.clone();
 
 	return payload;
 }

--- a/packages/svelte/tests/runtime-runes/samples/head-payload-validation/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/head-payload-validation/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+	mode: ['server'],
+	async test({ errors, assert }) {
+		assert.equal(errors, []);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/head-payload-validation/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/head-payload-validation/main.svelte
@@ -1,0 +1,7 @@
+{#snippet head()}
+	<title>Cool</title>
+{/snippet}
+
+<svelte:head>
+	{@render head()}
+</svelte:head>


### PR DESCRIPTION
Closes #15753

We could've changed the validation to use something else in case of `head` but i thought it would've been nicer to just refactor the head payload to be a class too (also with a nice `clone` method) so we could check `instanceof`.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`