### PR TITLE
fix: Unmount non deferred components immedietly

### DIFF
--- a/.changeset/cuddly-owls-smile.md
+++ b/.changeset/cuddly-owls-smile.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: unmount not deferred components immediately

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
@@ -51,7 +51,8 @@ export function component(node, get_component, render_fn) {
 
 		var defer = should_defer_append();
 
-		if (effect) {
+		// For sync context: immediately pause the old effect
+		if (!defer && effect) {
 			pause_effect(effect);
 			effect = null;
 		}


### PR DESCRIPTION
Note: Alternative to #16633 | Close this, if that PR gets merged

Follows up https://github.com/sveltejs/svelte/pull/16624


[failing test case w/ 16638](https://svelte.dev/playground/hello-world?version=pr-16624#H4sIAAAAAAAAE62RT2-cMBDFv8rUirQgoSU59EJYIuilxx56Kz04eNhYMWNkD7tdIb57BSyQSNt_Ug-W8Lw3Y95vekGyQZGIz2iMhbN1RkGASjOqUESi1ga9SL71gi_t6BsLIlq68rbd-xMaHmvP0uOtemWJkdiLRKS-crrlrKSSddNax5BD7WwDu32cX1t2j2_kYpWLd_J4DDJUlpRmbQkOcOdZMgbsOgwfF8Mn27SWkHg0KHT6hCrYup4ghwSKyU8l1x1VU12hkRdUwUmaDiNoPBzg4_19CP30OjvkzhEQnuGLs432GAR1CIdsMZTskb_qBm3HQTAp9TwtHMfNP1jyMH8MJaXxBofS547ZEliqjK5eD_084W3aD-tlyNgejwbTeO7KSkrbbPNqD708S81rqlULhzRu5xc3UHEmIsH4g0UyshyiX23_9u7_uPk7rGusFipXXpUlbw3ujT0Gu8qhZIR8t2C64l4pbFaFnp29rN4J6HuWLw9ZnsYvD38Zq7gZq_h_sYp_iFX8NlZxI9b3SLDU5qxJiaSWxuPwE86mRLTmAwAA) | [The same test case with this PR](https://svelte.dev/playground/hello-world?version=pr-16633#H4sIAAAAAAAAE62RT2-cMBDFv8rUirQgoSU59EJYIuilxx56Kz04eNhYMWNkD7tdIb57BSyQSNt_Ug-W8Lw3Y95vekGyQZGIz2iMhbN1RkGASjOqUESi1ga9SL71gi_t6BsLIlq68rbd-xMaHmvP0uOtemWJkdiLRKS-crrlrKSSddNax5BD7WwDu32cX1t2j2_kYpWLd_J4DDJUlpRmbQkOcOdZMgbsOgwfF8Mn27SWkHg0KHT6hCrYup4ghwSKyU8l1x1VU12hkRdUwUmaDiNoPBzg4_19CP30OjvkzhEQnuGLs432GAR1CIdsMZTskb_qBm3HQTAp9TwtHMfNP1jyMH8MJaXxBofS547ZEliqjK5eD_084W3aD-tlyNgejwbTeO7KSkrbbPNqD708S81rqlULhzRu5xc3UHEmIsH4g0UyshyiX23_9u7_uPk7rGusFipXXpUlbw3ujT0Gu8qhZIR8t2C64l4pbFaFnp29rN4J6HuWLw9ZnsYvD38Zq7gZq_h_sYp_iFX8NlZxI9b3SLDU5qxJiaSWxuPwE86mRLTmAwAA)

In the previous PR, components - even deferred being un-mounted immediately. This PR adds a check so that only non deferred components are unmounted immediately. 

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
