### PR TITLE
fix: use push_renderer_if_inactive in compiled components

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -408,9 +408,19 @@ export function client_component(analysis, options) {
 
 	if (analysis.custom_renderer) {
 		component_block.body.unshift(
-			b.var('$$pop_renderer', b.call('$.push_renderer', b.id('$renderer')))
+			b.var('$$pop_renderer', b.call('$.push_renderer_if_inactive', b.id('$renderer')))
 		);
-		component_block.body.push(b.stmt(b.call('$$pop_renderer')));
+		// $$pop_renderer may be null if renderer was already active — use optional call
+		component_block.body.push(
+			b.stmt(
+				/** @type {any} */ ({
+					type: 'CallExpression',
+					callee: b.id('$$pop_renderer'),
+					arguments: [],
+					optional: true
+				})
+			)
+		);
 	}
 
 	let should_inject_props =

--- a/packages/svelte/src/internal/client/custom-renderer/state.js
+++ b/packages/svelte/src/internal/client/custom-renderer/state.js
@@ -30,6 +30,18 @@ export function push_renderer($renderer) {
 }
 
 /**
+ * Push a renderer only if no renderer is currently active.
+ * Used by compiled components — if render() already pushed a renderer,
+ * the component should use that one rather than overriding with its own import.
+ * @param {Renderer<any, any, any, any>} $renderer
+ * @returns {(() => void) | null}
+ */
+export function push_renderer_if_inactive($renderer) {
+	if (renderer !== null) return null;
+	return push_renderer($renderer);
+}
+
+/**
  * @template T
  * @param {() => T} fn
  * @returns {T}

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -186,4 +186,4 @@ export {
 export { strict_equals, equals } from './dev/equality.js';
 export { log_if_contains_state } from './dev/console-log.js';
 export { invoke_error_boundary } from './error-handling.js';
-export { push_renderer, without_renderer } from './custom-renderer/state.js';
+export { push_renderer, push_renderer_if_inactive, without_renderer } from './custom-renderer/state.js';


### PR DESCRIPTION
Hi @paoloricciuti — I'm excited about this PR. I've been trying out the custom renderer API for a terminal renderer and ran into an issue with reactive updates.

One problem I ran into is that when `render()` is called with a renderer that has been configured with context (e.g. a render queue for incremental updates), the compiled component's `push_renderer($renderer)` call overrides it with the statically imported default renderer. Effects created during the component capture the imported renderer, so when they re-run on `$state` changes, `renderer.setText` is called on the wrong instance — one without the mount-time configuration.

In practice this means that if you create a renderer with `createRenderer()` for the static import (as required by the compiler), and then create a second configured instance in your `mount()` function to pass to `renderer.render()`, the configured instance is only used during initial tree construction. Any subsequent reactive updates (`$state` changes triggering `template_effect` re-runs) go through the unconfigured import instead. This effectively makes reactive state changes invisible to the renderer's infrastructure — text updates, attribute changes, and DOM mutations from effects all bypass whatever context the `render()` caller set up.

The sequence:
1. `render()` calls `push_renderer(mountRenderer)` — renderer with context ✓
2. Compiled component calls `push_renderer($renderer)` — statically imported, no context ✗
3. `template_effect` captures `r: renderer` — gets the import, not the mount renderer
4. On `$state` change, effect re-run calls `set_text` → `renderer.setText` on wrong instance

To fix this I propose `push_renderer_if_inactive()` which only pushes if no renderer is currently active. The compiled component uses this instead of `push_renderer`, so if `render()` already pushed a renderer, the component respects it.