### PR TITLE
fix: unset batch before flushing queued effects

### DIFF
--- a/.changeset/grumpy-boats-beg.md
+++ b/.changeset/grumpy-boats-beg.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep input in sync when binding updated via effect

--- a/.changeset/shiny-walls-fix.md
+++ b/.changeset/shiny-walls-fix.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent infinite async loop

--- a/.changeset/thick-mice-kick.md
+++ b/.changeset/thick-mice-kick.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: exclude derived writes from effect abort and rescheduling

--- a/packages/svelte/src/internal/client/dev/debug.js
+++ b/packages/svelte/src/internal/client/dev/debug.js
@@ -63,6 +63,13 @@ export function log_effect_tree(effect, depth = 0) {
 
 		// eslint-disable-next-line no-console
 		console.log(callsite);
+	} else {
+		// eslint-disable-next-line no-console
+		console.groupCollapsed(`%cfn`, `font-weight: normal`);
+		// eslint-disable-next-line no-console
+		console.log(effect.fn);
+		// eslint-disable-next-line no-console
+		console.groupEnd();
 	}
 
 	if (effect.deps !== null) {

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -489,10 +489,11 @@ function flush_effects() {
 
 	try {
 		var flush_count = 0;
-		var batch = /** @type {Batch} */ (current_batch);
 		set_is_updating_effect(true);
 
 		while (queued_root_effects.length > 0) {
+			var batch = /** @type {Batch} */ (current_batch);
+
 			if (flush_count++ > 1000) {
 				if (DEV) {
 					var updates = new Map();
@@ -519,7 +520,6 @@ function flush_effects() {
 				infinite_loop_guard();
 			}
 
-			batch = /** @type {Batch} */ (current_batch);
 			batch.process(queued_root_effects);
 			old_values.clear();
 		}

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -461,7 +461,7 @@ export function flushSync(fn) {
 			if (queued_root_effects.length === 0) {
 				current_batch?.flush();
 
-				// TODO this feels wrong
+				// we need to check again, in case we just updated an `$effect.pending()`
 				if (queued_root_effects.length === 0) {
 					// this would be reset in `flush_effects()` but since we are early returning here,
 					// we need to reset it here as well in case the first time there's 0 queued root effects

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -444,7 +444,7 @@ export function flushSync(fn) {
 		e.flush_sync_in_effect();
 	}
 
-	var prev_flushing_sync = is_flushing_sync;
+	var was_flushing_sync = is_flushing_sync;
 	is_flushing_sync = true;
 
 	try {
@@ -474,7 +474,7 @@ export function flushSync(fn) {
 			flush_effects();
 		}
 	} finally {
-		is_flushing_sync = prev_flushing_sync;
+		is_flushing_sync = was_flushing_sync;
 	}
 }
 

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -450,8 +450,6 @@ export function flushSync(fn) {
 	try {
 		var result;
 
-		var batch = Batch.ensure();
-
 		if (fn) {
 			flush_effects();
 			result = fn();
@@ -461,10 +459,7 @@ export function flushSync(fn) {
 			flush_tasks();
 
 			if (queued_root_effects.length === 0) {
-				// TODO this might need adjustment
-				if (batch === current_batch) {
-					batch.flush();
-				}
+				current_batch?.flush();
 
 				// TODO this feels wrong
 				if (queued_root_effects.length === 0) {
@@ -492,7 +487,7 @@ function flush_effects() {
 		set_is_updating_effect(true);
 
 		while (queued_root_effects.length > 0) {
-			var batch = /** @type {Batch} */ (current_batch);
+			var batch = Batch.ensure();
 
 			if (flush_count++ > 1000) {
 				if (DEV) {

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -70,7 +70,7 @@ let last_scheduled_effect = null;
 
 let is_flushing = false;
 
-export let flushing_sync = false;
+let flushing_sync = false;
 
 export class Batch {
 	/**
@@ -407,12 +407,12 @@ export class Batch {
 		return (this.#deferred ??= deferred()).promise;
 	}
 
-	static ensure(autoflush = true) {
+	static ensure() {
 		if (current_batch === null) {
 			const batch = (current_batch = new Batch());
 			batches.add(current_batch);
 
-			if (autoflush) {
+			if (!flushing_sync) {
 				Batch.enqueue(() => {
 					if (current_batch !== batch) {
 						// a flushSync happened in the meantime
@@ -455,7 +455,7 @@ export function flushSync(fn) {
 	try {
 		var result;
 
-		const batch = Batch.ensure(false);
+		const batch = Batch.ensure();
 
 		if (fn) {
 			batch.flush_effects();

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -563,7 +563,7 @@ function flush_queued_effects(effects) {
 		var effect = effects[i++];
 
 		if ((effect.f & (DESTROYED | INERT)) === 0 && is_dirty(effect)) {
-			var wv = write_version;
+			var n = current_batch ? current_batch.current.size : 0;
 
 			update_effect(effect);
 
@@ -586,7 +586,11 @@ function flush_queued_effects(effects) {
 
 			// if state is written in a user effect, abort and re-schedule, lest we run
 			// effects that should be removed as a result of the state change
-			if (write_version > wv && (effect.f & USER_EFFECT) !== 0) {
+			if (
+				current_batch !== null &&
+				current_batch.current.size > n &&
+				(effect.f & USER_EFFECT) !== 0
+			) {
 				break;
 			}
 		}

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -341,13 +341,13 @@ export class Batch {
 
 	flush() {
 		if (queued_root_effects.length > 0) {
-			this.flush_effects();
+			flush_effects();
 		} else {
 			this.#commit();
 		}
 
 		if (current_batch !== this) {
-			// this can happen if a `flushSync` occurred during `this.flush_effects()`,
+			// this can happen if a `flushSync` occurred during `flush_effects()`,
 			// which is permitted in legacy mode despite being a terrible idea
 			return;
 		}
@@ -357,10 +357,6 @@ export class Batch {
 		}
 
 		this.deactivate();
-	}
-
-	flush_effects() {
-		flush_effects();
 	}
 
 	/**
@@ -454,11 +450,10 @@ export function flushSync(fn) {
 	try {
 		var result;
 
-		const batch = Batch.ensure();
+		var batch = Batch.ensure();
 
 		if (fn) {
-			batch.flush_effects();
-
+			flush_effects();
 			result = fn();
 		}
 
@@ -473,7 +468,7 @@ export function flushSync(fn) {
 
 				// TODO this feels wrong
 				if (queued_root_effects.length === 0) {
-					// this would be reset in `batch.flush_effects()` but since we are early returning here,
+					// this would be reset in `flush_effects()` but since we are early returning here,
 					// we need to reset it here as well in case the first time there's 0 queued root effects
 					last_scheduled_effect = null;
 
@@ -481,7 +476,7 @@ export function flushSync(fn) {
 				}
 			}
 
-			batch.flush_effects();
+			flush_effects();
 		}
 	} finally {
 		is_flushing_sync = prev_flushing_sync;

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -21,8 +21,7 @@ import {
 	is_updating_effect,
 	set_is_updating_effect,
 	set_signal_status,
-	update_effect,
-	write_version
+	update_effect
 } from '../runtime.js';
 import * as e from '../errors.js';
 import { flush_tasks } from '../dom/task.js';

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -69,7 +69,7 @@ let last_scheduled_effect = null;
 
 let is_flushing = false;
 
-let flushing_sync = false;
+let is_flushing_sync = false;
 
 export class Batch {
 	/**
@@ -411,7 +411,7 @@ export class Batch {
 			const batch = (current_batch = new Batch());
 			batches.add(current_batch);
 
-			if (!flushing_sync) {
+			if (!is_flushing_sync) {
 				Batch.enqueue(() => {
 					if (current_batch !== batch) {
 						// a flushSync happened in the meantime
@@ -448,8 +448,8 @@ export function flushSync(fn) {
 		e.flush_sync_in_effect();
 	}
 
-	var prev_flushing_sync = flushing_sync;
-	flushing_sync = true;
+	var prev_flushing_sync = is_flushing_sync;
+	is_flushing_sync = true;
 
 	try {
 		var result;
@@ -484,7 +484,7 @@ export function flushSync(fn) {
 			batch.flush_effects();
 		}
 	} finally {
-		flushing_sync = prev_flushing_sync;
+		is_flushing_sync = prev_flushing_sync;
 	}
 }
 

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -33,7 +33,7 @@ import * as e from '../errors.js';
 import { legacy_mode_flag, tracing_mode_flag } from '../../flags/index.js';
 import { get_stack, tag_proxy } from '../dev/tracing.js';
 import { component_context, is_runes } from '../context.js';
-import { Batch, schedule_effect } from './batch.js';
+import { Batch, flushing_sync, schedule_effect } from './batch.js';
 import { proxy } from '../proxy.js';
 import { execute_derived } from './deriveds.js';
 
@@ -179,7 +179,7 @@ export function internal_set(source, value) {
 
 		source.v = value;
 
-		const batch = Batch.ensure();
+		const batch = Batch.ensure(!flushing_sync);
 		batch.capture(source, old_value);
 
 		if (DEV) {

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -324,14 +324,16 @@ export function mark_reactions(signal, status, schedule_async = true) {
 			continue;
 		}
 
+		var should_schedule = (flags & DIRTY) === 0 && (schedule_async || (flags & ASYNC) === 0);
+
 		// don't set a DIRTY reaction to MAYBE_DIRTY
-		if ((flags & DIRTY) === 0 && (schedule_async || (flags & ASYNC) === 0)) {
+		if (should_schedule) {
 			set_signal_status(reaction, status);
 		}
 
 		if ((flags & DERIVED) !== 0) {
 			mark_reactions(/** @type {Derived} */ (reaction), MAYBE_DIRTY);
-		} else if ((flags & DIRTY) === 0 && (schedule_async || (flags & ASYNC) === 0)) {
+		} else if (should_schedule) {
 			schedule_effect(/** @type {Effect} */ (reaction));
 		}
 	}

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -301,9 +301,10 @@ export function increment(source) {
 /**
  * @param {Value} signal
  * @param {number} status should be DIRTY or MAYBE_DIRTY
+ * @param {boolean} schedule_async
  * @returns {void}
  */
-function mark_reactions(signal, status) {
+export function mark_reactions(signal, status, schedule_async = true) {
 	var reactions = signal.reactions;
 	if (reactions === null) return;
 
@@ -324,13 +325,13 @@ function mark_reactions(signal, status) {
 		}
 
 		// don't set a DIRTY reaction to MAYBE_DIRTY
-		if ((flags & DIRTY) === 0) {
+		if ((flags & DIRTY) === 0 && (schedule_async || (flags & ASYNC) === 0)) {
 			set_signal_status(reaction, status);
 		}
 
 		if ((flags & DERIVED) !== 0) {
 			mark_reactions(/** @type {Derived} */ (reaction), MAYBE_DIRTY);
-		} else if ((flags & DIRTY) === 0) {
+		} else if ((flags & DIRTY) === 0 && (schedule_async || (flags & ASYNC) === 0)) {
 			schedule_effect(/** @type {Effect} */ (reaction));
 		}
 	}

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -33,7 +33,7 @@ import * as e from '../errors.js';
 import { legacy_mode_flag, tracing_mode_flag } from '../../flags/index.js';
 import { get_stack, tag_proxy } from '../dev/tracing.js';
 import { component_context, is_runes } from '../context.js';
-import { Batch, flushing_sync, schedule_effect } from './batch.js';
+import { Batch, schedule_effect } from './batch.js';
 import { proxy } from '../proxy.js';
 import { execute_derived } from './deriveds.js';
 
@@ -179,7 +179,7 @@ export function internal_set(source, value) {
 
 		source.v = value;
 
-		const batch = Batch.ensure(!flushing_sync);
+		var batch = Batch.ensure();
 		batch.capture(source, old_value);
 
 		if (DEV) {

--- a/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/Component.svelte
@@ -1,0 +1,7 @@
+<script>
+	const der = $derived(false);
+
+	$effect(() => {
+		der
+	});
+</script>

--- a/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	async test() {}
+});

--- a/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Component from './Component.svelte'	
+	const arr = Array.from({length: 10001});
+</script>
+
+{#each arr}
+	<Component />
+{/each}

--- a/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/1000-reading-derived-effects/main.svelte
@@ -1,5 +1,5 @@
 <script>
-	import Component from './Component.svelte'	
+	import Component from './Component.svelte';
 	const arr = Array.from({length: 10001});
 </script>
 

--- a/packages/svelte/tests/runtime-runes/samples/async-binding-update-while-focused/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-binding-update-while-focused/_config.js
@@ -1,0 +1,26 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+
+		const [input] = target.querySelectorAll('input');
+
+		input.focus();
+		input.value = '3';
+		input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+		await tick();
+
+		assert.equal(input.value, '3');
+		assert.htmlEqual(target.innerHTML, `<p>3</p> <input type="number" />`);
+
+		input.focus();
+		input.value = '1';
+		input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+		await tick();
+
+		assert.equal(input.value, '2');
+		assert.htmlEqual(target.innerHTML, `<p>2</p> <input type="number" />`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-binding-update-while-focused/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-binding-update-while-focused/main.svelte
@@ -1,0 +1,27 @@
+<script>
+	let value = $state(0)
+	const min = 2
+	const max = 5
+
+	$effect(() => {
+		setValue()
+	})
+
+	function setValue() {
+		if (value < min) {
+			value = min
+		}
+		if (value > max) {
+			value = max
+		}
+	}
+</script>
+
+<svelte:boundary>
+	<p>{await value}</p>
+	<input type="number" bind:value />
+
+	{#snippet pending()}
+		<p>loading...</p>
+	{/snippet}
+</svelte:boundary>

--- a/packages/svelte/tests/runtime-runes/samples/async-effect-triggers-await/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-effect-triggers-await/_config.js
@@ -1,0 +1,32 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+
+		const [increment] = target.querySelectorAll('button');
+
+		increment.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<p>1</p>
+				<p>1</p>
+			`
+		);
+
+		increment.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<p>2</p>
+				<p>2</p>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-effect-triggers-await/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-effect-triggers-await/main.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	let data = $state(Promise.resolve(0));
+
+	let count = $state(0);
+	let unrelated = $state(0);
+
+	$effect(() => {
+		data = Promise.resolve(count)
+		unrelated = count;
+	});
+</script>
+
+<svelte:boundary>
+	<button onclick={() => count += 1}>increment</button>
+	<p>{JSON.stringify((await data), null, 2)}</p>
+	{#if true}
+		<!-- inside if block to force it into a different render effect -->
+		<p>{unrelated}</p>
+	{/if}
+
+	{#snippet pending()}
+		<p>loading...</p>
+	{/snippet}
+</svelte:boundary>

--- a/packages/svelte/tests/runtime-runes/samples/binding-update-while-focused-2/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/binding-update-while-focused-2/_config.js
@@ -1,0 +1,24 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const [input] = target.querySelectorAll('input');
+
+		input.focus();
+		input.value = '3';
+		input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+		flushSync();
+
+		assert.equal(input.value, '3');
+		assert.htmlEqual(target.innerHTML, `<p>3</p> <input type="number" />`);
+
+		input.focus();
+		input.value = '1';
+		input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+		flushSync();
+
+		assert.equal(input.value, '2');
+		assert.htmlEqual(target.innerHTML, `<p>2</p> <input type="number" />`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/binding-update-while-focused-2/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/binding-update-while-focused-2/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let value = $state(0)
+	const min = 2
+	const max = 5
+
+	$effect(() => {
+		setValue()
+	})
+
+	function setValue() {
+		if (value < min) {
+			value = min
+		}
+		if (value > max) {
+			value = max
+		}
+	}
+</script>
+
+<p>{value}</p>
+<input type="number" bind:value />


### PR DESCRIPTION
- fixes #16413 (and closes #16464)
- fixes #16423 (and closes #16477)
- fixes #16403

I wish I could claim credit for this but it's all @dummdidumm, I'm just opening a PR to make working on it easier. Essentially, we now create a fresh batch to handle any state changes that occur during effects that run after the prior batch is committed

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
