### PR TITLE
fix: remove scheduled roots invariant

### DIFF
--- a/.changeset/weak-teams-learn.md
+++ b/.changeset/weak-teams-learn.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove scheduled roots invariant

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -38,7 +38,6 @@ import { defer_effect } from './utils.js';
 import { UNINITIALIZED } from '../../../constants.js';
 import { set_signal_status } from './status.js';
 import { legacy_is_updating_store } from './store.js';
-import { invariant } from '../../shared/dev.js';
 import { log_effect_tree } from '../dev/debug.js';
 
 /** @type {Set<Batch>} */
@@ -544,9 +543,7 @@ export class Batch {
 					batch.discard();
 				}
 			} else if (sources.length > 0) {
-				if (DEV) {
-					invariant(batch.#roots.length === 0, 'Batch has scheduled roots');
-				}
+				const should_execute = batch.#roots.length === 0;
 
 				// A batch was unskipped in a later batch -> tell prior batches to unskip it, too
 				if (is_earlier) {
@@ -592,8 +589,9 @@ export class Batch {
 					}
 				}
 
-				// Only apply and traverse when we know we triggered async work with marking the effects
-				if (batch.#roots.length > 0) {
+				// Only apply and traverse when we know we triggered async work with marking the effects,
+				// and there wasn't already work scheduled to run (e.g. directly afterwards via the microtask queue)
+				if (batch.#roots.length > 0 && should_execute) {
 					batch.apply();
 
 					for (var root of batch.#roots) {
@@ -716,7 +714,7 @@ export class Batch {
 
 				if (!is_flushing_sync) {
 					queue_micro_task(() => {
-						if (current_batch !== batch) {
+						if (!batches.has(batch) || batch.#pending.size > 0) {
 							// a flushSync happened in the meantime
 							return;
 						}

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -714,7 +714,7 @@ export class Batch {
 
 				if (!is_flushing_sync) {
 					queue_micro_task(() => {
-						if (!batches.has(batch) || batch.#pending.size > 0) {
+						if (current_batch !== batch) {
 							// a flushSync happened in the meantime
 							return;
 						}


### PR DESCRIPTION
Working on adjacent issues, two things became apparent:
- the way we check if the microtask in `ensure` is outdated is wrong. `current_batch` could be `null` for other reasons. Instead check if it's still alive. _Update: extracted this into #18131_
- the "batch has scheduled roots" invariant is wrong: you can end up with scheduled roots if you have multiple batches that are scheduled to be resolved in the same microtask. This can happen like this: first batch goes into queue, does `queue_microtask`, another microtask that was scheduled earlier resolves, this one also schedules a batch, which does not do `queue_microtask` (because we queued one already) and instead just adds another entry to the list of tasks. Then two batches are in the task queue, and if the first commits it might try to rebase the second one, which is scheduled to flush directly afterwards, and then the invariant check wrongfully crashes the process.

Fixes #18071 and fixes #17940
