### PR TITLE
disallow semicolons in declaration tags

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -107,10 +107,14 @@ export function parse_expression_at(parser, source, index) {
  */
 export function parse_statement_at(parser, source, index) {
 	const acorn = parser.ts ? TSParser : JSParser;
-	const end = find_matching_bracket(source, index, '{');
+	let end = find_matching_bracket(source, index, '{');
 	if (end === undefined) e.unexpected_eof(source.length);
 
-	const padded_source = `${' '.repeat(index)}${source.slice(index, end)};`;
+	while (source[end - 1] === ';') {
+		end -= 1;
+	}
+
+	const padded_source = `${' '.repeat(index)}${source.slice(index, end)}`;
 	const { onComment, add_comments } = get_comment_handlers(
 		padded_source,
 		parser.root.comments,

--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -127,7 +127,6 @@ function read_declaration(parser) {
 	}
 
 	parser.index = /** @type {number} */ (declaration.end);
-	parser.eat(';');
 	parser.allow_whitespace();
 	parser.eat('}', true);
 

--- a/packages/svelte/src/compiler/print/index.js
+++ b/packages/svelte/src/compiler/print/index.js
@@ -605,7 +605,41 @@ const svelte_visitors = (comments) => ({
 
 	DeclarationTag(node, context) {
 		context.write('{');
-		context.visit(node.declaration);
+
+		const open = context.new();
+		const join = context.new();
+		const child_context = context.new();
+
+		context.append(child_context);
+
+		child_context.write(`${node.declaration.kind} `);
+		child_context.append(open);
+
+		const declarations = node.declaration.declarations;
+		let first = true;
+
+		for (const d of declarations) {
+			if (!first) child_context.append(join);
+			first = false;
+
+			child_context.visit(d);
+		}
+
+		const length = child_context.measure() + 2 * (declarations.length - 1);
+
+		const multiline = child_context.multiline || (declarations.length > 1 && length > 50);
+
+		if (multiline) {
+			context.multiline = true;
+
+			if (declarations.length > 1) open.indent();
+			join.write(',');
+			join.newline();
+			if (declarations.length > 1) context.dedent();
+		} else {
+			join.write(', ');
+		}
+
 		context.write('}');
 	},
 

--- a/packages/svelte/tests/print/samples/declaration-tag/input.svelte
+++ b/packages/svelte/tests/print/samples/declaration-tag/input.svelte
@@ -1,6 +1,6 @@
 {#if visible}
 	{let count = 1}
-	{const doubled = count * 2;}
+	{const doubled = count * 2}
 	{const label = 'count'}
 	{const format = (value) => `${label}: ${value}`}
 	<p>{format(doubled)}</p>

--- a/packages/svelte/tests/print/samples/declaration-tag/output.svelte
+++ b/packages/svelte/tests/print/samples/declaration-tag/output.svelte
@@ -1,7 +1,7 @@
 {#if visible}
-	{let count = 1;}
-	{const doubled = count * 2;}
-	{const label = 'count';}
-	{const format = (value) => `${label}: ${value}`;}
+	{let count = 1}
+	{const doubled = count * 2}
+	{const label = 'count'}
+	{const format = (value) => `${label}: ${value}`}
 	<p>{format(doubled)}</p>
 {/if}


### PR DESCRIPTION
I think we should disallow semicolons in declaration tags, because syntactic ambiguity is always unfortunate and `;}` (the little-used 'winking grinch' emoticon) looks pretty ugly.

We should _definitely_ remove it from code generated with `print`, even though it unfortunately requires us to duplicate some of the logic in the `ts` printer.