### PR TITLE
chore: fix types of binding.blocker

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1184,7 +1184,15 @@ function calculate_blockers(instance, scopes, analysis) {
 		trace_references(body, reads_writes, reads_writes);
 
 		const max = [...reads_writes].reduce((max, binding) => {
-			return binding.blocker ? Math.max(binding.blocker.property.value, max) : max;
+			if (binding.blocker) {
+				let property = /** @type {ESTree.SimpleLiteral & { value: number }} */ (
+					binding.blocker.property
+				);
+
+				return Math.max(property.value, max);
+			}
+
+			return max;
 		}, -1);
 
 		if (max === -1) continue;

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -141,7 +141,7 @@ export class Binding {
 	 * otherwise the initial value will not have been assigned.
 	 * It is a member expression of the form `$$blockers[n]`.
 	 * TODO the blocker is set during transform which feels a bit grubby
-	 * @type {MemberExpression & { object: Identifier, property: SimpleLiteral & { value: number } } | null}
+	 * @type {MemberExpression | null}
 	 */
 	blocker = null;
 


### PR DESCRIPTION
Typechecking is failing after #17137 — I should have spotted this sooner