### PR TITLE
docs: remove 'thus', fix some phrasing

### DIFF
--- a/documentation/docs/03-template-syntax/08-@html.md
+++ b/documentation/docs/03-template-syntax/08-@html.md
@@ -22,7 +22,7 @@ It also will not compile Svelte code.
 
 ## Styling
 
-Content rendered this way is 'invisible' to Svelte and thus will not receive [scoped styles](scoped-styles). In other words, this will not work, and the `a` and `img` styles will be regarded as unused:
+Content rendered this way is 'invisible' to Svelte and as such will not receive [scoped styles](scoped-styles). In other words, this will not work, and the `a` and `img` styles will be regarded as unused:
 
 <!-- prettier-ignore -->
 ```svelte

--- a/documentation/docs/06-runtime/03-lifecycle-hooks.md
+++ b/documentation/docs/06-runtime/03-lifecycle-hooks.md
@@ -41,7 +41,7 @@ If a function is returned from `onMount`, it will be called when the component i
 </script>
 ```
 
-> [!NOTE] This behaviour will only work when the function passed to `onMount` _synchronously_ returns a value. `async` functions always return a `Promise`, and thus cannot _synchronously_ return a function.
+> [!NOTE] This behaviour will only work when the function passed to `onMount` is _synchronous_. `async` functions always return a `Promise`.
 
 ## `onDestroy`
 

--- a/documentation/docs/07-misc/07-v5-migration-guide.md
+++ b/documentation/docs/07-misc/07-v5-migration-guide.md
@@ -245,7 +245,7 @@ In Svelte 4, you can add event modifiers to handlers:
 <button on:click|once|preventDefault={handler}>...</button>
 ```
 
-Modifiers are specific to `on:` and thus do not work with modern event handlers. Adding things like `event.preventDefault()` inside the handler itself is preferable, since all the logic lives in one place rather than being split between handler and modifiers.
+Modifiers are specific to `on:` and so do not work with modern event handlers. Adding things like `event.preventDefault()` inside the handler itself is preferable, since all the logic lives in one place rather than being split between handler and modifiers.
 
 Since event handlers are just functions, you can create your own wrappers as necessary:
 
@@ -340,7 +340,7 @@ When spreading props, local event handlers must go _after_ the spread, or they r
 
 ## Snippets instead of slots
 
-In Svelte 4, content can be passed to components using slots. Svelte 5 replaces them with snippets, which are more powerful and flexible, and so slots have been deprecated in Svelte 5.
+In Svelte 4, content can be passed to components using slots. Svelte 5 replaces them with snippets, which are more powerful and flexible, and so slots are deprecated in Svelte 5.
 
 They continue to work, however, and you can pass snippets to a component that uses slots:
 
@@ -835,7 +835,7 @@ Assignments to destructured parts of a `@const` declaration are no longer allowe
 
 ### :is(...), :has(...), and :where(...) are scoped
 
-Previously, Svelte did not analyse selectors inside `:is(...)`, `:has(...)`, and `:where(...)`, effectively treating them as global. Svelte 5 analyses them in the context of the current component. Thus, some selectors may now be treated as unused if they were relying on this treatment. To fix this, use `:global(...)` inside the `:is(...)/:has(...)/:where(...)` selectors.
+Previously, Svelte did not analyse selectors inside `:is(...)`, `:has(...)`, and `:where(...)`, effectively treating them as global. Svelte 5 analyses them in the context of the current component. Some selectors may now therefore be treated as unused if they were relying on this treatment. To fix this, use `:global(...)` inside the `:is(...)/:has(...)/:where(...)` selectors.
 
 When using Tailwind's `@apply` directive, add a `:global` selector to preserve rules that use Tailwind-generated `:is(...)` selectors:
 
@@ -964,7 +964,7 @@ Since these mismatches are extremely rare, Svelte 5 assumes that the values are 
 
 ### Hydration works differently
 
-Svelte 5 makes use of comments during server-side rendering which are used for more robust and efficient hydration on the client. Thus, you shouldn't remove comments from your HTML output if you intend to hydrate it, and if you manually authored HTML to be hydrated by a Svelte component, you need to adjust that HTML to include said comments at the correct positions.
+Svelte 5 makes use of comments during server-side rendering which are used for more robust and efficient hydration on the client. You therefore should not remove comments from your HTML output if you intend to hydrate it, and if you manually authored HTML to be hydrated by a Svelte component, you need to adjust that HTML to include said comments at the correct positions.
 
 ### `onevent` attributes are delegated
 

--- a/documentation/docs/98-reference/.generated/compile-errors.md
+++ b/documentation/docs/98-reference/.generated/compile-errors.md
@@ -392,7 +392,7 @@ In legacy mode, it was possible to reassign or bind to the each block argument i
 {/each}
 ```
 
-This turned out to be buggy and unpredictable, particularly when working with derived values (such as `array.map(...)`), and thus is forbidden in runes mode. You can achieve the same outcome by using the index instead:
+This turned out to be buggy and unpredictable, particularly when working with derived values (such as `array.map(...)`), and as such is forbidden in runes mode. You can achieve the same outcome by using the index instead:
 
 ```svelte
 <script>

--- a/packages/svelte/messages/compile-errors/script.md
+++ b/packages/svelte/messages/compile-errors/script.md
@@ -54,7 +54,7 @@ In legacy mode, it was possible to reassign or bind to the each block argument i
 {/each}
 ```
 
-This turned out to be buggy and unpredictable, particularly when working with derived values (such as `array.map(...)`), and thus is forbidden in runes mode. You can achieve the same outcome by using the index instead:
+This turned out to be buggy and unpredictable, particularly when working with derived values (such as `array.map(...)`), and as such is forbidden in runes mode. You can achieve the same outcome by using the index instead:
 
 ```svelte
 <script>


### PR DESCRIPTION
#16550 made various 'corrections', some of which made sense ('server-side rendering' should always be hyphenated), others less so. Our docs strive for a conversational tone, in which colloquialisms (such as 'as such' for 'therefore') are preferable to stilted words like 'thus' which just don't occur in spoken English and make everything sound clunky. Nevertheless this PR tries to find a balance between them, while fixing some of the awkward phrasing.

Some usages of 'as such' were, I would argue, perfectly fine. For example in the context of

> Content rendered this way is 'invisible' to Svelte and as such will not receive scoped styles'

'as such' expands to

> Content rendered this way is 'invisible' to Svelte and (as it is invisible to Svelte) will not receive scoped styles'

unless you take the overly prescriptive and not-universally-agreed upon view that 'such' in this context can only refer to a noun.

In a programming context, 'deprecated' is most commonly used as a status rather than an action, so 'are deprecated' doesn't need to be changed to 'have been deprecated' which makes things less consistent.