### PR TITLE
fix: preserve old dependencies when updating reaction inside fork

### DIFF
--- a/.changeset/fuzzy-spies-love.md
+++ b/.changeset/fuzzy-spies-love.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: preserve old dependencies when updating reaction inside fork

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -43,7 +43,13 @@ import {
 	set_dev_current_component_function,
 	set_dev_stack
 } from './context.js';
-import { Batch, batch_values, flushSync, schedule_effect } from './reactivity/batch.js';
+import {
+	Batch,
+	batch_values,
+	current_batch,
+	flushSync,
+	schedule_effect
+} from './reactivity/batch.js';
 import { handle_error } from './error-handling.js';
 import { UNINITIALIZED } from '../../constants.js';
 import { captured_signals } from './legacy.js';
@@ -249,10 +255,16 @@ export function update_reaction(reaction) {
 		var result = fn();
 		var deps = reaction.deps;
 
+		// Don't remove reactions during fork;
+		// they must remain for when fork is discarded
+		var is_fork = current_batch?.is_fork;
+
 		if (new_deps !== null) {
 			var i;
 
-			remove_reactions(reaction, skipped_deps);
+			if (!is_fork) {
+				remove_reactions(reaction, skipped_deps);
+			}
 
 			if (deps !== null && skipped_deps > 0) {
 				deps.length = skipped_deps + new_deps.length;
@@ -268,7 +280,7 @@ export function update_reaction(reaction) {
 					(deps[i].reactions ??= []).push(reaction);
 				}
 			}
-		} else if (deps !== null && skipped_deps < deps.length) {
+		} else if (!is_fork && deps !== null && skipped_deps < deps.length) {
 			remove_reactions(reaction, skipped_deps);
 			deps.length = skipped_deps;
 		}

--- a/packages/svelte/tests/runtime-runes/samples/fork-derived-dependency-rollback/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/fork-derived-dependency-rollback/_config.js
@@ -1,0 +1,25 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	skip_no_async: true,
+	async test({ assert, target }) {
+		const [fork_btn, _toggle_btn, inc_count_1_btn] = target.querySelectorAll('button');
+		const p = /** @type {HTMLElement} */ (target.querySelector('p'));
+
+		assert.equal(p.textContent, '0');
+
+		// Trigger derived to re-evaluate during fork and switch to tracking count_2
+		flushSync(() => {
+			fork_btn.click();
+		});
+
+		assert.equal(p.textContent, '0');
+
+		flushSync(() => {
+			inc_count_1_btn.click();
+		});
+
+		assert.equal(p.textContent, '1');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/fork-derived-dependency-rollback/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/fork-derived-dependency-rollback/main.svelte
@@ -1,0 +1,27 @@
+<script>
+	import { fork } from 'svelte';
+
+	let show_count_1 = $state(true);
+	let count_1 = $state(0);
+	let count_2 = $state(0);
+
+	const count = $derived(show_count_1 ? count_1 : count_2);
+</script>
+
+<!-- This if block causes the derived to execute during the fork, switching its dependency
+     away from count_1 and over to count_2. After discard, count_1 should still be tracked. -->
+{#if count}
+{/if}
+
+<button onclick={() => {
+	const f = fork(() => {
+		show_count_1 = !show_count_1;
+	});
+	f.discard();
+}}>fork toggle</button>
+
+<button onclick={() => show_count_1 = !show_count_1}>toggle</button>
+<button onclick={() => count_1++}>increment count 1</button>
+<button onclick={() => count_2++}>increment count 2</button>
+
+<p>{count}</p>


### PR DESCRIPTION
#17335 contains two separate fixes — this extracts one of them, so that they can be reviewed separately

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x]  If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
