### PR TITLE
docs: add skill true frontmatter

### DIFF
--- a/documentation/docs/07-misc/01-best-practices.md
+++ b/documentation/docs/07-misc/01-best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: Best practices
+skill: true
 name: svelte-core-bestpractices
 description: Guidance on writing fast, robust, modern Svelte code. Load this skill whenever in a Svelte project and asked to write/edit or analyze a Svelte component or module. Covers reactivity, event handling, styling, integration with libraries and more.
 ---


### PR DESCRIPTION
This adds a `skill: true` to the frontmatter of the bestpractices skill/doc. This way when we sync we can concern ourselves to only the documents that need to be skills (we will write one for sveltekit too) without targeting specific files in the `ai-tools` repo