### PR TITLE
fix: avoid unnecessary read version increments

### DIFF
--- a/.changeset/sweet-adults-complain.md
+++ b/.changeset/sweet-adults-complain.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid unnecessary read version increments

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -469,7 +469,7 @@ export function update_reaction(reaction) {
 		// we need to increment the read version to ensure that
 		// any dependencies in this reaction aren't marked with
 		// the same version
-		if (previous_reaction !== reaction) {
+		if (previous_reaction !== null && previous_reaction !== reaction) {
 			read_version++;
 
 			if (untracked_writes !== null) {


### PR DESCRIPTION
Fixes #15262

Apologies @trueadm , you were right in #15694 that the check was _not_ redundant, my suggestion was wrong. `reaction` cannot be `null`, so when `previous_reaction` is `null` the check was now `true` when it should've been `false`. Therefore reinstating this check.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
