### PR TITLE
feat: ignore component options in `compileModule`

### DIFF
--- a/.changeset/violet-ways-sleep.md
+++ b/.changeset/violet-ways-sleep.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: ignore component options in `compileModule`

--- a/packages/svelte/src/compiler/validate-options.js
+++ b/packages/svelte/src/compiler/validate-options.js
@@ -8,7 +8,7 @@ import * as w from './warnings.js';
  * @typedef {(input: Input, keypath: string) => Required<Output>} Validator
  */
 
-const common = {
+const common_options = {
 	filename: string('(unknown)'),
 
 	// default to process.cwd() where it exists to replicate svelte4 behavior (and make Deno work with this as well)
@@ -44,110 +44,120 @@ const common = {
 	warningFilter: fun(() => true)
 };
 
+const component_options = {
+	accessors: deprecate(w.options_deprecated_accessors, boolean(false)),
+
+	css: validator('external', (input) => {
+		if (input === true || input === false) {
+			throw_error(
+				'The boolean options have been removed from the css option. Use "external" instead of false and "injected" instead of true'
+			);
+		}
+		if (input === 'none') {
+			throw_error(
+				'css: "none" is no longer a valid option. If this was crucial for you, please open an issue on GitHub with your use case.'
+			);
+		}
+
+		if (input !== 'external' && input !== 'injected') {
+			throw_error(`css should be either "external" (default, recommended) or "injected"`);
+		}
+
+		return input;
+	}),
+
+	cssHash: fun(({ css, hash }) => {
+		return `svelte-${hash(css)}`;
+	}),
+
+	// TODO this is a sourcemap option, would be good to put under a sourcemap namespace
+	cssOutputFilename: string(undefined),
+
+	customElement: boolean(false),
+
+	discloseVersion: boolean(true),
+
+	immutable: deprecate(w.options_deprecated_immutable, boolean(false)),
+
+	legacy: removed(
+		'The legacy option has been removed. If you are using this because of legacy.componentApi, use compatibility.componentApi instead'
+	),
+
+	compatibility: object({
+		componentApi: list([4, 5], 5)
+	}),
+
+	loopGuardTimeout: warn_removed(w.options_removed_loop_guard_timeout),
+
+	name: string(undefined),
+
+	namespace: list(['html', 'mathml', 'svg']),
+
+	modernAst: boolean(false),
+
+	outputFilename: string(undefined),
+
+	preserveComments: boolean(false),
+
+	fragments: list(['html', 'tree']),
+
+	preserveWhitespace: boolean(false),
+
+	runes: boolean(undefined),
+
+	hmr: boolean(false),
+
+	sourcemap: validator(undefined, (input) => {
+		// Source maps can take on a variety of values, including string, JSON, map objects from magic-string and source-map,
+		// so there's no good way to check type validity here
+		return input;
+	}),
+
+	enableSourcemap: warn_removed(w.options_removed_enable_sourcemap),
+
+	hydratable: warn_removed(w.options_removed_hydratable),
+
+	format: removed(
+		'The format option has been removed in Svelte 4, the compiler only outputs ESM now. Remove "format" from your compiler options. ' +
+			'If you did not set this yourself, bump the version of your bundler plugin (vite-plugin-svelte/rollup-plugin-svelte/svelte-loader)'
+	),
+
+	tag: removed(
+		'The tag option has been removed in Svelte 5. Use `<svelte:options customElement="tag-name" />` inside the component instead. ' +
+			'If that does not solve your use case, please open an issue on GitHub with details.'
+	),
+
+	sveltePath: removed(
+		'The sveltePath option has been removed in Svelte 5. ' +
+			'If this option was crucial for you, please open an issue on GitHub with your use case.'
+	),
+
+	// These two were primarily created for svelte-preprocess (https://github.com/sveltejs/svelte/pull/6194),
+	// but with new TypeScript compilation modes strictly separating types it's not necessary anymore
+	errorMode: removed(
+		'The errorMode option has been removed. If you are using this through svelte-preprocess with TypeScript, ' +
+			'use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead'
+	),
+
+	varsReport: removed(
+		'The vars option has been removed. If you are using this through svelte-preprocess with TypeScript, ' +
+			'use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead'
+	)
+};
+
 export const validate_module_options =
 	/** @type {Validator<ModuleCompileOptions, ValidatedModuleCompileOptions>} */ (
 		object({
-			...common
+			...common_options,
+			...Object.fromEntries(Object.keys(component_options).map((key) => [key, () => {}]))
 		})
 	);
 
 export const validate_component_options =
 	/** @type {Validator<CompileOptions, ValidatedCompileOptions>} */ (
 		object({
-			...common,
-
-			accessors: deprecate(w.options_deprecated_accessors, boolean(false)),
-
-			css: validator('external', (input) => {
-				if (input === true || input === false) {
-					throw_error(
-						'The boolean options have been removed from the css option. Use "external" instead of false and "injected" instead of true'
-					);
-				}
-				if (input === 'none') {
-					throw_error(
-						'css: "none" is no longer a valid option. If this was crucial for you, please open an issue on GitHub with your use case.'
-					);
-				}
-
-				if (input !== 'external' && input !== 'injected') {
-					throw_error(`css should be either "external" (default, recommended) or "injected"`);
-				}
-
-				return input;
-			}),
-
-			cssHash: fun(({ css, hash }) => {
-				return `svelte-${hash(css)}`;
-			}),
-
-			// TODO this is a sourcemap option, would be good to put under a sourcemap namespace
-			cssOutputFilename: string(undefined),
-
-			customElement: boolean(false),
-
-			discloseVersion: boolean(true),
-
-			immutable: deprecate(w.options_deprecated_immutable, boolean(false)),
-
-			legacy: removed(
-				'The legacy option has been removed. If you are using this because of legacy.componentApi, use compatibility.componentApi instead'
-			),
-
-			compatibility: object({
-				componentApi: list([4, 5], 5)
-			}),
-
-			loopGuardTimeout: warn_removed(w.options_removed_loop_guard_timeout),
-
-			name: string(undefined),
-
-			namespace: list(['html', 'mathml', 'svg']),
-
-			modernAst: boolean(false),
-
-			outputFilename: string(undefined),
-
-			preserveComments: boolean(false),
-
-			fragments: list(['html', 'tree']),
-
-			preserveWhitespace: boolean(false),
-
-			runes: boolean(undefined),
-
-			hmr: boolean(false),
-
-			sourcemap: validator(undefined, (input) => {
-				// Source maps can take on a variety of values, including string, JSON, map objects from magic-string and source-map,
-				// so there's no good way to check type validity here
-				return input;
-			}),
-
-			enableSourcemap: warn_removed(w.options_removed_enable_sourcemap),
-			hydratable: warn_removed(w.options_removed_hydratable),
-			format: removed(
-				'The format option has been removed in Svelte 4, the compiler only outputs ESM now. Remove "format" from your compiler options. ' +
-					'If you did not set this yourself, bump the version of your bundler plugin (vite-plugin-svelte/rollup-plugin-svelte/svelte-loader)'
-			),
-			tag: removed(
-				'The tag option has been removed in Svelte 5. Use `<svelte:options customElement="tag-name" />` inside the component instead. ' +
-					'If that does not solve your use case, please open an issue on GitHub with details.'
-			),
-			sveltePath: removed(
-				'The sveltePath option has been removed in Svelte 5. ' +
-					'If this option was crucial for you, please open an issue on GitHub with your use case.'
-			),
-			// These two were primarily created for svelte-preprocess (https://github.com/sveltejs/svelte/pull/6194),
-			// but with new TypeScript compilation modes strictly separating types it's not necessary anymore
-			errorMode: removed(
-				'The errorMode option has been removed. If you are using this through svelte-preprocess with TypeScript, ' +
-					'use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead'
-			),
-			varsReport: removed(
-				'The vars option has been removed. If you are using this through svelte-preprocess with TypeScript, ' +
-					'use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead'
-			)
+			...common_options,
+			...component_options
 		})
 	);
 


### PR DESCRIPTION
This causes `compileModule` to ignore component options, while still erroring on unknown options, which is useful for things like vite-plugin-svelte which don't know _which_ options should be ignored in the module case

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
