### PR TITLE
docs: update outdated Svelte Society editor support link URL

### DIFF
--- a/documentation/docs/01-introduction/02-getting-started.md
+++ b/documentation/docs/01-introduction/02-getting-started.md
@@ -25,7 +25,7 @@ There are also [plugins for other bundlers](/packages#bundler-plugins), but we r
 
 The Svelte team maintains a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode), and there are integrations with various other [editors](https://sveltesociety.dev/collection/editor-support-c85c080efc292a34) and tools as well.
 
-You can also check your code from the command line using `sv check`(https://github.com/sveltejs/cli).
+You can also check your code from the command line using [`sv check`](https://github.com/sveltejs/cli).
 
 
 ## Getting help


### PR DESCRIPTION
**Fixes** https://github.com/sveltejs/kit/issues/14941

This PR addresses the issue of the support link in the Editor Tooling section of the Getting Started documentation resulting in a "No content found" page.

---

### What's Fixed

Updated the link within the 'documentation/docs/01-introduction/02-getting-started.md' file. The text and surrounding formatting have been preserved exactly as they were, with **only the URL being modified**.

* **Old URL:** `https://sveltesociety.dev/resources#editor-support`
* **New URL:** `https://sveltesociety.dev/collection/editor-support-c85c080efc292a34`

### Why This Change Matters

The old link resulted in a "No content found" error, causing confusion for new users seeking editor setup instructions. This change ensures the documentation provides **accurate, working resources** so beginners can easily find supported editor integrations.

---

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

This PR only updates documentation and does not modify any source code or logic.

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` (N/A, documentation change only)