### PR TITLE
Docs: Updated the custom elements documentation to include $host

### DIFF
--- a/documentation/docs/07-misc/04-custom-elements.md
+++ b/documentation/docs/07-misc/04-custom-elements.md
@@ -128,3 +128,4 @@ Custom elements can be a useful way to package components for consumption in a n
 - Polyfills are required to support older browsers
 - You can use Svelte's context feature between regular Svelte components within a custom element, but you can't use them across custom elements. In other words, you can't use `setContext` on a parent custom element and read that with `getContext` in a child custom element.
 - Don't declare properties or attributes starting with `on`, as their usage will be interpreted as an event listener. In other words, Svelte treats `<custom-element oneworld={true}></custom-element>` as `customElement.addEventListener('eworld', true)` (and not as `customElement.oneworld = true`)
+- If you would like to dispatch custom events or just access the host element then you can use the [\$host](https://svelte.dev/docs/svelte/$host) rune.


### PR DESCRIPTION
Follows up on [#16652 ](https://github.com/sveltejs/svelte/issues/16652)

Description:
The docs for [Custom Elements](https://svelte.dev/docs/svelte/custom-elements) didn't include a reference to the [$host](https://svelte.dev/docs/svelte/$host) rune which caused confusion on how to get a host element into the component code.

The PR as a line added at the bottom of [04-custom-elements.md](documentation/docs/07-misc/04-custom-elements.md) which simply states that for dispatching custom events or accessing the host element you can use the [$host](https://svelte.dev/docs/svelte/$host) rune.