### PR TITLE
fix: update `$effect.pending()` immediately after a batch is removed

### DIFF
--- a/.changeset/popular-tips-lie.md
+++ b/.changeset/popular-tips-lie.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: update `$effect.pending()` immediately after a batch is removed

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -26,7 +26,6 @@ import { Batch, effect_pending_updates } from '../../reactivity/batch.js';
 import { internal_set, source } from '../../reactivity/sources.js';
 import { tag } from '../../dev/tracing.js';
 import { createSubscriber } from '../../../../reactivity/create-subscriber.js';
-import { raf } from '../../timing.js';
 
 /**
  * @typedef {{

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -22,10 +22,11 @@ import { get_next_sibling } from '../operations.js';
 import { queue_micro_task } from '../task.js';
 import * as e from '../../errors.js';
 import { DEV } from 'esm-env';
-import { Batch } from '../../reactivity/batch.js';
+import { Batch, effect_pending_updates } from '../../reactivity/batch.js';
 import { internal_set, source } from '../../reactivity/sources.js';
 import { tag } from '../../dev/tracing.js';
 import { createSubscriber } from '../../../../reactivity/create-subscriber.js';
+import { raf } from '../../timing.js';
 
 /**
  * @typedef {{
@@ -91,6 +92,12 @@ export class Boundary {
 	 * @type {Source<number> | null}
 	 */
 	#effect_pending = null;
+
+	#effect_pending_update = () => {
+		if (this.#effect_pending) {
+			internal_set(this.#effect_pending, this.#pending_count);
+		}
+	};
 
 	#effect_pending_subscriber = createSubscriber(() => {
 		this.#effect_pending = source(this.#pending_count);
@@ -238,11 +245,7 @@ export class Boundary {
 			this.parent.#update_pending_count(d);
 		}
 
-		queueMicrotask(() => {
-			if (this.#effect_pending) {
-				internal_set(this.#effect_pending, this.#pending_count);
-			}
-		});
+		effect_pending_updates.add(this.#effect_pending_update);
 	}
 
 	get_effect_pending() {

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -299,6 +299,8 @@ export class Batch {
 
 	deactivate() {
 		current_batch = null;
+
+		flush_pending_update();
 	}
 
 	neuter() {
@@ -322,13 +324,7 @@ export class Batch {
 			batches.delete(this);
 		}
 
-		current_batch = null;
-
-		for (const update of effect_pending_updates) {
-			effect_pending_updates.delete(update);
-			update();
-			break;
-		}
+		this.deactivate();
 	}
 
 	flush_effects() {
@@ -426,6 +422,18 @@ export class Batch {
 		}
 
 		return current_batch;
+	}
+}
+
+function flush_pending_update() {
+	for (const update of effect_pending_updates) {
+		effect_pending_updates.delete(update);
+		update();
+
+		if (current_batch !== null) {
+			// only do one at a time
+			break;
+		}
 	}
 }
 

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -49,6 +49,9 @@ export let batch_deriveds = null;
 /** @type {Effect[]} Stack of effects, dev only */
 export let dev_effect_stack = [];
 
+/** @type {Set<() => void>} */
+export let effect_pending_updates = new Set();
+
 /** @type {Effect[]} */
 let queued_root_effects = [];
 
@@ -320,6 +323,12 @@ export class Batch {
 		}
 
 		current_batch = null;
+
+		for (const update of effect_pending_updates) {
+			effect_pending_updates.delete(update);
+			update();
+			break;
+		}
 	}
 
 	flush_effects() {

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -300,7 +300,15 @@ export class Batch {
 	deactivate() {
 		current_batch = null;
 
-		flush_pending_update();
+		for (const update of effect_pending_updates) {
+			effect_pending_updates.delete(update);
+			update();
+
+			if (current_batch !== null) {
+				// only do one at a time
+				break;
+			}
+		}
 	}
 
 	neuter() {
@@ -424,18 +432,6 @@ export class Batch {
 		}
 
 		return current_batch;
-	}
-}
-
-function flush_pending_update() {
-	for (const update of effect_pending_updates) {
-		effect_pending_updates.delete(update);
-		update();
-
-		if (current_batch !== null) {
-			// only do one at a time
-			break;
-		}
 	}
 }
 

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -394,6 +394,8 @@ export class Batch {
 			this.#effects = [];
 
 			this.flush();
+		} else {
+			this.deactivate();
 		}
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/async-effect-pending/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-effect-pending/_config.js
@@ -1,0 +1,81 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const [increment, shift] = target.querySelectorAll('button');
+
+		shift.click();
+		shift.click();
+		shift.click();
+
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<button>shift</button>
+				<p>0</p>
+				<p>0</p>
+				<p>0</p>
+				<p>pending: 0</p>
+			`
+		);
+
+		increment.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<button>shift</button>
+				<p>0</p>
+				<p>0</p>
+				<p>0</p>
+				<p>pending: 3</p>
+			`
+		);
+
+		shift.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<button>shift</button>
+				<p>0</p>
+				<p>0</p>
+				<p>0</p>
+				<p>pending: 2</p>
+			`
+		);
+
+		shift.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<button>shift</button>
+				<p>0</p>
+				<p>0</p>
+				<p>0</p>
+				<p>pending: 1</p>
+			`
+		);
+
+		shift.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<button>shift</button>
+				<p>1</p>
+				<p>1</p>
+				<p>1</p>
+				<p>pending: 0</p>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-effect-pending/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-effect-pending/main.svelte
@@ -1,0 +1,32 @@
+<script>
+	let value = $state(0);
+	let deferreds = [];
+
+	function push(value) {
+		const deferred = Promise.withResolvers();
+		deferreds.push({ value, deferred });
+		return deferred.promise;
+	}
+
+	function shift() {
+		const d = deferreds.shift();
+		d?.deferred.resolve(d.value);
+	}
+</script>
+
+<button onclick={() => value++}>increment</button>
+<button onclick={() => shift()}>shift</button>
+
+<svelte:boundary>
+	<p>{await push(value)}</p>
+	<p>{await push(value)}</p>
+	<p>{await push(value)}</p>
+
+	<p>pending: {$effect.pending()}</p>
+
+	{#snippet pending()}
+		<p>loading...</p>
+	{/snippet}
+</svelte:boundary>
+
+


### PR DESCRIPTION
This makes `$effect.pending()` updates more predictable and reliable

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
