### PR TITLE
fix: don't restore batch in `#await`

### DIFF
--- a/.changeset/shaky-jars-cut.md
+++ b/.changeset/shaky-jars-cut.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't restore batch in `#await`

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -33,7 +33,6 @@ import {
 	set_hydrating,
 	skip_nodes
 } from '../dom/hydration.js';
-import { create_text } from '../dom/operations.js';
 
 /**
  *
@@ -102,11 +101,11 @@ export function capture() {
 		var previous_dev_stack = dev_stack;
 	}
 
-	return function restore() {
+	return function restore(activate_batch = true) {
 		set_active_effect(previous_effect);
 		set_active_reaction(previous_reaction);
 		set_component_context(previous_component_context);
-		previous_batch?.activate();
+		if (activate_batch) previous_batch?.activate();
 
 		if (was_hydrating) {
 			set_hydrating(true);


### PR DESCRIPTION
#16977 had one slight regression which might contribute to #16990: The batch from earlier was restored, but that doesn't make sense in this situations since this has nothing to do with our new async logic of batches suspending until pending work is done. As a result you could end up with a batch being created, and then the restore then instead reverting to an earlier batch that was already done, which means a ghost-batch ends up in the set of batches, subsequently triggering time traveling when it shouldn't. This may help with #16990

No test because basically impossible to do so

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
