### PR TITLE
fix: ensure map iteration order is correct

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -144,6 +144,7 @@ export function async_derived(fn, location) {
 				batch.increment();
 
 				deferreds.get(batch)?.reject(STALE_REACTION);
+				deferreds.delete(batch); // delete to ensure correct order in Map iteration below
 				deferreds.set(batch, d);
 			}
 		}


### PR DESCRIPTION
quick follow-up to #16944
Resetting a map entry does not change its position in the map when iterating. We need to make sure that reset makes that batch jump "to the front" for the "reject all stale batches" logic below. Edge case for which I can't come up with a test case but it _is_ a possibility.
