### PR TITLE
fix: reconnect disconnect deriveds after batch processing

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/async-derived-unowned/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-derived-unowned/Component.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { double } = $props();
+	double; // forces derived into UNOWNED mode
+</script>
+
+<p>{double}</p>

--- a/packages/svelte/tests/runtime-runes/samples/async-derived-unowned/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-derived-unowned/_config.js
@@ -1,0 +1,30 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		button?.click();
+		await tick();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>1</button>
+				<p>2</p>
+			`
+		);
+
+		button?.click();
+		await tick();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>2</button>
+				<p>4</p>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-derived-unowned/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-derived-unowned/main.svelte
@@ -1,0 +1,19 @@
+<script>
+	import Component from './Component.svelte';
+	let count = $state(0);
+	const double = $derived(count * 2);
+</script>
+
+<svelte:boundary>
+	{await new Promise((r) => {
+		// long enough for the test to do all its other stuff while this is pending
+		setTimeout(r, 10);
+	})}
+	{#snippet pending()}{/snippet}
+</svelte:boundary>
+
+<button onclick={() => count += 1}>{count}</button>
+
+{#if count > 0}
+	<Component {double} />
+{/if}


### PR DESCRIPTION
WIP. This is a different take on #17095 — rather than change `is_dirty`, which is already a slightly confusing chunk of code, what if we reconnect deriveds after batches are processed? I worry that calling a function called `is_dirty` purely for its side-effects will make things harder to follow in future. We're already breaking the rules by having side-effects in `is_dirty` at all, and I would love to find a way to clean that up (other than setting `MAYBE_DIRTY` signals to `CLEAN`, which feels okay).

On that: I'm pretty sure we're using terminology incorrectly at present. A derived is `UNOWNED` if it is _created_ outside an active reaction, and as such that flag should never be toggled, unlike `DISCONNECTED` which describes the current state of a derived. I feel like this corner of the codebase is overdue for an inspection.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
