### PR TITLE
fix: flush pending changes after rendering `failed` snippet

### DIFF
--- a/.changeset/slimy-turtles-yell.md
+++ b/.changeset/slimy-turtles-yell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: flush pending changes after rendering `failed` snippet

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -30,7 +30,6 @@ import {
 	skip_nodes,
 	set_hydrate_node
 } from '../hydration.js';
-import { get_next_sibling } from '../operations.js';
 import { queue_micro_task } from '../task.js';
 import * as e from '../../errors.js';
 import * as w from '../../warnings.js';
@@ -409,6 +408,7 @@ export class Boundary {
 		if (failed) {
 			queue_micro_task(() => {
 				this.#failed_effect = this.#run(() => {
+					Batch.ensure();
 					this.#is_creating_fallback = true;
 
 					try {

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-23/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-23/_config.js
@@ -1,0 +1,12 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const btn = target.querySelector('button');
+		btn?.click();
+		await tick();
+
+		assert.deepEqual(logs, ['attachment']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-23/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-23/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	let fail = $state(false);
+
+	function error() {
+		throw new Error('oops');
+	}
+
+	function attachment() {
+		console.log('attachment');
+	}
+</script>
+
+<svelte:boundary>
+	{fail ? error() : 'all good'}
+	<button onclick={() => fail = true}>fail</button>
+	
+	{#snippet failed()}
+		<div {@attach attachment}>oops!</div>
+	{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
fixes #16730

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
