### PR TITLE
fix: handle default parameters scope leaks

### DIFF
--- a/.changeset/modern-terms-refuse.md
+++ b/.changeset/modern-terms-refuse.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: handle default parameters scope leaks

--- a/packages/svelte/tests/runtime-runes/samples/function-parameter-shadowing/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/function-parameter-shadowing/_config.js
@@ -1,0 +1,7 @@
+import { test } from '../../test';
+
+export default test({
+	test({ assert, logs }) {
+		assert.deepEqual(logs, [42, 43]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/function-parameter-shadowing/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/function-parameter-shadowing/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let value = $state(42);
+
+	function shadow(output = value) {
+		const value = 1337;
+		return output;
+	}
+
+	console.log(shadow());
+	value += 1;
+	console.log(shadow());
+</script>


### PR DESCRIPTION
Use separate scopes for function declarations/expressions and function bodies. This prevents variable declarations from leaking into default parameter initialization expressions.

Closes #17785.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
