### PR TITLE
fix: preserve dirty status of deferred effects

### DIFF
--- a/.changeset/cool-insects-argue.md
+++ b/.changeset/cool-insects-argue.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: preserve dirty status of deferred effects

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -283,19 +283,15 @@ export class Batch {
 			if (!skip && effect.fn !== null) {
 				if (is_branch) {
 					effect.f ^= CLEAN;
-				} else if ((flags & EFFECT) !== 0) {
-					if ((flags & CLEAN) === 0) {
+				} else if ((flags & CLEAN) === 0) {
+					if ((flags & EFFECT) !== 0) {
 						this.#effects.push(effect);
-					}
-				} else if (async_mode_flag && (flags & RENDER_EFFECT) !== 0) {
-					if ((flags & CLEAN) === 0) {
+					} else if (async_mode_flag && (flags & RENDER_EFFECT) !== 0) {
 						this.#render_effects.push(effect);
-					}
-				} else if (is_dirty(effect)) {
-					if ((flags & ASYNC) !== 0) {
+					} else if ((flags & ASYNC) !== 0) {
 						var effects = effect.b?.pending ? this.#boundary_async_effects : this.#async_effects;
 						effects.push(effect);
-					} else {
+					} else if (is_dirty(effect)) {
 						if ((effect.f & BLOCK_EFFECT) !== 0) this.#block_effects.push(effect);
 						update_effect(effect);
 					}

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -27,7 +27,7 @@ import * as e from '../errors.js';
 import { flush_tasks } from '../dom/task.js';
 import { DEV } from 'esm-env';
 import { invoke_error_boundary } from '../error-handling.js';
-import { mark_reactions, old_values } from './sources.js';
+import { old_values } from './sources.js';
 import { unlink_effect } from './effects.js';
 import { unset_context } from './async.js';
 

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -301,10 +301,9 @@ export function increment(source) {
 /**
  * @param {Value} signal
  * @param {number} status should be DIRTY or MAYBE_DIRTY
- * @param {boolean} schedule_async
  * @returns {void}
  */
-export function mark_reactions(signal, status, schedule_async = true) {
+function mark_reactions(signal, status) {
 	var reactions = signal.reactions;
 	if (reactions === null) return;
 
@@ -324,16 +323,14 @@ export function mark_reactions(signal, status, schedule_async = true) {
 			continue;
 		}
 
-		var should_schedule = (flags & DIRTY) === 0 && (schedule_async || (flags & ASYNC) === 0);
-
 		// don't set a DIRTY reaction to MAYBE_DIRTY
-		if (should_schedule) {
+		if ((flags & DIRTY) === 0) {
 			set_signal_status(reaction, status);
 		}
 
 		if ((flags & DERIVED) !== 0) {
 			mark_reactions(/** @type {Derived} */ (reaction), MAYBE_DIRTY);
-		} else if (should_schedule) {
+		} else {
 			schedule_effect(/** @type {Effect} */ (reaction));
 		}
 	}

--- a/packages/svelte/tests/runtime-runes/samples/async-effect-conservative/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-effect-conservative/_config.js
@@ -1,0 +1,28 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		await tick();
+
+		const [increment] = target.querySelectorAll('button');
+
+		assert.deepEqual(logs, [false]);
+		assert.htmlEqual(target.innerHTML, '<button>increment</button><p>0</p>');
+
+		increment.click();
+		await tick();
+		assert.deepEqual(logs, [false]);
+		assert.htmlEqual(target.innerHTML, '<button>increment</button><p>1</p>');
+
+		increment.click();
+		await tick();
+		assert.deepEqual(logs, [false, true]);
+		assert.htmlEqual(target.innerHTML, '<button>increment</button><p>2</p>');
+
+		increment.click();
+		await tick();
+		assert.deepEqual(logs, [false, true]);
+		assert.htmlEqual(target.innerHTML, '<button>increment</button><p>3</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-effect-conservative/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-effect-conservative/main.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	let count = $state(0);
+	let two_or_larger = $derived(count >= 2);
+
+	$effect(() => {
+		console.log(two_or_larger);
+	});
+</script>
+
+<svelte:boundary>
+	<button onclick={() => count += 1}>increment</button>
+	<p>{await count}</p>
+
+	{#snippet pending()}
+		<p>loading...</p>
+	{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
Ironically, the part of #16482 that fixed the infinite loop bug in #16403 introduced an even worse infinite loop that made remote functions unusable. I have learned, for the 19th or so time, that it is _absolutely_ not safe to `mark_reactions` when triggering a batch re-run.

It turns out we (which in this case is the royal 'we') were doing something rather silly: we were queueing _all_ leaf effects when traversing the tree, not just the `DIRTY`/`MAYBE_DIRTY` ones. In the common case that's fine, because they get flushed immediately and they get filtered with `is_dirty`, but if the effects are deferred (because async work is happening) then on the next run they are all marked `DIRTY` and re-executed.

This PR makes everything somewhat more efficient. Firstly, it only queues effects that are not `CLEAN`. (We can't use an `is_dirty` check during traversal, because that can cause deriveds to be re-evaluated with inconsistent data.) Secondly, it notes whether they were `DIRTY` or `MAYBE_DIRTY` at the time of deferral, and restores that status to prevent unnecessary re-runs of `MAYBE_DIRTY` effects.

I wasn't able to whittle the remote functions infinite loop thing down to a test case, but I verified the fix locally which will have to do for now as it's 1am and I'm supposed to be demoing this stuff on [YouTube](https://www.youtube.com/watch?v=kL4Tp8RmJwo) tomorrow.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
