### PR TITLE
fix: ensure correct order of template effect values

### DIFF
--- a/.changeset/healthy-crabs-marry.md
+++ b/.changeset/healthy-crabs-marry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure correct order of template effect values

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -34,7 +34,7 @@ export class Memoizer {
 	}
 
 	apply() {
-		return [...this.#async, ...this.#sync].map((memo, i) => {
+		return [...this.#sync, ...this.#async].map((memo, i) => {
 			memo.id.name = `$${i}`;
 			return memo.id;
 		});

--- a/packages/svelte/tests/runtime-runes/samples/async-template-async-sync-mixed/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-template-async-sync-mixed/_config.js
@@ -1,0 +1,9 @@
+import { tick } from 'svelte';
+import { ok, test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, '<p>foo bar</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-template-async-sync-mixed/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-template-async-sync-mixed/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	function foo() {
+		return 'foo';
+	}
+
+	async function bar() {
+		return Promise.resolve('bar');
+	}
+</script>
+
+<svelte:boundary>
+	<p>{foo()} {await bar()}</p>
+
+	{#snippet pending()}
+		<p>pending</p>
+	{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
Compiler does sync then async but `memoizer.apply` did it the other way around

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
