### PR TITLE
fix: transitions might render animated elements without animation styles applied for the duration of some rendering frames when they start

### DIFF
--- a/.changeset/tiny-poems-scream.md
+++ b/.changeset/tiny-poems-scream.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: transitions might render animated elements without animation styles applied for the duration of some rendering frames when they start

--- a/.changeset/tiny-poems-scream.md
+++ b/.changeset/tiny-poems-scream.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: transitions might render animated elements without animation styles applied for the duration of some rendering frames when they start
+fix: use `fill: 'forwards'` on transition animations to prevent flicker

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -381,9 +381,17 @@ function animate(element, options, counterpart, t2, on_finish) {
 	// create a dummy animation that lasts as long as the delay (but with whatever devtools
 	// multiplier is in effect). in the common case that it is `0`, we keep it anyway so that
 	// the CSS keyframes aren't created until the DOM is updated
-	var animation = element.animate(keyframes, { duration: delay });
+	//
+	// fill forwards to prevent the element to render without animation styles applied
+	// when entering the onfinish callback, can be verified by adding a breakpoint in the onfinish callback
+	// see https://github.com/sveltejs/svelte/issues/14732
+	var animation = element.animate(keyframes, { duration: delay, fill: 'forwards' });
 
 	animation.onfinish = () => {
+		// have to manually cancel the dummy animation to remove it from the animations stack
+		// because it fill forwards
+		animation.cancel();
+
 		// for bidirectional transitions, we start from the current position,
 		// rather than doing a full intro/outro
 		var t1 = counterpart?.t() ?? 1 - t2;

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -382,14 +382,12 @@ function animate(element, options, counterpart, t2, on_finish) {
 	// multiplier is in effect). in the common case that it is `0`, we keep it anyway so that
 	// the CSS keyframes aren't created until the DOM is updated
 	//
-	// fill forwards to prevent the element to render without animation styles applied
-	// when entering the onfinish callback, can be verified by adding a breakpoint in the onfinish callback
+	// fill forwards to prevent the element from rendering without styles applied
 	// see https://github.com/sveltejs/svelte/issues/14732
 	var animation = element.animate(keyframes, { duration: delay, fill: 'forwards' });
 
 	animation.onfinish = () => {
-		// have to manually cancel the dummy animation to remove it from the animations stack
-		// because it fill forwards
+		// remove dummy animation from the stack to prevent conflict with main animation
 		animation.cancel();
 
 		// for bidirectional transitions, we start from the current position,


### PR DESCRIPTION
Fix the issue reported at https://github.com/sveltejs/svelte/issues/14732

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
