### PR TITLE
Fix {@const} staleness in callbacks for prop-derived values

### DIFF
--- a/.changeset/fix-const-tag-callback-dependency.md
+++ b/.changeset/fix-const-tag-callback-dependency.md
@@ -1,0 +1,7 @@
+---
+'svelte': patch
+---
+
+Fix: {@const} inside {#each} now correctly updates when prop-derived value is used only in array callbacks like .find(), .filter(), .some()
+
+Fixes issue #17992 where prop-derived {@const} declarations would become stale in legacy mode when the prop was only referenced inside a callback closure.

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/function.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/function.js
@@ -16,9 +16,14 @@ export function visit_function(node, context) {
 		}
 	}
 
+	const keep_expression_tracking =
+		context.state.expression &&
+		!context.state.analysis.runes &&
+		context.state.derived_function_depth === context.state.function_depth;
+
 	context.next({
 		...context.state,
 		function_depth: context.state.function_depth + 1,
-		expression: null
+		expression: keep_expression_tracking ? context.state.expression : null
 	});
 }

--- a/packages/svelte/tests/runtime-legacy/samples/const-tag-each-find-prop-dependency/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/const-tag-each-find-prop-dependency/_config.js
@@ -1,0 +1,18 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: '<p></p>',
+
+	test({ assert, component, target }) {
+		component.selectedItemId = 'a';
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, '<p>2</p>');
+
+		component.selectedItemId = 'b';
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, '<p>4</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/const-tag-each-find-prop-dependency/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/const-tag-each-find-prop-dependency/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	export let selectedItemId = null;
+
+	const groups = [
+		{
+			items: [
+				{ id: 'a', seats: 2 },
+				{ id: 'b', seats: 4 }
+			]
+		}
+	];
+</script>
+
+{#each groups as group}
+	{@const selectedItem = group.items.find((item) => item.id === selectedItemId)}
+	<p>{selectedItem?.seats ?? ''}</p>
+{/each}


### PR DESCRIPTION
## Fix: {@const} inside {#each} now updates with prop-derived values in callbacks

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

## Related Issue
Fixes #17992

## Problem
In legacy mode, `{@const}` declarations would become stale when a prop reference appeared only inside array method callbacks like `.find()`, `.filter()`, or `.some()`. 

**Example of the bug:**
```svelte
export let selectedItemId = null;

{#each groups as group}
    {@const selectedItem = group.items.find((item) => item.id === selectedItemId)}
    <p>{selectedItem?.seats}</p>
{/each}