### PR TITLE
chore: emit `await_reactivity_loss` in `for await` loops

### DIFF
--- a/.changeset/quiet-donuts-wonder.md
+++ b/.changeset/quiet-donuts-wonder.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: emit `await_reactivity_loss` in `for await` loops

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -27,6 +27,7 @@ import { EachBlock } from './visitors/EachBlock.js';
 import { ExportNamedDeclaration } from './visitors/ExportNamedDeclaration.js';
 import { ExpressionStatement } from './visitors/ExpressionStatement.js';
 import { Fragment } from './visitors/Fragment.js';
+import { ForOfStatement } from './visitors/ForOfStatement.js';
 import { FunctionDeclaration } from './visitors/FunctionDeclaration.js';
 import { FunctionExpression } from './visitors/FunctionExpression.js';
 import { HtmlTag } from './visitors/HtmlTag.js';
@@ -104,6 +105,7 @@ const visitors = {
 	ExportNamedDeclaration,
 	ExpressionStatement,
 	Fragment,
+	ForOfStatement,
 	FunctionDeclaration,
 	FunctionExpression,
 	HtmlTag,

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -26,8 +26,8 @@ import { DebugTag } from './visitors/DebugTag.js';
 import { EachBlock } from './visitors/EachBlock.js';
 import { ExportNamedDeclaration } from './visitors/ExportNamedDeclaration.js';
 import { ExpressionStatement } from './visitors/ExpressionStatement.js';
-import { Fragment } from './visitors/Fragment.js';
 import { ForOfStatement } from './visitors/ForOfStatement.js';
+import { Fragment } from './visitors/Fragment.js';
 import { FunctionDeclaration } from './visitors/FunctionDeclaration.js';
 import { FunctionExpression } from './visitors/FunctionExpression.js';
 import { HtmlTag } from './visitors/HtmlTag.js';
@@ -104,8 +104,8 @@ const visitors = {
 	EachBlock,
 	ExportNamedDeclaration,
 	ExpressionStatement,
-	Fragment,
 	ForOfStatement,
+	Fragment,
 	FunctionDeclaration,
 	FunctionExpression,
 	HtmlTag,

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/ForOfStatement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/ForOfStatement.js
@@ -1,0 +1,20 @@
+/** @import { Expression, ForOfStatement, Pattern, Statement, VariableDeclaration } from 'estree' */
+/** @import { ComponentContext } from '../types' */
+import * as b from '#compiler/builders';
+import { dev, is_ignored } from '../../../../state.js';
+
+/**
+ * @param {ForOfStatement} node
+ * @param {ComponentContext} context
+ */
+export function ForOfStatement(node, context) {
+	if (node.await && dev && !is_ignored(node, 'await_reactivity_loss')) {
+		const left = /** @type {VariableDeclaration | Pattern} */ (context.visit(node.left));
+		const argument = /** @type {Expression} */ (context.visit(node.right));
+		const body = /** @type {Statement} */ (context.visit(node.body));
+		const right = b.call('$.for_await_track_reactivity_loss', argument);
+		return b.for_of(left, right, body, true);
+	}
+
+	context.next();
+}

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -215,6 +215,23 @@ export function export_default(declaration) {
 }
 
 /**
+ * @param {ESTree.VariableDeclaration | ESTree.Pattern} left
+ * @param {ESTree.Expression} right
+ * @param {ESTree.Statement} body
+ * @param {boolean} [await]
+ * @returns {ESTree.ForOfStatement}
+ */
+export function for_of(left, right, body, await = false) {
+	return {
+		type: 'ForOfStatement',
+		left,
+		right,
+		body,
+		await
+	};
+}
+
+/**
  * @param {ESTree.Identifier} id
  * @param {ESTree.Pattern[]} params
  * @param {ESTree.BlockStatement} body

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -218,16 +218,16 @@ export function export_default(declaration) {
  * @param {ESTree.VariableDeclaration | ESTree.Pattern} left
  * @param {ESTree.Expression} right
  * @param {ESTree.Statement} body
- * @param {boolean} [await]
+ * @param {boolean} [_await]
  * @returns {ESTree.ForOfStatement}
  */
-export function for_of(left, right, body, await = false) {
+export function for_of(left, right, body, _await = false) {
 	return {
 		type: 'ForOfStatement',
 		left,
 		right,
 		body,
-		await
+		await: _await
 	};
 }
 

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -98,7 +98,11 @@ export {
 	props_id,
 	with_script
 } from './dom/template.js';
-export { save, track_reactivity_loss } from './reactivity/async.js';
+export {
+	for_await_track_reactivity_loss,
+	save,
+	track_reactivity_loss
+} from './reactivity/async.js';
 export { flushSync as flush, suspend } from './reactivity/batch.js';
 export {
 	async_derived,

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -150,6 +150,7 @@ export async function* for_await_track_reactivity_loss(async_iterator) {
 	} finally {
 		// If the iterator had a normal completion and `return` is defined on the iterator, call it and return the value
 		if (normal_completion && async_iterator.return !== undefined) {
+			// eslint-disable-next-line no-unsafe-finally
 			return /** @type {TReturn} */ (
 				(await track_reactivity_loss(async_iterator.return()))().value
 			);

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -126,7 +126,7 @@ export async function track_reactivity_loss(promise) {
  * after the `async_iterator` return resolves (if it runs)
  * @template T
  * @template TReturn
- * @param {Iterable<T, TReturn> | AsyncIterable<T, TReturn>} iterable
+ * @param {Iterable<T> | AsyncIterable<T>} iterable
  * @returns {AsyncGenerator<T, TReturn | undefined>}
  */
 export async function* for_await_track_reactivity_loss(iterable) {

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -140,6 +140,10 @@ export async function* for_await_track_reactivity_loss(iterable) {
 	// @ts-ignore
 	const iterator = iterable[Symbol.asyncIterator]?.() ?? iterable[Symbol.iterator]?.();
 
+	if (iterator === undefined) {
+		throw new TypeError('value is not async iterable');
+	}
+
 	/** Whether the completion of the iterator was "normal", meaning it wasn't ended via `break` or a similar method */
 	let normal_completion = false;
 	try {

--- a/packages/svelte/tests/runtime-runes/samples/async-reactivity-loss-for-await/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-reactivity-loss-for-await/_config.js
@@ -1,0 +1,24 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	html: `<button>a</button><button>b</button><p>pending</p>`,
+
+	async test({ assert, target, warnings }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, '<button>a</button><button>b</button><h1>3</h1>');
+
+		assert.equal(
+			warnings[0],
+			'Detected reactivity loss when reading `values[1]`. This happens when state is read in an async function after an earlier `await`'
+		);
+
+		assert.equal(warnings[1].name, 'TracedAtError');
+
+		assert.equal(warnings.length, 2);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-reactivity-loss-for-await/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-reactivity-loss-for-await/main.svelte
@@ -1,0 +1,24 @@
+<script>
+	let values = $state([1, 2]);
+
+	async function get_total() {
+		let total = 0;
+
+		for await (const n of values) {
+			total += n;
+		}
+
+		return total;
+	}
+</script>
+
+<button onclick={() => values[0]++}>a</button>
+<button onclick={() => values[1]++}>b</button>
+
+<svelte:boundary>
+	<h1>{await get_total()}</h1>
+
+	{#snippet pending()}
+		<p>pending</p>
+	{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
Currently, `await` expressions not inside an async derived are wrapped in `track_reactivity_loss` in dev to warn of a reactivity loss. 
However, `for await` loops are not. This PR fixes that. 

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
