### PR TITLE
feat: support TrustedHTML in {@html} expressions

### DIFF
--- a/.changeset/trusted-html-support.md
+++ b/.changeset/trusted-html-support.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: support TrustedHTML in `{@html}` expressions

--- a/packages/svelte/src/internal/client/dom/blocks/snippet.js
+++ b/packages/svelte/src/internal/client/dom/blocks/snippet.js
@@ -83,7 +83,7 @@ export function createRawSnippet(fn) {
 			hydrate_next();
 		} else {
 			var html = snippet.render().trim();
-			var fragment = create_fragment_from_html(html, true);
+			var fragment = create_fragment_from_html(html);
 			element = /** @type {Element} */ (get_first_child(fragment));
 
 			if (DEV && (get_next_sibling(element) !== null || element.nodeType !== ELEMENT_NODE)) {

--- a/packages/svelte/src/internal/client/dom/reconciler.js
+++ b/packages/svelte/src/internal/client/dom/reconciler.js
@@ -1,5 +1,3 @@
-/** @import {} from 'trusted-types' */
-
 import { create_element } from './operations.js';
 
 const policy = /* @__PURE__ */ globalThis?.window?.trustedTypes?.createPolicy(
@@ -19,11 +17,9 @@ function create_trusted_html(html) {
 
 /**
  * @param {string} html
- * @param {boolean} trusted
  */
-export function create_fragment_from_html(html, trusted = false) {
+export function create_fragment_from_html(html) {
 	var elem = create_element('template');
-	html = html.replaceAll('<!>', '<!---->'); // XHTML compliance
-	elem.innerHTML = trusted ? create_trusted_html(html) : html;
+	elem.innerHTML = create_trusted_html(html.replaceAll('<!>', '<!---->')); // XHTML compliance
 	return elem.content;
 }

--- a/packages/svelte/src/internal/client/dom/template.js
+++ b/packages/svelte/src/internal/client/dom/template.js
@@ -70,7 +70,7 @@ export function from_html(content, flags) {
 		}
 
 		if (node === undefined) {
-			node = create_fragment_from_html(has_start ? content : '<!>' + content, true);
+			node = create_fragment_from_html(has_start ? content : '<!>' + content);
 			if (!is_fragment) node = /** @type {TemplateNode} */ (get_first_child(node));
 		}
 
@@ -118,7 +118,7 @@ function from_namespace(content, flags, ns = 'svg') {
 		}
 
 		if (!node) {
-			var fragment = /** @type {DocumentFragment} */ (create_fragment_from_html(wrapped, true));
+			var fragment = /** @type {DocumentFragment} */ (create_fragment_from_html(wrapped));
 			var root = /** @type {Element} */ (get_first_child(fragment));
 
 			if (is_fragment) {


### PR DESCRIPTION
Follow-up to #16271.

## Summary

- Allow `{@html}` blocks to accept `TrustedHTML` objects (from TrustedTypes policies) without coercing them to strings
- This enables usage like `{@html myPolicy.createHTML(someHTML)}`
- Works in regular HTML, SVG, and MathML contexts

## Changes

- **`html.js`**: Instead of calling `create_fragment_from_html`, create the wrapper element directly (`<template>`, `<svg>`, or `<math>` depending on context) and assign the value to `innerHTML`. This preserves `TrustedHTML` objects.
- **`reconciler.js`**: Removed the `trusted` parameter from `create_fragment_from_html` since it's no longer used by `{@html}` and all remaining callers want trusted HTML.
- **`template.js`** and **`snippet.js`**: Removed the second argument from `create_fragment_from_html` calls.

## Notes

No tests added because JSDOM doesn't implement TrustedTypes.