### PR TITLE
docs: clarify context state getter pattern

### DIFF
--- a/documentation/docs/06-runtime/02-context.md
+++ b/documentation/docs/06-runtime/02-context.md
@@ -163,6 +163,52 @@ export const [getCounter, setCounter] = createContext<Counter>();
 
 Svelte will warn you if you get it wrong.
 
+If the state needs to be reassigned, such as with a primitive value, pass a function that reads the current value:
+
+<!-- codeblock:start {"title":"Context with reassignable state"} -->
+```svelte
+<!--- file: App.svelte --->
+<script>
+	import { setCount } from './context.ts';
+	import Child from './Child.svelte';
+
+	let count = $state(0);
+
+	setCount(() => count);
+</script>
+
+<button onclick={() => count += 1}>
+	increment
+</button>
+
+<Child />
+
+<button onclick={() => count = 0}>
+	reset
+</button>
+```
+
+```svelte
+<!--- file: Child.svelte --->
+<script>
+	import { getCount } from './context.ts';
+
+	const count = getCount();
+</script>
+
+<p>{count()}</p>
+```
+
+```ts
+/// file: context.ts
+import { createContext } from 'svelte';
+
+export const [getCount, setCount] = createContext<() => number>();
+```
+<!-- codeblock:end -->
+
+This keeps the consumer from capturing the initial value.
+
 ## Component testing
 
 When writing [component tests](testing#Unit-and-component-tests-with-Vitest-Component-testing), it can be useful to create a wrapper component that sets the context in order to check the behaviour of a component that uses it. As of version 5.49, you can do this sort of thing:

--- a/documentation/docs/06-runtime/02-context.md
+++ b/documentation/docs/06-runtime/02-context.md
@@ -163,51 +163,7 @@ export const [getCounter, setCounter] = createContext<Counter>();
 
 Svelte will warn you if you get it wrong.
 
-If the state needs to be reassigned, such as with a primitive value, pass a function that reads the current value:
-
-<!-- codeblock:start {"title":"Context with reassignable state"} -->
-```svelte
-<!--- file: App.svelte --->
-<script>
-	import { setCount } from './context.ts';
-	import Child from './Child.svelte';
-
-	let count = $state(0);
-
-	setCount(() => count);
-</script>
-
-<button onclick={() => count += 1}>
-	increment
-</button>
-
-<Child />
-
-<button onclick={() => count = 0}>
-	reset
-</button>
-```
-
-```svelte
-<!--- file: Child.svelte --->
-<script>
-	import { getCount } from './context.ts';
-
-	const count = getCount();
-</script>
-
-<p>{count()}</p>
-```
-
-```ts
-/// file: context.ts
-import { createContext } from 'svelte';
-
-export const [getCount, setCount] = createContext<() => number>();
-```
-<!-- codeblock:end -->
-
-This keeps the consumer from capturing the initial value.
+Similarly, to pass primitive values through context, use functions as described in [Passing state into functions]($state#Passing-state-into-functions)
 
 ## Component testing
 

--- a/documentation/docs/06-runtime/02-context.md
+++ b/documentation/docs/06-runtime/02-context.md
@@ -163,7 +163,7 @@ export const [getCounter, setCounter] = createContext<Counter>();
 
 Svelte will warn you if you get it wrong.
 
-Similarly, to pass primitive values through context, use functions as described in [Passing state into functions]($state#Passing-state-into-functions)
+Similarly, to pass primitive values through context, use functions as described in [Passing state into functions]($state#Passing-state-into-functions).
 
 ## Component testing
 


### PR DESCRIPTION
Closes #18022

This updates the context docs to show the getter pattern for state that may be reassigned, such as primitive state. The new example passes a function through context so children read the current value instead of capturing the initial value.

This is a docs-only clarification and does not change runtime behavior.

Validation:

- `git diff --check`
- `pnpm exec prettier --check documentation/docs/06-runtime/02-context.md`

Full `pnpm test`/`pnpm lint` were not run because this only changes documentation.