### PR TITLE
fix: cleanup event handlers on media elements

### DIFF
--- a/.changeset/thin-dolls-cover.md
+++ b/.changeset/thin-dolls-cover.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: cleanup event handlers on media elements

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -112,8 +112,14 @@ export function event(event_name, dom, handler, capture, passive) {
 	var options = { capture, passive };
 	var target_handler = create_event(event_name, dom, handler, options);
 
-	// @ts-ignore
-	if (dom === document.body || dom === window || dom === document) {
+	if (
+		dom === document.body ||
+		// @ts-ignore
+		dom === window ||
+		// @ts-ignore
+		dom === document ||
+		dom instanceof HTMLMediaElement
+	) {
 		teardown(() => {
 			dom.removeEventListener(event_name, target_handler, options);
 		});

--- a/packages/svelte/tests/runtime-runes/samples/event-media-element-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-media-element-cleanup/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+import { expect, vi } from 'vitest';
+
+const handler = vi.fn();
+
+export default test({
+	props: {
+		handler
+	},
+	async test({ target }) {
+		const button = target.querySelector('button');
+		const video = target.querySelector('video');
+
+		button?.click();
+		flushSync();
+		video?.dispatchEvent(new Event('someevent'));
+		expect(handler).not.toHaveBeenCalled();
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-media-element-cleanup/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-media-element-cleanup/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	const { handler } = $props();
+	let show = $state(true);
+</script>
+
+<button onclick={() => show = false}>show/hide</button>
+{#if show}
+	<video onsomeevent={handler}></video>
+{/if}


### PR DESCRIPTION
Fixes #14245 - this is FF-only problem because when `canplay` fires, the video element is still connected to the DOM in Chrome, but already detached in FF. [REPL](https://svelte.dev/playground/af22b7498721433ab48844b41a9f8937?version=5.33.2#H4sIAAAAAAAAA5VTwW7bMAz9FVUbUAdI7GTdgMF1Aiz7gR16m4dAlhlHiCIZEu02MPzvo61kWZsc2pv1SL7HR9IdN-IAPOW-BY3AvrFWlWCZNVKYWosjn_Kt0uB5-rvjeKyH3AEg_FT5o67jUE1YITzcwqU1CAaJhmdeOlXjKjc5akBG-YWGX6RVCLlnS_bZo0CItkJ7mDye04ZmwF3CQyRLLlwmK1U7kmZFg2jN4EEruV920YQtVyy6Erp7jUz61fAZJpAlgWU1qJyYTfdJbd_024-Kd7MZC15nqjLWAROLxXFzgFKJzU74jRQ1KuppNgstjhrDV46FMmWKO-WXXfDYB9w7ucz5DrH2aZKU9tloK8qYtE0JLrauSmoQcpcUqioauS8aY0jStgp8slbVmrD1iD18mb8svs_jQ_0154FcNGgHtfAatuOs9uFlRyEoS4GChgfj9LoQy_FqiuOeHs9hovJWQ6xtFd1feO6nDGLZOEdH8CRcBRgr_9MaAxKhnJzK-_7cAaoDNDVVwnUH_0vk_JKZ8w-KnE78tgKylsy94ftns42Hymhy2_eJ-H2madOAT-TCNhiFUyV20Xi68Sl7mM_nrztfZcl4PXRIXaK2hNH_hfCCPEXXQP-HXkLpZzorno7L6f8CM2ijbuYDAAA=)

Looks like just removing the listeners in the teardown is enough. But I'm not sure whether there are more timing-tricky cases.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
