### PR TITLE
fix: prevent `#each` array key from blowing up on updates

### DIFF
--- a/.changeset/olive-hounds-smile.md
+++ b/.changeset/olive-hounds-smile.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: prevent `#each` array key from blowing up on updates

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -183,13 +183,16 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 	});
 
 	/** @type {V[]} */
-	var array;
+	var array = [];
+
+	/** @type {any[]} */
+	var key_list = [];
 
 	var first_run = true;
 
 	function commit() {
 		state.fallback = fallback;
-		reconcile(state, array, anchor, flags, get_key);
+		reconcile(state, array, key_list, anchor, flags);
 
 		if (fallback !== null) {
 			if (array.length === 0) {
@@ -231,6 +234,7 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 		}
 
 		var keys = new Set();
+		key_list = new Array(length);
 		var batch = /** @type {Batch} */ (current_batch);
 		var defer = should_defer_append();
 
@@ -249,6 +253,7 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 
 			var value = array[index];
 			var key = get_key(value, index);
+			key_list[index] = key;
 
 			var item = first_run ? null : items.get(key);
 
@@ -363,12 +368,12 @@ function skip_to_branch(effect) {
  * @template V
  * @param {EachState} state
  * @param {Array<V>} array
+ * @param {any[]} key_list
  * @param {Element | Comment | Text} anchor
  * @param {number} flags
- * @param {(value: V, index: number) => any} get_key
  * @returns {void}
  */
-function reconcile(state, array, anchor, flags, get_key) {
+function reconcile(state, array, key_list, anchor, flags) {
 	var is_animated = (flags & EACH_IS_ANIMATED) !== 0;
 
 	var length = array.length;
@@ -405,7 +410,7 @@ function reconcile(state, array, anchor, flags, get_key) {
 	if (is_animated) {
 		for (i = 0; i < length; i += 1) {
 			value = array[i];
-			key = get_key(value, i);
+			key = key_list[i];
 			effect = /** @type {EachItem} */ (items.get(key)).e;
 
 			// offscreen == coming in now, no animation in that case,
@@ -419,7 +424,7 @@ function reconcile(state, array, anchor, flags, get_key) {
 
 	for (i = 0; i < length; i += 1) {
 		value = array[i];
-		key = get_key(value, i);
+		key = key_list[i];
 
 		effect = /** @type {EachItem} */ (items.get(key)).e;
 

--- a/packages/svelte/tests/runtime-runes/samples/each-key-array-literal/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-key-array-literal/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	async test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		if (!button) {
+			throw new Error('Expected button to exist');
+		}
+
+		flushSync(() => button.click());
+
+		const items = [...target.querySelectorAll('li')].map((li) => li.textContent);
+		assert.deepEqual(items, ['banana', 'carrot', 'doughnut', 'egg']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-key-array-literal/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-key-array-literal/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	let things = $state([
+		{ group: 1, id: 1, name: 'apple' },
+		{ group: 1, id: 2, name: 'banana' },
+		{ group: 2, id: 1, name: 'carrot' },
+		{ group: 2, id: 2, name: 'doughnut' },
+		{ group: 3, id: 5, name: 'egg' }
+	]);
+</script>
+
+<button onclick={() => things.shift()}>Remove first thing</button>
+
+<ul>
+	{#each things as thing ([thing.group, thing.id])}
+		<li>{thing.name}</li>
+	{/each}
+</ul>


### PR DESCRIPTION
Fixes #17721

Keyed `#each` blocks accept any object, but array-literal keys (e.g. `([thing.group, thing.id])`) could crash on updates because `get_key` was called multiple times per update, producing new array instances and causing internal `Map` lookups to miss. This change computes keys once per update, stores them in `key_list`, and reuses them throughout `reconcile()` (including the animation prepass), preventing the runtime error even though array-literal keys remain inherently unstable for identity across updates.

---
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
