### PR TITLE
docs: add CSS custom properties section to style directive

### DIFF
--- a/documentation/docs/03-template-syntax/17-style.md
+++ b/documentation/docs/03-template-syntax/17-style.md
@@ -42,3 +42,9 @@ even over `!important` properties:
 <div style:color="red" style="color: blue">This will be red</div>
 <div style:color="red" style="color: blue !important">This will still be red</div>
 ```
+
+You can set CSS custom properties:
+
+```svelte
+<div style:--columns={columns}>...</div>
+```


### PR DESCRIPTION
Adds documentation for using CSS custom properties with the `style:` directive. I think this was lost at some point during the great transition. It's only mentioned in the [best practices](https://svelte.dev/docs/svelte/best-practices#Using-JavaScript-variables-in-CSS) section, so I thought it would make sense to include it.