### PR TITLE
fix: disallow `export { foo as default }` in `<script module>`

### DIFF
--- a/.changeset/curly-buttons-burn.md
+++ b/.changeset/curly-buttons-burn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: disallow `export { foo as default }` in `<script module>`

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
@@ -11,6 +11,17 @@ export function ExportNamedDeclaration(node, context) {
 	// visit children, so bindings are correctly initialised
 	context.next();
 
+	if (
+		context.state.ast_type &&
+		node.specifiers.some((specifier) =>
+			specifier.exported.type === 'Identifier'
+				? specifier.exported.name === 'default'
+				: specifier.exported.value === 'default'
+		)
+	) {
+		e.module_illegal_default_export(node);
+	}
+
 	if (node.declaration?.type === 'VariableDeclaration') {
 		// in runes mode, forbid `export let`
 		if (

--- a/packages/svelte/tests/validator/samples/default-export-indirect/errors.json
+++ b/packages/svelte/tests/validator/samples/default-export-indirect/errors.json
@@ -1,0 +1,14 @@
+[
+	{
+		"code": "module_illegal_default_export",
+		"message": "A component cannot have a default export",
+		"start": {
+			"line": 3,
+			"column": 1
+		},
+		"end": {
+			"line": 3,
+			"column": 33
+		}
+	}
+]

--- a/packages/svelte/tests/validator/samples/default-export-indirect/errors.json
+++ b/packages/svelte/tests/validator/samples/default-export-indirect/errors.json
@@ -4,11 +4,11 @@
 		"message": "A component cannot have a default export",
 		"start": {
 			"line": 3,
-			"column": 1
+			"column": 4
 		},
 		"end": {
 			"line": 3,
-			"column": 33
+			"column": 32
 		}
 	}
 ]

--- a/packages/svelte/tests/validator/samples/default-export-indirect/input.svelte
+++ b/packages/svelte/tests/validator/samples/default-export-indirect/input.svelte
@@ -1,0 +1,4 @@
+<script module>
+    let answer = 42;
+    export { answer as default};
+</script>


### PR DESCRIPTION
Currently, the compiler will throw an error if you use `export default` in a component.
However, it doesn't throw if you use `export { foo as default }` or `export { foo as 'default' }`. This fixes that.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
