### PR TITLE
fix: emit `snippet_invalid_export` instead of `undefined_export` for exported snippets

### DIFF
--- a/.changeset/thick-snakes-look.md
+++ b/.changeset/thick-snakes-look.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: emit `snippet_invalid_export` instead of `undefined_export` for exported snippets

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -789,7 +789,14 @@ export function analyze_component(root, source, options) {
 				if (specifier.local.type !== 'Identifier') continue;
 
 				const binding = analysis.module.scope.get(specifier.local.name);
-				if (!binding) e.export_undefined(specifier, specifier.local.name);
+				if (!binding) {
+					const instance_binding = analysis.instance.scope.get(specifier.local.name);
+					if (instance_binding?.kind === 'snippet') {
+						e.snippet_invalid_export(specifier);
+					} else {
+						e.export_undefined(specifier, specifier.local.name);
+					}
+				}
 			}
 		}
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -790,8 +790,8 @@ export function analyze_component(root, source, options) {
 
 				const binding = analysis.module.scope.get(specifier.local.name);
 				if (!binding) {
-					const instance_binding = analysis.instance.scope.get(specifier.local.name);
-					if (instance_binding?.kind === 'snippet') {
+					const template_binding = analysis.template.scope.get(specifier.local.name);
+					if (template_binding?.kind === 'snippet') {
 						e.snippet_invalid_export(specifier);
 					} else {
 						e.export_undefined(specifier, specifier.local.name);

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -787,14 +787,13 @@ export function analyze_component(root, source, options) {
 		if (node.type === 'ExportNamedDeclaration' && node.specifiers !== null && node.source == null) {
 			for (const specifier of node.specifiers) {
 				if (specifier.local.type !== 'Identifier') continue;
-
-				const binding = analysis.module.scope.get(specifier.local.name);
+				const name = specifier.local.name;
+				const binding = analysis.module.scope.get(name);
 				if (!binding) {
-					const template_binding = analysis.template.scope.get(specifier.local.name);
-					if (template_binding?.kind === 'snippet') {
+					if ([...analysis.snippets].find((snippet) => snippet.expression.name === name)) {
 						e.snippet_invalid_export(specifier);
 					} else {
-						e.export_undefined(specifier, specifier.local.name);
+						e.export_undefined(specifier, name);
 					}
 				}
 			}

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -526,7 +526,6 @@ export function analyze_component(root, source, options) {
 			has_global: false
 		},
 		source,
-		undefined_exports: new Map(),
 		snippet_renderers: new Map(),
 		snippets: new Set(),
 		async_deriveds: new Set()

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SnippetBlock.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SnippetBlock.js
@@ -35,11 +35,6 @@ export function SnippetBlock(node, context) {
 	if (can_hoist) {
 		const binding = /** @type {Binding} */ (context.state.scope.get(name));
 		context.state.analysis.module.scope.declarations.set(name, binding);
-	} else {
-		const undefined_export = context.state.analysis.undefined_exports.get(name);
-		if (undefined_export) {
-			e.snippet_invalid_export(undefined_export);
-		}
 	}
 
 	node.metadata.can_hoist = can_hoist;

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -95,7 +95,6 @@ export interface ComponentAnalysis extends Analysis {
 	};
 	/** @deprecated use `source` from `state.js` instead */
 	source: string;
-	undefined_exports: Map<string, Node>;
 	/**
 	 * Every render tag/component, and whether it could be definitively resolved or not
 	 */

--- a/packages/svelte/tests/compiler-errors/samples/snippet-invalid-export/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/snippet-invalid-export/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'snippet_invalid_export',
+		message:
+			'An exported snippet can only reference things declared in a `<script module>`, or other exportable snippets',
+		position: [26, 29]
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/snippet-invalid-export/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/snippet-invalid-export/main.svelte
@@ -1,0 +1,11 @@
+<script module>
+	export { foo }
+</script>
+
+<script>
+	let x = 42;
+</script>
+
+{#snippet foo()}
+	{x}
+{/snippet}


### PR DESCRIPTION
Closes #16474
I'm not entirely sure if this is the best way to do this, as I don't know if there's any other reason that a snippet wouldn't be able to be exported, but this should work.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
