### PR TITLE
chore: run boundary async effects in the context of the current batch

### DIFF
--- a/.changeset/selfish-pets-teach.md
+++ b/.changeset/selfish-pets-teach.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: run boundary async effects in the context of the current batch


### PR DESCRIPTION
We need to rethink how boundaries and batches work in relation to each other, per https://github.com/sveltejs/svelte/pull/16959#issuecomment-3407390636. As a starting point, we can get rid of `#boundary_async_effects`, since separating them out achieves nothing — the distinction is whether the async effect should delay the batch from committing, but that's determined inside the async effect itself, _not_ during traversal, so the only impact of having this array is that the effect runs outside the batch context. But that isn't useful (it doesn't save us from re-running it as necessary), it's just an extra array allocation/iteration.

This will enable further experimentation since we can now guarantee that `current_batch` exists for all suspendy async effects.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
