### PR TITLE
fix:  properly clean up component lifecycle order issue

### DIFF
--- a/.changeset/chilled-donkeys-ring.md
+++ b/.changeset/chilled-donkeys-ring.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: fixed component lifecycle timing issue in #key blocks. its now properly cleaned up before new instance are created.


### PR DESCRIPTION
- move effect cleanup to happen before new creation in key function
- ensure proper lifecycle order. destroy old component -> create new component
- so now the order is script -> mount -> abort -> destroy -> script -> mount

fixes #16563

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
