### PR TITLE
chore: skip static index update

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -243,8 +243,6 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 
 				if (is_reactive_index) {
 					internal_set(/** @type {Value<number>} */ (item.i), i);
-				} else {
-					item.i = i;
 				}
 
 				if (defer) {


### PR DESCRIPTION
This is unnecessary — if `is_reactive_index` is false, it's because we're in an unkeyed each block (in which the index of a given block can never change) or one that doesn't _use_ the index. Either way there is no reason to update it after creation

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
