### PR TITLE
fix: ensure `<svelte:boundary>` properly removes error content in production mode

### DIFF
--- a/.changeset/eleven-roses-speak.md
+++ b/.changeset/eleven-roses-speak.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure <svelte:boundary> properly removes error content in production mode

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -291,31 +291,21 @@ export function handle_error(error, effect, previous_effect, component_context) 
 		is_throwing_error = true;
 	}
 
-	if (
-		!DEV ||
-		component_context === null ||
-		!(error instanceof Error) ||
-		handled_errors.has(error)
-	) {
-		propagate_error(error, effect);
-		return;
-	}
+	if (DEV && component_context !== null && error instanceof Error && !handled_errors.has(error)) {
+		handled_errors.add(error);
 
-	handled_errors.add(error);
+		const component_stack = [];
 
-	const component_stack = [];
+		const effect_name = effect.fn?.name;
 
-	const effect_name = effect.fn?.name;
+		if (effect_name) {
+			component_stack.push(effect_name);
+		}
 
-	if (effect_name) {
-		component_stack.push(effect_name);
-	}
+		/** @type {ComponentContext | null} */
+		let current_context = component_context;
 
-	/** @type {ComponentContext | null} */
-	let current_context = component_context;
-
-	while (current_context !== null) {
-		if (DEV) {
+		while (current_context !== null) {
 			/** @type {string} */
 			var filename = current_context.function?.[FILENAME];
 
@@ -323,35 +313,36 @@ export function handle_error(error, effect, previous_effect, component_context) 
 				const file = filename.split('/').pop();
 				component_stack.push(file);
 			}
+
+			current_context = current_context.p;
 		}
 
-		current_context = current_context.p;
-	}
-
-	const indent = is_firefox ? '  ' : '\t';
-	define_property(error, 'message', {
-		value: error.message + `\n${component_stack.map((name) => `\n${indent}in ${name}`).join('')}\n`
-	});
-	define_property(error, 'component_stack', {
-		value: component_stack
-	});
-
-	const stack = error.stack;
-
-	// Filter out internal files from callstack
-	if (stack) {
-		const lines = stack.split('\n');
-		const new_lines = [];
-		for (let i = 0; i < lines.length; i++) {
-			const line = lines[i];
-			if (line.includes('svelte/src/internal')) {
-				continue;
-			}
-			new_lines.push(line);
-		}
-		define_property(error, 'stack', {
-			value: new_lines.join('\n')
+		const indent = is_firefox ? '  ' : '\t';
+		define_property(error, 'message', {
+			value:
+				error.message + `\n${component_stack.map((name) => `\n${indent}in ${name}`).join('')}\n`
 		});
+		define_property(error, 'component_stack', {
+			value: component_stack
+		});
+
+		const stack = error.stack;
+
+		// Filter out internal files from callstack
+		if (stack) {
+			const lines = stack.split('\n');
+			const new_lines = [];
+			for (let i = 0; i < lines.length; i++) {
+				const line = lines[i];
+				if (line.includes('svelte/src/internal')) {
+					continue;
+				}
+				new_lines.push(line);
+			}
+			define_property(error, 'stack', {
+				value: new_lines.join('\n')
+			});
+		}
 	}
 
 	propagate_error(error, effect);

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-22/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-22/Child.svelte
@@ -1,0 +1,3 @@
+<script>
+	throw new Error();
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-22/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-22/_config.js
@@ -1,0 +1,11 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	test({ assert, target }) {
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, '<p>error occurred</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-22/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-22/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	import Child from "./Child.svelte"
+</script>
+
+<svelte:boundary>
+	<p>This should be removed</p>
+
+	{#if true}
+		<Child />
+	{/if}
+
+	{#snippet failed()}
+		<p>error occurred</p>
+	{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
fixes #15674 

When `DEV=false`, the `should_rethrow_error` check wasn't being performed, which led to errors during the initial mount not triggering `destroy_effect`. This prevented proper removal of elements inside the boundary. I belive this issue relates to commit 10897ac38c3c2828558329b345368372bcf2412d.

To address this, I've moved the DEV-specific logic into an explicit `if` block to distinguishes between DEV and non-DEV behaviors, ensuring consistency across both scenarios.

I couldn't run test with `DEV=false` because `DEV` is controlled by the `NODE_ENV=production` via `esm-env`. So I've added a test case to simulate a similar condition by creating an error scenario where `component_context` is `null`.


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
