### PR TITLE
fix: don't log `await_reactivity_loss` warning when signal is read in `untrack`

### DIFF
--- a/.changeset/big-readers-lie.md
+++ b/.changeset/big-readers-lie.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't log `await_reactivity_loss` warning when signal is read in `untrack`

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -606,7 +606,7 @@ export function get(signal) {
 
 	if (DEV) {
 		if (current_async_effect) {
-			var tracking = (current_async_effect.f & REACTION_IS_UPDATING) !== 0;
+			var tracking = (current_async_effect.f & REACTION_IS_UPDATING) !== 0 && !untracking;
 			var was_read = current_async_effect.deps?.includes(signal);
 
 			if (!tracking && !was_read) {


### PR DESCRIPTION
Closes #16381

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
