### PR TITLE
docs: add link from svelte-transition page to full transition docs

### DIFF
--- a/documentation/docs/98-reference/21-svelte-transition.md
+++ b/documentation/docs/98-reference/21-svelte-transition.md
@@ -2,4 +2,7 @@
 title: svelte/transition
 ---
 
+> [!NOTE]
+> For context and usage examples, see the main [transition documentation](../03-template-syntax/14-transition).
+
 > MODULE: svelte/transition


### PR DESCRIPTION
### Adds helpful context link to svelte-transition docs

This PR adds a notice at the top of the `/docs/svelte/svelte-transition` page that links to the main transition documentation (`/docs/svelte/transition`).

**Why:**
Newcomers looking for information on animations and transitions using `{#if}` blocks land on `svelte-transition`, which is autogenerated and lacks context. The real documentation with examples is `transition`. This link reduces confusion and improves discoverability.

**Changes:**
- Added a NOTE callout at the top of the svelte-transition reference page
- Links to the main transition documentation for context and usage examples
- Follows existing documentation formatting patterns

The change is minimal and only adds helpful navigation for users who land on the reference page first.