### PR TITLE
chore: squelch hydration warnings in tests

### DIFF
--- a/packages/svelte/tests/runtime-runes/samples/async-if-after-await-in-script/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-if-after-await-in-script/_config.js
@@ -6,11 +6,13 @@ export default test({
 
 	ssrHtml: '<p>yep</p>',
 
-	async test({ assert, target, variant }) {
+	async test({ assert, target, variant, warnings }) {
 		if (variant === 'dom') {
 			await tick();
 		}
 
 		assert.htmlEqual(target.innerHTML, '<p>yep</p>');
+
+		assert.deepEqual(warnings, []); // TODO not quite sure why this isn't populated yet
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/await-html-hydration/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/await-html-hydration/_config.js
@@ -3,5 +3,7 @@ import { test } from '../../test';
 export default test({
 	skip_no_async: true,
 	mode: ['hydrate'],
-	async test() {}
+	async test({ assert, warnings }) {
+		assert.deepEqual(warnings, []); // TODO not quite sure why this isn't populated yet
+	}
 });


### PR DESCRIPTION
Gets rid of some annoying console spam. I don't totally understand why `warnings` isn't populated by the time the assertions happen (it seems to happen just afterwards, except if I sleep for a few milliseconds and then do the assertion the warnings get swallowed altogether?) but for right now I don't much care