### PR TITLE
fix: prevent re-activated stale batches from break reactivity

### DIFF
--- a/.changeset/rude-vans-retire.md
+++ b/.changeset/rude-vans-retire.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent re-activated stale batches from break reactivity

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -421,6 +421,13 @@ export class Batch {
 	}
 
 	static ensure() {
+		if (current_batch !== null && !batches.has(current_batch)) {
+			// A previously committed batch was reactivated via async `restore`.
+			// Treat it as inactive so a new batch can be created to process updates.
+			current_batch = null;
+			batch_values = null;
+		}
+
 		if (current_batch === null) {
 			const batch = (current_batch = new Batch());
 			batches.add(current_batch);

--- a/packages/svelte/tests/runtime-runes/samples/async-resolve-stale/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-resolve-stale/_config.js
@@ -21,5 +21,9 @@ export default test({
 		input.dispatchEvent(new Event('input', { bubbles: true }));
 		await macrotask(6);
 		assert.htmlEqual(target.innerHTML, '<input> 3 | 12');
+		input.value = '';
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		await macrotask();
+		assert.htmlEqual(target.innerHTML, '<input> 4 | ');
 	}
 });


### PR DESCRIPTION
Tweaked @dummdidumm test a bit to also show how after the stale batch was `deactivated` it was basically freezing reactivity.

The problem is that if a previous promise resolves after another one the previous is restored and that re-activate an already committed branch and that just lingers around preventing new batches from being created.

The check was suggested by `codex` but I spent a bit of time figuring out if it was correct, and it seems it should work since once is committed the `batch` is removed from `batches` so if a `current_branch` is not in there it should mean that it's been committed, and it's now being re-activated.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
