### PR TITLE
chore: remove `set_is_updating_effect`

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -27,8 +27,6 @@ import {
 	get,
 	increment_write_version,
 	is_dirty,
-	is_updating_effect,
-	set_is_updating_effect,
 	update_effect
 } from '../runtime.js';
 import * as e from '../errors.js';
@@ -561,14 +559,12 @@ export function flushSync(fn) {
 }
 
 function flush_effects() {
-	var was_updating_effect = is_updating_effect;
 	is_flushing = true;
 
 	var source_stacks = DEV ? new Set() : null;
 
 	try {
 		var flush_count = 0;
-		set_is_updating_effect(true);
 
 		while (queued_root_effects.length > 0) {
 			var batch = Batch.ensure();
@@ -612,7 +608,6 @@ function flush_effects() {
 		}
 	} finally {
 		is_flushing = false;
-		set_is_updating_effect(was_updating_effect);
 
 		last_scheduled_effect = null;
 

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -13,9 +13,7 @@ import {
 	is_dirty,
 	untracking,
 	is_destroying_effect,
-	push_reaction_value,
-	set_is_updating_effect,
-	is_updating_effect
+	push_reaction_value
 } from '../runtime.js';
 import { equals, safe_equals } from './equality.js';
 import {
@@ -261,25 +259,17 @@ export function internal_set(source, value) {
 
 export function flush_eager_effects() {
 	eager_effects_deferred = false;
-	var prev_is_updating_effect = is_updating_effect;
-	set_is_updating_effect(true);
 
-	const inspects = Array.from(eager_effects);
-
-	try {
-		for (const effect of inspects) {
-			// Mark clean inspect-effects as maybe dirty and then check their dirtiness
-			// instead of just updating the effects - this way we avoid overfiring.
-			if ((effect.f & CLEAN) !== 0) {
-				set_signal_status(effect, MAYBE_DIRTY);
-			}
-
-			if (is_dirty(effect)) {
-				update_effect(effect);
-			}
+	for (const effect of eager_effects) {
+		// Mark clean inspect-effects as maybe dirty and then check their dirtiness
+		// instead of just updating the effects - this way we avoid overfiring.
+		if ((effect.f & CLEAN) !== 0) {
+			set_signal_status(effect, MAYBE_DIRTY);
 		}
-	} finally {
-		set_is_updating_effect(prev_is_updating_effect);
+
+		if (is_dirty(effect)) {
+			update_effect(effect);
+		}
 	}
 
 	eager_effects.clear();

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -43,25 +43,14 @@ import {
 	set_dev_current_component_function,
 	set_dev_stack
 } from './context.js';
-import {
-	Batch,
-	batch_values,
-	current_batch,
-	flushSync,
-	schedule_effect
-} from './reactivity/batch.js';
+import { Batch, batch_values, flushSync, schedule_effect } from './reactivity/batch.js';
 import { handle_error } from './error-handling.js';
 import { UNINITIALIZED } from '../../constants.js';
 import { captured_signals } from './legacy.js';
 import { without_reactive_context } from './dom/elements/bindings/shared.js';
 import { set_signal_status, update_derived_status } from './reactivity/status.js';
 
-export let is_updating_effect = false;
-
-/** @param {boolean} value */
-export function set_is_updating_effect(value) {
-	is_updating_effect = value;
-}
+let is_updating_effect = false;
 
 export let is_destroying_effect = false;
 


### PR DESCRIPTION
There's an `is_updating_effect` boolean that's used to know if we're, well, currently updating an effect. The only time we actually use it is to know if a derived is being read inside an effect, in which case it should be connected to the graph.

For reasons I'm not clear on, we set it inside `flush_effects` and `flush_eager_effects`. This is useless, since it's _also_ set when we update effects inside those functions. This allows us to tidy up some junk

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
