### PR TITLE
chore: add "untracked allows writes" test

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/untrack-allows-writes/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/untrack-allows-writes/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+// While we don't officially document it, `untrack` also allows to opt out of the "unsafe mutation" validation, which is what we test here
+export default test({
+	html: '<button>0 0 0</button>',
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>1 1 2</button>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/untrack-allows-writes/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/untrack-allows-writes/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { untrack } from "svelte";
+
+	let count = $state(0);
+	let mirrored = $state(0);
+	let double = $derived.by(() => {
+		untrack(() => {
+			mirrored = count;
+		});
+		return count * 2;
+	})
+</script>
+
+<button onclick={() => count++}>{count} {mirrored} {double}</button>


### PR DESCRIPTION
While we don't officially document it, `untrack` also allows to opt out of the "unsafe mutation" validation, which is what we test here.

For anyone coming across this: USE WITH CAUTION. This can cause graph inconsistencies leading to wrong values on initial render, as [seen here](https://svelte.dev/playground/8cace59b689c4432a64fe54adf140d12?version=5.53.11#H4sIAAAAAAAACm2PzWrDQAyEX0WIHuzG5KdHxzHk1nfo9mB7ZViy1i5rOT8s--7FcUJbyE3MN6ORInIzEJb4SdY6uLhgNWSkjZDOscDeWBqx_IooNz_7ZgGLZ-ro_Xo8k5VZa5uRXumdYyGWEUusxi4YL7ViJWbwLghEmFhC050gQR_cAAqXpMK94tloSaBzEwsc4G2URijb5vsnGUwILpB-CbWbWksz0hTMmfS6vWVZDoca4uxR8ij_Lyr5s3WpXsFuv8CUP4ZAMgV-8Hf4uMspV1xtft_kytd09dQJaehdAMNGTGMhEGsKJWxhB9tq42vFVTuJOAbHnTXd6RCXo-4Fq1Wq431KEJ_XJYjLh6naLNlaMRYodBUsJUyUvguUxtiLYY1l39iR0g_Ytq_z9AEAAA)

Doing this because we're gonna make use of it ourselves for remote functions, and this ensures we don't accidentally regress.
