### PR TITLE
fix: ensure tick resolves within a macrotask

### DIFF
--- a/.changeset/wise-bottles-explode.md
+++ b/.changeset/wise-bottles-explode.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure tick resolves within a macrotask

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -500,7 +500,13 @@ export function update_effect(effect) {
  */
 export async function tick() {
 	if (async_mode_flag) {
-		return new Promise((f) => requestAnimationFrame(() => f()));
+		return new Promise((f) => {
+			// Race them against each other - in almost all cases requestAnimationFrame will fire first,
+			// but e.g. in case the window is not focused or a view transition happens, requestAnimationFrame
+			// will be delayed and setTimeout helps us resolve fast enough in that case
+			requestAnimationFrame(() => f());
+			setTimeout(() => f());
+		});
 	}
 
 	await Promise.resolve();


### PR DESCRIPTION
Race them against each other - in almost all cases requestAnimationFrame will fire first, but e.g. in case the window is not focused or a view transition happens, requestAnimationFrame will be delayed and setTimeout helps us resolve fast enough in that case

Fixes #16429
Fixes https://github.com/sveltejs/kit/issues/14220

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
