### PR TITLE
feat: Implement getOrInsert and getOrInsertComputed methods

### DIFF
--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -153,6 +153,22 @@ export class SvelteMap extends Map {
 		return super.get(key);
 	}
 
+	getOrInsert(key, value) {
+		if (super.has(key)) {
+			return /** @type {V} */ (super.get(key));
+		}
+		this.set(key, value);
+		return super.get(key);
+	}
+
+	getOrInsertComputed(key, callbackfn) {
+		if (super.has(key)) {
+			return /** @type {V} */ (super.get(key));
+		}
+		this.set(key, callbackfn(key));
+		return super.get(key);
+	}
+
 	/**
 	 * @param {K} key
 	 * @param {V} value


### PR DESCRIPTION
What
Adds support for Map.prototype.getOrInsert and Map.prototype.getOrInsertComputed to SvelteMap.

Why
The [upsert proposal](https://github.com/tc39/proposal-upsert) has reached stage 4, is included in TypeScript's ESNext lib, and is now supported by all major browsers. However, calling these methods on a SvelteMap instance would throw since the wrapper class didn't implement them.
This is a common pattern for cache-style maps:

How
On a cache hit, uses super.get(key) directly to avoid registering a redundant reactive dependency (the caller already holds the key)
On a cache miss, delegates to this.set() which handles all reactivity signaling (size, version, per-key sources)
Existence check uses super.has() (not this.has()) to avoid spurious reactive dependencies on the version source