### PR TITLE
fix: remove unncessary guards that require CSP privilege when removing event attributes

### DIFF
--- a/.changeset/hot-seals-hang.md
+++ b/.changeset/hot-seals-hang.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove unncessary guards that require CSP privilege when removing event attributes

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -26,12 +26,8 @@ export const root_event_handles = new Set();
 export function replay_events(dom) {
 	if (!hydrating) return;
 
-	if (dom.onload) {
-		dom.removeAttribute('onload');
-	}
-	if (dom.onerror) {
-		dom.removeAttribute('onerror');
-	}
+	dom.removeAttribute('onload');
+	dom.removeAttribute('onerror');
 	// @ts-expect-error
 	const event = dom.__e;
 	if (event !== undefined) {


### PR DESCRIPTION
In the client code `replay_events`, accessing `dom.onload` and `dom.onerror` causes CSP violations without unsafe-inline for script-src-attr or script-src. Fortunately the guards are unnecessary because `Element.removeAttribute` is a no-op when it doesn't exist ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute)), so it's straightforward cleanup that shaves bytes regardless of the CSP behavior.

Reproduction - https://github.com/ryanatkn/svelte-reproduction-csp-inline-script in [this commit](https://github.com/ryanatkn/svelte-reproduction-csp-inline-script/commit/e1350667e30dd0478115c65b66b428f1f4adc211)

From what I can tell, this partially addresses a couple of issues but doesn't close them - it only silences the problems when the handlers are not added (they're included for SSR, see [here](https://github.com/sveltejs/svelte/blob/1c2fc210232c16d2eb0fdb20d9bac3cef2b87897/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js#L268)), but when present you still get errors. Specifically the repro in #14014 stops erroring with this fix (as does mine) but the repro in #14270 which looks like a duplicate continues to have one of the two errors, caused by the presence of onload and onerror. (not their detection as this PR addresses)

This may be related to some SvelteKit issues like htps://github.com/sveltejs/kit/issues/11747 but I didn't see any that could be fully closed by it, it doesn't address the root cause. 

![svelte-screen](https://github.com/user-attachments/assets/242e9d58-b878-4a5b-b69f-d0328f3b1714)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
