### PR TITLE
chore: simplify props

### DIFF
--- a/.changeset/new-trees-behave.md
+++ b/.changeset/new-trees-behave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: simplify props

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -15,8 +15,6 @@ export const DESTROYED = 1 << 14;
 export const EFFECT_RAN = 1 << 15;
 /** 'Transparent' effects do not create a transition boundary */
 export const EFFECT_TRANSPARENT = 1 << 16;
-/** Svelte 4 legacy mode props need to be handled with deriveds and be recognized elsewhere, hence the dedicated flag */
-export const LEGACY_DERIVED_PROP = 1 << 17;
 export const INSPECT_EFFECT = 1 << 18;
 export const HEAD_EFFECT = 1 << 19;
 export const EFFECT_HAS_DERIVED = 1 << 20;

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -277,11 +277,17 @@ export function prop(props, key, flags, fallback) {
 	// or `createClassComponent(Component, props)`
 	var is_entry_props = STATE_SYMBOL in props || LEGACY_PROPS in props;
 
-	var setter =
-		(bindable &&
-			(get_descriptor(props, key)?.set ??
-				(is_entry_props && key in props && ((v) => (props[key] = v))))) ||
-		undefined;
+	/** @type {((v: V) => void) | undefined} */
+	var setter;
+
+	/** @type {() => V} */
+	var getter;
+
+	if (bindable) {
+		setter =
+			get_descriptor(props, key)?.set ??
+			(is_entry_props && key in props ? (v) => (props[key] = v) : undefined);
+	}
 
 	var fallback_value = /** @type {V} */ (fallback);
 	var fallback_dirty = true;
@@ -307,11 +313,9 @@ export function prop(props, key, flags, fallback) {
 		}
 
 		prop_value = get_fallback();
-		if (setter) setter(prop_value);
+		setter?.(prop_value);
 	}
 
