### PR TITLE
chore: update acorn parser `ecmaVersion` to parse import attributes

### DIFF
--- a/.changeset/brave-baboons-suffer.md
+++ b/.changeset/brave-baboons-suffer.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: update acorn parser `ecmaVersion` to parse import attributes

--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -36,7 +36,7 @@ export function parse(source, typescript, is_script) {
 		ast = parser.parse(source, {
 			onComment,
 			sourceType: 'module',
-			ecmaVersion: 13,
+			ecmaVersion: 16,
 			locations: true
 		});
 	} finally {
@@ -64,7 +64,7 @@ export function parse_expression_at(source, typescript, index) {
 	const ast = parser.parseExpressionAt(source, index, {
 		onComment,
 		sourceType: 'module',
-		ecmaVersion: 13,
+		ecmaVersion: 16,
 		locations: true
 	});
 


### PR DESCRIPTION
After fixing #12551 I realized that it'd probably be best to bump the acorn parser to support import attributes in regular JS, so this does that. 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
