### PR TITLE
chore: fix spelling errors in media-query and test file

### DIFF
--- a/packages/svelte/src/reactivity/media-query.js
+++ b/packages/svelte/src/reactivity/media-query.js
@@ -7,7 +7,7 @@ const parenthesis_regex = /\(.+\)/;
 //
 // eg: new MediaQuery('screen')
 //
-// however because of the auto-parenthesis logic in the constructor since there's no parentehesis
+// however because of the auto-parenthesis logic in the constructor since there's no parenthesis
 // in the media query they'll be surrounded by parenthesis
 //
 // however we can check if the media query is only composed of these keywords

--- a/packages/svelte/tests/runtime-runes/samples/error-boundary-12/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/error-boundary-12/main.svelte
@@ -15,6 +15,6 @@
 	{d}
 
 	{#snippet failed()}
-		<p>Error occured</p>
+		<p>Error occurred</p>
 	{/snippet}
 </svelte:boundary>


### PR DESCRIPTION
## Summary
- Fix `parentehesis` -> `parenthesis` in `packages/svelte/src/reactivity/media-query.js` comment
- Fix `occured` -> `occurred` in `packages/svelte/tests/runtime-runes/samples/error-boundary-12/main.svelte`