### PR TITLE
fix: settle batch after DOM updates

### DIFF
--- a/.changeset/loud-chairs-tease.md
+++ b/.changeset/loud-chairs-tease.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: settle batch after DOM updates

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -196,6 +196,8 @@ export class Batch {
 			flush_queued_effects(target.effects);
 
 			previous_batch = null;
+
+			this.#deferred?.resolve();
 		}
 
 		batch_values = null;
@@ -432,8 +434,6 @@ export class Batch {
 
 		this.committed = true;
 		batches.delete(this);
-
-		this.#deferred?.resolve();
 	}
 
 	/**

--- a/packages/svelte/tests/runtime-runes/samples/async-settled-after-dom/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-settled-after-dom/_config.js
@@ -1,0 +1,27 @@
+import { settled, tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	async test({ assert, target }) {
+		const [shift, update] = target.querySelectorAll('button');
+
+		shift.click();
+		await tick();
+
+		assert.htmlEqual(target.innerHTML, '<button>shift</button><button>update</button><p>hello</p>');
+
+		update.click();
+		const promise = settled();
+
+		await tick();
+		shift.click();
+		await promise;
+
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>shift</button><button>update</button><p>goodbye</p>'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-settled-after-dom/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-settled-after-dom/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	let text = $state('hello');
+
+	const resolvers = [];
+
+	function push(value) {
+		const { promise, resolve } = Promise.withResolvers();
+		resolvers.push(() => resolve(value));
+		return promise;
+	}
+</script>
+
+<button onclick={() => resolvers.shift()?.()}>shift</button>
+<button onclick={() => text = 'goodbye'}>update</button>
+
+<svelte:boundary>
+	<p>{await push(text)}</p>
+
+	{#snippet pending()}{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
extracted from #17038. interestingly the test still passes on `main` — something to do with the code `await promise` not running for an extra microtask, or something — but i don't trust it. this is better

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
