### PR TITLE
chore: add `batch.id` property

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -79,6 +79,7 @@ export let collected_effects = null;
 let uid = 1;
 
 export class Batch {
+	// for debugging. TODO remove once async is stable
 	id = uid++;
 
 	/**


### PR DESCRIPTION
I cannot tell you how many times I have temporarily added this code to make it easier to debug some async stuff. I am extremely bored of doing so. I'm just going to add it to `main` to save myself the annoyance. We can remove it once everything async is stable