### PR TITLE
fix: better optimization of await expressions

### DIFF
--- a/.changeset/odd-plants-lead.md
+++ b/.changeset/odd-plants-lead.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better optimization of await expressions

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -6,7 +6,7 @@ import { walk } from 'zimmerframe';
 import { parse } from '../1-parse/acorn.js';
 import * as e from '../../errors.js';
 import * as w from '../../warnings.js';
-import { extract_identifiers } from '../../utils/ast.js';
+import { extract_identifiers, has_await_expression } from '../../utils/ast.js';
 import * as b from '#compiler/builders';
 import { Scope, ScopeRoot, create_scopes, get_rune, set_scope } from '../scope.js';
 import check_graph_for_cycles from './utils/check_graph_for_cycles.js';

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
@@ -12,7 +12,7 @@ import {
 import * as b from '#compiler/builders';
 import { sanitize_template_string } from '../../../../../utils/sanitize_template_string.js';
 import { regex_whitespaces_strict } from '../../../../patterns.js';
-import { has_await } from '../../../../../utils/ast.js';
+import { has_await_expression } from '../../../../../utils/ast.js';
 
 /** Opens an if/each block, so that we can remove nodes in the case of a mismatch */
 export const block_open = b.literal(BLOCK_OPEN);
@@ -315,7 +315,7 @@ export class PromiseOptimiser {
 
 		const promises = b.array(
 			this.expressions.map((expression) => {
-				return expression.type === 'AwaitExpression' && !has_await(expression.argument)
+				return expression.type === 'AwaitExpression' && !has_await_expression(expression.argument)
 					? expression.argument
 					: b.call(b.thunk(expression, true));
 			})

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -611,16 +611,20 @@ export function build_assignment_value(operator, left, right) {
 }
 
 /**
- * @param {ESTree.Expression} expression
+ * @param {ESTree.Node} node
  */
-export function has_await(expression) {
+export function has_await_expression(node) {
 	let has_await = false;
 
-	walk(expression, null, {
+	walk(node, null, {
 		AwaitExpression(_node, context) {
 			has_await = true;
 			context.stop();
-		}
+		},
+		// don't traverse into these
+		FunctionDeclaration() {},
+		FunctionExpression() {},
+		ArrowFunctionExpression() {}
 	});
 
 	return has_await;

--- a/packages/svelte/src/compiler/utils/builders.js
+++ b/packages/svelte/src/compiler/utils/builders.js
@@ -2,7 +2,7 @@
 import { walk } from 'zimmerframe';
 import { regex_is_valid_identifier } from '../phases/patterns.js';
 import { sanitize_template_string } from './sanitize_template_string.js';
-import { has_await } from './ast.js';
+import { has_await_expression } from './ast.js';
 
 /**
  * @param {Array<ESTree.Expression | ESTree.SpreadElement | null>} elements
@@ -451,7 +451,7 @@ export function thunk(expression, async = false) {
 export function unthunk(expression) {
 	// optimize `async () => await x()`, but not `async () => await x(await y)`
 	if (expression.async && expression.body.type === 'AwaitExpression') {
-		if (!has_await(expression.body.argument)) {
+		if (!has_await_expression(expression.body.argument)) {
 			return unthunk(arrow(expression.params, expression.body.argument));
 		}
 	}


### PR DESCRIPTION
a small fix that will be helpful in some upcoming work. If you have something like this...

```svelte
{await x(async () => await y)}
```

...then today we generate this...

```js
$.template_effect(($0) => $.set_text(text, $0), void 0, [async () => await x(async () => await y)]);
```

...when in fact we only need this, because the inner `await` is inside a function boundary:

```js
$.template_effect(($0) => $.set_text(text, $0), void 0, [() => x(async () => await y)]);
```

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
