### PR TITLE
fix: correct derived resolve order + don't process discarded batches

### DIFF
--- a/.changeset/cold-areas-tap.md
+++ b/.changeset/cold-areas-tap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: resolve prior pending deriveds correctly

--- a/.changeset/wild-lands-fail.md
+++ b/.changeset/wild-lands-fail.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't process discarded or finished batches

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -188,7 +188,7 @@ export class Batch {
 
 	#decrement_queued = false;
 
-	/** @type {Set<Batch>} */
+	/** @type {Set<Batch>} Batches that need to resolve before this one can */
 	#blockers = new Set();
 
 	#is_deferred() {
@@ -255,6 +255,8 @@ export class Batch {
 	}
 
 	#process() {
+		if (!batches.has(this)) return;
+
 		if (flush_count++ > 1000) {
 			batches.delete(this);
 			infinite_loop_guard();
@@ -361,8 +363,6 @@ export class Batch {
 		}
 
 		if (next_batch !== null) {
-			batches.add(next_batch);
-
 			if (DEV) {
 				for (const source of this.current.keys()) {
 					/** @type {Set<Source>} */ (source_stacks).add(source);
@@ -517,6 +517,8 @@ export class Batch {
 		for (const batch of batches) {
 			var is_earlier = batch.id < this.id;
 
+			if (batch === current_batch) continue; // this batch was just created while flushing the current one, don't rebase it
+
 			/** @type {Source[]} */
 			var sources = [];
 
@@ -663,7 +665,27 @@ export class Batch {
 			}
 		}
 
-		if (this.#decrement_queued || skip) return;
+		if (this.#decrement_queued) return;
+		if (skip) {
+			if (this.#pending.size > 0) return;
+
+			// If this is the last value that was resolved we still might want to flush the batch to bring it to completion,
+			// else it might become a zombie batch that is never removed from the `batches` Set
+			const current = new Map(this.current);
+			for (const batch of batches) {
+				if (batch.id <= this.id) continue;
+				for (const source of batch.current.keys()) {
+					current.delete(source);
+				}
+			}
+			// If the subsequent batches combined superseed this one, we can discard it.
+			// Otherwise we'll need to flush it to update the UI with the distinct changes.
+			if (current.size === 0) {
+				this.discard();
+				return;
+			}
+		}
+
 		this.#decrement_queued = true;
 
 		queue_micro_task(() => {
@@ -716,10 +738,9 @@ export class Batch {
 	static ensure() {
 		if (current_batch === null) {
 			const batch = (current_batch = new Batch());
+			batches.add(current_batch);
 
 			if (!is_processing) {
-				batches.add(current_batch);
-
 				if (!is_flushing_sync) {
 					queue_micro_task(() => {
 						if (!batches.has(batch) || batch.#pending.size > 0) {
@@ -761,6 +782,7 @@ export class Batch {
 				for (const [source, [, is_derived]] of batch.current) {
 					// Derived values don't partake in the blocking mechanism, because a derived could
 					// be triggered in one batch already but not the other one yet, causing a false-positive
+					// TODO do we need ignore async_deriveds for that reason, too?
 					if (is_derived) continue;
 
 					intersects ||= this.current.has(source);

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -359,6 +359,7 @@ export class Batch {
 		// once more in that case - most of the time this will just clean up dirty branches.
 		if (this.#roots.length > 0) {
 			const batch = (next_batch ??= this);
+			batches.add(batch);
 			batch.#roots.push(...this.#roots.filter((r) => !batch.#roots.includes(r)));
 		}
 

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -672,19 +672,36 @@ export class Batch {
 
 			// If this is the last value that was resolved we still might want to flush the batch to bring it to completion,
 			// else it might become a zombie batch that is never removed from the `batches` Set
-			const current = new Map(this.current);
+			const current = new Map([...this.current].filter(([_, [, is_derived]]) => !is_derived));
+			let latest_overlap;
 			for (const batch of batches) {
 				if (batch.id <= this.id) continue;
 				for (const source of batch.current.keys()) {
+					if (current.has(source)) latest_overlap = batch;
 					current.delete(source);
 				}
 			}
-			// If the subsequent batches combined superseed this one, we can discard it.
-			// Otherwise we'll need to flush it to update the UI with the distinct changes.
+
 			if (current.size === 0) {
+				// If the subsequent batches combined superseed this one, we can discard it.
 				this.discard();
 				return;
+			} else if (latest_overlap) {
+				// Else we find the latest subsequent batch that overlaps with this one and make this one block on it,
+				// so that the changes resolve together with the rest of the changes in that batch. This guarantees
+				// glitch-free UI without tearing.
+				this.#blockers.add(latest_overlap); // TODO strictly speaking we should resolve this batch before the other one but in practise it hopefully doesn't matter
+				for (const batch of batches) {
+					batch.#blockers.delete(this);
+					if (batch.#blockers.size === 0 && !batch.#is_deferred()) {
+						batch.activate();
+						batch.#process();
+					}
+				}
+				return;
 			}
+
+			// If neither of the above is the case we need to flush now
 		}
 
 		this.#decrement_queued = true;

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -203,14 +203,15 @@ export function async_derived(fn, label, location) {
 				reactivity_loss_tracker = null;
 			}
 
+			var skip = error === STALE_REACTION;
+
 			if (decrement_pending) {
 				// don't trigger an update if we're only here because
 				// the promise was superseded before it could resolve
-				var skip = error === STALE_REACTION;
 				decrement_pending(skip);
 			}
 
-			if (error === STALE_REACTION || (effect.f & DESTROYED) !== 0) {
+			if (skip || (effect.f & DESTROYED) !== 0) {
 				return;
 			}
 
@@ -230,9 +231,8 @@ export function async_derived(fn, label, location) {
 
 				// All prior async derived runs are now stale
 				for (const [b, d] of deferreds) {
-					deferreds.delete(b);
-					if (b === batch) break;
-					d.resolve(value);
+					if (b.id <= batch.id) deferreds.delete(b);
+					if (b.id < batch.id) d.reject(STALE_REACTION);
 				}
 
 				if (DEV && location !== undefined) {

--- a/packages/svelte/tests/runtime-runes/samples/async-batch-order/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-batch-order/_config.js
@@ -1,0 +1,30 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+		const [increment, shift, middle] = target.querySelectorAll('button');
+		const [div] = target.querySelectorAll('div');
+
+		increment.click();
+		await tick();
+		increment.click();
+		await tick();
+		increment.click();
+		await tick();
+		middle.click(); // resolve the second increment which will make the if block go away and the first batch discarded
+		await tick();
+		assert.htmlEqual(div.innerHTML, '2 2');
+
+		shift.click();
+		await tick();
+		shift.click();
+		await tick();
+		shift.click();
+		await tick();
+		shift.click();
+		await tick();
+		assert.htmlEqual(div.innerHTML, '3 3');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-batch-order/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-batch-order/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let a = $state(0);
+
+	const deferred = []; 
+
+	function delay(value) {
+		if (!value) return value;
+		return new Promise((resolve) => deferred.push(() => resolve(value)));
+	}
+</script>
+
+<div>
+	{a} {await delay(a)}
+	{#if a < 2}
+		{await delay(a)}
+	{/if}
+</div>
+
+<button onclick={() => {a++;}}>a++</button>
+<button onclick={() => deferred.shift()?.()}>shift</button>
+<button onclick={() => deferred[2]()}>middle</button>

--- a/packages/svelte/tests/runtime-runes/samples/async-stale-derived-4/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-stale-derived-4/_config.js
@@ -1,0 +1,28 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+
+		const [increment, hide, pop] = target.querySelectorAll('button');
+
+		increment.click();
+		await tick();
+		pop.click();
+		await tick();
+		hide.click(); // hides the if block, which cancels the pending async inside, which means the batch can complete
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>increment</button> <button>hide</button> <button>pop</button> 1`
+		);
+
+		pop.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>increment</button> <button>hide</button> <button>pop</button> 1`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-stale-derived-4/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-stale-derived-4/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let show = $state(true);
+	let count = $state(0);
+
+	const queue = [];
+
+	function push(value) {
+		if (!value) return value;
+		return new Promise(r => queue.push(() => r(value)));
+	}
+</script>
+
+<button onclick={() => count += 1}>increment</button>
+<button onclick={() => show = false}>hide</button>
+<!-- pop() so that the outer one resolves first, not the one inside the if block -->
+<button onclick={() => queue.pop()?.()}>pop</button>
+
+{await push(count)}
+{#if show}
+	{await push(count)}
+{/if}

--- a/packages/svelte/tests/runtime-runes/samples/async-stale-derived-5/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-stale-derived-5/_config.js
@@ -1,0 +1,33 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+
+		const [increment, shift] = target.querySelectorAll('button');
+
+		increment.click();
+		await tick();
+		increment.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>3</button><button>shift</button><p>1 = 1</p><p>fizz: true</p><p>buzz: true</p>`
+		);
+
+		shift.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>3</button><button>shift</button><p>1 = 1</p><p>fizz: true</p><p>buzz: true</p>`
+		);
+
+		shift.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>3</button><button>shift</button><p>3 = 3</p><p>fizz: true</p><p>buzz: false</p>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-stale-derived-5/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-stale-derived-5/main.svelte
@@ -1,0 +1,197 @@
+<script>
+	import { getAbortSignal } from 'svelte';
+
+	const queue = [];
+
+	let n = $state(1);
+	let fizz = $state(true);
+	let buzz = $state(true);
+
+	function increment() {
+		n++;
+
+		fizz = n % 3 === 0;
+		buzz = n % 5 === 0;
+	}
+
+	function push(value) {
+		if (value === 1) return 1;
+		const d = Promise.withResolvers();
+
+		queue.push(() => d.resolve(value));
+
+		const signal = getAbortSignal();
+		signal.onabort = () => d.reject(signal.reason);
+
+		return d.promise;
+	}
+</script>
+
+<button onclick={increment}>
+	{$state.eager(n)}
+</button>
+
+<button onclick={() => queue.shift()?.()}>shift</button>
+
+<p>{n} = {await push(n)}</p>
+
+{#if true}
+	<p>fizz: {fizz}</p>
+{/if}
+
+{#if true}
+	<p>buzz: {buzz}</p>
+{/if}
+
+ 
+
+<!-- <script>
+	import { getAbortSignal } from 'svelte';
+
+	const queue = [];
+
+	function push(value) {
+		if (value === 1) return 1;
+		const d = Promise.withResolvers();
+
+		queue.push(() => d.resolve(value));
+
+		const signal = getAbortSignal();
+		signal.onabort = () => d.reject(signal.reason);
+
+		return d.promise;
+	}
+
+	function shift() {
+		queue.shift()?.();
+	}
+
+	function pop() {
+		queue.pop()?.();
+	}
+
+	let n = $state(1);
+</script>
+
+<button onclick={() => n++}>
+	{$state.eager(n)}
+</button>
+
+<button onclick={shift}>shift</button>
+<button onclick={pop}>pop</button>
+
+<p>{n} = {await push(n)}</p> -->
+
+
+<!-- <script>
+	let a = $state(0);
+
+	const deferred = []; 
+
+	function delay(value) {
+		if (!value) return value;
+		return new Promise((resolve) => deferred.push(() => resolve(value)));
+	}
+</script>
+
+{a} {await delay(a)}
+{#if a < 2}
+	{await delay(a)}
+{/if}
+
+<button onclick={() => {a++;}}>
+	a+1
+</button>
+<button onclick={() => {a+=2;}}>
+	a+2
+</button>
+<button onclick={() => deferred.shift()?.()}>shift</button>
+<button onclick={() => deferred[2]()}>middle</button> -->
+
+<!-- <script>
+	let a = $state(0);
+	let b = $derived(await delay(a * 2));
+	let c = $state(0);
+	let d = $derived(await delay(b + c));
+	// let e = $derived(d === (b + c));
+
+	const deferred = []; 
+
+	function delay(value) {
+		if (!value) return value;
+		return new Promise((resolve) => deferred.push(() => resolve(value)));
+	}
+</script>
+
+a {a} | b {b} | c {c} | d {d}
+<button onclick={() => {a++;}}>
+	a++
+</button>
+<button onclick={() => {c++;}}>
+	c++
+</button>
+<button onclick={() => deferred.shift()?.()}>shift</button>
+<button onclick={() => deferred.pop()?.()}>pop</button> -->
+
+<!-- <script>
+	let count = $state(0);
+	let other = $state(0);
+
+	const queue = [];
+	function push(v) {
+		return new Promise((r,e) => queue.push(() => v === 1 ? e(v) : r(v)));
+	}
+</script>
+
+<button onclick={() => {
+	if (count === 0) {
+		other++;
+		count++;
+	} else {
+		count++
+	}
+}}>increment</button>
+<button onclick={() => queue.pop()?.()}>pop</button>
+
+{#if count > 0}
+	<svelte:boundary>
+		{await push(count)} {count} {other}
+		{#snippet failed()}boom{/snippet}
+	</svelte:boundary> 
+{/if} -->
+
+<!-- <script>
+	let count1 = $state(0);
+	let count2 = $state(0);
+
+	const queued = [];
+
+	async function delay(v) {
+		if (!v) return v;
+		return new Promise(r => queued.push(() => r(v)));
+	}
+
+	function show(get) {
+		console.log('running', get());
+		return $state.eager(get()) !== get();
+	}
+</script>
+
+<button onclick={() => count1++}>increment</button> 
+<button onclick={() => count2++}>increment</button> 
+<button onclick={() => queued.shift()?.()}>resolve</button>
+ 
+{await delay(count1)}
+{await delay(count2)}
+
+{#if show(() => count1)}
+	<p>loading...</p>
+{:else}
+	<p>{count1}</p>
+{/if}
+
+{#if show(() => count2)}
+	<p>loading...</p>
+{:else}
+	<p>{count2}</p>
+{/if} -->


### PR DESCRIPTION
Fixes part of https://github.com/sveltejs/kit/issues/15431

This contains two fixes which combined make one of the tests pass. While doing so I realized that #18167 wasn't quite correct (because the changes that are correct and made the test pass regressed others) so I adjusted that, too.

The first change is in `deriveds.js#async-derived`, where we don't just `break` when we come across our own batch, because that assumes that `deferreds` contains batches in incrementing order. But that's not the case.

Through that I discovered that #18167 wasn't quite correct because it basically undoes the `decrement(skip)` behavior and by accident got all the tests passing. The real reason #18167 was passing its new test is that the related batch was flushed to completion (because `decrement(skip)` ran the flush again, because `skip` was `false`). But it's flawed as seen by the new `async-stale-derived-4` test. So I reverted part of #18167 and instead added logic to `decrement` to still run the batch if there is no more pending work left, or discard it if it's superseeded by the later batches.

The other change is to skip processing a batch if it's not in `batches` anymore. For that I tweaked where a new one is added to the Set, and skipping just-created-batches during `batch.#commit()`
