### PR TITLE
fix: emit `each_key_duplicate` error in production

### DIFF
--- a/.changeset/sharp-snakes-poke.md
+++ b/.changeset/sharp-snakes-poke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: emit `each_key_duplicate` error in production

--- a/packages/svelte/tests/runtime-legacy/samples/keyed-each-dev-unique-prod/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/keyed-each-dev-unique-prod/_config.js
@@ -1,0 +1,12 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		let button = target.querySelector('button');
+
+		button?.click();
+
+		assert.throws(flushSync, /each_key_duplicate/);
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/keyed-each-dev-unique-prod/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/keyed-each-dev-unique-prod/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	let data = [1, 2, 3];
+</script>
+
+<button onclick={() => data = [1, 1, 3, 1]}>add</button>
+{#each data as d (d)}
+	{d}
+{/each}


### PR DESCRIPTION
It looks like duplicate keys cause crashing only in one place.
In some cases it still can successfully render the list but will crash soon anyway, so I don't see reasons to add other checks.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
