### PR TITLE
fix: allow arbitrary content in `<select>` elements

### DIFF
--- a/.changeset/silent-adults-relax.md
+++ b/.changeset/silent-adults-relax.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow arbitrary content in `<select>` elements

--- a/packages/svelte/src/html-tree-validation.js
+++ b/packages/svelte/src/html-tree-validation.js
@@ -80,9 +80,6 @@ export function closing_tag_omitted(current, next) {
  */
 const disallowed_children = {
 	...autoclosing_children,
-	optgroup: { only: ['option', '#text'] },
-	// Strictly speaking, seeing an <option> doesn't mean we're in a <select>, but we assume it here
-	option: { only: ['#text'] },
 	form: { descendant: ['form'] },
 	a: { descendant: ['a'] },
 	button: { descendant: ['button'] },
@@ -92,8 +89,6 @@ const disallowed_children = {
 	h4: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
 	h5: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
 	h6: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
-	// https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inselect
-	select: { only: ['option', 'optgroup', '#text', 'hr', 'script', 'template'] },
 
 	// https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-intd
 	// https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-incaption


### PR DESCRIPTION
Until recently there were restrictions on what content could appear inside `<select>` and `<option>` elements. [That's no longer true](https://developer.chrome.com/blog/a-customizable-select), and so we should probably drop the compiler errors that prevent people from building customizable selects.

Closes #15617

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
