### PR TITLE
fix: Invoke error boundaries in the correct order

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-23/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-23/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target, logs }) {
+		let btn = target.querySelector('button');
+
+		btn?.click();
+		btn?.click();
+		flushSync();
+
+		assert.deepEqual(logs, ['error caught 1', 'error caught 2']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-23/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-23/main.svelte
@@ -2,6 +2,6 @@
   import Test from './test.svelte';
 </script>
 
-<svelte:boundary onerror={(e) => {console.log(e.stack)}}>
+<svelte:boundary onerror={(e) => {console.log('error caught root')}}>
   <Test />
 </svelte:boundary>

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-23/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-23/main.svelte
@@ -1,0 +1,7 @@
+<script lang="ts"> 
+  import Test from './test.svelte';
+</script>
+
+<svelte:boundary onerror={(e) => {console.log(e.stack)}}>
+  <Test />
+</svelte:boundary>

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-23/test.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-23/test.svelte
@@ -1,0 +1,22 @@
+<script>
+	let count = $state(0);
+
+	let test = $derived.by(() => {
+		if (count > 1) {
+			throw new Error('test');
+		}
+	});
+</script>
+
+<svelte:boundary onerror={(e) => {console.log('error caught 1')}}>
+		<div>Count: {count}</div>
+		<button onclick={() => count++}>Increment</button>
+		{count} / {test}
+</svelte:boundary>
+
+
+<svelte:boundary onerror={(e) => {console.log('error caught 2')}}>
+		<div>Count: {count}</div>
+		<button onclick={() => count++}>Increment</button>
+		{count} / {test}
+</svelte:boundary>

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-23/test.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-23/test.svelte
@@ -13,9 +13,3 @@
 		<button onclick={() => count++}>Increment</button>
 		{count} / {test}
 </svelte:boundary>
-
-<svelte:boundary onerror={(e) => {console.log('error caught 2')}}>
-		<div>Count: {count}</div>
-		<button onclick={() => count++}>Increment</button>
-		{count} / {test}
-</svelte:boundary>

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-23/test.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-23/test.svelte
@@ -14,7 +14,6 @@
 		{count} / {test}
 </svelte:boundary>
 
-
 <svelte:boundary onerror={(e) => {console.log('error caught 2')}}>
 		<div>Count: {count}</div>
 		<button onclick={() => count++}>Increment</button>


### PR DESCRIPTION
I'm totally baffled about this one right now. Apparently, errors bubble in the _wrong direction_, but only in some circumstances. If I inline `test.svelte` into `main.svelte` by moving the template inside of the error boundary (such that both boundaries are in `main.svelte`) it succeeds. It appears to have something to do with the fact that the outer boundary then has a component rendered inside of it which then contains a boundary. This makes me think it's some sort of effect scheduling issue... but I can't pin it down.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
