### PR TITLE
fix: resume outro-ed branches if they were kept around

### DIFF
--- a/.changeset/sad-shoes-help.md
+++ b/.changeset/sad-shoes-help.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: resume outro-ed branches if they were kept around

--- a/packages/svelte/src/internal/client/dom/blocks/branches.js
+++ b/packages/svelte/src/internal/client/dom/blocks/branches.js
@@ -90,6 +90,8 @@ export class BranchManager {
 			var offscreen = this.#offscreen.get(key);
 
 			if (offscreen) {
+				// effect could have been outro'ed before through a prior batch — resume if necessary
+				resume_effect(offscreen.effect);
 				this.#onscreen.set(key, offscreen.effect);
 				this.#offscreen.delete(key);
 

--- a/packages/svelte/tests/runtime-runes/samples/async-branch-reintro/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-branch-reintro/_config.js
@@ -1,0 +1,58 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		await tick();
+		const [inc_count, inc_both, shift] = target.querySelectorAll('button');
+
+		inc_both.click();
+		await tick();
+		inc_count.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<button>increment count</button>
+			<button>increment both</button>
+			<button>shift</button>
+			0
+			0
+			<button>0</button>
+		`
+		);
+
+		shift.click();
+		await tick();
+		shift.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment count</button>
+				<button>increment both</button>
+				<button>shift</button>
+				1
+				2
+				<button>1</button>
+			`
+		);
+
+		const button = /** @type {HTMLButtonElement} */ (target.querySelector('button:last-child'));
+		button.click();
+		await tick();
+		shift.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>increment count</button>
+				<button>increment both</button>
+				<button>shift</button>
+				2
+				2
+				<button>2</button>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-branch-reintro/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-branch-reintro/main.svelte
@@ -1,0 +1,23 @@
+<script>
+	let count = $state(0);
+	let other = $state(0);
+	let queued = [];
+
+	function push(v) {
+		if (!v) return v;
+
+		return new Promise((resolve) => {
+			queued.push(() => resolve(v));
+		});
+	}
+</script>
+
+<button onclick={() => count++}>increment count</button>
+<button onclick={() => {count++;other++}}>increment both</button>
+<button onclick={() => queued.shift()?.()}>shift</button>
+
+{await push(other)}
+{#if count % 2 === 0}
+	{await push(count)}
+	<button onclick={() => other++}>{other}</button>
+{/if}


### PR DESCRIPTION
If a branch is removed from the visible dom, it may be kept around because a subsequent batch will intro it again. If we don't resume the effects it will stay inert and therefore not react to updates anymore
