### PR TITLE
chore: replace queue_idle_task with queue_micro_task

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -6,7 +6,7 @@ import { create_event, delegate } from './events.js';
 import { add_form_reset_listener, autofocus } from './misc.js';
 import * as w from '../../warnings.js';
 import { LOADING_ATTR_SYMBOL } from '#client/constants';
-import { queue_idle_task } from '../task.js';
+import { queue_micro_task } from '../task.js';
 import { is_capture_event, is_delegated, normalize_attribute } from '../../../../utils.js';
 import {
 	active_effect,
@@ -65,7 +65,7 @@ export function remove_input_defaults(input) {
 
 	// @ts-expect-error
 	input.__on_r = remove_defaults;
-	queue_idle_task(remove_defaults);
+	queue_micro_task(remove_defaults);
 	add_form_reset_listener();
 }
 

--- a/packages/svelte/src/internal/client/dom/task.js
+++ b/packages/svelte/src/internal/client/dom/task.js
@@ -1,17 +1,8 @@
 import { run_all } from '../../shared/utils.js';
 import { is_flushing_sync } from '../reactivity/batch.js';
 
-// Fallback for when requestIdleCallback is not available
-const request_idle_callback =
-	typeof requestIdleCallback === 'undefined'
-		? (/** @type {() => void} */ cb) => setTimeout(cb, 1)
-		: requestIdleCallback;
-
 /** @type {Array<() => void>} */
 let micro_tasks = [];
-
-/** @type {Array<() => void>} */
-let idle_tasks = [];
 
 function run_micro_tasks() {
 	var tasks = micro_tasks;
@@ -19,14 +10,8 @@ function run_micro_tasks() {
 	run_all(tasks);
 }
 
-function run_idle_tasks() {
-	var tasks = idle_tasks;
-	idle_tasks = [];
-	run_all(tasks);
-}
-
 export function has_pending_tasks() {
-	return micro_tasks.length > 0 || idle_tasks.length > 0;
+	return micro_tasks.length > 0;
 }
 
 /**
@@ -52,25 +37,10 @@ export function queue_micro_task(fn) {
 }
 
 /**
- * @param {() => void} fn
- */
-export function queue_idle_task(fn) {
-	if (idle_tasks.length === 0) {
-		request_idle_callback(run_idle_tasks);
-	}
-
-	idle_tasks.push(fn);
-}
-
-/**
  * Synchronously run any queued tasks.
  */
 export function flush_tasks() {
 	if (micro_tasks.length > 0) {
 		run_micro_tasks();
-	}
-
-	if (idle_tasks.length > 0) {
-		run_idle_tasks();
 	}
 }


### PR DESCRIPTION
We use `queue_idle_task` in exactly one place — removing defaults from inputs. To my mind it really doesn't warrant this special treatment — you have to have _hundreds_ of `<input>` elements with a server-rendered `value` or `checked` attribute before it takes more than a single millisecond to remove all those attributes, at least on this four year old machine, and if they _don't_ have a `value` attribute then you're actually making things worse with `requestIdleCallback`.

Just feels like a bad use of our complexity budget.

I think we can actually go further in simplifying this — like, what if we didn't bother removing these attributes at all until the form in question gets reset? — but for now I'm focused on just removing `queue_idle_task` to unblock further simplifications as to how we schedule things.