### PR TITLE
fix: use local mutable sources for props in legacy mode in case they are indirectly invalidated

### DIFF
--- a/.changeset/orange-tips-pull.md
+++ b/.changeset/orange-tips-pull.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: use local mutable sources for props in legacy mode in case they are indirectly invalidated

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -335,7 +335,7 @@ export function prop(props, key, flags, fallback) {
 	}
 
 	// easy mode — prop is never written to
-	if ((flags & PROPS_IS_UPDATED) === 0) {
+	if ((flags & PROPS_IS_UPDATED) === 0 && runes) {
 		return getter;
 	}
 


### PR DESCRIPTION
This is a real strange one. There's a test, `binding-input-text-contextual-reactive`, that passes on `main` but [doesn't work in a real app](https://svelte.dev/playground/hello-world?version=5.33.10#H4sIAAAAAAAAE22RzW7CMBCEX2XrIgUkIHc3UPXWdyBImHgpbh3Hijf8KMq712tAFJVLEo9mJp93e-FUjUKKT7S2gWPTWg1j1IZQT8RU7IzFIOSqF3T27GMh6tfUh_fzcEBLrG1VwGd61ThCR7FGFKFqjadl6UrCk29aAosE8W91gAWsWC-pB904lLBTNuAUopMkZFHKYJg-Wqjt7g46Nv8djyW0b5Fr2LN-i8_4HkkIXV2r9hwREsq8Vn5sYLGEzag3cy6Cd8h0QogtLdbKOOO-skGygcuHzWT-3Rg3ziCHbBK7i_x-W9e_oqr215uqkD4SRaHNYXlBLozzHQFPelGKao_Vz7Y5lQK2xmmZzqgXPUcT0_A0xzC3zEHZDq-JBHlL-OUfsch90ov8wtLnzMp0rniZzYD2JsRpYnAZQee1IoTZLBq55jq6VBKXzYVC8lqGdTwpY48RRMi0huEXC7yvHW8CAAA=) (try editing the items — the summary never updates).

The diff below fixes it, but I cannot for the life of me make the test fail without it.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
