### PR TITLE
fix: set and flushSync state that should render in if when another state is set breaks reactivity temporarily

### DIFF
--- a/.changeset/tough-meals-scream.md
+++ b/.changeset/tough-meals-scream.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Restore flushSync optimizations from #15855 to replace the one from #15895

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -823,8 +823,6 @@ export function flushSync(fn) {
 	if (fn) {
 		is_flushing = true;
 		flush_queued_root_effects();
-
-		is_flushing = true;
 		result = fn();
 	}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -834,6 +834,9 @@ export function flushSync(fn) {
 		}
 
 		while (true) {
+			// is_flushing cannot be set to `true` before `flush_tasks` because it
+			// causes the regression at #16076, this can only be observed
+			// in browser and not in jsdom
 			flush_tasks();
 
 			if (queued_root_effects.length === 0) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -47,6 +47,7 @@ const handled_errors = new WeakSet();
 let is_throwing_error = false;
 
 let is_flushing = false;
+let is_flushing_sync = false;
 
 /** @type {Effect | null} */
 let last_scheduled_effect = null;
@@ -734,7 +735,9 @@ function flush_queued_effects(effects) {
 export function schedule_effect(signal) {
 	if (!is_flushing) {
 		is_flushing = true;
-		queueMicrotask(flush_queued_root_effects);
+		if (!is_flushing_sync) {
+			queueMicrotask(flush_queued_root_effects);
+		}
 	}
 
 	var effect = (last_scheduled_effect = signal);
@@ -818,23 +821,30 @@ function process_effects(root) {
  * @returns {T}
  */
 export function flushSync(fn) {
-	var result;
+	var previously_flushing_sync = is_flushing_sync;
 
-	if (fn) {
-		is_flushing = true;
-		flush_queued_root_effects();
-		result = fn();
-	}
+	try {
+		var result;
+		is_flushing_sync = true;
 
-	while (true) {
-		flush_tasks();
-
-		if (queued_root_effects.length === 0) {
-			return /** @type {T} */ (result);
+		if (fn) {
+			is_flushing = true;
+			flush_queued_root_effects();
+			result = fn();
 		}
 
-		is_flushing = true;
-		flush_queued_root_effects();
+		while (true) {
+			flush_tasks();
+
+			if (queued_root_effects.length === 0) {
+				return /** @type {T} */ (result);
+			}
+
+			is_flushing = true;
+			flush_queued_root_effects();
+		}
+	} finally {
+		is_flushing_sync = previously_flushing_sync;
 	}
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/set-and-flushsync-conditionally-rendered-state/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/set-and-flushsync-conditionally-rendered-state/_config.js
@@ -1,0 +1,33 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+// This test does not fail when the fix is removed, some jsdom/nodejs quirk, this requires browser mode to be tested
+export default test({
+	html: `<button>switch</button><div>flag : true</div>`,
+
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		// Verify initial state - only first div visible
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>switch</button>
+				<div>flag : true</div>
+			`
+		);
+
+		// Click the button
+		flushSync(() => button?.click());
+
+		// Verify after click - both divs should be visible
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>switch</button>
+				<div>flag : false</div>
+				<div>boolElText : false</div>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/set-and-flushsync-conditionally-rendered-state/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/set-and-flushsync-conditionally-rendered-state/main.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { flushSync } from 'svelte';
+
+	let flag = $state(true);
+	let boolElText = $state(true);
+
+	async function handleClick() {
+		flushSync(() => {
+			boolElText = !boolElText;
+		});
+
+		flag = !flag;
+	}
+</script>
+
+<button onclick={handleClick}>switch</button>
+
+<div>flag : {flag}</div>
+
+{#if !flag}
+	<div>boolElText : {boolElText}</div>
+{/if}


### PR DESCRIPTION
In this PR i'm restoring the `flushSync` optimization introduced in https://github.com/sveltejs/svelte/pull/15855 that was replaced by https://github.com/sveltejs/svelte/pull/15895.

I reverted https://github.com/sveltejs/svelte/pull/15895 and adapted https://github.com/sveltejs/svelte/pull/15855 to the more recent changes of `flushSync`

In particular the problem seems to be that setting `is_flushing` to `true` before calling `flush_tasks`
prevents the reactivity to work normally when a state is update in a `flushSync` and that same value is used in an `if block` that should be rendered after setting another `state` right after the `flushSync`.

Here are relevant playgrounds:

Before the regression
https://svelte.dev/playground/a89aaf76146c4571a996d7cd02e39d2f?version=5.28.2

When the regression was introduced
https://svelte.dev/playground/a89aaf76146c4571a996d7cd02e39d2f?version=5.28.3

Actual version, still broken
https://svelte.dev/playground/a89aaf76146c4571a996d7cd02e39d2f?version=5.33.14

Unfortunately I failed to reproduce the issue in the jsdom env, however it can be clearly tested both with `sv create` and in the playground.

Do you plan to upgrade vitest and switch to browser mode in the future?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
