### PR TITLE
fix: don't show adjusted error messages in boundaries

### DIFF
--- a/.changeset/large-balloons-agree.md
+++ b/.changeset/large-balloons-agree.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't show adjusted error messages in boundaries

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-3/_config.js
@@ -9,6 +9,6 @@ export default test({
 		flushSync();
 
 		assert.deepEqual(logs, ['error caught']);
-		assert.htmlEqual(target.innerHTML, `<div>Fallback!</div><button>+</button>`);
+		assert.htmlEqual(target.innerHTML, `<div>oh no!</div><button>+</button>`);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-3/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-3/main.svelte
@@ -1,6 +1,6 @@
 <script>
 	function throw_error() {
-		throw new Error('test')
+		throw new Error('oh no!')
 	}
 
 	let count = $state(0);
@@ -9,8 +9,8 @@
 <svelte:boundary onerror={(e) => console.log('error caught')}>
 	{count > 0 ? throw_error() : null}
 
-	{#snippet failed()}
-		<div>Fallback!</div>
+	{#snippet failed(e)}
+		<div>{e.message}</div>
 	{/snippet}
 </svelte:boundary>
 


### PR DESCRIPTION
Extracted from #15844:

When an error occurs in dev, we augment the message with information about where it happened when it gets printed to the console. At present, we _also_ show the augmented error message inside a boundary's `failed` snippet, which isn't intentional. Incredibly, this wasn't captured in the tests

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
