### PR TITLE
chore: disable HMR in playground

### DIFF
--- a/playgrounds/sandbox/svelte.config.js
+++ b/playgrounds/sandbox/svelte.config.js
@@ -1,6 +1,6 @@
 export default {
 	compilerOptions: {
-		hmr: true,
+		hmr: false,
 
 		experimental: {
 			async: true


### PR DESCRIPTION
this got toggled in a recent PR but it's actually very unhelpful to have HMR active in the sandbox most of the time, as it creates a bunch of extra effects that make debugging more complicated