### PR TITLE
chore: remove unused is_flushing variable

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -66,7 +66,6 @@ let queued_root_effects = [];
 /** @type {Effect | null} */
 let last_scheduled_effect = null;
 
-let is_flushing = false;
 export let is_flushing_sync = false;
 
 /**
@@ -589,8 +588,6 @@ export function flushSync(fn) {
 }
 
 function flush_effects() {
-	is_flushing = true;
-
 	var source_stacks = DEV ? new Set() : null;
 
 	try {
@@ -639,7 +636,6 @@ function flush_effects() {
 	} finally {
 		queued_root_effects = [];
 
-		is_flushing = false;
 		last_scheduled_effect = null;
 		collected_effects = null;
 


### PR DESCRIPTION
as of a few PRs ago this variable is unused