### PR TITLE
chore: simplify component pop

### DIFF
--- a/.changeset/new-candles-marry.md
+++ b/.changeset/new-candles-marry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: simplify internal component `pop()`

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -177,16 +177,18 @@ export function push(props, runes = false, fn) {
  */
 export function pop(component) {
 	if (component_context !== null) {
-		if (component !== undefined) {
-			component_context.x = component;
-		}
+		var effects = component_context.e;
 
-		const effects = component_context.e;
 		if (effects !== null) {
 			component_context.e = null;
+
 			for (var fn of effects) {
 				create_user_effect(fn);
 			}
+		}
+
+		if (component !== undefined) {
+			component_context.x = component;
 		}
 
 		component_context.m = true;

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -175,29 +175,28 @@ export function push(props, runes = false, fn) {
  * @returns {T}
  */
 export function pop(component) {
-	if (component_context !== null) {
-		var effects = component_context.e;
+	var context = /** @type {ComponentContext} */ (component_context);
+	var effects = context.e;
 
-		if (effects !== null) {
-			component_context.e = null;
+	if (effects !== null) {
+		context.e = null;
 
-			for (var fn of effects) {
-				create_user_effect(fn);
-			}
-		}
-
-		if (component !== undefined) {
-			component_context.x = component;
-		}
-
-		component_context = component_context.p;
-
-		if (DEV) {
-			dev_current_component_function = component_context?.function ?? null;
+		for (var fn of effects) {
+			create_user_effect(fn);
 		}
 	}
 
-	return component || /** @type {T} */ ({});
+	if (component !== undefined) {
+		context.x = component;
+	}
+
+	component_context = context.p;
+
+	if (DEV) {
+		dev_current_component_function = component_context?.function ?? null;
+	}
+
+	return component ?? /** @type {T} */ ({});
 }
 
 /** @returns {boolean} */

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -144,7 +144,6 @@ export function push(props, runes = false, fn) {
 		c: null,
 		d: false,
 		e: null,
-		m: false,
 		s: props,
 		x: null,
 		l: null

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -190,8 +190,6 @@ export function pop(component) {
 			component_context.x = component;
 		}
 
-		component_context.m = true;
-
 		component_context = component_context.p;
 
 		if (DEV) {

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -176,36 +176,28 @@ export function push(props, runes = false, fn) {
  * @returns {T}
  */
 export function pop(component) {
-	const context_stack_item = component_context;
-	if (context_stack_item !== null) {
+	if (component_context !== null) {
 		if (component !== undefined) {
-			context_stack_item.x = component;
+			component_context.x = component;
 		}
-		const component_effects = context_stack_item.e;
-		if (component_effects !== null) {
-			var previous_effect = active_effect;
-			var previous_reaction = active_reaction;
-			context_stack_item.e = null;
-			try {
-				for (var i = 0; i < component_effects.length; i++) {
-					var component_effect = component_effects[i];
-					set_active_effect(component_effect.effect);
-					set_active_reaction(component_effect.reaction);
-					create_user_effect(component_effect.fn);
-				}
-			} finally {
-				set_active_effect(previous_effect);
-				set_active_reaction(previous_reaction);
+
+		const effects = component_context.e;
+		if (effects !== null) {
+			component_context.e = null;
+			for (var fn of effects) {
+				create_user_effect(fn);
 			}
 		}
-		component_context = context_stack_item.p;
+
+		component_context.m = true;
+
+		component_context = component_context.p;
+
 		if (DEV) {
-			dev_current_component_function = context_stack_item.p?.function ?? null;
+			dev_current_component_function = component_context?.function ?? null;
 		}
-		context_stack_item.m = true;
 	}
-	// Micro-optimization: Don't set .a above to the empty object
-	// so it can be garbage-collected when the return here is unused
+
 	return component || /** @type {T} */ ({});
 }
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -179,16 +179,16 @@ export function teardown(fn) {
 export function user_effect(fn) {
 	validate_effect('$effect');
 
-	// Non-nested `$effect(...)` in a component should be deferred
-	// until the component is mounted
-	var defer =
-		active_effect !== null && (active_effect.f & BRANCH_EFFECT) !== 0 && active_reaction === null;
-
 	if (DEV) {
 		define_property(fn, 'name', {
 			value: '$effect'
 		});
 	}
+
+	// Non-nested `$effect(...)` in a component should be deferred
+	// until the component is mounted
+	var defer =
+		active_effect !== null && (active_effect.f & BRANCH_EFFECT) !== 0 && active_reaction === null;
 
 	if (defer) {
 		var context = /** @type {ComponentContext} */ (component_context);

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -182,10 +182,7 @@ export function user_effect(fn) {
 	// Non-nested `$effect(...)` in a component should be deferred
 	// until the component is mounted
 	var defer =
-		active_effect !== null &&
-		(active_effect.f & BRANCH_EFFECT) !== 0 &&
-		component_context !== null &&
-		!component_context.m;
+		active_effect !== null && (active_effect.f & BRANCH_EFFECT) !== 0 && active_reaction === null;
 
 	if (DEV) {
 		define_property(fn, 'name', {

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -185,15 +185,12 @@ export function user_effect(fn) {
 		});
 	}
 
-	// Non-nested `$effect(...)` in a component should be deferred
-	// until the component is mounted
-	var defer =
-		active_effect !== null && (active_effect.f & BRANCH_EFFECT) !== 0 && active_reaction === null;
-
-	if (defer) {
+	if (!active_reaction && active_effect && (active_effect.f & BRANCH_EFFECT) !== 0) {
+		// Top-level `$effect(...)` in a component — defer until mount
 		var context = /** @type {ComponentContext} */ (component_context);
 		(context.e ??= []).push(fn);
 	} else {
+		// Everything else — create immediately
 		return create_user_effect(fn);
 	}
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -195,11 +195,7 @@ export function user_effect(fn) {
 
 	if (defer) {
 		var context = /** @type {ComponentContext} */ (component_context);
-		(context.e ??= []).push({
-			fn,
-			effect: active_effect,
-			reaction: active_reaction
-		});
+		(context.e ??= []).push(fn);
 	} else {
 		return create_user_effect(fn);
 	}

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -18,8 +18,6 @@ export type ComponentContext = {
 	d: boolean;
 	/** deferred effects */
 	e: null | Array<() => void | (() => void)>;
-	/** mounted */
-	m: boolean;
 	/**
 	 * props — needed for legacy mode lifecycle functions, and for `createEventDispatcher`
 	 * @deprecated remove in 6.0

--- a/packages/svelte/src/internal/client/types.d.ts
+++ b/packages/svelte/src/internal/client/types.d.ts
@@ -17,11 +17,7 @@ export type ComponentContext = {
 	/** destroyed */
 	d: boolean;
 	/** deferred effects */
-	e: null | Array<{
-		fn: () => void | (() => void);
-		effect: null | Effect;
-		reaction: null | Reaction;
-	}>;
+	e: null | Array<() => void | (() => void)>;
 	/** mounted */
 	m: boolean;
 	/**


### PR DESCRIPTION
couple of changes here:

- the only time an effect gets deferred is if it's a top-level `$effect`. when `pop` runs, the current active effect/reaction are the same as they were when the effect was declared, so the `set_active_effect` and `set_active_reaction` calls are no-ops. By extension, we don't need to stash the current active effect/reaction, and we don't need to wrap the effect creation in a try-catch
- since we don't need to stash the effect/reaction, `component_context.e` can just be an array of functions rather than an array of objects — less memory usage for components with effects
- we can identify a top-level `$effect` because the current `active_effect` is a `BRANCH_EFFECT`, and the current `active_reaction` is `null`. These conditions do not obtain in any other circumstances. Consequently, we can remove the `m` flag — it's unnecessary. This saves more memory