### PR TITLE
fix: flush batches whenever an async value resolves

### DIFF
--- a/.changeset/metal-parents-train.md
+++ b/.changeset/metal-parents-train.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: flush batches whenever an async value resolves

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -52,8 +52,6 @@ export function flatten(sync, async, fn) {
 
 	Promise.all(async.map((expression) => async_derived(expression)))
 		.then((result) => {
-			batch?.activate();
-
 			restore();
 
 			try {

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -178,6 +178,8 @@ export class Batch {
 			flush_queued_effects(render_effects);
 			flush_queued_effects(effects);
 
+			previous_batch = null;
+
 			this.#deferred?.resolve();
 		} else {
 			this.#defer_effects(this.#render_effects);
@@ -280,17 +282,6 @@ export class Batch {
 
 	deactivate() {
 		current_batch = null;
-		previous_batch = null;
-
-		for (const update of effect_pending_updates) {
-			effect_pending_updates.delete(update);
-			update();
-
-			if (current_batch !== null) {
-				// only do one at a time
-				break;
-			}
-		}
 	}
 
 	flush() {
@@ -307,6 +298,16 @@ export class Batch {
 		}
 
 		this.deactivate();
+
+		for (const update of effect_pending_updates) {
+			effect_pending_updates.delete(update);
+			update();
+
+			if (current_batch !== null) {
+				// only do one at a time
+				break;
+			}
+		}
 	}
 
 	/**

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -375,21 +375,17 @@ export class Batch {
 	decrement() {
 		this.#pending -= 1;
 
-		if (this.#pending === 0) {
-			for (const e of this.#dirty_effects) {
-				set_signal_status(e, DIRTY);
-				schedule_effect(e);
-			}
-
-			for (const e of this.#maybe_dirty_effects) {
-				set_signal_status(e, MAYBE_DIRTY);
-				schedule_effect(e);
-			}
-
-			this.flush();
-		} else {
-			this.deactivate();
+		for (const e of this.#dirty_effects) {
+			set_signal_status(e, DIRTY);
+			schedule_effect(e);
 		}
+
+		for (const e of this.#maybe_dirty_effects) {
+			set_signal_status(e, MAYBE_DIRTY);
+			schedule_effect(e);
+		}
+
+		this.flush();
 	}
 
 	/** @param {() => void} fn */


### PR DESCRIPTION
This fixes a tricky bug that occurs with remote functions. I struggled to make a narrow repro, but the change is one that makes sense on the face of it: whenever an async value resolves, we update the batch, flushing the change through the effect tree. This has the effect of destroying anything inside blocks that would otherwise keep them alive.

It feels like we might actually need to go even further than this, and deactivate async work inside skipped branches, but I'm not immediately sure how to tackle that, so just making this change for now.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
