### PR TITLE
chore: fix `$.attachment` prop

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -275,7 +275,7 @@ export function build_component(node, component_name, context) {
 				);
 			}
 
-			push_prop(b.prop('get', b.call('$.attachment'), expression, true));
+			push_prop(b.prop('init', b.call('$.attachment'), expression, true));
 		}
 	}
 


### PR DESCRIPTION
This shouldn't be a getter. At the moment it's fine because a bug in `esrap` is masking it, but that bug will soon be fixed