### PR TITLE
fix: prevent batches from getting intertwined

### DIFF
--- a/.changeset/fresh-birds-jam.md
+++ b/.changeset/fresh-birds-jam.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent batches from getting intertwined

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -148,7 +148,7 @@ export class Boundary {
 				// need to use hydration boundary comments to report whether
 				// the pending or main block was rendered for a given
 				// boundary, and hydrate accordingly
-				queueMicrotask(() => {
+				Batch.enqueue(() => {
 					this.#main_effect = this.#run(() => {
 						Batch.ensure();
 						return branch(() => this.#children(this.#anchor));

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -615,7 +615,11 @@ export function suspend() {
 
 	return function unsuspend() {
 		boundary.update_pending_count(-1);
-		if (!pending) batch.decrement();
+
+		if (!pending) {
+			batch.activate();
+			batch.decrement();
+		}
 
 		unset_context();
 	};


### PR DESCRIPTION
No test for this because I can't figure how to make something broken without it, but I'm fairly sure this _is_ necessary. While debugging an app that uses remote functions, I noticed that batches weren't reliably getting removed, and in at least some cases the root cause is that the `queueMicrotask` callback in a boundary is getting tangled up with the `queueMicrotask` callback in `Batch.ensure`

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
