### PR TITLE
fix: prevent async render tag hydration mismatches

### DIFF
--- a/.changeset/two-places-speak.md
+++ b/.changeset/two-places-speak.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent async render tag hydration mismatches

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/RenderTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/RenderTag.js
@@ -37,7 +37,9 @@ export function RenderTag(node, context) {
 
 	context.state.template.push(...optimiser.render_block([statement]));
 
-	if (!context.state.is_standalone) {
+	// If the render tag is wrapped in $.async, that $.async call already contains surrounding markers,
+	// so we don't need to (or rather must not, to avoid hydration mismatches) add our own.
+	if (!optimiser.is_async() && !context.state.is_standalone) {
 		context.state.template.push(empty_comment);
 	}
 }

--- a/packages/svelte/tests/runtime-runes/samples/async-render-hydration/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-render-hydration/_config.js
@@ -1,0 +1,11 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['hydrate'],
+
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, `Count: 1 Double: 2`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-render-hydration/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-render-hydration/main.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	let count = $state(1);
+	async function getDouble(count: number) {
+		return count * 2;
+	}
+	const double = $derived(await getDouble(count));
+</script>
+
+Count: {count}
+
+{#snippet ssr(num: number)}
+	{num}
+{/snippet}
+
+Double: {@render ssr(double)}


### PR DESCRIPTION
If the render tag is wrapped in `$.async`, that `$.async` call already contains surrounding markers, so we must not add our own to avoid hydration mismatches. Related to #17641, fixes #17225

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
