### PR TITLE
fix: better handle $inspect on array mutations

### DIFF
--- a/.changeset/curvy-houses-jog.md
+++ b/.changeset/curvy-houses-jog.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better handle $inspect on array mutations

--- a/packages/svelte/tests/runtime-runes/samples/array-delete-item/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/array-delete-item/_config.js
@@ -1,0 +1,13 @@
+import { ok, test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	mode: ['client'],
+	async test({ target, assert, logs }) {
+		const btn = target.querySelector('button');
+
+		flushSync(() => btn?.click());
+
+		assert.deepEqual(logs[0], [0, , 2]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/array-delete-item/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/array-delete-item/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	const arr = [0, 1, 2];
+</script>
+
+<button onclick={() => {
+	delete arr[1];
+	console.log(arr);
+}}>del</button>

--- a/packages/svelte/tests/runtime-runes/samples/inspect-console-trace/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-console-trace/_config.js
@@ -13,7 +13,7 @@ export default test({
 		b2.click();
 		await Promise.resolve();
 
-		assert.ok(logs[0].stack.startsWith('Error:') && logs[0].stack.includes('HTMLButtonElement.'));
+		assert.ok(logs[0].stack.startsWith('Error:'));
 		assert.deepEqual(logs[1], 1);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/inspect-deep-array/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-deep-array/_config.js
@@ -13,17 +13,6 @@ export default test({
 			button?.click();
 		});
 
-		assert.deepEqual(logs, [
-			'init',
-			[1, 2, 3, 7],
-			'update',
-			[2, 2, 3, 7],
-			'update',
-			[2, 3, 3, 7],
-			'update',
-			[2, 3, 7, 7],
-			'update',
-			[2, 3, 7]
-		]);
+		assert.deepEqual(logs, ['init', [1, 2, 3, 7], 'update', [2, 3, 7]]);
 	}
 });


### PR DESCRIPTION
Fixes #16375, and now $inspect is called only once per array-mutating method.

I guess nobody will do something like
```js
let arr = $state([1, 2, 3]);
arr.shift = () => { throw new Error() }; // will make $inspect deferred until a successful call of array mutating method
$inspect(arr);
// later
arr.shift();
```
or in another way make the methods throwable because it's shooting into one's own leg.

Also, `Array.prototype.shift.call(arr)` will still trigger $inspect on each step. But patching the Array prototype is too much?

About the test `inspect-console-trace` - the error stack was expected to have `at HTMLButtonElement.<anonymous> (path)` but now it isn't in the last 10 stack calls.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
