### PR TITLE
chore: fix typos

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -334,7 +334,7 @@ function set_attributes(
 			// the value is set to the text content of the option element, and setting the value
 			// to null or undefined means the value is set to the string "null" or "undefined".
 			// To align with how we handle this case in non-spread-scenarios, this logic is needed.
-			// There's a super-edge-case bug here that is left in in favor of smaller code size:
+			// There's a super-edge-case bug here that is left in favor of smaller code size:
 			// Because of the "set missing props to null" logic above, we can't differentiate
 			// between a missing value and an explicitly set value of null or undefined. That means
 			// that once set, the value attribute of an <option> element can't be removed. This is

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -143,7 +143,7 @@ export function hydrate(component, options) {
 			e.hydration_failed();
 		}
 
-		// If an error occured above, the operations might not yet have been initialised.
+		// If an error occurred above, the operations might not yet have been initialised.
 		init_operations();
 		clear_text_content(target);
 


### PR DESCRIPTION
Remove the duplicate `an`.
Fix `occured` to `occurred`.