### PR TITLE
feat: add languages.current to svelte/reactivity/window

### DIFF
--- a/.changeset/shy-tomatoes-relate.md
+++ b/.changeset/shy-tomatoes-relate.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+add languages.current to svelte/reactivity/window

--- a/packages/svelte/src/reactivity/window/index.js
+++ b/packages/svelte/src/reactivity/window/index.js
@@ -154,3 +154,12 @@ export const devicePixelRatio = /* @__PURE__ */ new (class DevicePixelRatio {
 		return BROWSER ? window.devicePixelRatio : undefined;
 	}
 })();
+
+/**
+ * `languages.current` is a reactive view of `navigator.languages`. On the server it is `undefined`.
+ * @since
+ */
+export const languages = new ReactiveValue(
+	BROWSER ? () => navigator.languages : () => undefined,
+	(update) => on(window, 'languagechange', update)
+);

--- a/packages/svelte/tests/server-side-rendering/samples/reactivity-window/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/reactivity-window/_expected.html
@@ -1,1 +1,1 @@
-<!--[--><p>devicePixelRatio: </p> <p>innerHeight: </p> <p>innerWidth: </p> <p>online: </p> <p>outerHeight: </p> <p>outerWidth: </p> <p>screenLeft: </p> <p>screenTop: </p> <p>scrollX: </p> <p>scrollY: </p><!--]-->
+<!--[--><p>devicePixelRatio: </p> <p>innerHeight: </p> <p>innerWidth: </p> <p>languages: </p> <p>online: </p> <p>outerHeight: </p> <p>outerWidth: </p> <p>screenLeft: </p> <p>screenTop: </p> <p>scrollX: </p> <p>scrollY: </p><!--]-->

--- a/packages/svelte/tests/server-side-rendering/samples/reactivity-window/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/reactivity-window/main.svelte
@@ -1,10 +1,11 @@
 <script>
-	import { devicePixelRatio, innerHeight, innerWidth, online, outerHeight, outerWidth, screenLeft, screenTop, scrollX, scrollY } from "svelte/reactivity/window";
+	import { devicePixelRatio, innerHeight, innerWidth, languages, online, outerHeight, outerWidth, screenLeft, screenTop, scrollX, scrollY } from "svelte/reactivity/window";
 </script>
 
 <p>devicePixelRatio: {devicePixelRatio.current}</p>
 <p>innerHeight: {innerHeight.current}</p>
 <p>innerWidth: {innerWidth.current}</p>
+<p>languages: {languages.current}</p>
 <p>online: {online.current}</p>
 <p>outerHeight: {outerHeight.current}</p>
 <p>outerWidth: {outerWidth.current}</p>

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2224,6 +2224,10 @@ declare module 'svelte/reactivity/window' {
 	export const devicePixelRatio: {
 		get current(): number | undefined;
 	};
+	/**
+	 * `languages.current` is a reactive view of `navigator.languages`. On the server it is `undefined`.
+	 * */
+	export const languages: ReactiveValue<readonly string[] | undefined>;
 	class ReactiveValue<T> {
 		
 		constructor(fn: () => T, onsubscribe: (update: () => void) => void);


### PR DESCRIPTION
Adds a reactive view of `navigator.languages` to `svelte/reactivity/window` which updates on the `languagechange` window event.

This enables the adjustment of translated content without requiring a page load.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
