### PR TITLE
feat(runtime-browser): add support for <svelte:element this="contents">

### DIFF
--- a/.changeset/curvy-experts-join.md
+++ b/.changeset/curvy-experts-join.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+Add support for `<svelte:element this="contents">` to render children without wrapper element

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -96,7 +96,15 @@ export function element(node, get_tag, is_svg, render_fn, get_namespace, locatio
 			}
 		}
 
-		if (next_tag && next_tag !== current_tag) {
+		if (next_tag === 'contents') {
+			// Don't mount anything; just execute render_fn directly with anchor
+			effect = branch(() => {
+				if (render_fn) {
+					render_fn(anchor.parentNode, anchor);
+				}
+				/** @type {Effect} */ (active_effect).nodes_end = anchor;
+			});
+		} else if (next_tag && next_tag !== current_tag) {
 			effect = branch(() => {
 				element = hydrating
 					? /** @type {Element} */ (element)

--- a/packages/svelte/tests/runtime-browser/samples/svelte-element-contents/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/svelte-element-contents/_config.js
@@ -1,0 +1,12 @@
+import { test } from '../../assert';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, window }) {
+		await new Promise((r) => setTimeout(r, 1000));
+		assert.htmlEqual(
+			window.document.body.innerHTML,
+			`<main><strong>Hello</strong></main>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/svelte-element-contents/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/svelte-element-contents/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let tag = 'contents';
+</script>
+
+<svelte:element this={tag}>
+	<strong>Hello</strong>
+</svelte:element>


### PR DESCRIPTION
feat(runtime-browser): add support for <svelte:element this="contents"> to render children without wrapper

- Added handling in element block to treat "contents" as no-wrapper rendering
- Added runtime-browser test for this behavior

This enables `<svelte:element this="contents">` to render only its children without an extra wrapping element.  
This improves markup flexibility and reduces unnecessary DOM nodes in scenarios where a wrapper is not desired.

In issue #15666 discussion, it was suggested using a wrapper component like `MaybeTag` to achieve similar behavior.  
However, this solution eliminates the need for an additional wrapper component altogether by handling this directly in the compiler runtime.  
This simplifies usage and improves performance by avoiding extra components and markup.

This change provides a practical, built-in solution for the use case and aligns with idiomatic Svelte patterns.

### Before submitting the PR, please make sure you do the following

- [ ] Reference an existing issue or RFC if applicable (e.g., `Closes #15666`)
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`
- [ ] Clearly explain the problem this PR solves
- [ ] Include a test that fails without this PR but passes with it
- [ ] If you changed code in `packages/svelte/src`, add a changeset with `npx changeset`
- [ ] Run all tests with `pnpm test` and fix any failures
- [ ] Run lint with `pnpm lint` and fix any issues