### PR TITLE
docs: fix various typos in codebase documentation and comments

### DIFF
--- a/benchmarking/benchmarks/reactivity/tests/kairo_mux.bench.js
+++ b/benchmarking/benchmarks/reactivity/tests/kairo_mux.bench.js
@@ -6,12 +6,12 @@ export default () => {
 	const mux = $.derived(() => {
 		return Object.fromEntries(heads.map((h) => $.get(h)).entries());
 	});
-	const splited = heads
+	const split = heads
 		.map((_, index) => $.derived(() => $.get(mux)[index]))
 		.map((x) => $.derived(() => $.get(x) + 1));
 
 	const destroy = $.effect_root(() => {
-		splited.forEach((x) => {
+		split.forEach((x) => {
 			$.render_effect(() => {
 				$.get(x);
 			});
@@ -25,13 +25,13 @@ export default () => {
 				$.flush(() => {
 					$.set(heads[i], i);
 				});
-				assert.equal($.get(splited[i]), i + 1);
+				assert.equal($.get(split[i]), i + 1);
 			}
 			for (let i = 0; i < 10; i++) {
 				$.flush(() => {
 					$.set(heads[i], i * 2);
 				});
-				assert.equal($.get(splited[i]), i * 2 + 1);
+				assert.equal($.get(split[i]), i * 2 + 1);
 			}
 		}
 	};

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -114,7 +114,7 @@
 
 - fix: don't access inert block effects ([#17882](https://github.com/sveltejs/svelte/pull/17882))
 
-- fix: handle asnyc updates within pending boundary ([#17873](https://github.com/sveltejs/svelte/pull/17873))
+- fix: handle async updates within pending boundary ([#17873](https://github.com/sveltejs/svelte/pull/17873))
 
 - perf: avoid re-traversing the effect tree after `$:` assignments ([#17848](https://github.com/sveltejs/svelte/pull/17848))
 
@@ -1266,7 +1266,7 @@ Not published due to CI issue
 
 ### Patch Changes
 
-- fix: allow instrinsic `<svelte:...>` elements to inherit from `SvelteHTMLElements` ([#16424](https://github.com/sveltejs/svelte/pull/16424))
+- fix: allow intrinsic `<svelte:...>` elements to inherit from `SvelteHTMLElements` ([#16424](https://github.com/sveltejs/svelte/pull/16424))
 
 ## 5.36.6
 
@@ -1438,7 +1438,7 @@ Not published due to CI issue
 
 ### Patch Changes
 
-- fix: don't set state withing `with_parent` in proxy ([#16176](https://github.com/sveltejs/svelte/pull/16176))
+- fix: don't set state within `with_parent` in proxy ([#16176](https://github.com/sveltejs/svelte/pull/16176))
 
 - fix: use compiler-driven reactivity in legacy mode template expressions ([#16100](https://github.com/sveltejs/svelte/pull/16100))
 
@@ -1692,7 +1692,7 @@ Not published due to CI issue
 
 ### Patch Changes
 
-- fix: remove unncessary guards that require CSP privilege when removing event attributes ([#15846](https://github.com/sveltejs/svelte/pull/15846))
+- fix: remove unnecessary guards that require CSP privilege when removing event attributes ([#15846](https://github.com/sveltejs/svelte/pull/15846))
 
 - fix: rewrite destructuring logic to handle iterators ([#15813](https://github.com/sveltejs/svelte/pull/15813))
 
@@ -2207,7 +2207,7 @@ Not published due to CI issue
 
 ### Patch Changes
 
-- fix: omit unnecessary nullish coallescing in template expressions ([#15056](https://github.com/sveltejs/svelte/pull/15056))
+- fix: omit unnecessary nullish coalescing in template expressions ([#15056](https://github.com/sveltejs/svelte/pull/15056))
 
 - fix: more efficient template effect grouping ([#15050](https://github.com/sveltejs/svelte/pull/15050))
 
@@ -2581,7 +2581,7 @@ Not published due to CI issue
 
 - fix: better error messages for invalid HTML trees ([#14445](https://github.com/sveltejs/svelte/pull/14445))
 
-- fix: remove spreaded event handlers when they become nullish ([#14546](https://github.com/sveltejs/svelte/pull/14546))
+- fix: remove spread event handlers when they become nullish ([#14546](https://github.com/sveltejs/svelte/pull/14546))
 
 - fix: respect the unidirectional nature of time ([#14541](https://github.com/sveltejs/svelte/pull/14541))
 
@@ -4371,7 +4371,7 @@ For more details check out the [Svelte docs](https://svelte-omnisite.vercel.app/
 
 - feat: defer tasks without creating effects ([#11960](https://github.com/sveltejs/svelte/pull/11960))
 
-- fix: enusre dev validation in dynamic component works as intended ([#11985](https://github.com/sveltejs/svelte/pull/11985))
+- fix: ensure dev validation in dynamic component works as intended ([#11985](https://github.com/sveltejs/svelte/pull/11985))
 
 - feat: detach inert effects ([#11955](https://github.com/sveltejs/svelte/pull/11955))
 
@@ -4747,7 +4747,7 @@ For more details check out the [Svelte docs](https://svelte-omnisite.vercel.app/
 
 - fix: only warn about non-reactive state in runes mode ([#11434](https://github.com/sveltejs/svelte/pull/11434))
 
-- fix: prevent ownership validation from infering with component context ([#11438](https://github.com/sveltejs/svelte/pull/11438))
+- fix: prevent ownership validation from inferring with component context ([#11438](https://github.com/sveltejs/svelte/pull/11438))
 
 - fix: ensure $inspect untracks inspected object ([#11432](https://github.com/sveltejs/svelte/pull/11432))
 
@@ -5501,7 +5501,7 @@ For more details check out the [Svelte docs](https://svelte-omnisite.vercel.app/
 
 - fix: disallow exporting props, derived and reassigned state from within components ([#10430](https://github.com/sveltejs/svelte/pull/10430))
 
-- fix: improve indexed each array reconcilation ([#10422](https://github.com/sveltejs/svelte/pull/10422))
+- fix: improve indexed each array reconciliation ([#10422](https://github.com/sveltejs/svelte/pull/10422))
 
 - fix: add compiler error for each block mutations in runes mode ([#10428](https://github.com/sveltejs/svelte/pull/10428))
 
@@ -5731,7 +5731,7 @@ For more details check out the [Svelte docs](https://svelte-omnisite.vercel.app/
 
 - fix: keep intermediate number value representations ([`d171a39b0`](https://github.com/sveltejs/svelte/commit/d171a39b0ad97e2a05de1f38bc76a3d345e2b3d5))
 
-- feat: allow modifiying derived props ([#10080](https://github.com/sveltejs/svelte/pull/10080))
+- feat: allow modifying derived props ([#10080](https://github.com/sveltejs/svelte/pull/10080))
 
 - fix: improve signal consumer tracking behavior ([#10121](https://github.com/sveltejs/svelte/pull/10121))
 

--- a/packages/svelte/src/index-client.js
+++ b/packages/svelte/src/index-client.js
@@ -17,7 +17,7 @@ if (DEV) {
 		if (!(rune in globalThis)) {
 			// TODO if people start adjusting the "this can contain runes" config through v-p-s more, adjust this message
 			/** @type {any} */
-			let value; // let's hope noone modifies this global, but belts and braces
+			let value; // let's hope no one modifies this global, but belts and braces
 			Object.defineProperty(globalThis, rune, {
 				configurable: true,
 				// eslint-disable-next-line getter-return

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -584,7 +584,7 @@ function get_setters(element) {
 	var element_proto = Element.prototype;
 
 	// Stop at Element, from there on there's only unnecessary setters we're not interested in
-	// Do not use contructor.name here as that's unreliable in some browser environments
+	// Do not use constructor.name here as that's unreliable in some browser environments
 	while (element_proto !== proto) {
 		descriptors = get_descriptors(proto);
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -133,7 +133,7 @@ export function set_untracked_writes(value) {
  **/
 export let write_version = 1;
 
-/** @type {number} Used to version each read of a source of derived to avoid duplicating depedencies inside a reaction */
+/** @type {number} Used to version each read of a source of derived to avoid duplicating dependencies inside a reaction */
 let read_version = 0;
 
 export let update_version = read_version;

--- a/packages/svelte/tests/runtime-legacy/samples/each-block-array-literal/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/each-block-array-literal/_config.js
@@ -2,7 +2,7 @@ import { ok, test } from '../../test';
 
 export default test({
 	html: `
-		<button>racoon</button>
+		<button>raccoon</button>
 		<button>eagle</button>
 	`,
 
@@ -10,7 +10,7 @@ export default test({
 		assert.htmlEqual(
 			target.innerHTML,
 			`
-			<button>racoon</button>
+			<button>raccoon</button>
 			<button>eagle</button>
 		`
 		);

--- a/packages/svelte/tests/runtime-legacy/samples/event-handler-this-methods/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/event-handler-this-methods/_config.js
@@ -6,12 +6,12 @@ export default test({
 		// in real browsers. More realistically, you'd use this for e.g.
 		// this.select(), but that's harder to test than this.focus()
 
-		const wont = target.querySelector('.wont-focus');
+		const won't = target.querySelector('.won't-focus');
 		const will = target.querySelector('.will-focus');
-		ok(wont);
+		ok(won't);
 		ok(will);
 
-		wont.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+		won't.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
 		assert.equal(window.document.activeElement, window.document.body);
 
 		will.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-slot-5-cancelled-overflow/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-slot-5-cancelled-overflow/_config.js
@@ -3,7 +3,7 @@ import { test } from '../../test';
 
 // updated props in the middle of transitions
 // and cancelled the transition halfway
-// + spreaded props + overflow context
+// + spread props + overflow context
 
 export default test({
 	html: `

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-slot-6-spread-cancelled/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-slot-6-spread-cancelled/_config.js
@@ -3,7 +3,7 @@ import { test } from '../../test';
 
 // updated props in the middle of transitions
 // and cancelled the transition halfway
-// with spreaded props
+// with spread props
 
 export default test({
 	html: `

--- a/packages/svelte/tests/runtime-legacy/samples/transition-js-slot-7-spread-cancelled-overflow/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/transition-js-slot-7-spread-cancelled-overflow/_config.js
@@ -3,7 +3,7 @@ import { test } from '../../test';
 
 // updated props in the middle of transitions
 // and cancelled the transition halfway
-// + spreaded props + overflow context
+// + spread props + overflow context
 
 export default test({
 	html: `

--- a/packages/svelte/tests/runtime-runes/samples/async-derived-in-multiple-effects/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-derived-in-multiple-effects/Component.svelte
@@ -5,7 +5,7 @@
 
 	// Test setup:
 	// - component initialized while pending work
-	// - derived that depends on mulitple sources
+	// - derived that depends on multiple sources
 	// - indirect updates to subsequent deriveds
 	// - two sibling effects where the former influences the latter
 	// - first effect reads derived of second inside untrack

--- a/packages/svelte/tests/runtime-runes/samples/async-inspect-build/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-inspect-build/main.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   const test = async () => "test";
   await test();
-  $inspect("inspect after await shouldnt break builds");
+  $inspect("inspect after await shouldn't break builds");
 </script>
 
 works

--- a/packages/svelte/tests/runtime-runes/samples/not-actual-runes/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/not-actual-runes/_config.js
@@ -4,7 +4,7 @@ import { test } from '../../test';
 export default test({
 	html: `
   <p>1 4 0</p>
-  <button>Shouldnt be reactive</button>
+  <button>Shouldn't be reactive</button>
   `,
 
 	test({ assert, target }) {
@@ -15,7 +15,7 @@ export default test({
 			target.innerHTML,
 			`
   			<p>1 4 0</p>
-  			<button>Shouldnt be reactive</button>
+  			<button>Shouldn't be reactive</button>
   			`
 		);
 	}

--- a/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/not-actual-runes/main.svelte
@@ -17,4 +17,4 @@
 </script>
 
 <p>{foo} {baz.x} {baz.y}</p>
-<button on:click={() => foo = 5}>Shouldnt be reactive</button>
+<button on:click={() => foo = 5}>Shouldn't be reactive</button>

--- a/packages/svelte/tests/validator/samples/rest-eachblock-binding-3/input.svelte
+++ b/packages/svelte/tests/validator/samples/rest-eachblock-binding-3/input.svelte
@@ -1,5 +1,5 @@
 <script>
-	let objArray = [{ bar: {foo: '1', id: 0, innerValue: "test"} }, { bar: {foo: '2', id:1, innerValue: "Somethin"} }]
+	let objArray = [{ bar: {foo: '1', id: 0, innerValue: "test"} }, { bar: {foo: '2', id:1, innerValue: "Something"} }]
 </script>
 
 {#each objArray as { bar: { id, ...rest } } (id)}

--- a/packages/svelte/tests/validator/samples/rest-eachblock-binding/input.svelte
+++ b/packages/svelte/tests/validator/samples/rest-eachblock-binding/input.svelte
@@ -1,5 +1,5 @@
 <script>
-	let objArray = [{foo: '1', id: 0, innerValue: "test"}, {foo: '2', id:1, innerValue: "Somethin"}]
+	let objArray = [{foo: '1', id: 0, innerValue: "test"}, {foo: '2', id:1, innerValue: "Something"}]
 </script>
 
 {#each objArray as { id, ...rest } (id)}


### PR DESCRIPTION
Fixes a few minor typos across the codebase (e.g. 'depedencies' -> 'dependencies', 'contructor' -> 'constructor').