### PR TITLE
allow class/function expressions in tags

### DIFF
--- a/packages/svelte/src/compiler/phases/1-parse/state/tag.js
+++ b/packages/svelte/src/compiler/phases/1-parse/state/tag.js
@@ -12,7 +12,7 @@ import { find_matching_bracket, match_bracket } from '../utils/bracket.js';
 
 const regex_whitespace_with_closing_curly_brace = /\s*}/y;
 const regex_supported_declaration = /(?:let|const)\b/y;
-const regex_unsupported_declaration = /(?:var|function|class|type|interface|enum)\b/y;
+const regex_unsupported_declaration = /(?:var|type|interface|enum)\b/y;
 
 const pointy_bois = { '<': '>' };
 

--- a/packages/svelte/tests/validator/samples/declaration-tag-invalid-function/errors.json
+++ b/packages/svelte/tests/validator/samples/declaration-tag-invalid-function/errors.json
@@ -1,14 +1,1 @@
-[
-	{
-		"code": "declaration_tag_invalid_type",
-		"message": "Declaration tags must be `let` or `const` declarations",
-		"start": {
-			"line": 2,
-			"column": 2
-		},
-		"end": {
-			"line": 2,
-			"column": 10
-		}
-	}
-]
+[]


### PR DESCRIPTION
We shouldn't error on encountering `class` and `function`, because they are treated as expressions rather than declarations