### PR TITLE
move config into svelte.config.js

### DIFF
--- a/playgrounds/sandbox/svelte.config.js
+++ b/playgrounds/sandbox/svelte.config.js
@@ -1,0 +1,5 @@
+export default {
+	compilerOptions: {
+		hmr: true
+	}
+};

--- a/playgrounds/sandbox/vite.config.js
+++ b/playgrounds/sandbox/vite.config.js
@@ -7,14 +7,7 @@ export default defineConfig({
 		minify: false
 	},
 
-	plugins: [
-		inspect(),
-		svelte({
-			compilerOptions: {
-				hmr: true
-			}
-		})
-	],
+	plugins: [inspect(), svelte()],
 
 	optimizeDeps: {
 		// svelte is a local workspace package, optimizing it would require dev server restarts with --force for every change


### PR DESCRIPTION
I'm going to extract as much as possible out of #15844 and into their own PRs, so that it's less huge (and because it's useful independently of the `await` stuff)

starting with an easy one that I'll self-merge once green