### PR TITLE
fix: Add check for builtin custom elements in `set_custom_element_data`

### DIFF
--- a/.changeset/fuzzy-shrimps-dream.md
+++ b/.changeset/fuzzy-shrimps-dream.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: Add check for builtin custom elements in `set_custom_element_data`

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -241,7 +241,7 @@ export function set_custom_element_data(node, prop, value) {
 			(setters_cache.has(node.nodeName) ||
 			// customElements may not be available in browser extension contexts
 			!customElements ||
-			customElements.get(node.tagName.toLowerCase())
+			customElements.get(node.getAttribute('is') || node.tagName.toLowerCase())
 				? get_setters(node).includes(prop)
 				: value && typeof value === 'object')
 		) {

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -238,7 +238,7 @@ export function set_custom_element_data(node, prop, value) {
 			// Don't compute setters for custom elements while they aren't registered yet,
 			// because during their upgrade/instantiation they might add more setters.
 			// Instead, fall back to a simple "an object, then set as property" heuristic.
-			(setters_cache.has(node.nodeName) ||
+			(setters_cache.has(node.getAttribute('is') || node.nodeName) ||
 			// customElements may not be available in browser extension contexts
 			!customElements ||
 			customElements.get(node.getAttribute('is') || node.tagName.toLowerCase())
@@ -546,9 +546,10 @@ var setters_cache = new Map();
 
 /** @param {Element} element */
 function get_setters(element) {
-	var setters = setters_cache.get(element.nodeName);
+	var cache_key = element.getAttribute('is') || element.nodeName;
+	var setters = setters_cache.get(cache_key);
 	if (setters) return setters;
-	setters_cache.set(element.nodeName, (setters = []));
+	setters_cache.set(cache_key, (setters = []));
 
 	var descriptors;
 	var proto = element; // In the case of custom elements there might be setters on the instance

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/_config.js
@@ -20,5 +20,8 @@ export default test({
 		const [value1, value2] = target.querySelectorAll('value-element');
 		assert.equal(value1.shadowRoot?.innerHTML, '<span>test</span>');
 		assert.equal(value2.shadowRoot?.innerHTML, '<span>test</span>');
+
+		const value_builtin = target.querySelectorAll('div');
+		assert.equal(value_builtin.shadowRoot?.innerHTML, '<span>test</span>');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/_config.js
@@ -22,6 +22,6 @@ export default test({
 		assert.equal(value2.shadowRoot?.innerHTML, '<span>test</span>');
 
 		const value_builtin = target.querySelector('div');
-		assert.equal(value_builtin.shadowRoot?.innerHTML, '<span>test</span>');
+		assert.equal(value_builtin?.shadowRoot?.innerHTML, '<span>test</span>');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/_config.js
@@ -21,7 +21,7 @@ export default test({
 		assert.equal(value1.shadowRoot?.innerHTML, '<span>test</span>');
 		assert.equal(value2.shadowRoot?.innerHTML, '<span>test</span>');
 
-		const value_builtin = target.querySelectorAll('div');
+		const value_builtin = target.querySelector('div');
 		assert.equal(value_builtin.shadowRoot?.innerHTML, '<span>test</span>');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/main.svelte
@@ -15,6 +15,24 @@
 			}
 		});
 	}
+	if(!customElements.get('value-builtin')) {
+		customElements.define('value-builtin', class extends HTMLDivElement {
+
+			constructor() {
+				super();
+				this.attachShadow({ mode: 'open' });
+			}
+
+			set value(v) {
+				if (this.__value !== v) {
+					this.__value = v;
+					this.shadowRoot.innerHTML = `<span>${v}</span>`;
+				}
+			}
+		}, {
+			extends: "div"
+		});
+	}
 </script>
 
 <my-element string="test" object={{ test: true }}></my-element>
@@ -22,3 +40,4 @@
 
 <value-element value="test"></value-element>
 <value-element {...{value: "test"}}></value-element>
+<div is="value-builtin" value="test"></div>

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-attributes/main.svelte
@@ -30,7 +30,7 @@
 				}
 			}
 		}, {
-			extends: "div"
+			extends: 'div'
 		});
 	}
 </script>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Fixes #16591 

This PR introduces a check for builtin custom elements (`is` attribute) inside the `set_custom_element_data` helper in order to correctly set properties that have a setter.

I would like to add tests but I am not familiar with the codebase and wasn't able to find the correct path.