### PR TITLE
chore: move stuff from `analysis` into global compiler state

### DIFF
--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -96,6 +96,7 @@ export function compileModule(source, options) {
  * @returns {Record<string, any>}
  */
 
+// TODO 6.0 remove unused `filename`
 /**
  * The parse function parses a component, returning only its abstract syntax tree.
  *
@@ -104,14 +105,15 @@ export function compileModule(source, options) {
  *
  * The `loose` option, available since 5.13.0, tries to always return an AST even if the input will not successfully compile.
  *
+ * The `filename` option is unused and will be removed in Svelte 6.0.
+ *
  * @param {string} source
  * @param {{ filename?: string; rootDir?: string; modern?: boolean; loose?: boolean }} [options]
  * @returns {AST.Root | LegacyRoot}
  */
-export function parse(source, { filename, rootDir, modern, loose } = {}) {
+export function parse(source, { modern, loose } = {}) {
 	source = remove_bom(source);
 	state.reset_warning_filter(() => false);
-	state.reset(source, { filename: filename ?? '(unknown)', rootDir });
 
 	const ast = _parse(source, loose);
 	return to_public_ast(source, ast, modern);

--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -20,9 +20,8 @@ export { default as preprocess } from './preprocess/index.js';
  */
 export function compile(source, options) {
 	source = remove_bom(source);
-	state.reset_warning_filter(options.warningFilter);
+	state.reset_warnings(options.warningFilter);
 	const validated = validate_component_options(options, '');
-	state.reset(source, validated);
 
 	let parsed = _parse(source);
 
@@ -64,9 +63,8 @@ export function compile(source, options) {
  */
 export function compileModule(source, options) {
 	source = remove_bom(source);
-	state.reset_warning_filter(options.warningFilter);
+	state.reset_warnings(options.warningFilter);
 	const validated = validate_module_options(options, '');
-	state.reset(source, validated);
 
 	const analysis = analyze_module(source, validated);
 	return transform_module(analysis, source, validated);
@@ -113,7 +111,7 @@ export function compileModule(source, options) {
  */
 export function parse(source, { modern, loose } = {}) {
 	source = remove_bom(source);
-	state.reset_warning_filter(() => false);
+	state.reset_warnings(() => false);
 
 	const ast = _parse(source, loose);
 	return to_public_ast(source, ast, modern);

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -135,7 +135,7 @@ export function migrate(source, { filename, use_ts } = {}) {
 		});
 
 		reset_warnings(() => false);
-		reset({ filename: filename ?? '(unknown)' });
+		reset({ dev: false, filename: filename ?? '(unknown)' });
 
 		let parsed = parse(source);
 

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -9,7 +9,7 @@ import { parse } from '../phases/1-parse/index.js';
 import { regex_valid_component_name } from '../phases/1-parse/state/element.js';
 import { analyze_component } from '../phases/2-analyze/index.js';
 import { get_rune } from '../phases/scope.js';
-import { reset, reset_warning_filter } from '../state.js';
+import { reset, reset_warnings } from '../state.js';
 import {
 	extract_identifiers,
 	extract_all_identifiers_from_expression,
@@ -134,8 +134,8 @@ export function migrate(source, { filename, use_ts } = {}) {
 			return start + style_placeholder + end;
 		});
 
-		reset_warning_filter(() => false);
-		reset(source, { filename: filename ?? '(unknown)' });
+		reset_warnings(() => false);
+		reset({ filename: filename ?? '(unknown)' });
 
 		let parsed = parse(source);
 

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -135,7 +135,6 @@ export function migrate(source, { filename, use_ts } = {}) {
 		});
 
 		reset_warnings(() => false);
-		reset({ dev: false, filename: filename ?? '(unknown)' });
 
 		let parsed = parse(source);
 

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -9,6 +9,7 @@ import { create_fragment } from './utils/create.js';
 import read_options from './read/options.js';
 import { is_reserved } from '../../../utils.js';
 import { disallow_children } from '../2-analyze/visitors/shared/special-element.js';
+import * as state from '../../state.js';
 
 const regex_position_indicator = / \(\d+:\d+\)$/;
 
@@ -301,6 +302,8 @@ export class Parser {
  * @returns {AST.Root}
  */
 export function parse(template, loose = false) {
+	state.set_source(template);
+
 	const parser = new Parser(template, loose);
 	return parser.root;
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -271,7 +271,11 @@ export function analyze_module(source, options) {
 		classes: new Map()
 	};
 
-	state.reset(options);
+	state.reset({
+		dev: options.dev,
+		filename: options.filename,
+		rootDir: options.rootDir
+	});
 
 	walk(
 		/** @type {Node} */ (ast),
@@ -510,7 +514,11 @@ export function analyze_component(root, source, options) {
 		snippets: new Set()
 	};
 
-	state.reset(options);
+	state.reset({
+		dev: options.dev,
+		filename: options.filename,
+		rootDir: options.rootDir
+	});
 
 	if (!runes) {
 		// every exported `let` or `var` declaration becomes a prop, everything else becomes an export

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -274,7 +274,8 @@ export function analyze_module(source, options) {
 	state.reset({
 		dev: options.dev,
 		filename: options.filename,
-		rootDir: options.rootDir
+		rootDir: options.rootDir,
+		runes: true
 	});
 
 	walk(
@@ -517,7 +518,8 @@ export function analyze_component(root, source, options) {
 	state.reset({
 		dev: options.dev,
 		filename: options.filename,
-		rootDir: options.rootDir
+		rootDir: options.rootDir,
+		runes: true
 	});
 
 	if (!runes) {

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -516,6 +516,7 @@ export function analyze_component(root, source, options) {
 	};
 
 	state.reset({
+		component_name: analysis.name,
 		dev: options.dev,
 		filename: options.filename,
 		rootDir: options.rootDir,

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -76,6 +76,7 @@ import { UseDirective } from './visitors/UseDirective.js';
 import { VariableDeclarator } from './visitors/VariableDeclarator.js';
 import is_reference from 'is-reference';
 import { mark_subtree_dynamic } from './visitors/shared/fragment.js';
+import * as state from '../../state.js';
 
 /**
  * @type {Visitors}
@@ -240,6 +241,7 @@ export function analyze_module(source, options) {
 	/** @type {AST.JSComment[]} */
 	const comments = [];
 
+	state.set_source(source);
 	const ast = parse(source, comments, false, false);
 
 	const { scope, scopes } = create_scopes(ast, new ScopeRoot(), false, null);
@@ -268,6 +270,8 @@ export function analyze_module(source, options) {
 		comments,
 		classes: new Map()
 	};
+
+	state.reset(options);
 
 	walk(
 		/** @type {Node} */ (ast),
@@ -505,6 +509,8 @@ export function analyze_component(root, source, options) {
 		snippet_renderers: new Map(),
 		snippets: new Set()
 	};
+
+	state.reset(options);
 
 	if (!runes) {
 		// every exported `let` or `var` declaration becomes a prop, everything else becomes an export

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -34,6 +34,7 @@ export interface ReactiveStatement {
  */
 export interface Analysis {
 	module: Js;
+	/** @deprecated use `component_name` from `state.js` instead */
 	name: string; // TODO should this be filename? it's used in `compileModule` as well as `compile`
 	/** @deprecated use `runes` from `state.js` instead */
 	runes: boolean;
@@ -91,6 +92,7 @@ export interface ComponentAnalysis extends Analysis {
 		keyframes: string[];
 		has_global: boolean;
 	};
+	/** @deprecated use `source` from `state.js` instead */
 	source: string;
 	undefined_exports: Map<string, Node>;
 	/**

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -35,6 +35,7 @@ export interface ReactiveStatement {
 export interface Analysis {
 	module: Js;
 	name: string; // TODO should this be filename? it's used in `compileModule` as well as `compile`
+	/** @deprecated use `runes` from `state.js` instead */
 	runes: boolean;
 	immutable: boolean;
 	tracing: boolean;

--- a/packages/svelte/src/compiler/state.js
+++ b/packages/svelte/src/compiler/state.js
@@ -77,8 +77,9 @@ export function pop_ignore() {
  *
  * @param {(warning: Warning) => boolean} fn
  */
-export function reset_warning_filter(fn = () => true) {
+export function reset_warnings(fn = () => true) {
 	warning_filter = fn;
+	warnings = [];
 }
 
 /**
@@ -91,11 +92,9 @@ export function is_ignored(node, code) {
 }
 
 /**
- * @param {string} _source
  * @param {{ dev?: boolean; filename: string; rootDir?: string }} options
  */
-export function reset(_source, options) {
-	source = _source;
+export function reset(options) {
 	const root_dir = options.rootDir?.replace(/\\/g, '/');
 	filename = options.filename.replace(/\\/g, '/');
 
@@ -106,8 +105,6 @@ export function reset(_source, options) {
 		filename = filename.replace(root_dir, '').replace(/^[/\\]/, '');
 	}
 
-	set_source(source);
-	warnings = [];
 	ignore_stack = [];
 	ignore_map.clear();
 }

--- a/packages/svelte/src/compiler/state.js
+++ b/packages/svelte/src/compiler/state.js
@@ -16,6 +16,8 @@ export let warnings = [];
  */
 export let filename;
 
+export let component_name = '<unknown>';
+
 /**
  * The original source code
  * @type {string}
@@ -97,6 +99,7 @@ export function is_ignored(node, code) {
  * @param {{
  *   dev: boolean;
  *   filename: string;
+ *   component_name?: string;
  *   rootDir?: string;
  *   runes: boolean;
  * }} state
@@ -105,8 +108,9 @@ export function reset(state) {
 	const root_dir = state.rootDir?.replace(/\\/g, '/');
 	filename = state.filename.replace(/\\/g, '/');
 
-	dev = !!state.dev;
-	runes = !!state.runes;
+	dev = state.dev;
+	runes = state.runes;
+	component_name = state.component_name ?? '(unknown)';
 
 	if (typeof root_dir === 'string' && filename.startsWith(root_dir)) {
 		// make filename relative to rootDir

--- a/packages/svelte/src/compiler/state.js
+++ b/packages/svelte/src/compiler/state.js
@@ -28,6 +28,8 @@ export let source;
  */
 export let dev;
 
+export let runes = false;
+
 export let locator = getLocator('', { offsetLine: 1 });
 
 /** @param {string} value */
@@ -92,13 +94,19 @@ export function is_ignored(node, code) {
 }
 
 /**
- * @param {{ dev: boolean; filename: string; rootDir?: string }} state
+ * @param {{
+ *   dev: boolean;
+ *   filename: string;
+ *   rootDir?: string;
+ *   runes: boolean;
+ * }} state
  */
 export function reset(state) {
 	const root_dir = state.rootDir?.replace(/\\/g, '/');
 	filename = state.filename.replace(/\\/g, '/');
 
 	dev = !!state.dev;
+	runes = !!state.runes;
 
 	if (typeof root_dir === 'string' && filename.startsWith(root_dir)) {
 		// make filename relative to rootDir

--- a/packages/svelte/src/compiler/state.js
+++ b/packages/svelte/src/compiler/state.js
@@ -92,13 +92,13 @@ export function is_ignored(node, code) {
 }
 
 /**
- * @param {{ dev?: boolean; filename: string; rootDir?: string }} options
+ * @param {{ dev: boolean; filename: string; rootDir?: string }} state
  */
-export function reset(options) {
-	const root_dir = options.rootDir?.replace(/\\/g, '/');
-	filename = options.filename.replace(/\\/g, '/');
+export function reset(state) {
+	const root_dir = state.rootDir?.replace(/\\/g, '/');
+	filename = state.filename.replace(/\\/g, '/');
 
-	dev = !!options.dev;
+	dev = !!state.dev;
 
 	if (typeof root_dir === 'string' && filename.startsWith(root_dir)) {
 		// make filename relative to rootDir

--- a/packages/svelte/src/compiler/state.js
+++ b/packages/svelte/src/compiler/state.js
@@ -30,6 +30,12 @@ export let dev;
 
 export let locator = getLocator('', { offsetLine: 1 });
 
+/** @param {string} value */
+export function set_source(value) {
+	source = value;
+	locator = getLocator(source, { offsetLine: 1 });
+}
+
 /**
  * @param {AST.SvelteNode & { start?: number | undefined }} node
  */
@@ -100,7 +106,7 @@ export function reset(_source, options) {
 		filename = filename.replace(root_dir, '').replace(/^[/\\]/, '');
 	}
 
-	locator = getLocator(source, { offsetLine: 1 });
+	set_source(source);
 	warnings = [];
 	ignore_stack = [];
 	ignore_map.clear();


### PR DESCRIPTION
per https://github.com/sveltejs/svelte/pull/16255#discussion_r2175461400, this scratches an itch I've had for a while: we put a lot of stuff on `context.state.analysis` that doesn't really form part of the analysis phase, it's just a convenient place to stick it.

It would be _more_ convenient if that stuff was part of the global state exported from `state.js` — just as we guard dev-only compiler logic in `if (dev)` rather than `if (context.state.analysis.dev)` we could also do `if (runes)`, for example.

While doing this I realised that we don't need to do `state.reset` inside `parse(...)`, because we only actually need to reset `source` and `locator`. This means `parse` no longer needs to take an unused `filename` option, so we can remove this in Svelte 6 and make that API simpler.

This PR doesn't replace all the occurrences of `context.state.analysis.runes` (and `.name`, etc) because that would likely create merge conflicts. That can be done as an easy follow-up when there's less stuff in the PR queue.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
