### PR TITLE
fix(print): cover aliased type imports

### DIFF
--- a/packages/svelte/tests/print/samples/type-import-alias/input.svelte
+++ b/packages/svelte/tests/print/samples/type-import-alias/input.svelte
@@ -1,0 +1,1 @@
+<script lang="ts">import { foo, type bar as baz } from "bof";</script>

--- a/packages/svelte/tests/print/samples/type-import-alias/output.svelte
+++ b/packages/svelte/tests/print/samples/type-import-alias/output.svelte
@@ -1,0 +1,3 @@
+<script lang="ts">
+	import { foo, type bar as baz } from "bof";
+</script>


### PR DESCRIPTION
Fixes #18211

  The printer should keep `type` before the imported name when a type-only specifier is aliased inside a mixed import:

  ```svelte
  import { foo, type bar as baz } from "bof";
```