### PR TITLE
fix: export `wait` function from internal client index

### DIFF
--- a/.changeset/fix-wait-export.md
+++ b/.changeset/fix-wait-export.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: export `wait` function from internal client index

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -103,7 +103,8 @@ export {
 	run,
 	save,
 	track_reactivity_loss,
-	run_after_blockers
+	run_after_blockers,
+	wait
 } from './reactivity/async.js';
 export { eager, flushSync as flush } from './reactivity/batch.js';
 export {

--- a/packages/svelte/tests/runtime-runes/samples/async-const-wait/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-const-wait/_config.js
@@ -1,0 +1,18 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	props: {
+		a_promise: Promise.resolve(10),
+		b_promise: Promise.resolve(20)
+	},
+
+	async test({ assert, target }) {
+		await tick();
+		await tick();
+
+		assert.htmlEqual(target.innerHTML, `<p>30</p>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-const-wait/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-const-wait/main.svelte
@@ -1,0 +1,16 @@
+<script>
+	let { a_promise, b_promise } = $props();
+</script>
+
+<svelte:boundary>
+	{@const a = await a_promise}
+	{#if true}
+		<svelte:boundary>
+			{@const b = await b_promise}
+			{#if true}
+				{@const sum = a + b}
+				<p>{sum}</p>
+			{/if}
+		</svelte:boundary>
+	{/if}
+</svelte:boundary>


### PR DESCRIPTION
PR #17461 added the `wait` function to `reactivity/async.js` and modified the compiler to generate `$.wait()` calls, but forgot to export it from `index.js`.

This causes a runtime error when using multiple `await` expressions inside `$derived()` with `experimental.async: true`:

```
TypeError: $.wait is not a function. (In '$.wait([$$promises[20], $$promises[20]])', '$.wait' is undefined)
```

The `$.wait` function is called by the compiler when there are multiple async blockers that need to be waited on together.

Fixes #17529

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Added test `async-derived-multiple-blockers` which uses multiple async deriveds together, triggering the `$.wait` call that was previously missing.