### PR TITLE
feat: add support of handleEvent object listener

### DIFF
--- a/.changeset/rare-feet-hang.md
+++ b/.changeset/rare-feet-hang.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: add support of handleEvent object as event listener

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -39,9 +39,11 @@ type Booleanish = boolean | 'true' | 'false';
 // Event Handler Types
 // ----------------------------------------------------------------------
 
-type EventHandler<E extends Event = Event, T extends EventTarget = Element> = (
-	event: E & { currentTarget: EventTarget & T }
-) => any;
+type EventHandler<E extends Event = Event, T extends EventTarget = Element> =
+	| ((event: E & { currentTarget: EventTarget & T }) => any)
+	| {
+			handleEvent: (event: E & { currentTarget: EventTarget & T }) => any;
+	  };
 
 export type ClipboardEventHandler<T extends EventTarget> = EventHandler<ClipboardEvent, T>;
 export type CompositionEventHandler<T extends EventTarget> = EventHandler<CompositionEvent, T>;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/events.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/events.js
@@ -151,7 +151,7 @@ export function build_event_handler(node, metadata, context) {
 	}
 
 	// wrap the handler in a function, so the expression is re-evaluated for each event
-	let call = b.call(b.member(handler, 'apply', false, true), b.this, b.id('$$args'));
+	let call = b.call('$.call_event_handler', handler, b.this, b.id('$$evt'), b.id('$$data'));
 
 	if (dev) {
 		const loc = locator(/** @type {number} */ (node.start));
@@ -165,7 +165,8 @@ export function build_event_handler(node, metadata, context) {
 			'$.apply',
 			b.thunk(handler),
 			b.this,
-			b.id('$$args'),
+			b.id('$$evt'),
+			b.id('$$data'),
 			b.id(context.state.analysis.name),
 			loc && b.array([b.literal(loc.line), b.literal(loc.column)]),
 			has_side_effects(node) && b.true,
@@ -173,7 +174,7 @@ export function build_event_handler(node, metadata, context) {
 		);
 	}
 
-	return b.function(null, [b.rest(b.id('$$args'))], b.block([b.stmt(call)]));
+	return b.function(null, [b.id('$$evt'), b.rest(b.id('$$data'))], b.block([b.stmt(call)]));
 }
 
 /**

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -1,7 +1,7 @@
 import { DEV } from 'esm-env';
 import { hydrating, set_hydrating } from '../hydration.js';
 import { get_descriptors, get_prototype_of } from '../../../shared/utils.js';
-import { create_event, delegate } from './events.js';
+import { call_event_handler, create_event, delegate } from './events.js';
 import { add_form_reset_listener, autofocus } from './misc.js';
 import * as w from '../../warnings.js';
 import { LOADING_ATTR_SYMBOL } from '#client/constants';
@@ -376,7 +376,7 @@ export function set_attributes(element, prev, next, css_hash, skip_warning = fal
 					 * @param {Event} evt
 					 */
 					function handle(evt) {
-						current[key].call(this, evt);
+						call_event_handler(current[key], this, evt);
 					}
 
 					current[event_handle_key] = create_event(event_name, element, handle, opts);

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -37,7 +37,13 @@ export {
 	STYLE
 } from './dom/elements/attributes.js';
 export { set_class } from './dom/elements/class.js';
