### PR TITLE
fix invalid negative values in sourcemap column indexes

### DIFF
--- a/packages/svelte/tests/sourcemaps/test.ts
+++ b/packages/svelte/tests/sourcemaps/test.ts
@@ -102,7 +102,7 @@ const { test, run } = suite<SourcemapTest>(async (config, cwd) => {
 		*/
 		for (let l = 0; l < decoded.length; l++) {
 			for (let m of decoded[l]) {
-				if (m.find((i) => i < 0)) {
+				if (m.some((i) => i < 0)) {
 					throw new Error(
 						`Invalid mapping with negative value ${JSON.stringify(m)} at line ${l} of the decoded mappings of ${info} sourcemap\n${JSON.stringify(map)}`
 					);


### PR DESCRIPTION
- [x]  check for invalid index values in decoded sourcemaps of existing samples
- [x] ~~find and fix why existing sourcemap tests did not detect this ( mappings should be traced back more strictly)~~  -> existing tests never tracked the script tag itself
- [x] find and fix underlying issue  (fixed by https://github.com/sveltejs/svelte/pull/17428 ) 


### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
