### PR TITLE
docs: mention update method on svelte-action page

### DIFF
--- a/documentation/docs/03-template-syntax/12-use.md
+++ b/documentation/docs/03-template-syntax/12-use.md
@@ -39,6 +39,7 @@ An action can be called with an argument:
 ```
 
 The action is only called once (but not during server-side rendering) — it will _not_ run again if the argument changes.
+However, the action _can_ [return an object](./svelte-action#ActionReturn) containing an `update` method that will be run when the argument changes.
 
 > [!LEGACY]
 > Prior to the `$effect` rune, actions could return an object with `update` and `destroy` methods, where `update` would be called with the latest value of the argument if it changed. Using effects is preferred.


### PR DESCRIPTION
This mentions that a Svelte action can return an object with an `update` method.

Without this it's easy for someone who hasn't read the corresponding Reference page to mis-interpret the previous sentence as meaning  that there is no mechanism for automatically re-running or updating actions when arguments change.

Preview of the edited page: https://svelte-dev-git-preview-svelte-15977-svelte.vercel.app/docs/svelte/use