### PR TITLE
chore(elements.d.ts): add "Accept-CH" as valid value for `http-equiv`

### DIFF
--- a/.changeset/thick-books-fail.md
+++ b/.changeset/thick-books-fail.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: add "Accept-CH" as valid value for `http-equiv`

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1268,6 +1268,7 @@ export interface HTMLMetaAttributes extends HTMLAttributes<HTMLMetaElement> {
 	charset?: string | undefined | null;
 	content?: string | undefined | null;
 	'http-equiv'?:
+	  | 'accept-ch'
 		| 'content-security-policy'
 		| 'content-type'
 		| 'default-style'


### PR DESCRIPTION
It seems like this is a valid value and it has been working for me, however I did find conflicting information on whether it is supported or not.

Supporting Evidence:
- https://github.com/WICG/client-hints-infrastructure?tab=readme-ov-file#opt-in-mechanism
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Client_hints#overview
- https://developer.chrome.com/docs/privacy-security/user-agent-client-hints#introducing_the_new_user-agent_client_hints
- https://github.com/httpwg/http-extensions/issues/189

Conflicting Evidence:
- https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv

