### PR TITLE
chore: disable automatic vercel deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "git": {
-    "deploymentEnabled": false
-  }
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"git": {
+		"deploymentEnabled": false
+	}
 }


### PR DESCRIPTION
The repo has to be connected to a Vercel project in order to activate Agent, but we don't want to actually deploy anything. This takes care of that