### PR TITLE
fix: restore hydration state after `await` in `<script>`

### DIFF
--- a/.changeset/sweet-doors-brush.md
+++ b/.changeset/sweet-doors-brush.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: restore hydration state after `await` in `<script>`

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -40,11 +40,7 @@ import { TitleElement } from './visitors/TitleElement.js';
 import { UpdateExpression } from './visitors/UpdateExpression.js';
 import { VariableDeclaration } from './visitors/VariableDeclaration.js';
 import { SvelteBoundary } from './visitors/SvelteBoundary.js';
-import {
-	create_child_block,
-	call_component_renderer,
-	create_async_block
-} from './visitors/shared/utils.js';
+import { call_component_renderer, create_async_block } from './visitors/shared/utils.js';
 
 /** @type {Visitors} */
 const global_visitors = {
@@ -248,7 +244,7 @@ export function server_component(analysis, options) {
 	]);
 
 	if (analysis.instance.has_await) {
-		component_block = b.block([create_child_block(component_block, true)]);
+		component_block = b.block([create_async_block(component_block)]);
 	}
 
 	// trick esrap into including comments

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -48,6 +48,8 @@ export function flatten(sync, async, fn) {
 
 	var restore = capture();
 
+	var was_hydrating = hydrating;
+
 	Promise.all(async.map((expression) => async_derived(expression)))
 		.then((result) => {
 			batch?.activate();
@@ -65,6 +67,10 @@ export function flatten(sync, async, fn) {
 
 			batch?.deactivate();
 			unset_context();
+
+			if (was_hydrating) {
+				set_hydrating(false);
+			}
 		})
 		.catch((error) => {
 			invoke_error_boundary(error, parent);

--- a/packages/svelte/tests/runtime-runes/samples/async-no-pending-await-in-script/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-no-pending-await-in-script/_config.js
@@ -1,0 +1,13 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	skip_mode: ['server'],
+
+	ssrHtml: '<p>hello</p>',
+
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, '<p>hello</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-no-pending-await-in-script/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-no-pending-await-in-script/main.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	await 1;
+</script>
+
+{#if true}
+	<p>hello</p>
+{/if}


### PR DESCRIPTION
another case we weren't handling — we need to jump ahead to the end marker around a component with `await` in the `<script>`. There's a bit more footwork involved in this case because we run the callback synchronously

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
