### PR TITLE
fix: add types for `part` attribute to svg attributes

### DIFF
--- a/.changeset/seven-colts-obey.md
+++ b/.changeset/seven-colts-obey.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add types for `part` attribute to svg attributes

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1553,6 +1553,7 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	height?: number | string | undefined | null;
 	id?: string | undefined | null;
 	lang?: string | undefined | null;
+	part?: string | undefined | null;
 	max?: number | string | undefined | null;
 	media?: string | undefined | null;
 	// On the `textPath` element


### PR DESCRIPTION
Adds the `part` attribute the `<svg>` element's attributes.
Closes #16498.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
