### PR TITLE
fix: improve derived_references_self error message with debugging context

### DIFF
--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -36,6 +36,8 @@ See the [migration guide](/docs/svelte/v5-migration-guide#Components-are-no-long
 
 > A derived value cannot reference itself recursively
 
+> A derived value `%label%` cannot reference itself recursively
+
 ## each_key_duplicate
 
 > Keyed each block has duplicate key at indexes %a% and %b%

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -112,11 +112,14 @@ export function component_api_invalid_new(component, name) {
 
 /**
  * A derived value cannot reference itself recursively
+ * @param {string | undefined | null} [label]
  * @returns {never}
  */
-export function derived_references_self() {
+export function derived_references_self(label) {
 	if (DEV) {
-		const error = new Error(`derived_references_self\nA derived value cannot reference itself recursively\nhttps://svelte.dev/e/derived_references_self`);
+		const error = new Error(`derived_references_self\n${label
+			? `The derived \`${label}\` cannot reference itself recursively`
+			: `A derived value cannot reference itself recursively`}\nhttps://svelte.dev/e/derived_references_self`);
 
 		error.name = 'Svelte error';
 

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -359,7 +359,7 @@ export function execute_derived(derived) {
 		set_eager_effects(new Set());
 		try {
 			if (includes.call(stack, derived)) {
-				e.derived_references_self();
+				e.derived_references_self(derived.label);
 			}
 
 			stack.push(derived);


### PR DESCRIPTION
## What this PR does

Improves the `derived_references_self` runtime error message to include the derived value label when available, helping developers identify which derived value is self-referencing.

## Why

When a derived value references itself recursively, Svelte throws a generic error:
```
A derived value cannot reference itself recursively
```

This gives no hint about *which* derived value is the problem. In components with many derived values, developers must add `console.log` statements or step through code to find the culprit.

## Changes

- Added an optional `label` parameter to the `derived_references_self` error function in `packages/svelte/messages/client-errors/errors.md` and the generated `errors.js`
- When a derived has a label (e.g. from `async_derived` or `$props()`), the error message now includes it: `The derived \`myValue\` cannot reference itself recursively`
- When no label is available, the original generic message is preserved for backward compatibility
- Updated the call site in `deriveds.js` to pass `derived.label` to the error function