### PR TITLE
fix: robustify blocker calculation

### DIFF
--- a/.changeset/true-cities-retire.md
+++ b/.changeset/true-cities-retire.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: robustify blocker calculation

--- a/packages/svelte/tests/runtime-runes/samples/async-bind-factory-function-remote/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-bind-factory-function-remote/_config.js
@@ -1,0 +1,14 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['async-server', 'client', 'hydrate'],
+	ssrHtml: 'true true true true true',
+
+	async test({ assert, target }) {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		await tick();
+
+		assert.htmlEqual(target.innerHTML, 'true true true true true');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-bind-factory-function-remote/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-bind-factory-function-remote/main.svelte
@@ -1,0 +1,41 @@
+<script>
+	let checked = $derived(await new Promise((r) => setTimeout(() => r(true)), 10));
+
+	const checkedFactory = () => {
+		return () => checked;
+	}
+
+	function indirectCheckedFactory() {
+		return checkedFactory();
+	}
+
+	function callFactory(factory) {
+		return factory();
+	}
+
+	function indirectCallFactory() {
+		return callFactory(indirectCheckedFactory);
+	}
+
+	function indirectChecked2() {
+		const indirect = () => checkedFactory()();
+		return indirect;
+	}
+</script>
+
+<!-- force into separate effects -->
+{#if true}
+	{checkedFactory()()}
+{/if}
+{#if true}
+	{indirectCheckedFactory()()}
+{/if}
+{#if true}
+	{callFactory(checkedFactory)()}
+{/if}
+{#if true}
+	{indirectCallFactory()()}
+{/if}
+{#if true}
+	{indirectChecked2()()}
+{/if}


### PR DESCRIPTION
This was actually several bugs:
- We used `scopes` for the blockers, that's actually the template scopes, should be `instance.scopes` instead
- We missed setting the scope for `touch`
- We didn't take return statements into account when calculating blockers. We cannot know when/if something within the return statement is called, so we gotta assume it is and touch everything transitively from it

Combined this fixes #17667 (and possibly other cases not showing up in the issue tracker yet)

Initially I just thought "ok I guess we have to traverse into functions, too" but then I thought that feels too unoptimized and came up with the return-statement-inspection, at which point I discovered the other bugs.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
