### PR TITLE
fix: ensure async deriveds always get dependencies from thennable

### DIFF
--- a/.changeset/orange-chefs-float.md
+++ b/.changeset/orange-chefs-float.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure async deriveds always get dependencies from thennable

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -120,6 +120,9 @@ export function async_derived(fn, location) {
 
 		try {
 			var p = fn();
+			// Make sure to always access the then property to read any signals
+			// it might access, so that we track them as dependencies.
+			if (prev) Promise.resolve(p).catch(() => {}); // avoid unhandled rejection
 		} catch (error) {
 			p = Promise.reject(error);
 		}

--- a/packages/svelte/tests/runtime-runes/samples/async-derived-reverse-order/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-derived-reverse-order/_config.js
@@ -1,0 +1,41 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const [increment, pop] = target.querySelectorAll('button');
+
+		increment.click();
+		await tick();
+
+		pop.click();
+		await tick();
+
+		pop.click();
+		await tick();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<button>pop</button>
+				<p>1</p>
+			`
+		);
+
+		increment.click();
+		await tick();
+
+		pop.click();
+		await tick();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment</button>
+				<button>pop</button>
+				<p>2</p>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-derived-reverse-order/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-derived-reverse-order/main.svelte
@@ -1,0 +1,35 @@
+
+<script>
+	let count = $state(0);
+
+	let deferreds = [];
+
+	class X {
+		constructor(promise) {
+			this.promise = promise;
+		}
+		
+		get then() {
+			count;
+
+			return (resolve) => this.promise.then(() => count).then(resolve)
+		}
+	}
+
+	function push() {
+		const deferred = Promise.withResolvers();
+		deferreds.push(deferred);
+		return new X(deferred.promise);
+	}
+</script>
+
+<button onclick={() => count += 1}>increment</button>
+<button onclick={() => deferreds.pop()?.resolve(count)}>pop</button>
+
+<svelte:boundary>
+	<p>{await push()}</p>
+
+	{#snippet pending()}
+		<p>loading...</p>
+	{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
When an async derived already has a previous promise that is still pending, we were not accessing the `then` property of the new promise. If that property access causes signals to be read, that meant that those dependencies were lost and as such the derived wouldn't rerun anymore when it should. The fix is to make sure to always access the thennable.

Discovered this while working on the `query.stream` PR (it didn't update in some cases and this is the reason why)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
