### PR TITLE
fix: reset `is_flushing` if `flushSync` is called and there's no scheduled effect

### DIFF
--- a/.changeset/flat-points-kick.md
+++ b/.changeset/flat-points-kick.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: reset `is_flushing` if `flushSync` is called and there's no scheduled effect

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -688,6 +688,13 @@ export function flushSync(fn) {
 		flush_tasks();
 
 		if (queued_root_effects.length === 0) {
+			// this would be reset in `flush_queued_root_effects` but since we are early returning here,
+			// we need to reset it here as well
+			is_flushing = false;
+			last_scheduled_effect = null;
+			if (DEV) {
+				dev_effect_stack = [];
+			}
 			return /** @type {T} */ (result);
 		}
 

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-no-scheduled/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-no-scheduled/_config.js
@@ -1,0 +1,16 @@
+import { ok, test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const btn = target.querySelector('button');
+		const main = target.querySelector('main');
+		ok(main);
+		console.log(main.innerHTML);
+		assert.htmlEqual(main.innerHTML, `<div>true</div>`);
+		// we don't want to use flush sync (or tick that use it inside) since we are testing that calling `flushSync` once
+		// when there are no scheduled effects does not cause reactivity to break
+		btn?.click();
+		await Promise.resolve();
+		assert.htmlEqual(main.innerHTML, `<div>false</div> <div>false</div>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-no-scheduled/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-no-scheduled/main.svelte
@@ -1,0 +1,23 @@
+<script>
+	import { flushSync } from 'svelte'
+	
+	let flag = $state(true)
+	let test = $state(true);	
+</script>
+
+<button onclick={()=>{
+	flushSync(() => {
+		test = !test
+	})
+		
+	flag = !flag;
+}}>switch</button>
+
+<main>
+	<div>{flag}</div>
+	
+	{#if !flag}
+		<div>{test} </div>
+	{/if}
+</main>
+


### PR DESCRIPTION
Closes #16076

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`