### PR TITLE
chore: log effect functions in log_effect_tree

### DIFF
--- a/packages/svelte/src/internal/client/dev/debug.js
+++ b/packages/svelte/src/internal/client/dev/debug.js
@@ -63,6 +63,13 @@ export function log_effect_tree(effect, depth = 0) {
 
 		// eslint-disable-next-line no-console
 		console.log(callsite);
+	} else {
+		// eslint-disable-next-line no-console
+		console.groupCollapsed(`%cfn`, `font-weight: normal`);
+		// eslint-disable-next-line no-console
+		console.log(effect.fn);
+		// eslint-disable-next-line no-console
+		console.groupEnd();
 	}
 
 	if (effect.deps !== null) {


### PR DESCRIPTION
this makes `log_effect_tree` more helpful — you can click in devtools to see the location of the function, which makes a huge difference when trying to understand the shape of the effect tree