### PR TITLE
fix: rewrite destructuring logic to handle iterators

### DIFF
--- a/.changeset/serious-moles-yell.md
+++ b/.changeset/serious-moles-yell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: wrap array destructuring in spread to avoid iterator edge case

--- a/.changeset/serious-moles-yell.md
+++ b/.changeset/serious-moles-yell.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: wrap array destructuring in spread to avoid iterator edge case
+fix: rewrite destructuring logic to handle iterators

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -2,7 +2,7 @@
 /** @import { Binding } from '#compiler' */
 /** @import { ComponentClientTransformState, ComponentContext } from '../types' */
 import { dev } from '../../../../state.js';
-import { extract_paths } from '../../../../utils/ast.js';
+import { extract_paths, is_array } from '../../../../utils/ast.js';
 import * as b from '#compiler/builders';
 import * as assert from '../../../../utils/assert.js';
 import { get_rune } from '../../../scope.js';
@@ -142,7 +142,7 @@ export function VariableDeclaration(node, context) {
 					);
 				} else {
 					const tmp = context.state.scope.generate('tmp');
-					const paths = extract_paths(declarator.id);
+					const paths = extract_paths(declarator.id, is_array(value, context.state.scope));
 					declarations.push(
 						b.declarator(b.id(tmp), value),
 						...paths.map((path) => {
@@ -170,7 +170,10 @@ export function VariableDeclaration(node, context) {
 						)
 					);
 				} else {
-					const bindings = extract_paths(declarator.id);
+					const bindings = extract_paths(
+						declarator.id,
+						rune === '$derived' ? is_array(value, context.state.scope) : false
+					);
 
 					const init = /** @type {CallExpression} */ (declarator.init);
 
@@ -305,7 +308,7 @@ function create_state_declarators(declarator, { scope, analysis }, value) {
 	}
 
 	const tmp = scope.generate('tmp');
-	const paths = extract_paths(declarator.id);
+	const paths = extract_paths(declarator.id, is_array(declarator.init, scope));
 	return [
 		b.declarator(b.id(tmp), value),
 		...paths.map((path) => {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -2,7 +2,7 @@
 /** @import { Binding } from '#compiler' */
 /** @import { ComponentClientTransformState, ComponentContext } from '../types' */
 import { dev } from '../../../../state.js';
-import { extract_paths, is_array } from '../../../../utils/ast.js';
+import { build_pattern, extract_paths } from '../../../../utils/ast.js';
 import * as b from '#compiler/builders';
 import * as assert from '../../../../utils/assert.js';
 import { get_rune } from '../../../scope.js';
@@ -141,20 +141,20 @@ export function VariableDeclaration(node, context) {
 						b.declarator(declarator.id, create_state_declarator(declarator.id, value))
 					);
 				} else {
-					const tmp = context.state.scope.generate('tmp');
-					const paths = extract_paths(declarator.id, is_array(value, context.state.scope));
+					const [pattern, replacements] = build_pattern(declarator.id, context.state.scope);
 					declarations.push(
-						b.declarator(b.id(tmp), value),
-						...paths.map((path) => {
-							const value = path.expression?.(b.id(tmp));
-							const binding = context.state.scope.get(/** @type {Identifier} */ (path.node).name);
-							return b.declarator(
-								path.node,
-								binding?.kind === 'state' || binding?.kind === 'raw_state'
-									? create_state_declarator(binding.node, value)
-									: value
-							);
-						})
+						b.declarator(pattern, value),
+						.../** @type {[Identifier, Identifier][]} */ ([...replacements]).map(
+							([original, replacement]) => {
+								const binding = context.state.scope.get(original.name);
+								return b.declarator(
+									original,
+									binding?.kind === 'state' || binding?.kind === 'raw_state'
+										? create_state_declarator(binding.node, replacement)
+										: replacement
+								);
+							}
+						)
 					);
 				}
 
@@ -170,11 +170,7 @@ export function VariableDeclaration(node, context) {
 						)
 					);
 				} else {
-					const bindings = extract_paths(
-						declarator.id,
-						rune === '$derived' ? is_array(value, context.state.scope) : false
-					);
-
+					const [pattern, replacements] = build_pattern(declarator.id, context.state.scope);
 					const init = /** @type {CallExpression} */ (declarator.init);
 
 					/** @type {Identifier} */
@@ -192,10 +188,16 @@ export function VariableDeclaration(node, context) {
 						);
 					}
 
-					for (let i = 0; i < bindings.length; i++) {
-						const binding = bindings[i];
+					for (let i = 0; i < replacements.size; i++) {
+						const [original, replacement] = [...replacements][i];
 						declarations.push(
-							b.declarator(binding.node, b.call('$.derived', b.thunk(binding.expression(rhs))))
+							b.declarator(
+								original,
+								b.call(
+									'$.derived',
+									b.arrow([], b.block([b.let(pattern, rhs), b.return(replacement)]))
+								)
+							)
 						);
 					}
 				}
@@ -307,24 +309,19 @@ function create_state_declarators(declarator, { scope, analysis }, value) {
 		];
 	}
 
-	const tmp = scope.generate('tmp');
-	const paths = extract_paths(declarator.id, true);
+	const [pattern, replacements] = build_pattern(declarator.id, scope);
 	return [
-		b.declarator(
-			b.id(tmp),
-			declarator.id.type === 'ArrayPattern' && !is_array(value, scope)
-				? b.array([b.spread(value)])
-				: value
-		),
-		...paths.map((path) => {
-			const value = path.expression?.(b.id(tmp));
-			const binding = scope.get(/** @type {Identifier} */ (path.node).name);
-			return b.declarator(
-				path.node,
-				binding?.kind === 'state'
-					? b.call('$.mutable_source', value, analysis.immutable ? b.true : undefined)
-					: value
-			);
-		})
+		b.declarator(pattern, value),
+		.../** @type {[Identifier, Identifier][]} */ ([...replacements]).map(
+			([original, replacement]) => {
+				const binding = scope.get(original.name);
+				return b.declarator(
+					original,
+					binding?.kind === 'state'
+						? b.call('$.mutable_source', replacement, analysis.immutable ? b.true : undefined)
+						: replacement
+				);
+			}
+		)
 	];
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -308,9 +308,14 @@ function create_state_declarators(declarator, { scope, analysis }, value) {
 	}
 
 	const tmp = scope.generate('tmp');
-	const paths = extract_paths(declarator.id, is_array(declarator.init, scope));
+	const paths = extract_paths(declarator.id, true);
 	return [
-		b.declarator(b.id(tmp), value),
+		b.declarator(
+			b.id(tmp),
+			declarator.id.type === 'ArrayPattern' && !is_array(value, scope)
+				? b.array([b.spread(value)])
+				: value
+		),
 		...paths.map((path) => {
 			const value = path.expression?.(b.id(tmp));
 			const binding = scope.get(/** @type {Identifier} */ (path.node).name);

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
@@ -182,9 +182,14 @@ function create_state_declarators(declarator, scope, value) {
 	}
 
 	const tmp = scope.generate('tmp');
-	const paths = extract_paths(declarator.id, is_array(declarator.init, scope));
+	const paths = extract_paths(declarator.id, true);
 	return [
-		b.declarator(b.id(tmp), value), // TODO inject declarator for opts, so we can use it below
+		b.declarator(
+			b.id(tmp),
+			declarator.id.type === 'ArrayPattern' && !is_array(value, scope)
+				? b.array([b.spread(value)])
+				: value
+		), // TODO inject declarator for opts, so we can use it below
 		...paths.map((path) => {
 			const value = path.expression?.(b.id(tmp));
 			return b.declarator(path.node, value);

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/VariableDeclaration.js
@@ -2,7 +2,7 @@
 /** @import { Binding } from '#compiler' */
 /** @import { Context } from '../types.js' */
 /** @import { Scope } from '../../../scope.js' */
-import { build_fallback, extract_paths } from '../../../../utils/ast.js';
+import { build_fallback, extract_paths, is_array } from '../../../../utils/ast.js';
 import * as b from '#compiler/builders';
 import { get_rune } from '../../../scope.js';
 import { walk } from 'zimmerframe';
@@ -182,7 +182,7 @@ function create_state_declarators(declarator, scope, value) {
 	}
 
 	const tmp = scope.generate('tmp');
-	const paths = extract_paths(declarator.id);
+	const paths = extract_paths(declarator.id, is_array(declarator.init, scope));
 	return [
 		b.declarator(b.id(tmp), value), // TODO inject declarator for opts, so we can use it below
 		...paths.map((path) => {

--- a/packages/svelte/src/compiler/phases/3-transform/shared/assignments.js
+++ b/packages/svelte/src/compiler/phases/3-transform/shared/assignments.js
@@ -1,7 +1,7 @@
-/** @import { AssignmentExpression, AssignmentOperator, Expression, Node, Pattern } from 'estree' */
+/** @import { AssignmentExpression, AssignmentOperator, Expression, Identifier, Node, Pattern } from 'estree' */
 /** @import { Context as ClientContext } from '../client/types.js' */
 /** @import { Context as ServerContext } from '../server/types.js' */
-import { extract_paths, is_array, is_expression_async } from '../../../utils/ast.js';
+import { build_pattern, is_expression_async } from '../../../utils/ast.js';
 import * as b from '#compiler/builders';
 
 /**
@@ -23,24 +23,23 @@ export function visit_assignment_expression(node, context, build_assignment) {
 
 		let changed = false;
 
-		const assignments = extract_paths(
-			node.left,
-			!should_cache && is_array(value, context.state.scope)
-		).map((path) => {
-			const value = path.expression?.(rhs);
+		const [pattern, replacements] = build_pattern(node.left, context.state.scope);
 
-			let assignment = build_assignment('=', path.node, value, context);
-			if (assignment !== null) changed = true;
-
-			return (
-				assignment ??
-				b.assignment(
-					'=',
-					/** @type {Pattern} */ (context.visit(path.node)),
-					/** @type {Expression} */ (context.visit(value))
-				)
-			);
-		});
+		const assignments = [
+			b.let(pattern, rhs),
+			...[...replacements].map(([original, replacement]) => {
+				let assignment = build_assignment(node.operator, original, replacement, context);
+				if (assignment !== null) changed = true;
+				return b.stmt(
+					assignment ??
+						b.assignment(
+							'=',
+							/** @type {Identifier} */ (context.visit(original)),
+							/** @type {Expression} */ (context.visit(replacement))
+						)
+				);
+			})
+		];
 
 		if (!changed) {
 			// No change to output -> nothing to transform -> we can keep the original assignment
@@ -48,32 +47,32 @@ export function visit_assignment_expression(node, context, build_assignment) {
 		}
 
 		const is_standalone = /** @type {Node} */ (context.path.at(-1)).type.endsWith('Statement');
-		const sequence = b.sequence(assignments);
+		const block = b.block(assignments);
 
 		if (!is_standalone) {
 			// this is part of an expression, we need the sequence to end with the value
-			sequence.expressions.push(rhs);
+			block.body.push(b.return(rhs));
 		}
 
-		if (should_cache) {
-			// the right hand side is a complex expression, wrap in an IIFE to cache it
-			const iife = b.arrow(
-				[
-					!is_array(value, context.state.scope) && node.left.type === 'ArrayPattern'
-						? b.array_pattern([b.rest(rhs)])
-						: rhs
-				],
-				sequence
+		const iife = b.arrow(should_cache ? [rhs] : [], block);
+
+		const iife_is_async =
+			is_expression_async(value) ||
+			assignments.some(
+				(assignment) =>
+					(assignment.type === 'ExpressionStatement' &&
+						is_expression_async(assignment.expression)) ||
+					(assignment.type === 'VariableDeclaration' &&
+						assignment.declarations.some(
+							(declaration) =>
+								is_expression_async(declaration.id) ||
+								(declaration.init && is_expression_async(declaration.init))
+						))
 			);
 
-			const iife_is_async =
-				is_expression_async(value) ||
-				assignments.some((assignment) => is_expression_async(assignment));
-
-			return iife_is_async ? b.await(b.call(b.async(iife), value)) : b.call(iife, value);
-		}
-
-		return sequence;
+		return iife_is_async
+			? b.await(b.call(b.async(iife), should_cache ? value : undefined))
+			: b.call(iife, should_cache ? value : undefined);
 	}
 
 	if (node.left.type !== 'Identifier' && node.left.type !== 'MemberExpression') {

--- a/packages/svelte/src/compiler/phases/3-transform/shared/assignments.js
+++ b/packages/svelte/src/compiler/phases/3-transform/shared/assignments.js
@@ -54,6 +54,10 @@ export function visit_assignment_expression(node, context, build_assignment) {
 			block.body.push(b.return(rhs));
 		}
 
+		if (is_standalone && !should_cache) {
+			return block;
+		}
+
 		const iife = b.arrow(should_cache ? [rhs] : [], block);
 
 		const iife_is_async =

--- a/packages/svelte/src/compiler/phases/3-transform/shared/assignments.js
+++ b/packages/svelte/src/compiler/phases/3-transform/shared/assignments.js
@@ -33,7 +33,7 @@ export function visit_assignment_expression(node, context, build_assignment) {
 				return b.stmt(
 					assignment ??
 						b.assignment(
-							'=',
+							node.operator,
 							/** @type {Identifier} */ (context.visit(original)),
 							/** @type {Expression} */ (context.visit(replacement))
 						)

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -28,7 +28,7 @@ const globals = {
 	'Math.max': [NUMBER, Math.max],
 	'Math.random': [NUMBER],
 	'Math.floor': [NUMBER, Math.floor],
-	// @ts-expect-error
+	// @ts-ignore
 	'Math.f16round': [NUMBER, Math.f16round],
 	'Math.round': [NUMBER, Math.round],
 	'Math.abs': [NUMBER, Math.abs],
@@ -630,9 +630,10 @@ export class Scope {
 
 	/**
 	 * @param {string} preferred_name
+	 * @param {(name: string, counter: number) => string} [generator]
 	 * @returns {string}
 	 */
-	generate(preferred_name) {
+	generate(preferred_name, generator = (name, counter) => `${name}_${counter}`) {
 		if (this.#porous) {
 			return /** @type {Scope} */ (this.parent).generate(preferred_name);
 		}
@@ -647,7 +648,7 @@ export class Scope {
 			this.root.conflicts.has(name) ||
 			is_reserved(name)
 		) {
-			name = `${preferred_name}_${n++}`;
+			name = generator(preferred_name, n++);
 		}
 
 		this.references.set(name, []);

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -154,20 +154,18 @@ export function build_pattern(id, scope) {
 	}
 
 	const pattern = walk(id, null, {
-		_(node, { path, next }) {
-			if (
-				(node.type === 'Identifier' &&
-					is_reference(node, /** @type {ESTree.Pattern} */ (path.at(-1))) &&
-					names.has(node.name)) ||
-				(node.type === 'MemberExpression' && map.has(node))
-			) {
-				return (
-					map.get(node) ??
-					b.id(/** @type {string} */ (names.get(/** @type {ESTree.Identifier} */ (node).name)))
-				);
+		Identifier(node, context) {
+			if (is_reference(node, /** @type {ESTree.Pattern} */ (context.path.at(-1)))) {
+				const name = names.get(node.name);
+				if (name) return b.id(name);
 			}
+		},
 
-			next();
+		MemberExpression(node, context) {
+			const n = map.get(node);
+			if (n) return n;
+
+			context.next();
 		}
 	});
 

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -135,8 +135,6 @@ export function unwrap_pattern(pattern, nodes = []) {
  * @returns {[ESTree.Pattern, Map<ESTree.Identifier | ESTree.MemberExpression, ESTree.Identifier>]}
  */
 export function build_pattern(id, scope) {
-	const nodes = unwrap_pattern(id);
-
 	/** @type {Map<ESTree.Identifier | ESTree.MemberExpression, ESTree.Identifier>} */
 	const map = new Map();
 
@@ -145,11 +143,13 @@ export function build_pattern(id, scope) {
 
 	let counter = 0;
 
-	for (const node of nodes) {
-		map.set(node, b.id(scope.generate(`$$${++counter}`, (_, counter) => `$$${counter}`)));
+	for (const node of unwrap_pattern(id)) {
+		const name = scope.generate(`$$${++counter}`, (_, counter) => `$$${counter}`);
+
+		map.set(node, b.id(name));
 
 		if (node.type === 'Identifier') {
-			names.set(node.name, /** @type {ESTree.Identifier} */ (map.get(node)).name);
+			names.set(node.name, name);
 		}
 	}
 

--- a/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/client/index.svelte.js
@@ -7,12 +7,12 @@ let c = 3;
 let d = 4;
 
 export function update(array) {
-	(() => {
+	{
 		let [$$1, $$2] = array;
 
 		$.set(a, $$1, true);
 		$.set(b, $$2, true);
-	})();
+	};
 
 	[c, d] = array;
 }

--- a/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/client/index.svelte.js
@@ -8,8 +8,8 @@ let d = 4;
 
 export function update(array) {
 	(
-		$.set(a, array[0], true),
-		$.set(b, array[1], true)
+		$.set(a, [...array][0], true),
+		$.set(b, [...array][1], true)
 	);
 
 	[c, d] = array;

--- a/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/destructured-assignments/_expected/client/index.svelte.js
@@ -7,10 +7,12 @@ let c = 3;
 let d = 4;
 
 export function update(array) {
-	(
-		$.set(a, [...array][0], true),
-		$.set(b, [...array][1], true)
-	);
+	(() => {
+		let [$$1, $$2] = array;
+
+		$.set(a, $$1, true);
+		$.set(b, $$2, true);
+	})();
 
 	[c, d] = array;
 }


### PR DESCRIPTION
Currently, the compiler assumes that whenever you use array destructuring that the object you're destructuring is an array, and can be interpreted as this:
```js
let [a, b] = object;
// svelte thinks this is equivalent:
let a = object[0];
let b = object[1];
```
However, due to iterators, and anything else using `Symbol.iterator`, [this breaks things](https://svelte.dev/playground/hello-world?version=5.28.1#H4sIAAAAAAAACm2OwWrDMAyGX0WIHZI1tDtnaaDssvuOSQ6Oo4KZIwdbWReM3304Zd1luoj_4_-QIrKaCWt8J2sd3Jy3ExQ0GaGpxAqvxlLAuoso25J7GWD1a12W5Ri-yEpmowr0H9eOhVgC1tgE7c0ibc8AlgQ67VaWAc7wFEQJFbHnXgCeu49tHp09GiGvxPmhKCFmK89myE7w8nrPKa9U7um6shbjGAxrTzOx_Hn7qcNh76Wem9Pjl2ZcRRyDY22N_jzHh53at2yBCRB3PzWne7nFCoW-BWvxK6WhQlHG3gxPWF-VDZR-AAOQ59NbAQAA). This fixes that by reusing the original destructuring structure, like so:
```js
let [a, b] = object;
// becomes
let [$$1, $$2] = object;
let a = $.state($.proxy($$1));
let b = $.state($.proxy($$2));
```

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
