### PR TITLE
fix: avoid inline event handlers for hydration event replay under `csp`

### DIFF
--- a/.changeset/csp-friendly-event-replay.md
+++ b/.changeset/csp-friendly-event-replay.md
@@ -1,0 +1,8 @@
+---
+'svelte': patch
+---
+
+fix: avoid inline event handlers for hydration event replay under `csp`
+
+When `render({ csp })` is set, the inline `onload="this.__e=event"` attribute (ref #11642) is replaced with a single capturing listener injected into `<head>`. The script's sha256 is added to `result.hashes.script`. 
+Closes #14014.

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
@@ -274,8 +274,9 @@ export function build_element_attributes(node, context, transform) {
 	}
 
 	if (events_to_capture.size !== 0) {
+		// swap the inline attribute for a head script when `csp` is set
 		for (const event of events_to_capture) {
-			context.state.template.push(b.literal(` ${event}="this.__e=event"`));
+			context.state.template.push(b.call('$.event_capture', b.id('$$renderer'), b.literal(event)));
 		}
 	}
 

--- a/packages/svelte/src/internal/server/event-capture.js
+++ b/packages/svelte/src/internal/server/event-capture.js
@@ -1,0 +1,12 @@
+/**
+ * head script that catches `load`/`error` on cached elements before hydration
+ * attaches the real listeners. replaces the per-element `onload="this.__e=event"`
+ * attribute when `csp` is set on `render()`. if you change the body, update the
+ * hash below — the test in `event-capture.test.ts` will tell you the new value.
+ */
+// the `if(e.target)` guard skips events whose target is unset (e.g. retargeted to window)
+export const EVENT_CAPTURE_SCRIPT =
+	'var r=(e)=>{if(e.target)e.target.__e=e};document.addEventListener("load",r,true);document.addEventListener("error",r,true);';
+
+/** sha256 of {@link EVENT_CAPTURE_SCRIPT} */
+export const EVENT_CAPTURE_SCRIPT_SHA256 = 'sha256-VyPjBqafUNeHE2rLgLKQN7xM97MwGeuS77U6ASqjaYY=';

--- a/packages/svelte/src/internal/server/event-capture.test.ts
+++ b/packages/svelte/src/internal/server/event-capture.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from 'vitest';
+import { Renderer, SSRState } from './renderer.js';
+import { EVENT_CAPTURE_SCRIPT, EVENT_CAPTURE_SCRIPT_SHA256 } from './event-capture.js';
+import { sha256 } from './crypto.js';
+import { event_capture } from './index.js';
+
+test('EVENT_CAPTURE_SCRIPT_SHA256 matches the hashed script body', async () => {
+	// Drift guard: if you change EVENT_CAPTURE_SCRIPT, recompute the hash.
+	expect(`sha256-${await sha256(EVENT_CAPTURE_SCRIPT)}`).toBe(EVENT_CAPTURE_SCRIPT_SHA256);
+});
+
+test('event_capture returns inline attribute when csp is not enabled', () => {
+	const renderer = new Renderer(new SSRState('sync'));
+	expect(event_capture(renderer, 'onload')).toBe(' onload="this.__e=event"');
+	expect(renderer.global.needs_event_replay_script).toBe(false);
+});
+
+test('event_capture returns empty string and arms the head script under csp.hash', () => {
+	const renderer = new Renderer(new SSRState('sync', '', { hash: true }));
+	expect(event_capture(renderer, 'onload')).toBe('');
+	expect(event_capture(renderer, 'onerror')).toBe('');
+	expect(renderer.global.needs_event_replay_script).toBe(true);
+});
+
+test('event_capture returns empty string and arms the head script under csp.nonce', () => {
+	const renderer = new Renderer(new SSRState('sync', '', { nonce: 'abc' }));
+	expect(event_capture(renderer, 'onload')).toBe('');
+	expect(renderer.global.needs_event_replay_script).toBe(true);
+});

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -25,6 +25,23 @@ import { Renderer } from './renderer.js';
 import * as e from './errors.js';
 import { ssr_context } from './context.js';
 
+/**
+ * Returns the inline `onload`/`onerror` capture attribute, or `''` if `csp.nonce`
+ * or `csp.hash` is set (renderer injects a head script instead).
+ *
+ * @param {Renderer} renderer
+ * @param {string} name
+ * @returns {string}
+ */
+export function event_capture(renderer, name) {
+	const csp = renderer.global.csp;
+	if (csp.nonce || csp.hash) {
+		renderer.global.needs_event_replay_script = true;
+		return '';
+	}
+	return ` ${name}="this.__e=event"`;
+}
+
 // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
 // https://infra.spec.whatwg.org/#noncharacter
 const INVALID_ATTR_NAME_CHAR_REGEX =

--- a/packages/svelte/src/internal/server/renderer.js
+++ b/packages/svelte/src/internal/server/renderer.js
@@ -14,6 +14,7 @@ import { sha256 } from './crypto.js';
 import * as devalue from 'devalue';
 import { has_own_property, noop } from '../shared/utils.js';
 import { escape_html } from '../../escaping.js';
+import { EVENT_CAPTURE_SCRIPT, EVENT_CAPTURE_SCRIPT_SHA256 } from './event-capture.js';
 
 /** @typedef {'head' | 'body'} RendererType */
 /** @typedef {{ [key in RendererType]: string }} AccumulatedContent */
@@ -510,7 +511,7 @@ export class Renderer {
 	 * @returns {RenderOutput}
 	 */
 	static render(component, options = {}) {
-		/** @type {AccumulatedContent | undefined} */
+		/** @type {(AccumulatedContent & { hashes: { script: Sha256Source[] } }) | undefined} */
 		let sync;
 		/** @type {Promise<AccumulatedContent & { hashes: { script: Sha256Source[] } }> | undefined} */
 		let async;
@@ -535,9 +536,10 @@ export class Renderer {
 				}
 			},
 			hashes: {
-				value: {
-					script: ''
-				}
+				get: () => ({
+					// trigger the lazy render so `script_hashes` is populated
+					script: (sync ??= Renderer.#render(component, options)).hashes.script
+				})
 			},
 			then: {
 				value:
@@ -556,7 +558,7 @@ export class Renderer {
 								head: result.head,
 								body: result.body,
 								html: result.body,
-								hashes: { script: [] }
+								hashes: { script: result.hashes.script }
 							});
 							return Promise.resolve(user_result);
 						}
@@ -629,8 +631,8 @@ export class Renderer {
 	 *
 	 * @template {Record<string, any>} Props
 	 * @param {Component<Props>} component
-	 * @param {{ props?: Omit<Props, '$$slots' | '$$events'>; context?: Map<any, any>; idPrefix?: string }} options
-	 * @returns {AccumulatedContent}
+	 * @param {{ props?: Omit<Props, '$$slots' | '$$events'>; context?: Map<any, any>; idPrefix?: string; csp?: Csp; transformError?: (error: unknown) => unknown }} options
+	 * @returns {AccumulatedContent & { hashes: { script: Sha256Source[] } }}
 	 */
 	static #render(component, options) {
 		var previous_context = ssr_context;
@@ -812,6 +814,18 @@ export class Renderer {
 			head += `<style id="${hash}">${code}</style>`;
 		}
 
+		// prepend so the listener attaches before any `<svelte:head>`
+		// emitted `<link>`/`<script>` below it can fire
+		if (renderer.global.needs_event_replay_script) {
+			let csp_attr = '';
+			if (renderer.global.csp.nonce) {
+				csp_attr = ` nonce="${renderer.global.csp.nonce}"`;
+			} else if (renderer.global.csp.hash) {
+				renderer.global.csp.script_hashes.push(EVENT_CAPTURE_SCRIPT_SHA256);
+			}
+			head = `<script${csp_attr}>${EVENT_CAPTURE_SCRIPT}</script>` + head;
+		}
+
 		return {
 			head,
 			body,
@@ -887,6 +901,11 @@ export class SSRState {
 
 	/** @readonly @type {Set<{ hash: string; code: string }>} */
 	css = new Set();
+
+	/** Set by `event_capture` under `csp` to ask the renderer to inject the head script.
+	 * @type {boolean}
+	 */
+	needs_event_replay_script = false;
 
 	/**
 	 * `transformError` passed to `render`. Called when an error boundary catches an error.

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-hash/_config.js
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-hash/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+// under `csp.hash`: no inline `onload` attrs, head script + hash returned, and
+// the script lands BEFORE user `<svelte:head>` content (otherwise a cached
+// preload could fire its `load` event before the listener attaches)
+
+export default test({
+	csp: { hash: true },
+	script_hashes: ['sha256-VyPjBqafUNeHE2rLgLKQN7xM97MwGeuS77U6ASqjaYY=']
+});

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-hash/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-hash/_expected.html
@@ -1,0 +1,2 @@
+<img alt="a" src="/a.png" />
+<img alt="b" src="/b.png" />

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-hash/_expected_head.html
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-hash/_expected_head.html
@@ -1,0 +1,1 @@
+<script>var r=(e)=>{if(e.target)e.target.__e=e};document.addEventListener("load",r,true);document.addEventListener("error",r,true);</script><link rel="preload" as="image" href="/preloaded.png" />

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-hash/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-hash/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let { onloaded = () => {}, onfailed = () => {} } = $props();
+</script>
+
+<svelte:head>
+	<link rel="preload" as="image" href="/preloaded.png" onload={onloaded} />
+</svelte:head>
+
+<img alt="a" src="/a.png" onload={onloaded} onerror={onfailed} />
+<img alt="b" src="/b.png" onload={onloaded} />

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-nonce/_config.js
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-nonce/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+// With `csp.nonce`, the head script is emitted with `nonce="..."` and no hash needs to be returned to the framework.
+
+export default test({
+	csp: { nonce: 'abc123' },
+	script_hashes: []
+});

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-nonce/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-nonce/_expected.html
@@ -1,0 +1,1 @@
+<img alt="a" src="/a.png" />

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-nonce/_expected_head.html
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-nonce/_expected_head.html
@@ -1,0 +1,1 @@
+<script nonce="abc123">var r=(e)=>{if(e.target)e.target.__e=e};document.addEventListener("load",r,true);document.addEventListener("error",r,true);</script>

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-nonce/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-csp-nonce/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { onloaded = () => {} } = $props();
+</script>
+
+<img alt="a" src="/a.png" onload={onloaded} onerror={onloaded} />

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-no-csp/_config.js
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-no-csp/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+// with no `csp`, inline attrs emitted as before. `html_equal` strips them, so we use `withoutNormalizeHtml` to assert the literal output
+
+export default test({
+	withoutNormalizeHtml: true,
+	script_hashes: []
+});

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-no-csp/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-no-csp/_expected.html
@@ -1,0 +1,1 @@
+<!--[--><img alt="a" src="/a.png" onload="this.__e=event" onerror="this.__e=event"/><!--]-->

--- a/packages/svelte/tests/server-side-rendering/samples/event-replay-no-csp/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/event-replay-no-csp/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { onloaded = () => {} } = $props();
+</script>
+
+<img alt="a" src="/a.png" onload={onloaded} onerror={onloaded} />


### PR DESCRIPTION
Closes #14014. Completes the CSP fix started in #15846, which removed the matching guarded reads in `replay_events` but left the inline emission in place.

### Problem

Since #11642, hydratable `<img>`/`<link>`/`<iframe>`/… are SSR-emitted with `onload="this.__e=event" onerror="this.__e=event"` so cached resources whose `load`/`error` fires before hydration aren't lost. Strict CSP blocks this without `'unsafe-hashes'` + a sha256 allowance for the literal `this.__e=event`.

current solution is to add this to the csp config: `'unsafe-hashes'` + the sha256 of `this.__e=event` scoped to `script-src-attr` ([Rican7, Mar 2025](https://github.com/sveltejs/svelte/issues/14014#issuecomment-2738264028)).

### Fix

When `render({ csp: { hash: true | nonce: '...' } })` is set:

- compiler emits `$.event_capture($$renderer, name)` instead of the literal attribute (`server/visitors/shared/element.js`)
- runtime helper returns `''` and arms a flag on `SSRState` (`internal/server/index.js`)
- `Renderer.#close_render` prepends a single capturing-listener `<script>` to `<head>`:
  ```js
  var r = (e) => {
    if (e.target) e.target.__e = e;
  };
  document.addEventListener("load", r, true);
  document.addEventListener("error", r, true);
  ```
- the script's sha256 is pushed into the existing `result.hashes.script` array (under `csp.hash`) or the tag carries `nonce="..."` (under `csp.nonce`). SvelteKit already wires `hashes.script` into the response CSP header.

`replay_events` is unchanged — still reads `node.__e` after hydration.

If `csp` isn't configured, output doesn't change.

For people using the fixed sha hash in csp config, it'll keep working. But you'll be able to cleanup `script-src-attr` block as `mode: 'auto'` will work automatically.

### Drive-by

Sync `render(...).hashes.script` was hard-coded to `''` (a string, against its declared `Sha256Source[]` type). Made it a lazy getter that triggers the render and returns the real array — needed for the new tests. Minor behavior change: reading `.hashes` now triggers the render, so render errors can surface there too.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
