### PR TITLE
fix: set deferreds on initial suspense, too

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -146,14 +146,14 @@ export function async_derived(fn, label, location) {
 
 		var batch = /** @type {Batch} */ (current_batch);
 
-		// we only increment the batch's pending state for updates, not creation, otherwise
-		// we will decrement to zero before the work that depends on this promise (e.g. a
-		// template effect) has initialized, causing the batch to resolve prematurely
-		if (should_suspend && (effect.f & REACTION_RAN) !== 0) {
-			var decrement_pending = increment_pending();
-		}
-
 		if (should_suspend) {
+			// we only increment the batch's pending state for updates, not creation, otherwise
+			// we will decrement to zero before the work that depends on this promise (e.g. a
+			// template effect) has initialized, causing the batch to resolve prematurely
+			if ((effect.f & REACTION_RAN) !== 0) {
+				var decrement_pending = increment_pending();
+			}
+
 			if (/** @type {Boundary} */ (parent.b).is_rendered()) {
 				deferreds.get(batch)?.reject(STALE_REACTION);
 				deferreds.delete(batch); // delete to ensure correct order in Map iteration below


### PR DESCRIPTION
The combination of #17873 and #17805 resulted in a bad merge of the latter because it wasn't up to date with main. This fixes it. No changeset because not released yet.
