### PR TITLE
fix: silence a11y warning for inert elements

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y.js
@@ -999,7 +999,9 @@ export function check_element(node, context) {
 	const is_labelled = attribute_map.has('aria-label') || attribute_map.has('aria-labelledby');
 
 	if (node.name === 'a' || node.name === 'button') {
-		const is_hidden = get_static_value(attribute_map.get('aria-hidden')) === 'true';
+		const is_hidden =
+			get_static_value(attribute_map.get('aria-hidden')) === 'true' ||
+			get_static_value(attribute_map.get('inert'));
 
 		if (!has_spread && !is_hidden && !is_labelled && !has_content(node)) {
 			w.a11y_consider_explicit_label(node);

--- a/packages/svelte/tests/validator/samples/a11y-consider-explicit-label/input.svelte
+++ b/packages/svelte/tests/validator/samples/a11y-consider-explicit-label/input.svelte
@@ -5,6 +5,7 @@
 <a href="/#" aria-label="Valid empty link"></a>
 
 <button aria-hidden='true'></button>
+<button inert></button>
 <a href="/#" aria-hidden='true'><b></b></a>
 
 <button>Click me</button>


### PR DESCRIPTION
closes #15814 

I thought about a case where the children are inside an inert parent, perhaps in this case we should skip a11y validation altogether for all the children?

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
