### PR TITLE
chore: disable inspector in playground

### DIFF
--- a/playgrounds/sandbox/package.json
+++ b/playgrounds/sandbox/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "prepare": "node scripts/create-app-svelte.js",
-    "dev": "vite --host",
-    "ssr": "node --conditions=development ./ssr-dev.js",
+    "dev": "SVELTE_INSPECTOR_OPTIONS=false vite --host",
+    "ssr": "SVELTE_INSPECTOR_OPTIONS=false node --conditions=development ./ssr-dev.js",
     "build": "vite build --outDir dist/client && vite build --outDir dist/server --ssr ssr-prod.js",
     "prod": "npm run build && node dist/server/ssr-prod",
     "preview": "vite preview",


### PR DESCRIPTION
QOL thing — when I'm using the sandbox to debug internals, I often get _very_ confused about why some code is running, and it always turns out to be because the inspector has mounted alongside the app. This disables it so I don't need to always remember to prefix `pnpm dev` with `SVELTE_INSPECTOR_OPTIONS=false` myself