### PR TITLE
chore: correct spelling errors in test files

### DIFF
--- a/packages/svelte/tests/css/samples/global-block/expected.css
+++ b/packages/svelte/tests/css/samples/global-block/expected.css
@@ -39,7 +39,7 @@
 		/*}*/
 	}
 
-	/* ...wich is equivalent to `div :global { &.x { ...} }` ... */
+	/* ...which is equivalent to `div :global { &.x { ...} }` ... */
 	div.svelte-xyz {
 		&.x {
 			color: green;
@@ -51,7 +51,7 @@
 		color: green;
 	}
 
-	/* ...and therefore `div { :global.x { ... }` aswell */
+	/* ...and therefore `div { :global.x { ... }` as well */
 	div.svelte-xyz {
 		&.x {
 			color: green;

--- a/packages/svelte/tests/css/samples/global-block/input.svelte
+++ b/packages/svelte/tests/css/samples/global-block/input.svelte
@@ -41,7 +41,7 @@
 		}
 	}
 
-	/* ...wich is equivalent to `div :global { &.x { ...} }` ... */
+	/* ...which is equivalent to `div :global { &.x { ...} }` ... */
 	div :global {
 		&.x {
 			color: green;
@@ -53,7 +53,7 @@
 		color: green;
 	}
 
-	/* ...and therefore `div { :global.x { ... }` aswell */
+	/* ...and therefore `div { :global.x { ... }` as well */
 	div {
 		:global.x {
 			color: green;

--- a/packages/svelte/tests/sourcemaps/test.ts
+++ b/packages/svelte/tests/sourcemaps/test.ts
@@ -8,9 +8,9 @@ import { decode } from '@jridgewell/sourcemap-codec';
 type SourceMapEntry =
 	| string
 	| {
-			/** If not the first occurence, but the nth should be found */
+			/** If not the first occurrence, but the nth should be found */
 			idxOriginal?: number;
-			/** If not the first occurence, but the nth should be found */
+			/** If not the first occurrence, but the nth should be found */
 			idxGenerated?: number;
 			/** The original string to find */
 			str: string;


### PR DESCRIPTION
Fix several spelling errors in test files:

- `wich` → `which` in CSS global-block test comment (input.svelte + expected.css)
- `aswell` → `as well` in CSS global-block test comment (input.svelte + expected.css)
- `occurence` → `occurrence` in sourcemaps test type definition (test.ts)