### PR TITLE
fix: ensure `$inspect` after top level await doesn't break builds

### DIFF
--- a/.changeset/clear-birds-invite.md
+++ b/.changeset/clear-birds-invite.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure `$inspect` after top level await doesn't break builds

--- a/packages/svelte/src/compiler/phases/3-transform/shared/transform-async.js
+++ b/packages/svelte/src/compiler/phases/3-transform/shared/transform-async.js
@@ -95,7 +95,8 @@ export function transform_body(instance_body, runner, transform) {
 				);
 
 				if (expression.type === 'EmptyStatement') {
-					return null;
+					// Keep indices stable for async sequencing while avoiding array holes in run([...]).
+					return b.thunk(b.void0, false);
 				}
 
 				return expression.type === 'AwaitExpression'

--- a/packages/svelte/tests/runtime-runes/samples/async-inspect-build/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-inspect-build/_config.js
@@ -1,0 +1,10 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	ssrHtml: 'works',
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, 'works');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-inspect-build/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-inspect-build/main.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  const test = async () => "test";
+  await test();
+  $inspect("inspect after await shouldnt break builds");
+</script>
+
+works

--- a/packages/svelte/tests/snapshot/samples/async-top-level-inspect-server/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-top-level-inspect-server/_expected/client/index.svelte.js
@@ -6,7 +6,7 @@ var root = $.from_html(`<p> </p>`);
 
 export default function Async_top_level_inspect_server($$anchor) {
 	var data;
-	var $$promises = $.run([async () => data = await Promise.resolve(42),,]);
+	var $$promises = $.run([async () => data = await Promise.resolve(42), () => void 0]);
 	var p = root();
 	var text = $.child(p, true);
 

--- a/packages/svelte/tests/snapshot/samples/async-top-level-inspect-server/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-top-level-inspect-server/_expected/server/index.svelte.js
@@ -3,7 +3,7 @@ import * as $ from 'svelte/internal/server';
 
 export default function Async_top_level_inspect_server($$renderer) {
 	var data;
-	var $$promises = $$renderer.run([async () => data = await Promise.resolve(42),,]);
+	var $$promises = $$renderer.run([async () => data = await Promise.resolve(42), () => void 0]);
 
 	$$renderer.push(`<p>`);
 	$$renderer.async([$$promises[1]], ($$renderer) => $$renderer.push(() => $.escape(data)));


### PR DESCRIPTION
Turn empty statements into empty thunks so that `$.run/$$render.run` don't throw (as they expect functions as input)

Fixes #17514
