### PR TITLE
fix: SvelteURL search setter uses unnormalized value

### DIFF
--- a/.changeset/fix-svelte-url-search-normalization.md
+++ b/.changeset/fix-svelte-url-search-normalization.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: SvelteURL `search` setter now returns the normalized value, matching native URL behavior

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -171,7 +171,7 @@ export class SvelteURL extends URL {
 
 	set search(value) {
 		super.search = value;
-		set(this.#search, value);
+		set(this.#search, super.search);
 		this.#searchParams[REPLACE](super.searchParams);
 	}
 

--- a/packages/svelte/src/reactivity/url.test.ts
+++ b/packages/svelte/src/reactivity/url.test.ts
@@ -115,6 +115,35 @@ test('url.searchParams', () => {
 	cleanup();
 });
 
+test('url.search normalizes value', () => {
+	const url = new SvelteURL('https://svelte.dev');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(url.search);
+		});
+	});
+
+	flushSync(() => {
+		// setting without ? prefix — URL normalizes to "?foo=bar"
+		url.search = 'foo=bar';
+	});
+
+	flushSync(() => {
+		url.search = '?baz=qux';
+	});
+
+	flushSync(() => {
+		// lone "?" is normalized to ""
+		url.search = '?';
+	});
+
+	assert.deepEqual(log, ['', '?foo=bar', '?baz=qux', '']);
+
+	cleanup();
+});
+
 test('SvelteURL instanceof URL', () => {
 	assert.ok(new SvelteURL('https://svelte.dev') instanceof URL);
 });


### PR DESCRIPTION
## Summary

- The `SvelteURL` `search` setter stored the raw input `value` instead of `super.search`, unlike every other setter in the class
- This caused `url.search` to return incorrect values when the URL API normalizes the input (e.g. adding the `?` prefix, or stripping a lone `?`)
- For example: `url.search = 'foo=bar'` would return `'foo=bar'` instead of `'?foo=bar'`

## Test plan

- [x] Added `url.search normalizes value` test covering:
  - Setting search without `?` prefix
  - Setting search with `?` prefix (existing behavior)
  - Setting search to lone `?` (normalized to `""`)
- [x] All existing reactivity tests pass (46/46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)