### PR TITLE
chore: improve benchmarks

### DIFF
--- a/benchmarking/benchmarks/reactivity/index.js
+++ b/benchmarking/benchmarks/reactivity/index.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import 'svelte/internal/flags/async';
 import {
 	sbench_create_0to1,
 	sbench_create_1000to1,

--- a/benchmarking/benchmarks/reactivity/tests/clean_effects.bench.js
+++ b/benchmarking/benchmarks/reactivity/tests/clean_effects.bench.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import * as $ from 'svelte/internal/client';
+
+export default () => {
+	const a = $.state(1);
+	const b = $.state(2);
+
+	let total = 0;
+
+	const destroy = $.effect_root(() => {
+		for (let i = 0; i < 1000; i += 1) {
+			$.render_effect(() => {
+				total += $.get(a);
+			});
+		}
+
+		$.render_effect(() => {
+			total += $.get(b);
+		});
+	});
+
+	return {
+		destroy,
+		run() {
+			for (let i = 0; i < 5; i++) {
+				total = 0;
+				$.flush(() => $.set(b, i));
+				assert.equal(total, i);
+			}
+		}
+	};
+};


### PR DESCRIPTION
This makes the benchmarks slightly more honest — it adds the async flag, and a benchmark that tests the (common) scenario where most effects are clean. Relevant to #18035, will self-merge so we can do a fresh comparison