### PR TITLE
fix: handle shadowed function names correctly

### DIFF
--- a/.changeset/sad-eggs-read.md
+++ b/.changeset/sad-eggs-read.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: handle shadowed function names correctly

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -1101,14 +1101,20 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			const scope = state.scope.child();
 			scopes.set(node, scope);
 
-			if (node.id) scope.declare(node.id, 'normal', 'function');
+			if (node.id) {
+				scopes.set(node.id, state.scope); // so that declarations within with the same name are not confused with the function name
+				scope.declare(node.id, 'normal', 'function');
+			}
 
 			add_params(scope, node.params);
 			next({ scope });
 		},
 
 		FunctionDeclaration(node, { state, next }) {
-			if (node.id) state.scope.declare(node.id, 'normal', 'function', node);
+			if (node.id) {
+				scopes.set(node.id, state.scope); // so that declarations within with the same name are not confused with the function name
+				state.scope.declare(node.id, 'normal', 'function', node);
+			}
 
 			const scope = state.scope.child();
 			scopes.set(node, scope);

--- a/packages/svelte/tests/runtime-runes/samples/derived-name-shadowed/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-name-shadowed/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `42`
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-name-shadowed/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-name-shadowed/main.svelte
@@ -1,0 +1,8 @@
+<script module>
+	function foo() {
+		const foo = $derived(42);
+		return () => foo;
+	}
+</script>
+
+{foo()()}


### PR DESCRIPTION
Fixes #17750 (though the change that causes the issue only surfaced this more general bug)

We were not adding the correct scope to function ids. Instead it was part of the function body/params scope, which leads to bugs when the function name is shadowed within the function.
