### PR TITLE
chore: eagerly assign labels to async deriveds

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -209,11 +209,11 @@ export function VariableDeclaration(node, context) {
 						let call = b.call(
 							'$.async_derived',
 							b.thunk(expression, true),
+							dev && b.literal(declarator.id.name),
 							location ? b.literal(location) : undefined
 						);
 
 						call = should_save ? save(call) : b.await(call);
-						if (dev) call = b.call('$.tag', call, b.literal(declarator.id.name));
 
 						declarations.push(b.declarator(declarator.id, call));
 					} else {
@@ -244,15 +244,14 @@ export function VariableDeclaration(node, context) {
 							call = b.call(
 								'$.async_derived',
 								b.thunk(expression, true),
+								dev &&
+									b.literal(
+										`[$derived ${declarator.id.type === 'ArrayPattern' ? 'iterable' : 'object'}]`
+									),
 								location ? b.literal(location) : undefined
 							);
 
 							call = should_save ? save(call) : b.await(call);
-						}
-
-						if (dev) {
-							const label = `[$derived ${declarator.id.type === 'ArrayPattern' ? 'iterable' : 'object'}]`;
-							call = b.call('$.tag', call, b.literal(label));
 						}
 
 						declarations.push(b.declarator(id, call));

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -93,11 +93,12 @@ export function derived(fn) {
 /**
  * @template V
  * @param {() => V | Promise<V>} fn
+ * @param {string} [label]
  * @param {string} [location] If provided, print a warning if the value is not read immediately after update
  * @returns {Promise<Source<V>>}
  */
 /*#__NO_SIDE_EFFECTS__*/
-export function async_derived(fn, location) {
+export function async_derived(fn, label, location) {
 	let parent = /** @type {Effect | null} */ (active_effect);
 
 	if (parent === null) {
@@ -108,6 +109,8 @@ export function async_derived(fn, location) {
 
 	var promise = /** @type {Promise<V>} */ (/** @type {unknown} */ (undefined));
 	var signal = source(/** @type {V} */ (UNINITIALIZED));
+
+	if (DEV) signal.label = label;
 
 	// only suspend in async deriveds created on initialisation
 	var should_suspend = !active_reaction;


### PR DESCRIPTION
In dev we assign labels to signals for easier debugging. Generally, this is done with the `$.tag(signal, label)` helper, but in the case of async deriveds this generally happens too late for be useful if, like me, you're debugging the internals (e.g. logging `source.label` inside `internal_set`).

This fixes it by passing the label to `async_derived` instead. Will self-merge once green to unblock other work