### PR TITLE
fix: skip processing discarded/resolved batches

### DIFF
--- a/.changeset/funny-actors-occur.md
+++ b/.changeset/funny-actors-occur.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip processing discarded/resolved batches

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -255,6 +255,10 @@ export class Batch {
 	}
 
 	#process() {
+		if (DEV) {
+			invariant(batches.has(this), 'processing a discarded/resolved batch');
+		}
+
 		if (flush_count++ > 1000) {
 			batches.delete(this);
 			infinite_loop_guard();
@@ -668,7 +672,10 @@ export class Batch {
 
 		queue_micro_task(() => {
 			this.#decrement_queued = false;
-			this.flush();
+
+			if (batches.has(this)) {
+				this.flush();
+			}
 		});
 	}
 


### PR DESCRIPTION
small fix extracted from #18177, with a tweak — rather than checking the set in every `#process` call, we just avoid calling `flush()` in the rare case that a batch has already been discarded or resolved, and add an `invariant(...)` to guarantee we can't end up processing a resolved batch some other way