### PR TITLE
fix: better code generation for const tags with async dependencies

### DIFF
--- a/.changeset/witty-streets-carry.md
+++ b/.changeset/witty-streets-carry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: better code generation for const tags with async dependencies

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/ConstTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/ConstTag.js
@@ -1,4 +1,4 @@
-/** @import { Pattern } from 'estree' */
+/** @import { Expression, Identifier, Pattern } from 'estree' */
 /** @import { AST } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
 /** @import { ExpressionMetadata } from '../../../nodes.js' */
@@ -88,8 +88,8 @@ export function ConstTag(node, context) {
 
 /**
  * @param {ComponentContext['state']} state
- * @param {import('estree').Identifier} id
- * @param {import('estree').Expression} expression
+ * @param {Identifier} id
+ * @param {Expression} expression
  * @param {ExpressionMetadata} metadata
  * @param {import('#compiler').Binding[]} bindings
  */
@@ -99,7 +99,9 @@ function add_const_declaration(state, id, expression, metadata, bindings) {
 	const after = dev ? [b.stmt(b.call('$.get', id))] : [];
 
 	const has_await = metadata.has_await;
-	const blockers = [...metadata.dependencies].map((dep) => dep.blocker).filter((b) => b !== null);
+	const blockers = [...metadata.dependencies]
+		.map((dep) => dep.blocker)
+		.filter((b) => b !== null && b.object !== state.async_consts?.id);
 
 	if (has_await || state.async_consts || blockers.length > 0) {
 		const run = (state.async_consts ??= {
@@ -112,7 +114,11 @@ function add_const_declaration(state, id, expression, metadata, bindings) {
 		const assignment = b.assignment('=', id, expression);
 		const body = after.length === 0 ? assignment : b.block([b.stmt(assignment), ...after]);
 
-		if (blockers.length > 0) run.thunks.push(b.thunk(b.call('Promise.all', b.array(blockers))));
+		if (blockers.length === 1) {
+			run.thunks.push(b.thunk(/** @type {Expression} */ (blockers[0])));
+		} else if (blockers.length > 0) {
+			run.thunks.push(b.thunk(b.call('Promise.all', b.array(blockers))));
+		}
 
 		run.thunks.push(b.thunk(body, has_await));
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/ConstTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/ConstTag.js
@@ -15,7 +15,7 @@ export function ConstTag(node, context) {
 	const has_await = node.metadata.expression.has_await;
 	const blockers = [...node.metadata.expression.dependencies]
 		.map((dep) => dep.blocker)
-		.filter((b) => b !== null);
+		.filter((b) => b !== null && b.object !== context.state.async_consts?.id);
 
 	if (has_await || context.state.async_consts || blockers.length > 0) {
 		const run = (context.state.async_consts ??= {
@@ -30,7 +30,9 @@ export function ConstTag(node, context) {
 			context.state.init.push(b.let(identifier.name));
 		}
 
-		if (blockers.length > 0) {
+		if (blockers.length === 1) {
+			run.thunks.push(b.thunk(/** @type {Expression} */ (blockers[0])));
+		} else if (blockers.length > 0) {
 			run.thunks.push(b.thunk(b.call('Promise.all', b.array(blockers))));
 		}
 

--- a/packages/svelte/tests/snapshot/samples/async-const/_config.js
+++ b/packages/svelte/tests/snapshot/samples/async-const/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({ compileOptions: { experimental: { async: true } } });

--- a/packages/svelte/tests/snapshot/samples/async-const/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-const/_expected/client/index.svelte.js
@@ -1,0 +1,35 @@
+import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/async';
+import * as $ from 'svelte/internal/client';
+
+var root_1 = $.from_html(`<p> </p>`);
+
+export default function Async_const($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+
+	{
+		var consequent = ($$anchor) => {
+			let a;
+			let b;
+
+			var promises = $.run([
+				async () => a = (await $.save($.async_derived(async () => (await $.save(1))())))(),
+				() => b = $.derived(() => $.get(a) + 1)
+			]);
+
+			var p = root_1();
+			var text = $.child(p, true);
+
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, $.get(b)), void 0, void 0, [promises[1]]);
+			$.append($$anchor, p);
+		};
+
+		$.if(node, ($$render) => {
+			if (true) $$render(consequent);
+		});
+	}
+
+	$.append($$anchor, fragment);
+}

--- a/packages/svelte/tests/snapshot/samples/async-const/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-const/_expected/server/index.svelte.js
@@ -1,0 +1,33 @@
+import 'svelte/internal/flags/async';
+import * as $ from 'svelte/internal/server';
+
+export default function Async_const($$renderer) {
+	if (true) {
+		$$renderer.push('<!--[-->');
+
+		let a;
+		let b;
+
+		var promises = $$renderer.run([
+			async () => {
+				a = (await $.save(1))();
+			},
+
+			() => {
+				b = a + 1;
+			}
+		]);
+
+		$$renderer.push(`<p>`);
+
+		$$renderer.async([promises[1]], ($$renderer) => {
+			$$renderer.push(() => $.escape(b));
+		});
+
+		$$renderer.push(`</p>`);
+	} else {
+		$$renderer.push('<!--[!-->');
+	}
+
+	$$renderer.push(`<!--]-->`);
+}

--- a/packages/svelte/tests/snapshot/samples/async-const/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/async-const/index.svelte
@@ -1,0 +1,6 @@
+{#if true}
+	{@const a = await 1}
+	{@const b = a + 1}
+
+	<p>{b}</p>
+{/if}


### PR DESCRIPTION
Fixes a small thing I noticed while looking into #17461 — whenever you have a `@const` tag after an `await`, it injects an async thunk that runs before the declaration _even if the declaration is directly above_ — in other words, for something like [this](https://svelte.dev/playground/hello-world?version=5.48.0#H4sIAAAAAAAAE23MwQoCIRSF4VeR26ZIGtrKFLXrHbKFM15BsKuMt6YQ3z0sWgRtP_5zCpC5Iig4YQhRzHEKVizReka7AgnOB8ygzgX4mVrXAOR3dUxpk-8YuNlgMv7zMRIjcQYFZeGd4OmGVZPmchgjZRZG7ISZjWex_fGhuVh_lDT3aV-G2ndpr6l03lVNIIHxwaDepxcJbHyYPVlQzoSM9QXh4fvQ4QAAAA)...

```svelte
{#if true}
	{@const a = await 1}
	{@const b = a + 1}

	<p>{b}</p>
{/if}

```

...we get this unnecessary middle promise:

```diff
var promises = $.run([
	async () => a = (await $.save($.async_derived(async () => (await $.save(1))())))(),
+	() => Promise.all([promises[0]]),
	() => b = $.derived(() => $.get(a) + 1)
]);
```

This PR removes it, and also gets rid of `Promise.all` in the case where there's only a single promise.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
