### PR TITLE
fix: add `typeParams` to `SnippetBlock` for legacy parser

### DIFF
--- a/.changeset/polite-tips-enjoy.md
+++ b/.changeset/polite-tips-enjoy.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add `typeParams` to `SnippetBlock` for legacy parser

--- a/packages/svelte/src/compiler/legacy.js
+++ b/packages/svelte/src/compiler/legacy.js
@@ -378,7 +378,8 @@ export function convert(source, ast) {
 					end: node.end,
 					expression: node.expression,
 					parameters: node.parameters,
-					children: node.body.nodes.map((child) => visit(child))
+					children: node.body.nodes.map((child) => visit(child)),
+					typeParams: node.typeParams
 				};
 			},
 			// @ts-expect-error

--- a/packages/svelte/tests/parser-legacy/samples/generic-snippets/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/generic-snippets/input.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+</script>
+
+{#snippet generic<T extends string>(val: T)}
+	{val}
+{/snippet}
+
+{#snippet complex_generic<T extends { bracket: "<" } | "<" | Set<"<>">>(val: T)}
+	{val}
+{/snippet}

--- a/packages/svelte/tests/parser-legacy/samples/generic-snippets/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/generic-snippets/output.json
@@ -1,0 +1,244 @@
+{
+	"html": {
+		"type": "Fragment",
+		"start": 30,
+		"end": 192,
+		"children": [
+			{
+				"type": "Text",
+				"start": 28,
+				"end": 30,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "SnippetBlock",
+				"start": 30,
+				"end": 92,
+				"expression": {
+					"type": "Identifier",
+					"start": 40,
+					"end": 47,
+					"name": "generic"
+				},
+				"parameters": [
+					{
+						"type": "Identifier",
+						"start": 66,
+						"end": 72,
+						"loc": {
+							"start": {
+								"line": 4,
+								"column": 36
+							},
+							"end": {
+								"line": 4,
+								"column": 42
+							}
+						},
+						"name": "val",
+						"typeAnnotation": {
+							"type": "TSTypeAnnotation",
+							"start": 69,
+							"end": 72,
+							"loc": {
+								"start": {
+									"line": 4,
+									"column": 39
+								},
+								"end": {
+									"line": 4,
+									"column": 42
+								}
+							},
+							"typeAnnotation": {
+								"type": "TSTypeReference",
+								"start": 71,
+								"end": 72,
+								"loc": {
+									"start": {
+										"line": 4,
+										"column": 41
+									},
+									"end": {
+										"line": 4,
+										"column": 42
+									}
+								},
+								"typeName": {
+									"type": "Identifier",
+									"start": 71,
+									"end": 72,
+									"loc": {
+										"start": {
+											"line": 4,
+											"column": 41
+										},
+										"end": {
+											"line": 4,
+											"column": 42
+										}
+									},
+									"name": "T"
+								}
+							}
+						}
+					}
+				],
+				"children": [
+					{
+						"type": "MustacheTag",
+						"start": 76,
+						"end": 81,
+						"expression": {
+							"type": "Identifier",
+							"start": 77,
+							"end": 80,
+							"loc": {
+								"start": {
+									"line": 5,
+									"column": 2
+								},
+								"end": {
+									"line": 5,
+									"column": 5
+								}
+							},
+							"name": "val"
+						}
+					}
+				],
+				"typeParams": "T extends string"
+			},
+			{
+				"type": "Text",
+				"start": 92,
+				"end": 94,
+				"raw": "\n\n",
+				"data": "\n\n"
+			},
+			{
+				"type": "SnippetBlock",
+				"start": 94,
+				"end": 192,
+				"expression": {
+					"type": "Identifier",
+					"start": 104,
+					"end": 119,
+					"name": "complex_generic"
+				},
+				"parameters": [
+					{
+						"type": "Identifier",
+						"start": 166,
+						"end": 172,
+						"loc": {
+							"start": {
+								"line": 8,
+								"column": 72
+							},
+							"end": {
+								"line": 8,
+								"column": 78
+							}
+						},
+						"name": "val",
+						"typeAnnotation": {
+							"type": "TSTypeAnnotation",
+							"start": 169,
+							"end": 172,
+							"loc": {
+								"start": {
+									"line": 8,
+									"column": 75
+								},
+								"end": {
+									"line": 8,
+									"column": 78
+								}
+							},
+							"typeAnnotation": {
+								"type": "TSTypeReference",
+								"start": 171,
+								"end": 172,
+								"loc": {
+									"start": {
+										"line": 8,
+										"column": 77
+									},
+									"end": {
+										"line": 8,
+										"column": 78
+									}
+								},
+								"typeName": {
+									"type": "Identifier",
+									"start": 171,
+									"end": 172,
+									"loc": {
+										"start": {
+											"line": 8,
+											"column": 77
+										},
+										"end": {
+											"line": 8,
+											"column": 78
+										}
+									},
+									"name": "T"
+								}
+							}
+						}
+					}
+				],
+				"children": [
+					{
+						"type": "MustacheTag",
+						"start": 176,
+						"end": 181,
+						"expression": {
+							"type": "Identifier",
+							"start": 177,
+							"end": 180,
+							"loc": {
+								"start": {
+									"line": 9,
+									"column": 2
+								},
+								"end": {
+									"line": 9,
+									"column": 5
+								}
+							},
+							"name": "val"
+						}
+					}
+				],
+				"typeParams": "T extends { bracket: \"<\" } | \"<\" | Set<\"<>\">"
+			}
+		]
+	},
+	"instance": {
+		"type": "Script",
+		"start": 0,
+		"end": 28,
+		"context": "default",
+		"content": {
+			"type": "Program",
+			"start": 18,
+			"end": 19,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 2,
+					"column": 0
+				}
+			},
+			"body": [],
+			"sourceType": "module"
+		}
+	}
+}


### PR DESCRIPTION
I forgot to add it to the legacy parser too which is needed for language-tools.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`