### PR TITLE
fix: don't destroy effect roots created inside of deriveds

### DIFF
--- a/.changeset/lemon-weeks-call.md
+++ b/.changeset/lemon-weeks-call.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't destroy effect roots created inside of deriveds

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -148,7 +148,11 @@ function create_effect(type, fn, sync, push = true) {
 		}
 
 		// if we're in a derived, add the effect there too
-		if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
+		if (
+			active_reaction !== null &&
+			(active_reaction.f & DERIVED) !== 0 &&
+			(type & ROOT_EFFECT) === 0
+		) {
 			var derived = /** @type {Derived} */ (active_reaction);
 			(derived.effects ??= []).push(effect);
 		}

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -54,7 +54,7 @@ export interface Reaction extends Signal {
 export interface Derived<V = unknown> extends Value<V>, Reaction {
 	/** The derived function */
 	fn: () => V;
-	/** Effects created inside this signal */
+	/** Effects created inside this signal. Used to destroy those effects when the derived reruns or is cleaned up */
 	effects: null | Effect[];
 	/** Parent effect or derived */
 	parent: Effect | Derived | null;

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -1390,4 +1390,55 @@ describe('signals', () => {
 			destroy();
 		};
 	});
+
+	test('$effect.root inside deriveds stay alive independently', () => {
+		const log: any[] = [];
+		const c = state(0);
+		const cleanup: any[] = [];
+		const inner_states: any[] = [];
+
+		const d = derived(() => {
+			const destroy = effect_root(() => {
+				const x = state(0);
+				inner_states.push(x);
+
+				effect(() => {
+					log.push('inner ' + $.get(x));
+					return () => {
+						log.push('inner destroyed');
+					};
+				});
+			});
+
+			cleanup.push(destroy);
+
+			return $.get(c);
+		});
+
+		return () => {
+			log.push($.get(d));
+			flushSync();
+
+			assert.deepEqual(log, [0, 'inner 0']);
+			log.length = 0;
+
+			set(inner_states[0], 1);
+			flushSync();
+
+			assert.deepEqual(log, ['inner destroyed', 'inner 1']);
+			log.length = 0;
+
+			set(c, 1);
+			log.push($.get(d));
+			flushSync();
+
+			assert.deepEqual(log, [1, 'inner 0']);
+			log.length = 0;
+
+			cleanup.forEach((fn) => fn());
+			flushSync();
+
+			assert.deepEqual(log, ['inner destroyed', 'inner destroyed']);
+		};
+	});
 });


### PR DESCRIPTION
We were wrongfully adding effect roots to `derived.effects`, too, which meant those were destroyed when the derived reran.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
