### PR TITLE
chore: minor each tweak

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -483,7 +483,7 @@ function reconcile(state, array, anchor, flags, get_key) {
 			matched = [];
 			stashed = [];
 
-			while (current !== null && current.k !== key) {
+			while (current !== null && current !== item) {
 				// If the each block isn't inert and an item has an effect that is already inert,
 				// skip over adding it to our seen Set as the item is already being handled
 				if ((current.e.f & INERT) === 0) {


### PR DESCRIPTION
tiny change — saves a property lookup in a hot code path. will self-merge once green