### PR TITLE
fix: handle event delegation in custom elements

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
@@ -60,7 +60,9 @@ export function Attribute(node, context) {
 			}
 
 			node.metadata.delegated =
-				parent?.type === 'RegularElement' && can_delegate_event(node.name.slice(2));
+				parent?.type === 'RegularElement' &&
+				can_delegate_event(node.name.slice(2)) &&
+				!context.state.analysis.custom_element;
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -258,7 +258,13 @@ export function handle_event_propagation(event) {
 						// -> the target could not have been disabled because it emits the event in the first place
 						event.target === current_target)
 				) {
-					delegated.call(current_target, event);
+					if (Array.isArray(delegated)) {
+						for (const handler of delegated) {
+							handler.call(current_target, event);
+						}
+					} else if (typeof delegated === "function") {
+						delegated.call(current_target, event);
+					}
 				}
 			} catch (error) {
 				if (throw_error) {


### PR DESCRIPTION
Attempt to fix issue #17057 where handle_event_propagation breaks when delegated events are arrays instead of functions in custom elements.

Changes:
1. Compiler: Don't delegate events in custom element builds
2. Runtime: Handle both function and array delegates defensively

This prevents cross-version compatibility issues with custom elements.

Not a perfect solution. Is this the most practical path forward, or is there a cleaner approach that allows cross-version compatibility?