### PR TITLE
fix: `append_styles` in an effect to make them available on mount

### DIFF
--- a/.changeset/shaggy-comics-fail.md
+++ b/.changeset/shaggy-comics-fail.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: `append_styles` in an effect to make them available on mount

--- a/.changeset/wise-hairs-pay.md
+++ b/.changeset/wise-hairs-pay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: always inject styles when compiling as a custom element

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -451,6 +451,8 @@ export function analyze_component(root, source, options) {
 		}
 	}
 
+	const is_custom_element = !!options.customElementOptions || options.customElement;
+
 	// TODO remove all the ?? stuff, we don't need it now that we're validating the config
 	/** @type {ComponentAnalysis} */
 	const analysis = {
@@ -500,13 +502,13 @@ export function analyze_component(root, source, options) {
 		needs_props: false,
 		event_directive_node: null,
 		uses_event_attributes: false,
-		custom_element: options.customElementOptions ?? options.customElement,
-		inject_styles: options.css === 'injected' || options.customElement,
-		accessors: options.customElement
-			? true
-			: (runes ? false : !!options.accessors) ||
-				// because $set method needs accessors
-				options.compatibility?.componentApi === 4,
+		custom_element: is_custom_element,
+		inject_styles: options.css === 'injected' || is_custom_element,
+		accessors:
+			is_custom_element ||
+			(runes ? false : !!options.accessors) ||
+			// because $set method needs accessors
+			options.compatibility?.componentApi === 4,
 		reactive_statements: new Map(),
 		binding_groups: new Map(),
 		slot_names: new Map(),

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -621,8 +621,9 @@ export function client_component(analysis, options) {
 		);
 	}
 
-	if (analysis.custom_element) {
-		const ce = analysis.custom_element;
+	const ce = options.customElementOptions ?? options.customElement;
+
+	if (ce) {
 		const ce_props = typeof ce === 'boolean' ? {} : ce.props || {};
 
 		/** @type {ESTree.Property[]} */

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,6 +1,6 @@
 import { DEV } from 'esm-env';
-import { queue_micro_task } from './task.js';
 import { register_style } from '../dev/css.js';
+import { effect } from '../reactivity/effects.js';
 
 /**
  * @param {Node} anchor
@@ -8,7 +8,7 @@ import { register_style } from '../dev/css.js';
  */
 export function append_styles(anchor, css) {
 	// Use `queue_micro_task` to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
-	queue_micro_task(() => {
+	effect(() => {
 		var root = anchor.getRootNode();
 
 		var target = /** @type {ShadowRoot} */ (root).host

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/host-rune-access-injected-css/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/host-rune-access-injected-css/_config.js
@@ -1,0 +1,21 @@
+import { test } from '../../assert';
+const tick = () => Promise.resolve();
+
+export default test({
+	async test({ assert, target }) {
+		target.innerHTML = '<custom-element></custom-element>';
+		/** @type {any} */
+		const el = target.querySelector('custom-element');
+
+		/** @type {string} */
+		let html = '';
+		const handle_evt = (e) => (html = e.detail);
+		el.addEventListener('html', handle_evt);
+
+		await tick();
+		await tick();
+		await tick();
+
+		assert.ok(html.includes('<style'));
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/host-rune-access-injected-css/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/host-rune-access-injected-css/main.svelte
@@ -1,0 +1,16 @@
+<svelte:options css="injected" customElement="custom-element"/>
+
+<script lang="ts">
+  $effect(() => {
+    $host().dispatchEvent(new CustomEvent("html", { detail: $host().shadowRoot?.innerHTML }));
+  })
+</script>
+
+<button class="btn">btn</button>
+
+<style >
+  .btn {
+    width: 123px;
+    height: 123px;
+  }
+</style>

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-injected-styles/Thing.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-injected-styles/Thing.svelte
@@ -1,0 +1,9 @@
+<svelte:options customElement={{ tag: 'my-thing' }} />
+
+<h1>hello</h1>
+
+<style>
+	h1 {
+		color: red;
+	}
+</style>

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-injected-styles/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-injected-styles/_config.js
@@ -1,0 +1,15 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	async test({ assert, target }) {
+		const thing = /** @type HTMLElement & { object: { test: true }; } */ (
+			target.querySelector('my-thing')
+		);
+
+		await tick();
+
+		assert.include(thing.shadowRoot?.innerHTML, 'red');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-injected-styles/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-injected-styles/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import './Thing.svelte';
+</script>
+
+<my-thing></my-thing>


### PR DESCRIPTION
Closes #16472

Small technicality...I'm pretty sure the actual reproduction doesn't work anyway...but that was not working even before. The reason is that the reproduction is missing css inject. However this got me thinking...given that the style tag is meant to be inside the custom element shouldn't we always inject when building a custom element?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`