### PR TITLE
feat: add `isStateProxy` utility to check for Svelte `$state` proxies

### DIFF
--- a/.changeset/grumpy-taxes-hug.md
+++ b/.changeset/grumpy-taxes-hug.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: add `isStateProxy` utility to check for Svelte `$state` proxies

--- a/documentation/docs/02-runes/02-$state.md
+++ b/documentation/docs/02-runes/02-$state.md
@@ -167,6 +167,8 @@ To take a static snapshot of a deeply reactive `$state` proxy, use `$state.snaps
 
 This is handy when you want to pass some state to an external library or API that doesn't expect a proxy, such as `structuredClone`.
 
+If you need to branch logic based on whether a value is a state proxy _without_ cloning it, use [`isStateProxy`](svelte-reactivity#isStateProxy) from `svelte/reactivity`.
+
 ## `$state.eager`
 
 When state changes, it may not be reflected in the UI immediately if it is used by an `await` expression, because [updates are synchronized](await-expressions#Synchronized-updates).

--- a/documentation/docs/98-reference/21-svelte-reactivity.md
+++ b/documentation/docs/98-reference/21-svelte-reactivity.md
@@ -4,4 +4,6 @@ title: svelte/reactivity
 
 Svelte provides reactive versions of various built-ins like [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), [`Set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) and [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) that can be used just like their native counterparts, as well as a handful of additional utilities for handling reactivity.
 
+It also includes helpers for integration boundaries, such as `isStateProxy(value)` to check whether a value is a Svelte `$state` proxy.
+
 > MODULE: svelte/reactivity

--- a/packages/svelte/src/reactivity/index-client.js
+++ b/packages/svelte/src/reactivity/index-client.js
@@ -5,3 +5,4 @@ export { SvelteURL } from './url.js';
 export { SvelteURLSearchParams } from './url-search-params.js';
 export { MediaQuery } from './media-query.js';
 export { createSubscriber } from './create-subscriber.js';
+export { isStateProxy } from './is-state-proxy.js';

--- a/packages/svelte/src/reactivity/index-server.js
+++ b/packages/svelte/src/reactivity/index-server.js
@@ -21,3 +21,12 @@ export class MediaQuery {
 export function createSubscriber(_) {
 	return () => {};
 }
+
+/**
+ * Returns `false` on the server because `$state` proxies are a client runtime concept.
+ *
+ * @param {unknown} _value
+ */
+export function isStateProxy(_value) {
+	return false;
+}

--- a/packages/svelte/src/reactivity/is-state-proxy.js
+++ b/packages/svelte/src/reactivity/is-state-proxy.js
@@ -1,0 +1,10 @@
+import { get_proxied_value } from '../internal/client/proxy.js';
+
+/**
+ * Returns `true` if `value` is a Svelte `$state` proxy.
+ *
+ * @param {unknown} value
+ */
+export function isStateProxy(value) {
+	return !Object.is(value, get_proxied_value(value));
+}

--- a/packages/svelte/src/reactivity/is-state-proxy.test.ts
+++ b/packages/svelte/src/reactivity/is-state-proxy.test.ts
@@ -1,0 +1,23 @@
+import { assert, test } from 'vitest';
+import { proxy } from '../internal/client/proxy.js';
+import { isStateProxy as is_state_proxy_client } from './index-client.js';
+import { isStateProxy as is_state_proxy_server } from './index-server.js';
+
+test('isStateProxy detects state proxies on client', () => {
+	const proxied_object = proxy({ a: 1 });
+	const proxied_array = proxy([1, 2, 3]);
+
+	assert.equal(is_state_proxy_client(proxied_object), true);
+	assert.equal(is_state_proxy_client(proxied_array), true);
+	assert.equal(is_state_proxy_client({ a: 1 }), false);
+	assert.equal(is_state_proxy_client([1, 2, 3]), false);
+	assert.equal(is_state_proxy_client('x'), false);
+	assert.equal(is_state_proxy_client(null), false);
+	assert.equal(is_state_proxy_client(NaN), false);
+});
+
+test('isStateProxy always returns false on server export', () => {
+	assert.equal(is_state_proxy_server(proxy({ a: 1 })), false);
+	assert.equal(is_state_proxy_server({ a: 1 }), false);
+	assert.equal(is_state_proxy_server(null), false);
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-is-state-proxy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-is-state-proxy/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	html: '<div>true false false</div><button>true 0</button>',
+
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => {
+			button?.click();
+		});
+
+		assert.htmlEqual(target.innerHTML, '<div>true false false</div><button>true 1</button>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-is-state-proxy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-is-state-proxy/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { isStateProxy } from 'svelte/reactivity';
+
+	let proxied = $state({ count: 0 });
+	let plain = { count: 0 };
+</script>
+
+<div>{isStateProxy(proxied)} {isStateProxy(plain)} {isStateProxy(null)}</div>
+<button onclick={() => (proxied.count += 1)}>{isStateProxy(proxied)} {proxied.count}</button>

--- a/packages/svelte/tests/types/reactivity.ts
+++ b/packages/svelte/tests/types/reactivity.ts
@@ -1,0 +1,10 @@
+import { isStateProxy } from 'svelte/reactivity';
+
+const unknown_value: unknown = {};
+const is_proxy: boolean = isStateProxy(unknown_value);
+
+// Keep these values used so strict checks stay happy
+is_proxy;
+
+// @ts-expect-error requires exactly one argument
+isStateProxy();

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2487,6 +2487,11 @@ declare module 'svelte/reactivity' {
 	 * @since 5.7.0
 	 */
 	export function createSubscriber(start: (update: () => void) => (() => void) | void): () => void;
+	/**
+	 * Returns `true` if `value` is a Svelte `$state` proxy.
+	 *
+	 * */
+	export function isStateProxy(value: unknown): boolean;
 	class ReactiveValue<T> {
 		
 		constructor(fn: () => T, onsubscribe: (update: () => void) => void);


### PR DESCRIPTION
Fixes: #15345 
Fixes: #15908 

This PR adds a new utility, `isStateProxy(value)`, to svelte/reactivity.

Users may need to know whether a value is a `$state` proxy without cloning it.
`$state.snapshot` is a conversion API, not a detection API, and may do unnecessary work when only a boolean check is needed.