### PR TITLE
fix: attach __svelte_meta correctly to elements following a CSS wrapper

### DIFF
--- a/.changeset/nervous-hotels-clean.md
+++ b/.changeset/nervous-hotels-clean.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: attach \_\_svelte_meta correctly to elements following a CSS wrapper
+fix: attach `__svelte_meta` correctly to elements following a CSS wrapper

--- a/.changeset/nervous-hotels-clean.md
+++ b/.changeset/nervous-hotels-clean.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: attach \_\_svelte_meta correctly to elements following a CSS wrapper

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -1,7 +1,7 @@
 /** @import { BlockStatement, Expression, ExpressionStatement, Identifier, MemberExpression, Pattern, Property, SequenceExpression, Statement } from 'estree' */
 /** @import { AST } from '#compiler' */
 /** @import { ComponentContext } from '../../types.js' */
-import { dev, is_ignored } from '../../../../../state.js';
+import { dev, is_ignored, locator } from '../../../../../state.js';
 import { get_attribute_chunks, object } from '../../../../../utils/ast.js';
 import * as b from '#compiler/builders';
 import { build_bind_this, memoize_expression, validate_binding } from '../shared/utils.js';
@@ -440,6 +440,13 @@ export function build_component(node, component_name, context, anchor = context.
 	}
 
 	if (Object.keys(custom_css_props).length > 0) {
+		if (dev) {
+			const loc = locator(node.start);
+			if (loc) {
+				context.state.locations.push([loc.line, loc.column]);
+			}
+		}
+
 		context.state.template.push(
 			context.state.metadata.namespace === 'svg'
 				? '<g><!></g>'

--- a/packages/svelte/tests/runtime-runes/samples/svelte-meta-css-wrapper/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-meta-css-wrapper/Component.svelte
@@ -1,0 +1,7 @@
+<h2>hello from component</h2>
+
+<style>
+	h2 {
+		color: var(--color);
+	}
+</style>

--- a/packages/svelte/tests/runtime-runes/samples/svelte-meta-css-wrapper/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-meta-css-wrapper/_config.js
@@ -1,0 +1,42 @@
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	html: `
+		<h1>hello</h1>
+		<svelte-css-wrapper style="display: contents; --color: red;">
+			<h2 class="svelte-13kae5a">hello from component</h2>
+		</svelte-css-wrapper>
+		<p>goodbye</p>
+	`,
+
+	async test({ target, assert }) {
+		const h1 = target.querySelector('h1');
+		const h2 = target.querySelector('h2');
+		const p = target.querySelector('p');
+
+		// @ts-expect-error
+		assert.deepEqual(h1.__svelte_meta.loc, {
+			file: 'main.svelte',
+			line: 5,
+			column: 0
+		});
+
+		// @ts-expect-error
+		assert.deepEqual(h2.__svelte_meta.loc, {
+			file: 'Component.svelte',
+			line: 1,
+			column: 0
+		});
+
+		// @ts-expect-error
+		assert.deepEqual(p.__svelte_meta.loc, {
+			file: 'main.svelte',
+			line: 7,
+			column: 0
+		});
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-meta-css-wrapper/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-meta-css-wrapper/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Component from './Component.svelte';
+</script>
+
+<h1>hello</h1>
+<Component --color="red" />
+<p>goodbye</p>


### PR DESCRIPTION
spotted while working on #15538 — if we insert a `<svelte-css-wrapper>`, it desyncs the template from the `locations` array, meaning the `__svelte_meta` object (which allows things like the inspector to work) is attached to the wrong element

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
