### PR TITLE
fix: only `select_option` if `'value'` is in `next`

### DIFF
--- a/.changeset/smooth-weeks-hide.md
+++ b/.changeset/smooth-weeks-hide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only `select_option` if `'value'` is in `next`

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -486,7 +486,7 @@ export function attribute_effect(
 
 		set_attributes(element, prev, next, css_hash, skip_warning);
 
-		if (inited && is_select) {
+		if (inited && is_select && 'value' in next) {
 			select_option(/** @type {HTMLSelectElement} */ (element), next.value, false);
 		}
 

--- a/packages/svelte/tests/runtime-runes/samples/spread-element-input-select/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/spread-element-input-select/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const select = target.querySelector('select');
+		ok(select);
+		const [option1, option2] = select;
+
+		assert.ok(option1.selected);
+		assert.ok(!option2.selected);
+
+		const btn = target.querySelector('button');
+		flushSync(() => {
+			btn?.click();
+		});
+		assert.ok(option1.selected);
+		assert.ok(!option2.selected);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/spread-element-input-select/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/spread-element-input-select/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let { value = "Hello", spread = { disabled: false } } = $props();
+</script>
+
+<button onclick={()=> spread = { disabled: false }}></button>
+
+<select bind:value {...spread}>
+  <option>Hello</option>
+  <option>World</option>
+</select>


### PR DESCRIPTION
Closes #16030

Small regression introduced in #15961 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`