### PR TITLE
docs: fix chat autoscroll example for async mode

### DIFF
--- a/.changeset/fix-async-chat.md
+++ b/.changeset/fix-async-chat.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+docs: fix chat autoscroll example for async mode

--- a/documentation/docs/02-runes/04-$effect.md
+++ b/documentation/docs/02-runes/04-$effect.md
@@ -172,33 +172,35 @@ $effect(() => {
 
 ## `$effect.pre`
 
-In rare cases, you may need to run code _before_ the DOM updates. For this we can use the `$effect.pre` rune:
+In rare cases, you may need to run code _before_ the DOM updates. For this we can use the `$effect.pre` rune.
+
+> [!NOTE] In experimental async mode, `$effect.pre` runs after the DOM has been updated, the same as `$effect`. For patterns that need to capture DOM state before an update — such as chat autoscroll — use an event listener to track the relevant state instead. The example below works correctly in both modes:
 
 ```svelte
 <script>
-	import { tick } from 'svelte';
-
 	let div = $state();
 	let messages = $state([]);
 
 	// ...
 
-	$effect.pre(() => {
+	let autoscroll = true;
+
+	$effect(() => {
 		if (!div) return; // not yet mounted
 
 		// reference `messages` array length so that this code re-runs whenever it changes
 		messages.length;
 
 		// autoscroll when new messages are added
-		if (div.offsetHeight + div.scrollTop > div.scrollHeight - 20) {
-			tick().then(() => {
-				div.scrollTo(0, div.scrollHeight);
-			});
+		if (autoscroll) {
+			div.scrollTo(0, div.scrollHeight);
 		}
 	});
 </script>
 
-<div bind:this={div}>
+<div bind:this={div} onscroll={() => {
+	autoscroll = div.offsetHeight + div.scrollTop > div.scrollHeight - 20;
+}}>
 	{#each messages as message}
 		<p>{message}</p>
 	{/each}

--- a/documentation/docs/06-runtime/03-lifecycle-hooks.md
+++ b/documentation/docs/06-runtime/03-lifecycle-hooks.md
@@ -98,21 +98,20 @@ Instead of `beforeUpdate` use `$effect.pre` and instead of `afterUpdate` use `$e
 
 ### Chat window example
 
-To implement a chat window that autoscrolls to the bottom when new messages appear (but only if you were _already_ scrolled to the bottom), we need to measure the DOM before we update it.
+To implement a chat window that autoscrolls to the bottom when new messages appear (but only if you were _already_ scrolled to the bottom), we track scroll position via an `onscroll` handler and use `$effect` to scroll when messages change.
 
 In Svelte 4, we do this with `beforeUpdate`, but this is a flawed approach — it fires before _every_ update, whether it's relevant or not. In the example below, we need to introduce checks like `updatingMessages` to make sure we don't mess with the scroll position when someone toggles dark mode.
 
-With runes, we can use `$effect.pre`, which behaves the same as `$effect` but runs before the DOM is updated. As long as we explicitly reference `messages` inside the effect body, it will run whenever `messages` changes, but _not_ when `theme` changes.
+With runes, we track whether the user is at the bottom via an `onscroll` handler and react to `messages` changes with `$effect`. As long as we explicitly reference `messages` inside the effect body, it will run whenever `messages` changes, but _not_ when `theme` changes. This approach also works correctly in experimental async mode, where `$effect.pre` runs after the DOM has been updated.
 
 `beforeUpdate`, and its equally troublesome counterpart `afterUpdate`, are therefore deprecated in Svelte 5.
 
 - [Before](/playground/untitled#H4sIAAAAAAAAE31WXa_bNgz9K6yL1QmWOLlrC-w6H8MeBgwY9tY9NfdBtmlbiywZkpyPBfnvo2zLcZK28AWuRPGI5OGhkEuQc4EmiL9eAskqDOLg97oOZoE9125jDigs0t6oRqfOsjap5rXd7uTO8qpW2sIFEsyVxn_qjFmcAcstar-xPN3DFXKtKgi768IVgQku0ELj3Lgs_kZjWIEGNpAzYXDlHWyJFZI1zJjeh4O5uvl_DY8oUkVeVoFuJKYls-_CGYS25Aboj0EtWNqel0wWoBoLTGZgmdgDS9zW4Uz4NsrswPHoyutN4xInkylstnBxdmIhh8m7xzqmoNE2Wq46n1RJQzEbq4g-JQSl7e-HDx-GdaTy3KD9E3lRWvj5Zu9QX1QN20dj7zyHz8s-1S6lW7Cpz3RnXTcm04hIlfdFuO8p2mQ5-3a06cqjrn559bF_2NHOnRZ5I1PLlXQNyQT-hedMHeUEDyjtdMxsa4n2eIbNhlTwhyRthaOKOmYtniwF6pwt0wXa6MBEg0OibZec27gz_dk3UrZ6hB2LLYoiv521Yd8Gt-foTrfhiCDP0lC9VUUhcDLU49Xe_9943cNvEArHfAjxeBTovvXiNpFynfEDpIIZs9kFbg52QbeNHWZzebz32s7xHco3nJAJl1nshmhz8dYOQJDyZetnbb2gTWe-vEeWlrfpZMavr56ldb29eNt6UXvgwgFbp_WC0tl2RK25rGk6lYz3nUI2lzvBXGHhPZPGWmKUXFNBKqdaW259wl_aHbiqoVIZdpE60Nax6IOujT0LbFFxIVTCxCRR2XloUcYNvSbnGHKBp763jHoj59xiZWJI0Wm0P_m3MSS985xkasn-cFq20xTDy3J5KFcjgUTD69BHdcHIjz431z28IqlxGcPSfdFnrGDZn6gD6lyo45zyHAD-btczf-98nhQxHEvKfeUtOVkSejD3q-9X7JbzjGtsdUxlKdFU8qGsT78uaw848syWMXz85Waq2Gnem4mAn3prweq4q6Y3JEpnqMmnPoFRgmd3ySW0LLRqSKlwYHriCvJvUs2yjMaaoA-XzTXLeGMe45zmhv_XAno3Mj0xF7USuqNvnE9H343QHlq-eAgxpbTPNR9yzUkgLjwSR0NK4wKoxy-jDg-9vy8sUSToakzW-9fX13Em9Q8T6Z26uZhBN36XUYo5q7ggLXBZoub2Ofv7g6GCZfTxe034NCjiudXj7Omla0eTfo7QBPOcYxbE7qG-vl3_B1G-_i_JCAAA)
-- [After](/playground/untitled#H4sIAAAAAAAAE31WXa-jNhD9K7PsdknUQJLurtRLPqo-VKrU1327uQ8GBnBjbGSb5KZR_nvHgMlXtyIS9njO-MyZGZRzUHCBJkhez4FkNQZJ8HvTBLPAnhq3MQcUFmlvVKszZ1mbTPPGbndyZ3ndKG3hDJZne7hAoVUNYY8JV-RBPgIt2AprhA18MpZZnIQ50_twuvLHNRrDSjRXj9fwiCJTBLIKdCsxq5j9EM4gtBU3QD8GjWBZd14xWYJqLTCZg2ViDyx1W4cz4dv0hsiB49FRHkyfsCgws3GjcTKZwmYLZ2feWc9o1W8zJQ2Fb62i5JUQRNRHgs-fx3WsisKg_RN5WVn4-WrvUd9VA9tH4-AcwbfFQIpkLWByvWzqSe2sk3kyjUlOec_XPU-3TRaz_75tuvKoi19e3OvipSpamVmupJM2F_gXnnJ1lBM8oLQjHceys8R7PMFms4HwD2lRhzeEe-EsvluSrHe2TJdo4wMTLY48XKwPzm0KGm2r5ajFtRYU4TWOY7-ddWHfxhDP0QkQhnf5PWRnVVkKnIx8fZsOb5dR16nwG4TCCRdCMphWQ7z1_DoOcp3zA2SCGbPZBa5jd0G_TRxmc36Me-mG6A7l60XIlMs8ce2-OXtrDyBItdz6qVjPadObzx-RZdV1nJjx64tXad1sz962njceOHfAzmk9JzrbXqg1lw3NkZL7vgE257t-uMDcO6attSSokpmgFqVMO2U93e_dDlzOUKsc-3t6zNZp6K9cG3sS2KGSUqiUiUmq8tNYoJwbmvpTAoXA96GyjCojI26xNglk6DpwOPm7NdRYp4ia0JL94bTqRiGB5WJxqFY37RGPoz3c6i4jP3rcUA7wmhqNywQW7om_YQ2L4UQdUBdCHSPiOQJ8bFcxHzeK0jKBY0XcV95SkCWlD9t-9eOM3TLKucauiyktJdpaPqT19ddF4wFHntsqgS-_XE01e48GMwnw02AtWZP02QyGVOkcNfk072CU4PkduZSWpVYt9SkcmJ64hPwHpWF5ziVls3wIFmmW89Y83vMeGf5PBxjcyPSkXNy10J18t3x6-a6CDtBq6SGklNKeazFyLahB3PVIGo2UbhOgGi9vKjzW_j6xVFFD17difXx5ebll0vwvkcGpn4sZ9MN3vqFYsJoL6gUuK9TcPrO_PxgzWMRfflSEr2NHPJf6lj1957rRpH8CNMG84JgHidUtXt4u_wK21LXERAgAAA==)
 
 <!-- prettier-ignore -->
 ```svelte
 <script>
-	import { ---beforeUpdate, afterUpdate,--- tick } from 'svelte';
+	---import { beforeUpdate, afterUpdate, tick } from 'svelte';---
 
 	---let updatingMessages = false;---
 	let theme = +++$state('dark')+++;
@@ -120,20 +119,24 @@ With runes, we can use `$effect.pre`, which behaves the same as `$effect` but ru
 
 	let viewport;
 
+	+++let autoscroll = true;+++
+
 	---beforeUpdate(() => {---
-	+++$effect.pre(() => {+++
-		---if (!updatingMessages) return;---
+	---	if (!updatingMessages) return;---
+	---	const autoscroll = viewport && viewport.offsetHeight + viewport.scrollTop > viewport.scrollHeight - 50;---
+	---	if (autoscroll) {---
+	---		tick().then(() => {---
+	---			viewport.scrollTo(0, viewport.scrollHeight);---
+	---		});---
+	---	}---
+	---	updatingMessages = false;---
+	---});---
+	+++$effect(() => {+++
 		+++messages;+++
-		const autoscroll = viewport && viewport.offsetHeight + viewport.scrollTop > viewport.scrollHeight - 50;
-
-		if (autoscroll) {
-			tick().then(() => {
-				viewport.scrollTo(0, viewport.scrollHeight);
-			});
-		}
-
-		---updatingMessages = false;---
-	});
+		+++if (autoscroll) {+++
+			+++viewport?.scrollTo(0, viewport.scrollHeight);+++
+		+++}+++
+	+++});+++
 
 	function handleKeydown(event) {
 		if (event.key === 'Enter') {
@@ -152,7 +155,7 @@ With runes, we can use `$effect.pre`, which behaves the same as `$effect` but ru
 </script>
 
 <div class:dark={theme === 'dark'}>
-	<div bind:this={viewport}>
+	<div bind:this={viewport} +++onscroll={() => { autoscroll = viewport.offsetHeight + viewport.scrollTop > viewport.scrollHeight - 50; }}+++>
 		{#each messages as message}
 			<p>{message}</p>
 		{/each}


### PR DESCRIPTION
## Summary
- replace the `$effect.pre` + `tick()` chat autoscroll pattern with `onscroll` state tracking plus `$effect`
- update the lifecycle hooks docs example to match the async-safe approach
- keep the docs consistent with experimental async mode behavior

Fixes #18300

## Validation
- `pnpm exec prettier --check documentation/docs/02-runes/04-$effect.md documentation/docs/06-runtime/03-lifecycle-hooks.md`