### PR TITLE
chore: move set_signal_status into separate module

### DIFF
--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -22,8 +22,7 @@ import {
 	active_reaction,
 	get,
 	set_active_effect,
-	set_active_reaction,
-	set_signal_status
+	set_active_reaction
 } from '../../runtime.js';
 import {
 	hydrate_next,
@@ -43,6 +42,7 @@ import { tag } from '../../dev/tracing.js';
 import { createSubscriber } from '../../../../reactivity/create-subscriber.js';
 import { create_text } from '../operations.js';
 import { defer_effect } from '../../reactivity/utils.js';
+import { set_signal_status } from '../../reactivity/status.js';
 
 /**
  * @typedef {{

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -29,7 +29,6 @@ import {
 	is_dirty,
 	is_updating_effect,
 	set_is_updating_effect,
-	set_signal_status,
 	update_effect
 } from '../runtime.js';
 import * as e from '../errors.js';
@@ -40,6 +39,7 @@ import { flush_eager_effects, old_values, set_eager_effects, source, update } fr
 import { eager_effect, unlink_effect } from './effects.js';
 import { defer_effect } from './utils.js';
 import { UNINITIALIZED } from '../../../constants.js';
+import { set_signal_status } from './status.js';
 
 /** @type {Set<Batch>} */
 const batches = new Set();

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -17,7 +17,6 @@ import {
 import {
 	active_reaction,
 	active_effect,
-	set_signal_status,
 	update_reaction,
 	increment_write_version,
 	set_active_effect,
@@ -37,6 +36,7 @@ import { UNINITIALIZED } from '../../../constants.js';
 import { batch_values, current_batch } from './batch.js';
 import { unset_context } from './async.js';
 import { deferred } from '../../shared/utils.js';
+import { set_signal_status } from './status.js';
 
 /** @type {Effect | null} */
 export let current_async_effect = null;

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -9,7 +9,6 @@ import {
 	remove_reactions,
 	set_active_reaction,
 	set_is_destroying_effect,
-	set_signal_status,
 	untrack,
 	untracking
 } from '../runtime.js';
@@ -44,6 +43,7 @@ import { component_context, dev_current_component_function, dev_stack } from '..
 import { Batch, current_batch, schedule_effect } from './batch.js';
 import { flatten } from './async.js';
 import { without_reactive_context } from '../dom/elements/bindings/shared.js';
+import { set_signal_status } from './status.js';
 
 /**
  * @param {'$effect' | '$effect.pre' | '$inspect'} rune

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -6,7 +6,6 @@ import {
 	untracked_writes,
 	get,
 	set_untracked_writes,
-	set_signal_status,
 	untrack,
 	increment_write_version,
 	update_effect,
@@ -40,6 +39,7 @@ import { component_context, is_runes } from '../context.js';
 import { Batch, batch_values, eager_block_effects, schedule_effect } from './batch.js';
 import { proxy } from '../proxy.js';
 import { execute_derived } from './deriveds.js';
+import { set_signal_status } from './status.js';
 
 /** @type {Set<any>} */
 export let eager_effects = new Set();

--- a/packages/svelte/src/internal/client/reactivity/status.js
+++ b/packages/svelte/src/internal/client/reactivity/status.js
@@ -1,0 +1,12 @@
+/** @import { Signal } from '#client' */
+import { CLEAN, DIRTY, MAYBE_DIRTY } from '#client/constants';
+
+const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
+
+/**
+ * @param {Signal} signal
+ * @param {number} status
+ */
+export function set_signal_status(signal, status) {
+	signal.f = (signal.f & STATUS_MASK) | status;
+}

--- a/packages/svelte/src/internal/client/reactivity/utils.js
+++ b/packages/svelte/src/internal/client/reactivity/utils.js
@@ -1,6 +1,6 @@
 /** @import { Derived, Effect, Value } from '#client' */
 import { CLEAN, DERIVED, DIRTY, MAYBE_DIRTY, WAS_MARKED } from '#client/constants';
-import { set_signal_status } from '../runtime.js';
+import { set_signal_status } from './status.js';
 
 /**
  * @param {Value[] | null} deps

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -56,6 +56,7 @@ import { handle_error } from './error-handling.js';
 import { UNINITIALIZED } from '../../constants.js';
 import { captured_signals } from './legacy.js';
 import { without_reactive_context } from './dom/elements/bindings/shared.js';
+import { set_signal_status } from './reactivity/status.js';
 
 export let is_updating_effect = false;
 
@@ -716,17 +717,6 @@ export function untrack(fn) {
 	} finally {
 		untracking = previous_untracking;
 	}
-}
-
-const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
-
-/**
- * @param {Signal} signal
- * @param {number} status
- * @returns {void}
- */
-export function set_signal_status(signal, status) {
-	signal.f = (signal.f & STATUS_MASK) | status;
 }
 
 /**

--- a/packages/svelte/src/legacy/legacy-client.js
+++ b/packages/svelte/src/legacy/legacy-client.js
@@ -3,7 +3,7 @@ import { DIRTY, LEGACY_PROPS, MAYBE_DIRTY } from '../internal/client/constants.j
 import { user_pre_effect } from '../internal/client/reactivity/effects.js';
 import { mutable_source, set } from '../internal/client/reactivity/sources.js';
 import { hydrate, mount, unmount } from '../internal/client/render.js';
-import { active_effect, get, set_signal_status } from '../internal/client/runtime.js';
+import { active_effect, get } from '../internal/client/runtime.js';
 import { flushSync } from '../internal/client/reactivity/batch.js';
 import { define_property, is_array } from '../internal/shared/utils.js';
 import * as e from '../internal/client/errors.js';
@@ -12,6 +12,7 @@ import { DEV } from 'esm-env';
 import { FILENAME } from '../constants.js';
 import { component_context, dev_current_component_function } from '../internal/client/context.js';
 import { async_mode_flag } from '../internal/flags/index.js';
+import { set_signal_status } from '../internal/client/reactivity/status.js';
 
 /**
  * Takes the same options as a Svelte 4 component and the component function and returns a Svelte 4 compatible component.


### PR DESCRIPTION
this is just to make the #17362 diff more manageable. will self-merge once green