### PR TITLE
docs: add $state destructure example using $derived

### DIFF
--- a/documentation/docs/02-runes/02-$state.md
+++ b/documentation/docs/02-runes/02-$state.md
@@ -63,6 +63,17 @@ let { done, text } = todos[0];
 todos[0].done = !todos[0].done;
 ```
 
+However, if you destructure a reactive value with `$derived`, the references will now be reactive:
+
+```js
+let todos = [{ done: false, text: 'add more todos' }];
+// ---cut---
+let { done, text } = $derived(todos[0]);
+
+// this will now affect the value of `done`
+todos[0].done = !todos[0].done;
+```
+
 ### Classes
 
 Class instances are not proxied. Instead, you can use `$state` in class fields (whether public or private), or as the first assignment to a property immediately inside the `constructor`:


### PR DESCRIPTION
This provides a missing example for destructuring reactive $state objects with $derived. I was unaware this was possible until seeing a related StackOverflow answer. I believe other users will benefit from learning this too.

Test: https://svelte.dev/playground/9f2c5885ac2d4e39a40e69983f7ce8b4?version=5.35.2