### PR TITLE
chore: use dev: false in sandbox

### DIFF
--- a/playgrounds/sandbox/run.js
+++ b/playgrounds/sandbox/run.js
@@ -73,7 +73,7 @@ for (const generate of /** @type {const} */ (['client', 'server'])) {
 		}
 
 		const compiled = compile(source, {
-			dev: true,
+			dev: false,
 			filename: input,
 			generate,
 			runes: argv.values.runes
@@ -90,7 +90,7 @@ for (const generate of /** @type {const} */ (['client', 'server'])) {
 		// generate with fragments: 'tree'
 		if (generate === 'client') {
 			const compiled = compile(source, {
-				dev: true,
+				dev: false,
 				filename: input,
 				generate,
 				runes: argv.values.runes,
@@ -114,7 +114,7 @@ for (const generate of /** @type {const} */ (['client', 'server'])) {
 		const source = fs.readFileSync(input, 'utf-8');
 
 		const compiled = compileModule(source, {
-			dev: true,
+			dev: false,
 			filename: input,
 			generate
 		});


### PR DESCRIPTION
QOL thing — i use the sandbox a lot to see how stuff compiles, and `dev: true` introduces a lot of noise that i almost never want