### PR TITLE
fix: invoke parent boundary of deriveds that throw

### DIFF
--- a/.changeset/early-tips-prove.md
+++ b/.changeset/early-tips-prove.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: invoke parent boundary of deriveds that throw

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -83,7 +83,14 @@ export function boundary(node, props, boundary_fn) {
 				});
 			};
 
-			onerror?.(error, reset);
+			var previous_reaction = active_reaction;
+
+			try {
+				set_active_reaction(null);
+				onerror?.(error, reset);
+			} finally {
+				set_active_reaction(previous_reaction);
+			}
 
 			if (boundary_effect) {
 				destroy_effect(boundary_effect);

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -2,7 +2,7 @@
 
 import { BOUNDARY_EFFECT, EFFECT_TRANSPARENT } from '#client/constants';
 import { component_context, set_component_context } from '../../context.js';
-import { reset_is_throwing_error } from '../../error-handling.js';
+import { invoke_error_boundary, reset_is_throwing_error } from '../../error-handling.js';
 import { block, branch, destroy_effect, pause_effect } from '../../reactivity/effects.js';
 import {
 	active_effect,
@@ -115,8 +115,8 @@ export function boundary(node, props, boundary_fn) {
 									() => reset
 								);
 							});
-						} catch {
-							// do nothing, handle_error has already been invoked
+						} catch (error) {
+							invoke_error_boundary(error, /** @type {Effect} */ (boundary.parent));
 						}
 
 						reset_is_throwing_error();

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -74,6 +74,7 @@ export function boundary(node, props, boundary_fn) {
 			}
 
 			var reset = () => {
+				// TODO does this make sense?
 				pause_effect(boundary_effect);
 
 				with_boundary(boundary, () => {

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -2,7 +2,7 @@
 
 import { BOUNDARY_EFFECT, EFFECT_TRANSPARENT } from '#client/constants';
 import { component_context, set_component_context } from '../../context.js';
-import { invoke_error_boundary, reset_is_throwing_error } from '../../error-handling.js';
+import { invoke_error_boundary } from '../../error-handling.js';
 import { block, branch, destroy_effect, pause_effect } from '../../reactivity/effects.js';
 import {
 	active_effect,
@@ -80,7 +80,6 @@ export function boundary(node, props, boundary_fn) {
 				with_boundary(boundary, () => {
 					is_creating_fallback = false;
 					boundary_effect = branch(() => boundary_fn(anchor));
-					reset_is_throwing_error();
 				});
 			};
 
@@ -119,7 +118,6 @@ export function boundary(node, props, boundary_fn) {
 							invoke_error_boundary(error, /** @type {Effect} */ (boundary.parent));
 						}
 
-						reset_is_throwing_error();
 						is_creating_fallback = false;
 					});
 				});
@@ -131,7 +129,6 @@ export function boundary(node, props, boundary_fn) {
 		}
 
 		boundary_effect = branch(() => boundary_fn(anchor));
-		reset_is_throwing_error();
 	}, EFFECT_TRANSPARENT | BOUNDARY_EFFECT);
 
 	if (hydrating) {

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -2,7 +2,7 @@
 
 import { BOUNDARY_EFFECT, EFFECT_TRANSPARENT } from '#client/constants';
 import { component_context, set_component_context } from '../../context.js';
-import { handle_error, reset_is_throwing_error } from '../../error-handling.js';
+import { reset_is_throwing_error } from '../../error-handling.js';
 import { block, branch, destroy_effect, pause_effect } from '../../reactivity/effects.js';
 import {
 	active_effect,
@@ -107,8 +107,8 @@ export function boundary(node, props, boundary_fn) {
 									() => reset
 								);
 							});
-						} catch (error) {
-							handle_error(error, boundary);
+						} catch {
+							// do nothing, handle_error has already been invoked
 						}
 
 						reset_is_throwing_error();

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -2,14 +2,13 @@
 
 import { BOUNDARY_EFFECT, EFFECT_TRANSPARENT } from '#client/constants';
 import { component_context, set_component_context } from '../../context.js';
