### PR TITLE
chore: ensure treeshaking test runs during CI

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -138,7 +138,7 @@
     "templating"
   ],
   "scripts": {
-    "build": "rollup -c && pnpm generate",
+    "build": "rollup -c && pnpm generate && node scripts/check-treeshakeability.js",
     "dev": "node scripts/process-messages -w & rollup -cw",
     "check": "tsc --project tsconfig.runtime.json && tsc && cd ./tests/types && tsc",
     "check:tsgo": "tsgo --project tsconfig.runtime.json --skipLibCheck && tsgo --skipLibCheck",
@@ -146,7 +146,7 @@
     "generate": "node scripts/process-messages && node ./scripts/generate-types.js",
     "generate:version": "node ./scripts/generate-version.js",
     "generate:types": "node ./scripts/generate-types.js && tsc -p tsconfig.generated.json",
-    "prepublishOnly": "pnpm build && node scripts/check-treeshakeability.js",
+    "prepublishOnly": "pnpm build",
     "knip": "pnpm dlx knip"
   },
   "devDependencies": {


### PR DESCRIPTION
Would've caught the regression in #18250 - without this the tests were all green, giving a false sense of "this is correct"
