### PR TITLE
fix: double event processing in Firefox (#16522)

### DIFF
--- a/.changeset/chilly-bananas-train.md
+++ b/.changeset/chilly-bananas-train.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Fix double event processing in firefox due to event object being garbage collected (#16522)
+fix: double event processing in firefox due to event object being garbage collected

--- a/.changeset/chilly-bananas-train.md
+++ b/.changeset/chilly-bananas-train.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Fix double event processing in firefox due to event object being garbage collected (#16522)

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -143,7 +143,7 @@ export function delegate(events) {
 
 // used to store the reference to the currently propagated event
 // to prevent garbage collection between microtasks in Firefox
-// If the event object is GCed to early, the expando __root property
+// If the event object is GCed too early, the expando __root property
 // set on the event object is lost, causing the event delegation
 // to process the event twice
 let last_propagated_event = null;

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -141,6 +141,13 @@ export function delegate(events) {
 	}
 }
 
+// used to store the reference to the currently propagated event
+// to prevent garbage collection between microtasks in Firefox
+// If the event object is GCed to early, the expando __root property
+// set on the event object is lost, causing the event delegation
+// to process the event twice
+let last_propagated_event = null;
+
 /**
  * @this {EventTarget}
  * @param {Event} event
@@ -152,6 +159,8 @@ export function handle_event_propagation(event) {
 	var event_name = event.type;
 	var path = event.composedPath?.() || [];
 	var current_target = /** @type {null | Element} */ (path[0] || event.target);
+
+	last_propagated_event = event;
 
 	// composedPath contains list of nodes the event has propagated through.
 	// We check __root to skip all nodes below it in case this is a


### PR DESCRIPTION
Firefox seems to garbage collect event objects during event propagation if no global/shared reference to the event object is kept between multiple event handlers. That discards the `__root` marker set on the event object to early, leading to duplicate processing.

I am not sure what is a good way to test this.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs (#16522)
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
