### PR TITLE
fix: use content-box ResizeObserver for clientWidth/clientHeight bindings

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/bindings/size.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/size.js
@@ -98,7 +98,14 @@ export function bind_resize_observer(element, type, set) {
  * @param {(size: number) => void} set
  */
 export function bind_element_size(element, type, set) {
-	var unsub = resize_observer_border_box.observe(element, () => set(element[type]));
+	// Use content-box for clientWidth/clientHeight because they exclude scrollbars.
+	// When scrollbars appear/disappear, the content-box size changes, but border-box doesn't.
+	// Use border-box for offsetWidth/offsetHeight because they include borders.
+	var observer =
+		type === 'clientWidth' || type === 'clientHeight'
+			? resize_observer_content_box
+			: resize_observer_border_box;
+	var unsub = observer.observe(element, () => set(element[type]));
 
 	effect(() => {
 		// The update could contain reads which should be ignored


### PR DESCRIPTION
Fixes issue where `bind:clientWidth` and `bind:clientHeight` do not update when scrollbars appear or disappear. The border-box ResizeObserver does not fire in this case because the border-box size (which includes the scrollbar area) does not change. However, the content-box size does change when scrollbars appear, so using content-box ResizeObserver for clientWidth/clientHeight ensures the binding updates correctly.

For offsetWidth/offsetHeight, we continue using border-box ResizeObserver as these properties include borders, which matches the border-box size.

Fixes #17457