### PR TITLE
fix: add warning when you read object property within attachments in legacy mode

### DIFF
--- a/.changeset/breezy-pears-punch.md
+++ b/.changeset/breezy-pears-punch.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add warning when you read object property within attachments in legacy mode

--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -556,6 +556,12 @@ Elements with ARIA roles must use a valid, non-abstract ARIA role. A reference t
 <div role="toooltip"></div>
 ```
 
+### attachment_legacy_member_access
+
+```
+Using `@attach` with a function from an object in legacy mode can cause unnecessary reruns of the attachment function if you mutate that object.
+```
+
 ### attribute_avoid_is
 
 ```

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -1,3 +1,7 @@
+## attachment_legacy_member_access
+
+> Using `@attach` with a function from an object in legacy mode can cause unnecessary reruns of the attachment function if you mutate that object.
+
 ## attribute_avoid_is
 
 > The "is" attribute is not supported cross-browser and should be avoided

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/AttachTag.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/AttachTag.js
@@ -1,7 +1,9 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
 
+import { walk } from 'zimmerframe';
 import { mark_subtree_dynamic } from './shared/fragment.js';
+import * as w from '../../../warnings.js';
 
 /**
  * @param {AST.AttachTag} node
@@ -9,5 +11,16 @@ import { mark_subtree_dynamic } from './shared/fragment.js';
  */
 export function AttachTag(node, context) {
 	mark_subtree_dynamic(context.path);
+	if (!context.state.analysis.runes) {
+		walk(
+			node.expression,
+			{},
+			{
+				MemberExpression(node) {
+					w.attachment_legacy_member_access(node);
+				}
+			}
+		);
+	}
 	context.next({ ...context.state, expression: node.metadata.expression });
 }

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -106,6 +106,7 @@ export const codes = [
 	'state_referenced_locally',
 	'store_rune_conflict',
 	'css_unused_selector',
+	'attachment_legacy_member_access',
 	'attribute_avoid_is',
 	'attribute_global_event_reference',
 	'attribute_illegal_colon',
@@ -675,6 +676,14 @@ export function store_rune_conflict(node, name) {
  */
 export function css_unused_selector(node, name) {
 	w(node, 'css_unused_selector', `Unused CSS selector "${name}"\nhttps://svelte.dev/e/css_unused_selector`);
+}
+
+/**
+ * Using `@attach` with a function from an object in legacy mode can cause unnecessary reruns of the attachment function if you mutate that object.
+ * @param {null | NodeLike} node
+ */
+export function attachment_legacy_member_access(node) {
+	w(node, 'attachment_legacy_member_access', `Using \`@attach\` with a function from an object can cause unnecessary reruns of the attachment function if you mutate that object in legacy mode.\nhttps://svelte.dev/e/attachment_legacy_member_access`);
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/attachment-legacy-member-access/input.svelte
+++ b/packages/svelte/tests/validator/samples/attachment-legacy-member-access/input.svelte
@@ -1,0 +1,14 @@
+<script>
+	let state = {
+		count: 0,
+		attachment(){
+			
+		}
+	};
+</script>
+
+<button onclick={()=>{
+	state.count++;
+}}>{state.count}</button>
+
+<div {@attach state.attachment}></div>

--- a/packages/svelte/tests/validator/samples/attachment-legacy-member-access/warnings.json
+++ b/packages/svelte/tests/validator/samples/attachment-legacy-member-access/warnings.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "attachment_legacy_member_access",
+		"message": "Using `@attach` with a function from an object in legacy mode can cause unnecessary reruns of the attachment function if you mutate that object.",
+		"start": {
+			"line": 14,
+			"column": 14
+		},
+		"end": {
+			"line": 14,
+			"column": 30
+		}
+	}
+]


### PR DESCRIPTION
This adds a warning when you are in legacy mode and you set the expression of an attachment reading from an object.

if you have a component like this

```svelte
<script>
    let state = {
        count: 0,
        attachment: (node)=>{
            alert("attachment run");
        }
    };
</script>

<button onclick={()=>{
    state.count++;
}}>{state.count}</button>

<div {@attach state.attachment}></div>
```
and you don't realise you are in legacy mode the attachment will rerun every time you change count because you are updating `state.count` and in legacy mode that invalidate the whole `state` object (hence also `state.attachment` which means the attachment reruns).

While the above example is blatantly in legacy mode this is more subtle.

```html
<script>
    import { State } from "some-lib";
    let state = new State();
</script>

<button onclick={()=>{
    state.count++;
}}>{state.count}</button>

<div {@attach state.attachment}></div>
```

This is up for discussion because i wonder if this warning could be too intrusive...an alternative @dummdidumm suggested is that we could opt in to runes mode if you use `@attach`...however this would be a breaking change (although probably not breaking for a lot of people) and since it's a new feature we can just label it as a bug. This would also hinder the adoption of attachments a bit and it would be cool if we could use them in legacy mode.

WDYT?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`