### PR TITLE
fix: remove `untrack` circular dependency

### DIFF
--- a/.changeset/late-weeks-unite.md
+++ b/.changeset/late-weeks-unite.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove `untrack` circular dependency

--- a/packages/svelte/src/store/utils.js
+++ b/packages/svelte/src/store/utils.js
@@ -1,5 +1,5 @@
 /** @import { Readable } from './public' */
-import { untrack } from '../index-client.js';
+import { untrack } from '../internal/client/runtime.js';
 import { noop } from '../internal/shared/utils.js';
 
 /**


### PR DESCRIPTION
Closes #17899 by importing `untrack` from the actual file instead of the `index-client.js`. Verified by packing the library and launching a build with it.