### PR TITLE
fix: use named symbols everywhere

### DIFF
--- a/.changeset/red-moles-talk.md
+++ b/.changeset/red-moles-talk.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: use named symbols everywhere

--- a/packages/svelte/src/constants.js
+++ b/packages/svelte/src/constants.js
@@ -32,7 +32,7 @@ export const ELEMENT_IS_NAMESPACED = 1;
 export const ELEMENT_PRESERVE_ATTRIBUTE_CASE = 1 << 1;
 export const ELEMENT_IS_INPUT = 1 << 2;
 
-export const UNINITIALIZED = Symbol();
+export const UNINITIALIZED = Symbol('uninitialized');
 
 // Dev-time component properties
 export const FILENAME = Symbol('filename');

--- a/packages/svelte/src/internal/client/reactivity/store.js
+++ b/packages/svelte/src/internal/client/reactivity/store.js
@@ -21,7 +21,7 @@ export let legacy_is_updating_store = false;
  */
 let is_store_binding = false;
 
-let IS_UNMOUNTED = Symbol();
+let IS_UNMOUNTED = Symbol('unmounted');
 
 /**
  * Gets the current value of a store. If the store isn't subscribed to yet, it will create a proxy

--- a/packages/svelte/src/reactivity/url-search-params.js
+++ b/packages/svelte/src/reactivity/url-search-params.js
@@ -4,7 +4,7 @@ import { tag } from '../internal/client/dev/tracing.js';
 import { get } from '../internal/client/runtime.js';
 import { get_current_url } from './url.js';
 
-export const REPLACE = Symbol();
+export const REPLACE = Symbol('replace');
 
 /**
  * A reactive version of the built-in [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) object.


### PR DESCRIPTION
This isn't _really_ a fix since these should never surface to the user, but it's useful for debugging when they do, as in https://github.com/sveltejs/kit/pull/15779. Instead of seeing `Symbol()` we see e.g. `Symbol(uninitialized)` which makes it easier to understand where a bug is coming from.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
