### PR TITLE
chore: simplify batch.flush

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -348,9 +348,7 @@ export class Batch {
 			this.#commit_callbacks.clear();
 
 			this.#commit();
-
 			this.#deferred?.resolve();
-			batch_values = null;
 		}
 
 		this.deactivate();


### PR DESCRIPTION
another extraction from #17805. I always felt bad about `this.process([])`, and this PR replaces it with the steps that actually occur — even though this is arguably duplicative, I find it much easier to understand.

It also allows us to avoid activating batches with no queued effects, thanks to the change in #17809. This saves us a bit of work in a not-that-uncommon case.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
