### PR TITLE
chore: add --tag legacy to prevent svelte 4 being published as latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "cd packages/svelte && pnpm build && cd ../../ && pnpm -r lint",
     "format": "pnpm -r format",
     "changeset:version": "changeset version && pnpm -r generate:version && git add --all",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "changeset publish --tag legacy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#15965 caused 4.2.20 to be released. Unfortunately it was tagged as `latest`. This should prevent that from happening if we need to cut another 4.x release.