### PR TITLE
fix: correctly print `!doctype` during `print`

### DIFF
--- a/.changeset/smooth-comics-shine.md
+++ b/.changeset/smooth-comics-shine.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: correctly print `!doctype` during `print`

--- a/packages/svelte/src/compiler/print/index.js
+++ b/packages/svelte/src/compiler/print/index.js
@@ -112,12 +112,13 @@ function base_element(node, context) {
 	}
 
 	const multiline_attributes = attributes(node.attributes, child_context);
-
+	const is_doctype_node = node.name.toLowerCase() === '!doctype';
 	const is_self_closing =
 		is_void(node.name) || (node.type === 'Component' && node.fragment.nodes.length === 0);
 	let multiline_content = false;
 
-	if (is_self_closing) {
+	if (is_doctype_node) child_context.write(`>`);
+	else if (is_self_closing) {
 		child_context.write(`${multiline_attributes ? '' : ' '}/>`);
 	} else {
 		child_context.write('>');

--- a/packages/svelte/tests/print/samples/html-document/input.svelte
+++ b/packages/svelte/tests/print/samples/html-document/input.svelte
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Svelte App</title>
+    </head>
+    <body>
+        <div>Hello World</div>
+    </body>
+</html>

--- a/packages/svelte/tests/print/samples/html-document/output.svelte
+++ b/packages/svelte/tests/print/samples/html-document/output.svelte
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1.0"
+		/>
+		<title>Svelte App</title>
+	</head>
+	<body><div>Hello World</div></body>
+</html>


### PR DESCRIPTION
Currently: 
```html
<!doctype html />
```

After
```html
<!doctype html>
```

Partially unblocks https://github.com/sveltejs/cli/pull/840

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
