### PR TITLE
fix: don't mark deriveds as clean if updating during teardown

### DIFF
--- a/.changeset/old-insects-divide.md
+++ b/.changeset/old-insects-divide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't mark deriveds as clean if updating during teardown

--- a/packages/svelte/tests/runtime-runes/samples/effect-teardown-stale-value/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-teardown-stale-value/_config.js
@@ -1,0 +1,22 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	html: `<button>toggle (false)</button>`,
+
+	async test({ assert, target, logs }) {
+		assert.deepEqual(logs, ['up', { foo: false, bar: false }]);
+
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+		assert.deepEqual(logs, [
+			'up',
+			{ foo: false, bar: false },
+			'down',
+			{ foo: false, bar: false },
+			'up',
+			{ foo: true, bar: true }
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-teardown-stale-value/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-teardown-stale-value/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	let foo = $state(false)
+	let bar = $derived(foo)
+
+	$effect(() => {
+		console.log('up', { foo, bar });
+
+		return () =>{
+			console.log('down', { foo, bar });
+		};
+	});
+</script>
+
+<button onclick={() => foo = !foo}>toggle ({foo})</button>


### PR DESCRIPTION
Fixes the issue reported here: https://www.reddit.com/r/sveltejs/comments/1ku7skr/can_someone_explain_this_weird_behavior_i_really. Previously, deriveds read during effect teardown were being marked clean, which caused them to hold onto incorrect values if they depended on state that had just changed

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
