### PR TITLE
docs: correct the suggested type for custom events without detail (Svelte 4)

### DIFF
--- a/.changeset/fifty-buckets-return.md
+++ b/.changeset/fifty-buckets-return.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+correct the suggested type for custom events without detail

--- a/packages/svelte/src/index-client.js
+++ b/packages/svelte/src/index-client.js
@@ -114,7 +114,7 @@ function create_custom_event(type, detail, { bubbles = false, cancelable = false
  * The event dispatcher can be typed to narrow the allowed event names and the type of the `detail` argument:
  * ```ts
  * const dispatch = createEventDispatcher<{
- *  loaded: never; // does not take a detail argument
+ *  loaded: null; // does not take a detail argument
  *  change: string; // takes a detail argument of type string, which is required
  *  optional: number | null; // takes an optional detail argument of type number
  * }>();

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -381,7 +381,7 @@ declare module 'svelte' {
 	 * The event dispatcher can be typed to narrow the allowed event names and the type of the `detail` argument:
 	 * ```ts
 	 * const dispatch = createEventDispatcher<{
-	 *  loaded: never; // does not take a detail argument
+	 *  loaded: null; // does not take a detail argument
 	 *  change: string; // takes a detail argument of type string, which is required
 	 *  optional: number | null; // takes an optional detail argument of type number
 	 * }>();


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it. -> NA
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
    Tests are OK, except for those using Playwright, which I didn't install. Linting crashes for me with an Eslint "Cannot find module" error. I'm holding off on fixing these setup issues, I'm not sure if it's worth it for a one-word docs change.

---

I tried to follow the guidance given by the docs for `createEventDispatcher` to type a custom event without a detail argument. The function documentation mentions that the `never` type can be used for this. However, when doing this, I'm getting a Typescript error `Expected 2-3 arguments, but got 1` when calling `createEventDispatcher`.

I searched the dedicated v4 docs site and found [this section on createEventDispatcher](https://v4.svelte.dev/docs/typescript#script-lang-ts-events) which includes `event: null; // does not accept a payload`. I assume that "payload" & "detail" mean the same thing, and that suggesting to use "never" was a mistake in the function docs (or something that was never updated). With "null" it works as expected! 