### PR TITLE
chore: deactivate batch after async derived resolves

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -197,6 +197,8 @@ export function async_derived(fn, label, location) {
 			if (decrement_pending) {
 				decrement_pending();
 			}
+
+			batch.deactivate();
 		};
 
 		d.promise.then(handler, (e) => handler(null, e || 'unknown'));


### PR DESCRIPTION
Extracted from #17805. Similar to #17864, I'm not aware of any bugs resulting from this, but the fact that we're setting `current_batch` before calling `internal_set` and then not _unsetting_ `current_batch` feels like something that could potentially bite us.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
