### PR TITLE
Update $effect and testing docs to mention issues with push on state array

### DIFF
--- a/documentation/docs/07-misc/02-testing.md
+++ b/documentation/docs/07-misc/02-testing.md
@@ -147,7 +147,13 @@ test('Effect', () => {
  * @param {() => any} getValue
  */
 export function logger(getValue) {
-	/** @type {any[]} */
+	/**
+	 * must not be a `$state`
+	 * 
+	 * @see https://svelte.dev/docs/svelte/$effect#When-not-to-use-$effect-untrack
+	 * 
+	 * @type {any[]}
+	 **/
 	let log = [];
 
 	$effect(() => {


### PR DESCRIPTION
Should prevent misunderstaings like https://github.com/sveltejs/svelte/issues/16092

This PR clarify in the testing `$effect` examples to not use `$state` on the array the `$effect` is using push and also adds a separate `untrack` section in the `$effect` doc to guard the user against updating the value of `$state` while depending on its value. 

This should further clarify some misundarsting some users have when dealing with `$state` vs "regular variables".

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