-export { apply, event, delegate, replay_events } from './dom/elements/events.js';
+export {
+	apply,
+	call_event_handler,
+	event,
+	delegate,
+	replay_events
+} from './dom/elements/events.js';
 export { autofocus, remove_textarea_child } from './dom/elements/misc.js';
 export { set_style } from './dom/elements/style.js';
 export { animation, transition } from './dom/elements/transitions.js';

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -184,6 +184,7 @@ export function spread_attributes(attrs, css_hash, classes, styles, flags = 0) {
 	for (name in attrs) {
 		// omit functions, internal svelte properties and invalid attribute names
 		if (typeof attrs[name] === 'function') continue;
+		if (name[0] === 'o' && name[1] === 'n' && typeof attrs[name] === 'object') continue;
 		if (name[0] === '$' && name[1] === '$') continue; // faster than name.startsWith('$$')
 		if (INVALID_ATTR_NAME_CHAR_REGEX.test(name)) continue;
 

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object-dev/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object-dev/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, logs }) {
+		const [b1] = target.querySelectorAll('button');
+
+		b1.click();
+		flushSync();
+		assert.htmlEqual(target.innerHTML, '<button data-step="2">clicks: 2</button>');
+		assert.deepEqual(logs, []);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object-dev/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object-dev/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let count = $state(0);
+
+	let onclick = $state({
+		handleEvent() {
+			count += +this.dataset.step;
+		}
+	});
+</script>
+
+<button data-step="2" {onclick}>
+	clicks: {count}
+</button>

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object-invalid/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object-invalid/_config.js
@@ -1,0 +1,31 @@
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, warnings, logs, errors }) {
+		const handler = (/** @type {any} */ e) => {
+			e.stopImmediatePropagation();
+		};
+
+		window.addEventListener('error', handler, true);
+
+		const [b1, b2] = target.querySelectorAll('button');
+
+		b1.click();
+		b2.click();
+		assert.deepEqual(logs, []);
+		assert.deepEqual(warnings, [
+			'`click` handler at main.svelte:6:17 should be a function. Did you mean to add a leading `() =>`?',
+			'`click` handler at main.svelte:7:17 should be a function. Did you mean to add a leading `() =>`?'
+		]);
+		assert.include(errors[0], 'is not a function');
+		assert.include(errors[2], 'is not a function');
+
+		window.removeEventListener('error', handler, true);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object-invalid/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object-invalid/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let empty = {};
+	let wrong = { handleEvent: "bad" };
+</script>
+
+<button onclick={empty}>click</button>
+<button onclick={wrong}>click</button>

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object-ssr/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object-ssr/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>a</button><button>b</button><button>c</button><button>d</button>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object-ssr/child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object-ssr/child.svelte
@@ -1,0 +1,6 @@
+<script>
+    const props = $props();
+</script>
+
+<button onclick={props.onclick}>c</button>
+<button {...props}>d</button>

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object-ssr/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object-ssr/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	import Child from "./child.svelte";
+
+	const onclick = {
+		handleEvent() {}
+	};
+</script>
+
+<button {onclick}>a</button>
+<button {...{onclick}}>b</button>
+
+<Child {onclick} />

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object/_config.js
@@ -1,0 +1,22 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	test({ assert, target, logs }) {
+		const buttons = target.querySelectorAll('button');
+
+		buttons.forEach((b) => b.click());
+		flushSync();
+		buttons.forEach((b) => b.click());
+		flushSync();
+		buttons.forEach((b) => b.click());
+		flushSync();
+		assert.deepEqual(logs, [2, 5, 6, 7, 9, 11]);
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button data-step="2">clicks: 11</button><button data-step="3">inc</button><button>next</button>'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-handler-object/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-handler-object/main.svelte
@@ -1,0 +1,39 @@
+<script>
+	import { on } from 'svelte/events';
+
+	let count = $state(0);
+
+	let onclick = $state.raw({
+		handleEvent() {
+			count += +this.dataset.step;
+			console.log(count);
+		}
+	});
+
+	function click2() {
+		count++;
+		console.log(count);
+	}
+
+	function click3() {
+		count += 2;
+		console.log(count);
+	}
+
+	let btn;
+	$effect(() => {
+		return on(btn, 'click', () => {
+			if (onclick.handleEvent !== click2) {
+				onclick.handleEvent = click2;
+			} else {
+				onclick = { handleEvent: click3 };
+			}
+		});
+	});
+</script>
+
+<button data-step="2" {onclick}>
+	clicks: {count}
+</button>
+<button data-step="3" {...{onclick}}>inc</button>
+<button bind:this={btn}>next</button>


### PR DESCRIPTION
Closes #8196

The type of `on:event` on components is still function only, though it works with the object handler. Not sure where to fix it.

In the following case, it can be considered kind of a breaking change:
```ts
const props: HTMLAttributes = $props();
// later
props.onclick(); // will error when `onclick` is an object handler

someFnAcceptingCallback(props.onclick); // same problem
```
and any other place where the event handler is expected to be function only.

Also, the handler object seems to never get hoisted.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
