### PR TITLE
fix: unset_context when not already in an async derived

### DIFF
--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -213,7 +213,7 @@ export function VariableDeclaration(node, context) {
 							location ? b.literal(location) : undefined
 						);
 
-						call = should_save ? save(call) : b.await(call);
+						call = should_save ? save(call, true) : b.await(call);
 
 						declarations.push(b.declarator(declarator.id, call));
 					} else {
@@ -251,7 +251,7 @@ export function VariableDeclaration(node, context) {
 								location ? b.literal(location) : undefined
 							);
 
-							call = should_save ? save(call) : b.await(call);
+							call = should_save ? save(call, true) : b.await(call);
 						}
 
 						declarations.push(b.declarator(id, call));

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -635,6 +635,6 @@ export function has_await_expression(node) {
  * @param {ESTree.Expression} expression
  * @param {boolean} unset
  */
-export function save(expression, unset) {
+export function save(expression, unset = false) {
 	return b.call(b.await(b.call('$.save', expression, unset && b.true)));
 }

--- a/packages/svelte/src/compiler/utils/ast.js
+++ b/packages/svelte/src/compiler/utils/ast.js
@@ -633,7 +633,8 @@ export function has_await_expression(node) {
 /**
  * Turns `await ...` to `(await $.save(...))()`
  * @param {ESTree.Expression} expression
+ * @param {boolean} unset
  */
-export function save(expression) {
-	return b.call(b.await(b.call('$.save', expression)));
+export function save(expression, unset) {
+	return b.call(b.await(b.call('$.save', expression, unset && b.true)));
 }

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -149,9 +149,10 @@ export function capture() {
  * `await a + b` becomes `(await $.save(a))() + b`
  * @template T
  * @param {Promise<T>} promise
+ * @param {boolean} unset
  * @returns {Promise<() => T>}
  */
-export async function save(promise) {
+export async function save(promise, unset) {
 	var batch = current_batch;
 	var active = /** @type {Effect} */ (active_effect);
 	var restore = capture();
@@ -159,15 +160,7 @@ export async function save(promise) {
 
 	return () => {
 		restore();
-		// If there's a boundary, the surrounding system will call unset_context at the appropriate time
-		if (!active.b) {
-			// If this is the last in a chain of async operations, the context would stay around
-			// until the next async operation happens, which can result in weird/buggy behavior
-			// because other sync work might suddenly be associated with an async batch.
-			queue_micro_task(() => {
-				if (batch === current_batch) unset_context();
-			});
-		}
+		if (unset) queue_micro_task(unset_context);
 		return value;
 	};
 }

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -154,13 +154,21 @@ export function capture() {
  */
 export async function save(promise, unset) {
 	var batch = current_batch;
-	var active = /** @type {Effect} */ (active_effect);
 	var restore = capture();
 	var value = await promise;
 
 	return () => {
+		if (unset) {
+			// If this is happening outside the context of an async derived,
+			// context will not automatically be unset
+			queue_micro_task(() => {
+				if (batch === current_batch) {
+					unset_context();
+				}
+			});
+		}
+
 		restore();
-		if (unset) queue_micro_task(unset_context);
 		return value;
 	};
 }


### PR DESCRIPTION
This is the fix in https://github.com/sveltejs/svelte/pull/18289#discussion_r3305747228, but saves us creating a bunch of microtasks