### PR TITLE
chore: better async setContext test

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/async-set-context/A.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-set-context/A.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { setContext } from "svelte";
+	import B from "./B.svelte";
+
+	let greeting = 'hello';
+	setContext("greeting", greeting);
+
+	await Promise.resolve();
+
+	let recipient = 'world';
+</script>
+
+<B {recipient} />

--- a/packages/svelte/tests/runtime-runes/samples/async-set-context/B.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-set-context/B.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { setContext } from "svelte";
+	import C from "./C.svelte";
+
+	let { recipient } = $props();
+
+	// svelte-ignore state_referenced_locally
+	setContext("recipient", recipient);
+	await Promise.resolve();
+</script>
+
+<C />

--- a/packages/svelte/tests/runtime-runes/samples/async-set-context/C.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-set-context/C.svelte
@@ -2,6 +2,7 @@
 	import { getContext } from "svelte";
 
   let greeting = getContext("greeting");
+  let recipient = getContext("recipient");
 </script>
 
-<p>{greeting}</p>
+<p>{greeting} {recipient}</p>

--- a/packages/svelte/tests/runtime-runes/samples/async-set-context/Outer.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-set-context/Outer.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-	import { setContext } from "svelte";
-	import Inner from "./Inner.svelte";
-
-	setContext("greeting", "hi");
-	await Promise.resolve();
-</script>
-
-<Inner />

--- a/packages/svelte/tests/runtime-runes/samples/async-set-context/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-set-context/_config.js
@@ -3,9 +3,9 @@ import { test } from '../../test';
 
 export default test({
 	mode: ['client', 'async-server'],
-	ssrHtml: `<p>hi</p>`,
+	ssrHtml: `<p>hello world</p>`,
 	async test({ assert, target }) {
 		await tick();
-		assert.htmlEqual(target.innerHTML, '<p>hi</p>');
+		assert.htmlEqual(target.innerHTML, '<p>hello world</p>');
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/async-set-context/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-set-context/main.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import Outer from "./Outer.svelte";
+	import A from "./A.svelte";
 
 	await Promise.resolve();
 </script>
 
-<Outer />
+<A />


### PR DESCRIPTION
The test added in #17031 was sufficient at the time, but with the advent of out-of-order rendering it is no longer adequate. Reverting the `src` changes in that PR does _not_ cause the tests to fail. I know this because I was tempted to make that change while looking into something else.

Beefing up the test should eliminate that temptation in future. Will self-merge once green to unblock the work I was doing when I ran into this

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
