### PR TITLE
chore: fix constructor typo in attributes comment

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -584,7 +584,7 @@ function get_setters(element) {
 	var element_proto = Element.prototype;
 
 	// Stop at Element, from there on there's only unnecessary setters we're not interested in
-	// Do not use contructor.name here as that's unreliable in some browser environments
+	// Do not use constructor.name here as that's unreliable in some browser environments
 	while (element_proto !== proto) {
 		descriptors = get_descriptors(proto);
 


### PR DESCRIPTION
## Summary
- Fix the `constructor` typo in the attributes comment.

## Related issue
- N/A

## Guideline alignment
- Read `CONTRIBUTING.md` and kept this to one focused text-only file change.
- No behavior, test, fixture, changeset, or generated-file changes.

## Test plan
- `git diff --check`
- Not run: comment-only change.
