### PR TITLE
docs: Add prominent link to svelte/reactivity from state

### DIFF
--- a/documentation/docs/02-runes/02-$state.md
+++ b/documentation/docs/02-runes/02-$state.md
@@ -63,6 +63,12 @@ let { done, text } = todos[0];
 todos[0].done = !todos[0].done;
 ```
 
+### State for Collections
+
+Arrays aren't the only structure you might want to use when setting reactive state for a collection of items. The temptation is to reach for Javascript built-in classes like `Set`, `Map`, `URL` and wrap them in `state()`, but this approach won't work.
+
+Use Svelte's own reactive versions instead. You can import `SvelteSet`, `SvelteMap`, `SvelteURL` and other reactive classes in [`svelte/reactivity`](svelte-reactivity).
+
 ### Classes
 
 Class instances are not proxied. Instead, you can use `$state` in class fields (whether public or private), or as the first assignment to a property immediately inside the `constructor`:


### PR DESCRIPTION
This risks overlapping with #13571 but the `svelte/reactivity` docs page still risks being a content island, which is a shame since tools like `SvelteMap`, `SvelteSet` are an incredibly natural go-to.

This change to the $state docs would follow my natural mental model, if i'm discovering Svelte today for the first time or on a refresher course.

_"Great, runes exist. State is a rune for setting the reactive source. What if I want to use $state for one thing? Ok, now what if I want to use $state for many things at once?"_

I suggest an outright section "State for Collections" inside the $state doc page. 

