### PR TITLE
chore: improve old value implementation performance

### DIFF
--- a/.changeset/early-ties-study.md
+++ b/.changeset/early-ties-study.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: improve old value implementation performance

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -75,4 +75,4 @@ export type Source<V = unknown> = Value<V>;
 
 export type MaybeSource<T = unknown> = T | Source<T>;
 
-export type ValueNode = { s: Source, n: null | ValueNode, v: any };
+export type ValueNode = { s: Source; n: null | ValueNode; v: any };

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -74,3 +74,5 @@ export interface Effect extends Reaction {
 export type Source<V = unknown> = Value<V>;
 
 export type MaybeSource<T = unknown> = T | Source<T>;
+
+export type ValueNode = { s: Source, n: null | ValueNode, v: any };

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -26,7 +26,7 @@ import {
 	EFFECT_IS_UPDATING
 } from './constants.js';
 import { flush_tasks } from './dom/task.js';
-import { internal_set, old_values } from './reactivity/sources.js';
+import { clear_old_value_node, internal_set, get_old_value_node } from './reactivity/sources.js';
 import { destroy_derived_effects, update_derived } from './reactivity/deriveds.js';
 import * as e from './errors.js';
 import { FILENAME } from '../../constants.js';
@@ -676,7 +676,7 @@ function flush_queued_root_effects() {
 				var collected_effects = process_effects(root_effects[i]);
 				flush_queued_effects(collected_effects);
 			}
-			old_values.clear();
+			clear_old_value_node();
 		}
 	} finally {
 		is_flushing = false;
@@ -928,8 +928,11 @@ export function get(signal) {
 		}
 	}
 
