### PR TITLE
docs: fix code sample for using global directive to preserve unused C…

### DIFF
--- a/packages/svelte/messages/compile-warnings/style.md
+++ b/packages/svelte/messages/compile-warnings/style.md
@@ -10,7 +10,7 @@ In some situations a selector may target an element that is not 'visible' to the
 <div class="post">{@html content}</div>
 
 <style>
-  .post :global {
+  :global(.post) {
     p {...}
   }
 </style>


### PR DESCRIPTION
…SS selector

In my testing, the existing demonstration of using `:global()` for preserving unused CSS selectors does not work. Using the provided syntax achieves the desired preservation. 

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
