### PR TITLE
docs: add description for derived_references_self error

### DIFF
--- a/documentation/docs/98-reference/.generated/client-errors.md
+++ b/documentation/docs/98-reference/.generated/client-errors.md
@@ -52,6 +52,33 @@ See the [migration guide](/docs/svelte/v5-migration-guide#Components-are-no-long
 A derived value cannot reference itself recursively
 ```
 
+This error occurs when a `$derived` value reads itself during evaluation, either directly or through a chain of other derived values.
+
+```js
+let count = $state(0);
+
+// directly references itself
+let total = $derived(total + count);
+```
+
+The cycle can also be indirect:
+
+```js
+let a = $derived(b + 1);
+let b = $derived(a + 1);
+```
+
+To fix this, identify which value in the chain should be the source of truth and make it a `$state` instead, updating it explicitly (for example in an event handler):
+
+```js
+let count = $state(0);
+let total = $state(0);
+
+function add() {
+	total += count;
+}
+```
+
 ### each_key_duplicate
 
 ```

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -36,6 +36,33 @@ See the [migration guide](/docs/svelte/v5-migration-guide#Components-are-no-long
 
 > A derived value cannot reference itself recursively
 
+This error occurs when a `$derived` value reads itself during evaluation, either directly or through a chain of other derived values.
+
+```js
+let count = $state(0);
+
+// directly references itself
+let total = $derived(total + count);
+```
+
+The cycle can also be indirect:
+
+```js
+let a = $derived(b + 1);
+let b = $derived(a + 1);
+```
+
+To fix this, identify which value in the chain should be the source of truth and make it a `$state` instead, updating it explicitly (for example in an event handler):
+
+```js
+let count = $state(0);
+let total = $state(0);
+
+function add() {
+	total += count;
+}
+```
+
 ## each_key_duplicate
 
 > Keyed each block has duplicate key at indexes %a% and %b%


### PR DESCRIPTION
## Summary

Closes #17481

Adds documentation for the `derived_references_self` runtime error, which previously had no description on the error page.

Covers:
- What the error means (a `$derived` reading itself during evaluation)
- Direct self-reference example
- Indirect cycle example (two deriveds referencing each other)
- How to fix it: break the cycle by using `$state` and updating explicitly

This is a revised version of #17629, with corrected examples and a valid fix suggestion.