### PR TITLE
fix: emit right error for a shadowed invalid rune name

### DIFF
--- a/.changeset/tall-cherries-fix.md
+++ b/.changeset/tall-cherries-fix.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: emit right error for a shadowed invalid rune

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
@@ -39,7 +39,7 @@ export function Identifier(node, context) {
 		if (
 			is_rune(node.name) &&
 			context.state.scope.get(node.name) === null &&
-			context.state.scope.get(node.name.slice(1)) === null
+			context.state.scope.get(node.name.slice(1))?.kind !== 'store_sub'
 		) {
 			/** @type {Expression} */
 			let current = node;

--- a/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'rune_invalid_name',
+		message: '`$state.foo` is not a valid rune'
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js
+++ b/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js
@@ -1,0 +1,5 @@
+class State {
+	value = $state.foo();
+}
+
+export const state = new State();


### PR DESCRIPTION
Fixes #12888

I'm a bit unsure but looks like I fixed it in the right place.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
