### PR TITLE
fix: typings for dimension bindings

### DIFF
--- a/.changeset/clever-cats-invent.md
+++ b/.changeset/clever-cats-invent.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: typings for dimension bindings

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -844,6 +844,10 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	readonly 'bind:borderBoxSize'?: Array<ResizeObserverSize> | undefined | null;
 	readonly 'bind:devicePixelContentBoxSize'?: Array<ResizeObserverSize> | undefined | null;
 	readonly 'bind:focused'?: boolean | undefined | null;
+	readonly 'bind:clientWidth'?: number | undefined | null;
+	readonly 'bind:clientHeight'?: number | undefined | null;
+	readonly 'bind:offsetWidth'?: number | undefined | null;
+	readonly 'bind:offsetHeight'?: number | undefined | null;
 
 	// SvelteKit
 	'data-sveltekit-keepfocus'?: true | '' | 'off' | undefined | null;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`


Fixes https://github.com/sveltejs/language-tools/issues/2741. The reason it doesn't error with `bind:clientWidth={clientWidth}` is that language-tools has special handling to generate an assignment in the `svelte2tsx` virtual code. Alternatively, it could be solved in language tools with a similar handling, but I feel like it's better to keep the types in `svelte/elements`. Plus, all the other one-way bindings are in `svelte/elements`. Only these few were missing. 