### PR TITLE
docs: use "set up" (verb) instead of "setup" (noun)

### DIFF
--- a/documentation/docs/07-misc/02-testing.md
+++ b/documentation/docs/07-misc/02-testing.md
@@ -181,7 +181,7 @@ export default defineConfig({
 		/* ... */
 	],
 	test: {
-		// If you are testing components client-side, you need to setup a DOM environment.
+		// If you are testing components client-side, you need to set up a DOM environment.
 		// If not all your files should have this environment, you can use a
 		// `// @vitest-environment jsdom` comment at the top of the test files instead.
 		environment: 'jsdom'

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -21,7 +21,7 @@ import { disable_async_mode_flag, enable_async_mode_flag } from '../../src/inter
 
 /**
  * @param runes runes mode
- * @param fn A function that returns a function because we first need to setup all the signals
+ * @param fn A function that returns a function because we first need to set up all the signals
  * 			 and then execute the test in order to simulate a real component
  */
 function run_test(runes: boolean, fn: (runes: boolean) => () => void) {


### PR DESCRIPTION
Fix incorrect use of "setup" (noun/adjective) where the verb form "set up" should be used:

- `tests/signals/test.ts`: "need to setup all the signals" → "need to set up all the signals"
- `documentation/docs/07-misc/02-testing.md`: "you need to setup a DOM environment" → "you need to set up a DOM environment"