+import { handle_error, reset_is_throwing_error } from '../../error-handling.js';
 import { block, branch, destroy_effect, pause_effect } from '../../reactivity/effects.js';
 import {
 	active_effect,
 	active_reaction,
-	handle_error,
 	set_active_effect,
-	set_active_reaction,
-	reset_is_throwing_error
+	set_active_reaction
 } from '../../runtime.js';
 import {
 	hydrate_next,

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -74,7 +74,6 @@ export function boundary(node, props, boundary_fn) {
 			}
 
 			var reset = () => {
-				// TODO does this make sense?
 				pause_effect(boundary_effect);
 
 				with_boundary(boundary, () => {

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -109,7 +109,7 @@ export function boundary(node, props, boundary_fn) {
 								);
 							});
 						} catch (error) {
-							handle_error(error, boundary, null, boundary.ctx);
+							handle_error(error, boundary);
 						}
 
 						reset_is_throwing_error();

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -44,10 +44,7 @@ export function invoke_error_boundary(error, effect) {
 				// @ts-expect-error
 				current.fn(error);
 				return;
-			} catch {
-				// Remove boundary flag from effect (TODO is this still useful?)
-				current.f ^= BOUNDARY_EFFECT;
-			}
+			} catch {}
 		}
 
 		current = current.parent;

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -77,7 +77,7 @@ function should_rethrow_error(effect) {
  * @param {Error} error
  * @param {Effect} effect
  */
-function adjust_error(error, effect) {
+export function adjust_error(error, effect) {
 	if (adjusted_errors.has(error)) return;
 	adjusted_errors.add(error);
 

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -2,18 +2,12 @@
 import { DEV } from 'esm-env';
 import { FILENAME } from '../../constants.js';
 import { is_firefox } from './dom/operations.js';
-import { BOUNDARY_EFFECT, DESTROYED } from './constants.js';
+import { BOUNDARY_EFFECT } from './constants.js';
 import { define_property } from '../shared/utils.js';
 
 // Used for DEV time error handling
 /** @param {WeakSet<Error>} value */
 const adjusted_errors = new WeakSet();
-
-let is_throwing_error = false;
-
-export function reset_is_throwing_error() {
-	is_throwing_error = false;
-}
 
 /** @type {null | unknown} */
 let current_error = null;
@@ -58,18 +52,7 @@ export function invoke_error_boundary(error, effect) {
 		current = current.parent;
 	}
 
-	is_throwing_error = false;
 	throw error;
-}
-
-/**
- * @param {Effect} effect
- */
-function should_rethrow_error(effect) {
-	return (
-		(effect.f & DESTROYED) === 0 &&
-		(effect.parent === null || (effect.parent.f & BOUNDARY_EFFECT) === 0)
-	);
 }
 
 /**

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -9,19 +9,11 @@ import { define_property } from '../shared/utils.js';
 /** @param {WeakSet<Error>} value */
 const adjusted_errors = new WeakSet();
 
-/** @type {null | unknown} */
-let current_error = null;
-
 /**
  * @param {unknown} error
  * @param {Effect} effect
  */
 export function handle_error(error, effect) {
-	if (error === current_error) {
-		// TODO is this necessary?
-		return;
-	}
-
 	if (DEV && error instanceof Error) {
 		adjust_error(error, effect);
 	}

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -76,11 +76,6 @@ function adjust_error(error, effect) {
 		value: error.message + `\n${component_stack.map((name) => `\n${indent}in ${name}`).join('')}\n`
 	});
 
-	// TODO what is this for? can we get rid of it?
-	define_property(error, 'component_stack', {
-		value: component_stack
-	});
-
 	// Filter out internal files from callstack
 	if (error.stack) {
 		define_property(error, 'stack', {

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -6,10 +6,6 @@ import { BOUNDARY_EFFECT, EFFECT_RAN } from './constants.js';
 import { define_property } from '../shared/utils.js';
 import { active_effect } from './runtime.js';
 
-// Used for DEV time error handling
-/** @param {WeakSet<Error>} value */
-const adjusted_errors = new WeakSet();
-
 /**
  * @param {unknown} error
  */
@@ -55,8 +51,11 @@ export function invoke_error_boundary(error, effect) {
 	throw error;
 }
 
+/** @type {WeakSet<Error>} */
+const adjusted_errors = new WeakSet();
+
 /**
- * Add useful information to the error message/stack
+ * Add useful information to the error message/stack in development
  * @param {Error} error
  * @param {Effect} effect
  */

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -21,9 +21,8 @@ let current_error = null;
 /**
  * @param {unknown} error
  * @param {Effect} effect
- * @param {Effect | null} [previous_effect]
  */
-export function handle_error(error, effect, previous_effect = null) {
+export function handle_error(error, effect) {
 	if (error === current_error) {
 		// TODO is this necessary?
 		return;

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -62,22 +62,21 @@ function adjust_error(error, effect) {
 	if (adjusted_errors.has(error)) return;
 	adjusted_errors.add(error);
 
-	const component_stack = [effect.fn?.name || '<unknown>'];
-	const indent = is_firefox ? '  ' : '\t';
-
+	var indent = is_firefox ? '  ' : '\t';
+	var component_stack = `\n${indent}in ${effect.fn?.name || '<unknown>'}`;
 	var context = effect.ctx;
 
 	while (context !== null) {
-		component_stack.push(context.function?.[FILENAME].split('/').pop());
+		component_stack += `\n${indent}in ${context.function?.[FILENAME].split('/').pop()}`;
 		context = context.p;
 	}
 
 	define_property(error, 'message', {
-		value: error.message + `\n${component_stack.map((name) => `\n${indent}in ${name}`).join('')}\n`
+		value: error.message + `\n${component_stack}\n`
 	});
 
-	// Filter out internal files from callstack
 	if (error.stack) {
+		// Filter out internal modules
 		define_property(error, 'stack', {
 			value: error.stack
 				.split('\n')

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -11,6 +11,10 @@ const handled_errors = new WeakSet();
 
 let is_throwing_error = false;
 
+export function reset_is_throwing_error() {
+	is_throwing_error = false;
+}
+
 /**
  * @param {unknown} error
  * @param {Effect} effect
@@ -89,7 +93,7 @@ export function handle_error(error, effect, previous_effect = null) {
 		}
 	}
 
-	propagate_error(error, effect);
+	invoke_error_boundary(error, effect);
 
 	if (should_rethrow_error(effect)) {
 		throw error;
@@ -100,7 +104,7 @@ export function handle_error(error, effect, previous_effect = null) {
  * @param {unknown} error
  * @param {Effect} effect
  */
-function propagate_error(error, effect) {
+function invoke_error_boundary(error, effect) {
 	/** @type {Effect | null} */
 	var current = effect;
 
@@ -131,8 +135,4 @@ function should_rethrow_error(effect) {
 		(effect.f & DESTROYED) === 0 &&
 		(effect.parent === null || (effect.parent.f & BOUNDARY_EFFECT) === 0)
 	);
-}
-
-export function reset_is_throwing_error() {
-	is_throwing_error = false;
 }

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -1,0 +1,138 @@
+/** @import { ComponentContext, Effect } from '#client' */
+import { DEV } from 'esm-env';
+import { FILENAME } from '../../constants.js';
+import { is_firefox } from './dom/operations.js';
+import { BOUNDARY_EFFECT, DESTROYED } from './constants.js';
+import { define_property } from '../shared/utils.js';
+
+// Used for DEV time error handling
+/** @param {WeakSet<Error>} value */
+const handled_errors = new WeakSet();
+
+let is_throwing_error = false;
+
+/**
+ * @param {unknown} error
+ * @param {Effect} effect
+ * @param {Effect | null} [previous_effect]
+ */
+export function handle_error(error, effect, previous_effect = null) {
+	var component_context = effect.ctx;
+
+	if (is_throwing_error) {
+		if (previous_effect === null) {
+			is_throwing_error = false;
+		}
+
+		if (should_rethrow_error(effect)) {
+			throw error;
+		}
+
+		return;
+	}
+
+	if (previous_effect !== null) {
+		is_throwing_error = true;
+	}
+
+	if (DEV && component_context !== null && error instanceof Error && !handled_errors.has(error)) {
+		handled_errors.add(error);
+
+		const component_stack = [];
+
+		const effect_name = effect.fn?.name;
+
+		if (effect_name) {
+			component_stack.push(effect_name);
+		}
+
+		/** @type {ComponentContext | null} */
+		let current_context = component_context;
+
+		while (current_context !== null) {
+			/** @type {string} */
+			var filename = current_context.function?.[FILENAME];
+
+			if (filename) {
+				const file = filename.split('/').pop();
+				component_stack.push(file);
+			}
+
+			current_context = current_context.p;
+		}
+
+		const indent = is_firefox ? '  ' : '\t';
+		define_property(error, 'message', {
+			value:
+				error.message + `\n${component_stack.map((name) => `\n${indent}in ${name}`).join('')}\n`
+		});
+		define_property(error, 'component_stack', {
+			value: component_stack
+		});
+
+		const stack = error.stack;
+
+		// Filter out internal files from callstack
+		if (stack) {
+			const lines = stack.split('\n');
+			const new_lines = [];
+			for (let i = 0; i < lines.length; i++) {
+				const line = lines[i];
+				if (line.includes('svelte/src/internal')) {
+					continue;
+				}
+				new_lines.push(line);
+			}
+			define_property(error, 'stack', {
+				value: new_lines.join('\n')
+			});
+		}
+	}
+
+	propagate_error(error, effect);
+
+	if (should_rethrow_error(effect)) {
+		throw error;
+	}
+}
+
+/**
+ * @param {unknown} error
+ * @param {Effect} effect
+ */
+function propagate_error(error, effect) {
+	/** @type {Effect | null} */
+	var current = effect;
+
+	while (current !== null) {
+		if ((current.f & BOUNDARY_EFFECT) !== 0) {
+			try {
+				// @ts-expect-error
+				current.fn(error);
+				return;
+			} catch {
+				// Remove boundary flag from effect
+				current.f ^= BOUNDARY_EFFECT;
+			}
+		}
+
+		current = current.parent;
+	}
+
+	is_throwing_error = false;
+	throw error;
+}
+
+/**
+ * @param {Effect} effect
+ */
+function should_rethrow_error(effect) {
+	return (
+		(effect.f & DESTROYED) === 0 &&
+		(effect.parent === null || (effect.parent.f & BOUNDARY_EFFECT) === 0)
+	);
+}
+
+export function reset_is_throwing_error() {
+	is_throwing_error = false;
+}

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -15,26 +15,18 @@ export function reset_is_throwing_error() {
 	is_throwing_error = false;
 }
 
+/** @type {null | unknown} */
+let current_error = null;
+
 /**
  * @param {unknown} error
  * @param {Effect} effect
  * @param {Effect | null} [previous_effect]
  */
 export function handle_error(error, effect, previous_effect = null) {
-	if (is_throwing_error) {
-		if (previous_effect === null) {
-			is_throwing_error = false;
-		}
-
-		if (should_rethrow_error(effect)) {
-			throw error;
-		}
-
+	if (error === current_error) {
+		// TODO is this necessary?
 		return;
-	}
-
-	if (previous_effect !== null) {
-		is_throwing_error = true;
 	}
 
 	if (DEV && error instanceof Error) {
@@ -42,10 +34,6 @@ export function handle_error(error, effect, previous_effect = null) {
 	}
 
 	invoke_error_boundary(error, effect);
-
-	if (should_rethrow_error(effect)) {
-		throw error;
-	}
 }
 
 /**

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -81,7 +81,7 @@ export function adjust_error(error, effect) {
 	if (adjusted_errors.has(error)) return;
 	adjusted_errors.add(error);
 
-	const component_stack = [effect.fn?.name ?? '<unknown>'];
+	const component_stack = [effect.fn?.name || '<unknown>'];
 	const indent = is_firefox ? '  ' : '\t';
 
 	var context = effect.ctx;

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -20,13 +20,18 @@ export function handle_error(error) {
 		adjust_error(error, effect);
 	}
 
-	if ((effect.f & EFFECT_RAN) !== 0) {
-		invoke_error_boundary(error, effect);
-	} else if ((effect.f & BOUNDARY_EFFECT) !== 0) {
-		// invoke directly
+	if ((effect.f & EFFECT_RAN) === 0) {
+		// if the error occurred while creating this subtree, we let it
+		// bubble up until it hits a boundary that can handle it
+		if ((effect.f & BOUNDARY_EFFECT) === 0) {
+			throw error;
+		}
+
+		// @ts-expect-error
 		effect.fn(error);
 	} else {
-		throw error;
+		// otherwise we bubble up the effect tree ourselves
+		invoke_error_boundary(error, effect);
 	}
 }
 

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -37,22 +37,19 @@ export function handle_error(error) {
 
 /**
  * @param {unknown} error
- * @param {Effect} effect
+ * @param {Effect | null} effect
  */
 export function invoke_error_boundary(error, effect) {
-	/** @type {Effect | null} */
-	var current = effect;
-
-	while (current !== null) {
-		if ((current.f & BOUNDARY_EFFECT) !== 0) {
+	while (effect !== null) {
+		if ((effect.f & BOUNDARY_EFFECT) !== 0) {
 			try {
 				// @ts-expect-error
-				current.fn(error);
+				effect.fn(error);
 				return;
 			} catch {}
 		}
 
-		current = current.parent;
+		effect = effect.parent;
 	}
 
 	throw error;

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -51,7 +51,7 @@ export function invoke_error_boundary(error, effect) {
 				current.fn(error);
 				return;
 			} catch {
-				// Remove boundary flag from effect
+				// Remove boundary flag from effect (TODO is this still useful?)
 				current.f ^= BOUNDARY_EFFECT;
 			}
 		}

--- a/packages/svelte/src/internal/client/error-handling.js
+++ b/packages/svelte/src/internal/client/error-handling.js
@@ -40,7 +40,7 @@ export function handle_error(error, effect, previous_effect = null) {
  * @param {unknown} error
  * @param {Effect} effect
  */
-function invoke_error_boundary(error, effect) {
+export function invoke_error_boundary(error, effect) {
 	/** @type {Effect | null} */
 	var current = effect;
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -114,13 +114,8 @@ function create_effect(type, fn, sync, push = true) {
 	}
 
 	if (sync) {
-		try {
-			update_effect(effect);
-			effect.f |= EFFECT_RAN;
-		} catch (e) {
-			destroy_effect(effect);
-			throw e;
-		}
+		update_effect(effect);
+		effect.f |= EFFECT_RAN;
 	} else if (fn !== null) {
 		schedule_effect(effect);
 	}

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -114,8 +114,13 @@ function create_effect(type, fn, sync, push = true) {
 	}
 
 	if (sync) {
-		update_effect(effect);
-		effect.f |= EFFECT_RAN;
+		try {
+			update_effect(effect);
+			effect.f |= EFFECT_RAN;
+		} catch (e) {
+			destroy_effect(effect);
+			throw e;
+		}
 	} else if (fn !== null) {
 		schedule_effect(effect);
 	}

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -433,7 +433,11 @@ export function destroy_block_effect_children(signal) {
 export function destroy_effect(effect, remove_dom = true) {
 	var removed = false;
 
-	if ((remove_dom || (effect.f & HEAD_EFFECT) !== 0) && effect.nodes_start !== null) {
+	if (
+		(remove_dom || (effect.f & HEAD_EFFECT) !== 0) &&
+		effect.nodes_start !== null &&
+		effect.nodes_end !== null
+	) {
 		remove_effect_dom(effect.nodes_start, /** @type {TemplateNode} */ (effect.nodes_end));
 		removed = true;
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -358,18 +358,6 @@ export function update_reaction(reaction) {
 	}
 }
 
-/** @param {Reaction} reaction */
-function get_effect(reaction) {
-	/** @type {Reaction | null;} */
-	var r = reaction;
-
-	while (r !== null && (r.f & DERIVED) !== 0) {
-		r = /** @type {Derived} */ (r).parent;
-	}
-
-	return /** @type {Effect | null} */ (r);
-}
-
 /**
  * @template V
  * @param {Reaction} signal

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -271,10 +271,11 @@ export function reset_is_throwing_error() {
 /**
  * @param {unknown} error
  * @param {Effect} effect
- * @param {Effect | null} previous_effect
- * @param {ComponentContext | null} component_context
+ * @param {Effect | null} [previous_effect]
  */
-export function handle_error(error, effect, previous_effect, component_context) {
+export function handle_error(error, effect, previous_effect = null) {
+	var component_context = effect.ctx;
+
 	if (is_throwing_error) {
 		if (previous_effect === null) {
 			is_throwing_error = false;
@@ -558,7 +559,6 @@ export function update_effect(effect) {
 	set_signal_status(effect, CLEAN);
 
 	var previous_effect = active_effect;
-	var previous_component_context = component_context;
 	var was_updating_effect = is_updating_effect;
 
 	active_effect = effect;
@@ -602,7 +602,7 @@ export function update_effect(effect) {
 			dev_effect_stack.push(effect);
 		}
 	} catch (error) {
-		handle_error(error, effect, previous_effect, previous_component_context || effect.ctx);
+		handle_error(error, effect, previous_effect);
 	} finally {
 		is_updating_effect = was_updating_effect;
 		active_effect = previous_effect;
@@ -637,14 +637,14 @@ function infinite_loop_guard() {
 		if (last_scheduled_effect !== null) {
 			if (DEV) {
 				try {
-					handle_error(error, last_scheduled_effect, null, null);
+					handle_error(error, last_scheduled_effect);
 				} catch (e) {
 					// Only log the effect stack if the error is re-thrown
 					log_effect_stack();
 					throw e;
 				}
 			} else {
-				handle_error(error, last_scheduled_effect, null, null);
+				handle_error(error, last_scheduled_effect);
 			}
 		} else {
 			if (DEV) {
@@ -721,7 +721,7 @@ function flush_queued_effects(effects) {
 					}
 				}
 			} catch (error) {
-				handle_error(error, effect, null, effect.ctx);
+				handle_error(error, effect);
 			}
 		}
 	}
@@ -785,7 +785,7 @@ function process_effects(root) {
 						update_effect(effect);
 					}
 				} catch (error) {
-					handle_error(error, effect, null, effect.ctx);
+					handle_error(error, effect);
 				}
 			}
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -29,7 +29,7 @@ import { flush_tasks } from './dom/task.js';
 import { internal_set, old_values } from './reactivity/sources.js';
 import { destroy_derived_effects, update_derived } from './reactivity/deriveds.js';
 import * as e from './errors.js';
-import { FILENAME } from '../../constants.js';
+
 import { tracing_mode_flag } from '../flags/index.js';
 import { tracing_expressions, get_stack } from './dev/tracing.js';
 import {
@@ -39,12 +39,7 @@ import {
 	set_component_context,
 	set_dev_current_component_function
 } from './context.js';
-import { is_firefox } from './dom/operations.js';
-
-// Used for DEV time error handling
-/** @param {WeakSet<Error>} value */
-const handled_errors = new WeakSet();
-let is_throwing_error = false;
+import { handle_error } from './error-handling.js';
 
 let is_flushing = false;
 
@@ -225,132 +220,6 @@ export function check_dirtiness(reaction) {
 	}
 
 	return false;
-}
-
-/**
- * @param {unknown} error
- * @param {Effect} effect
- */
-function propagate_error(error, effect) {
-	/** @type {Effect | null} */
-	var current = effect;
-
-	while (current !== null) {
-		if ((current.f & BOUNDARY_EFFECT) !== 0) {
-			try {
-				// @ts-expect-error
-				current.fn(error);
-				return;
-			} catch {
-				// Remove boundary flag from effect
-				current.f ^= BOUNDARY_EFFECT;
-			}
-		}
-
-		current = current.parent;
-	}
-
-	is_throwing_error = false;
-	throw error;
-}
-
-/**
- * @param {Effect} effect
- */
-function should_rethrow_error(effect) {
-	return (
-		(effect.f & DESTROYED) === 0 &&
-		(effect.parent === null || (effect.parent.f & BOUNDARY_EFFECT) === 0)
-	);
-}
-
-export function reset_is_throwing_error() {
-	is_throwing_error = false;
-}
-
-/**
- * @param {unknown} error
- * @param {Effect} effect
- * @param {Effect | null} [previous_effect]
- */
-export function handle_error(error, effect, previous_effect = null) {
-	var component_context = effect.ctx;
-
-	if (is_throwing_error) {
-		if (previous_effect === null) {
-			is_throwing_error = false;
-		}
-
-		if (should_rethrow_error(effect)) {
-			throw error;
-		}
-
-		return;
-	}
-
-	if (previous_effect !== null) {
-		is_throwing_error = true;
-	}
-
-	if (DEV && component_context !== null && error instanceof Error && !handled_errors.has(error)) {
-		handled_errors.add(error);
-
-		const component_stack = [];
-
-		const effect_name = effect.fn?.name;
-
-		if (effect_name) {
-			component_stack.push(effect_name);
-		}
-
-		/** @type {ComponentContext | null} */
-		let current_context = component_context;
-
-		while (current_context !== null) {
-			/** @type {string} */
-			var filename = current_context.function?.[FILENAME];
-
-			if (filename) {
-				const file = filename.split('/').pop();
-				component_stack.push(file);
-			}
-
-			current_context = current_context.p;
-		}
-
-		const indent = is_firefox ? '  ' : '\t';
-		define_property(error, 'message', {
-			value:
-				error.message + `\n${component_stack.map((name) => `\n${indent}in ${name}`).join('')}\n`
-		});
-		define_property(error, 'component_stack', {
-			value: component_stack
-		});
-
-		const stack = error.stack;
-
-		// Filter out internal files from callstack
-		if (stack) {
-			const lines = stack.split('\n');
-			const new_lines = [];
-			for (let i = 0; i < lines.length; i++) {
-				const line = lines[i];
-				if (line.includes('svelte/src/internal')) {
-					continue;
-				}
-				new_lines.push(line);
-			}
-			define_property(error, 'stack', {
-				value: new_lines.join('\n')
-			});
-		}
-	}
-
-	propagate_error(error, effect);
-
-	if (should_rethrow_error(effect)) {
-		throw error;
-	}
 }
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-12/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-12/_config.js
@@ -5,9 +5,8 @@ export default test({
 	test({ assert, target }) {
 		const btn = target.querySelector('button');
 
-		btn?.click();
-		flushSync();
-
-		assert.htmlEqual(target.innerHTML, `<button>change</button><p>Error occured</p>`);
+		assert.throws(() => {
+			flushSync(() => btn?.click());
+		}, /kaboom/);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-12/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-12/main.svelte
@@ -1,20 +1,18 @@
 <script>
 	let count = $state(0);
 
-	const things = $derived.by(() => {
+	const d = $derived.by(() => {
 		if (count === 1) {
-			throw new Error('123')
+			throw new Error('kaboom')
 		}
-		return [1, 2 ,3]
+		return count
 	})
 </script>
 
 <button onclick={() => count++}>change</button>
 
 <svelte:boundary>
-	{#each things as thing}
-		<p>{thing}</p>
-	{/each}
+	{d}
 
 	{#snippet failed()}
 		<p>Error occured</p>

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-13/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-13/Child.svelte
@@ -1,7 +1,14 @@
 <script>
-	const { things } = $props();
+	const { count } = $props();
+
+	const d = $derived.by(() => {
+		if (count === 1) {
+			throw new Error('kaboom')
+		}
+		return count
+	});
 
 	$effect(() => {
-		things
-	})
+		d;
+	});
 </script>

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-13/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-13/_config.js
@@ -8,6 +8,6 @@ export default test({
 		btn?.click();
 		flushSync();
 
-		assert.htmlEqual(target.innerHTML, `<button>change</button><p>Error occured</p>`);
+		assert.htmlEqual(target.innerHTML, `<button>change</button><p>Error occurred</p>`);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-13/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-13/main.svelte
@@ -2,21 +2,14 @@
 	import Child from './Child.svelte';
 
 	let count = $state(0);
-
-	const things = $derived.by(() => {
-		if (count === 1) {
-			throw new Error('123')
-		}
-		return [1, 2 ,3]
-	})
 </script>
 
 <button onclick={() => count++}>change</button>
 
 <svelte:boundary>
-	<Child {things} />
+	<Child {count} />
 
 	{#snippet failed()}
-		<p>Error occured</p>
+		<p>Error occurred</p>
 	{/snippet}
 </svelte:boundary>

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-18/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-18/_config.js
@@ -5,11 +5,11 @@ export default test({
 	test({ assert, target }) {
 		let btn = target.querySelector('button');
 
-		btn?.click();
-		btn?.click();
-
 		assert.throws(() => {
-			flushSync();
+			flushSync(() => {
+				btn?.click();
+				btn?.click();
+			});
 		}, /test\n\n\tin {expression}\n/);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-18/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-18/main.svelte
@@ -1,16 +1,18 @@
 <script>
 	let count = $state(0);
 
-	let test = $derived.by(() => {
+	function maybe_throw() {
 		if (count > 1) {
 			throw new Error('test');
 		}
-	});
+
+		return count;
+	}
 </script>
 
 <svelte:boundary onerror={(e) => { throw(e) }}>
-		<div>Count: {count}</div>
-		<button onclick={() => count++}>Increment</button>
-		{count} / {test}
+	<div>Count: {count}</div>
+	<button onclick={() => count++}>Increment</button>
+	{count} / {maybe_throw()}
 </svelte:boundary>
 


### PR DESCRIPTION
Decided to take a look at our error handling logic. It's rather convoluted and also wrong.

If you have a situation like [this](https://svelte.dev/playground/7a3e7978ef6c4ec39fd2928ae2afa31e?version=5.33.14)...

```svelte
<!-- App.svelte -->
<script>
  import Component from './Component.svelte';
</script>

<svelte:boundary>
  <Component />
	
  {#snippet failed()}
    <p>outer failed</p>
  {/snippet}
</svelte:boundary>
```

```svelte
<script>
  let d = $derived.by(() => {
    throw new Error('kaboom');
  });
</script>

<svelte:boundary>
  {d}
	
  {#snippet failed()}
    <p>inner failed</p>
  {/snippet}
</svelte:boundary>
```

...the inner boundary fails, even though `d` is declared outside it. That's obviously incorrect (you can't have boundaries triggering non-deterministically based on where a value happens to be read first). Bit embarrassed I didn't catch this in the initial review. 

This PR fixes that behaviour and also simplifies things a decent amount (no more `is_throwing_error` and `should_rethrow_error` and `previous_effect` and other hard-to-follow stuff) and removes some hot path try-catches. It also continues the project of slimming down `runtime.js` in favour of different modules for different purposes — we're finally under 1,000 LOC.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
