### PR TITLE
chore: better HTML normalization test helper

### DIFF
--- a/packages/svelte/tests/html_equal.js
+++ b/packages/svelte/tests/html_equal.js
@@ -121,63 +121,53 @@ export function normalize_new_line(html) {
 	return html.replace(/\r\n/g, '\n');
 }
 
-export function setup_html_equal() {
-	/**
-	 * @param {string} actual
-	 * @param {string} expected
-	 * @param {string} [message]
-	 */
-	const assert_html_equal = (actual, expected, message) => {
-		try {
-			assert.deepEqual(normalize_html(window, actual), normalize_html(window, expected), message);
-		} catch (e) {
-			if (Error.captureStackTrace)
-				Error.captureStackTrace(/** @type {Error} */ (e), assert_html_equal);
-			throw e;
-		}
-	};
+/**
+ * @param {string} actual
+ * @param {string} expected
+ * @param {string} [message]
+ */
+export const assert_html_equal = (actual, expected, message) => {
+	try {
+		assert.deepEqual(normalize_html(window, actual), normalize_html(window, expected), message);
+	} catch (e) {
+		if (Error.captureStackTrace)
+			Error.captureStackTrace(/** @type {Error} */ (e), assert_html_equal);
+		throw e;
+	}
+};
 
-	/**
-	 *
-	 * @param {string} actual
-	 * @param {string} expected
-	 * @param {{ preserveComments?: boolean, withoutNormalizeHtml?: boolean }} param2
-	 * @param {string} [message]
-	 */
-	const assert_html_equal_with_options = (
-		actual,
-		expected,
-		{ preserveComments, withoutNormalizeHtml },
-		message
-	) => {
-		try {
-			assert.deepEqual(
-				withoutNormalizeHtml
-					? normalize_new_line(actual.trim()).replace(
-							/(<!(--)?.*?\2>)/g,
-							preserveComments !== false ? '$1' : ''
-						)
-					: normalize_html(window, actual.trim(), { preserveComments }),
-				withoutNormalizeHtml
-					? normalize_new_line(expected.trim()).replace(
-							/(<!(--)?.*?\2>)/g,
-							preserveComments !== false ? '$1' : ''
-						)
-					: normalize_html(window, expected.trim(), { preserveComments }),
-				message
-			);
-		} catch (e) {
-			if (Error.captureStackTrace)
-				Error.captureStackTrace(/** @type {Error} */ (e), assert_html_equal_with_options);
-			throw e;
-		}
-	};
-
-	return {
-		assert_html_equal,
-		assert_html_equal_with_options
-	};
-}
-
-// Common case without options
-export const { assert_html_equal, assert_html_equal_with_options } = setup_html_equal();
+/**
+ *
+ * @param {string} actual
+ * @param {string} expected
+ * @param {{ preserveComments?: boolean, withoutNormalizeHtml?: boolean }} param2
+ * @param {string} [message]
+ */
+export const assert_html_equal_with_options = (
+	actual,
+	expected,
+	{ preserveComments, withoutNormalizeHtml },
+	message
+) => {
+	try {
+		assert.deepEqual(
+			withoutNormalizeHtml
+				? normalize_new_line(actual.trim()).replace(
+						/(<!(--)?.*?\2>)/g,
+						preserveComments !== false ? '$1' : ''
+					)
+				: normalize_html(window, actual.trim(), { preserveComments }),
+			withoutNormalizeHtml
+				? normalize_new_line(expected.trim()).replace(
+						/(<!(--)?.*?\2>)/g,
+						preserveComments !== false ? '$1' : ''
+					)
+				: normalize_html(window, expected.trim(), { preserveComments }),
+			message
+		);
+	} catch (e) {
+		if (Error.captureStackTrace)
+			Error.captureStackTrace(/** @type {Error} */ (e), assert_html_equal_with_options);
+		throw e;
+	}
+};

