### PR TITLE
fix: add `srcObject` to permitted `<audio>`/`<video>` attributes

### DIFF
--- a/.changeset/plenty-poets-read.md
+++ b/.changeset/plenty-poets-read.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: add `srcObject` to permitted `<audio>`/`<video>` attributes

--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -1239,6 +1239,7 @@ export interface HTMLMediaAttributes<T extends HTMLMediaElement> extends HTMLAtt
 	playsinline?: boolean | undefined | null;
 	preload?: 'auto' | 'none' | 'metadata' | '' | undefined | null;
 	src?: string | undefined | null;
+	srcobject?: MediaStream | MediaSource | File | Blob;
 	/**
 	 * a value between 0 and 1
 	 */


### PR DESCRIPTION
Allows you to do this sort of thing...

```svelte
<script lang="ts">
  const webcam = await navigator.mediaDevices.getUserMedia({ video: true });
</script>

<video autoplay srcObject={webcam}></video>
```

...or even just this..

```svelte
<video
  autoplay
  srcObject={await navigator.mediaDevices.getUserMedia({ video: true })}
></video>
```

...which I think is pretty neat.  It _does_ give you an a11y warning about missing captions, which might be a bit overzealous — will open a PR for that next.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
