### PR TITLE
fix: robustify custom elements event handling

### DIFF
--- a/.changeset/stupid-geckos-kneel.md
+++ b/.changeset/stupid-geckos-kneel.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: robustify custom elements event handling

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Attribute.js
@@ -59,8 +59,13 @@ export function Attribute(node, context) {
 				context.state.analysis.uses_event_attributes = true;
 			}
 
+			// Don't use event delegation in custom element builds, as it can cause
+			// conflicts with the outer app's event delegation across shadow DOM boundaries
+			// when different Svelte versions are involved
 			node.metadata.delegated =
-				parent?.type === 'RegularElement' && can_delegate_event(node.name.slice(2));
+				parent?.type === 'RegularElement' &&
+				!context.state.analysis.custom_element &&
+				can_delegate_event(node.name.slice(2));
 		}
 	}
 }

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-no-delegation/MyButton.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-no-delegation/MyButton.svelte
@@ -1,0 +1,7 @@
+<svelte:options customElement={{ tag: 'my-button' }} />
+
+<script>
+	let count = $state(0);
+</script>
+
+<button onclick={() => count++}>clicks: {count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-no-delegation/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-no-delegation/_config.js
@@ -1,0 +1,34 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+// Tests that custom element builds don't use event delegation, and that
+// events still work correctly on both the inner button and the outer custom element.
+// This prevents cross-version conflicts across shadow DOM boundaries (https://github.com/sveltejs/svelte/issues/17057).
+export default test({
+	mode: ['client'],
+	async test({ assert, target }) {
+		await tick();
+
+		const my_button = target.querySelector('my-button');
+		const button = my_button?.shadowRoot?.querySelector('button');
+		const p = target.querySelector('p');
+
+		assert.ok(button, 'Button should exist inside shadow DOM');
+
+		// Verify the inner button does NOT use event delegation (__click property)
+		// because it's compiled as part of a custom element
+		assert.equal(
+			/** @type {any} */ (button)?.__click,
+			undefined,
+			'Custom element internals should not use event delegation'
+		);
+
+		button?.click();
+		await tick();
+
+		assert.include(button?.textContent, 'clicks: 1');
+
+		// The outer onclick should also fire due to event propagation
+		assert.htmlEqual(p?.innerHTML ?? '', 'outer: 1');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/custom-element-no-delegation/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/custom-element-no-delegation/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import './MyButton.svelte';
+	let outer_count = $state(0);
+</script>
+
+<my-button onclick={() => outer_count++}></my-button>
+<p>outer: {outer_count}</p>

--- a/packages/svelte/tests/runtime-runes/samples/event-delegation-backwards-compat/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-delegation-backwards-compat/_config.js
@@ -1,0 +1,40 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+// Tests backwards compatibility with old Svelte versions that stored delegated
+// event handlers as arrays [fn, ...data] instead of plain functions.
+// This is important for cross-version web component interop.
+// (also see https://github.com/sveltejs/svelte/issues/17057)
+export default test({
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+		const p = target.querySelector('p');
+
+		// Simulate old Svelte format: delegated handlers stored as arrays [fn, ...data]
+		// This is what older Svelte versions did with "hoisted" event handlers
+		let old_handler_called = false;
+		const inner_div = document.createElement('div');
+		button?.parentElement?.insertBefore(inner_div, button);
+
+		/** @type {any} */ (inner_div).__click = [
+			(/** @type {Event} */ event, /** @type {string} */ extra) => {
+				old_handler_called = true;
+				assert.equal(extra, 'old-data');
+			},
+			'old-data'
+		];
+
+		flushSync(() => {
+			inner_div.click();
+		});
+
+		assert.equal(old_handler_called, true, 'Old array-format handler should be called');
+
+		// Check that normal delegated handler still works
+		flushSync(() => {
+			button?.click();
+		});
+
+		assert.htmlEqual(p?.innerHTML ?? '', '1');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/event-delegation-backwards-compat/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-delegation-backwards-compat/main.svelte
@@ -1,0 +1,8 @@
+<div>
+	<button onclick={() => count++}>click me</button>
+	<p>{count}</p>
+</div>
+
+<script>
+	let count = $state(0);
+</script>


### PR DESCRIPTION
- add backwards compatibility for custom elements created with an earlier Svelte 5 version, were the format of delegation was different
- remove event delegation from custom element components to avoid such problems in the future

Fixes #17057

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
