### PR TITLE
docs: fix spacing around option tag in bind docs

### DIFF
--- a/documentation/docs/03-template-syntax/12-bind.md
+++ b/documentation/docs/03-template-syntax/12-bind.md
@@ -241,7 +241,7 @@ When the value of an `<option>` matches its text content, the attribute can be o
 </select>
 ```
 
-You can give the `<select>` a default value by adding a `selected` attribute to the`<option>` (or options, in the case of `<select multiple>`) that should be initially selected. If the `<select>` is part of a form, it will revert to that selection when the form is reset. Note that for the initial render the value of the binding takes precedence if it's not `undefined`.
+You can give the `<select>` a default value by adding a `selected` attribute to the `<option>` (or options, in the case of `<select multiple>`) that should be initially selected. If the `<select>` is part of a form, it will revert to that selection when the form is reset. Note that for the initial render the value of the binding takes precedence if it's not `undefined`.
 
 ```svelte
 <select bind:value={selected}>


### PR DESCRIPTION
## Summary
- Fix the missing space before `<option>` in the bind documentation.

## Related issue
- N/A

## Guideline alignment
- Read `CONTRIBUTING.md` and kept this to one focused docs-only file change.
- No behavior, test, fixture, changeset, or generated-file changes.

## Test plan
- `git diff --check`
- Not run: docs-only spacing fix.
