### PR TITLE
chore: remove some todos

### DIFF
--- a/.changeset/happy-countries-dance.md
+++ b/.changeset/happy-countries-dance.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: remove some todos

--- a/packages/svelte/src/compiler/legacy.js
+++ b/packages/svelte/src/compiler/legacy.js
@@ -190,7 +190,7 @@ export function convert(source, ast) {
 			ClassDirective(node) {
 				return { ...node, type: 'Class' };
 			},
-			Comment(node) {
+			TemplateComment(node) {
 				return {
 					...node,
 					ignores: extract_svelte_ignore(node.start, node.data, false)

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1362,7 +1362,7 @@ const template = {
 			);
 		}
 	},
-	Comment(node, { state }) {
+	TemplateComment(node, { state }) {
 		const migrated = migrate_svelte_ignore(node.data);
 		if (migrated !== node.data) {
 			state.str.overwrite(node.start + '<!--'.length, node.end - '-->'.length, migrated);
@@ -1707,14 +1707,14 @@ function extract_type_and_comment(declarator, state, path) {
 }
 
 // Ensure modifiers are applied in the same order as Svelte 4
-const modifier_order = [
+const modifier_order = /** @type {const} */ ([
 	'preventDefault',
 	'stopPropagation',
 	'stopImmediatePropagation',
 	'self',
 	'trusted',
 	'once'
-];
+]);
 
 /**
  * @param {AST.RegularElement | AST.SvelteElement | AST.SvelteWindow | AST.SvelteDocument | AST.SvelteBody} element

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -1,5 +1,4 @@
 /** @import { AST } from '#compiler' */
-/** @import { Comment } from 'estree' */
 // @ts-expect-error acorn type definitions are borked in the release we use
 import { isIdentifierStart, isIdentifierChar } from 'acorn';
 import fragment from './state/fragment.js';

--- a/packages/svelte/src/compiler/phases/1-parse/state/element.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/element.js
@@ -59,7 +59,7 @@ export default function element(parser) {
 		parser.eat('-->', true);
 
 		parser.append({
-			type: 'Comment',
+			type: 'TemplateComment',
 			start,
 			end: parser.index,
 			data
@@ -302,7 +302,7 @@ export default function element(parser) {
 	if (is_top_level_script_or_style) {
 		parser.eat('>', true);
 
-		/** @type {AST.Comment | null} */
+		/** @type {AST.TemplateComment | null} */
 		let prev_comment = null;
 		for (let i = current.fragment.nodes.length - 1; i >= 0; i--) {
 			const node = current.fragment.nodes[i];
@@ -311,7 +311,7 @@ export default function element(parser) {
 				break;
 			}
 
-			if (node.type === 'Comment') {
+			if (node.type === 'TemplateComment') {
 				prev_comment = node;
 				break;
 			} else if (node.type !== 'Text' || node.data.trim()) {

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -89,13 +89,13 @@ const visitors = {
 		/** @type {string[]} */
 		const ignores = [];
 
-		if (parent?.type === 'Fragment' && node.type !== 'Comment' && node.type !== 'Text') {
+		if (parent?.type === 'Fragment' && node.type !== 'TemplateComment' && node.type !== 'Text') {
 			const idx = parent.nodes.indexOf(/** @type {any} */ (node));
 
 			for (let i = idx - 1; i >= 0; i--) {
 				const prev = parent.nodes[i];
 
-				if (prev.type === 'Comment') {
+				if (prev.type === 'TemplateComment') {
 					ignores.push(
 						...extract_svelte_ignore(
 							prev.start + 4 /* '<!--'.length */,

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SnippetBlock.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SnippetBlock.js
@@ -71,7 +71,7 @@ export function SnippetBlock(node, context) {
 				(node) =>
 					node.type !== 'SnippetBlock' &&
 					(node.type !== 'Text' || node.data.trim()) &&
-					node.type !== 'Comment'
+					node.type !== 'TemplateComment'
 			)
 		) {
 			e.snippet_conflict(node);

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Text.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Text.js
@@ -34,7 +34,7 @@ export function Text(node, context) {
 			for (const child of parent.nodes) {
 				if (child === node) break;
 
-				if (child.type === 'Comment') {
+				if (child.type === 'TemplateComment') {
 					is_ignored ||= extract_svelte_ignore(
 						child.start + 4,
 						child.data,

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/index.js
@@ -510,7 +510,7 @@ export function check_element(node, context) {
 		}
 		case 'figure': {
 			const children = node.fragment.nodes.filter((node) => {
-				if (node.type === 'Comment') return false;
+				if (node.type === 'TemplateComment') return false;
 				if (node.type === 'Text') return regex_not_whitespace.test(node.data);
 				return true;
 			});

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/component.js
@@ -127,14 +127,14 @@ export function visit_component(node, context) {
 		context.visit(attribute, attribute.type === 'LetDirective' ? default_state : context.state);
 	}
 
-	/** @type {AST.Comment[]} */
+	/** @type {AST.TemplateComment[]} */
 	let comments = [];
 
 	/** @type {Record<string, AST.Fragment['nodes']>} */
 	const nodes = { default: [] };
 
 	for (const child of node.fragment.nodes) {
-		if (child.type === 'Comment') {
+		if (child.type === 'TemplateComment') {
 			comments.push(child);
 			continue;
 		}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/element.js
@@ -98,7 +98,7 @@ export function validate_element(node, context) {
 			} else if (
 				parent.body.nodes.filter(
 					(n) =>
-						n.type !== 'Comment' &&
+						n.type !== 'TemplateComment' &&
 						n.type !== 'ConstTag' &&
 						(n.type !== 'Text' || n.data.trim() !== '')
 				).length > 1

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -19,7 +19,6 @@ import { BlockStatement } from './visitors/BlockStatement.js';
 import { BreakStatement } from './visitors/BreakStatement.js';
 import { CallExpression } from './visitors/CallExpression.js';
 import { ClassBody } from './visitors/ClassBody.js';
-import { Comment } from './visitors/Comment.js';
 import { Component } from './visitors/Component.js';
 import { ConstTag } from './visitors/ConstTag.js';
 import { DebugTag } from './visitors/DebugTag.js';
@@ -53,6 +52,7 @@ import { SvelteBoundary } from './visitors/SvelteBoundary.js';
 import { SvelteHead } from './visitors/SvelteHead.js';
 import { SvelteSelf } from './visitors/SvelteSelf.js';
 import { SvelteWindow } from './visitors/SvelteWindow.js';
+import { TemplateComment } from './visitors/TemplateComment.js';
 import { TitleElement } from './visitors/TitleElement.js';
 import { TransitionDirective } from './visitors/TransitionDirective.js';
 import { UpdateExpression } from './visitors/UpdateExpression.js';
@@ -96,7 +96,6 @@ const visitors = {
 	BreakStatement,
 	CallExpression,
 	ClassBody,
-	Comment,
 	Component,
 	ConstTag,
 	DebugTag,
@@ -130,6 +129,7 @@ const visitors = {
 	SvelteHead,
 	SvelteSelf,
 	SvelteWindow,
+	TemplateComment,
 	TitleElement,
 	TransitionDirective,
 	UpdateExpression,

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/CallExpression.js
@@ -82,7 +82,7 @@ export function CallExpression(node, context) {
 		['debug', 'dir', 'error', 'group', 'groupCollapsed', 'info', 'log', 'trace', 'warn'].includes(
 			node.callee.property.name
 		) &&
-		node.arguments.some((arg) => arg.type !== 'Literal') // TODO more cases?
+		node.arguments.some((arg) => arg.type === 'SpreadElement' || !context.state.scope.evaluate(arg).is_known)
 	) {
 		return b.call(
 			node.callee,

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/TemplateComment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/TemplateComment.js
@@ -2,10 +2,10 @@
 /** @import { ComponentContext } from '../types' */
 
 /**
- * @param {AST.Comment} node
+ * @param {AST.TemplateComment} node
  * @param {ComponentContext} context
  */
-export function Comment(node, context) {
+export function TemplateComment(node, context) {
 	// We'll only get here if comments are not filtered out, which they are unless preserveComments is true
 	context.state.template.push_comment(node.data);
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
@@ -28,7 +28,7 @@ export const empty_comment = b.literal(EMPTY_COMMENT);
  * @param {ComponentContext} context
  */
 export function process_children(nodes, { visit, state }) {
-	/** @type {Array<AST.Text | AST.Comment | AST.ExpressionTag>} */
+	/** @type {Array<AST.Text | AST.TemplateComment | AST.ExpressionTag>} */
 	let sequence = [];
 
 	function flush() {
@@ -41,9 +41,9 @@ export function process_children(nodes, { visit, state }) {
 		for (let i = 0; i < sequence.length; i++) {
 			const node = sequence[i];
 
-			if (node.type === 'Text' || node.type === 'Comment') {
+			if (node.type === 'Text' || node.type === 'TemplateComment') {
 				quasi.value.cooked +=
-					node.type === 'Comment' ? `<!--${node.data}-->` : escape_html(node.data);
+					node.type === 'TemplateComment' ? `<!--${node.data}-->` : escape_html(node.data);
 			} else {
 				const evaluated = state.scope.evaluate(node.expression);
 
@@ -68,7 +68,7 @@ export function process_children(nodes, { visit, state }) {
 	for (let i = 0; i < nodes.length; i += 1) {
 		const node = nodes[i];
 
-		if (node.type === 'Text' || node.type === 'Comment' || node.type === 'ExpressionTag') {
+		if (node.type === 'Text' || node.type === 'TemplateComment' || node.type === 'ExpressionTag') {
 			sequence.push(node);
 		} else {
 			if (sequence.length > 0) {

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -165,7 +165,7 @@ export function clean_nodes(
 	const regular = [];
 
 	for (const node of nodes) {
-		if (node.type === 'Comment' && !preserve_comments) {
+		if (node.type === 'TemplateComment' && !preserve_comments) {
 			continue;
 		}
 
@@ -285,7 +285,7 @@ export function clean_nodes(
 	// and would still call node.replaceWith() on the script tag, it would be a no-op because the script tag has no parent.
 	if (trimmed.length === 1 && first.type === 'RegularElement' && first.name === 'script') {
 		trimmed.push({
-			type: 'Comment',
+			type: 'TemplateComment',
 			data: '',
 			start: -1,
 			end: -1

--- a/packages/svelte/src/compiler/types/css.d.ts
+++ b/packages/svelte/src/compiler/types/css.d.ts
@@ -15,7 +15,7 @@ export namespace _CSS {
 			end: number;
 			styles: string;
 			/** Possible comment atop the style tag */
-			comment: AST.Comment | null;
+			comment: AST.TemplateComment | null;
 		};
 	}
 

--- a/packages/svelte/src/compiler/types/legacy-nodes.d.ts
+++ b/packages/svelte/src/compiler/types/legacy-nodes.d.ts
@@ -210,7 +210,7 @@ export interface LegacyWindow extends BaseElement {
 }
 
 export interface LegacyComment extends BaseNode {
-	type: 'Comment';
+	type: 'TemplateComment';
 	/** the contents of the comment */
 	data: string;
 	/** any svelte-ignore directives — <!-- svelte-ignore a b c --> would result in ['a', 'b', 'c'] */

--- a/packages/svelte/src/compiler/types/template.d.ts
+++ b/packages/svelte/src/compiler/types/template.d.ts
@@ -43,7 +43,7 @@ export namespace AST {
 
 	export interface Fragment {
 		type: 'Fragment';
-		nodes: Array<Text | Tag | ElementLike | Block | Comment>;
+		nodes: Array<Text | Tag | ElementLike | Block | TemplateComment>;
 		/** @internal */
 		metadata: {
 			/**
@@ -144,9 +144,8 @@ export namespace AST {
 	}
 
 	/** An HTML comment */
-	// TODO rename to disambiguate
-	export interface Comment extends BaseNode {
-		type: 'Comment';
+	export interface TemplateComment extends BaseNode {
+		type: 'TemplateComment';
 		/** the contents of the comment */
 		data: string;
 	}
@@ -247,7 +246,17 @@ export namespace AST {
 		name: string;
 		/** The 'y' in `on:x={y}` */
 		expression: null | Expression;
-		modifiers: string[]; // TODO specify
+		modifiers: Array<
+			| 'capture'
+			| 'nonpassive'
+			| 'once'
+			| 'passive'
+			| 'preventDefault'
+			| 'self'
+			| 'stopImmediatePropagation'
+			| 'stopPropagation'
+			| 'trusted'
+		>;
 		/** @internal */
 		metadata: {
 			expression: ExpressionMetadata;
@@ -604,7 +613,7 @@ export namespace AST {
 		| AST.SpreadAttribute
 		| Directive
 		| AST.AttachTag
-		| AST.Comment
+		| AST.TemplateComment
 		| Block;
 
 	export type SvelteNode = Node | TemplateNode | AST.Fragment | _CSS.Node | Script;

--- a/packages/svelte/tests/parser-legacy/samples/comment-with-ignores/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/comment-with-ignores/output.json
@@ -5,7 +5,7 @@
 		"end": 31,
 		"children": [
 			{
-				"type": "Comment",
+				"type": "TemplateComment",
 				"start": 0,
 				"end": 31,
 				"data": " svelte-ignore foo, bar ",

--- a/packages/svelte/tests/parser-legacy/samples/comment/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/comment/output.json
@@ -5,7 +5,7 @@
 		"end": 18,
 		"children": [
 			{
-				"type": "Comment",
+				"type": "TemplateComment",
 				"start": 0,
 				"end": 18,
 				"data": " a comment ",

--- a/packages/svelte/tests/parser-legacy/samples/dynamic-element-string/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/dynamic-element-string/output.json
@@ -21,7 +21,7 @@
 				"data": "\n"
 			},
 			{
-				"type": "Comment",
+				"type": "TemplateComment",
 				"start": 45,
 				"end": 69,
 				"data": " prettier-ignore ",
@@ -83,7 +83,7 @@
 				"data": "\n"
 			},
 			{
-				"type": "Comment",
+				"type": "TemplateComment",
 				"start": 162,
 				"end": 186,
 				"data": " prettier-ignore ",

--- a/packages/svelte/tests/parser-modern/samples/comment-before-script/output.json
+++ b/packages/svelte/tests/parser-modern/samples/comment-before-script/output.json
@@ -8,7 +8,7 @@
 		"type": "Fragment",
 		"nodes": [
 			{
-				"type": "Comment",
+				"type": "TemplateComment",
 				"start": 0,
 				"end": 27,
 				"data": "should not error out"

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1145,7 +1145,7 @@ declare module 'svelte/compiler' {
 
 		export interface Fragment {
 			type: 'Fragment';
-			nodes: Array<Text | Tag | ElementLike | Block | Comment>;
+			nodes: Array<Text | Tag | ElementLike | Block | TemplateComment>;
 		}
 
 		export interface Root extends BaseNode {
@@ -1220,9 +1220,8 @@ declare module 'svelte/compiler' {
 		}
 
 		/** An HTML comment */
-		// TODO rename to disambiguate
-		export interface Comment extends BaseNode {
-			type: 'Comment';
+		export interface TemplateComment extends BaseNode {
+			type: 'TemplateComment';
 			/** the contents of the comment */
 			data: string;
 		}
@@ -1296,7 +1295,17 @@ declare module 'svelte/compiler' {
 			name: string;
 			/** The 'y' in `on:x={y}` */
 			expression: null | Expression;
-			modifiers: string[];
+			modifiers: Array<
+				| 'capture'
+				| 'nonpassive'
+				| 'once'
+				| 'passive'
+				| 'preventDefault'
+				| 'self'
+				| 'stopImmediatePropagation'
+				| 'stopPropagation'
+				| 'trusted'
+			>;
 		}
 
 		/** A `style:` directive */
@@ -1544,7 +1553,7 @@ declare module 'svelte/compiler' {
 			| AST.SpreadAttribute
 			| Directive
 			| AST.AttachTag
-			| AST.Comment
+			| AST.TemplateComment
 			| Block;
 
 		export type SvelteNode = Node | TemplateNode | AST.Fragment | _CSS.Node | Script;
@@ -1599,7 +1608,7 @@ declare module 'svelte/compiler' {
 				end: number;
 				styles: string;
 				/** Possible comment atop the style tag */
-				comment: AST.Comment | null;
+				comment: AST.TemplateComment | null;
 			};
 		}
 


### PR DESCRIPTION
This clears up some `// TODO` comments. It shouldn't change much behavior-wise, as it's mostly tweaks to types. 

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
