### PR TITLE
chore: move `capture_signals` to legacy module

### DIFF
--- a/.changeset/swift-cherries-know.md
+++ b/.changeset/swift-cherries-know.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: move `capture_signals` to legacy module

--- a/packages/svelte/src/internal/client/dev/tracing.js
+++ b/packages/svelte/src/internal/client/dev/tracing.js
@@ -4,7 +4,7 @@ import { snapshot } from '../../shared/clone.js';
 import { define_property } from '../../shared/utils.js';
 import { DERIVED, ASYNC, PROXY_PATH_SYMBOL, STATE_SYMBOL } from '#client/constants';
 import { effect_tracking } from '../reactivity/effects.js';
-import { active_reaction, captured_signals, set_captured_signals, untrack } from '../runtime.js';
+import { active_reaction, untrack } from '../runtime.js';
 
 /**
  * @typedef {{

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -138,11 +138,11 @@ export {
 	mark_store_binding
 } from './reactivity/store.js';
 export { boundary, pending } from './dom/blocks/boundary.js';
+export { invalidate_inner_signals } from './legacy.js';
 export { set_text } from './render.js';
 export {
 	get,
 	safe_get,
-	invalidate_inner_signals,
 	tick,
 	untrack,
 	exclude_from_object,

--- a/packages/svelte/src/internal/client/legacy.js
+++ b/packages/svelte/src/internal/client/legacy.js
@@ -1,0 +1,46 @@
+/** @import { Value } from '#client' */
+import { internal_set } from './reactivity/sources.js';
+import { untrack } from './runtime.js';
+
+/**
+ * @type {Set<Value> | null}
+ * @deprecated
+ */
+export let captured_signals = null;
+
+/**
+ * Capture an array of all the signals that are read when `fn` is called
+ * @template T
+ * @param {() => T} fn
+ */
+function capture_signals(fn) {
+	var previous_captured_signals = captured_signals;
+
+	try {
+		captured_signals = new Set();
+
+		untrack(fn);
+
+		if (previous_captured_signals !== null) {
+			for (var signal of captured_signals) {
+				previous_captured_signals.add(signal);
+			}
+		}
+
+		return captured_signals;
+	} finally {
+		captured_signals = previous_captured_signals;
+	}
+}
+
+/**
+ * Invokes a function and captures all signals that are read during the invocation,
+ * then invalidates them.
+ * @param {() => any} fn
+ * @deprecated
+ */
+export function invalidate_inner_signals(fn) {
+	for (var signal of capture_signals(fn)) {
+		internal_set(signal, signal.v);
+	}
+}

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -22,7 +22,7 @@ import {
 	STALE_REACTION,
 	ERROR_VALUE
 } from './constants.js';
-import { internal_set, old_values } from './reactivity/sources.js';
+import { old_values } from './reactivity/sources.js';
 import {
 	destroy_derived_effects,
 	execute_derived,
@@ -45,6 +45,7 @@ import * as w from './warnings.js';
 import { Batch, batch_deriveds, flushSync, schedule_effect } from './reactivity/batch.js';
 import { handle_error } from './error-handling.js';
 import { UNINITIALIZED } from '../../constants.js';
+import { captured_signals } from './legacy.js';
 
 export let is_updating_effect = false;
 
@@ -137,14 +138,6 @@ export function set_update_version(value) {
 // If we are working with a get() chain that has no active container,
 // to prevent memory leaks, we skip adding the reaction.
 export let skip_reaction = false;
-// Handle collecting all signals which are read during a specific time frame
-/** @type {Set<Value> | null} */
-export let captured_signals = null;
-
-/** @param {Set<Value> | null} value */
-export function set_captured_signals(value) {
-	captured_signals = value;
-}
 
 export function increment_write_version() {
 	return ++write_version;
@@ -531,9 +524,7 @@ export function get(signal) {
 	var flags = signal.f;
 	var is_derived = (flags & DERIVED) !== 0;
 
-	if (captured_signals !== null) {
-		captured_signals.add(signal);
-	}
+	captured_signals?.add(signal);
 
 	// Register the dependency on the current reaction signal.
 	if (active_reaction !== null && !untracking) {
@@ -711,45 +702,6 @@ function depends_on_old_values(derived) {
  */
 export function safe_get(signal) {
 	return signal && get(signal);
-}
-
-/**
- * Capture an array of all the signals that are read when `fn` is called
- * @template T
- * @param {() => T} fn
- */
-function capture_signals(fn) {
-	var previous_captured_signals = captured_signals;
-	captured_signals = new Set();
-
-	var captured = captured_signals;
-	var signal;
-
-	try {
-		untrack(fn);
-		if (previous_captured_signals !== null) {
-			for (signal of captured_signals) {
-				previous_captured_signals.add(signal);
-			}
-		}
-	} finally {
-		captured_signals = previous_captured_signals;
-	}
-
-	return captured;
-}
-
-/**
- * Invokes a function and captures all signals that are read during the invocation,
- * then invalidates them.
- * @param {() => any} fn
- */
-export function invalidate_inner_signals(fn) {
-	var captured = capture_signals(() => untrack(fn));
-
-	for (var signal of captured) {
-		internal_set(signal, signal.v);
-	}
 }
 
 /**


### PR DESCRIPTION
Spotted an opportunity to tidy up `runtime.js` a bit more by moving some legacy code into a separate module. Was able to simplify things a bit at the same time — removing the double untrack, removing some unnecessary variables

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
