### PR TITLE
feat: enable TS autocomplete for Svelte HTML element definitions

### DIFF
--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -2066,7 +2066,7 @@ export interface SvelteHTMLElements {
 		failed?: import('svelte').Snippet<[error: unknown, reset: () => void]>;
 	};
 
-	[name: string]: { [name: string]: any };
+	[name: string & {}]: { [name: string]: any };
 }
 
 export type ClassValue = string | import('clsx').ClassArray | import('clsx').ClassDictionary;

--- a/packages/svelte/svelte-html.d.ts
+++ b/packages/svelte/svelte-html.d.ts
@@ -8,7 +8,7 @@ import * as svelteElements from './elements.js';
 /**
  * @internal do not use
  */
-type HTMLProps<Property extends string, Override> = Omit<
+type HTMLProps<Property extends keyof svelteElements.SvelteHTMLElements, Override> = Omit<
 	import('./elements.js').SvelteHTMLElements[Property],
 	keyof Override
 > &

--- a/packages/svelte/svelte-html.d.ts
+++ b/packages/svelte/svelte-html.d.ts
@@ -250,7 +250,7 @@ declare global {
 			};
 			// don't type svelte:options, it would override the types in svelte/elements and it isn't extendable anyway
 
-			[name: string]: { [name: string]: any };
+			[name: string & {}]: { [name: string]: any };
 		}
 	}
 }


### PR DESCRIPTION
Covers https://github.com/sveltejs/svelte/issues/15971.

**TL;DR:** adds autocomplete support to `SvelteHTMLElements` while preserving its functionality that key can be any string using `string & {}` TS trick.

### Demonstration
![image](https://github.com/user-attachments/assets/9f3c918f-bd22-4d8a-9d7d-5411de9ecaeb)
![image](https://github.com/user-attachments/assets/d82af6af-f425-4749-b8ed-260948505a37)

---

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
