### PR TITLE
fix: don't reexecute derived with no dependencies on teardown

### DIFF
--- a/.changeset/clever-toys-decide.md
+++ b/.changeset/clever-toys-decide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't reexecute derived with no dependencies on teardown

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -653,8 +653,12 @@ export function get(signal) {
 
 			var value = derived.v;
 
-			// if the derived is dirty, or depends on the values that just changed, re-execute
-			if ((derived.f & CLEAN) !== 0 || depends_on_old_values(derived)) {
+			// if the derived is dirty and has reactions, or depends on the values that just changed, re-execute
+			// (a derived can be maybe_dirty due to the effect destroy removing its last reaction)
+			if (
+				((derived.f & CLEAN) === 0 && derived.reactions !== null) ||
+				depends_on_old_values(derived)
+			) {
 				value = execute_derived(derived);
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/props-derived-teardown/Teardown.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived-teardown/Teardown.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { onDestroy } from 'svelte'
+	
+	const { callback } = $props()
+	
+	onDestroy(() => {
+		callback()
+	})
+</script>
+
+<div>teardown</div>

--- a/packages/svelte/tests/runtime-runes/samples/props-derived-teardown/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived-teardown/_config.js
@@ -1,0 +1,30 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>click</button>
+				<div>teardown</div>
+				<div>1</div>
+				<div>2</div>
+				<div>3</div>
+			`
+		);
+		const [increment] = target.querySelectorAll('button');
+
+		increment.click();
+		flushSync();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>click</button>
+				<div>1</div>
+				<div>3</div>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/props-derived-teardown/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/props-derived-teardown/main.svelte
@@ -1,0 +1,25 @@
+<script>
+	import { SvelteSet } from 'svelte/reactivity'
+	import Teardown from './Teardown.svelte'
+
+	class Test {
+		originalIds = $state.raw([1, 2, 3])
+		ids = $derived(new SvelteSet(this.originalIds))
+	}
+
+	let show = $state(true)
+	const test = new Test()
+
+	function callback() {
+		test.ids.delete(2)
+	}
+</script>
+
+
+<button onclick={() => (show = !show)}>click</button>
+{#if show}
+	<Teardown {callback} />
+{/if}
+{#each test.ids as id}
+	<div>{id}</div>
+{/each}


### PR DESCRIPTION
The prior logic was wrong because it reexecuted when something was clean, but we want to when it's not. The remaining fix was to also check the reactions: A derived is set to `MAYBE_DIRTY` if it doesn't have any reactions anymore as a result of e.g. an effect that listened to it tearing down. We don't want to rerun in that case.

Fixes #16363

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
