### PR TITLE
fix: treat each blocks with async dependencies as uncontrolled

### DIFF
--- a/.changeset/fair-files-cover.md
+++ b/.changeset/fair-files-cover.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: treat each blocks with async dependencies as uncontrolled

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
@@ -105,7 +105,7 @@ export function process_children(nodes, initial, is_element, context) {
 				is_element &&
 				// In case it's wrapped in async the async logic will want to skip sibling nodes up until the end, hence we cannot make this controlled
 				// TODO switch this around and instead optimize for elements with a single block child and not require extra comments (neither for async nor normally)
-				!(node.body.metadata.has_await || node.metadata.expression.has_await)
+				!(node.body.metadata.has_await || node.metadata.expression.is_async())
 			) {
 				node.metadata.is_controlled = true;
 			} else {


### PR DESCRIPTION
Oddly enough I can't seem to produce a failing test around this, but the following code...

```svelte
<script lang="ts">
	import Dummy from './Dummy.svelte';

	const array = await [1, 2];
</script>

<article>
	{#each await array}
		<div>
			<Dummy />
		</div>
	{/each}
</article>
```

...will fail to hydrate, because of the `is_controlled` optimisation being incorrectly applied.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
