### PR TITLE
fix: better input cursor restoration for `bind:value`

### DIFF
--- a/.changeset/fair-aliens-wait.md
+++ b/.changeset/fair-aliens-wait.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better input cursor restoration for `bind:value`

--- a/packages/svelte/src/internal/client/dom/elements/bindings/input.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/input.js
@@ -43,14 +43,22 @@ export function bind_value(input, get, set = get) {
 		if (value !== (value = get())) {
 			var start = input.selectionStart;
 			var end = input.selectionEnd;
+			var length = input.value.length;
 
 			// the value is coerced on assignment
 			input.value = value ?? '';
 
 			// Restore selection
 			if (end !== null) {
-				input.selectionStart = start;
-				input.selectionEnd = Math.min(end, input.value.length);
+				var new_length = input.value.length;
+				// If cursor was at end and new input is longer, move cursor to new end
+				if (start === end && end === length && new_length > length) {
+					input.selectionStart = new_length;
+					input.selectionEnd = new_length;
+				} else {
+					input.selectionStart = start;
+					input.selectionEnd = Math.min(end, new_length);
+				}
 			}
 		}
 	});


### PR DESCRIPTION
If cursor was at end and new input is longer, move cursor to new end

No test because not possible to reproduce using our test setup.

Follow-up to #14649, fixes #16577, fixes #14979

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
