### PR TITLE
chore: robustify `flatten`

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -76,14 +76,17 @@ export function flatten(blockers, sync, async, fn) {
 
 	// Full path: has async expressions
 	function run() {
-		restore();
 		Promise.all(async.map((expression) => async_derived(expression)))
 			.then((result) => finish([...sync.map(d), ...result]))
 			.catch((error) => invoke_error_boundary(error, parent));
 	}
 
 	if (blocker_promise) {
-		blocker_promise.then(run);
+		blocker_promise.then(() => {
+			restore();
+			run();
+			unset_context();
+		});
 	} else {
 		run();
 	}


### PR DESCRIPTION
Extracted from #17805. Currently we restore context in`flatten` unnecessarily in the case where we have async expressions but no blockers (the context is already correct), and we don't unset context after blockers resolve in the case where we have them. The first bit is suboptimal, but the second bit feels bug-shaped, even though I'm not currently aware of any actual bugs that have resulted from this.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
