### PR TITLE
fix: improve error message for migration errors when slot would be renamed

### DIFF
--- a/.changeset/strong-coins-peel.md
+++ b/.changeset/strong-coins-peel.md
@@ -1,5 +1,5 @@
 ---
-'svelte': minor
+'svelte': patch
 ---
 
 The migration warning when slots cannot be migrated due to naming conflicts now states the name of the slot causing the issue

--- a/.changeset/strong-coins-peel.md
+++ b/.changeset/strong-coins-peel.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-The migration warning when slots cannot be migrated due to naming conflicts now states the name of the slot causing the issue
+fix: improve error message for migration errors when slot would be renamed

--- a/.changeset/strong-coins-peel.md
+++ b/.changeset/strong-coins-peel.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+The migration warning when slots cannot be migrated due to naming conflicts now states the name of the slot causing the issue

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1307,7 +1307,7 @@ const template = {
 			name = state.scope.generate(slot_name);
 			if (name !== slot_name) {
 				throw new MigrationError(
-					'This migration would change the name of a slot making the component unusable'
+					`This migration would change the name of a slot (${slot_name} to ${name}) making the component unusable`
 				);
 			}
 		}
@@ -1880,7 +1880,7 @@ function handle_identifier(node, state, path) {
 				let new_name = state.scope.generate(name);
 				if (new_name !== name) {
 					throw new MigrationError(
-						'This migration would change the name of a slot making the component unusable'
+						`This migration would change the name of a slot (${name} to ${new_name}) making the component unusable`
 					);
 				}
 			}

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-3/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-$derived-derived-var-3/output.svelte
@@ -1,4 +1,4 @@
-<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot making the component unusable -->
+<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot (derived to derived_1) making the component unusable -->
 <script>
 	let derived;
 </script>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-slot-change-name/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-slot-change-name/output.svelte
@@ -1,4 +1,4 @@
-<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot making the component unusable -->
+<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot (body to body_1) making the component unusable -->
 <script>
 	let body;
 </script>

--- a/packages/svelte/tests/migrate/samples/impossible-migrate-slot-non-identifier/output.svelte
+++ b/packages/svelte/tests/migrate/samples/impossible-migrate-slot-non-identifier/output.svelte
@@ -1,2 +1,2 @@
-<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot making the component unusable -->
+<!-- @migration-task Error while migrating Svelte code: This migration would change the name of a slot (dashed-name to dashed_name) making the component unusable -->
 <slot name="dashed-name"></slot>


### PR DESCRIPTION
The warning would just say

> This migration would change the name of a slot making the component unusable

Now it says

> This migration would change the name of a slot (derived to derived_1) making the component unusable

I'm totally open to changing the message itself.
For me, as a newbie, it was really unhelpful to not have any context so I included the name of the "bad" slot here.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`