### PR TITLE
docs: Fix number input incorrect empty or invalid value

### DIFF
--- a/documentation/docs/03-template-syntax/11-bind.md
+++ b/documentation/docs/03-template-syntax/11-bind.md
@@ -75,7 +75,7 @@ In the case of a numeric input (`type="number"` or `type="range"`), the value wi
 <p>{a} + {b} = {a + b}</p>
 ```
 
-If the input is empty or invalid (in the case of `type="number"`), the value is `undefined`.
+If the input is empty or invalid (in the case of `type="number"`), the value is `null`.
 
 Since 5.6.0, if an `<input>` has a `defaultValue` and is part of a form, it will revert to that value instead of the empty string when the form is reset. Note that for the initial render the value of the binding takes precedence unless it is `null` or `undefined`.
 


### PR DESCRIPTION
Fix #15811 

Either docs or code is incorrect, current value is `null` and not `undefined` as written in docs.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
