### PR TITLE
fix: don't override `$destroy/set/on` instance methods in dev mode

### DIFF
--- a/.changeset/orange-geckos-rest.md
+++ b/.changeset/orange-geckos-rest.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't override `$destroy/set/on` instance methods in dev mode

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -352,7 +352,7 @@ export function client_component(analysis, options) {
 			)
 		);
 	} else if (dev) {
-		component_returned_object.push(b.spread(b.call(b.id('$.legacy_api'))));
+		component_returned_object.unshift(b.spread(b.call(b.id('$.legacy_api'))));
 	}
 
 	const push_args = [b.id('$$props'), b.literal(analysis.runes)];


### PR DESCRIPTION
Don't think we need a test for this

Fixes #17988
