### PR TITLE
fix: don't deactivate other batches

### DIFF
--- a/.changeset/eleven-moons-smash.md
+++ b/.changeset/eleven-moons-smash.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't deactivate other batches

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -299,6 +299,10 @@ export class Batch {
 	}
 
 	deactivate() {
+		// If we're not the current batch, don't deactivate,
+		// else we could create zombie batches that are never flushed
+		if (current_batch !== this) return;
+
 		current_batch = null;
 		batch_values = null;
 	}

--- a/packages/svelte/tests/runtime-runes/samples/async-batch-timing/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-batch-timing/Component.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	let { ref } = $props();
+
+	let tick = $state(0);
+	let ref_exists = $state(true);
+ 
+	$effect(() => {
+		tick;
+		ref_exists = ref !== null;
+	});
+</script>
+
+<p>{ref_exists}</p>
+<button onclick={() => tick++}>check</button>

--- a/packages/svelte/tests/runtime-runes/samples/async-batch-timing/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-batch-timing/_config.js
@@ -1,0 +1,23 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+// This test regresses against batches deactivating other batches than themselves
+export default test({
+	async test({ assert, target }) {
+		await tick(); // settle initial await
+
+		const button = target.querySelector('button');
+
+		button?.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<div>div</div>
+				<p>true</p>
+				<button>check</button>
+				<p></p>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-batch-timing/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-batch-timing/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	import Component from "./Component.svelte";
+
+	let ref = $state(null);
+
+	let foo = $derived(await 1);
+</script>
+
+<div bind:this={ref}>div</div>
+
+<Component {ref} />
+
+{#if foo} 
+	<p></p>
+{/if}


### PR DESCRIPTION
There's a possibility of a race condition where `batch.deactivate()` is called while `current_batch !== batch`, and so it would deactivate another batch, which can lead to zombie batches that are never flushed, subsequently leading to wrong `batch_values`. This fixes that by checking if the current batch is the own batch.

Fixes #17109

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
