### PR TITLE
chore: Fix typo in Svelte <svelte:window> docs page

### DIFF
--- a/documentation/docs/05-special-elements/02-svelte-window.md
+++ b/documentation/docs/05-special-elements/02-svelte-window.md
@@ -32,7 +32,7 @@ You can also bind to the following properties:
 - `outerHeight`
 - `scrollX`
 - `scrollY`
-- `online` — an alias for `window.navigator.onLine`
+- `online` — an alias for `window.navigator.online`
 - `devicePixelRatio`
 
 All except `scrollX` and `scrollY` are readonly.


### PR DESCRIPTION
Change "window.navigator.onLine" to "window.navigator.online" on the [\<svelte:window\> docs page.](https://svelte.dev/docs/svelte/svelte-window)

### Before submitting the PR, please make sure you do the following

<!-- - [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs -->
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
<!-- - [ ] Ideally, include a test that fails without this PR but passes with it. -->
<!-- - [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`). -->

<!-- 
### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
-->
