### PR TITLE
fix: allow `$derived(await ...)` in disconnected effect roots

### DIFF
--- a/.changeset/fine-corners-lay.md
+++ b/.changeset/fine-corners-lay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow `$derived(await ...)` in disconnected effect roots

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -187,7 +187,10 @@ export function async_derived(fn, label, location) {
 				var decrement_pending = increment_pending();
 			}
 
-			if (/** @type {Boundary} */ (parent.b).is_rendered()) {
+			if (
+				// boundary can be null if the async derived is inside an $effect.root not connected to the component render tree
+				parent.b?.is_rendered()
+			) {
 				batch.async_deriveds.get(effect)?.reject(OBSOLETE);
 			} else {
 				// While the boundary is still showing pending, a new run supersedes all older in-flight runs

--- a/packages/svelte/tests/runtime-runes/samples/async-async-disconnected-effect-root/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-async-disconnected-effect-root/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	// Test that an async derived inside an $effect.root not connected to the component tree still works
+	async test({ assert, logs }) {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		assert.deepEqual(logs, [1]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-async-disconnected-effect-root/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-async-disconnected-effect-root/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	setTimeout(() => {
+		$effect.root(() => {
+			async function fn() {
+				const value = $derived(await 1);
+				return { get value() { return value } };
+			}
+			fn().then(r => console.log(r.value));
+		})
+	})
+</script>


### PR DESCRIPTION
If `$effect.root` is created outside the component tree, the boundary property is null

Fixes #18188
