### PR TITLE
fix: reapply new batch after `#commit`

### DIFF
--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -363,6 +363,8 @@ export class Batch {
 		// TODO fix the underlying cause, otherwise this will likely regress when non-async mode is removed
 		if (async_mode_flag && !batches.has(this)) {
 			this.#commit();
+			// Rebases can activate other batches or null it out, therefore restore the new one here
+			current_batch = next_batch;
 		}
 
 		// Edge case: During traversal new branches might create effects that run immediately and set state,


### PR DESCRIPTION
Fixes a regression of #18170 (not released yet therefore no changeset). `current_batch` is nulled out if the `#commit` rebases other branches, and that can lead to nullpointers down the line.

No test right now but it's part of getting the failing SvelteKit test passing.
