### PR TITLE
Boundary batch first run

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -135,11 +135,10 @@ export function async_derived(fn, location) {
 		prev = promise;
 
 		var batch = /** @type {Batch} */ (current_batch);
-		var pending = boundary.pending;
 
 		if (should_suspend) {
 			boundary.update_pending_count(1);
-			if (!pending) batch.increment();
+			batch.increment();
 		}
 
 		/**
@@ -151,7 +150,7 @@ export function async_derived(fn, location) {
 
 			current_async_effect = null;
 
-			if (!pending) batch.activate();
+			batch.activate();
 
 			if (error) {
 				if (error !== STALE_REACTION) {
@@ -181,7 +180,7 @@ export function async_derived(fn, location) {
 
 			if (should_suspend) {
 				boundary.update_pending_count(-1);
-				if (!pending) batch.decrement();
+				batch.decrement();
 			}
 
 			unset_context();

--- a/packages/svelte/tests/runtime-runes/samples/async-attachment/Inner.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-attachment/Inner.svelte
@@ -1,0 +1,10 @@
+<script>
+	function renderContent(node) {
+		node.textContent = 'foo';
+	}
+ 
+	const test = await Promise.resolve('foo');
+</script>
+
+<p>{test}</p>
+<div {@attach renderContent}></div>

--- a/packages/svelte/tests/runtime-runes/samples/async-attachment/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-attachment/_config.js
@@ -1,0 +1,9 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, '<p>foo</p><div>foo</div>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-attachment/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-attachment/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import Inner from './Inner.svelte';
+</script>
+
+<svelte:boundary>
+	<Inner />
+
+	{#snippet pending()}
+		<p>pending</p>
+	{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
This adjusts the logic of the first processing of an async boundary: Previously, it would only increment/decrement the pending count of a batch on subsequent runs, but this has multiple problems:
- batches will get deactivated, and so certain changes (like chains of top level async deriveds) would create multiple batches, which is wrong. They should all be associated with the same batch
- while async work is happening, the scheduled flush of the batch runs, and will run any `$effect`s that were already picked up, because from its point of view there is no pending work

Additionally, currently after async work has finished which causes more effects (from within attachments, or top level `$effect`s after async work) to be created this effects are never run because they are marked as dirty, but there's no flush scheduled.

The fix is
- to always increment/decrement the pending count (done)
- to run the flush work in a decrement in a microtask to give room for subsequent effects to be created and picked up (done)
- to properly assign component `$effect`s to the component context (todo)

There's also some tests failing. One of them needs #16698 merged first, another one needs #16621 (that test was always failing when you tried it in the playground, weirdly the test passed up until now for some reason). The remaining need investigation.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
