### PR TITLE
chore: defense-in-depth against script escapes

### DIFF
--- a/packages/svelte/src/internal/server/dev.js
+++ b/packages/svelte/src/internal/server/dev.js
@@ -42,6 +42,7 @@ function print_error(renderer, message) {
 	console.error(message);
 	renderer.head((r) =>
 		r.push(
+			// ensure that `</script>` can't leak in to the script contents
 			`<script>console.error(${JSON.stringify(message).replaceAll('</', '<\\u002f')})</script>`
 		)
 	);


### PR DESCRIPTION
This is real belt-and-braces stuff — it applies to dev-only code that doesn't involve user input — but it popped up in a recent review and there's no harm in buttoning it up against any future changes.

Essentially, by replacing `</` with `<\u002f` we make it impossible for this code to inject something like the following into your `<head>` (which again, to be clear, cannot happen today _anyway_ so this is not a vulnerability):

```html
<script>console.log("hello</script><script>alert(42)</script>")</script>
```