### PR TITLE
chore: reduce some select.value indirection

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -166,20 +166,6 @@ export function parse_directive_name(name) {
 }
 
 /**
- * @param {ComponentClientTransformState} state
- * @param {string} id
- * @param {Expression | undefined} init
- * @param {Expression} value
- * @param {ExpressionStatement} update
- */
-export function build_update_assignment(state, id, init, value, update) {
-	state.init.push(b.var(id, init));
-	state.update.push(
-		b.if(b.binary('!==', b.id(id), b.assignment('=', b.id(id), value)), b.block([update]))
-	);
-}
-
-/**
  * Serializes `bind:this` for components and elements.
  * @param {Identifier | MemberExpression | SequenceExpression} expression
  * @param {Expression} value


### PR DESCRIPTION
ran into this needless indirection while working on async stuff — select value handling looks like it needs a bit of a tidy up, of which this is an easy first start. self-merging to unblock since it should be very uncontroversial