### PR TITLE
chore: only skip effects when deferring

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -244,7 +244,9 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 					item.i = i;
 				}
 
-				batch.skipped_effects.delete(item.e);
+				if (defer) {
+					batch.skipped_effects.delete(item.e);
+				}
 			} else {
 				item = create_item(
 					first_run ? anchor : null,


### PR DESCRIPTION
Occurred to me that there's no point messing around with `skipped_effects` in an `each` block if we're not deferring (i.e. it's being created, or it's being updated in non-async mode). 

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
