### PR TITLE
fix: only use iterator destructuring logic if there's an array pattern

### DIFF
--- a/.changeset/smooth-cameras-repair.md
+++ b/.changeset/smooth-cameras-repair.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only use iterator destructuring logic if there's an array pattern

--- a/packages/svelte/tests/snapshot/samples/destructure-derived-arrays/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/destructure-derived-arrays/_expected/client/index.svelte.js
@@ -1,0 +1,60 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+export default function Destructure_derived_arrays($$anchor) {
+	let $$d = $.derived(() => ({})),
+		a = $.derived(() => $.get($$d).a),
+		b = $.derived(() => $.get($$d).b),
+		c = $.derived(() => $.get($$d).c);
+
+	let $$d_1 = $.derived(() => []),
+		d = $.derived(() => {
+			let [$$1, $$2, $$3] = $.get($$d_1);
+
+			return $$1;
+		}),
+		e = $.derived(() => {
+			let [$$1, $$2, $$3] = $.get($$d_1);
+
+			return $$2;
+		}),
+		f = $.derived(() => {
+			let [$$1, $$2, $$3] = $.get($$d_1);
+
+			return $$3;
+		});
+
+	let $$d_2 = $.derived(() => []),
+		g = $.derived(() => {
+			let { g: $$4, h: $$5, i: [$$6] } = $.get($$d_2);
+
+			return $$4;
+		}),
+		h = $.derived(() => {
+			let { g: $$4, h: $$5, i: [$$6] } = $.get($$d_2);
+
+			return $$5;
+		}),
+		j = $.derived(() => {
+			let { g: $$4, h: $$5, i: [$$6] } = $.get($$d_2);
+
+			return $$6;
+		});
+
+	let $$d_3 = $.derived(() => []),
+		k = $.derived(() => {
+			let { k: $$7, l: $$8, m: { n: [$$9] } } = $.get($$d_3);
+
+			return $$7;
+		}),
+		l = $.derived(() => {
+			let { k: $$7, l: $$8, m: { n: [$$9] } } = $.get($$d_3);
+
+			return $$8;
+		}),
+		o = $.derived(() => {
+			let { k: $$7, l: $$8, m: { n: [$$9] } } = $.get($$d_3);
+
+			return $$9;
+		});
+}

--- a/packages/svelte/tests/snapshot/samples/destructure-derived-arrays/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/destructure-derived-arrays/_expected/server/index.svelte.js
@@ -1,0 +1,8 @@
+import * as $ from 'svelte/internal/server';
+
+export default function Destructure_derived_arrays($$payload) {
+	let { a, b, c } = {};
+	let [d, e, f] = [];
+	let { g, h, i: [j] } = [];
+	let { k, l, m: { n: [o] } } = [];
+}

--- a/packages/svelte/tests/snapshot/samples/destructure-derived-arrays/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/destructure-derived-arrays/index.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { a, b, c } = $derived({});
+	let [d, e, f] = $derived([]);
+	let { g, h, i: [j] } = $derived([]);
+	let { k, l, m: { n: [o] } } = $derived([]);
+</script>
+


### PR DESCRIPTION
Closes #15996

The logic introduced in #15813 produce much more chunky code...while this is not really a problem since the generated code should gzip wonderfully we really don't need to use that logic unless there's an `ArrayPattern` in the declarator.

I've added a snapshot test but I'm not sure is worth having but i can remove it easily if we think it's not worth.

Also this is walking the `ObjectPattern` because if at any point in the destructure there's an array we need to fall back to what @Ocean-OS introduced for the same reason.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`