### PR TITLE
chore: always populate batch_values when updating a derived

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -28,13 +28,7 @@ import {
 import { equals, safe_equals } from './equality.js';
 import * as e from '../errors.js';
 import * as w from '../warnings.js';
-import {
-	async_effect,
-	destroy_effect,
-	destroy_effect_children,
-	effect_tracking,
-	teardown
-} from './effects.js';
+import { async_effect, destroy_effect, destroy_effect_children, teardown } from './effects.js';
 import { eager_effects, internal_set, set_eager_effects, source } from './sources.js';
 import { get_error } from '../../shared/dev.js';
 import { async_mode_flag, tracing_mode_flag } from '../../flags/index.js';
@@ -400,11 +394,7 @@ export function update_derived(derived) {
 	// During time traveling we don't want to reset the status so that
 	// traversal of the graph in the other batches still happens
 	if (batch_values !== null) {
-		// only cache the value if we're in a tracking context, otherwise we won't
-		// clear the cache in `mark_reactions` when dependencies are updated
-		if (effect_tracking() || current_batch?.is_fork) {
-			batch_values.set(derived, value);
-		}
+		batch_values.set(derived, value);
 	} else {
 		update_derived_status(derived);
 	}


### PR DESCRIPTION
Never really understood this code if I'm honest. It _was_ necessary at one point (it was introduced in #17105, and if you rewind the repo to that PR and remove the `if` guard, tests fail) but it doesn't seem to be doing anything now, possibly as a result of the scheduling refactor.

And it's contributing to some undesirable behaviour — if we only populate `batch_values` when we're reading a derived while an effect is running, then we _don't_ populate `batch_values` when we call `update_derived` inside `is_dirty`. In practice what this means is that we execute the derived once when we're checking to see if an effect that depends on it needs to re-run, and then again when we re-run the effect. That's silly!

This PR doesn't fix that by itself. We additionally need `is_dirty(d)` to return `false` if `batch_values.has(d)`. But we can't do that yet, because in some circumstances it will lead to a derived incorrectly remaining `DIRTY`. Needs further investigation, either in this PR or a follow-up.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
