### PR TITLE
docs: best practices

### DIFF
--- a/documentation/docs/07-misc/01-best-practices.md
+++ b/documentation/docs/07-misc/01-best-practices.md
@@ -5,7 +5,7 @@ description: Guidance on writing fast, robust, modern Svelte code. Load this ski
 ---
 
 <!-- llm-ignore-start -->
-This document outlines some best practices that will help you write fast, robust Svelte apps. It is also available as a `svelte-best-practices` skill for your agents.
+This document outlines some best practices that will help you write fast, robust Svelte apps. It is also available as a `svelte-core-bestpractices` skill for your agents.
 <!-- llm-ignore-end -->
 
 ## `$state`


### PR DESCRIPTION
Based on #17727 but with a few changes:

- smaller (fewer tokens)
- removed some bits that are really just summarising existing docs
- added an explicit 'don't use these legacy features' section
- shuffled some things around a bit