-	if (is_destroying_effect && old_values.has(signal)) {
-		return old_values.get(signal);
+	if (is_destroying_effect) {
+		const value_node = get_old_value_node(signal);
+		if (value_node !== null) {
+			return value_node.v;
+		}
 	}
 
 	return signal.v;


### PR DESCRIPTION
This improves the signal runtime performance by opting for a linked list rather than a Map for storing old values. In theory a Map should be O(1) for lookups, but they come with overhead in terms when both setting a value and when clearing the Map down. Instead, using a linked list avoids this overhead except in the case where there might be many signal changes in the same update – in which case, maybe we should still opt to use a Map for those cases. Here are the benchmark results:

Main:

```
{
  benchmark: 'sbench_create_signals',
  time: '401.26',
  gc_time: '29.60'
}
{ benchmark: 'sbench_create_0to1', time: '8.17', gc_time: '0.00' }
{ benchmark: 'sbench_create_1to1', time: '29.06', gc_time: '0.59' }
{ benchmark: 'sbench_create_2to1', time: '27.08', gc_time: '0.52' }
{ benchmark: 'sbench_create_4to1', time: '25.51', gc_time: '0.61' }
{ benchmark: 'sbench_create_1000to1', time: '24.78', gc_time: '0.49' }
{ benchmark: 'sbench_create_1to2', time: '12.27', gc_time: '0.00' }
{ benchmark: 'sbench_create_1to4', time: '16.14', gc_time: '1.18' }
{ benchmark: 'sbench_create_1to8', time: '13.43', gc_time: '1.21' }
{ benchmark: 'sbench_create_1to1000', time: '4.89', gc_time: '0.00' }
{
  benchmark: 'kairo_avoidable_owned',
  time: '415.52',
  gc_time: '77.30'
}
{
  benchmark: 'kairo_avoidable_unowned',
  time: '507.39',
  gc_time: '73.81'
}
{ benchmark: 'kairo_broad_owned', time: '414.50', gc_time: '2.02' }
{ benchmark: 'kairo_broad_unowned', time: '413.50', gc_time: '2.16' }
{ benchmark: 'kairo_deep_owned', time: '181.87', gc_time: '1.93' }
{ benchmark: 'kairo_deep_unowned', time: '806.19', gc_time: '4.01' }
{ benchmark: 'kairo_diamond_owned', time: '340.28', gc_time: '34.45' }
{
  benchmark: 'kairo_diamond_unowned',
  time: '434.26',
  gc_time: '34.75'
}
{ benchmark: 'kairo_triangle_owned', time: '96.85', gc_time: '4.79' }
{
  benchmark: 'kairo_triangle_unowned',
  time: '198.79',
  gc_time: '4.57'
}
{ benchmark: 'kairo_mux_owned', time: '298.60', gc_time: '3.77' }
{ benchmark: 'kairo_mux_unowned', time: '450.16', gc_time: '3.95' }
{ benchmark: 'kairo_repeated_owned', time: '54.82', gc_time: '5.33' }
{ benchmark: 'kairo_repeated_unowned', time: '55.61', gc_time: '5.08' }
{ benchmark: 'kairo_unstable_owned', time: '88.33', gc_time: '5.46' }
{
  benchmark: 'kairo_unstable_unowned',
  time: '103.47',
  gc_time: '4.81'
}
{ benchmark: 'mol_bench_owned', time: '231.41', gc_time: '0.75' }
{ benchmark: 'mol_bench_unowned', time: '248.76', gc_time: '1.18' }

Finished reactivity benchmarks.

{ suite_time: '5902.90', suite_gc_time: '304.32' }
```

This PR:

```
{
  benchmark: 'sbench_create_signals',
  time: '296.43',
  gc_time: '78.94'
}
{ benchmark: 'sbench_create_0to1', time: '7.96', gc_time: '0.00' }
{ benchmark: 'sbench_create_1to1', time: '19.28', gc_time: '1.72' }
{ benchmark: 'sbench_create_2to1', time: '17.12', gc_time: '1.84' }
{ benchmark: 'sbench_create_4to1', time: '15.60', gc_time: '1.78' }
{ benchmark: 'sbench_create_1000to1', time: '14.50', gc_time: '1.63' }
{ benchmark: 'sbench_create_1to2', time: '9.62', gc_time: '0.53' }
{ benchmark: 'sbench_create_1to4', time: '19.26', gc_time: '6.70' }
{ benchmark: 'sbench_create_1to8', time: '14.69', gc_time: '3.57' }
{ benchmark: 'sbench_create_1to1000', time: '4.36', gc_time: '0.00' }
{
  benchmark: 'kairo_avoidable_owned',
  time: '359.36',
  gc_time: '67.77'
}
{
  benchmark: 'kairo_avoidable_unowned',
  time: '450.11',
  gc_time: '67.10'
}
{ benchmark: 'kairo_broad_owned', time: '416.18', gc_time: '1.68' }
{ benchmark: 'kairo_broad_unowned', time: '414.42', gc_time: '2.45' }
{ benchmark: 'kairo_deep_owned', time: '178.57', gc_time: '1.29' }
{ benchmark: 'kairo_deep_unowned', time: '823.22', gc_time: '3.19' }
{ benchmark: 'kairo_diamond_owned', time: '310.31', gc_time: '31.70' }
{
  benchmark: 'kairo_diamond_unowned',
  time: '406.96',
  gc_time: '31.66'
}
{ benchmark: 'kairo_triangle_owned', time: '93.90', gc_time: '5.69' }
{
  benchmark: 'kairo_triangle_unowned',
  time: '199.99',
  gc_time: '6.23'
}
{ benchmark: 'kairo_mux_owned', time: '299.27', gc_time: '3.63' }
{ benchmark: 'kairo_mux_unowned', time: '451.08', gc_time: '3.53' }
{ benchmark: 'kairo_repeated_owned', time: '51.61', gc_time: '4.41' }
{ benchmark: 'kairo_repeated_unowned', time: '52.58', gc_time: '4.54' }
{ benchmark: 'kairo_unstable_owned', time: '83.56', gc_time: '5.82' }
{
  benchmark: 'kairo_unstable_unowned',
  time: '101.41',
  gc_time: '5.96'
}
{ benchmark: 'mol_bench_owned', time: '232.01', gc_time: '0.80' }
{ benchmark: 'mol_bench_unowned', time: '249.05', gc_time: '1.24' }

Finished reactivity benchmarks.

{ suite_time: '5592.41', suite_gc_time: '345.40' }
```