### PR TITLE
fix: ensure eager effects don't break reactions chain

### DIFF
--- a/.changeset/silent-teeth-invent.md
+++ b/.changeset/silent-teeth-invent.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure eager effects don't break reactions chain

--- a/packages/svelte/tests/runtime-runes/samples/inspect-derived-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-derived-4/_config.js
@@ -1,0 +1,35 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+import { normalise_inspect_logs } from '../../../helpers';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, target, logs }) {
+		const [b] = target.querySelectorAll('button');
+
+		b.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<button>first unseen: 1</button>`);
+
+		b.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<button>first unseen: 2</button>`);
+
+		b.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<button>first unseen:</button>`);
+
+		assert.deepEqual(normalise_inspect_logs(logs), [
+			[0, 1, 2],
+			[1, 2],
+			'at SvelteSet.add',
+			[2],
+			'at SvelteSet.add',
+			[],
+			'at SvelteSet.add'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/inspect-derived-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-derived-4/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import {SvelteSet} from "svelte/reactivity";
+	const ids = [0,1,2];
+	const seenIds = new SvelteSet();
+
+	const unseenIds = $derived(ids.filter((id) => !seenIds.has(id)));
+	
+	const currentId = $derived(unseenIds.at(0));
+	$inspect(unseenIds)
+</script>
+
+<button onclick={() => seenIds.add(currentId)}>
+	first unseen: {currentId}
+</button>


### PR DESCRIPTION
Execution of eager effects didn't set `is_updating_effect`, which meant the logic in `get` would wrongfully prevent dependencies being added to `reactions` of sources/deriveds.

Fixes #17133
fixes https://github.com/sveltejs/svelte/issues/17130

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
