### PR TITLE
fix: add type for svg `<mask>` element `mask-type` attribute

### DIFF
--- a/.changeset/open-streets-retire.md
+++ b/.changeset/open-streets-retire.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add type for svg `<mask>` element `mask-type` attribute

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1703,6 +1703,7 @@ export interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DO
 	markerWidth?: number | string | undefined | null;
 	mask?: string | undefined | null;
 	maskContentUnits?: number | string | undefined | null;
+	'mask-type'?: 'alpha' | 'luminance' | undefined | null;
 	maskUnits?: number | string | undefined | null;
 	mathematical?: number | string | undefined | null;
 	mode?: number | string | undefined | null;


### PR DESCRIPTION
Adds the `mask-type` attribute to the `SVGAttributes` interface.
Closes #16999

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
