### PR TITLE
Fix  spelling in code comments

### DIFF
--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -267,7 +267,7 @@ export function proxy(value) {
 					if (other_s !== undefined) {
 						set(other_s, UNINITIALIZED);
 					} else if (i in target) {
-						// If the item exists in the original, we need to create a uninitialized source,
+						// If the item exists in the original, we need to create an uninitialized source,
 						// else a later read of the property would result in a source being created with
 						// the value of the original item at that index.
 						other_s = with_parent(() => source(UNINITIALIZED, stack));

--- a/packages/svelte/src/internal/server/renderer.js
+++ b/packages/svelte/src/internal/server/renderer.js
@@ -386,7 +386,7 @@ export class Renderer {
 	}
 
 	/**
-	 * Collect all of the `onDestroy` callbacks regsitered during rendering. In an async context, this is only safe to call
+	 * Collect all of the `onDestroy` callbacks registered during rendering. In an async context, this is only safe to call
 	 * after awaiting `collect_async`.
 	 *
 	 * Child renderers are "porous" and don't affect execution order, but component body renderers

--- a/packages/svelte/tests/runtime-browser/assert.js
+++ b/packages/svelte/tests/runtime-browser/assert.js
@@ -166,7 +166,7 @@ export function test(args) {
 	return args;
 }
 
-// TypeScript needs the type of assertions to be directly visible, not infered, which is why
+// TypeScript needs the type of assertions to be directly visible, not inferred, which is why
 // we can't have it on the test suite type.
 /**
  * @param {any} value

--- a/packages/svelte/tests/runtime-runes/samples/mount-props-updates/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/mount-props-updates/_config.js
@@ -22,7 +22,7 @@ export default test({
 			target.innerHTML,
 			// bar is not set in the parent because it's a readonly property
 			// baz is not set in the parent because while it's a bindable property,
-			// it wasn't set initially so it's treated as a readonly proeprty
+			// it wasn't set initially so it's treated as a readonly property
 			`
 			<button>reset</button> foo 3
 			<div><button>update</button> 1 2 3 4</div>


### PR DESCRIPTION
 Fixes grammar and spelling errors in code comments:

  - `a uninitialized` → `an uninitialized` (article correction)
  - `regsitered` → `registered` (correct spelling)
  - `infered` → `inferred` (correct spelling)
  - `proeprty` → `property` (correct spelling)