### PR TITLE
chore: remove some unnecessary code

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -599,15 +599,6 @@ function resume_children(effect, local) {
 	if ((effect.f & INERT) === 0) return;
 	effect.f ^= INERT;
 
-	// If a dependency of this effect changed while it was paused,
-	// schedule the effect to update. we don't use `check_dirtiness`
-	// here because we don't want to eagerly recompute a derived like
-	// `{#if foo}{foo.bar()}{/if}` if `foo` is now `undefined
-	if ((effect.f & CLEAN) !== 0) {
-		set_signal_status(effect, DIRTY);
-		schedule_effect(effect);
-	}
-
 	var child = effect.first;
 
 	while (child !== null) {


### PR DESCRIPTION
follow-up to #16150. While merging `main` into the `async` branch I realised that I messed up the condition here — we only want to schedule effects that are dirty, not the ones that are clean. But it turns out they're _already_ scheduled, and this code is completely unnecessary.

We do still need it on the `async` branch, but not here

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
