### PR TITLE
chore: remove actions-permissions monitor

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -15,7 +15,6 @@ jobs:
       contents: read # to clone the repo
     steps:
       - name: monitor action permissions
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: check user authorization # user needs triage permission
         uses: actions/github-script@v7
         id: check-permissions

--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -14,7 +14,6 @@ jobs:
     name: 'Update comment'
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
these have now served their purpose, and no longer need to slow down our CI (it takes around a minute to set up which is outrageous)