### PR TITLE
Revert "feat: enable TS autocomplete for Svelte HTML element definitions"

### DIFF
--- a/.changeset/dry-squids-compete.md
+++ b/.changeset/dry-squids-compete.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+Revert "feat: enable TS autocomplete for Svelte HTML element definitions"

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -2066,7 +2066,7 @@ export interface SvelteHTMLElements {
 		failed?: import('svelte').Snippet<[error: unknown, reset: () => void]>;
 	};
 
-	[name: string & {}]: { [name: string]: any };
+	[name: string]: { [name: string]: any };
 }
 
 export type ClassValue = string | import('clsx').ClassArray | import('clsx').ClassDictionary;

--- a/packages/svelte/svelte-html.d.ts
+++ b/packages/svelte/svelte-html.d.ts
@@ -8,7 +8,7 @@ import * as svelteElements from './elements.js';
 /**
  * @internal do not use
  */
-type HTMLProps<Property extends keyof svelteElements.SvelteHTMLElements, Override> = Omit<
+type HTMLProps<Property extends string, Override> = Omit<
 	import('./elements.js').SvelteHTMLElements[Property],
 	keyof Override
 > &
@@ -250,7 +250,7 @@ declare global {
 			};
 			// don't type svelte:options, it would override the types in svelte/elements and it isn't extendable anyway
 
-			[name: string & {}]: { [name: string]: any };
+			[name: string]: { [name: string]: any };
 		}
 	}
 }


### PR DESCRIPTION
Reverts #15972, since it caused #16046 — a far more pressing limitation than the one #15972 addressed