### PR TITLE
docs: add link from svelte-transition reference to transition guide

### DIFF
--- a/documentation/docs/98-reference/21-svelte-transition.md
+++ b/documentation/docs/98-reference/21-svelte-transition.md
@@ -2,4 +2,6 @@
 title: svelte/transition
 ---
 
+For usage information, see the [transition directive](../03-template-syntax/14-transition) documentation.
+
 > MODULE: svelte/transition


### PR DESCRIPTION
## Summary

Adds a helpful link at the top of the `svelte/transition` reference page pointing to the transition directive documentation.

## Problem

As noted in #15296, newcomers looking for information about animations/transitions may land on the API reference page at `/docs/svelte/svelte-transition`, which is auto-generated and lacks context. They then have difficulty finding the actual usage guide at `/docs/svelte/transition` with examples and explanations.

## Solution

Added a single line at the top of the reference page:

> For usage information, see the [transition directive](../03-template-syntax/14-transition) documentation.

This provides a clear path for users to find the comprehensive documentation.

Fixes #15296

---

🤖 Generated with [Claude Code](https://claude.ai/code)