### PR TITLE
chore: simplify `<pre>` cleaning

### DIFF
--- a/.changeset/fifty-llamas-know.md
+++ b/.changeset/fifty-llamas-know.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: simplify `<pre>` cleaning

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -271,19 +271,12 @@ export function clean_nodes(
 
 	var first = trimmed[0];
 
-	// initial newline inside a `<pre>` is disregarded, if not followed by another newline
+	// if first text node inside a <pre> is a single newline, discard it, because otherwise
+	// the browser will do it for us which could break hydration
 	if (parent.type === 'RegularElement' && parent.name === 'pre' && first?.type === 'Text') {
-		const text = first.data.replace(regex_starts_with_newline, '');
-		if (text !== first.data) {
-			const tmp = text.replace(regex_starts_with_newline, '');
-			if (text === tmp) {
-				first.data = text;
-				first.raw = first.raw.replace(regex_starts_with_newline, '');
-				if (first.data === '') {
-					trimmed.shift();
-					first = trimmed[0];
-				}
-			}
+		if (first.data === '\n' || first.data === '\r\n') {
+			trimmed.shift();
+			first = trimmed[0];
 		}
 	}
 


### PR DESCRIPTION
was looking into how we can make fewer things in #15538 need to be aware of the templating mode (which will make everything more robust) and ran into this `<pre>` logic. Took me a while to wrap my head round it but it turns out we way overcomplicated things in #14922 — the essence of this logic is that if the first node inside a `<pre>` is a single newline, we need to strip it because otherwise hydration breaks:

```js
document.body.innerHTML = `<pre>
<div>...</div>
</pre>`;

document.body.querySelector('pre').firstChild; // DIV, not the newline
```

Instead of doing a convoluted song and dance we can just express that directly. For #15538, we _do_ want to strip any remaining leading newline, but that should happen in `template_to_functions`, not here