### PR TITLE
test: add regression test for dir attribute with siblings (#15126)

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/element-dir-attribute-siblings/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/element-dir-attribute-siblings/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<h1 dir="auto">Hello</h1> <h1 dir="auto">World</h1>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/element-dir-attribute-siblings/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/element-dir-attribute-siblings/main.svelte
@@ -1,0 +1,2 @@
+<h1 dir="auto">Hello</h1>
+<h1 dir="auto">World</h1>


### PR DESCRIPTION
## Summary

- Adds a regression test for #15126 where elements with `dir="auto"` caused a compiler crash (`Cannot read properties of null (reading 'type')`) when sibling content was present
- The bug was fixed as a side effect of compiler refactoring between v5.19.3 and v5.51.3, but no regression test existed

## Test plan

- [x] New test passes in all 4 modes: dom, hydrate, ssr, async-ssr
- [x] Covers the exact reproduction from the issue (multiple `dir="auto"` elements with siblings)