### PR TITLE
chore: allow testing in production env

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/production/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/production/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	production: true
+});

--- a/packages/svelte/tests/runtime-runes/samples/production/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/production/main.svelte
@@ -1,0 +1,7 @@
+<script>
+    import { DEV } from "esm-env";
+console.info("prod", DEV)
+    if (DEV) {
+        throw new Error("Dev-only code must not run");
+    }
+</script>


### PR DESCRIPTION
Add the ability to set `DEV` to `false` for test.
It's supposed to be
```js
if (config.production) fn = run_in_production(fn);
```
But due to https://github.com/vitest-dev/vitest/issues/7712 unmocking doesn't work, so instead such tests are moved to the end of the queue.

This should allow adding the correct tests to #16724.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
