### PR TITLE
chore: prevent two concurrent running release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+concurrency:
+  # prevent two release workflows from running at once
+  # race conditions here can result in releases failing
+  group: ${{ github.workflow }}
+
 permissions: {}
 jobs:
   release:


### PR DESCRIPTION
If two concurrent `release` jobs are run on `main` - one to publish a new release, and a second one that adds to the next release - then a race condition can result in the first release not getting published. This should hopefully address that by ensuring that only one `release` job can run at once.

Side effects of this: Merging multiple PRs to `main` will be a little slower in updating the release PR. And GH will only queue a single run additional. If a third PR is merge while the first is still running, I believe the third one will be canceled and will need to be manually rerun.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
