### PR TITLE
fix: keep deriveds reactive after their original parent effect was destroyed

### DIFF
--- a/.changeset/sad-forks-go.md
+++ b/.changeset/sad-forks-go.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep deriveds reactive after their original parent effect was destroyed

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -11,7 +11,8 @@ import {
 	STALE_REACTION,
 	ASYNC,
 	WAS_MARKED,
-	CONNECTED
+	CONNECTED,
+	DESTROYED
 } from '#client/constants';
 import {
 	active_reaction,
@@ -296,7 +297,9 @@ function get_derived_parent_effect(derived) {
 	var parent = derived.parent;
 	while (parent !== null) {
 		if ((parent.f & DERIVED) === 0) {
-			return /** @type {Effect} */ (parent);
+			// The original parent effect might've been destroyed but the derived
+			// is used elsewhere now - do not return the destroyed effect in that case
+			return (parent.f & DESTROYED) === 0 ? /** @type {Effect} */ (parent) : null;
 		}
 		parent = parent.parent;
 	}

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -1391,6 +1391,33 @@ describe('signals', () => {
 		};
 	});
 
+	test('derived whose original parent effect has been destroyed keeps updating', () => {
+		return () => {
+			let count: Source<number>;
+			let double: Derived<number>;
+			const destroy = effect_root(() => {
+				render_effect(() => {
+					count = state(0);
+					double = derived(() => $.get(count) * 2);
+				});
+			});
+
+			flushSync();
+			assert.equal($.get(double!), 0);
+
+			destroy();
+			flushSync();
+
+			set(count!, 1);
+			flushSync();
+			assert.equal($.get(double!), 2);
+
+			set(count!, 2);
+			flushSync();
+			assert.equal($.get(double!), 4);
+		};
+	});
+
 	test('$effect.root inside deriveds stay alive independently', () => {
 		const log: any[] = [];
 		const c = state(0);


### PR DESCRIPTION
Use case: Remote queries that are created on one screen, then are used again on another screen. Original parent effect is destroyed in that case but derived should still be reactive. It wasn't prior to this fix because inside `get` the `destroyed` variable would be true and so deps would not properly be recorded.

Fixes https://github.com/sveltejs/kit/issues/14814
Fixes #17082

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
