### PR TITLE
Fix #13638: Svelte 5: Custom element's default <slot> not created when n

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -114,13 +114,13 @@ if (typeof HTMLElement === 'function') {
 				const $$slots = {};
 				const existing_slots = get_custom_elements_slots(this);
 				for (const name of this.$$s) {
-					if (name in existing_slots) {
-						if (name === 'default' && !this.$$d.children) {
-							this.$$d.children = create_slot(name);
-							$$slots.default = true;
-						} else {
-							$$slots[name] = create_slot(name);
-						}
+					if (name === 'default' && !this.$$d.children) {
+						// Always create the default slot, even if no children are present initially,
+						// because children may be added dynamically later (fixes #13638)
+						this.$$d.children = create_slot(name);
+						$$slots.default = true;
+					} else if (name !== 'default' && name in existing_slots) {
+						$$slots[name] = create_slot(name);
 					}
 				}
 				for (const attribute of this.attributes) {

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/no-initial-children-default-slot/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/no-initial-children-default-slot/_config.js
@@ -1,0 +1,25 @@
+import { test } from '../../assert';
+const tick = () => Promise.resolve();
+
+export default test({
+	async test({ assert, target }) {
+		// Mount the custom element with no initial children
+		target.innerHTML = `<my-widget></my-widget>`;
+		await tick();
+
+		/** @type {any} */
+		const ce = target.querySelector('my-widget');
+
+		// The default slot should be created even without initial children
+		assert.htmlEqual(ce.shadowRoot.innerHTML, `<slot></slot>`);
+
+		// Now add a child dynamically
+		const span = document.createElement('span');
+		span.textContent = 'hello';
+		ce.appendChild(span);
+		await tick();
+
+		// The slot element should still be present to render the dynamically added child
+		assert.htmlEqual(ce.shadowRoot.innerHTML, `<slot></slot>`);
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/no-initial-children-default-slot/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/no-initial-children-default-slot/main.svelte
@@ -1,0 +1,3 @@
+<svelte:options customElement="my-widget" />
+
+<slot></slot>


### PR DESCRIPTION
Fixes #13638

## Summary
This PR fixes: Svelte 5: Custom element's default <slot> not created when no initial children are passed

## Changes
```
.../internal/client/dom/elements/custom-element.js | 14 ++++++------
 .../no-initial-children-default-slot/_config.js    | 25 ++++++++++++++++++++++
 .../no-initial-children-default-slot/main.svelte   |  3 +++
 3 files changed, 35 insertions(+), 7 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).