### PR TITLE
fix: account for empty statements when visiting in transform async

### DIFF
--- a/.changeset/kind-dolls-cry.md
+++ b/.changeset/kind-dolls-cry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: account for empty statements when visiting in transform async

--- a/packages/svelte/tests/runtime-runes/samples/async-transform-empty-statements/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-transform-empty-statements/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	async test() {}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-transform-empty-statements/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-transform-empty-statements/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	await Promise.resolve(42);
+	const { name } = $props();
+</script>
+
+{name}


### PR DESCRIPTION
Closes #17454

In the case showcased in the repro, visiting the `VariableDeclarator` returns an empty statement which doesn't have a `declarations` property...I've adjousted the types to reflect the actual return value.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`