### PR TITLE
chore: better `bench:compare` script

### DIFF
--- a/benchmarking/compare/index.js
+++ b/benchmarking/compare/index.js
@@ -80,10 +80,10 @@ for (let i = 0; i < results[0].length; i += 1) {
 		}
 
 		if (min !== 0) {
-			console.group(`${metric}: fastest is ${branches[min_index]}`);
+			console.group(`${metric}: fastest is ${char(min_index)} (${branches[min_index]})`);
 			times.forEach((time, b) => {
 				console.log(
-					`${branches[b]}: ${'◼'.repeat(Math.round(20 * (time / max)))} (${time.toFixed(2)}ms)`
+					`${char(b)}: ${'◼'.repeat(Math.round(20 * (time / max)))} (${time.toFixed(2)}ms)`
 				);
 			});
 			console.groupEnd();
@@ -91,4 +91,8 @@ for (let i = 0; i < results[0].length; i += 1) {
 	}
 
 	console.groupEnd();
+}
+
+function char(i) {
+	return String.fromCharCode(97 + i);
 }

--- a/benchmarking/compare/index.js
+++ b/benchmarking/compare/index.js
@@ -86,9 +86,10 @@ for (let i = 0; i < results[0].length; i += 1) {
 		if (min !== 0) {
 			console.group(`${metric}: fastest is ${char(min_index)} (${branches[min_index]})`);
 			times.forEach((time, b) => {
-				console.log(
-					`${char(b)}: ${'◼'.repeat(Math.round(20 * (time / max)))} (${time.toFixed(2)}ms)`
-				);
+				const SIZE = 20;
+				const n = Math.round(SIZE * (time / max));
+
+				console.log(`${char(b)}: ${'◼'.repeat(n)}${' '.repeat(SIZE - n)} ${time.toFixed(2)}ms`);
 			});
 			console.groupEnd();
 		}

--- a/benchmarking/compare/index.js
+++ b/benchmarking/compare/index.js
@@ -67,19 +67,24 @@ for (let i = 0; i < results[0].length; i += 1) {
 	for (const metric of ['time', 'gc_time']) {
 		const times = results.map((result) => +result[i][metric]);
 		let min = Infinity;
+		let max = -Infinity;
 		let min_index = -1;
 
 		for (let b = 0; b < times.length; b += 1) {
 			if (times[b] < min) {
 				min = times[b];
 				min_index = b;
+			} else {
+				max = times[b];
 			}
 		}
 
 		if (min !== 0) {
 			console.group(`${metric}: fastest is ${branches[min_index]}`);
 			times.forEach((time, b) => {
-				console.log(`${branches[b]}: ${time.toFixed(2)}ms (${((time / min) * 100).toFixed(2)}%)`);
+				console.log(
+					`${branches[b]}: ${'◼'.repeat(Math.round(20 * (time / max)))} (${time.toFixed(2)}ms)`
+				);
 			});
 			console.groupEnd();
 		}

--- a/benchmarking/compare/index.js
+++ b/benchmarking/compare/index.js
@@ -71,11 +71,15 @@ for (let i = 0; i < results[0].length; i += 1) {
 		let min_index = -1;
 
 		for (let b = 0; b < times.length; b += 1) {
-			if (times[b] < min) {
-				min = times[b];
+			const time = times[b];
+
+			if (time < min) {
+				min = time;
 				min_index = b;
-			} else {
-				max = times[b];
+			}
+
+			if (time > max) {
+				max = time;
 			}
 		}
 


### PR DESCRIPTION
The output of `pnpm bench:compare` is very hard to read. This makes it actually usable. Self-merging so I can use it on existing PRs