### PR TITLE
fix: skip block comments in read_value to prevent apostrophe parsing error

### DIFF
--- a/.changeset/three-pears-build.md
+++ b/.changeset/three-pears-build.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ignore comments when reading CSS values

--- a/packages/svelte/src/compiler/phases/1-parse/read/style.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/style.js
@@ -524,6 +524,16 @@ function read_value(parser) {
 			in_url = true;
 		} else if ((char === ';' || char === '{' || char === '}') && !in_url && !quote_mark) {
 			return value.trim();
+		} else if (char === '/' && !in_url && !quote_mark && parser.template[parser.index + 1] === '*') {
+			parser.index += 2;
+			while (parser.index < parser.template.length) {
+				if (parser.template[parser.index] === '*' && parser.template[parser.index + 1] === '/') {
+					parser.index += 2;
+					break;
+				}
+				parser.index++;
+			}
+			continue;
 		}
 
 		value += char;

--- a/packages/svelte/src/compiler/phases/1-parse/read/style.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/style.js
@@ -524,7 +524,12 @@ function read_value(parser) {
 			in_url = true;
 		} else if ((char === ';' || char === '{' || char === '}') && !in_url && !quote_mark) {
 			return value.trim();
-		} else if (char === '/' && !in_url && !quote_mark && parser.template[parser.index + 1] === '*') {
+		} else if (
+			char === '/' &&
+			!in_url &&
+			!quote_mark &&
+			parser.template[parser.index + 1] === '*'
+		) {
 			parser.index += 2;
 			while (parser.index < parser.template.length) {
 				if (parser.template[parser.index] === '*' && parser.template[parser.index + 1] === '/') {

--- a/packages/svelte/tests/css/samples/comment-with-apostrophe/expected.css
+++ b/packages/svelte/tests/css/samples/comment-with-apostrophe/expected.css
@@ -1,0 +1,4 @@
+
+	p.svelte-xyz {
+		padding: 0 /* it's a comment */ 1em;
+	}

--- a/packages/svelte/tests/css/samples/comment-with-apostrophe/input.svelte
+++ b/packages/svelte/tests/css/samples/comment-with-apostrophe/input.svelte
@@ -1,0 +1,7 @@
+<p>red</p>
+
+<style>
+	p {
+		padding: 0 /* it's a comment */ 1em;
+	}
+</style>


### PR DESCRIPTION
Fixes #18134.

## Problem

`read_value()` in `packages/svelte/src/compiler/phases/1-parse/read/style.js` has no logic to skip CSS block comments (`/* ... */`). When the parser encounters an apostrophe inside a comment, it sets `quote_mark = "'"` — treating it as the start of a string literal — then never finds a matching closing quote, and ultimately throws `unexpected_eof` at the end of the style block.

Minimal repro:

```svelte
<style>
  /* it's a comment */
  .foo { color: red; }
</style>
```

→ `Error: Unexpected end of input`

## Fix

Add a `/* ... */` skip path inside the `read_value` loop, mirroring the same pattern already used in `allow_comment_or_whitespace`. When `/*` is detected outside a string or url context, the parser advances past the entire comment without adding its content to the value string.