### PR TITLE
docs: `$props` destructuring is reactive

### DIFF
--- a/documentation/docs/02-runes/05-$props.md
+++ b/documentation/docs/02-runes/05-$props.md
@@ -35,6 +35,8 @@ On the other side, inside `MyComponent.svelte`, we can receive props with the `$
 <p>this component is {+++adjective+++}</p>
 ```
 
+> [!NOTE] If you use destructuring with a `$props` declaration, the resulting variables will all be reactive.
+
 ## Fallback values
 
 Destructuring allows us to declare fallback values, which are used if the parent component does not set a given prop (or the value is `undefined`):


### PR DESCRIPTION
Unlike [`$derived`](https://svelte.dev/docs/svelte/$derived#Destructuring),

> If you use destructuring with a `$derived` declaration, the resulting variables will all be reactive

the `$props` documentation does not specify that the destructured variables are reactive. This is all it says:

> ...though more commonly, you’ll [_destructure_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) your props:

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
