### PR TITLE
chore: exclude vite optimized deps from stack traces

### DIFF
--- a/.changeset/dirty-planes-tell.md
+++ b/.changeset/dirty-planes-tell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: exclude vite optimized deps from stack traces

--- a/packages/svelte/src/internal/client/dev/tracing.js
+++ b/packages/svelte/src/internal/client/dev/tracing.js
@@ -153,16 +153,20 @@ export function get_stack(label) {
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
+		const posixified = line.replaceAll('\\', '/');
 
 		if (line === 'Error') {
 			continue;
 		}
+
 		if (line.includes('validate_each_keys')) {
 			return null;
 		}
-		if (line.includes('svelte/src/internal') || line.includes('svelte\\src\\internal')) {
+
+		if (posixified.includes('svelte/src/internal') || posixified.includes('node_modules/.vite')) {
 			continue;
 		}
+
 		new_lines.push(line);
 	}
 


### PR DESCRIPTION
quick follow-up to #17001. We remove Svelte internals from the stack trace so that you only see user code, which makes it much easier to find the source of a change. But the heuristic we use for 'Svelte internals' is that the line includes 'svelte/src/internal', which doesn't work if the code has been bundled.

Unfortunately, that's usually the case, because Vite will bundle stuff in `node_modules` unless you tell it not to. We can account for that by also excluding `node_modules/.vite`. It won't fix _every_ setup but it fixes the most common case.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
