### PR TITLE
fix: ensure each block animations don't mess with transitions

### DIFF
--- a/.changeset/tiny-loops-wonder.md
+++ b/.changeset/tiny-loops-wonder.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure each block animations don't mess with transitions

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -394,8 +394,12 @@ function reconcile(state, array, anchor, flags, get_key) {
 			key = get_key(value, i);
 			item = /** @type {EachItem} */ (items.get(key));
 
-			item.a?.measure();
-			(to_animate ??= new Set()).add(item);
+			// offscreen == coming in now, no animation in that case,
+			// else this would happen https://github.com/sveltejs/svelte/issues/17181
+			if (item.o) {
+				item.a?.measure();
+				(to_animate ??= new Set()).add(item);
+			}
 		}
 	}
 


### PR DESCRIPTION
This ensures that an animation does not run when the element is first transitioning in. Else the animation would mess with the transition (overriding its animation basically). Due to our test setup it's not testable but I veryfied it fixes #17181 (tested all reproductions in there)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
