### PR TITLE
fix: strip trailing semicolons in style directive reactive updates

### DIFF
--- a/.changeset/cuddly-cougars-grow.md
+++ b/.changeset/cuddly-cougars-grow.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: strip trailing semicolons in style directive reactive updates

--- a/packages/svelte/src/internal/client/dom/elements/style.js
+++ b/packages/svelte/src/internal/client/dom/elements/style.js
@@ -1,3 +1,4 @@
+import { DEV } from 'esm-env';
 import { to_style } from '../../../shared/attributes.js';
 import { hydrating } from '../hydration.js';
 
@@ -15,10 +16,18 @@ function update_styles(dom, prev = {}, next, priority) {
 			if (value == null) {
 				dom.style.removeProperty(key);
 			} else {
+				var str_value = String(value);
+
+				if (DEV && /;+\s*$/.test(str_value)) {
+					// eslint-disable-next-line no-console
+					console.warn(
+						`[svelte] Style directive value for "${key}" has a trailing semicolon which is invalid and will be removed. Remove the trailing ";" from the value.`
+					);
+				}
+
 				// setProperty rejects values with trailing semicolons; strip them so that
 				// reactive updates behave consistently with the initial cssText assignment
-				var str_value = String(value).replace(/;+\s*$/, '');
-				dom.style.setProperty(key, str_value, priority);
+				dom.style.setProperty(key, str_value.replace(/;+\s*$/, ''), priority);
 			}
 		}
 	}

--- a/packages/svelte/src/internal/client/dom/elements/style.js
+++ b/packages/svelte/src/internal/client/dom/elements/style.js
@@ -12,7 +12,7 @@ function update_styles(dom, prev = {}, next, priority) {
 		var value = next[key];
 
 		if (prev[key] !== value) {
-			if (next[key] == null) {
+			if (value == null) {
 				dom.style.removeProperty(key);
 			} else {
 				// setProperty rejects values with trailing semicolons; strip them so that

--- a/packages/svelte/src/internal/client/dom/elements/style.js
+++ b/packages/svelte/src/internal/client/dom/elements/style.js
@@ -15,7 +15,10 @@ function update_styles(dom, prev = {}, next, priority) {
 			if (next[key] == null) {
 				dom.style.removeProperty(key);
 			} else {
-				dom.style.setProperty(key, value, priority);
+				// setProperty rejects values with trailing semicolons; strip them so that
+				// reactive updates behave consistently with the initial cssText assignment
+				var str_value = String(value).replace(/;+\s*$/, '');
+				dom.style.setProperty(key, str_value, priority);
 			}
 		}
 	}

--- a/packages/svelte/tests/runtime-browser/samples/style-directive-trailing-semicolon/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/style-directive-trailing-semicolon/_config.js
@@ -1,0 +1,21 @@
+import { assert_ok, test } from '../../assert';
+
+export default test({
+	html: `<div style="color: red;"></div>`,
+
+	test({ assert, target, window, component }) {
+		const div = target.querySelector('div');
+		assert_ok(div);
+
+		// Initial value with trailing semicolon — should produce valid CSS
+		assert.equal(window.getComputedStyle(div).color, 'rgb(255, 0, 0)');
+
+		// Update to a new value that also has a trailing semicolon
+		component.color = 'blue;';
+		assert.equal(window.getComputedStyle(div).color, 'rgb(0, 0, 255)');
+
+		// Update to a value without trailing semicolon — should still work
+		component.color = 'green';
+		assert.equal(window.getComputedStyle(div).color, 'rgb(0, 128, 0)');
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/style-directive-trailing-semicolon/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/style-directive-trailing-semicolon/main.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	export let color = 'red;';
+</script>
+
+<div style:color={color}></div>


### PR DESCRIPTION
## What's happening

When a `style:` directive value contains a trailing semicolon, initial render and reactive updates behave differently:

- **Initial render** — Svelte sets `dom.style.cssText`, which is lenient and accepts trailing semicolons (the browser strips them).
- **Reactive update** — Svelte calls `dom.style.setProperty(key, value)`, which silently rejects values containing semicolons. The style never updates.

Reproduction from #18182:
```svelte
<script>
  let angle = $state(250);
  let style = $derived(`conic-gradient(red ${angle}deg, blue 0);`);
</script>

<div style:background={style}>Test</div>
<button onclick={() => angle = 50}>Update</button>
```
Click the button — background never changes because `setProperty` drops the value.

## Fix

In `update_styles`, strip trailing semicolons from the value before passing it to `setProperty`, so both paths handle the input consistently.

```js
var str_value = String(value).replace(/;+\s*$/, '');
dom.style.setProperty(key, str_value, priority);
```

This is intentionally narrow — only trailing semicolons are removed, which is what the browser would strip anyway. Semicolons inside the value (e.g. in `url("data:...")`) are not affected.

Note: #18173 handles the related SSR/security case for structural semicolons in the `to_style` path. This PR covers the client-side reactive update path in `update_styles`.

Closes #18182