-	/** @type {() => V} */
-	var getter;
 	if (runes) {
 		getter = () => {
 			var value = /** @type {V} */ (props[key]);

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -8,12 +8,11 @@ import {
 	PROPS_IS_UPDATED
 } from '../../../constants.js';
 import { get_descriptor, is_function } from '../../shared/utils.js';
-import { mutable_source, set, source, update } from './sources.js';
+import { set, source, update } from './sources.js';
 import { derived, derived_safe_equal } from './deriveds.js';
-import { get, captured_signals, untrack } from '../runtime.js';
-import { safe_equals } from './equality.js';
+import { get, untrack } from '../runtime.js';
 import * as e from '../errors.js';
-import { LEGACY_DERIVED_PROP, LEGACY_PROPS, STATE_SYMBOL } from '#client/constants';
+import { LEGACY_PROPS, STATE_SYMBOL } from '#client/constants';
 import { proxy } from '../proxy.js';
 import { capture_store_binding } from './store.js';
 import { legacy_mode_flag } from '../../flags/index.js';
@@ -326,14 +325,8 @@ export function prop(props, key, flags, fallback) {
 			return value;
 		};
 	} else {
-		// Svelte 4 did not trigger updates when a primitive value was updated to the same value.
-		// Replicate that behavior through using a derived
-		var derived_getter = (immutable ? derived : derived_safe_equal)(
-			() => /** @type {V} */ (props[key])
-		);
-		derived_getter.f |= LEGACY_DERIVED_PROP;
 		getter = () => {
-			var value = get(derived_getter);
+			var value = /** @type {V} */ (props[key]);
 			if (value !== undefined) fallback_value = /** @type {V} */ (undefined);
 			return value === undefined ? fallback_value : value;
 		};

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -373,27 +373,16 @@ export function prop(props, key, flags, fallback) {
 	}
 
 	return function (/** @type {any} */ value, /** @type {boolean} */ mutation) {
-		// legacy nonsense — need to ensure the source is invalidated when necessary
-		// also needed for when handling inspect logic so we can inspect the correct source signal
-		if (captured_signals !== null) {
-			// invoke getters so that signals are picked up by `invalidate_inner_signals`
-			getter();
-			get(current_value);
-		}
-
 		if (arguments.length > 0) {
 			const new_value = mutation ? get(current_value) : runes && bindable ? proxy(value) : value;
 
 			if (!current_value.equals(new_value)) {
 				set(current_value, new_value);
+
 				// To ensure the fallback value is consistent when used with proxies, we
 				// update the local fallback_value, but only if the fallback is actively used
 				if (fallback_used && fallback_value !== undefined) {
 					fallback_value = new_value;
-				}
-
-				if (has_destroyed_component_ctx(current_value)) {
-					return value;
 				}
 
 				untrack(() => get(current_value)); // force a synchronisation immediately
@@ -402,6 +391,7 @@ export function prop(props, key, flags, fallback) {
 			return value;
 		}
 
+		// TODO is this still necessary post-#16263?
 		if (has_destroyed_component_ctx(current_value)) {
 			return current_value.v;
 		}

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -322,7 +322,15 @@ export function prop(props, key, flags, fallback) {
 	} else {
 		getter = () => {
 			var value = /** @type {V} */ (props[key]);
-			if (value !== undefined) fallback_value = /** @type {V} */ (undefined);
+
+			if (value !== undefined) {
+				// in legacy mode, we don't revert to the fallback value
+				// if the prop goes from defined to undefined. The easiest
+				// way to model this is to make the fallback undefined
+				// as soon as the prop has a value
+				fallback_value = /** @type {V} */ (undefined);
+			}
+
 			return value === undefined ? fallback_value : value;
 		};
 	}

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -259,7 +259,6 @@ function has_destroyed_component_ctx(current_value) {
  * @returns {(() => V | ((arg: V) => V) | ((arg: V, mutation: boolean) => V))}
  */
 export function prop(props, key, flags, fallback) {
-	var immutable = (flags & PROPS_IS_IMMUTABLE) !== 0;
 	var runes = !legacy_mode_flag || (flags & PROPS_IS_RUNES) !== 0;
 	var bindable = (flags & PROPS_IS_BINDABLE) !== 0;
 	var lazy = (flags & PROPS_IS_LAZY_INITIAL) !== 0;
@@ -361,7 +360,7 @@ export function prop(props, key, flags, fallback) {
 
 	// prop is written to, but there's no binding, which means we
 	// create a derived that we can write to locally
-	var d = (immutable ? derived : derived_safe_equal)(getter);
+	var d = ((flags & PROPS_IS_IMMUTABLE) !== 0 ? derived : derived_safe_equal)(getter);
 
 	// Capture the initial value if it's bindable
 	if (bindable) get(d);

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -265,11 +265,8 @@ export function prop(props, key, flags, fallback) {
 
 	var fallback_value = /** @type {V} */ (fallback);
 	var fallback_dirty = true;
-	var fallback_used = false;
 
 	var get_fallback = () => {
-		fallback_used = true;
-
 		if (fallback_dirty) {
 			fallback_dirty = false;
 
@@ -320,7 +317,6 @@ export function prop(props, key, flags, fallback) {
 			var value = /** @type {V} */ (props[key]);
 			if (value === undefined) return get_fallback();
 			fallback_dirty = true;
-			fallback_used = false;
 			return value;
 		};
 	} else {
@@ -371,9 +367,7 @@ export function prop(props, key, flags, fallback) {
 
 			set(d, new_value);
 
-			// To ensure the fallback value is consistent when used with proxies, we
-			// update the local fallback_value, but only if the fallback is actively used
-			if (fallback_used && fallback_value !== undefined) {
+			if (fallback_value !== undefined) {
 				fallback_value = new_value;
 			}
 

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -382,8 +382,6 @@ export function prop(props, key, flags, fallback) {
 				if (fallback_used && fallback_value !== undefined) {
 					fallback_value = new_value;
 				}
-
-				untrack(() => get(current_value)); // force a synchronisation immediately
 			}
 
 			return value;

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -328,7 +328,7 @@ export function prop(props, key, flags, fallback) {
 	}
 
 	// prop is never written to — we only need a getter
-	if (runes && (flags & PROPS_IS_UPDATED) === 0) {
+	if ((flags & PROPS_IS_UPDATED) === 0) {
 		return getter;
 	}
 

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -374,14 +374,12 @@ export function prop(props, key, flags, fallback) {
 		if (arguments.length > 0) {
 			const new_value = mutation ? get(current_value) : runes && bindable ? proxy(value) : value;
 
-			if (!current_value.equals(new_value)) {
-				set(current_value, new_value);
+			set(current_value, new_value);
 
-				// To ensure the fallback value is consistent when used with proxies, we
-				// update the local fallback_value, but only if the fallback is actively used
-				if (fallback_used && fallback_value !== undefined) {
-					fallback_value = new_value;
-				}
+			// To ensure the fallback value is consistent when used with proxies, we
+			// update the local fallback_value, but only if the fallback is actively used
+			if (fallback_used && fallback_value !== undefined) {
+				fallback_value = new_value;
 			}
 
 			return value;

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -20,7 +20,6 @@ import {
 	STATE_SYMBOL,
 	BLOCK_EFFECT,
 	ROOT_EFFECT,
-	LEGACY_DERIVED_PROP,
 	DISCONNECTED,
 	EFFECT_IS_UPDATING,
 	STALE_REACTION
@@ -863,17 +862,7 @@ export function invalidate_inner_signals(fn) {
 	var captured = capture_signals(() => untrack(fn));
 
 	for (var signal of captured) {
-		// Go one level up because derived signals created as part of props in legacy mode
-		if ((signal.f & LEGACY_DERIVED_PROP) !== 0) {
-			for (const dep of /** @type {Derived} */ (signal).deps || []) {
-				if ((dep.f & DERIVED) === 0) {
-					// Use internal_set instead of set here and below to avoid mutation validation
-					internal_set(dep, dep.v);
-				}
-			}
-		} else {
-			internal_set(signal, signal.v);
-		}
+		internal_set(signal, signal.v);
 	}
 }
 


### PR DESCRIPTION
While looking into #16263 I realised that we can _drastically_ simplify the `prop` implementation now that deriveds are writable. Some of the code in red is pretty hard to understand, but deleting it causes no tests to fail. Just to be safe, I added a changeset so that this creates a new version that we can roll back from if it causes any issues.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
