### PR TITLE
fix: repair dynamic component truthy/falsy hydration mismatches

### DIFF
--- a/.changeset/silly-mammals-fold.md
+++ b/.changeset/silly-mammals-fold.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: repair dynamic component truthy/falsy hydration mismatches

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
@@ -1,8 +1,17 @@
 /** @import { TemplateNode, Dom } from '#client' */
 import { EFFECT_TRANSPARENT } from '#client/constants';
 import { block } from '../../reactivity/effects.js';
-import { hydrate_next, hydrating } from '../hydration.js';
+import {
+	hydrate_next,
+	hydrate_node,
+	hydrating,
+	read_hydration_instruction,
+	set_hydrate_node,
+	set_hydrating,
+	skip_nodes
+} from '../hydration.js';
 import { BranchManager } from './branches.js';
+import { HYDRATION_START, HYDRATION_START_ELSE } from '../../../../constants.js';
 
 /**
  * @template P
@@ -13,7 +22,11 @@ import { BranchManager } from './branches.js';
  * @returns {void}
  */
 export function component(node, get_component, render_fn) {
+	/** @type {TemplateNode | undefined} */
+	var hydration_start_node;
+
 	if (hydrating) {
+		hydration_start_node = hydrate_node;
 		hydrate_next();
 	}
 
@@ -21,6 +34,28 @@ export function component(node, get_component, render_fn) {
 
 	block(() => {
 		var component = get_component() ?? null;
+
+		if (hydrating) {
+			var data = read_hydration_instruction(/** @type {TemplateNode} */ (hydration_start_node));
+
+			var server_had_component = data === HYDRATION_START;
+			var client_has_component = component !== null;
+
+			if (server_had_component !== client_has_component) {
+				// Hydration mismatch: skip the server-rendered nodes and render fresh
+				var anchor = skip_nodes();
+
+				set_hydrate_node(anchor);
+				branches.anchor = anchor;
+
+				set_hydrating(false);
+				branches.ensure(component, component && ((target) => render_fn(target, component)));
+				set_hydrating(true);
+
+				return;
+			}
+		}
+
 		branches.ensure(component, component && ((target) => render_fn(target, component)));
 	}, EFFECT_TRANSPARENT);
 }

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -97,16 +97,16 @@ export function css_props(renderer, is_html, props, component, dynamic = false) 
 		renderer.push(`<g style="${styles}">`);
 	}
 
-	if (dynamic) {
+	component();
+
+	if (!dynamic) {
 		renderer.push('<!---->');
 	}
 
-	component();
-
 	if (is_html) {
-		renderer.push(`<!----></svelte-css-wrapper>`);
+		renderer.push('</svelte-css-wrapper>');
 	} else {
-		renderer.push(`<!----></g>`);
+		renderer.push('</g>');
 	}
 }
 

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-component-css-props/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-component-css-props/Component.svelte
@@ -1,0 +1,7 @@
+<div>Hello</div>
+
+<style>
+	div {
+		color: var(--color);
+	}
+</style>

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-component-css-props/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-component-css-props/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			`<svelte-css-wrapper style="display: contents; --color: red;"><div class="svelte-lsmn3l">Hello</div></svelte-css-wrapper>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-component-css-props/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-component-css-props/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Component from './Component.svelte';
+	let Comp = Component;
+</script>
+
+<svelte:component this={Comp} --color="red" />

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-component-falsy-hydrate/HelloWorld.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-component-falsy-hydrate/HelloWorld.svelte
@@ -1,0 +1,1 @@
+<div>Hello world</div>

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-component-falsy-hydrate/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-component-falsy-hydrate/_config.js
@@ -1,0 +1,9 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<h1>Test</h1> <div>Hello world</div>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/dynamic-component-falsy-hydrate/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/dynamic-component-falsy-hydrate/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import HelloWorld from './HelloWorld.svelte';
+
+	let Component = $state();
+
+	$effect.pre(() => {
+		Component = HelloWorld;
+	});
+</script>
+
+<h1>Test</h1>
+
+<Component />


### PR DESCRIPTION
Fixes #17735

Use the if/else hydration markers to know what "branch" (component or no component) was rendered, and repair if differing.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
