### PR TITLE
chore: require pr number as input when manually invoking pkg.pr.new

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -13,7 +13,7 @@ on:
       pr:
         description: 'PR number to comment on'
         required: true
-        type: number        
+        type: number
 
 permissions: {}
 


### PR DESCRIPTION
AFAICT there's no good way to get the PR associated with a commit if that commit is on a fork, so... when running manually you just have to provide your PR number.

In the future: We could potentially still run this workflow automatically on forks if the fork owner has write access to this repo. If it's ever annoying enough to spend the time for us to make that change...