### PR TITLE
chore: ts-ignore Math.f16round

### DIFF
--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -28,7 +28,7 @@ const globals = {
 	'Math.max': [NUMBER, Math.max],
 	'Math.random': [NUMBER],
 	'Math.floor': [NUMBER, Math.floor],
-	// @ts-expect-error
+	// @ts-ignore
 	'Math.f16round': [NUMBER, Math.f16round],
 	'Math.round': [NUMBER, Math.round],
 	'Math.abs': [NUMBER, Math.abs],


### PR DESCRIPTION
extracted from #15893 — whether it's an error or not depends on TypeScript. using `ignore` instead of `expect-error` means it won't fail with an up to date `"dom"` lib or whatever it is that controls this stuff