### PR TITLE
fix: propagate async @const blockers through closure references

### DIFF
--- a/.changeset/iife-await-const-blocker.md
+++ b/.changeset/iife-await-const-blocker.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: propagate async `@const` blockers through closure references so template expressions like `{(() => host)()}` correctly wait for the awaited value

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -52,15 +52,6 @@ export class Memoizer {
 	 * @param {ExpressionMetadata} metadata
 	 */
 	check_blockers(metadata) {
-		for (const binding of metadata.dependencies) {
-			if (binding.blocker) {
-				this.#blockers.add(binding.blocker);
-			}
-		}
-
-		// Also consider references reached through closures (e.g. `() => host` inside
-		// an interpolation). Otherwise blockers attached to such bindings are missed
-		// and the resulting effect runs before the async value is assigned.
 		for (const binding of metadata.references) {
 			if (binding.blocker) {
 				this.#blockers.add(binding.blocker);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -57,6 +57,15 @@ export class Memoizer {
 				this.#blockers.add(binding.blocker);
 			}
 		}
+
+		// Also consider references reached through closures (e.g. `() => host` inside
+		// an interpolation). Otherwise blockers attached to such bindings are missed
+		// and the resulting effect runs before the async value is assigned.
+		for (const binding of metadata.references) {
+			if (binding.blocker) {
+				this.#blockers.add(binding.blocker);
+			}
+		}
 	}
 
 	apply() {

--- a/packages/svelte/src/compiler/phases/nodes.js
+++ b/packages/svelte/src/compiler/phases/nodes.js
@@ -102,13 +102,6 @@ export class ExpressionMetadata {
 		if (!this.#blockers) {
 			this.#blockers = new Set();
 
-			for (const d of this.dependencies) {
-				if (d.blocker) this.#blockers.add(d.blocker);
-			}
-
-			// Also consider references reached through closures (e.g. `() => host` inside
-			// an interpolation). Otherwise blockers attached to such bindings are missed
-			// and the template_effect runs before the async value is assigned.
 			for (const r of this.references) {
 				if (r.blocker) this.#blockers.add(r.blocker);
 			}

--- a/packages/svelte/src/compiler/phases/nodes.js
+++ b/packages/svelte/src/compiler/phases/nodes.js
@@ -105,6 +105,13 @@ export class ExpressionMetadata {
 			for (const d of this.dependencies) {
 				if (d.blocker) this.#blockers.add(d.blocker);
 			}
+
+			// Also consider references reached through closures (e.g. `() => host` inside
+			// an interpolation). Otherwise blockers attached to such bindings are missed
+			// and the template_effect runs before the async value is assigned.
+			for (const r of this.references) {
+				if (r.blocker) this.#blockers.add(r.blocker);
+			}
 		}
 
 		return this.#blockers;

--- a/packages/svelte/tests/runtime-runes/samples/async-each-const-await-iife/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-each-const-await-iife/_config.js
@@ -1,0 +1,14 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+// Tests that an IIFE referencing an `await` @const inside an {#each} block
+// correctly registers the async dependency so the template waits for the
+// resolved value instead of rendering with `undefined`.
+export default test({
+	mode: ['client', 'hydrate', 'async-server'],
+	ssrHtml: '<p>example.com</p>',
+	async test({ assert, target }) {
+		await tick();
+		assert.htmlEqual(target.innerHTML, '<p>example.com</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-each-const-await-iife/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-each-const-await-iife/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	async function get_host() {
+		return 'example.com';
+	}
+</script>
+
+{#each { length: 1 } as nothing}
+	{@const host = await get_host()}
+	<p>{(() => host)()}</p>
+{/each}


### PR DESCRIPTION
Right now, if you have the following:

```svelte
{@const data = await foo}
<p>{(() => data)()}<p>
```

It will blow up during CSR, because it tries to read `data` before it exists. The solution to this is to consider references inside closures as blockers for those closures. This _does_ mean we'll overblock in some circumstances, such as:

```svelte
{@const data = await foo}
<button onclick={() => data}>foo<button>
```

But I wonder if that's actually incorrect? If the user were to click `onclick` before `data` is ready, it would blow up.