### PR TITLE
fix: allow instrinsic `<svelte:...>` elements to inherit from `SvelteHTMLElements`

### DIFF
--- a/.changeset/funny-masks-build.md
+++ b/.changeset/funny-masks-build.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow instrinsic `<svelte:...>` elements to inherit from `SvelteHTMLElements`

--- a/packages/svelte/svelte-html.d.ts
+++ b/packages/svelte/svelte-html.d.ts
@@ -239,18 +239,6 @@ declare global {
 			use: HTMLProps<'use', SVGAttributes>;
 			view: HTMLProps<'view', SVGAttributes>;
 
-			// Svelte specific
-			'svelte:window': HTMLProps<'svelte:window', HTMLAttributes>;
-			'svelte:body': HTMLProps<'svelte:body', HTMLAttributes>;
-			'svelte:document': HTMLProps<'svelte:document', HTMLAttributes>;
-			'svelte:fragment': { slot?: string };
-			'svelte:head': { [name: string]: any };
-			'svelte:boundary': {
-				onerror?: (error: unknown, reset: () => void) => void;
-				failed?: import('svelte').Snippet<[error: unknown, reset: () => void]>;
-			};
-			// don't type svelte:options, it would override the types in svelte/elements and it isn't extendable anyway
-
 			[name: string]: { [name: string]: any };
 		}
 	}


### PR DESCRIPTION
supersedes #16390

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
