### PR TITLE
fix: more frequently update `bind:buffered` to actual value

### DIFF
--- a/.changeset/short-impalas-exist.md
+++ b/.changeset/short-impalas-exist.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: more frequently update `bind:buffered` to actual value

--- a/packages/svelte/src/internal/client/dom/elements/bindings/media.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/media.js
@@ -64,16 +64,18 @@ export function bind_current_time(media, get, set = get) {
 export function bind_buffered(media, set) {
 	/** @type {{ start: number; end: number; }[]} */
 	var current;
+
 	// `buffered` can update without emitting any event, so we check it on various events.
 	// By specs, `buffered` always returns a new object, so we have to compare deeply.
 	listen(media, ['loadedmetadata', 'progress', 'timeupdate', 'seeking'], () => {
-		var buf = media.buffered;
+		var ranges = media.buffered;
+
 		if (
 			!current ||
-			current.length !== buf.length ||
-			current.some((range, i) => buf.start(i) !== range.start || buf.end(i) !== range.end)
+			current.length !== ranges.length ||
+			current.some((range, i) => ranges.start(i) !== range.start || ranges.end(i) !== range.end)
 		) {
-			current = time_ranges_to_array(buf);
+			current = time_ranges_to_array(ranges);
 			set(current);
 		}
 	});


### PR DESCRIPTION
Closes #7400

Firefox also uses these events to [update the built-in video control's buffered track](https://hg-edge.mozilla.org/mozilla-central/file/a031b94b3d8e1d98ec6ae030cfda68b778df6edb/toolkit/content/widgets/videocontrols.js#l838) if I found the right file.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
