### PR TITLE
docs: proper example code for hints on preserving reactivity

### DIFF
--- a/documentation/docs/02-runes/02-$state.md
+++ b/documentation/docs/02-runes/02-$state.md
@@ -61,7 +61,7 @@ let todos = [{ done: false, text: 'add more todos' }];
 let { done, text } = todos[0];
 
 // this will not affect the value of `done`
-todos[0].done = !todos[0].done;
+done = !done;
 ```
 
 ### Classes


### PR DESCRIPTION
The [docs about deep state](https://svelte.dev/docs/svelte/$state#Deep-state) contain a code example that should demonstrate that primitive values are no longer reactive after destructuring:

```ts
let { done, text } = todos[0];

// this will not affect the value of `done`
todos[0].done = !todos[0].done;
```

However, the assignment in this example code does not use the destructed references. So it actually works, when it should not. It's indeed just the working code from the example code block above. I'd like to update the example to show the broken version.

[Here's a playground](https://svelte.dev/playground/hello-world?version=5.55.0#H4sIAAAAAAAAE22QzWrDMBCEX2WzFJKAcZKr_AO99R0sHxxrU5sqK2Ntmhajdy-yGkqglz18O7Oa0YLcXQkVvpG1Du5utgZ2ZEYhs8cML6Mlj6pZUL6nqIsAs4frdZpy_0lWIjt3nv7jvWMhFo8KS9_P4yS1Zi2WBMQZ56GCFy-d0K6JfIlDi3FMCi6d9ZQlIvQlCradMXB1MyXzNu6C5nZfaH6cXSC6M4gOCFAlaXNsC83l4S8Dl8OpTs2XVZJb4ncZAogT5zflYTgl3fkm4hgc93bsP6plt4eq_jU1xzaP70EFmydQhLA2TVWexSEmSVdrzZhhzIpK5huFNkPpRnsf2aBafyD8AMemPf-oAQAA) with the code from the examples in the docs. As you can see clicking the counter button works just fine.

We have to ensure to actually use the destructed `done` variable. I updated the docs accordingly:

```ts
let { done, text } = todos[0];

// this will not affect the value of `done`
done = !done;
```

[Here's a playground](https://svelte.dev/playground/hello-world?version=5.55.0#H4sIAAAAAAAAE21P0WrDMAz8FVUM2kJo11c3Cext_1DnIY3VNcyVQ6yuG8b_PhRT9rIXGZ3vdHcJub8RGnwn7wM8wuwdbMiNQm6LFV5GTxHNKaH8TMpTAKun6m2advGLvCh27iP9hw-BhVgiGqzjMI-TtJateBKQ4EKEBl6i9EKbk-JJhxUXmAxceh-pKojQtxhY987BLcxUxGv9y5a77dHy82wCVVegCsjQFOrptTtarvd_Gbi-HtrSPC2UnSf-kGsGCRLiqt5fD4V3vosEhsCDH4fPJm220LSQ1AYaWOl7zHnpVYKnp-VO96y-5UZrGSvUZGhkvlPuKpR-9I-RHZqlb_4F3CUZjZYBAAA) with this updated example. If you click the button nothing happens, as intended by this negative example.

Maybe instead of changing both sides of the assignment to just `done` we could also just change either side, e.g. `todos[0].done = done` or `done = !todos[0].done;` then? Those are both also broken, but I'm not sure if this is more or less confusing.

What's furthermore interesting, but maybe a bit too much for this place in the docs and probably not a good practice anyways: If you destruct something other than a primitive value (object or array) it actually works since those are deeply proxified. [Here's a playground showing that](https://svelte.dev/playground/hello-world?version=5.55.0#H4sIAAAAAAAAE21Q0W7CMAz8FWNNAqSqjNfQVtrb_oHwUBozIoJTNWZsivLvU4gqJLQXP5zvfOeLyP2VUOEnOefh7idnYEXGCpk1VniyjgKqfUT5HTMvA1jNqo9xrMM3OcnYsQ_0Hz54FmIJqLAJw2RH6TRrcSQg3vgALbwF6YVW-4zHPLQMno0V6zkoiMYzKTj1LlCqyl7oRxQse2Pg6icqp5Z5lzQf1jvNs0mE560Ksg4StEWwfz_sNDebZy5uztuutBEflNoRf8k5gXjxYdFsztvCO95EPIPnwdnh0sbVGtoO4tOszrGhhcULtEvp0UD5Ks5B6hdaysGKSacZK8zRUcl0o3SoUHrr7pYNqtLLH9mjUT7LAQAA).

And lastly, [destructuring works just fine for derived](https://svelte.dev/docs/svelte/$derived#Destructuring), but I guess it would also be confusing to mention that here. And since recently, derived values are writable, so it actually works, just in case [here's a playground showing that](https://svelte.dev/playground/hello-world?version=5.55.0#H4sIAAAAAAAAE21PQWrDMBD8irIUYoNJmqtiG3rrH6wcFGtTiygrY22SFqG_F1mEXnrZhdmZ2ZkIpG8IEj7ROS-efnFGVGgso6mhgYt1GEAOEfhnzrwMQPNSfczzLjzQccbOOuB_-OiJkTiAhDaMi525V6TYIQv2xgfRibfAmrEaMh7zUGw8oRQX7QI2BWH8Zim22hhx8wsW8TbfkqJTfVT0so1ZnLKvwcU-0FQrd3hfWe3-LwW106Ev3ePK2TmkL55Scd-0--lQeOc7syfhaXR2vHaxqkXXl0-iE5u8jymtzUr0EiK_K9JeETSQS4Dk5Y7p1ABr656WDMi1aPoFsce5M48BAAA) with this example.

I hope this helps. Let me know if you would prefer a different solution to this.

### Before submitting the PR, please make sure you do the following

- [ ] ~It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs~
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] ~Ideally, include a test that fails without this PR but passes with it.~
- [ ] ~If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).~

### Tests and linting

- [ ] ~Run the tests with `pnpm test` and lint the project with `pnpm lint`~