--- a/packages/svelte/tests/html_equal.js
+++ b/packages/svelte/tests/html_equal.js
@@ -96,7 +96,7 @@ function clean_children(node, opts) {
 	}
 
 	if (has_element_children && node.parentNode) {
-		node.innerHTML = `\n\t${node.innerHTML.replace(/\n/g, '\n\t')}\n`;
+		node.innerHTML = `\n\  ${node.innerHTML.replace(/\n/g, '\n  ')}\n`;
 	}
 
 	if (template) {

--- a/packages/svelte/tests/html_equal.js
+++ b/packages/svelte/tests/html_equal.js
@@ -26,6 +26,7 @@ function clean_children(node, opts) {
 	});
 
 	attributes.forEach((attr) => {
+		// Strip out the special onload/onerror hydration events from the test output
 		if ((attr.name === 'onload' || attr.name === 'onerror') && attr.value === 'this.__e=event') {
 			return;
 		}
@@ -67,6 +68,7 @@ function clean_children(node, opts) {
 			continue;
 		}
 
+		// add newlines for better readability and potentially recurse into children
 		if (child.nodeType === 1 || child.nodeType === 8) {
 			if (previous?.nodeType === 3) {
 				const prev = /** @type {Text} */ (previous);
@@ -95,6 +97,7 @@ function clean_children(node, opts) {
 		text.data = text.data.trimEnd();
 	}
 
+	// indent code for better readability
 	if (has_element_children && node.parentNode) {
 		node.innerHTML = `\n\  ${node.innerHTML.replace(/\n/g, '\n  ')}\n`;
 	}

--- a/packages/svelte/tests/runtime-legacy/samples/binding-select/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-select/_config.js
@@ -25,7 +25,7 @@ export default test({
 			<p>selected: one</p>
 
 			<select>
-				<option${variant === 'hydrate' ? ' selected' : ''}>one</option$>
+				<option${variant === 'hydrate' ? ' selected' : ''}>one</option>
 				<option>two</option>
 				<option>three</option>
 			</select>
@@ -54,7 +54,7 @@ export default test({
 			<p>selected: two</p>
 
 			<select>
-				<option${variant === 'hydrate' ? ' selected' : ''}>one</option$>
+				<option${variant === 'hydrate' ? ' selected' : ''}>one</option>
 				<option>two</option>
 				<option>three</option>
 			</select>

--- a/packages/svelte/tests/runtime-legacy/samples/input-list/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/input-list/_config.js
@@ -4,7 +4,9 @@ export default test({
 	html: `
 		<input list='suggestions'>
 		<datalist id='suggestions'>
-			<option value='foo'/><option value='bar'/><option value='baz'/>
+			<option value='foo'></option>
+			<option value='bar'></option>
+			<option value='baz'></option>
 		</datalist>
 	`
 });

--- a/packages/svelte/tests/runtime-legacy/samples/namespace-html/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/namespace-html/_config.js
@@ -9,7 +9,7 @@ export default test({
 
 		<math>
 			<mrow></mrow>
-		</svg>
+		</math>
 
 		<div class="hi">hi</div>
 	`,

--- a/packages/svelte/tests/runtime-legacy/samples/select-in-each/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/select-in-each/_config.js
@@ -7,7 +7,7 @@ export default test({
 			target.innerHTML,
 			`
 			<select>
-				<option${variant === 'hydrate' ? ' selected' : ''} value="a">A</option$>
+				<option${variant === 'hydrate' ? ' selected' : ''} value="a">A</option>
 				<option value="b">B</option>
 			</select>
 			selected: a
@@ -23,7 +23,7 @@ export default test({
 			target.innerHTML,
 			`
 			<select>
-				<option${variant === 'hydrate' ? ' selected' : ''} value="a">A</option$>
+				<option${variant === 'hydrate' ? ' selected' : ''} value="a">A</option>
 				<option value="b">B</option>
 			</select>
 			selected: b

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -86,9 +86,7 @@ function unhandled_rejection_handler(err: Error) {
 
 const listeners = process.rawListeners('unhandledRejection');
 
-const { assert_html_equal, assert_html_equal_with_options } = setup_html_equal({
-	removeDataSvelte: true
-});
+const { assert_html_equal, assert_html_equal_with_options } = setup_html_equal();
 
 beforeAll(() => {
 	// @ts-expect-error TODO huh?

--- a/packages/svelte/tests/runtime-legacy/shared.ts
+++ b/packages/svelte/tests/runtime-legacy/shared.ts
@@ -7,7 +7,7 @@ import { flushSync, hydrate, mount, unmount } from 'svelte';
 import { render } from 'svelte/server';
 import { afterAll, assert, beforeAll } from 'vitest';
 import { compile_directory, fragments } from '../helpers.js';
-import { setup_html_equal } from '../html_equal.js';
+import { assert_html_equal, assert_html_equal_with_options } from '../html_equal.js';
 import { raf } from '../animation-helpers.js';
 import type { CompileOptions } from '#compiler';
 import { suite_with_variants, type BaseTest } from '../suite.js';
@@ -85,8 +85,6 @@ function unhandled_rejection_handler(err: Error) {
 }
 
 const listeners = process.rawListeners('unhandledRejection');
-
-const { assert_html_equal, assert_html_equal_with_options } = setup_html_equal();
 
 beforeAll(() => {
 	// @ts-expect-error TODO huh?


### PR DESCRIPTION
This fixes a particular bugbear of mine with our test setup.

We have an `assert.htmlEqual` utility that compares two HTML strings. Before doing so it normalizes them, because otherwise you'd have to pay very close attention to hydration markers and whitespace and stuff that distracts from the thing being tested (if a test _does_ need to pay attention to those things it is able to do so, but `htmlEqual` is the wrong tool).

The trouble is that the output of the normalization process is prohibitively difficult to read, and my brain gets fatigued trying to work out what needs to change about the output when I see something like this:

```diff
- Expected
+ Received

  <select><option selected="" value="[object Object]">put
  your
  left
  leg
  in</option><option value="[object Object]">your
  left
  leg
  out</option><option value="[object Object]">in,
  out,
  in,
- out</option><option value="[object Object]">wiggle
+ out</option><option value="[object Object]">shake
  it
  all
  about</option></select><label><input type="checkbox">
  put
  your
  left
  leg
  in</label><h2>Pending
  tasks</h2><p>put
  your
  left
  leg
  in</p><p>your
  left
  leg
  out</p><p>in,
  out,
  in,
- out</p><p>wiggle
+ out</p><p>shake
  it
  all
  about</p>
```

With this PR, you get something much more readable:

```diff
- Expected
+ Received

  <select>
        <option value="[object Object]">put your left leg in</option>
        <option value="[object Object]">your left leg out</option>
        <option value="[object Object]">in, out, in, out</option>
-       <option value="[object Object]">wiggle it all about</option>
+       <option value="[object Object]">shake it all about</option>
  </select>
  <label>
        <input type="checkbox"> put your left leg in
  </label>
  <h2>Pending tasks</h2>
  <p>put your left leg in</p>
  <p>your left leg out</p>
  <p>in, out, in, out</p>
- <p>wiggle it all about</p>
+ <p>shake it all about</p>
```

Better still: it caught some errors in the tests that our existing normalization was glossing over.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
