### PR TITLE
fix: only emit `for_await_track_reactivity_loss` in async mode

### DIFF
--- a/.changeset/tender-masks-bow.md
+++ b/.changeset/tender-masks-bow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: only emit `for_await_track_reactivity_loss` in async mode

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/ForOfStatement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/ForOfStatement.js
@@ -8,7 +8,12 @@ import { dev, is_ignored } from '../../../../state.js';
  * @param {ComponentContext} context
  */
 export function ForOfStatement(node, context) {
-	if (node.await && dev && !is_ignored(node, 'await_reactivity_loss')) {
+	if (
+		node.await &&
+		dev &&
+		!is_ignored(node, 'await_reactivity_loss') &&
+		context.state.options.experimental.async
+	) {
 		const left = /** @type {VariableDeclaration | Pattern} */ (context.visit(node.left));
 		const argument = /** @type {Expression} */ (context.visit(node.right));
 		const body = /** @type {Statement} */ (context.visit(node.body));


### PR DESCRIPTION
It turns out I didn't check if `options.experimental.async` was `true` when emitting `for_await_track_reactivity_loss` in #16521, this fixes that. Should help @gyzerok with #16610 for the time being. 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
