### PR TITLE
fix: use consistent spelling in script_unknown_attribute warning

### DIFF
--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -842,7 +842,7 @@ Reassignments of module-level declarations will not cause reactive statements to
 ### script_unknown_attribute
 
 ```
-Unrecognized attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it
+Unrecognised attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it
 ```
 
 ### slot_element_deprecated

--- a/packages/svelte/messages/compile-warnings/template.md
+++ b/packages/svelte/messages/compile-warnings/template.md
@@ -107,7 +107,7 @@ This code will work when the component is rendered on the client (which is why t
 
 ## script_unknown_attribute
 
-> Unrecognized attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it
+> Unrecognised attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it
 
 ## slot_element_deprecated
 

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -804,11 +804,11 @@ export function script_context_deprecated(node) {
 }
 
 /**
- * Unrecognized attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it
+ * Unrecognised attribute — should be one of `generics`, `lang` or `module`. If this exists for a preprocessor, ensure that the preprocessor removes it
  * @param {null | NodeLike} node
  */
 export function script_unknown_attribute(node) {
-	w(node, 'script_unknown_attribute', `Unrecognized attribute — should be one of \`generics\`, \`lang\` or \`module\`. If this exists for a preprocessor, ensure that the preprocessor removes it\nhttps://svelte.dev/e/script_unknown_attribute`);
+	w(node, 'script_unknown_attribute', `Unrecognised attribute — should be one of \`generics\`, \`lang\` or \`module\`. If this exists for a preprocessor, ensure that the preprocessor removes it\nhttps://svelte.dev/e/script_unknown_attribute`);
 }
 
 /**


### PR DESCRIPTION
## Summary

The `script_unknown_attribute` warning message used American English (`Unrecognized`) while every other user-facing error/warning in the compiler uses British English (`Unrecognised`):

- `options_unrecognised` error: `Unrecognised compiler option…`
- `unknown_code` warning: `is not a recognised code`

This change updates `script_unknown_attribute` to match, then regenerates `warnings.js` and the reference documentation from the source message file via `node scripts/process-messages`.

## Test plan
- Spelling change is isolated to the `script_unknown_attribute` warning message
- `warnings.js` and generated docs were updated by running `node scripts/process-messages`
- All three occurrences (source, generated JS, generated docs) are consistent