### PR TITLE
chore: add sandbox output files to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -31,6 +31,8 @@ packages/svelte/tests/parser-modern/samples/*/_actual.json
 packages/svelte/tests/parser-modern/samples/*/output.json
 packages/svelte/types
 packages/svelte/compiler/index.js
+playgrounds/sandbox/dist/*
+playgrounds/sandbox/output/*
 playgrounds/sandbox/src/*
 
 **/node_modules


### PR DESCRIPTION
If you had any output files from previous sandbox runs, these would get checked and failed by Prettier. We were already ignore `src`, so now we're ignoring `dist` and `output` as well.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
