### PR TITLE
test: cover pre-subscription updates in toStore

### DIFF
--- a/packages/svelte/tests/store/test.ts
+++ b/packages/svelte/tests/store/test.ts
@@ -609,6 +609,24 @@ describe('toStore', () => {
 		unsubscribe();
 	});
 
+	it('uses the latest state when subscribed after a pre-subscription update', () => {
+		const count = source(0);
+
+		const store = toStore(() => $.get(count));
+
+		set(count, 1);
+
+		const log: number[] = [];
+
+		const unsubscribe = store.subscribe((value) => {
+			log.push(value);
+		});
+
+		assert.deepEqual(log, [1]);
+
+		unsubscribe();
+	});
+
 	it('creates a writable store from state', () => {
 		const count = source(0);
 


### PR DESCRIPTION

**Repo:** sveltejs/svelte (⭐ 82000)
**Type:** test
**Files changed:** 1
**Lines:** +18/-0

## What
Adds a focused regression test for `toStore` in the store test suite. The new case verifies that when the underlying reactive state changes after `toStore` is created but before the first subscriber attaches, the subscriber receives only the latest value instead of a stale initial snapshot.

## Why
`toStore` contains explicit logic for this pre-subscription update path, which makes it a real compatibility edge rather than incidental behavior. Locking it down with a dedicated test helps prevent regressions in a subtle part of the store bridge between reactive state and the public store API.

## Testing
Attempted to run `pnpm test packages/svelte/tests/store/test.ts`, but the sandbox blocked `pnpm` from creating its cache directory under `/Users/bojun/Library/pnpm`. No automated checks completed locally in this environment.

## Risk
Low - test-only change in an existing suite with no production code changes.
