### PR TITLE
reactivity: run $effect immediately after async derived resolves (non-suspend path)(#16497)

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -184,6 +184,13 @@ export function async_derived(fn, location) {
 			if (should_suspend) {
 				boundary.update_pending_count(-1);
 				if (!pending) batch.decrement();
+			} else {
+				// Ensure effects depending on this async derived run promptly when we didn't suspend
+				// and there is no pending boundary — commit queued work immediately.
+				if (!pending) {
+					batch.flush();
+					batch.deactivate();
+				}
 			}
 
 			unset_context();


### PR DESCRIPTION
[Bug] Fixes issue where $effect does not run immediately after an async derived resolves unless another “wakeup” occurs. See sveltejs/svelte#16497.

[Change] In async_derived()’s handler, when the derived did not suspend and the boundary is not pending, explicitly flush and deactivate the current batch so user effects run right away.

[modified] packages/svelte/src/internal/client/reactivity/deriveds.js
In async_derived.handler:

    - After internal_set(signal, value), if !should_suspend && !pending, call:
        - batch.flush();
        - batch.deactivate();

Behavior before vs after: 
  - Before: $effect runs only after a subsequent wake/wakeup following async derived resolution.
  - After: $effect runs immediately after the async derived resolves in the non-suspend path.

Related
- Fixes: #16497