### PR TITLE
feat: Enhanced XHTML support

### DIFF
--- a/.changeset/red-clouds-shout.md
+++ b/.changeset/red-clouds-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Better X(HT)ML suppoprt

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-template/template.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-template/template.js
@@ -101,7 +101,7 @@ function stringify(item) {
 		const value = item.attributes[key];
 
 		str += ` ${key}`;
-		if (value !== undefined) str += `="${escape_html(value, true)}"`;
+		str += `="${value !== undefined ? escape_html(value, true) : ''}"`;
 	}
 
 	if (is_void(item.name)) {

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-element.js
@@ -1,5 +1,5 @@
 /** @import { Effect, EffectNodes, TemplateNode } from '#client' */
-import { FILENAME, NAMESPACE_SVG } from '../../../../constants.js';
+import { FILENAME, NAMESPACE_HTML, NAMESPACE_SVG } from '../../../../constants.js';
 import {
 	hydrate_next,
 	hydrate_node,
@@ -69,9 +69,7 @@ export function element(node, get_tag, is_svg, render_fn, get_namespace, locatio
 			if (next_tag) {
 				element = hydrating
 					? /** @type {Element} */ (element)
-					: ns
-						? document.createElementNS(ns, next_tag)
-						: document.createElement(next_tag);
+					: document.createElementNS(ns || NAMESPACE_HTML, next_tag);
 
 				if (DEV && location) {
 					// @ts-expect-error

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,6 +1,7 @@
 import { DEV } from 'esm-env';
 import { register_style } from '../dev/css.js';
 import { effect } from '../reactivity/effects.js';
+import { NAMESPACE_HTML } from '../../../constants.js';
 
 /**
  * @param {Node} anchor
@@ -18,7 +19,9 @@ export function append_styles(anchor, css) {
 		// Always querying the DOM is roughly the same perf as additionally checking for presence in a map first assuming
 		// that you'll get cache hits half of the time, so we just always query the dom for simplicity and code savings.
 		if (!target.querySelector('#' + css.hash)) {
-			const style = document.createElement('style');
+			const style = /** @type {HTMLStyleElement} */ (
+				document.createElementNS(NAMESPACE_HTML, 'style')
+			);
 			style.id = css.hash;
 			style.textContent = css.code;
 

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -83,7 +83,10 @@ export function set_value(element, value) {
 				value ?? undefined) ||
 		// @ts-expect-error
 		// `progress` elements always need their value set when it's `0`
-		(element.value === value && (value !== 0 || element.nodeName !== 'PROGRESS'))
+		(element.value === value &&
+			(value !== 0 ||
+				element.namespaceURI !== NAMESPACE_HTML ||
+				element.nodeName.toUpperCase() !== 'PROGRESS'))
 	) {
 		return;
 	}
@@ -168,7 +171,7 @@ export function set_attribute(element, attribute, value, skip_warning) {
 		if (
 			attribute === 'src' ||
 			attribute === 'srcset' ||
-			(attribute === 'href' && element.nodeName === 'LINK')
+			(attribute === 'href' && element.nodeName.toUpperCase() === 'LINK')
 		) {
 			if (!skip_warning) {
 				check_src_in_dev_hydration(element, attribute, value ?? '');
@@ -280,7 +283,12 @@ function set_attributes(
 	should_remove_defaults = false,
 	skip_warning = false
 ) {
-	if (hydrating && should_remove_defaults && element.tagName === 'INPUT') {
+	if (
+		hydrating &&
+		should_remove_defaults &&
+		element.namespaceURI === NAMESPACE_HTML &&
+		element.tagName.toUpperCase() === 'INPUT'
+	) {
 		var input = /** @type {HTMLInputElement} */ (element);
 		var attribute = input.type === 'checkbox' ? 'defaultChecked' : 'defaultValue';
 
@@ -302,7 +310,8 @@ function set_attributes(
 	}
 
 	var current = prev || {};
-	var is_option_element = element.tagName === 'OPTION';
+	var is_option_element =
+		element.namespaceURI === NAMESPACE_HTML && element.tagName.toUpperCase() === 'OPTION';
 
 	for (var key in prev) {
 		if (!(key in next)) {
@@ -347,7 +356,7 @@ function set_attributes(
 		}
 
 		if (key === 'class') {
-			var is_html = element.namespaceURI === 'http://www.w3.org/1999/xhtml';
+			var is_html = element.namespaceURI === NAMESPACE_HTML;
 			set_class(element, is_html, value, css_hash, prev?.[CLASS], next[CLASS]);
 			current[key] = value;
 			current[CLASS] = next[CLASS];
@@ -505,7 +514,7 @@ export function attribute_effect(
 		/** @type {Record<symbol, Effect>} */
 		var effects = {};
 
-		var is_select = element.nodeName === 'SELECT';
+		var is_select = element.nodeName.toUpperCase() === 'SELECT';
 		var inited = false;
 
 		managed(() => {

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -2,6 +2,7 @@ import { createClassComponent } from '../../../../legacy/legacy-client.js';
 import { effect_root, render_effect } from '../../reactivity/effects.js';
 import { append } from '../template.js';
 import { define_property, get_descriptor, object_keys } from '../../../shared/utils.js';
+import { NAMESPACE_HTML } from '../../../../constants.js';
 
 /**
  * @typedef {Object} CustomElementPropDefinition
@@ -98,7 +99,9 @@ if (typeof HTMLElement === 'function') {
 					 * @param {Element} anchor
 					 */
 					return (anchor) => {
-						const slot = document.createElement('slot');
+						const slot = /** @type {HTMLSlotElement} */ (
+							document.createElementNS(NAMESPACE_HTML, 'slot')
+						);
 						if (name !== 'default') slot.name = name;
 
 						append(anchor, slot);

--- a/packages/svelte/src/internal/client/dom/operations.js
+++ b/packages/svelte/src/internal/client/dom/operations.js
@@ -7,6 +7,7 @@ import { active_effect } from '../runtime.js';
 import { async_mode_flag } from '../../flags/index.js';
 import { TEXT_NODE, EFFECT_RAN } from '#client/constants';
 import { eager_block_effects } from '../reactivity/batch.js';
+import { NAMESPACE_HTML } from '../../../constants.js';
 
 // export these for reference in the compiled code, making global name deduplication unnecessary
 /** @type {Window} */
@@ -227,10 +228,7 @@ export function should_defer_append() {
  */
 export function create_element(tag, namespace, is) {
 	let options = is ? { is } : undefined;
-	if (namespace) {
-		return document.createElementNS(namespace, tag, options);
-	}
-	return document.createElement(tag, options);
+	return document.createElementNS(namespace || NAMESPACE_HTML, tag, options);
 }
 
 export function create_fragment() {

--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -1,6 +1,10 @@
+import { NAMESPACE_HTML } from '../../../constants.js';
+
 /** @param {string} html */
 export function create_fragment_from_html(html) {
-	var elem = document.createElement('template');
+	var elem = /** @type {HTMLTemplateElement} */ (
+		document.createElementNS(NAMESPACE_HTML, 'template')
+	);
 	elem.innerHTML = html.replaceAll('<!>', '<!---->'); // XHTML compliance
 	return elem.content;
 }


### PR DESCRIPTION
Closes #16540
Follow up to https://github.com/sveltejs/svelte/commit/a86e52b17466ff8c5bd6268932da6954d08a87d6

This PR adds support for using Svelte in XHTML and XML documents by:

1. Producing XML-compliant output for boolean attributes (e.g., `required` becomes `required=""`)
2. Using proper namespace checks for uses of `tagName` / `nodeName`, as well as ensuring that the values have the correct case.
3. Replaces use of `document.createElement` with `document.createElementNS`, defaulting to the HTML namespace. This ensures that even documents loaded in pure XML mode (e.g., `index.xml`, as opposed to `index.xhtml`) will work correctly.
