### PR TITLE
fix: move store setup/cleanup outside of async component body

### DIFF
--- a/.changeset/new-fireants-bake.md
+++ b/.changeset/new-fireants-bake.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: move store setup/cleanup outside of async component body

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -209,7 +209,8 @@ export function client_component(analysis, options) {
 
 	/** @type {ESTree.Statement[]} */
 	const store_setup = [];
-
+	/** @type {ESTree.Statement} */
+	let store_init = b.empty;
 	/** @type {ESTree.VariableDeclaration[]} */
 	const legacy_reactive_declarations = [];
 
@@ -227,8 +228,9 @@ export function client_component(analysis, options) {
 		if (binding.kind === 'store_sub') {
 			if (store_setup.length === 0) {
 				needs_store_cleanup = true;
-				store_setup.push(
-					b.const(b.array_pattern([b.id('$$stores'), b.id('$$cleanup')]), b.call('$.setup_stores'))
+				store_init = b.const(
+					b.array_pattern([b.id('$$stores'), b.id('$$cleanup')]),
+					b.call('$.setup_stores')
 				);
 			}
 
@@ -379,9 +381,16 @@ export function client_component(analysis, options) {
 		analysis.slot_names.size > 0;
 
 	if (analysis.instance.has_await) {
+		const params = [b.id('$$anchor')];
+		if (should_inject_props) {
+			params.push(b.id('$$props'));
+		}
+		if (store_setup.length > 0) {
+			params.push(b.id('$$stores'));
+		}
 		const body = b.function_declaration(
 			b.id('$$body'),
-			should_inject_props ? [b.id('$$anchor'), b.id('$$props')] : [b.id('$$anchor')],
+			params,
 			b.block([
 				b.var('$$unsuspend', b.call('$.suspend')),
 				...component_block.body,
@@ -397,10 +406,12 @@ export function client_component(analysis, options) {
 		component_block = b.block([
 			b.var('fragment', b.call('$.comment')),
 			b.var('node', b.call('$.first_child', b.id('fragment'))),
-			b.stmt(b.call(body.id, b.id('node'), should_inject_props && b.id('$$props'))),
+			store_init,
+			b.stmt(b.call(body.id, b.id('node'), ...params.slice(1))),
 			b.stmt(b.call('$.append', b.id('$$anchor'), b.id('fragment')))
 		]);
 	} else {
+		component_block.body.unshift(store_init);
 		component_block.body.push(.../** @type {ESTree.Statement[]} */ (template.body));
 	}
 


### PR DESCRIPTION
Closes #16440

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
