### PR TITLE
chore: DRY out increment logic

### DIFF
--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -8,7 +8,7 @@ import {
 	is_array,
 	object_prototype
 } from '../shared/utils.js';
-import { state as source, set } from './reactivity/sources.js';
+import { state as source, set, increment } from './reactivity/sources.js';
 import { PROXY_PATH_SYMBOL, STATE_SYMBOL } from '#client/constants';
 import { UNINITIALIZED } from '../../constants.js';
 import * as e from './errors.js';
@@ -118,7 +118,7 @@ export function proxy(value) {
 				if (prop in target) {
 					const s = with_parent(() => source(UNINITIALIZED, stack));
 					sources.set(prop, s);
-					update_version(version);
+					increment(version);
 
 					if (DEV) {
 						tag(s, get_label(path, prop));
@@ -136,7 +136,7 @@ export function proxy(value) {
 					}
 				}
 				set(s, UNINITIALIZED);
-				update_version(version);
+				increment(version);
 			}
 
 			return true;
@@ -304,7 +304,7 @@ export function proxy(value) {
 					}
 				}
 
-				update_version(version);
+				increment(version);
 			}
 
 			return true;
@@ -341,14 +341,6 @@ function get_label(path, prop) {
 	if (typeof prop === 'symbol') return `${path}[Symbol(${prop.description ?? ''})]`;
 	if (regex_is_valid_identifier.test(prop)) return `${path}.${prop}`;
 	return /^\d+$/.test(prop) ? `${path}[${prop}]` : `${path}['${prop}']`;
-}
-
-/**
- * @param {Source<number>} signal
- * @param {1 | -1} [d]
- */
-function update_version(signal, d = 1) {
-	set(signal, signal.v + d);
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -260,6 +260,14 @@ export function update_pre(source, d = 1) {
 }
 
 /**
+ * Silently (without using `get`) increment a source
+ * @param {Source<number>} source
+ */
+export function increment(source) {
+	set(source, source.v + 1);
+}
+
+/**
  * @param {Value} signal
  * @param {number} status should be DIRTY or MAYBE_DIRTY
  * @returns {void}

--- a/packages/svelte/src/reactivity/create-subscriber.js
+++ b/packages/svelte/src/reactivity/create-subscriber.js
@@ -1,8 +1,7 @@
 import { get, tick, untrack } from '../internal/client/runtime.js';
 import { effect_tracking, render_effect } from '../internal/client/reactivity/effects.js';
-import { source } from '../internal/client/reactivity/sources.js';
+import { source, increment } from '../internal/client/reactivity/sources.js';
 import { tag } from '../internal/client/dev/tracing.js';
-import { increment } from './utils.js';
 import { DEV } from 'esm-env';
 
 /**

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -1,9 +1,8 @@
 /** @import { Source } from '#client' */
 import { DEV } from 'esm-env';
-import { set, source, state } from '../internal/client/reactivity/sources.js';
+import { set, source, state, increment } from '../internal/client/reactivity/sources.js';
 import { label, tag } from '../internal/client/dev/tracing.js';
 import { get, update_version } from '../internal/client/runtime.js';
-import { increment } from './utils.js';
 
 /**
  * A reactive version of the built-in [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object.

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -1,9 +1,8 @@
 /** @import { Source } from '#client' */
 import { DEV } from 'esm-env';
-import { source, set, state } from '../internal/client/reactivity/sources.js';
+import { source, set, state, increment } from '../internal/client/reactivity/sources.js';
 import { label, tag } from '../internal/client/dev/tracing.js';
 import { get, update_version } from '../internal/client/runtime.js';
-import { increment } from './utils.js';
 
 var read_methods = ['forEach', 'isDisjointFrom', 'isSubsetOf', 'isSupersetOf'];
 var set_like_methods = ['difference', 'intersection', 'symmetricDifference', 'union'];

--- a/packages/svelte/src/reactivity/url-search-params.js
+++ b/packages/svelte/src/reactivity/url-search-params.js
@@ -1,9 +1,8 @@
 import { DEV } from 'esm-env';
-import { state } from '../internal/client/reactivity/sources.js';
+import { state, increment } from '../internal/client/reactivity/sources.js';
 import { tag } from '../internal/client/dev/tracing.js';
 import { get } from '../internal/client/runtime.js';
 import { get_current_url } from './url.js';
-import { increment } from './utils.js';
 
 export const REPLACE = Symbol();
 

--- a/packages/svelte/src/reactivity/utils.js
+++ b/packages/svelte/src/reactivity/utils.js
@@ -1,7 +1,0 @@
-/** @import { Source } from '#client' */
-import { set } from '../internal/client/reactivity/sources.js';
-
-/** @param {Source<number>} source */
-export function increment(source) {
-	set(source, source.v + 1);
-}


### PR DESCRIPTION
we have two functions for silently incrementing sources (one in `proxy.js`, one in `reactivity/utils.js`). we only need one