### PR TITLE
fix: memoize repeated state reads in guard expressions

### DIFF
--- a/.changeset/wicked-keys-search.md
+++ b/.changeset/wicked-keys-search.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: memoize repeated state reads in guard expressions

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
@@ -12,6 +12,10 @@ export function IfBlock(node, context) {
 	context.state.template.push_comment();
 	const statements = [];
 
+	const { has_await } = node.metadata.expression;
+	const expression = build_expression(context, node.test, node.metadata.expression);
+	const test = has_await ? b.call('$.get', b.id('$$condition')) : expression;
+
 	const consequent = /** @type {BlockStatement} */ (context.visit(node.consequent));
 	const consequent_id = b.id(context.state.scope.generate('consequent'));
 
@@ -24,10 +28,6 @@ export function IfBlock(node, context) {
 		alternate_id = b.id(context.state.scope.generate('alternate'));
 		statements.push(b.var(alternate_id, b.arrow([b.id('$$anchor')], alternate)));
 	}
-
-	const { has_await } = node.metadata.expression;
-	const expression = build_expression(context, node.test, node.metadata.expression);
-	const test = has_await ? b.call('$.get', b.id('$$condition')) : expression;
 
 	/** @type {Expression[]} */
 	const args = [

--- a/packages/svelte/tests/runtime-runes/samples/guard-derived-short-circuit/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/guard-derived-short-circuit/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+import { flushSync } from 'svelte';
+
+export default test({
+	mode: ['client'],
+	async test({ target, assert }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+
+		assert.equal(target.textContent?.trim(), 'Trigger');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/guard-derived-short-circuit/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/guard-derived-short-circuit/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	let virtualItems = $state([{ index: 0 }, { index: 1 }, { index: 2 }]);
+	let centerRows = $state([{ depth: 2 }, { depth: 1 }, { depth: 1 }]);
+
+	let someChange = $state(false);
+	$effect(() => {
+		if (someChange) centerRows = [];
+	});
+</script>
+
+{#each virtualItems as row (row.index)}
+	{@const centerRow = centerRows[row.index]}
+	{#if centerRow != undefined && centerRow.depth != undefined && typeof centerRow === "object" && "depth" in centerRow && typeof centerRow.depth === "number"}
+		{#if centerRow.depth != undefined && centerRow.depth > 0}
+			Hello World<br />
+		{/if}
+	{/if}
+{/each}
+
+<button onclick={() => (someChange = true)}>Trigger</button>


### PR DESCRIPTION
Fixes #16850

Starting in Svelte 5.38.2, guard expressions such as `{#if centerRow && centerRow.depth}` could end up evaluating `$.get(centerRow)` multiple times within a single expression. This meant that the first null check and the subsequent `centerRow.depth` access might see different values, which could cause a `Cannot read properties of undefined` error. The fix changes `build_expression` so that it reads a state or derived signal exactly once per expression, caches that intermediate result, and then reuses it, while deliberately leaving reads inside nested functions untouched so that existing behavior continues to work as before. In addition, the `IfBlock` visitor was updated to compute the guard expression up front so that any nested blocks share the memoized value. If there is a more robust or idiomatic way to handle this in Svelte, I would very much appreciate any feedback or suggestions.

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
