### PR TITLE
fix: don't re-`attach` the same function to the same element

### DIFF
--- a/.changeset/red-tools-eat.md
+++ b/.changeset/red-tools-eat.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't re-`attach` the same function to the same element

--- a/packages/svelte/tests/runtime-runes/samples/attachment-same-fn/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/attachment-same-fn/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target, logs }) {
+		const p = target.querySelector('p');
+		const btn = target.querySelector('button');
+
+		assert.deepEqual(logs, ['up']);
+		assert.equal(p?.dataset.count, '0');
+
+		flushSync(() => {
+			btn?.click();
+		});
+
+		assert.deepEqual(logs, ['up']);
+		assert.equal(p?.dataset.count, '1');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/attachment-same-fn/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/attachment-same-fn/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	import { createAttachmentKey } from "svelte/attachments";
+
+	let count = $state(0);
+
+	const attachment = () => {
+			console.log("up");
+			return () => {
+				console.log("down");
+			}
+		}
+	
+	const props = $derived({
+		'data-count': count,
+		[createAttachmentKey()]: attachment
+	});
+</script>
+
+<p {...props}></p>
+
+<button onclick={() => count++}>{count}</button>


### PR DESCRIPTION
Closes #16044

As I've said on the issue I think it will have a performance impact both because we need to call `Object.getOwnPropertySymbols` on the previous values, find the function in it (and we need to do that for every attachment) and we also need to call `delete effects[that_symbol]` (I know delete is veeeeery slow)...that said we should gain by not recreating an effect so maybe worth it unnecessarily?

However it also just occurred to me that this is technically a breaking change since someone might rely on this behaviour? Also imagine a situation like this

```ts
function the_actual_attachment(node){
    // do stuff
}

function another_actual_attachment(node){
    // do stuff
}

function attachment_factory(arg){
    if(arg % 2 === 0) return the_actual_attachment;
    return another_actual_attachment;
}
```
this will basically not rerun if you switch the argument from 2 to 4.

So yeah I'm a bit contrived about this changes but I implemented it to see if it's possible so maybe let's discuss it.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`