### PR TITLE
chore: simplify/optimize source_ownership occurrence

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -236,15 +236,12 @@ function schedule_possible_effect_self_invalidation(signal, effect, root = true)
 	var reactions = signal.reactions;
 	if (reactions === null) return;
 
+	if (source_ownership?.reaction === active_reaction && source_ownership.sources.includes(signal)) {
+		return;
+	}
+
 	for (var i = 0; i < reactions.length; i++) {
 		var reaction = reactions[i];
-
-		if (
-			source_ownership?.reaction === active_reaction &&
-			source_ownership.sources.includes(signal)
-		) {
-			continue;
-		}
 
 		if ((reaction.f & DERIVED) !== 0) {
 			schedule_possible_effect_self_invalidation(/** @type {Derived} */ (reaction), effect, false);


### PR DESCRIPTION
was looking into whether we could use the new `update_version` mechanism to make it cheaper to answer 'was this source created inside the current reaction?', and noticed that we're currently doing a check inside a loop that should be outside, since the answer is always the same