### PR TITLE
fix: ensure "is standalone child" is correctly reset

### DIFF
--- a/.changeset/shy-parks-enjoy.md
+++ b/.changeset/shy-parks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure "is standalone child" is correctly reset

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/Fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/Fragment.js
@@ -63,6 +63,7 @@ export function Fragment(node, context) {
 	/** @type {ComponentClientTransformState} */
 	const state = {
 		...context.state,
+		is_standalone,
 		init: [],
 		snippets: [],
 		consts: [],
@@ -128,7 +129,7 @@ export function Fragment(node, context) {
 			// no need to create a template, we can just use the existing block's anchor
 			process_children(trimmed, () => b.id('$$anchor'), false, {
 				...context,
-				state: { ...state, is_standalone }
+				state
 			});
 		} else {
 			/** @type {(is_text: boolean) => Expression} */

--- a/packages/svelte/tests/runtime-runes/samples/async-render-component-hydration/Image.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-render-component-hydration/Image.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { src } = $props();
+</script>
+
+<img {src} />

--- a/packages/svelte/tests/runtime-runes/samples/async-render-component-hydration/Link.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-render-component-hydration/Link.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { children } = $props();
+</script>
+
+<a href="/">
+	{@render children()}
+</a>

--- a/packages/svelte/tests/runtime-runes/samples/async-render-component-hydration/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-render-component-hydration/_config.js
@@ -1,0 +1,14 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['hydrate'],
+
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<a href="/"><div>card</div> <img src="https://svelte.dev" /></a>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-render-component-hydration/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-render-component-hydration/main.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import Image from "./Image.svelte";
+	import Link from "./Link.svelte";
+
+	let url = $derived(await 'https://svelte.dev');
+</script>
+
+<Link>
+	<div>card</div>
+	<Image src={url} />
+</Link>


### PR DESCRIPTION
We didn't set this back to `false`, which can lead to wrong results if the parent happened to have it set to `true`

Fixes #17730
