### PR TITLE
chore: simplify batch logic

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/await.js
+++ b/packages/svelte/src/internal/client/dom/blocks/await.js
@@ -22,7 +22,7 @@ import {
 	set_dev_current_component_function,
 	set_dev_stack
 } from '../../context.js';
-import { flushSync } from '../../reactivity/batch.js';
+import { flushSync, is_flushing_sync } from '../../reactivity/batch.js';
 
 const PENDING = 0;
 const THEN = 1;
@@ -126,7 +126,7 @@ export function await_block(node, get_input, pending_fn, then_fn, catch_fn) {
 
 				// without this, the DOM does not update until two ticks after the promise
 				// resolves, which is unexpected behaviour (and somewhat irksome to test)
-				flushSync();
+				if (!is_flushing_sync) flushSync();
 			}
 		}
 	}

--- a/packages/svelte/src/internal/client/dom/task.js
+++ b/packages/svelte/src/internal/client/dom/task.js
@@ -10,10 +10,6 @@ function run_micro_tasks() {
 	run_all(tasks);
 }
 
-export function has_pending_tasks() {
-	return micro_tasks.length > 0;
-}
-
 /**
  * @param {() => void} fn
  */
@@ -40,7 +36,7 @@ export function queue_micro_task(fn) {
  * Synchronously run any queued tasks.
  */
 export function flush_tasks() {
-	if (micro_tasks.length > 0) {
+	while (micro_tasks.length > 0) {
 		run_micro_tasks();
 	}
 }

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -244,7 +244,6 @@ export async function async_body(fn) {
 		if (pending) {
 			batch.flush();
 		} else {
-			batch.activate();
 			batch.decrement();
 		}
 

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -212,7 +212,6 @@ export class Batch {
 			// newly updated sources, which could lead to infinite loops when effects run over and over again.
 			previous_batch = current_batch;
 			current_batch = null;
-			batches.delete(this);
 
 			flush_queued_effects(render_effects);
 			flush_queued_effects(effects);
@@ -360,7 +359,7 @@ export class Batch {
 
 		if (queued_root_effects.length > 0) {
 			flush_effects();
-		} else {
+		} else if (this.#pending === 0) {
 			this.#commit();
 		}
 
@@ -368,10 +367,6 @@ export class Batch {
 			// this can happen if a `flushSync` occurred during `flush_effects()`,
 			// which is permitted in legacy mode despite being a terrible idea
 			return;
-		}
-
-		if (this.#pending === 0) {
-			batches.delete(this);
 		}
 
 		this.deactivate();
@@ -388,6 +383,7 @@ export class Batch {
 		}
 
 		this.#callbacks.clear();
+		batches.delete(this);
 	}
 
 	increment() {

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -23,7 +23,7 @@ import {
 	update_effect
 } from '../runtime.js';
 import * as e from '../errors.js';
-import { flush_tasks, has_pending_tasks, queue_micro_task } from '../dom/task.js';
+import { flush_tasks, queue_micro_task } from '../dom/task.js';
 import { DEV } from 'esm-env';
 import { invoke_error_boundary } from '../error-handling.js';
 import { old_values } from './sources.js';
@@ -355,18 +355,16 @@ export class Batch {
 	}
 
 	flush() {
-		this.activate();
-
 		if (queued_root_effects.length > 0) {
+			this.activate();
 			flush_effects();
+
+			if (current_batch !== null && current_batch !== this) {
+				// this can happen if a new batch was created during `flush_effects()`
+				return;
+			}
 		} else if (this.#pending === 0) {
 			this.#commit();
-		}
-
-		if (current_batch !== null && current_batch !== this) {
-			// this can happen if a `flushSync` occurred during `flush_effects()`,
-			// which is permitted in legacy mode despite being a terrible idea
-			return;
 		}
 
 		this.deactivate();
@@ -468,14 +466,17 @@ export function flushSync(fn) {
 		var result;
 
 		if (fn) {
-			flush_effects();
+			if (current_batch !== null) {
+				flush_effects();
+			}
+
 			result = fn();
 		}
 
 		while (true) {
 			flush_tasks();
 
-			if (queued_root_effects.length === 0 && !has_pending_tasks()) {
+			if (queued_root_effects.length === 0) {
 				current_batch?.flush();
 
 				// we need to check again, in case we just updated an `$effect.pending()`

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -356,6 +356,8 @@ export class Batch {
 	}
 
 	flush() {
+		this.activate();
+
 		if (queued_root_effects.length > 0) {
 			flush_effects();
 		} else {


### PR DESCRIPTION
I'm working to simplify some of the batching logic as a precursor to a larger overhaul that will hopefully make some of the gnarlier edge cases easier to wrangle.

This is a small step in that direction. Previously, we would reinstate a batch at the end of its life — this is one of those things that gets shoehorned into a codebase just to get the tests passing, but it never really made much sense to me. Turns out we don't need it.

The outcome is a simpler batch lifecycle — when you `flush` a batch, it either sticks around because it has pending async work or it gets removed straight away, with no zombie in-between state.

More to come in follow-up PRs