### PR TITLE
fix:Added optional chaining to prevent console errors upon disconnecting element from the DOM

### DIFF
--- a/.changeset/wild-vans-sip.md
+++ b/.changeset/wild-vans-sip.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Added optional chaining to prevent console errors upon disconnecting element from the DOM

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -197,7 +197,7 @@ if (typeof HTMLElement === 'function') {
 			// In a microtask, because this could be a move within the DOM
 			Promise.resolve().then(() => {
 				if (!this.$$cn && this.$$c) {
-					this.$$c.$destroy();
+					this.$$c?.$destroy();
 					this.$$me();
 					this.$$c = undefined;
 				}


### PR DESCRIPTION
Sometimes, when custom elements are disconnected from the DOM, errors appear in the console. This simple fix prevents that.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
