### PR TITLE
Fix/@sveltejs/svelte/16114

### DIFF
--- a/.changeset/light-rivers-jump.md
+++ b/.changeset/light-rivers-jump.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Store deriveds old value before updating them for consistency with directly assigned sources when reading in teardown functions

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -185,8 +185,12 @@ export function update_derived(derived) {
 		// that also happens before user_effect teardown.
 		//
 		// store old value only if not inside a teardown function
-		// because in legacy mode, bindable props are deriveds
-		// and they are executed during teardown.
+		// because we only need to save the old values before
+		// the cleanup is triggered othewise accessing
+		// a derived during cleanup will return the incorrect
+		// value in case the derived wasn't in the deps of the effect,
+		// or the teardown was executed because the component was
+		// destroyed.
 		if (!is_destroying_effect) {
 			var old_value = derived.v;
 			old_values.set(derived, old_value);

--- a/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-no-setter/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-no-setter/Component.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { onDestroy } from 'svelte';
+
+	let { checked = $bindable(), count = $bindable() } = $props();
+
+	onDestroy(() => {
+		console.log(`${count} ${checked}`);
+	});
+</script>
+
+<p>Count: {count}</p>

--- a/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-no-setter/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-no-setter/_config.js
@@ -1,0 +1,63 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, logs, target }) {
+		/** @type {HTMLButtonElement | null} */
+		const increment_btn = target.querySelector('#increment');
+		/** @type {HTMLButtonElement | null} */
+		const toggle_btn = target.querySelector('#toggle');
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 0');
+		}
+
+		// Click increment: count=1
+		flushSync(() => {
+			increment_btn?.click();
+		});
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 1');
+		}
+
+		// Click increment again: count=2, components with count < 2 should unmount and log old values
+		flushSync(() => {
+			increment_btn?.click();
+		});
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 2');
+		}
+
+		// Toggle show to hide components that depend on show
+		flushSync(() => {
+			toggle_btn?.click();
+		});
+
+		// Should log old values during cleanup from the six components guarded by `count < 2`:
+		// 1. Component with bind: "1 true"
+		// 2. Component with spread: "1 true"
+		// 3. Component with normal props: "1 true"
+		// 4. Runes dynamic component with bind: "1 true"
+		// 5. Runes dynamic component with spread: "1 true"
+		// 6. Runes dynamic component with normal props: "1 true"
+		// Then from the four components guarded by `show`:
+		// 7. Component with bind (show): "2 true" (old value of checked)
+		// 8. Runes dynamic component with bind (show): "2 true"
+		// 9. Runes dynamic component with spread (show): "2 true"
+		// 10. Runes dynamic component with normal props (show): "2 true"
+		assert.deepEqual(logs, [
+			'1 true',
+			'1 true',
+			'1 true',
+			'1 true',
+			'1 true',
+			'1 true',
+			'2 true',
+			'2 true',
+			'2 true',
+			'2 true'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-no-setter/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-no-setter/main.svelte
@@ -1,0 +1,52 @@
+<script>
+	import Component from './Component.svelte';
+
+	let show = $state(true);
+	let count = $state(0);
+	let spread = $derived({ checked: show, count });
+
+	// Runes dynamic component pattern
+	let DynComponent1 = $derived(count < 2 ? Component : undefined);
+	let DynComponent2 = $derived(show ? Component : undefined);
+</script>
+
+<button id="increment" onclick={() => count++}>Increment count</button>
+<button id="toggle" onclick={() => (show = !show)}>Toggle show</button>
+
+<!-- count with bind -->
+{#if count < 2}
+	<Component bind:count bind:checked={show} />
+{/if}
+
+<!-- spread syntax -->
+{#if count < 2}
+	<Component {...spread} />
+{/if}
+
+<!-- normal prop -->
+{#if count < 2}
+	<Component {count} checked={show} />
+{/if}
+
+<!-- prop only accessed in destroy -->
+{#if show}
+	<Component bind:count bind:checked={show} />
+{/if}
+
+<!-- runes dynamic component pattern -->
+<DynComponent1 bind:count bind:checked={show} />
+
+<!-- runes dynamic component pattern with spread -->
+<DynComponent1 {...spread} />
+
+<!-- runes dynamic component pattern with normal props -->
+<DynComponent1 {count} checked={show} />
+
+<!-- runes dynamic component pattern (show) -->
+<DynComponent2 bind:count bind:checked={show} />
+
+<!-- runes dynamic component pattern with spread (show) -->
+<DynComponent2 {...spread} />
+
+<!-- runes dynamic component pattern with normal props (show) -->
+<DynComponent2 {count} checked={show} />

--- a/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-with-setter/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-with-setter/Component.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { onDestroy } from 'svelte';
+
+	let { checked = $bindable(), count = $bindable() } = $props();
+
+	onDestroy(() => {
+		console.log(`${count} ${checked}`);
+	});
+</script>
+
+<p>Count: {count}</p>
+
+<button onclick={() => count--}>Decrement count</button>
+<button onclick={() => (checked = !checked)}>Toggle checked</button>

--- a/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-with-setter/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-with-setter/_config.js
@@ -1,0 +1,63 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, logs, target }) {
+		/** @type {HTMLButtonElement | null} */
+		const increment_btn = target.querySelector('#increment');
+		/** @type {HTMLButtonElement | null} */
+		const toggle_btn = target.querySelector('#toggle');
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 0');
+		}
+
+		// Click increment: count=1
+		flushSync(() => {
+			increment_btn?.click();
+		});
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 1');
+		}
+
+		// Click increment again: count=2, components with count < 2 should unmount and log old values
+		flushSync(() => {
+			increment_btn?.click();
+		});
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 2');
+		}
+
+		// Toggle show to hide components that depend on show
+		flushSync(() => {
+			toggle_btn?.click();
+		});
+
+		// Should log old values during cleanup from the six components guarded by `count < 2`:
+		// 1. Component with bind: "1 true"
+		// 2. Component with spread: "1 true"
+		// 3. Component with normal props: "1 true"
+		// 4. Runes dynamic component with bind: "1 true"
+		// 5. Runes dynamic component with spread: "1 true"
+		// 6. Runes dynamic component with normal props: "1 true"
+		// Then from the four components guarded by `show`:
+		// 7. Component with bind (show): "2 true" (old value of checked)
+		// 8. Runes dynamic component with bind (show): "2 true"
+		// 9. Runes dynamic component with spread (show): "2 true"
+		// 10. Runes dynamic component with normal props (show): "2 true"
+		assert.deepEqual(logs, [
+			'1 true',
+			'1 true',
+			'1 true',
+			'1 true',
+			'1 true',
+			'1 true',
+			'2 true',
+			'2 true',
+			'2 true',
+			'2 true'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-with-setter/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bindable-props-cleanup-with-setter/main.svelte
@@ -1,0 +1,52 @@
+<script>
+	import Component from './Component.svelte';
+
+	let show = $state(true);
+	let count = $state(0);
+	let spread = $derived({ checked: show, count });
+
+	// Runes dynamic component pattern
+	let DynComponent1 = $derived(count < 2 ? Component : undefined);
+	let DynComponent2 = $derived(show ? Component : undefined);
+</script>
+
+<button id="increment" onclick={() => count++}>Increment count</button>
+<button id="toggle" onclick={() => (show = !show)}>Toggle show</button>
+
+<!-- count with bind -->
+{#if count < 2}
+	<Component bind:count bind:checked={show} />
+{/if}
+
+<!-- spread syntax -->
+{#if count < 2}
+	<Component {...spread} />
+{/if}
+
+<!-- normal prop -->
+{#if count < 2}
+	<Component {count} checked={show} />
+{/if}
+
+<!-- prop only accessed in destroy -->
+{#if show}
+	<Component bind:count bind:checked={show} />
+{/if}
+
+<!-- runes dynamic component pattern -->
+<DynComponent1 bind:count bind:checked={show} />
+
+<!-- runes dynamic component pattern with spread -->
+<DynComponent1 {...spread} />
+
+<!-- runes dynamic component pattern with normal props -->
+<DynComponent1 {count} checked={show} />
+
+<!-- runes dynamic component pattern (show) -->
+<DynComponent2 bind:count bind:checked={show} />
+
+<!-- runes dynamic component pattern with spread (show) -->
+<DynComponent2 {...spread} />
+
+<!-- runes dynamic component pattern with normal props (show) -->
+<DynComponent2 {count} checked={show} />

--- a/packages/svelte/tests/runtime-runes/samples/derived-cleanup-old-value/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-cleanup-old-value/_config.js
@@ -1,0 +1,39 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, logs, target }) {
+		/** @type {HTMLButtonElement | null} */
+		const increment_btn = target.querySelector('#increment');
+		/** @type {HTMLButtonElement | null} */
+		const overwrite_btn = target.querySelector('#overwrite');
+
+		// Initial state: count=1, derived_value=1
+
+		// Click to increment count: count=2, derived_value=4
+		flushSync(() => {
+			increment_btn?.click();
+		});
+
+		// Click to increment count: count=3, derived_value=9
+		flushSync(() => {
+			increment_btn?.click();
+		});
+
+		// Click to overwrite derived_value: count=3, derived_value=7
+		flushSync(() => {
+			overwrite_btn?.click();
+		});
+
+		// Should log old value during cleanup (4) and new value during setup (9)
+		assert.deepEqual(logs, [
+			'$effect: 1',
+			'$effect teardown: 1',
+			'$effect: 4',
+			'$effect teardown: 4',
+			'$effect: 9',
+			'$effect teardown: 9',
+			'$effect: 7'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-cleanup-old-value/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-cleanup-old-value/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	let count = $state(1);
+	let derived_value = $derived(count * count);
+
+	$effect(() => {
+		console.log(`$effect: ${derived_value}`);
+		return () => {
+			console.log(`$effect teardown: ${derived_value}`);
+		};
+	});
+</script>
+
+<button id="increment" onclick={() => count++}>Increment s</button>
+<button id="overwrite" onclick={() => (derived_value = 7)}>Overwrite derived_value</button>
+
+<p>count: {count}</p>
+<p>derived_value: {derived_value}</p>

--- a/packages/svelte/tests/runtime-runes/samples/regular-props-cleanup-old-value/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/regular-props-cleanup-old-value/Component.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { onDestroy } from 'svelte';
+
+	let { checked, count } = $props();
+
+	onDestroy(() => {
+		console.log(`${count} ${checked}`);
+	});
+</script>
+
+<p>Count: {count}</p>

--- a/packages/svelte/tests/runtime-runes/samples/regular-props-cleanup-old-value/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/regular-props-cleanup-old-value/_config.js
@@ -1,0 +1,49 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, logs, target }) {
+		/** @type {HTMLButtonElement | null} */
+		const increment_btn = target.querySelector('#increment');
+		/** @type {HTMLButtonElement | null} */
+		const toggle_btn = target.querySelector('#toggle');
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 0');
+		}
+
+		// Click increment: count=1
+		flushSync(() => {
+			increment_btn?.click();
+		});
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 1');
+		}
+
+		// Click increment again: count=2, components with count < 2 should unmount and log old values
+		flushSync(() => {
+			increment_btn?.click();
+		});
+
+		for (const p of target.querySelectorAll('p')) {
+			assert.equal(p.innerHTML, 'Count: 2');
+		}
+
+		// Toggle show to hide components that depend on show
+		flushSync(() => {
+			toggle_btn?.click();
+		});
+
+		// Should log old values during cleanup from the four components guarded by `count < 2`:
+		// 1. Component with normal props: "1 true"
+		// 2. Component with spread: "1 true"
+		// 3. Runes dynamic component with normal props: "1 true"
+		// 4. Runes dynamic component with spread: "1 true"
+		// Then from the three components guarded by `show`:
+		// 5. Component with normal props (show): "2 true" (old value of checked)
+		// 6. Runes dynamic component with normal props (show): "2 true"
+		// 7. Runes dynamic component with spread (show): "2 true"
+		assert.deepEqual(logs, ['1 true', '1 true', '1 true', '1 true', '2 true', '2 true', '2 true']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/regular-props-cleanup-old-value/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/regular-props-cleanup-old-value/main.svelte
@@ -1,0 +1,41 @@
+<script>
+	import Component from './Component.svelte';
+
+	let show = $state(true);
+	let count = $state(0);
+	let spread = $derived({ checked: show, count });
+
+	// Runes dynamic component pattern
+	let DynComponent1 = $derived(count < 2 ? Component : undefined);
+	let DynComponent2 = $derived(show ? Component : undefined);
+</script>
+
+<button id="increment" onclick={() => count++}>Increment count</button>
+<button id="toggle" onclick={() => (show = !show)}>Toggle show</button>
+
+<!-- normal props -->
+{#if count < 2}
+	<Component {count} checked={show} />
+{/if}
+
+<!-- spread syntax -->
+{#if count < 2}
+	<Component {...spread} />
+{/if}
+
+<!-- prop only accessed in destroy -->
+{#if show}
+	<Component {count} checked={show} />
+{/if}
+
+<!-- runes dynamic component pattern with normal props -->
+<DynComponent1 {count} checked={show} />
+
+<!-- runes dynamic component pattern with spread -->
+<DynComponent1 {...spread} />
+
+<!-- runes dynamic component pattern (show) with normal props -->
+<DynComponent2 {count} checked={show} />
+
+<!-- runes dynamic component pattern with spread (show) -->
+<DynComponent2 {...spread} />


### PR DESCRIPTION
Fixes: https://github.com/sveltejs/svelte/issues/16114

When a `$state` or a `$derived` is directly set by the user, we properly add it to the `old_values` `Map`.

However when a derived is updated as a result of the `check_dirtiness` check during `flush_queued_effects`, we do not save the old value, hence the value read in a teardown function of a `$effect` is not the old value but the new one, this is incosistent with the "old value behavior" that was recently introduced.

In this PR i save the old value when the `$derived` is updated, so that it will be used by teardown functions of `$effect`s.

However while working on this i've noticed that there's an edge case when working with child components.

While passing a prop in certain conditions (either a legacy bindable or a prop accessed via `$.prop` because it has a setter somewhere in the code) the original `$state` is wrapped in a `derived`. When the child component is destroyed the teardown functions might read `$.prop` values that did not got update because thay were not read (perhaps in the template). This means that is possible that during the execution of the teardown the values of the derived are either `null` because they were never initialized because nothing ever read from it, or they are outdated. I've opened a separate issue for this: https://github.com/sveltejs/svelte/issues/16262.

This bug is present both before and after the changes of this PR.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
