### PR TITLE
docs: add missing 'at' in sentence three of description

### DIFF
--- a/documentation/docs/05-special-elements/04-svelte-body.md
+++ b/documentation/docs/05-special-elements/04-svelte-body.md
@@ -8,7 +8,7 @@ title: <svelte:body>
 
 Similarly to `<svelte:window>`, this element allows you to add listeners to events on `document.body`, such as `mouseenter` and `mouseleave`, which don't fire on `window`. It also lets you use [actions](use) on the `<body>` element.
 
-As with `<svelte:window>` and `<svelte:document>`, this element may only appear the top level of your component and must never be inside a block or element.
+As with `<svelte:window>` and `<svelte:document>`, this element may only appear at the top level of your component and must never be inside a block or element.
 
 ```svelte
 <svelte:body onmouseenter={handleMouseenter} onmouseleave={handleMouseleave} use:someAction />


### PR DESCRIPTION
Adds a missing 'at' in the third sentence of the description for clarity.

This is a small documentation typo fix and does not affect functionality or code logic.