### PR TITLE
chore: fix SSR context

### DIFF
--- a/packages/svelte/src/index-server.js
+++ b/packages/svelte/src/index-server.js
@@ -1,11 +1,11 @@
-/** @import { Component } from '#server' */
-import { current_component } from './internal/server/context.js';
+/** @import { SSRContext } from '#server' */
+import { ssr_context } from './internal/server/context.js';
 import { noop } from './internal/shared/utils.js';
 import * as e from './internal/server/errors.js';
 
 /** @param {() => void} fn */
 export function onDestroy(fn) {
-	var context = /** @type {Component} */ (current_component);
+	var context = /** @type {SSRContext} */ (ssr_context);
 	(context.d ??= []).push(fn);
 }
 

--- a/packages/svelte/src/internal/server/types.d.ts
+++ b/packages/svelte/src/internal/server/types.d.ts
@@ -1,14 +1,16 @@
-export interface Component {
+import type { Element } from './dev';
+
+export interface SSRContext {
 	/** parent */
-	p: null | Component;
-	/** context */
+	p: null | SSRContext;
+	/** component context */
 	c: null | Map<unknown, unknown>;
 	/** ondestroy */
 	d: null | Array<() => void>;
-	/**
-	 * dev mode only: the component function
-	 */
+	/** dev mode only: the current component function */
 	function?: any;
+	/** dev mode only: the current element */
+	element?: Element;
 }
 
 export interface RenderOutput {

--- a/packages/svelte/tests/server-side-rendering/test.ts
+++ b/packages/svelte/tests/server-side-rendering/test.ts
@@ -11,6 +11,7 @@ import { compile_directory, should_update_expected, try_read_file } from '../hel
 import { assert_html_equal_with_options } from '../html_equal.js';
 import { suite_with_variants, type BaseTest } from '../suite.js';
 import type { CompileOptions } from '#compiler';
+import { seen } from '../../src/internal/server/dev.js';
 
 interface SSRTest extends BaseTest {
 	mode?: ('sync' | 'async')[];
@@ -68,6 +69,8 @@ const { test, run } = suite_with_variants<SSRTest, 'sync' | 'async', CompileOpti
 		const Component = (await import(`${test_dir}/_output/server/main.svelte.js`)).default;
 		const expected_html = try_read_file(`${test_dir}/_expected.html`);
 		const is_async = variant === 'async';
+
+		seen?.clear();
 
 		let rendered;
 		try {


### PR DESCRIPTION
this puts the current element in the SSR context (formerly known as `current_component`, but no longer component-specific) so that `push_element` and `pop_element` have the desired behaviour in async mode as well as sync mode.

it also fixes the test, which was failing for a stupid reason — the error message had already been 'seen' so was being ignored when the test re-ran in async mode