### PR TITLE
fix: flush when pending boundaries resolve

### DIFF
--- a/.changeset/swift-starfishes-knock.md
+++ b/.changeset/swift-starfishes-knock.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: flush when pending boundaries resolve

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -33,6 +33,7 @@ import { Batch, current_batch, effect_pending_updates } from '../../reactivity/b
 import { internal_set, source } from '../../reactivity/sources.js';
 import { tag } from '../../dev/tracing.js';
 import { createSubscriber } from '../../../../reactivity/create-subscriber.js';
+import { flushSync } from 'svelte';
 
 /**
  * @typedef {{
@@ -285,6 +286,10 @@ export class Boundary {
 				this.#anchor.before(this.#offscreen_fragment);
 				this.#offscreen_fragment = null;
 			}
+
+			queue_micro_task(() => {
+				Batch.ensure().flush();
+			});
 		}
 	}
 

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -287,6 +287,9 @@ export class Boundary {
 				this.#offscreen_fragment = null;
 			}
 
+			// TODO this feels like a little bit of a kludge, but until we
+			// overhaul the boundary/batch relationship it's probably
+			// the most pragmatic solution available to us
 			queue_micro_task(() => {
 				Batch.ensure().flush();
 			});

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -33,7 +33,6 @@ import { Batch, current_batch, effect_pending_updates } from '../../reactivity/b
 import { internal_set, source } from '../../reactivity/sources.js';
 import { tag } from '../../dev/tracing.js';
 import { createSubscriber } from '../../../../reactivity/create-subscriber.js';
-import { flushSync } from 'svelte';
 
 /**
  * @typedef {{

--- a/packages/svelte/tests/runtime-runes/samples/async-attachment-in-block/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-attachment-in-block/_config.js
@@ -1,0 +1,11 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client', 'hydrate'],
+
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, '<div>attachment ran</div>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-attachment-in-block/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-attachment-in-block/main.svelte
@@ -1,0 +1,9 @@
+{#if await true}
+	<div
+		{@attach (node) => {
+			node.textContent = 'attachment ran';
+		}}
+	>
+		attachment did not run
+	</div>
+{/if}


### PR DESCRIPTION
This fixes a somewhat nasty bug that prevents effects (such as attachments) running inside newly-resolved pending boundaries under some circumstances.

As the comment suggests, it feels like a _bit_ of a kludge, but for now we need it.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
