### PR TITLE
fix: duplicated "of" in events.js comment

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -237,7 +237,7 @@ export function handle_event_propagation(event) {
 	});
 
 	// This started because of Chromium issue https://chromestatus.com/feature/5128696823545856,
-	// where removal or moving of of the DOM can cause sync `blur` events to fire, which can cause logic
+	// where removal or moving of the DOM can cause sync `blur` events to fire, which can cause logic
 	// to run inside the current `active_reaction`, which isn't what we want at all. However, on reflection,
 	// it's probably best that all event handled by Svelte have this behaviour, as we don't really want
 	// an event handler to run in the context of another reaction or effect.

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -239,7 +239,7 @@ export function handle_event_propagation(event) {
 	// This started because of Chromium issue https://chromestatus.com/feature/5128696823545856,
 	// where removal or moving of the DOM can cause sync `blur` events to fire, which can cause logic
 	// to run inside the current `active_reaction`, which isn't what we want at all. However, on reflection,
-	// it's probably best that all event handled by Svelte have this behaviour, as we don't really want
+	// it's probably best that all events handled by Svelte have this behaviour, as we don't really want
 	// an event handler to run in the context of another reaction or effect.
 	var previous_reaction = active_reaction;
 	var previous_effect = active_effect;


### PR DESCRIPTION
One-line typo fix in `packages/svelte/src/internal/client/dom/elements/events.js`: "removal or moving of of the DOM" → "removal or moving of the DOM". No code/behavior change.