### PR TITLE
fix: Use STATE_SYMBOL to de-proxy component in unmount (#16656)

### DIFF
--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -301,7 +301,7 @@ let mounted_components = new WeakMap();
  * @returns {Promise<void>}
  */
 export function unmount(component, options) {
-	const fn = mounted_components.get(component);
+	const fn = mounted_components.get(component[STATE_SYMBOL]);
 
 	if (fn) {
 		mounted_components.delete(component);


### PR DESCRIPTION
loses #16656

### Description
This PR addresses a bug where calling the `unmount` method on a component instance created with `$state` would fail due to the instance being a proxy.

### Fix
The `unmount` method now correctly retrieves the component's raw instance using `component[STATE_SYMBOL]` from the proxy, allowing it to be properly found in the `mounted_components` map.

### Tests
- [ ] Ran `pnpm test` and all tests passed.
- [ ] Ran `pnpm lint` and all lint checks passed.

### Additional Information
This change implements the solution suggested by maintainers in the issue thread, ensuring a correct fix that aligns with Svelte's internal design.