### PR TITLE
fix: skip static optimisation for stateless deriveds after await

### DIFF
--- a/.changeset/deep-pears-juggle.md
+++ b/.changeset/deep-pears-juggle.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip static optimisation for stateless deriveds after `await`

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -336,7 +336,9 @@ export function RegularElement(node, context) {
 		trimmed.every(
 			(node) =>
 				node.type === 'Text' ||
-				(!node.metadata.expression.has_state && !node.metadata.expression.has_await)
+				(!node.metadata.expression.has_state &&
+					!node.metadata.expression.has_await &&
+					!node.metadata.expression.has_blockers())
 		) &&
 		trimmed.some((node) => node.type === 'ExpressionTag');
 

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -134,7 +134,7 @@ export function build_template_chunk(
 
 			const evaluated = state.scope.evaluate(value);
 
-			has_await ||= node.metadata.expression.has_await;
+			has_await ||= node.metadata.expression.has_await || node.metadata.expression.has_blockers();
 			has_state ||= has_await || (node.metadata.expression.has_state && !evaluated.is_known);
 
 			if (values.length === 1) {

--- a/packages/svelte/tests/runtime-runes/samples/async-static-derived-after-await/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-static-derived-after-await/_config.js
@@ -1,0 +1,9 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<p>hello</p>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-static-derived-after-await/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-static-derived-after-await/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	await 0;
+	let message = $derived('hello');
+</script>
+
+<p>{message}</p>


### PR DESCRIPTION
For expressions that we know will not change, we set text content during component initialisation rather than in an effect:

```js
p.textContent = 'whatever';
```

This fails if the right-hand side isn't known at initialisation time, and in the case of a derived that comes after an `await` but has no dynamic dependencies...

```svelte
<script>
	await 0;
	let message = $derived('hello');
</script>

<p>{message}</p>
```

...it results in `$.get(undefined)`, since the derived isn't created until after initialisation. This fixes it.

It's a real edge case, but it's one I ran into while looking into #17271 — will self-merge once green to unblock further exploration.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
