### PR TITLE
fix: track the user's getter of `bind:this`

### DIFF
--- a/.changeset/rude-frogs-train.md
+++ b/.changeset/rude-frogs-train.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: track the user's getter of `bind:this`

--- a/documentation/docs/03-template-syntax/12-bind.md
+++ b/documentation/docs/03-template-syntax/12-bind.md
@@ -364,6 +364,8 @@ Components also support `bind:this`, allowing you to interact with component ins
 </script>
 ```
 
+> [!NOTE] In case of using [the function bindings](#Function-bindings), the getter is required to ensure that the correct value is nullified on component or element destruction.
+
 ## bind:_property_ for components
 
 ```svelte

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js
@@ -192,17 +192,18 @@ function build_assignment(operator, left, right, context) {
 		path.at(-1) === 'Component' ||
 		path.at(-1) === 'SvelteComponent' ||
 		(path.at(-1) === 'ArrowFunctionExpression' &&
-			path.at(-2) === 'SequenceExpression' &&
-			(path.at(-3) === 'Component' ||
-				path.at(-3) === 'SvelteComponent' ||
-				path.at(-3) === 'BindDirective'))
+			(path.at(-2) === 'BindDirective' ||
+				(path.at(-2) === 'Component' && path.at(-3) === 'Fragment') ||
+				(path.at(-2) === 'SequenceExpression' &&
+					(path.at(-3) === 'Component' ||
+						path.at(-3) === 'SvelteComponent' ||
+						path.at(-3) === 'BindDirective'))))
 	) {
 		should_transform = false;
 	}
 
 	if (left.type === 'MemberExpression' && should_transform) {
 		const callee = callees[operator];
-
 		return /** @type {Expression} */ (
 			context.visit(
 				b.call(

--- a/packages/svelte/tests/runtime-runes/samples/bind-getter-setter-loop/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/bind-getter-setter-loop/_config.js
@@ -1,0 +1,16 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const [btn] = target.querySelectorAll('button');
+
+		flushSync(() => {
+			btn.click();
+		});
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>Shuffle</button> <br> <b>5</b><b>1</b><b>4</b><b>2</b><b>3</b> <br> 51423'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/bind-getter-setter-loop/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/bind-getter-setter-loop/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let arr = $state([1, 2, 3, 4, 5]);
+	let elements = $state([]);
+</script>
+
+<button onclick={() => arr = [5, 1, 4, 2, 3]}>Shuffle</button><br>
+{#each arr as item, i (item)}
+	<b bind:this={() => elements[i], (v) => elements[i] = v }>{item}</b>
+{/each}
+<br>
+{#each elements as elem}
+	{elem.textContent}
+{/each}


### PR DESCRIPTION
Closes #16547 + more correct work of `bind:this` with function bindings in loops.

This fix started triggering falsy `assignment_value_stale` on the setters, so I adjusted `build_assignment` but not really sure how good it is.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
