### PR TITLE
chore: `reaction_sources` -> `source_ownership`

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -140,7 +140,7 @@ export function set(source, value, should_proxy = false) {
 		(!untracking || (active_reaction.f & INSPECT_EFFECT) !== 0) &&
 		is_runes() &&
 		(active_reaction.f & (DERIVED | BLOCK_EFFECT | INSPECT_EFFECT)) !== 0 &&
-		!(source_ownership?.sources.includes(source) && source_ownership.reaction === active_reaction)
+		!(source_ownership?.reaction === active_reaction && source_ownership.sources.includes(source))
 	) {
 		e.state_unsafe_mutation();
 	}

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -11,7 +11,7 @@ import {
 	untrack,
 	increment_write_version,
 	update_effect,
-	reaction_sources,
+	source_ownership,
 	check_dirtiness,
 	untracking,
 	is_destroying_effect,
@@ -140,7 +140,7 @@ export function set(source, value, should_proxy = false) {
 		(!untracking || (active_reaction.f & INSPECT_EFFECT) !== 0) &&
 		is_runes() &&
 		(active_reaction.f & (DERIVED | BLOCK_EFFECT | INSPECT_EFFECT)) !== 0 &&
-		!(reaction_sources?.[1].includes(source) && reaction_sources[0] === active_reaction)
+		!(source_ownership?.sources.includes(source) && source_ownership.reaction === active_reaction)
 	) {
 		e.state_unsafe_mutation();
 	}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -235,8 +235,12 @@ function schedule_possible_effect_self_invalidation(signal, effect, root = true)
 	for (var i = 0; i < reactions.length; i++) {
 		var reaction = reactions[i];
 
-		if (source_ownership?.sources.includes(signal) && source_ownership.reaction === active_reaction)
+		if (
+			source_ownership?.reaction === active_reaction &&
+			source_ownership.sources.includes(signal)
+		) {
 			continue;
+		}
 
 		if ((reaction.f & DERIVED) !== 0) {
 			schedule_possible_effect_self_invalidation(/** @type {Derived} */ (reaction), effect, false);
@@ -741,8 +745,8 @@ export function get(signal) {
 	// Register the dependency on the current reaction signal.
 	if (active_reaction !== null && !untracking) {
 		if (
-			!source_ownership?.sources.includes(signal) ||
-			source_ownership.reaction !== active_reaction
+			source_ownership?.reaction !== active_reaction ||
+			!source_ownership?.sources.includes(signal)
 		) {
 			var deps = active_reaction.deps;
 			if (signal.rv < read_version) {

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -86,17 +86,17 @@ export function set_active_effect(effect) {
 /**
  * When sources are created within a reaction, reading and writing
  * them within that reaction should not cause a re-run
- * @type {null | [active_reaction: Reaction, sources: Source[]]}
+ * @type {null | { reaction: Reaction, sources: Source[] }}
  */
-export let reaction_sources = null;
+export let source_ownership = null;
 
 /** @param {Value} value */
 export function push_reaction_value(value) {
 	if (active_reaction !== null && active_reaction.f & EFFECT_IS_UPDATING) {
-		if (reaction_sources === null) {
-			reaction_sources = [active_reaction, [value]];
+		if (source_ownership === null) {
+			source_ownership = { reaction: active_reaction, sources: [value] };
 		} else {
-			reaction_sources[1].push(value);
+			source_ownership.sources.push(value);
 		}
 	}
 }
@@ -235,7 +235,8 @@ function schedule_possible_effect_self_invalidation(signal, effect, root = true)
 	for (var i = 0; i < reactions.length; i++) {
 		var reaction = reactions[i];
 
-		if (reaction_sources?.[1].includes(signal) && reaction_sources[0] === active_reaction) continue;
+		if (source_ownership?.sources.includes(signal) && source_ownership.reaction === active_reaction)
+			continue;
 
 		if ((reaction.f & DERIVED) !== 0) {
 			schedule_possible_effect_self_invalidation(/** @type {Derived} */ (reaction), effect, false);
@@ -257,7 +258,7 @@ export function update_reaction(reaction) {
 	var previous_untracked_writes = untracked_writes;
 	var previous_reaction = active_reaction;
 	var previous_skip_reaction = skip_reaction;
-	var previous_reaction_sources = reaction_sources;
+	var previous_reaction_sources = source_ownership;
 	var previous_component_context = component_context;
 	var previous_untracking = untracking;
 
@@ -270,7 +271,7 @@ export function update_reaction(reaction) {
 		(flags & UNOWNED) !== 0 && (untracking || !is_updating_effect || active_reaction === null);
 	active_reaction = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? reaction : null;
 
-	reaction_sources = null;
+	source_ownership = null;
 	set_component_context(reaction.ctx);
 	untracking = false;
 	read_version++;
@@ -358,7 +359,7 @@ export function update_reaction(reaction) {
 		untracked_writes = previous_untracked_writes;
 		active_reaction = previous_reaction;
 		skip_reaction = previous_skip_reaction;
-		reaction_sources = previous_reaction_sources;
+		source_ownership = previous_reaction_sources;
 		set_component_context(previous_component_context);
 		untracking = previous_untracking;
 
@@ -739,7 +740,10 @@ export function get(signal) {
 
 	// Register the dependency on the current reaction signal.
 	if (active_reaction !== null && !untracking) {
-		if (!reaction_sources?.[1].includes(signal) || reaction_sources[0] !== active_reaction) {
+		if (
+			!source_ownership?.sources.includes(signal) ||
+			source_ownership.reaction !== active_reaction
+		) {
 			var deps = active_reaction.deps;
 			if (signal.rv < read_version) {
 				signal.rv = read_version;


### PR DESCRIPTION
Prompted by https://github.com/sveltejs/svelte/pull/15844/files#r2178611259 — the `reaction_sources` stuff is pretty inscrutable. Changing it to an object with named properties helps a bit, I think, (and I'd expect named properties to be microscopically faster to read than numbered ones) and doing the equality check before the `.includes` check is low-hanging fruit