### PR TITLE
chore: remove `b.async`

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/shared/assignments.js
+++ b/packages/svelte/src/compiler/phases/3-transform/shared/assignments.js
@@ -65,13 +65,14 @@ export function visit_assignment_expression(node, context, build_assignment) {
 				statements.push(b.return(rhs));
 			}
 
-			const iife = b.arrow([rhs], b.block(statements));
-
-			const iife_is_async =
+			const async =
 				is_expression_async(value) ||
 				assignments.some((assignment) => is_expression_async(assignment));
 
-			return iife_is_async ? b.await(b.call(b.async(iife), value)) : b.call(iife, value);
+			const iife = b.arrow([rhs], b.block(statements), async);
+			const call = b.call(iife, value);
+
+			return async ? b.await(call) : call;
 		}
 
 		const sequence = b.sequence(assignments);

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -57,15 +57,6 @@ export function assignment(operator, left, right) {
 }
 
 /**
- * @template T
- * @param {T & ESTree.BaseFunction} func
- * @returns {T & ESTree.BaseFunction}
- */
-export function async(func) {
-	return { ...func, async: true };
-}
-
-/**
  * @param {ESTree.Expression} argument
  * @returns {ESTree.AwaitExpression}
  */


### PR DESCRIPTION
noticed while reviewing #16542 — we have a `b.async` helper that just adds the `async` flag to an existing function expression, when we should just be passing that option to `b.arrow` or `b.function` etc