### PR TITLE
fix: don't run teardown effects when deriveds are unfreezed

### DIFF
--- a/.changeset/slimy-olives-cross.md
+++ b/.changeset/slimy-olives-cross.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't run teardown effects when deriveds are unfreezed

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -447,8 +447,8 @@ export function freeze_derived_effects(derived) {
 			// make it a noop so it doesn't get called again if the derived
 			// is unfrozen. we don't set it to `null`, because the existence
 			// of a teardown function is what determines whether the
-			// effect runs again during unfreezing
-			e.teardown = noop;
+			// effect runs again during unfreezing (but not for teardown-only effects)
+			if (e.fn !== null) e.teardown = noop;
 			e.ac = null;
 
 			remove_reactions(e, 0);
@@ -466,7 +466,7 @@ export function unfreeze_derived_effects(derived) {
 	for (const e of derived.effects) {
 		// if the effect was previously frozen — indicated by the presence
 		// of a teardown function — unfreeze it
-		if (e.teardown) {
+		if (e.teardown && e.fn !== null) {
 			update_effect(e);
 		}
 	}

--- a/packages/svelte/tests/runtime-runes/samples/async-state-eager-const/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-state-eager-const/_config.js
@@ -1,0 +1,21 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: { dev: true }, // for testing that teardown effect in eager $.get(loaded) doesn't lead to a crash (because it means REACTION_RAN is set, which means unfreeze_derived runs)
+	async test({ assert, target }) {
+		const [count, shift] = target.querySelectorAll('button');
+
+		shift.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<button>0</button><button>shift</button><p>0</p>`);
+
+		count.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<button>1</button><button>shift</button><p>0 (...)</p>`);
+
+		shift.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<button>1</button><button>shift</button><p>1</p>`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-state-eager-const/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-state-eager-const/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let count = $state(0);
+
+	let resolvers = [];
+
+	function push(value) {
+		const { promise, resolve } = Promise.withResolvers();
+		resolvers.push(() => resolve(value));
+		return promise;
+	}
+</script>
+
+<button onclick={() => count += 1}>{$state.eager(count)}</button>
+<button onclick={() => resolvers.shift()?.()}>shift</button>
+
+<svelte:boundary>
+	{@const loaded = $state.eager(count) === count}
+	<p>{await push(count)} {loaded ? '' : '(...)'}</p>
+
+	{#snippet pending()}{/snippet}
+</svelte:boundary>


### PR DESCRIPTION
The logic was flawed - a teardown effect only has a teardown function but not `fn` property, but unfreeze thought that everything with a `teardown` needs to be unfreezed

Helps with #18221 (though likely doesn't fix it completely, at least not the more general `batch.#roots`problems)