### PR TITLE
chore: tweak resource implementation

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/resource.js
+++ b/packages/svelte/src/internal/client/reactivity/resource.js
@@ -42,12 +42,6 @@ class Resource {
 	/** @type {Source<Promise<T>>} */
 	#promise;
 
-	/** @type {Derived<T | undefined>} */
-	#current = derived(() => {
-		if (!get(this.#ready)) return undefined;
-		return get(this.#raw);
-	});
-
 	/** {@type Source<any>} */
 	#error = state(undefined);
 
@@ -126,7 +120,7 @@ class Resource {
 	}
 
 	get current() {
-		return get(this.#current);
+		return get(this.#ready) ? get(this.#raw) : undefined;
 	}
 
 	get error() {


### PR DESCRIPTION
I _think_ we can simplify the implementation of `resource` a bit. @dummdidumm may have thoughts on some of the gnarlier edge cases that have cropped up in the course of developing remote functions, and whether this undoes the fixes