### PR TITLE
fix: serialize thenables in `hydratable`

### DIFF
--- a/.changeset/puny-dots-change.md
+++ b/.changeset/puny-dots-change.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: serialize thenables in `hydratable`

--- a/packages/svelte/src/internal/server/hydratable.js
+++ b/packages/svelte/src/internal/server/hydratable.js
@@ -3,7 +3,6 @@ import { async_mode_flag } from '../flags/index.js';
 import { get_render_context } from './render-context.js';
 import * as e from './errors.js';
 import * as devalue from 'devalue';
-import { get_stack } from '../shared/dev.js';
 import { DEV } from 'esm-env';
 import { get_user_code_location } from './dev.js';
 
@@ -56,8 +55,14 @@ function encode(key, value, unresolved) {
 	let uid = 1;
 
 	entry.serialized = devalue.uneval(entry.value, (value, uneval) => {
-		if (value instanceof Promise) {
-			const p = value
+		if (
+			value instanceof Promise ||
+			(typeof value === 'object' &&
+				value !== null &&
+				'then' in value &&
+				typeof value.then === 'function')
+		) {
+			const p = Promise.resolve(value)
 				.then((v) => `r(${uneval(v)})`)
 				.catch((devalue_error) =>
 					e.hydratable_serialization_failed(


### PR DESCRIPTION
This serializes thenables in `hydratable`. However, there is a slight discrepancy: if you have an object that is a thenable on the server, it will be converted to a `Promise` on the client. I'm not sure if we should:
1. convert thenables to `Promise`s (and maybe reflect that in the types?)
2. do nothing and close this PR 
3. resolve the thenable on the server, and on the client return an object that has the serialized contents of the thenable (excluding the original `then` function), with a `then` function that resolves to the awaited value, which would look like:
```js
const create_thenable = () => ({
  foo: 1,
  bar: 2,
  then(onresolve, onreject) {
    return Promise.resolve(Math.random()).then(onresolve, onreject);
  }
});
const thenable = await hydratable('test', create_thenable);
// on client: Object.assign({ foo: 1, bar: 2 }, { then: (a, b) => r(0.1234).then(a, b) });
```

Option 3 would probably be the best in terms of correctness, but it'd also be the most complex; we'd have to add some extra errors and checks for values that cannot be serialized (since there isn't a way to omit a property from a non-POJO while preserving its prototype, which would let us make `devalue` do the checking for us), which would raise the issue of having two types of serialization errors: those from `devalue` and those from `svelte`, which would make error handling trickier. Additionally, we'd likely have to preserve key order in thenables, which could get ugly. 

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
