### PR TITLE
feat: more complex partial evaluation

### DIFF
--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -122,6 +122,7 @@ function to_public_ast(source, ast, modern) {
 	if (modern) {
 		const clean = (/** @type {any} */ node) => {
 			delete node.metadata;
+			delete node.type_information;
 		};
 
 		ast.options?.attributes.forEach((attribute) => {

--- a/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
+++ b/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
@@ -20,8 +20,25 @@ const visitors = {
 	_(node, context) {
 		const n = context.next() ?? node;
 
-		// TODO there may come a time when we decide to preserve type annotations.
-		// until that day comes, we just delete them so they don't confuse esrap
+		const type_information = {};
+		if (Object.hasOwn(n, 'typeAnnotation')) {
+			type_information.annotation = n.typeAnnotation;
+		}
+		if (Object.hasOwn(n, 'typeParameters')) {
+			type_information.parameters = n.typeParameters;
+		}
+		if (Object.hasOwn(n, 'typeArguments')) {
+			type_information.arguments = n.typeArguments;
+		}
+		if (Object.hasOwn(n, 'returnType')) {
+			type_information.return = n.returnType;
+		}
+		Object.defineProperty(n, 'type_information', {
+			value: type_information,
+			writable: true,
+			configurable: true,
+			enumerable: false
+		});
 		delete n.typeAnnotation;
 		delete n.typeParameters;
 		delete n.typeArguments;

--- a/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
+++ b/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
@@ -43,6 +43,7 @@ const visitors = {
 		delete n.typeParameters;
 		delete n.typeArguments;
 		delete n.returnType;
+		// TODO figure out what this is exactly, and if it should be added to `type_information`
 		delete n.accessibility;
 	},
 	Decorator(node) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock_unfinished.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock_unfinished.js
@@ -14,7 +14,9 @@ export function IfBlock(node, context) {
 	const consequent = /** @type {BlockStatement} */ (context.visit(node.consequent));
 	context.state.template.push('<!>');
 	if (evaluated.is_truthy) {
-		context.state.init.push(b.stmt(b.call(b.arrow([b.id('$$anchor')], consequent), context.state.node)));
+		context.state.init.push(
+			b.stmt(b.call(b.arrow([b.id('$$anchor')], consequent), context.state.node))
+		);
 	} else {
 		const statements = [];
 		const consequent_id = context.state.scope.generate('consequent');

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock_unfinished.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock_unfinished.js
@@ -1,0 +1,82 @@
+/** @import { BlockStatement, Expression } from 'estree' */
+/** @import { AST } from '#compiler' */
+/** @import { ComponentContext } from '../types' */
+import * as b from '#compiler/builders';
+
+/**
+ * @param {AST.IfBlock} node
+ * @param {ComponentContext} context
+ */
+export function IfBlock(node, context) {
+	const test = /** @type {Expression} */ (context.visit(node.test));
+	const evaluated = context.state.scope.evaluate(test);
+
+	const consequent = /** @type {BlockStatement} */ (context.visit(node.consequent));
+	context.state.template.push('<!>');
+	if (evaluated.is_truthy) {
+		context.state.init.push(b.stmt(b.call(b.arrow([b.id('$$anchor')], consequent), context.state.node)));
+	} else {
+		const statements = [];
+		const consequent_id = context.state.scope.generate('consequent');
+		statements.push(b.var(b.id(consequent_id), b.arrow([b.id('$$anchor')], consequent)));
+
+		let alternate_id;
+
+		if (node.alternate) {
+			alternate_id = context.state.scope.generate('alternate');
+			const alternate = /** @type {BlockStatement} */ (context.visit(node.alternate));
+			const nodes = node.alternate.nodes;
+
+			let alternate_args = [b.id('$$anchor')];
+			if (nodes.length === 1 && nodes[0].type === 'IfBlock' && nodes[0].elseif) {
+				alternate_args.push(b.id('$$elseif'));
+			}
+
+			statements.push(b.var(b.id(alternate_id), b.arrow(alternate_args, alternate)));
+		}
+
+		/** @type {Expression[]} */
+		const args = [
+			node.elseif ? b.id('$$anchor') : context.state.node,
+			b.arrow(
+				[b.id('$$render')],
+				b.block([
+					b.if(
+						test,
+						b.stmt(b.call(b.id('$$render'), b.id(consequent_id))),
+						alternate_id ? b.stmt(b.call(b.id('$$render'), b.id(alternate_id), b.false)) : undefined
+					)
+				])
+			)
+		];
+
+		if (node.elseif) {
+			// We treat this...
+			//
+			//   {#if x}
+			//     ...
+			//   {:else}
+			//     {#if y}
+			//       <div transition:foo>...</div>
+			//     {/if}
+			//   {/if}
+			//
+			// ...slightly differently to this...
+			//
+			//   {#if x}
+			//     ...
+			//   {:else if y}
+			//     <div transition:foo>...</div>
+			//   {/if}
+			//
+			// ...even though they're logically equivalent. In the first case, the
+			// transition will only play when `y` changes, but in the second it
+			// should play when `x` or `y` change — both are considered 'local'
+			args.push(b.id('$$elseif'));
+		}
+
+		statements.push(b.stmt(b.call('$.if', ...args)));
+
+		context.state.init.push(b.block(statements));
+	}
+}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -78,7 +78,7 @@ export function build_template_chunk(
 				// If we have a single expression, then pass that in directly to possibly avoid doing
 				// extra work in the template_effect (instead we do the work in set_text).
 				if (evaluated.is_known) {
-					value = b.literal(evaluated.value);
+					value = b.literal(evaluated.value ?? '');
 				}
 
 				return { value, has_state };
@@ -97,7 +97,7 @@ export function build_template_chunk(
 			}
 
 			if (evaluated.is_known) {
-				quasi.value.cooked += evaluated.value + '';
+				quasi.value.cooked += (evaluated.value ?? '') + '';
 			} else {
 				if (!evaluated.is_defined) {
 					// add `?? ''` where necessary

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -64,12 +64,13 @@ export function build_template_chunk(
 			node.expression.name !== 'undefined' ||
 			state.scope.get('undefined')
 		) {
-			let value = memoize(
-				/** @type {Expression} */ (visit(node.expression, state)),
-				node.metadata.expression
-			);
+			let value = /** @type {Expression} */ (visit(node.expression, state));
 
 			const evaluated = state.scope.evaluate(value);
+
+			if (!evaluated.is_known) {
+				value = memoize(value, node.metadata.expression);
+			}
 
 			has_state ||= node.metadata.expression.has_state && !evaluated.is_known;
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/IfBlock_unfinished.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/IfBlock_unfinished.js
@@ -1,0 +1,54 @@
+/** @import { BlockStatement, Expression } from 'estree' */
+/** @import { AST } from '#compiler' */
+/** @import { ComponentContext } from '../types.js' */
+import { BLOCK_OPEN_ELSE } from '../../../../../internal/server/hydration.js';
+import * as b from '#compiler/builders';
+import { block_close, block_open } from './shared/utils.js';
+import { needs_new_scope } from '../../utils.js';
+
+/**
+ * @param {AST.IfBlock} node
+ * @param {ComponentContext} context
+ */
+export function IfBlock(node, context) {
+	const consequent = /** @type {BlockStatement} */ (context.visit(node.consequent));
+	const test = /** @type {Expression} */ (context.visit(node.test));
+	const evaluated = context.state.scope.evaluate(test);
+	if (evaluated.is_truthy) {
+		if (needs_new_scope(consequent)) {
+			context.state.template.push(consequent);
+		} else {
+			context.state.template.push(...consequent.body);
+		}
+	} else {
+		consequent.body.unshift(b.stmt(b.assignment('+=', b.id('$$payload.out'), block_open)));
+		let if_statement = b.if(test, consequent);
+
+		context.state.template.push(if_statement, block_close);
+
+		let index = 1;
+		let alt = node.alternate;
+		while (
+			alt &&
+			alt.nodes.length === 1 &&
+			alt.nodes[0].type === 'IfBlock' &&
+			alt.nodes[0].elseif
+		) {
+			const elseif = alt.nodes[0];
+			const alternate = /** @type {BlockStatement} */ (context.visit(elseif.consequent));
+			alternate.body.unshift(
+				b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal(`<!--[${index++}-->`)))
+			);
+			if_statement = if_statement.alternate = b.if(
+				/** @type {Expression} */ (context.visit(elseif.test)),
+				alternate
+			);
+			alt = elseif.alternate;
+		}
+
+		if_statement.alternate = alt ? /** @type {BlockStatement} */ (context.visit(alt)) : b.block([]);
+		if_statement.alternate.body.unshift(
+			b.stmt(b.assignment('+=', b.id('$$payload.out'), b.literal(BLOCK_OPEN_ELSE)))
+		);
+	}
+}

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -488,12 +488,12 @@ export function transform_inspect_rune(node, context) {
 }
 
 /**
- * Whether a `BlockStatement` needs to be a block statement as opposed to just inlining all of its statements. 
+ * Whether a `BlockStatement` needs to be a block statement as opposed to just inlining all of its statements.
  * @param {BlockStatement} block
  */
 export function needs_new_scope(block) {
-	const has_vars = block.body.some(child => child.type === 'VariableDeclaration');
-	const has_fns = block.body.some(child => child.type === 'FunctionDeclaration');
-	const has_class = block.body.some(child => child.type === 'ClassDeclaration');
+	const has_vars = block.body.some((child) => child.type === 'VariableDeclaration');
+	const has_fns = block.body.some((child) => child.type === 'FunctionDeclaration');
+	const has_class = block.body.some((child) => child.type === 'ClassDeclaration');
 	return has_vars || has_fns || has_class;
 }

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -1,7 +1,7 @@
 /** @import { Context } from 'zimmerframe' */
 /** @import { TransformState } from './types.js' */
 /** @import { AST, Binding, Namespace, ValidatedCompileOptions } from '#compiler' */
-/** @import { Node, Expression, CallExpression } from 'estree' */
+/** @import { Node, Expression, CallExpression, BlockStatement } from 'estree' */
 import {
 	regex_ends_with_whitespaces,
 	regex_not_whitespace,
@@ -485,4 +485,15 @@ export function transform_inspect_rune(node, context) {
 		const arg = node.arguments.map((arg) => /** @type {Expression} */ (visit(arg)));
 		return b.call('$.inspect', as_fn ? b.thunk(b.array(arg)) : b.array(arg));
 	}
+}
+
+/**
+ * Whether a `BlockStatement` needs to be a block statement as opposed to just inlining all of its statements. 
+ * @param {BlockStatement} block
+ */
+export function needs_new_scope(block) {
+	const has_vars = block.body.some(child => child.type === 'VariableDeclaration');
+	const has_fns = block.body.some(child => child.type === 'FunctionDeclaration');
+	const has_class = block.body.some(child => child.type === 'ClassDeclaration');
+	return has_vars || has_fns || has_class;
 }

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -122,7 +122,6 @@ const prototype_methods = {
 		substring: [STRING, call_bind(string_proto.substring)],
 		trimEnd: [STRING, call_bind(string_proto.trimEnd)],
 		trimStart: [STRING, call_bind(string_proto.trimStart)],
-		toWellFormed: [STRING, call_bind(string_proto.toWellFormed)],
 		//@ts-ignore
 		valueOf: [STRING, call_bind(string_proto.valueOf)]
 	},

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -616,7 +616,7 @@ class Evaluation {
 								);
 							if (fn && fn.async === false && !fn?.generator) {
 								const analysis = evaluate_function(fn, binding); // typescript won't tell you if a function is pure or if it could throw, so we have to do this regardless of type annotations
-								console.log({ fn, binding, analysis });
+								// console.log({ fn, binding, analysis });
 								if (!analysis.pure || !analysis.never_throws) {
 									// if its not pure, or we don't know if it could throw, we can't use any constant return values from the evaluation, but we can check if its nullish
 									this.values.add(NOT_NULL); // `NOT_NULL` doesn't have precedence over `UNKNOWN`, so if the value is nullish, this won't have precedence
@@ -1718,7 +1718,7 @@ function evaluate_function(fn, binding, stack = new Set(), [...seen_bindings] = 
 	 * - While currently all the globals we have are pure and error-free, that could change, so we shouldn't be too dependent on that in the future.
 	 * 	Things like `JSON.stringify` and a *lot* of array methods are prime examples. 
 	 */
-	1;
+	let thing;
 	const analysis = {
 		pure: true,
 		is_known: false,

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -1011,7 +1011,7 @@ export class Scope {
 	/**
 	 * A set of all the names referenced with this scope
 	 * — useful for generating unique names
-	 * @type {Map<string, { node: Identifier; path: AST.SvelteNode[] }[]>}
+	 * @type {Map<string, { node: Identifier; path: AST.SvelteNode[], scope: Scope }[]>}
 	 */
 	references = new Map();
 
@@ -1145,7 +1145,7 @@ export class Scope {
 
 		if (!references) this.references.set(node.name, (references = []));
 
-		references.push({ node, path });
+		references.push({ node, path, scope: this });
 
 		const binding = this.declarations.get(node.name);
 		if (binding) {

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -21,6 +21,7 @@ const UNKNOWN = Symbol('unknown');
 /** Includes `BigInt` */
 export const NUMBER = Symbol('number');
 export const STRING = Symbol('string');
+const NOT_NULL = Symbol('not null');
 /** @typedef {NUMBER | STRING | UNKNOWN | undefined | boolean} TYPE */
 /** @type {Record<string, [type: TYPE | TYPE[], fn?: Function]>} */
 const globals = {
@@ -296,6 +297,11 @@ class Evaluation {
 
 					if (!binding.updated && binding.initial !== null && !is_prop) {
 						binding.scope.evaluate(/** @type {Expression} */ (binding.initial), this.values);
+						break;
+					}
+
+					if (binding.kind === 'rest_prop' && !binding.updated) {
+						this.values.add(NOT_NULL);
 						break;
 					}
 				} else if (expression.name === 'undefined') {

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -22,7 +22,6 @@ const UNKNOWN = Symbol('unknown');
 export const NUMBER = Symbol('number');
 export const STRING = Symbol('string');
 /** @typedef {NUMBER | STRING | UNKNOWN | undefined | boolean} TYPE */
-
 /** @type {Record<string, [type: TYPE | TYPE[], fn?: Function]>} */
 const globals = {
 	BigInt: [NUMBER, BigInt],
@@ -70,6 +69,8 @@ const globals = {
 	'Number.isSafeInteger': [NUMBER, Number.isSafeInteger],
 	'Number.parseFloat': [NUMBER, Number.parseFloat],
 	'Number.parseInt': [NUMBER, Number.parseInt],
+	'Object.is': [[true, false], Object.is],
+	'Object.hasOwn': [[true, false], Object.hasOwn],
 	String: [STRING, String],
 	'String.fromCharCode': [STRING, String.fromCharCode],
 	'String.fromCodePoint': [STRING, String.fromCodePoint]
@@ -605,6 +606,9 @@ class Evaluation {
 
 				if (keypath && Object.hasOwn(global_constants, keypath)) {
 					this.values.add(global_constants[keypath]);
+					break;
+				} else if (keypath?.match(/\.name$/) && Object.hasOwn(globals, keypath.slice(0, -5))) {
+					this.values.add(globals[keypath.slice(0, -5)]?.[1]?.name ?? STRING);
 					break;
 				}
 

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -1698,7 +1698,7 @@ function evaluate_function(fn, binding, stack = new Set(), [...seen_bindings] = 
 	/**
 	 * This big blob of comments is for my (https://github.com/Ocean-OS) sanity and for that of anyone who tries working with this function. Feel free to modify this as the function evolves.
 	 * So, when evaluating functions at compile-time, there are a few things you have to avoid evaluating:
-	 * 
+	 *
 	 * - Side effects
 	 * 	A function that modifies state from outside of its scope should not be evaluated.
 	 * 	Additionally, since `$effect`s and `$derived`s exist, any reference to an external value could lead to a missed dependency if the function is evaluated by the compiler.
@@ -1706,17 +1706,17 @@ function evaluate_function(fn, binding, stack = new Set(), [...seen_bindings] = 
 	 * 	A function that could throw an error should not be evaluated. Additionally, `$derived`s could be reevaluated upon reading, which could throw an error.
 	 * 	The purpose of a compile-time evaluator is to replicate the behavior the function would have at runtime, but in compile time.
 	 * 	If an error is/could be thrown, that can not be replicated.
-	 * 
+	 *
 	 * So, how do we figure out if either of these things (could) happen in a function?
 	 * Well, for errors, it's relatively simple. If a `throw` statement is used in the function, then we assume that the error could be thrown at any time.
 	 * For side effects, it gets a bit tricky. External `Identifier`s that change their value are definitely side effects, but also any `MemberExpression` that isn't a known global constant could have a side effect, due to getters and `Proxy`s.
 	 * Additionally, since a function can call other functions, we check each individual function call: if it's a known global, we know its pure, and if we can find its definition, the parent function inherits its throwability and purity. If we cannot find its definition, we assume it is impure and could throw.
-	 * 
+	 *
 	 * A few other things to note/remember:
 	 * - Not all functions rely on return statements to determine the return value.
 	 * 	Arrow functions without a `BlockStatement` for a body use their expression body as an implicit `ReturnStatement`.
 	 * - While currently all the globals we have are pure and error-free, that could change, so we shouldn't be too dependent on that in the future.
-	 * 	Things like `JSON.stringify` and a *lot* of array methods are prime examples. 
+	 * 	Things like `JSON.stringify` and a *lot* of array methods are prime examples.
 	 */
 	let thing;
 	const analysis = {
@@ -1811,7 +1811,7 @@ function evaluate_function(fn, binding, stack = new Set(), [...seen_bindings] = 
 					}
 					if (
 						binding.scope !== fn_scope &&
-						!binding.updated && 
+						!binding.updated &&
 						context.state.current_call === 0 &&
 						!seen_bindings.includes(binding)
 					) {

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -70,7 +70,6 @@ const globals = {
 	'Number.parseFloat': [NUMBER, Number.parseFloat],
 	'Number.parseInt': [NUMBER, Number.parseInt],
 	'Object.is': [[true, false], Object.is],
-	'Object.hasOwn': [[true, false], Object.hasOwn],
 	String: [STRING, String],
 	'String.fromCharCode': [STRING, String.fromCharCode],
 	'String.fromCodePoint': [STRING, String.fromCodePoint]
@@ -117,7 +116,6 @@ const prototype_methods = {
 		startsWith: [[true, false], call_bind(string_proto.startsWith)],
 		endsWith: [[true, false], call_bind(string_proto.endsWith)],
 		isWellFormed: [[true, false], call_bind(string_proto.isWellFormed)],
-		lastIndexOf: [NUMBER, call_bind(string_proto.lastIndexOf)],
 		normalize: [STRING, call_bind(string_proto.normalize)],
 		padEnd: [STRING, call_bind(string_proto.padEnd)],
 		padStart: [STRING, call_bind(string_proto.padStart)],

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -115,7 +115,6 @@ const prototype_methods = {
 		codePointAt: [[NUMBER, undefined], call_bind(string_proto.codePointAt)],
 		startsWith: [[true, false], call_bind(string_proto.startsWith)],
 		endsWith: [[true, false], call_bind(string_proto.endsWith)],
-		isWellFormed: [[true, false], call_bind(string_proto.isWellFormed)],
 		normalize: [STRING, call_bind(string_proto.normalize)],
 		padEnd: [STRING, call_bind(string_proto.padEnd)],
 		padStart: [STRING, call_bind(string_proto.padStart)],

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -1495,13 +1495,7 @@ function get_type_of_ts_node(node, scope) {
 			return STRING;
 		case 'TSLiteralType':
 			return node.literal.type === 'Literal'
-				? typeof node.literal.value === 'string'
-					? STRING
-					: ['number', 'bigint'].includes(typeof node.literal.value)
-						? NUMBER
-						: typeof node.literal.value === 'boolean'
-							? [true, false]
-							: UNKNOWN
+				? node.literal.value
 				: node.literal.type === 'TemplateLiteral'
 					? STRING
 					: UNKNOWN;
@@ -1510,6 +1504,8 @@ function get_type_of_ts_node(node, scope) {
 		case 'TSNeverKeyword':
 		case 'TSVoidKeyword':
 			return undefined;
+		case 'TSNullKeyword':
+			return null;
 		default:
 			return UNKNOWN;
 	}

--- a/packages/svelte/tests/snapshot/samples/each-index-non-null/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/each-index-non-null/_expected/server/index.svelte.js
@@ -6,7 +6,7 @@ export default function Each_index_non_null($$payload) {
 	$$payload.out += `<!--[-->`;
 
 	for (let i = 0, $$length = each_array.length; i < $$length; i++) {
-		$$payload.out += `<p>index: ${$.escape(i)}</p>`;
+		$$payload.out += `<p>index: ${i}</p>`;
 	}
 
 	$$payload.out += `<!--]-->`;

--- a/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/client/index.svelte.js
@@ -18,7 +18,7 @@ export default function Text_nodes_deriveds($$anchor) {
 	var p = root();
 	var text = $.child(p);
 
+	text.nodeValue = '00';
 	$.reset(p);
-	$.template_effect(($0, $1) => $.set_text(text, `${$0 ?? ''}${$1 ?? ''}`), [text1, text2]);
 	$.append($$anchor, p);
 }

--- a/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/text-nodes-deriveds/_expected/server/index.svelte.js
@@ -12,5 +12,5 @@ export default function Text_nodes_deriveds($$payload) {
 		return count2;
 	}
 
-	$$payload.out += `<p>${$.escape(text1())}${$.escape(text2())}</p>`;
+	$$payload.out += `<p>00</p>`;
 }


### PR DESCRIPTION
Like #15781, this PR will add more partial evaluation to the compiler. Some of the goals here are:
- [x] Prototype methods for literals:
```svelte
<script>
    let greeting = 'Hello, world!';
</script>
<h1>Hello, {greeting.slice(-6)}</h1> <!-- compiled to Hello, world! -->
```
- [ ] Maybe more globals? 
- [x] Function analysis
- [ ] Maybe TypeScript type annotations/assertions? 
- [ ] Maybe add evaluated stuff to the template?

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
