### PR TITLE
fix: handle null target in append_styles to prevent crash (fix #17960)

### DIFF
--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -18,7 +18,7 @@ export function append_styles(anchor, css) {
 
 		// Always querying the DOM is roughly the same perf as additionally checking for presence in a map first assuming
 		// that you'll get cache hits half of the time, so we just always query the dom for simplicity and code savings.
-		if (!target.querySelector('#' + css.hash)) {
+		if (target && !target.querySelector('#' + css.hash)) {
 			const style = create_element('style');
 			style.id = css.hash;
 			style.textContent = css.code;


### PR DESCRIPTION
When `target` is null (e.g., `ownerDocument.head` is null), the `querySelector` call throws 'Cannot read properties of null'. This adds a null check before calling querySelector.

Fixes #17960