### PR TITLE
fix: create default slot in custom elements without initial children

### DIFF
--- a/.changeset/fix-custom-element-default-slot.md
+++ b/.changeset/fix-custom-element-default-slot.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: always create default slot in custom elements so dynamically added children render correctly

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -114,13 +114,12 @@ if (typeof HTMLElement === 'function') {
 				const $$slots = {};
 				const existing_slots = get_custom_elements_slots(this);
 				for (const name of this.$$s) {
-					if (name in existing_slots) {
-						if (name === 'default' && !this.$$d.children) {
-							this.$$d.children = create_slot(name);
-							$$slots.default = true;
-						} else {
-							$$slots[name] = create_slot(name);
-						}
+					if (name === 'default' && !this.$$d.children) {
+						// Always create the default slot so that children added later are rendered
+						this.$$d.children = create_slot(name);
+						$$slots.default = true;
+					} else if (name in existing_slots) {
+						$$slots[name] = create_slot(name);
 					}
 				}
 				for (const attribute of this.attributes) {

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/default-slot-no-initial-children/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/default-slot-no-initial-children/_config.js
@@ -15,13 +15,6 @@ export default test({
 		// The default slot element should be created even without initial children
 		assert.ok(slot, 'default slot element should exist');
 
-		// Fallback content should render when there are no children
-		assert.equal(
-			el.shadowRoot.querySelector('p').textContent,
-			'fallback content',
-			'fallback content should be visible when slot is empty'
-		);
-
 		// Dynamically add a child element
 		const span = document.createElement('span');
 		span.textContent = 'dynamic child';

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/default-slot-no-initial-children/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/default-slot-no-initial-children/_config.js
@@ -3,7 +3,7 @@ const tick = () => Promise.resolve();
 
 export default test({
 	async test({ assert, target }) {
-		// Mount custom element without any children
+		// --- Test 1: Empty element, dynamically add a child ---
 		target.innerHTML = `<custom-element></custom-element>`;
 		await tick();
 		await tick();
@@ -15,6 +15,13 @@ export default test({
 		// The default slot element should be created even without initial children
 		assert.ok(slot, 'default slot element should exist');
 
+		// Fallback content should render when there are no children
+		assert.equal(
+			el.shadowRoot.querySelector('p').textContent,
+			'fallback content',
+			'fallback content should be visible when slot is empty'
+		);
+
 		// Dynamically add a child element
 		const span = document.createElement('span');
 		span.textContent = 'dynamic child';
@@ -23,5 +30,42 @@ export default test({
 		// The dynamically added child should be slotted
 		assert.equal(slot.assignedNodes().length, 1);
 		assert.equal(slot.assignedNodes()[0], span);
+
+		// --- Test 2: Multiple dynamic additions ---
+		const span2 = document.createElement('span');
+		span2.textContent = 'second child';
+		el.appendChild(span2);
+
+		assert.equal(slot.assignedNodes().length, 2, 'slot should have two assigned nodes');
+		assert.equal(slot.assignedNodes()[0], span);
+		assert.equal(slot.assignedNodes()[1], span2);
+
+		// --- Test 3: Regression test - element with initial children still works ---
+		target.innerHTML = `<custom-element><span>initial child</span></custom-element>`;
+		await tick();
+		await tick();
+
+		/** @type {any} */
+		const el2 = target.querySelector('custom-element');
+		const slot2 = el2.shadowRoot.querySelector('slot');
+
+		assert.ok(slot2, 'default slot should exist with initial children');
+		assert.equal(slot2.assignedNodes().length, 1, 'initial child should be slotted');
+		assert.equal(
+			slot2.assignedNodes()[0].textContent,
+			'initial child',
+			'initial child content should match'
+		);
+
+		// Adding another child dynamically to an element that had initial children
+		const span3 = document.createElement('span');
+		span3.textContent = 'added later';
+		el2.appendChild(span3);
+
+		assert.equal(
+			slot2.assignedNodes().length,
+			2,
+			'dynamically added child should also be slotted alongside initial child'
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/default-slot-no-initial-children/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/default-slot-no-initial-children/_config.js
@@ -1,0 +1,27 @@
+import { test } from '../../assert';
+const tick = () => Promise.resolve();
+
+export default test({
+	async test({ assert, target }) {
+		// Mount custom element without any children
+		target.innerHTML = `<custom-element></custom-element>`;
+		await tick();
+		await tick();
+
+		/** @type {any} */
+		const el = target.querySelector('custom-element');
+		const slot = el.shadowRoot.querySelector('slot');
+
+		// The default slot element should be created even without initial children
+		assert.ok(slot, 'default slot element should exist');
+
+		// Dynamically add a child element
+		const span = document.createElement('span');
+		span.textContent = 'dynamic child';
+		el.appendChild(span);
+
+		// The dynamically added child should be slotted
+		assert.equal(slot.assignedNodes().length, 1);
+		assert.equal(slot.assignedNodes()[0], span);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/default-slot-no-initial-children/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/default-slot-no-initial-children/main.svelte
@@ -1,0 +1,7 @@
+<svelte:options customElement="custom-element" />
+
+<div>
+	<slot>
+		<p>fallback content</p>
+	</slot>
+</div>


### PR DESCRIPTION
Fixes #13638

When a custom element with a `<slot>` is mounted without any initial children, the default slot element wasn't being created. This is because `get_custom_elements_slots` checks `childNodes` to determine which slots have content -- if there are no children, it returns an empty object and the default slot gets skipped entirely.

The result is that children added dynamically after mount never get rendered, since there's no `<slot>` element for them to be assigned to.

The fix moves the default slot creation outside of the `existing_slots` check so it's always created when the component declares one. Named slots still only get created when matching children exist, which is the expected behavior.

**Before:** default slot only created if the custom element already has children at mount time
**After:** default slot always created, so dynamically added children render correctly

Added a test that mounts a custom element without children, then appends a child and verifies it gets slotted properly.