### PR TITLE
fix: track lazily created SvelteSet entries

### DIFF
--- a/.changeset/bright-sets-listen.md
+++ b/.changeset/bright-sets-listen.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: track lazily created SvelteSet entries

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -525,9 +525,10 @@ export function settled() {
 /**
  * @template V
  * @param {Value<V>} signal
+ * @param {boolean} [force]
  * @returns {V}
  */
-export function get(signal) {
+export function get(signal, force = false) {
 	var flags = signal.f;
 	var is_derived = (flags & DERIVED) !== 0;
 
@@ -540,7 +541,10 @@ export function get(signal) {
 		// we don't add the dependency, because that would create a memory leak
 		var destroyed = active_effect !== null && (active_effect.f & DESTROYED) !== 0;
 
-		if (!destroyed && (current_sources === null || !includes.call(current_sources, signal))) {
+		if (
+			!destroyed &&
+			(force || current_sources === null || !includes.call(current_sources, signal))
+		) {
 			var deps = active_reaction.deps;
 
 			if ((active_reaction.f & REACTION_IS_UPDATING) !== 0) {

--- a/packages/svelte/src/reactivity/set.js
+++ b/packages/svelte/src/reactivity/set.js
@@ -125,7 +125,7 @@ export class SvelteSet extends Set {
 			if (!has) {
 				// If the value doesn't exist, track the version in case it's added later
 				// but don't create sources willy-nilly to track all possible values
-				get(this.#version);
+				get(this.#version, true);
 				return false;
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/reactive-set-nullish-assignment/Button.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/reactive-set-nullish-assignment/Button.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	interface Props {
+		active?: boolean;
+		onclick: (e: MouseEvent) => void;
+	}
+
+	let { active, onclick }: Props = $props();
+</script>
+
+<button type="button" class={{ active }} {onclick}>
+	{active}
+</button>
+
+<style>
+	.active {
+		background: green;
+	}
+</style>

--- a/packages/svelte/tests/runtime-runes/samples/reactive-set-nullish-assignment/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/reactive-set-nullish-assignment/_config.js
@@ -1,0 +1,22 @@
+import { flushSync } from '../../../../src/index-client';
+import { test } from '../../test';
+
+export default test({
+	html: `<div><button class="svelte-xyz123" type="button">false</button> <button class="svelte-xyz123" type="button">false</button></div>`,
+
+	test({ assert, target }) {
+		const [first, second] = target.querySelectorAll('button');
+
+		flushSync(() => first.click());
+		assert.htmlEqual(
+			target.innerHTML,
+			`<div><button class="active svelte-xyz123" type="button">true</button> <button class="active svelte-xyz123" type="button">true</button></div>`
+		);
+
+		flushSync(() => second.click());
+		assert.htmlEqual(
+			target.innerHTML,
+			`<div><button class="svelte-xyz123" type="button">false</button> <button class="svelte-xyz123" type="button">false</button></div>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/reactive-set-nullish-assignment/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/reactive-set-nullish-assignment/main.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import Button from './Button.svelte';
+	import { SvelteSet } from 'svelte/reactivity';
+
+	class Setup {
+		#options: SvelteSet<string>;
+
+		toggle(value: string) {
+			this.#options ??= new SvelteSet();
+			if (this.#options.has(value)) {
+				this.#options.delete(value);
+			} else {
+				this.#options.add(value);
+			}
+		}
+
+		has(value: string) {
+			this.#options ??= new SvelteSet();
+			return this.#options.has(value);
+		}
+	}
+
+	const setup = new Setup();
+</script>
+
+<div>
+	<!-- broken -->
+	<Button onclick={() => setup.toggle('active')} active={setup.has('active')} />
+
+	<!-- working -->
+	<Button onclick={() => setup.toggle('active')} active={setup.has('active')} />
+</div>


### PR DESCRIPTION
Fixes #18214.

When a `SvelteSet` is created during the first `has` call with `??=`, the version source can be treated as a source created by the same reaction. That means the first caller does not subscribe, so it stays stale while later callers update.

This makes missing value checks subscribe to the set version even in that case, without creating per value sources for every missing value.

Added a regression test using the linked reproduction shape, including the child `Button` component.

### Test plan

```sh
pnpm --config.manage-package-manager-versions=false test runtime-runes -t reactive-set-nullish-assignment -- --reporter=dot
pnpm --config.manage-package-manager-versions=false test runtime-runes -t "reactive-set-nullish-assignment|reactive-set|side-effect-derived-set" -- --reporter=dot
pnpm --config.manage-package-manager-versions=false test runtime-runes -- --reporter=dot
pnpm --config.manage-package-manager-versions=false lint
git diff --check
```
