### PR TITLE
fix: always create default slot in custom elements without initial children

### DIFF
--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -121,6 +121,9 @@ if (typeof HTMLElement === 'function') {
 						} else {
 							$$slots[name] = create_slot(name);
 						}
+					} else if (name === 'default') {
+						this.$$d.children = create_slot(name);
+						$$slots.default = true;
 					}
 				}
 				for (const attribute of this.attributes) {


### PR DESCRIPTION
Fixes #13638

## Problem

When a Svelte custom element is created without any initial child nodes, `get_custom_elements_slots()` returns `{}`. The slot creation loop (`connectedCallback`) skips creating the default `<slot>` element because `default in existing_slots` is false. This means no `<slot>` elements exist in the shadow DOM, so dynamically added children have nowhere to be projected.

## Fix

If the `default` slot is defined in the component'\''s slot list (`this.$$s`) but not detected in the existing child nodes, create it anyway. The default slot should always be present in a custom element component, regardless of whether children were initially passed.