### PR TITLE
fix: revert props legacy mode regression

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -336,7 +336,7 @@ export function prop(props, key, flags, fallback) {
 	}
 
 	// prop is never written to — we only need a getter
-	if ((flags & PROPS_IS_UPDATED) === 0) {
+	if (runes && (flags & PROPS_IS_UPDATED) === 0) {
 		return getter;
 	}
 
@@ -362,8 +362,10 @@ export function prop(props, key, flags, fallback) {
 		};
 	}
 
-	// prop is written to, but there's no binding, which means we
-	// create a derived that we can write to locally
+	// Either prop is written to, but there's no binding, which means we
+	// create a derived that we can write to locally.
+	// Or we are in legacy mode where we always create a derived to replicate that
+	// Svelte 4 did not trigger updates when a primitive value was updated to the same value.
 	var d = ((flags & PROPS_IS_IMMUTABLE) !== 0 ? derived : derived_safe_equal)(getter);
 
 	// Capture the initial value if it's bindable

--- a/packages/svelte/tests/runtime-legacy/samples/prop-no-change/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/prop-no-change/_config.js
@@ -2,6 +2,7 @@ import { flushSync } from 'svelte';
 import { test } from '../../test';
 
 export default test({
+	accessors: false,
 	test({ assert, logs, target }) {
 		assert.deepEqual(logs, ['primitive', 'object']);
 		target.querySelector('button')?.click();


### PR DESCRIPTION
#16270 removed a condition which seemed to keep passing the corresponding test, but it actually introduced a regression since the PROPS_IS_UPDATED is always set when accessors should be created, which is the case by default in legacy mode tests. Setting accessors to false in the test reveals the regression, so this reverts that part of the refactoring.

No changeset since #16270 wasn't released yet

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
