### PR TITLE
fix: tag stores for `$inspect.trace()`

### DIFF
--- a/.changeset/silent-rockets-tease.md
+++ b/.changeset/silent-rockets-tease.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: tag stores for `$inspect.trace()`

--- a/packages/svelte/src/internal/client/dev/tracing.js
+++ b/packages/svelte/src/internal/client/dev/tracing.js
@@ -26,7 +26,7 @@ function log_entry(signal, entry) {
 		return;
 	}
 
-	const type = (signal.f & (DERIVED | ASYNC)) !== 0 ? '$derived' : '$state';
+	const type = get_type(signal);
 	const current_reaction = /** @type {Reaction} */ (active_reaction);
 	const dirty = signal.wv > current_reaction.wv || current_reaction.wv === 0;
 	const style = dirty
@@ -71,6 +71,15 @@ function log_entry(signal, entry) {
 
 	// eslint-disable-next-line no-console
 	console.groupEnd();
+}
+
+/**
+ * @param {Value} signal
+ * @returns {'$state' | '$derived' | 'store'}
+ */
+function get_type(signal) {
+	if ((signal.f & (DERIVED | ASYNC)) !== 0) return '$derived';
+	return signal.label?.startsWith('$') ? 'store' : '$state';
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -6,6 +6,7 @@ import { define_property, noop } from '../../shared/utils.js';
 import { get } from '../runtime.js';
 import { teardown } from './effects.js';
 import { mutable_source, set } from './sources.js';
+import { DEV } from 'esm-env';
 
 /**
  * Whether or not the prop currently being read is a store binding, as in
@@ -32,6 +33,10 @@ export function store_get(store, store_name, stores) {
 		source: mutable_source(undefined),
 		unsubscribe: noop
 	});
+
+	if (DEV) {
+		entry.source.label = store_name;
+	}
 
 	// if the component that setup this is already unmounted we don't want to register a subscription
 	if (entry.store !== store && !(IS_UNMOUNTED in stores)) {

--- a/packages/svelte/tests/runtime-runes/samples/inspect-trace-store/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-trace-store/_config.js
@@ -1,0 +1,30 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+import { normalise_trace_logs } from '../../../helpers.js';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	test({ assert, target, logs }) {
+		assert.deepEqual(normalise_trace_logs(logs), [
+			{ log: 'effect' },
+			{ log: 'store', highlighted: true },
+			{ log: '$count', highlighted: false },
+			{ log: 0 }
+		]);
+
+		logs.length = 0;
+
+		const [button] = target.querySelectorAll('button');
+		flushSync(() => button.click());
+
+		assert.deepEqual(normalise_trace_logs(logs), [
+			{ log: 'effect' },
+			{ log: 'store', highlighted: true },
+			{ log: '$count', highlighted: false },
+			{ log: 1 }
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/inspect-trace-store/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-trace-store/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { writable } from 'svelte/store';
+
+	const count = writable(0);
+
+	$effect(() => {
+		$inspect.trace('effect');
+		$count;
+	});
+</script>
+
+<button onclick={() => $count += 1}>
+	clicks: {$count}
+</button>


### PR DESCRIPTION
Before:

<img width="633" height="210" alt="image" src="https://github.com/user-attachments/assets/ee839089-256c-4c4e-9bb9-9a525d263141" />


After:

<img width="631" height="206" alt="image" src="https://github.com/user-attachments/assets/57b65612-04d1-4838-b1fe-2d097da3f275" />

Ought to be uncontroversial so I'm going to go ahead and self-merge once green — I need this to debug some remote functions/async stuff (it's tripping up over SvelteKit's internal stores, which I can't wait to get rid of)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
