### PR TITLE
fix: `@attach` opt's you into runes mode

### DIFF
--- a/.changeset/famous-rocks-poke.md
+++ b/.changeset/famous-rocks-poke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: `@attach` opt's you into runes mode

--- a/documentation/docs/03-template-syntax/09-@attach.md
+++ b/documentation/docs/03-template-syntax/09-@attach.md
@@ -7,6 +7,9 @@ Attachments are functions that run when an element is mounted to the DOM. Option
 > [!NOTE]
 > Attachments are available in Svelte 5.29 and newer.
 
+> [!NOTE]
+> Attachments also opt you in for runes mode so if you use them in a legacy component you would have to also migrate that component.
+
 ```svelte
 <!--- file: App.svelte --->
 <script>

--- a/documentation/docs/99-legacy/00-legacy-overview.md
+++ b/documentation/docs/99-legacy/00-legacy-overview.md
@@ -9,6 +9,6 @@ The following pages document these features for
 - people still using Svelte 3/4
 - people using Svelte 5, but with components that haven't yet been migrated
 
-Since Svelte 3/4 syntax still works in Svelte 5, we will distinguish between _legacy mode_ and _runes mode_. Once a component is in runes mode (which you can opt into by using runes, or by explicitly setting the `runes: true` compiler option), legacy mode features are no longer available.
+Since Svelte 3/4 syntax still works in Svelte 5, we will distinguish between _legacy mode_ and _runes mode_. Once a component is in runes mode (which you can opt into by using runes or attachments, or by explicitly setting the `runes: true` compiler option), legacy mode features are no longer available.
 
 If you're exclusively interested in the Svelte 3/4 syntax, you can browse its documentation at [v4.svelte.dev](https://v4.svelte.dev).

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -403,7 +403,23 @@ export function analyze_component(root, source, options) {
 
 	const component_name = get_component_name(options.filename);
 
-	const runes = options.runes ?? Array.from(module.scope.references.keys()).some(is_rune);
+	let runes = options.runes ?? Array.from(module.scope.references.keys()).some(is_rune);
+
+	// if we are not in runes mode by the bindings we need to check if there's any attachment
+	if (!runes) {
+		// we need to do it beforehand otherwise we would not be in runes mode until we hit an attachment
+		walk(
+			/** @type {AST.SvelteNode} */ (template.ast),
+			{},
+			{
+				AttachTag(_, context) {
+					runes = true;
+					// once we found one we can stop the traversal
+					context.stop();
+				}
+			}
+		);
+	}
 
 	if (!runes) {
 		for (let check of synthetic_stores_legacy_check) {


### PR DESCRIPTION
Alternative to #15948 that opts you in runes mode whenever you use an attachment.

Personally I'm in more in favour of #15948 because:

1. this is technically a breaking change (although we could just label it as a fix since it was just released)
2. using attachments in legacy mode in not generally a problem, is just confusing when you do from an object and mutate another property of that object in the same component and a warning can already guide you through the right solution
3. this would mean that if you want to use the new feature of spreading attachments through component you would have to migrate your component which sometimes (for big components) might not be feasible.

But we could also do this.

Not sure which kind of test i should add for this, any ideas?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
