### PR TITLE
chore: simplify `build_template`

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/EachBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/EachBlock.js
@@ -45,7 +45,7 @@ export function EachBlock(node, context) {
 	);
 
 	if (node.fallback) {
-		const open = b.stmt(b.call(b.member(b.id('$$payload'), b.id('push')), block_open));
+		const open = b.stmt(b.call(b.id('$$payload.push'), block_open));
 
 		const fallback = /** @type {BlockStatement} */ (context.visit(node.fallback));
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
@@ -103,11 +103,9 @@ function is_statement(node) {
 
 /**
  * @param {Array<Statement | Expression>} template
- * @param {Identifier} out
- * @param {AssignmentOperator | 'push'} operator
  * @returns {Statement[]}
  */
-export function build_template(template, out = b.id('$$payload'), operator = 'push') {
+export function build_template(template) {
 	/** @type {string[]} */
 	let strings = [];
 
@@ -118,32 +116,18 @@ export function build_template(template, out = b.id('$$payload'), operator = 'pu
 	const statements = [];
 
 	const flush = () => {
-		if (operator === 'push') {
-			statements.push(
-				b.stmt(
-					b.call(
-						b.member(out, b.id('push')),
-						b.template(
-							strings.map((cooked, i) => b.quasi(cooked, i === strings.length - 1)),
-							expressions
-						)
+		statements.push(
+			b.stmt(
+				b.call(
+					b.id('$$payload.push'),
+					b.template(
+						strings.map((cooked, i) => b.quasi(cooked, i === strings.length - 1)),
+						expressions
 					)
 				)
-			);
-		} else {
-			statements.push(
-				b.stmt(
-					b.assignment(
-						operator,
-						out,
-						b.template(
-							strings.map((cooked, i) => b.quasi(cooked, i === strings.length - 1)),
-							expressions
-						)
-					)
-				)
-			);
-		}
+			)
+		);
+
 		strings = [];
 		expressions = [];
 	};


### PR DESCRIPTION
titles are handled differently now, so we can do away with this junk