### PR TITLE
chore: remove component_context.d

### DIFF
--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -139,16 +139,15 @@ export function getAllContexts() {
  * @returns {void}
  */
 export function push(props, runes = false, fn) {
-	var ctx = (component_context = {
+	component_context = {
 		p: component_context,
 		c: null,
-		d: false,
 		e: null,
 		m: false,
 		s: props,
 		x: null,
 		l: null
-	});
+	};
 
 	if (legacy_mode_flag && !runes) {
 		component_context.l = {
@@ -158,10 +157,6 @@ export function push(props, runes = false, fn) {
 			r2: source(false)
 		};
 	}
-
-	teardown(() => {
-		/** @type {ComponentContext} */ (ctx).d = true;
-	});
 
 	if (DEV) {
 		// component function

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -269,14 +269,6 @@ export function spread_props(...props) {
 }
 
 /**
- * @param {Derived} current_value
- * @returns {boolean}
- */
-function has_destroyed_component_ctx(current_value) {
-	return current_value.ctx?.d ?? false;
-}
-
-/**
  * This function is responsible for synchronizing a possibly bound prop with the inner component state.
  * It is used whenever the compiler sees that the component writes to the prop, or when it has a default prop_value.
  * @template V

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -14,8 +14,6 @@ export type ComponentContext = {
 	p: null | ComponentContext;
 	/** context */
 	c: null | Map<unknown, unknown>;
-	/** destroyed */
-	d: boolean;
 	/** deferred effects */
 	e: null | Array<{
 		fn: () => void | (() => void);


### PR DESCRIPTION
since #16270, `has_destroyed_component_ctx` is unused. It was the only thing that needed `component_context.d`, so we can now get rid of that, and along with it the `teardown` function responsible for setting it — smaller component context objects, smaller effect graphs