### PR TITLE
chore: remove `parser.template_untrimmed`

### DIFF
--- a/.changeset/shiny-berries-call.md
+++ b/.changeset/shiny-berries-call.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: remove `parser.template_untrimmed`

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -24,12 +24,6 @@ export class Parser {
 	template;
 
 	/**
-	 * @readonly
-	 * @type {string}
-	 */
-	template_untrimmed;
-
-	/**
 	 * Whether or not we're in loose parsing mode, in which
 	 * case we try to continue parsing as much as possible
 	 * @type {boolean}
@@ -67,7 +61,6 @@ export class Parser {
 		}
 
 		this.loose = loose;
-		this.template_untrimmed = template;
 		this.template = template.trimEnd();
 
 		let match_lang;

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -370,14 +370,6 @@ export default function element(parser) {
 				// ... or we're followed by whitespace, for example near the end of the template,
 				// which we want to take in so that language tools has more room to work with
 				parser.allow_whitespace();
-				if (parser.index === parser.template.length) {
-					while (
-						parser.index < parser.template_untrimmed.length &&
-						regex_whitespace.test(parser.template_untrimmed[parser.index])
-					) {
-						parser.index++;
-					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION
this doesn't appear to do anything? No tests fail if we remove it. If it _is_ important for `parser.index` to be at the end of the file as opposed to `parser.template`, then we could just do this (where `source` is imported from `state.js`)...

```js
parser.allow_whitespace();
parser.index = source.length;
```

...but it's not clear to me what that would change.