### PR TITLE
fix: avoid false-positive infinite loop error

### DIFF
--- a/.changeset/shaggy-donuts-wait.md
+++ b/.changeset/shaggy-donuts-wait.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid false-positive infinite loop error

--- a/packages/svelte/tests/runtime-runes/samples/effect-loop-3/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-loop-3/Component.svelte
@@ -1,0 +1,8 @@
+<script>
+	let a = $state(0);
+	$effect(() => {
+		a = 1;
+	});
+</script>
+
+{a}

--- a/packages/svelte/tests/runtime-runes/samples/effect-loop-3/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-loop-3/_config.js
@@ -1,0 +1,11 @@
+import { test } from '../../test';
+
+export default test({
+	mode: ['client', 'hydrate'],
+
+	compileOptions: {
+		dev: true
+	},
+
+	html: `1`.repeat(2000)
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-loop-3/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-loop-3/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import Component from './Component.svelte';
+</script>
+
+{#each Array(2000) as _, i}
+	<Component />
+{/each}


### PR DESCRIPTION
Checks each effect's execution count and only advances the overall flush count if an inidivual effect was executed many times, hinting at a loop

The count overall is kept in place because theoretically there could be other infinite loops happening with no user effect in the mix.

Fixes part of #16548

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
