### PR TITLE
chore: fix typos in func name

### DIFF
--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/client/index.svelte.js
@@ -4,7 +4,7 @@ import * as $ from 'svelte/internal/client';
 var on_click = (_, count) => $.update(count);
 var root = $.from_html(`<h1></h1> <b></b> <button> </button> <h1></h1>`, 1);
 
-export default function Nullish_coallescence_omittance($$anchor) {
+export default function Nullish_coalescence_omittance($$anchor) {
 	let name = 'world';
 	let count = $.state(0);
 	var fragment = root();

--- a/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/nullish-coallescence-omittance/_expected/server/index.svelte.js
@@ -1,6 +1,6 @@
 import * as $ from 'svelte/internal/server';
 
-export default function Nullish_coallescence_omittance($$renderer) {
+export default function Nullish_coalescence_omittance($$renderer) {
 	let name = 'world';
 	let count = 0;
 


### PR DESCRIPTION
Fix `Nullish_coallescence_omittance` to `Nullish_coalescence_omittance`