### PR TITLE
fix: declare `let:` directives before `{@const}` on slotted elements

### DIFF
--- a/.changeset/quiet-rivers-melt.md
+++ b/.changeset/quiet-rivers-melt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: declare `let:` directives before `{@const}` declarations on slotted elements

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -201,8 +201,8 @@ export function RegularElement(node, context) {
 		}
 	}
 
-	// Let bindings first, they can be used on attributes
-	context.state.init.push(...lets);
+	// Let bindings first, they can be used on attributes and `{@const}` declarations
+	context.state.let_directives.push(...lets);
 
 	const node_id = context.state.node;
 

--- a/packages/svelte/tests/runtime-legacy/samples/let-directive-and-const-tag-slotted/Nested.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/let-directive-and-const-tag-slotted/Nested.svelte
@@ -1,0 +1,7 @@
+<script>
+	export let things;
+</script>
+
+{#each things as thing}
+	<slot name="foo" {thing} />
+{/each}

--- a/packages/svelte/tests/runtime-legacy/samples/let-directive-and-const-tag-slotted/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/let-directive-and-const-tag-slotted/_config.js
@@ -1,0 +1,15 @@
+import { test } from '../../test';
+
+// `let:` directives on a slotted element must be declared before sibling `{@const}`
+// declarations that capture them. In dev mode the `{@const}` derived is read eagerly,
+// so a wrong declaration order throws "Cannot access '...' before initialization".
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	html: `
+		<div slot="foo"><span>1</span></div>
+		<div slot="foo"><span>2</span></div>
+	`
+});

--- a/packages/svelte/tests/runtime-legacy/samples/let-directive-and-const-tag-slotted/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/let-directive-and-const-tag-slotted/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	import Nested from './Nested.svelte';
+</script>
+
+<Nested things={[1, 2]}>
+	<div slot="foo" let:thing>
+		{@const props = { thing }}
+		<span>{props.thing}</span>
+	</div>
+</Nested>


### PR DESCRIPTION
Fixes #18119 (missed a spot in #16985)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

## The bug

A `{@const}` that captures a `let:` slot prop throws `ReferenceError: Cannot access '<name>' before initialization` when the `let:` directive is on a *slotted element* (not on the component itself):

```svelte
<!-- Parent.svelte -->
{#each data as row}
  <slot name="row" {row}></slot>
{/each}

<!-- Consumer.svelte -->
<Parent>
  <tr slot="row" let:row>
    {@const props = { row }}
    <td>{props.row.label}</td>
  </tr>
</Parent>
```

This is the same class of bug as #16585, but #16985 only fixed the variant where `let:` is on the component itself. The slotted-element variant still regresses.

## Root cause

`{@const}` declarations are collected into `state.consts`, and `Fragment` emits them as `[...state.let_directives, ...state.consts, ...state.init]`. `LetDirective` declarations on a *component* are routed into `let_directives` (since #16985), so they correctly come first.

But in `RegularElement`, the `let:` declarations were pushed onto `context.state.init`:

```js
// Let bindings first, they can be used on attributes
context.state.init.push(...lets);
```

Since `init` is emitted *after* `consts`, the generated code declared the `{@const}` derived before the `let:` derived it depends on:

```js
const props = $.derived_safe_equal(() => ({ row: $.get(row) })); // ← references row
const row = $.derived_safe_equal(() => $$slotProps.row);          // ← declared after
```

In dev mode the `{@const}` derived is read eagerly (`$.get(props)`), so this hits the temporal dead zone and throws.

## The fix

Push the element's `let:` declarations into `let_directives` instead of `init`, so they precede `{@const}` declarations, mirroring the component-level handling from #16985. They still come before the element's own `init` (and therefore before any attributes that use them), since `Fragment` emits `let_directives` before `init`.

## Testing

Added `runtime-legacy/samples/let-directive-and-const-tag-slotted` (compiled with `dev: true`, which is where the eager read surfaces the error). It fails before this change with `Cannot access 'thing' before initialization` and passes after.

Full `runtime-legacy`, `runtime-runes`, `server-side-rendering`, `hydration`, `snapshot`, `css`, `validator` and `print` suites pass.