### PR TITLE
docs: add best practices page to the docs

### DIFF
--- a/documentation/docs/07-misc/01-best-practices.md
+++ b/documentation/docs/07-misc/01-best-practices.md
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Best practices
 ---
 
 This document is meant to collect a series of best practices to write not only correct but good Svelte code. The content of this page was originally created as a `SKILL.md` file but given it's content it can (and should) be used as a reference by human developers that wish to write the best possible Svelte code.
@@ -54,9 +54,9 @@ to allow `<MyComponent bind:value />`. This can get hairy when the value of the 
 
 ## Events on elements
 
-Every prop that starts with `on` is treated as an event listener for the element. To register a `click` listener on an element you can do `<button onclick={() => {}} />` 
+Every prop that starts with `on` is treated as an event listener for the element. To register a `click` listener on an element you can do `<button onclick={() => {}} />`
 
-> [!NOTE] In Svelte 5, `on` is no longer a directive, so you can't use `on:event`, you have to use `onevent`. 
+> [!NOTE] In Svelte 5, `on` is no longer a directive, so you can't use `on:event`, you have to use `onevent`.
 
 Since elements are just attributes you can spread them, use the `{onclick}` shorthand, etc.
 
@@ -103,7 +103,7 @@ this will add a style attribute with the `--columns:` variable that you can use 
 
 ## Dynamic classes
 
-Since `svelte@5.16.0` you can use `clsx` styles directly in the `class` attribute of an element. This means that arrays and objects can be used to declaratively define classes for an element without having to do manual string concatenation. 
+Since `svelte@5.16.0` you can use `clsx` styles directly in the `class` attribute of an element. This means that arrays and objects can be used to declaratively define classes for an element without having to do manual string concatenation.
 
 ```svelte
 <script>

--- a/documentation/docs/97-best-practices/index.md
+++ b/documentation/docs/97-best-practices/index.md
@@ -1,3 +1,0 @@
----
-title: Best Practices
----


### PR DESCRIPTION
This adds a best practices page to the docs...this was originally only a `SKILL.md` file in the mcp repo but we realized that it could (and should) serve as a general page for humans that wish to write the best svelte code.

The writing style and structure is basically the same as the SKILL and this will be used to sync with the actual SKILL in the mcp repo. I've added a disclaimer for the moment but if we can figure out how to make it sound more natural for humans without forgoing the concepts that help a skill (like progressive disclosure) that would be golden.

[rendered version](https://svelte-dev-git-preview-svelte-17727-svelte.vercel.app/docs/svelte/best-practices)

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
