### PR TITLE
feat: allow `$derived($state())` for deep reactive deriveds

### DIFF
--- a/.changeset/cyan-planes-yawn.md
+++ b/.changeset/cyan-planes-yawn.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: allow `$derived($state())` for deep reactive deriveds

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -121,7 +121,15 @@ export function CallExpression(node, context) {
 				is_class_property_definition(parent) ||
 				is_class_property_assignment_at_constructor_root(parent, context);
 
-			if (!valid) {
+			if (
+				!valid &&
+				(rune !== '$state' ||
+					!(
+						parent.type === 'CallExpression' &&
+						parent.callee.type === 'Identifier' &&
+						parent.callee.name === '$derived'
+					))
+			) {
 				e.state_invalid_placement(node, rune);
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/derived-state-init-class/Class.svelte.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-state-init-class/Class.svelte.js
@@ -1,0 +1,6 @@
+export class Test {
+	local_arr;
+	constructor(arr) {
+		this.local_arr = $derived($state(arr()));
+	}
+}

--- a/packages/svelte/tests/runtime-runes/samples/derived-state-init-class/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-state-init-class/Component.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { Test } from "./Class.svelte.js";
+	let { arr } = $props();
+
+	let test = new Test(() => arr);
+</script>
+
+<button onclick={()=>{
+	test.local_arr.push(test.local_arr.length + 1);
+}}>push</button>
+{#each test.local_arr as item}
+	<p>{item}</p>
+{/each}

--- a/packages/svelte/tests/runtime-runes/samples/derived-state-init-class/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-state-init-class/_config.js
@@ -1,0 +1,37 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ target, assert }) {
+		const [update_parent, push] = target.querySelectorAll('button');
+		let p_tags = target.querySelectorAll('p');
+
+		assert.equal(p_tags.length, 3);
+		assert.equal(p_tags[0].textContent, '1');
+		assert.equal(p_tags[1].textContent, '2');
+		assert.equal(p_tags[2].textContent, '3');
+
+		flushSync(() => {
+			push.click();
+		});
+
+		p_tags = target.querySelectorAll('p');
+
+		assert.equal(p_tags.length, 4);
+		assert.equal(p_tags[0].textContent, '1');
+		assert.equal(p_tags[1].textContent, '2');
+		assert.equal(p_tags[2].textContent, '3');
+		assert.equal(p_tags[3].textContent, '4');
+
+		flushSync(() => {
+			update_parent.click();
+		});
+
+		p_tags = target.querySelectorAll('p');
+
+		assert.equal(p_tags.length, 3);
+		assert.equal(p_tags[0].textContent, '4');
+		assert.equal(p_tags[1].textContent, '5');
+		assert.equal(p_tags[2].textContent, '6');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-state-init-class/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-state-init-class/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Component from './Component.svelte';
+	let arr = $state.raw([1, 2, 3]);
+</script>
+
+<button onclick={()=>{
+	arr = [4,5,6];
+}}>update</button>
+
+<Component {arr}/>

--- a/packages/svelte/tests/runtime-runes/samples/derived-state-init/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-state-init/Component.svelte
@@ -1,0 +1,12 @@
+<script>
+	let { arr } = $props();
+
+	let local_arr = $derived($state(arr));
+</script>
+
+<button onclick={()=>{
+	local_arr.push(local_arr.length + 1);
+}}>push</button>
+{#each local_arr as item}
+	<p>{item}</p>
+{/each}

--- a/packages/svelte/tests/runtime-runes/samples/derived-state-init/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-state-init/_config.js
@@ -1,0 +1,37 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ target, assert }) {
+		const [update_parent, push] = target.querySelectorAll('button');
+		let p_tags = target.querySelectorAll('p');
+
+		assert.equal(p_tags.length, 3);
+		assert.equal(p_tags[0].textContent, '1');
+		assert.equal(p_tags[1].textContent, '2');
+		assert.equal(p_tags[2].textContent, '3');
+
+		flushSync(() => {
+			push.click();
+		});
+
+		p_tags = target.querySelectorAll('p');
+
+		assert.equal(p_tags.length, 4);
+		assert.equal(p_tags[0].textContent, '1');
+		assert.equal(p_tags[1].textContent, '2');
+		assert.equal(p_tags[2].textContent, '3');
+		assert.equal(p_tags[3].textContent, '4');
+
+		flushSync(() => {
+			update_parent.click();
+		});
+
+		p_tags = target.querySelectorAll('p');
+
+		assert.equal(p_tags.length, 3);
+		assert.equal(p_tags[0].textContent, '4');
+		assert.equal(p_tags[1].textContent, '5');
+		assert.equal(p_tags[2].textContent, '6');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-state-init/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-state-init/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Component from './Component.svelte';
+	let arr = $state.raw([1, 2, 3]);
+</script>
+
+<button onclick={()=>{
+	arr = [4,5,6];
+}}>update</button>
+
+<Component {arr}/>


### PR DESCRIPTION
This needs discussion, but Dominic and I had this idea. Deriveds are not deeply reactive, but even nowadays you can kinda achieve deep reactivity for deriveds by doing

```ts
let local_arr = $derived.by(()=>{
	let _ = $state(arr);
	return _;
});
```
This is fine, but it's a bit boilerplatey. This PR is to allow a shorthand of this by allowing `$state` to be used in the `init` of a derived.
```ts
let local_arr = $derived($state(arr));
```
This basically gets compiled to
```
let local_arr = $.derived(() => $.get($.state($.proxy($$props.arr))));
```
So it works exactly the same.

Point of discussions:

1. This is a solution, but it feels a bit weird...shouldn't this be a new rune instead? (I don't think we should add a new rune...just trying to think aloud)
2. While testing this, I've discovered a quirk of this approach (which was obvious in hindsight): since when you proxify a proxy, we just return the original proxy when the prop is `$state` and not `$state.raw` you are actually mutating the parent

```svelte
<script>
	import Component from './Component.svelte';
	let arr = $state([1, 2, 3]);
</script>
{arr}
<Component {arr}/>
```

```svelte
<script>
	let { arr } = $props();

	let local_arr = $derived($state(arr));
</script>

<!-- this actually push to the parent state --!>
<button onclick={()=>{
	local_arr.push(local_arr.length + 1);
}}>push</button>
```

However, this is also true for the original trick that we currently "kinda" recommend.

I look at the server output, and it doesn't need any changes, since `$state` is just removed anyway.

WDYT should we do this?

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
