### PR TITLE
fix: ignore mutation validation for props that are not proxies in more cases

### DIFF
--- a/.changeset/modern-ducks-reflect.md
+++ b/.changeset/modern-ducks-reflect.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ignore mutation validation for props that are not proxies in more cases

--- a/packages/svelte/src/internal/client/dev/ownership.js
+++ b/packages/svelte/src/internal/client/dev/ownership.js
@@ -31,13 +31,14 @@ export function create_ownership_validator(props) {
 				return result;
 			}
 
-			let value = props[name];
+			/** @type {any} */
+			let value = props;
 
-			for (let i = 1; i < path.length - 1; i++) {
+			for (let i = 0; i < path.length - 1; i++) {
+				value = value[path[i]];
 				if (!value?.[STATE_SYMBOL]) {
 					return result;
 				}
-				value = value[path[i]];
 			}
 
 			const location = sanitize_location(`${component[FILENAME]}:${line}:${column}`);

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-ok/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-ok/_config.js
@@ -1,0 +1,18 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, warnings }) {
+		const btn = target.querySelector('button');
+		btn?.click();
+		flushSync();
+
+		assert.deepEqual(warnings, []);
+	},
+
+	warnings: []
+});

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-ok/child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-ok/child.svelte
@@ -1,0 +1,8 @@
+<script>
+	let { klass, getter_setter } = $props();
+</script>
+
+<button onclick={() => {
+	klass.y = 2;
+	getter_setter.y = 2;
+}}>mutate</button>

--- a/packages/svelte/tests/runtime-runes/samples/non-local-mutation-ok/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/non-local-mutation-ok/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	import Child from './child.svelte';
+
+	class X {
+		y = $state(1);
+	}
+
+	const klass = new X();
+
+	let y = $state(1);
+	const getter_setter = {
+		get y() {
+			return y;
+		},
+		set y(value) {
+			y = value;
+		}
+	}
+</script>
+
+<Child {klass}  {getter_setter} />


### PR DESCRIPTION
This fixes an off-by-one error - we did not bail if the top level of the prop wasn't a state already. Fixes #15727

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
