### PR TITLE
fix: allow `@debug` tags to reference awaited variables

### DIFF
--- a/.changeset/small-tools-walk.md
+++ b/.changeset/small-tools-walk.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow `@debug` tags to reference awaited variables

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/DebugTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/DebugTag.js
@@ -8,6 +8,10 @@ import * as b from '#compiler/builders';
  * @param {ComponentContext} context
  */
 export function DebugTag(node, context) {
+	const blockers = node.identifiers
+		.map((identifier) => context.state.scope.get(identifier.name)?.blocker)
+		.filter((blocker) => blocker != null);
+
 	const object = b.object(
 		node.identifiers.map((identifier) => {
 			const visited = b.call('$.snapshot', /** @type {Expression} */ (context.visit(identifier)));
@@ -20,9 +24,11 @@ export function DebugTag(node, context) {
 		})
 	);
 
-	const call = b.call('console.log', object);
+	const args = [b.thunk(b.block([b.stmt(b.call('console.log', object)), b.debugger]))];
 
-	context.state.init.push(
-		b.stmt(b.call('$.template_effect', b.thunk(b.block([b.stmt(call), b.debugger]))))
-	);
+	if (blockers.length > 0) {
+		args.push(b.array([]), b.array([]), b.array(blockers));
+	}
+
+	context.state.init.push(b.stmt(b.call('$.template_effect', ...args)));
 }

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/DebugTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/DebugTag.js
@@ -2,23 +2,34 @@
 /** @import { AST } from '#compiler' */
 /** @import { ComponentContext } from '../types.js' */
 import * as b from '#compiler/builders';
+import { create_child_block } from './shared/utils.js';
 
 /**
  * @param {AST.DebugTag} node
  * @param {ComponentContext} context
  */
 export function DebugTag(node, context) {
+	const blockers = node.identifiers
+		.map((identifier) => context.state.scope.get(identifier.name)?.blocker)
+		.filter((blocker) => blocker != null);
+
 	context.state.template.push(
-		b.stmt(
-			b.call(
-				'console.log',
-				b.object(
-					node.identifiers.map((identifier) =>
-						b.prop('init', identifier, /** @type {Expression} */ (context.visit(identifier)))
+		...create_child_block(
+			[
+				b.stmt(
+					b.call(
+						'console.log',
+						b.object(
+							node.identifiers.map((identifier) =>
+								b.prop('init', identifier, /** @type {Expression} */ (context.visit(identifier)))
+							)
+						)
 					)
-				)
-			)
-		),
-		b.debugger
+				),
+				b.debugger
+			],
+			b.array(blockers),
+			false
+		)
 	);
 }

--- a/packages/svelte/tests/runtime-runes/samples/async-debug-awaited-expression/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-debug-awaited-expression/_config.js
@@ -1,0 +1,18 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+	mode: ['client', 'async-server'],
+
+	async test({ assert, logs }) {
+		await tick();
+
+		assert.deepEqual(logs, [{ data: 'works' }]);
+	},
+	test_ssr({ assert, logs }) {
+		assert.deepEqual(logs, [{ data: 'works' }]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-debug-awaited-expression/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-debug-awaited-expression/main.svelte
@@ -1,0 +1,4 @@
+<svelte:boundary>
+	{@const data = await Promise.resolve("works")}
+	{@debug data}
+</svelte:boundary>


### PR DESCRIPTION
Fixes #18137
