### PR TITLE
fix: nullify `last_propagated_event` to avoid memory leak

### DIFF
--- a/.changeset/purple-hairs-glow.md
+++ b/.changeset/purple-hairs-glow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: nullify `last_propagated_event` to avoid memory leak

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -146,6 +146,7 @@ export function delegate(events) {
 // If the event object is GCed too early, the expando __root property
 // set on the event object is lost, causing the event delegation
 // to process the event twice
+/** @type {Event | null} */
 let last_propagated_event = null;
 
 /**
@@ -182,6 +183,7 @@ export function handle_event_propagation(event) {
 			// chain in case someone manually dispatches the same event object again.
 			// @ts-expect-error
 			event.__root = handler_element;
+			last_propagated_event = null;
 			return;
 		}
 


### PR DESCRIPTION
Small fix to #16527— since `last_propagated_event` is never nullified, it could leak an event object. 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
