### PR TITLE
feat: make internal Svelte Custom Element treeshakable

### DIFF
--- a/.changeset/warm-jokes-perform.md
+++ b/.changeset/warm-jokes-perform.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Make internal Svelte Custom Element treeshakable

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -10,11 +10,12 @@ import { define_property, get_descriptor, object_keys } from '../../../shared/ut
  * @property {'String'|'Boolean'|'Number'|'Array'|'Object'} [type]
  */
 
-/** @type {any} */
-let SvelteElement;
+function get_svelte_element_class() {
+	if (typeof HTMLElement !== 'function') {
+		return;
+	}
 
-if (typeof HTMLElement === 'function') {
-	SvelteElement = class extends HTMLElement {
+	return class extends HTMLElement {
 		/** The Svelte component constructor */
 		$$ctor;
 		/** Slots */
@@ -218,6 +219,9 @@ if (typeof HTMLElement === 'function') {
 		}
 	};
 }
+
+/** @type {any} */
+const SvelteElement = /* @__PURE__ */ get_svelte_element_class();
 
 /**
  * @param {string} prop


### PR DESCRIPTION
When inspecting my own application I noticed that despite not using any custom elements Svelte still includes code for it. This PR marks Svelte Custom Element with pure annotation so when it is not used it can safely removed.

I was not able to make it work with conditional assigment so I moved class definition into function, in my testing this reduces size of minified code by ~2kb.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
