### PR TITLE
chore: better log_effect_tree

### DIFF
--- a/packages/svelte/src/internal/client/dev/debug.js
+++ b/packages/svelte/src/internal/client/dev/debug.js
@@ -13,6 +13,7 @@ import {
 	ROOT_EFFECT
 } from '#client/constants';
 import { snapshot } from '../../shared/clone.js';
+import { untrack } from '../runtime.js';
 
 /**
  *
@@ -118,7 +119,7 @@ function log_dep(dep) {
 			`%c$derived %c${dep.label ?? '<unknown>'}`,
 			'font-weight: bold; color: CornflowerBlue',
 			'font-weight: normal',
-			snapshot(derived.v)
+			untrack(() => snapshot(derived.v))
 		);
 
 		if (derived.deps) {
@@ -135,7 +136,7 @@ function log_dep(dep) {
 			`%c$state %c${dep.label ?? '<unknown>'}`,
 			'font-weight: bold; color: CornflowerBlue',
 			'font-weight: normal',
-			snapshot(dep.v)
+			untrack(() => snapshot(dep.v))
 		);
 	}
 }


### PR DESCRIPTION
I use `log_effect_tree` a lot when trying to debug why things aren't updating as they should. While using it to wrap my head round #17240 it occurred to me that we could make it a little more useful by printing signal labels and, where applicable, nodes.

Before:

<img width="446" height="499" alt="image" src="https://github.com/user-attachments/assets/e8b4d81b-4963-4f8b-ac0b-c48f04fc1350" />


After:

<img width="432" height="546" alt="image" src="https://github.com/user-attachments/assets/22137878-4cd7-4b5b-8330-4856a276e6be" />
