### PR TITLE
fix: silence autofocus a11y warning inside `<dialog>`

### DIFF
--- a/.changeset/cuddly-humans-end.md
+++ b/.changeset/cuddly-humans-end.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: silence autofocus a11y warning inside `<dialog>`

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y.js
@@ -875,7 +875,7 @@ export function check_element(node, context) {
 		}
 
 		// no-autofocus
-		if (name === 'autofocus') {
+		if (name === 'autofocus' && node.name !== 'dialog' && !is_parent(context.path, ['dialog'])) {
 			w.a11y_autofocus(attribute);
 		}
 

--- a/packages/svelte/tests/validator/samples/a11y-no-autofocus/input.svelte
+++ b/packages/svelte/tests/validator/samples/a11y-no-autofocus/input.svelte
@@ -1,1 +1,6 @@
 <div autofocus></div>
+<dialog autofocus>
+</dialog>
+<dialog>
+	<input autofocus>
+</dialog>


### PR DESCRIPTION
closes #9225

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
