### PR TITLE
docs: fix alignment and visiblity for await example in docs

### DIFF
--- a/documentation/docs/03-template-syntax/05-await.md
+++ b/documentation/docs/03-template-syntax/05-await.md
@@ -70,10 +70,10 @@ Similarly, if you only want to show the error state, you can omit the `then` blo
 ```
 
 > [!NOTE] You can use `#await` with [`import(...)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) to render components lazily:
->
-> ```svelte
-> {#await import('./Component.svelte') then { default: Component }}
-> 	<Component />
-> {/await}
-> ```
+
+```svelte
+{#await import('./Component.svelte') then { default: Component }}
+	<Component />
+{/await}
+```
 


### PR DESCRIPTION
Updated the alignment and visiblity for the await example.

The last part is not visible when in a '>' md block.