### PR TITLE
fix: ensure unowned deriveds can add themselves as reactions while connected

### DIFF
--- a/.changeset/little-kings-smoke.md
+++ b/.changeset/little-kings-smoke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure unowned deriveds can add themselves as reactions while connected

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -294,7 +294,12 @@ export function update_reaction(reaction) {
 				reaction.deps = deps = new_deps;
 			}
 
-			if (!skip_reaction) {
+			if (
+				!skip_reaction ||
+				// Deriveds that already have reactions can cleanup, so we still add them as reactions
+				((flags & DERIVED) !== 0 &&
+					/** @type {import('#client').Derived} */ (reaction).reactions !== null)
+			) {
 				for (i = skipped_deps; i < deps.length; i++) {
 					(deps[i].reactions ??= []).push(reaction);
 				}

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -113,7 +113,7 @@ describe('signals', () => {
 	});
 
 	test('unowned deriveds are not added as reactions but trigger effects', () => {
-		var obj = state(undefined);
+		var obj = state<any>(undefined);
 
 		class C1 {
 			#v = state(0);
@@ -126,12 +126,10 @@ describe('signals', () => {
 		}
 
 		return () => {
-			console.log('1');
 			let d = derived(() => $.get(obj)?.v || '-');
 
 			const log: number[] = [];
 			assert.equal($.get(d), '-');
-			console.log('2');
 
 			let destroy = effect_root(() => {
 				render_effect(() => {
@@ -139,14 +137,11 @@ describe('signals', () => {
 				});
 			});
 
-			console.log('3');
 			set(obj, new C1());
 			flushSync();
-			console.log('4');
 			assert.equal($.get(d), '-');
-			$.get(obj)!.v = 1;
+			$.get(obj).v = 1;
 			flushSync();
-			console.log('5');
 			assert.equal($.get(d), 1);
 			assert.deepEqual(log, ['-', 1]);
 			destroy();


### PR DESCRIPTION
Fixes #15829 and potentially #15853

I can't quite articulate yet why this is right, but I _think_ it is. Basically, an unowned derived should still add itself as a reaction while it is properly connected, which means it can be cleaned up correctly - and this connection is indicated by it having reactions.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
