### PR TITLE
fix: add types for SVG bindable attributes

### DIFF
--- a/.changeset/cuddly-feet-doubt.md
+++ b/.changeset/cuddly-feet-doubt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add bindable dimension attributes types to SVG and MathML elements

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -464,14 +464,15 @@ export interface DOMAttributes<T extends EventTarget> {
 	onfullscreenerror?: EventHandler<Event, T> | undefined | null;
 	onfullscreenerrorcapture?: EventHandler<Event, T> | undefined | null;
 
-	xmlns?: string | undefined | null;
-
+	// Dimensions
 	readonly 'bind:contentRect'?: DOMRectReadOnly | undefined | null;
 	readonly 'bind:contentBoxSize'?: Array<ResizeObserverSize> | undefined | null;
 	readonly 'bind:borderBoxSize'?: Array<ResizeObserverSize> | undefined | null;
 	readonly 'bind:devicePixelContentBoxSize'?: Array<ResizeObserverSize> | undefined | null;
 	readonly 'bind:clientWidth'?: number | undefined | null;
 	readonly 'bind:clientHeight'?: number | undefined | null;
+
+	xmlns?: string | undefined | null;
 }
 
 // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/


### PR DESCRIPTION
The following props are bindable in SVG elements, but the type definition only includes them for HTML elements.

- contentRect
- contentBoxSize
- borderBoxSize
- devicePixelContentBoxSize
- clientWidth
- clientHeight

This means that currently, svelte-check throws an error for this line:

```
<text x="0" y="14" bind:contentRect={null, rect => console.log({rect})}>svg element</text>
```

Here's the error:

```
Error: Object literal may only specify known properties, and '"bind:contentRect"' does not exist in type 'HTMLProps<"text", SVGAttributes<any>>'. (ts)
```

I moved the definitions for these attributes from `HTMLAttributes` to the parent `DOMAttributes` object so they can be used by both HTML and SVG elements.

---

Weirdly, direct binding (without get/set functions) like below does **not** get flagged as an error. I'm not sure why.

```
<text x="0" y="14" bind:contentRect={rect}>svg element</text>
```

That _might_ indicate there is a deeper issue here in the typechecking process. But in the meantime this updated type definition seems to solve the issue. :)

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
