### PR TITLE
fix: correctly transform reassignments to class fields in SSR mode

### DIFF
--- a/.changeset/rude-drinks-relate.md
+++ b/.changeset/rude-drinks-relate.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly transform reassignments to class fields in SSR mode

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -24,7 +24,12 @@ export function AssignmentExpression(node, context) {
  * @returns {Expression | null}
  */
 function build_assignment(operator, left, right, context) {
-	if (context.state.analysis.runes && left.type === 'MemberExpression') {
+	if (
+		context.state.analysis.runes &&
+		left.type === 'MemberExpression' &&
+		left.object.type === 'ThisExpression' &&
+		!left.computed
+	) {
 		const name = get_name(left.property);
 		const field = name && context.state.state_fields.get(name);
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -49,11 +49,6 @@ function build_assignment(operator, left, right, context) {
 					/** @type {Expression} */ (context.visit(right))
 				);
 			}
-		} else if (field && (field.type === '$derived' || field.type === '$derived.by')) {
-			let value = /** @type {Expression} */ (
-				context.visit(build_assignment_value(operator, left, right))
-			);
-			return b.call(b.member(b.this, name), value);
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/AssignmentExpression.js
@@ -49,6 +49,15 @@ function build_assignment(operator, left, right, context) {
 					/** @type {Expression} */ (context.visit(right))
 				);
 			}
+		} else if (
+			field &&
+			(field.type === '$derived' || field.type === '$derived.by') &&
+			left.property.type === 'PrivateIdentifier'
+		) {
+			let value = /** @type {Expression} */ (
+				context.visit(build_assignment_value(operator, left, right))
+			);
+			return b.call(b.member(b.this, name), value);
 		}
 	}
 

--- a/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/client/index.svelte.js
@@ -5,7 +5,7 @@ export default function Class_state_field_constructor_assignment($$anchor, $$pro
 	$.push($$props, true);
 
 	class Foo {
-		#a = $.state();
+		#a = $.state(0);
 
 		get a() {
 			return $.get(this.#a);
@@ -16,10 +16,31 @@ export default function Class_state_field_constructor_assignment($$anchor, $$pro
 		}
 
 		#b = $.state();
+		#foo = $.derived(() => ({ bar: this.a * 2 }));
+
+		get foo() {
+			return $.get(this.#foo);
+		}
+
+		set foo(value) {
+			$.set(this.#foo, value);
+		}
+
+		#bar = $.derived(() => ({ baz: this.foo }));
+
+		get bar() {
+			return $.get(this.#bar);
+		}
+
+		set bar(value) {
+			$.set(this.#bar, value);
+		}
 
 		constructor() {
 			this.a = 1;
 			$.set(this.#b, 2);
+			this.foo.bar = 3;
+			this.bar = 4;
 		}
 	}
 

--- a/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/_expected/server/index.svelte.js
@@ -4,12 +4,33 @@ export default function Class_state_field_constructor_assignment($$payload, $$pr
 	$.push();
 
 	class Foo {
-		a;
+		a = 0;
 		#b;
+		#foo = $.derived(() => ({ bar: this.a * 2 }));
+
+		get foo() {
+			return this.#foo();
+		}
+
+		set foo($$value) {
+			return this.#foo($$value);
+		}
+
+		#bar = $.derived(() => ({ baz: this.foo }));
+
+		get bar() {
+			return this.#bar();
+		}
+
+		set bar($$value) {
+			return this.#bar($$value);
+		}
 
 		constructor() {
 			this.a = 1;
 			this.#b = 2;
+			this.foo.bar = 3;
+			this.bar = 4;
 		}
 	}
 

--- a/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/class-state-field-constructor-assignment/index.svelte
@@ -1,11 +1,14 @@
 <script>
 	class Foo {
-		a = $state();
+		a = $state(0);
 		#b = $state();
-
+		foo = $derived({ bar: this.a * 2 });
+		bar = $derived({ baz: this.foo });
 		constructor() {
 			this.a = 1;
 			this.#b = 2;
+			this.foo.bar = 3;
+			this.bar = 4;
 		}
 	}
 </script>


### PR DESCRIPTION
Fixes #16050. It appears that we weren't doing enough checks on reassignments in SSR mode, so reassignments like these...
```js
this.foo.bar = 5;
foo.bar = 5;
```
would be incorrectly transformed to
```js
this.bar(5);
this.bar(5);
```
If `this.bar` was a derived class field. Additionally, since derived class fields are now transformed to getters and setters per #15964, we don't need to transform (public) derived assignments to function calls. 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
