### PR TITLE
fix: add pending snippet to <svelte:boundary> types

### DIFF
--- a/packages/svelte/svelte-html.d.ts
+++ b/packages/svelte/svelte-html.d.ts
@@ -37,8 +37,8 @@ declare global {
 		): Key extends keyof ElementTagNameMap
 			? ElementTagNameMap[Key]
 			: Key extends keyof SVGElementTagNameMap
-				? SVGElementTagNameMap[Key]
-				: any;
+			? SVGElementTagNameMap[Key]
+			: any;
 		function createElement<Elements extends IntrinsicElements, Key extends keyof Elements, T>(
 			// "undefined | null" because of <svelte:element>
 			element: Key | undefined | null,
@@ -47,14 +47,14 @@ declare global {
 		): Key extends keyof ElementTagNameMap
 			? ElementTagNameMap[Key]
 			: Key extends keyof SVGElementTagNameMap
-				? SVGElementTagNameMap[Key]
-				: any;
+			? SVGElementTagNameMap[Key]
+			: any;
 
 		// For backwards-compatibility and ease-of-use, in case someone enhanced the typings from import('svelte/elements').HTMLAttributes/SVGAttributes
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		interface HTMLAttributes<T extends EventTarget = any> {}
+		interface HTMLAttributes<T extends EventTarget = any> { }
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		interface SVGAttributes<T extends EventTarget = any> {}
+		interface SVGAttributes<T extends EventTarget = any> { }
 
 		/**
 		 * Avoid using this interface directly. Instead use the `SvelteHTMLElements` interface exported by `svelte/elements`
@@ -247,6 +247,7 @@ declare global {
 			'svelte:boundary': {
 				onerror?: (error: unknown, reset: () => void) => void;
 				failed?: import('svelte').Snippet<[error: unknown, reset: () => void]>;
+				pending?: import('svelte').Snippet;
 			};
 			// don't type svelte:options, it would override the types in svelte/elements and it isn't extendable anyway
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

#16379 doesn't work on the following example

```svelte
<script lang="ts">
    let name = $state("World");

    await new Promise((resolve) => setTimeout(resolve, 1000));
</script>

<svelte:boundary>
    {#snippet pending()}
        <p>Loading...</p>
    {/snippet}
    {#snippet failed(error)}
        <p>Error: {error}</p>
    {/snippet}
<h1>Welcome to SvelteKit</h1>
<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
<p>Hello {name}!</p>
<button onclick={() => name = "SvelteKit"}>Click me</button>
</svelte:boundary>
```

```console
Error: Object literal may only specify known properties, and 'pending' does not exist in type '{ onerror?: ((error: unknown, reset: () => void) => void) | undefined; failed?: Snippet<[error: unknown, reset: () => void]> | undefined; }'. (ts)
<svelte:boundary>
    {#snippet pending()}
        <p>Loading...</p>
```
