### PR TITLE
fix: properly hydrate dynamic css props components and remove element removal

### DIFF
--- a/.changeset/twelve-foxes-smell.md
+++ b/.changeset/twelve-foxes-smell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: properly hydrate dynamic css props components and remove element removal

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -26,8 +26,4 @@ export function css_props(element, get_styles) {
 			}
 		}
 	});
-
-	teardown(() => {
-		element.remove();
-	});
 }

--- a/packages/svelte/tests/runtime-browser/samples/css-props-dynamic-component/A.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/css-props-dynamic-component/A.svelte
@@ -1,0 +1,7 @@
+<div>a</div>
+
+<style>
+	div{
+		color: var(--prop);
+	}
+</style>

--- a/packages/svelte/tests/runtime-browser/samples/css-props-dynamic-component/B.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/css-props-dynamic-component/B.svelte
@@ -1,0 +1,7 @@
+<div>b</div>
+
+<style>
+	div{
+		color: var(--prop);
+	}
+</style>

--- a/packages/svelte/tests/runtime-browser/samples/css-props-dynamic-component/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/css-props-dynamic-component/_config.js
@@ -1,0 +1,16 @@
+import { test } from '../../assert';
+import { flushSync } from 'svelte';
+
+export default test({
+	warnings: [],
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+		let div = /** @type {HTMLElement} */ (target.querySelector('div'));
+		assert.equal(getComputedStyle(div).color, 'rgb(255, 0, 0)');
+		flushSync(() => {
+			btn?.click();
+		});
+		div = /** @type {HTMLElement} */ (target.querySelector('div'));
+		assert.equal(getComputedStyle(div).color, 'rgb(255, 0, 0)');
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/css-props-dynamic-component/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/css-props-dynamic-component/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import A from "./B.svelte";
+	import B from "./A.svelte";
+	let value = $state(0);
+
+	let Comp = $derived(value % 2 === 0 ? A : B);
+</script>
+
+<button onclick={()=>value++}>click</button>
+
+<Comp --prop="red"/>


### PR DESCRIPTION
Closes #16115

Boi this was a rollercoaster. So the original bug was actually fixed just by removing the `teardown` in `css_props`...I'm pretty sure that with #11948 it was not needed anymore but stuck around. No test failed when i removed it.

However when I wrote the test for it it was failing to hydrate. When i checked with the same component on `main` it was still failing hydration. Every-time i fixed that hydration some other test was failing.

The reason is that `css_props` was used in two different ways depending if it was a `SvelteComponent` it produced a code like this

```ts
{
    $.css_props();
    $.component();
    $.reset();
}
```
while with a dynamic component was used like this
```ts
{
    $.component(..., ()=>{
        $.css_props();
        $$component();
        $.reset();
    });
}
```

since `$.component` set the `hydration_node` doing `next_sibling` and `$.css_props` does it by doing `first_child` the fact that the two were different was problematic.

Initially I thought of moving the logic outside of `build_component` for both dynamic `Component` and `SvelteComponent` since `build_component` it's already complex but it would've been kind of a mess to change all the rest of the things to satisfy hydration.

A nice thing is that now the `Component` visitor is much shorter.


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`