### PR TITLE
chore: switch to jrdigewell version of remapping library

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -166,7 +166,7 @@
     "vitest": "^2.1.9"
   },
   "dependencies": {
-    "@ampproject/remapping": "^2.3.0",
+    "@jridgewell/remapping": "^2.3.4",
     "@jridgewell/sourcemap-codec": "^1.5.0",
     "@sveltejs/acorn-typescript": "^1.0.5",
     "@types/estree": "^1.0.5",

--- a/packages/svelte/src/compiler/preprocess/index.js
+++ b/packages/svelte/src/compiler/preprocess/index.js
@@ -1,6 +1,6 @@
 /** @import { Processed, Preprocessor, MarkupPreprocessor, PreprocessorGroup } from './public.js' */
 /** @import { SourceUpdate, Source } from './private.js' */
-/** @import { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping' */
+/** @import { DecodedSourceMap, RawSourceMap } from '@jridgewell/remapping' */
 import { getLocator } from 'locate-character';
 import {
 	MappedCode,
@@ -25,7 +25,7 @@ class PreprocessResult {
 
 	// sourcemap_list is sorted in reverse order from last map (index 0) to first map (index -1)
 	// so we use sourcemap_list.unshift() to add new maps
-	// https://github.com/ampproject/remapping#multiple-transformations-of-a-file
+	// https://github.com/jridgewell/sourcemaps/tree/main/packages/remapping#multiple-transformations-of-a-file
 
 	/**
 	 * @default []

--- a/packages/svelte/src/compiler/preprocess/private.d.ts
+++ b/packages/svelte/src/compiler/preprocess/private.d.ts
@@ -1,4 +1,4 @@
-import { DecodedSourceMap } from '@ampproject/remapping';
+import { DecodedSourceMap } from '@jridgewell/remapping';
 import { Location } from 'locate-character';
 import { MappedCode } from '../utils/mapped_code.js';
 

--- a/packages/svelte/src/compiler/utils/mapped_code.js
+++ b/packages/svelte/src/compiler/utils/mapped_code.js
@@ -2,8 +2,8 @@
 /** @import { Processed } from '../preprocess/public.js' */
 /** @import { SourceMap } from 'magic-string' */
 /** @import { Source } from '../preprocess/private.js' */
-/** @import { DecodedSourceMap, SourceMapSegment, RawSourceMap } from '@ampproject/remapping' */
-import remapping from '@ampproject/remapping';
+/** @import { DecodedSourceMap, SourceMapSegment, RawSourceMap } from '@jridgewell/remapping' */
+import remapping from '@jridgewell/remapping';
 import { push_array } from './push_array.js';
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,9 @@ importers:
 
   packages/svelte:
     dependencies:
-      '@ampproject/remapping':
-        specifier: ^2.3.0
-        version: 2.3.0
+      '@jridgewell/remapping':
+        specifier: ^2.3.4
+        version: 2.3.4
       '@jridgewell/sourcemap-codec':
         specifier: ^1.5.0
         version: 1.5.0
@@ -456,6 +456,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
+
+  '@jridgewell/remapping@2.3.4':
+    resolution: {integrity: sha512-aG+WvAz17rhbzhKNkSeMLgbkPPK82ovXdONvmucbGhUqcroRFLLVhoGAk4xEI17gHpXgNX3sr0/B1ybRUsbEWw==}
 
   '@jridgewell/resolve-uri@3.1.1':
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
@@ -2775,6 +2778,11 @@ snapshots:
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@jridgewell/remapping@2.3.4':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.1': {}


### PR DESCRIPTION
 https://github.com/ampproject/remapping was archived. Strangely https://www.npmjs.com/package/@ampproject/remapping was not deprecated, but it looks like development has ceased on it

This fixes it for our users. It's still pulled into our `devDependencies` via `vitest`, so I filed an issue there: https://github.com/vitest-dev/vitest/issues/8417