### PR TITLE
Fix searchParams.set duplicate updates

### DIFF
--- a/.changeset/search-params-duplicate-set.md
+++ b/.changeset/search-params-duplicate-set.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Ensure reactive URL search params update when setting duplicate keys to the same joined value

--- a/.changeset/search-params-duplicate-set.md
+++ b/.changeset/search-params-duplicate-set.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Ensure reactive URL search params update when setting duplicate keys to the same joined value
+fix: update `SvelteURLSearchParams` when setting duplicate keys to the same joined value

--- a/packages/svelte/src/reactivity/url-search-params.js
+++ b/packages/svelte/src/reactivity/url-search-params.js
@@ -132,11 +132,12 @@ export class SvelteURLSearchParams extends URLSearchParams {
 	 * @returns {void}
 	 */
 	set(name, value) {
-		var previous = super.getAll(name).join('');
+		var previous = super.getAll(name);
 		super.set(name, value);
 		// can't use has(name, value), because for something like https://svelte.dev?foo=1&bar=2&foo=3
 		// if you set `foo` to 1, then foo=3 gets deleted whilst `has("foo", "1")` returns true
-		if (previous !== super.getAll(name).join('')) {
+		var current = super.getAll(name);
+		if (previous.length !== current.length || previous.some((value, i) => value !== current[i])) {
 			this.#update_url();
 			increment(this.#version);
 		}

--- a/packages/svelte/src/reactivity/url-search-params.test.ts
+++ b/packages/svelte/src/reactivity/url-search-params.test.ts
@@ -74,6 +74,25 @@ test('URLSearchParams.set updates when duplicate values collapse to the same joi
 	cleanup();
 });
 
+test('URLSearchParams.set updates when duplicate values collapse to the same comma-joined string', () => {
+	const params = new SvelteURLSearchParams('a=a&a=b');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.toString());
+		});
+	});
+
+	flushSync(() => {
+		params.set('a', 'a,b');
+	});
+
+	assert.deepEqual(log, ['a=a&a=b', 'a=a%2Cb']);
+
+	cleanup();
+});
+
 test('URLSearchParams.append', () => {
 	const params = new SvelteURLSearchParams();
 	const log: any = [];

--- a/packages/svelte/src/reactivity/url-search-params.test.ts
+++ b/packages/svelte/src/reactivity/url-search-params.test.ts
@@ -55,6 +55,25 @@ test('URLSearchParams.set', () => {
 	cleanup();
 });
 
+test('URLSearchParams.set updates when duplicate values collapse to the same joined string', () => {
+	const params = new SvelteURLSearchParams('a=ab&a=c');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(params.toString());
+		});
+	});
+
+	flushSync(() => {
+		params.set('a', 'abc');
+	});
+
+	assert.deepEqual(log, ['a=ab&a=c', 'a=abc']);
+
+	cleanup();
+});
+
 test('URLSearchParams.append', () => {
 	const params = new SvelteURLSearchParams();
 	const log: any = [];

--- a/packages/svelte/src/reactivity/url.test.ts
+++ b/packages/svelte/src/reactivity/url.test.ts
@@ -115,6 +115,25 @@ test('url.searchParams', () => {
 	cleanup();
 });
 
+test('url.searchParams.set updates url when duplicate values collapse to the same joined string', () => {
+	const url = new SvelteURL('https://svelte.dev?a=ab&a=c');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(url.href);
+		});
+	});
+
+	flushSync(() => {
+		url.searchParams.set('a', 'abc');
+	});
+
+	assert.deepEqual(log, ['https://svelte.dev/?a=ab&a=c', 'https://svelte.dev/?a=abc']);
+
+	cleanup();
+});
+
 test('url.search normalizes value', () => {
 	const url = new SvelteURL('https://svelte.dev');
 	const log: any = [];


### PR DESCRIPTION
## Summary
- detect `SvelteURLSearchParams#set` changes by comparing duplicate value lists instead of joined strings
- update reactive subscribers when duplicate params collapse to a single value with the same concatenated text
- cover both `SvelteURLSearchParams` and `SvelteURL.searchParams` synchronization

## Tests
- pnpm exec vitest run packages/svelte/src/reactivity/url-search-params.test.ts -t "URLSearchParams.set updates when duplicate values collapse to the same joined string"
- pnpm exec vitest run packages/svelte/src/reactivity/url-search-params.test.ts packages/svelte/src/reactivity/url.test.ts