### PR TITLE
fix: don't set state withing `with_parent` in proxy

### DIFF
--- a/.changeset/beige-plants-laugh.md
+++ b/.changeset/beige-plants-laugh.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't set state withing `with_parent` in proxy

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -93,21 +93,19 @@ export function proxy(value) {
 				// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor#invariants
 				e.state_descriptors_fixed();
 			}
-
-			with_parent(() => {
-				var s = sources.get(prop);
-
-				if (s === undefined) {
-					s = source(descriptor.value, stack);
+			var s = sources.get(prop);
+			if (s === undefined) {
+				s = with_parent(() => {
+					var s = source(descriptor.value, stack);
 					sources.set(prop, s);
-
 					if (DEV && typeof prop === 'string') {
 						tag(s, get_label(path, prop));
 					}
-				} else {
-					set(s, descriptor.value, true);
-				}
-			});
+					return s;
+				});
+			} else {
+				set(s, descriptor.value, true);
+			}
 
 			return true;
 		},
@@ -270,9 +268,9 @@ export function proxy(value) {
 				if (!has || get_descriptor(target, prop)?.writable) {
 					s = with_parent(() => {
 						var s = source(undefined, stack);
-						set(s, proxy(value));
 						return s;
 					});
+					set(s, proxy(value));
 
 					sources.set(prop, s);
 

--- a/packages/svelte/tests/runtime-runes/samples/proxy-set-with-parent/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-set-with-parent/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	async test() {}
+});

--- a/packages/svelte/tests/runtime-runes/samples/proxy-set-with-parent/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/proxy-set-with-parent/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	function with_writes(initialState) {
+	  const derive = $state(initialState)
+	  return derive
+	}
+
+	let data = $state({ example: 'Example' })
+	let my_derived = $derived(with_writes({ example: data.example }))
+
+	$effect(() => {
+		my_derived.example = 'Bar'
+	});
+</script>
+
+<input bind:value={data.example} />


### PR DESCRIPTION
Closes #16164

We can't `set` everywhere within `with_parent` otherwise if it's the first time we are reading a derived it could look like we are setting state in a derived (which you are not).

However this feels like it should work and currently it does not

```svelte
<script>
	function with_writes(initialState) {
	  const derive = $state(initialState)
	  return derive
	}

	let data = $state({ example: 'Example' })
	let my_derived = $derived(with_writes({ example: data.example }))

	$effect(() => {
		my_derived.example = 'Bar'
	});
</script>

<input bind:value={data.example} />

<!-- not in sync with data.example -->
{my_derived.example}
```

and apparently it never did...maybe it's just me being fuzzy because it's early in the morning but shouldn't `{my_derived.example}` update when `data.example` changes? The derived seems to be correctly updated.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`