### PR TITLE
fix: skip redundant batch.apply

### DIFF
--- a/.changeset/vast-dolls-dance.md
+++ b/.changeset/vast-dolls-dance.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip redundant batch.apply

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -340,7 +340,7 @@ export class Batch {
 
 	flush() {
 		if (queued_root_effects.length > 0) {
-			this.activate();
+			current_batch = this;
 			flush_effects();
 		} else if (this.#pending === 0 && !this.is_fork) {
 			// append/remove branches


### PR DESCRIPTION
tiny fix — just realised we're calling `this.apply()` (via `this.activate()`) unnecessarily, since it will happen again immediately after in `flush_effects`