### PR TITLE
fix: exclude derived writes from effect abort and rescheduling

### DIFF
--- a/.changeset/thick-mice-kick.md
+++ b/.changeset/thick-mice-kick.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: exclude derived writes from effect abort and rescheduling

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -323,6 +323,20 @@ export function execute_derived(derived) {
 	return value;
 }
 
+// in process_effects if state is written to in a user effect we reschedule the rest of the
+// tree. However if a derived is updated in an effect we also increase the write version
+// so we need to keep track of how many deriveds were written to in the effect so
+// that we can subtract that from the write version before rescheduling unnnecessarily
+let derived_writes = 0;
+
+export function get_derived_writes() {
+	return derived_writes;
+}
+
+export function reset_derived_writes() {
+	derived_writes = 0;
+}
+
 /**
  * @param {Derived} derived
  * @returns {void}
@@ -333,6 +347,7 @@ export function update_derived(derived) {
 	if (!derived.equals(value)) {
 		derived.v = value;
 		derived.wv = increment_write_version();
+		derived_writes++;
 	}
 
 	// don't mark derived clean if we're reading it inside a

--- a/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/Component.svelte
@@ -1,0 +1,7 @@
+<script>
+	const der = $derived(false);
+
+	$effect(() => {
+		der
+	});
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	async test() {}
+});

--- a/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Component from './Component.svelte'	
+	const arr = Array.from({length: 10001});
+</script>
+
+{#each arr}
+	<Component />
+{/each}


### PR DESCRIPTION
Closes #16423

One possible strategy to fix this issue (maybe not the best ?). We keep track of how many derived_writes we have before updating the effect and we subtract that number from the `write_version` to have check if something else increased it (namely setting a derived or a source).

One thing that I would've loved to confirm but failed to do so is check that the test in #16280, if rewritten with deriveds, still pass. But that's very convoluted and I was not able to find a way to rewrite it so that the derived was updated in the effect.

Let's discuss if this is a good strategy.

@dummdidumm also had the idea to use even and off numbers for `write_version` for deriveds and sources but that sounds a nightmare to debug.

Another idea I had was literally just a flag on the effect when `internal_set` is called.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`