### PR TITLE
chore: better log_effect_tree

### DIFF
--- a/packages/svelte/src/internal/client/dev/debug.js
+++ b/packages/svelte/src/internal/client/dev/debug.js
@@ -127,7 +127,7 @@ export function log_effect_tree(effect, depth = 0, is_reachable = true) {
 		}
 	}
 
-	var child_is_reachable = (flags & BRANCH_EFFECT) === 0 || (flags & CLEAN) === 0;
+	var child_is_reachable = is_reachable && ((flags & BRANCH_EFFECT) === 0 || (flags & CLEAN) === 0);
 
 	let child = effect.first;
 	while (child !== null) {


### PR DESCRIPTION
While working on the reactivity it's very helpful to be able to log a snapshot of the effect tree. This PR augments the existing `log_effect_tree` helper by marking unreachable-but-dirty effects, like so:

<img width="333" height="415" alt="image" src="https://github.com/user-attachments/assets/2c7501f7-b845-4271-b534-3a8be0ff62ee" />


(I had thought `log_inconsistent_branches` was designed to help with this but it didn't work for me. Do we need both? cc @dummdidumm)