### PR TITLE
fix: replace `undefined` with `void(0)` in CallExpressions

### DIFF
--- a/.changeset/ninety-olives-report.md
+++ b/.changeset/ninety-olives-report.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: replace `undefined` with `void(0)` in CallExpressions

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -100,7 +100,7 @@ export function call(callee, ...args) {
 	if (typeof callee === 'string') callee = id(callee);
 	args = args.slice();
 
-	// replacing missing arguments with `undefined`, unless they're at the end in which case remove them
+	// replacing missing arguments with `void(0)`, unless they're at the end in which case remove them
 	let i = args.length;
 	let popping = true;
 	while (i--) {

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -108,7 +108,7 @@ export function call(callee, ...args) {
 			if (popping) {
 				args.pop();
 			} else {
-				args[i] = id('undefined');
+				args[i] = void0;
 			}
 		} else {
 			popping = false;


### PR DESCRIPTION
Found this while working on #16688.
Like #15511, this acknowledges the fact that you can make a variable named `undefined`. Since `b.call` replaces non-trailing nullish arguments with `b.id('undefined')`, you can do [this sort of cursed thing](https://svelte.dev/playground/hello-world?version=5.38.6#H4sIAAAAAAAACm3LsQ6CMBRG4Vdp7gIkBPcqJG6O7uBQ7d-kyaUl7UU0hHc3DDq5fjlnpWBGkKYLmKNaYmKrSlgvsBXV5Dwjk-5Xkve0dztQ_b3O09TkJ1h2u5uMf_6IQRAkk6ZTfiQ_STeEQRii5mDhfIBVrerLSrWdKjhycTsO4XT4xatZjBd1TXH0GU1CjvxEWbgYi2qjmgQvIS1pxnarSYznxQdL2hnO2D6MeTLm5QAAAA==).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
