### PR TITLE
chore: simplify `<select>` initialization

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -393,13 +393,7 @@ export function RegularElement(node, context) {
 	if (!has_spread && needs_special_value_handling) {
 		for (const attribute of /** @type {AST.Attribute[]} */ (attributes)) {
 			if (attribute.name === 'value') {
-				build_element_special_value_attribute(
-					node.name,
-					node_id,
-					attribute,
-					context,
-					context.state
-				);
+				build_element_special_value_attribute(node.name, node_id, attribute, context);
 				break;
 			}
 		}
@@ -626,9 +620,9 @@ function build_custom_element_attribute_update_assignment(node_id, attribute, co
  * @param {Identifier} node_id
  * @param {AST.Attribute} attribute
  * @param {ComponentContext} context
- * @param {ComponentClientTransformState} state
  */
-function build_element_special_value_attribute(element, node_id, attribute, context, state) {
+function build_element_special_value_attribute(element, node_id, attribute, context) {
+	const state = context.state;
 	const is_select_with_value =
 		// attribute.metadata.dynamic would give false negatives because even if the value does not change,
 		// the inner options could still change, so we need to always treat it as reactive

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -666,7 +666,7 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 	);
 
 	if (is_select_with_value) {
-		state.init.push(b.stmt(b.call('$.init_select', node_id, b.thunk(value))));
+		state.init.push(b.stmt(b.call('$.init_select', node_id)));
 	}
 
 	if (has_state) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -22,12 +22,7 @@ import {
 	build_set_style
 } from './shared/element.js';
 import { process_children } from './shared/fragment.js';
-import {
-	build_render_statement,
-	build_template_chunk,
-	get_expression_id,
-	memoize_expression
-} from './shared/utils.js';
+import { build_render_statement, build_template_chunk, get_expression_id } from './shared/utils.js';
 import { visit_event_attribute } from './shared/events.js';
 
 /**
@@ -629,12 +624,7 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 		element === 'select' && attribute.value !== true && !is_text_attribute(attribute);
 
 	const { value, has_state } = build_attribute_value(attribute.value, context, (value, metadata) =>
-		metadata.has_call
-			? // if is a select with value we will also invoke `init_select` which need a reference before the template effect so we memoize separately
-				is_select_with_value
-				? memoize_expression(state, value)
-				: get_expression_id(state.expressions, value)
-			: value
+		metadata.has_call ? get_expression_id(state.expressions, value) : value
 	);
 
 	const evaluated = context.state.scope.evaluate(value);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -665,10 +665,6 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 			: inner_assignment
 	);
 
-	if (is_select_with_value) {
-		state.init.push(b.stmt(b.call('$.init_select', node_id)));
-	}
-
 	if (has_state) {
 		const id = b.id(state.scope.generate(`${node_id.name}_value`));
 
@@ -681,5 +677,9 @@ function build_element_special_value_attribute(element, node_id, attribute, cont
 		state.update.push(b.if(b.binary('!==', id, b.assignment('=', id, value)), b.block([update])));
 	} else {
 		state.init.push(update);
+	}
+
+	if (is_select_with_value) {
+		state.init.push(b.stmt(b.call('$.init_select', node_id)));
 	}
 }

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -515,11 +515,10 @@ export function attribute_effect(
 	if (is_select) {
 		var select = /** @type {HTMLSelectElement} */ (element);
 
-		queue_micro_task(() => {
+		effect(() => {
 			select_option(select, /** @type {Record<string | symbol, any>} */ (prev).value);
+			init_select(select);
 		});
-
-		init_select(select);
 	}
 
 	inited = true;

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -515,11 +515,9 @@ export function attribute_effect(
 	if (is_select) {
 		var select = /** @type {HTMLSelectElement} */ (element);
 
-		if (!inited) {
-			effect(() => {
-				select_option(select, /** @type {Record<string | symbol, any>} */ (prev).value);
-			});
-		}
+		queue_micro_task(() => {
+			select_option(select, /** @type {Record<string | symbol, any>} */ (prev).value);
+		});
 
 		init_select(select);
 	}

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -6,7 +6,7 @@ import { create_event, delegate } from './events.js';
 import { add_form_reset_listener, autofocus } from './misc.js';
 import * as w from '../../warnings.js';
 import { LOADING_ATTR_SYMBOL } from '#client/constants';
-import { queue_idle_task, queue_micro_task } from '../task.js';
+import { queue_idle_task } from '../task.js';
 import { is_capture_event, is_delegated, normalize_attribute } from '../../../../utils.js';
 import {
 	active_effect,

--- a/packages/svelte/src/internal/client/dom/elements/bindings/select.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/select.js
@@ -1,9 +1,9 @@
 import { effect } from '../../../reactivity/effects.js';
 import { listen_to_event_and_reset_event } from './shared.js';
-import { untrack } from '../../../runtime.js';
 import { is } from '../../../proxy.js';
 import { is_array } from '../../../../shared/utils.js';
 import * as w from '../../../warnings.js';
+import { queue_micro_task } from '../../task.js';
 
 /**
  * Selects the correct option(s) (depending on whether this is a multiple select)
@@ -51,11 +51,10 @@ export function select_option(select, value, mounting) {
  * current selection to the dom when it changes. Such
  * changes could for example occur when options are
  * inside an `#each` block.
- * @template V
  * @param {HTMLSelectElement} select
  */
 export function init_select(select) {
-	effect(() => {
+	queue_micro_task(() => {
 		var observer = new MutationObserver(() => {
 			// @ts-ignore
 			var value = select.__value;

--- a/packages/svelte/src/internal/client/dom/elements/bindings/select.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/select.js
@@ -53,16 +53,9 @@ export function select_option(select, value, mounting) {
  * inside an `#each` block.
  * @template V
  * @param {HTMLSelectElement} select
- * @param {() => V} [get_value]
  */
-export function init_select(select, get_value) {
-	let mounting = true;
+export function init_select(select) {
 	effect(() => {
-		if (get_value) {
-			select_option(select, untrack(get_value), mounting);
-		}
-		mounting = false;
-
 		var observer = new MutationObserver(() => {
 			// @ts-ignore
 			var value = select.__value;

--- a/packages/svelte/src/internal/client/dom/elements/bindings/select.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/select.js
@@ -3,7 +3,6 @@ import { listen_to_event_and_reset_event } from './shared.js';
 import { is } from '../../../proxy.js';
 import { is_array } from '../../../../shared/utils.js';
 import * as w from '../../../warnings.js';
-import { queue_micro_task } from '../../task.js';
 
 /**
  * Selects the correct option(s) (depending on whether this is a multiple select)


### PR DESCRIPTION
Follow-up to #16250. There's a lot of unnecessary dancing around with `<select>` values that we can solve by being smarter about the order in which things happen — if we initialize the child `<option>` values first, we don't need to muck about passing the value into the `init_select` function that sets up the `MutationObserver`.

This, in turn, will allow us to get rid of the special handling of that attribute, ~~but I'll do that as a follow-up.~~ changed my mind

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
