### PR TITLE
chore: fix editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 indent_style = tab
-indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
I don't know why exactly, but VS Code suddenly started paying attention to this line. An indent size of 2 inside an IDE is for masochists and barbarians. If that's your preference then that's up to you but there's certainly no reason to impose it on everyone who clones this repo.