### PR TITLE
docs: clarify untrack example

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -739,13 +739,15 @@ export function safe_get(signal) {
 /**
  * When used inside a [`$derived`](https://svelte.dev/docs/svelte/$derived) or [`$effect`](https://svelte.dev/docs/svelte/$effect),
  * any state read inside `fn` will not be treated as a dependency.
+ * `untrack` returns the value of `fn`.
  *
  * ```ts
+ * let data = $state({ count: 0 });
+ * let time = $state(Date.now());
+ *
  * $effect(() => {
  *   // this will run when `data` changes, but not when `time` changes
- *   save(data, {
- *     timestamp: untrack(() => time)
- *   });
+ *   console.log(data, untrack(() => time));
  * });
  * ```
  * @template T

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -591,13 +591,15 @@ declare module 'svelte' {
 	/**
 	 * When used inside a [`$derived`](https://svelte.dev/docs/svelte/$derived) or [`$effect`](https://svelte.dev/docs/svelte/$effect),
 	 * any state read inside `fn` will not be treated as a dependency.
+	 * `untrack` returns the value of `fn`.
 	 *
 	 * ```ts
+	 * let data = $state({ count: 0 });
+	 * let time = $state(Date.now());
+	 *
 	 * $effect(() => {
 	 *   // this will run when `data` changes, but not when `time` changes
-	 *   save(data, {
-	 *     timestamp: untrack(() => time)
-	 *   });
+	 *   console.log(data, untrack(() => time));
 	 * });
 	 * ```
 	 * */


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] This is a documentation change

### Description

Clarifies the `untrack` API docs by replacing the placeholder `save(...)` example with a self-contained example and explicitly noting that `untrack` returns the callback value.

Fixes #14949

### Verification

- `pnpm --filter svelte build`
- `pnpm exec prettier --check packages/svelte/src/internal/client/runtime.js packages/svelte/types/index.d.ts`
- `pnpm exec eslint --no-warn-ignored packages/svelte/src/internal/client/runtime.js packages/svelte/types/index.d.ts`
- `pnpm --filter svelte check`
- `git diff --check`