### PR TITLE
docs: clarify `$derived` `await` examples, dependency tracking

### DIFF
--- a/documentation/docs/03-template-syntax/19-await-expressions.md
+++ b/documentation/docs/03-template-syntax/19-await-expressions.md
@@ -71,8 +71,8 @@ This does not apply to sequential `await` expressions inside your `<script>` or 
 async function one() { return 1; }
 async function two() { return 2; }
 // ---cut---
-// these will run sequentially the first time,
-// but will update independently
+// `b` will not be created until `a` has resolved,
+// but once created they will update independently
 let a = $derived(await one());
 let b = $derived(await two());
 ```


### PR DESCRIPTION
Fixes #17660

The comment in `documentation/docs/03-template-syntax/19-await-expressions.md` describing sequential `$derived` `await` expressions was ambiguous -- "these will run sequentially the first time" did not clearly distinguish between creation order and update behavior. Updates the comment to explicitly state that `b` will not be created until `a` has resolved, making the sequential creation constraint clear while preserving the explanation that subsequent updates occur independently.