### PR TITLE
fix: improve compiler error message clarity

### DIFF
--- a/packages/svelte/messages/compile-errors/script.md
+++ b/packages/svelte/messages/compile-errors/script.md
@@ -4,7 +4,7 @@
 
 ## constant_assignment
 
-> Cannot assign to %thing%
+> Cannot assign to `%thing%`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state
 
 ## constant_binding
 

--- a/packages/svelte/src/compiler/errors.js
+++ b/packages/svelte/src/compiler/errors.js
@@ -93,7 +93,7 @@ export function bindable_invalid_location(node) {
  * @returns {never}
  */
 export function constant_assignment(node, thing) {
-	e(node, 'constant_assignment', `Cannot assign to ${thing}\nhttps://svelte.dev/e/constant_assignment`);
+	e(node, 'constant_assignment', `Cannot assign to `${thing}`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state\nhttps://svelte.dev/e/constant_assignment`);
 }
 
 /**

--- a/packages/svelte/tests/compiler-errors/samples/legacy-no-const-assignment/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/legacy-no-const-assignment/_config.js
@@ -3,6 +3,6 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'constant_assignment',
-		message: 'Cannot assign to constant'
+		message: 'Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state'
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/legacy-no-const-update/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/legacy-no-const-update/_config.js
@@ -3,6 +3,6 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'constant_assignment',
-		message: 'Cannot assign to constant'
+		message: 'Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state'
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/runes-no-const-assignment/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-no-const-assignment/_config.js
@@ -3,6 +3,6 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'constant_assignment',
-		message: 'Cannot assign to constant'
+		message: 'Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state'
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/runes-no-const-update/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-no-const-update/_config.js
@@ -3,6 +3,6 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'constant_assignment',
-		message: 'Cannot assign to constant'
+		message: 'Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state'
 	}
 });

--- a/packages/svelte/tests/validator/samples/assignment-to-const-2/errors.json
+++ b/packages/svelte/tests/validator/samples/assignment-to-const-2/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "constant_assignment",
-		"message": "Cannot assign to constant",
+		"message": "Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state",
 		"start": {
 			"line": 13,
 			"column": 24

--- a/packages/svelte/tests/validator/samples/assignment-to-const-3/errors.json
+++ b/packages/svelte/tests/validator/samples/assignment-to-const-3/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "constant_assignment",
-		"message": "Cannot assign to constant",
+		"message": "Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state",
 		"start": {
 			"line": 14,
 			"column": 3

--- a/packages/svelte/tests/validator/samples/assignment-to-const-4/errors.json
+++ b/packages/svelte/tests/validator/samples/assignment-to-const-4/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "constant_assignment",
-		"message": "Cannot assign to constant",
+		"message": "Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state",
 		"start": {
 			"line": 17,
 			"column": 2

--- a/packages/svelte/tests/validator/samples/assignment-to-const-5/errors.json
+++ b/packages/svelte/tests/validator/samples/assignment-to-const-5/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "constant_assignment",
-		"message": "Cannot assign to constant",
+		"message": "Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state",
 		"start": {
 			"line": 3,
 			"column": 1

--- a/packages/svelte/tests/validator/samples/assignment-to-const-7/errors.json
+++ b/packages/svelte/tests/validator/samples/assignment-to-const-7/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "constant_assignment",
-		"message": "Cannot assign to constant",
+		"message": "Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state",
 		"start": {
 			"line": 3,
 			"column": 1

--- a/packages/svelte/tests/validator/samples/assignment-to-const/errors.json
+++ b/packages/svelte/tests/validator/samples/assignment-to-const/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "constant_assignment",
-		"message": "Cannot assign to constant",
+		"message": "Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state",
 		"start": {
 			"line": 16,
 			"column": 2

--- a/packages/svelte/tests/validator/samples/const-tag-readonly-1/errors.json
+++ b/packages/svelte/tests/validator/samples/const-tag-readonly-1/errors.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "constant_assignment",
-		"message": "Cannot assign to constant",
+		"message": "Cannot assign to `constant`. If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state",
 		"start": {
 			"line": 7,
 			"column": 26


### PR DESCRIPTION
## What this PR does

Improves the `constant_assignment` compiler error message to include actionable guidance for developers.

## Why

The previous message "Cannot assign to constant" gave developers no direction on how to fix the issue. Developers encountering this error for the first time might not know that they need to use `let` instead of `const`, or `$state()` for reactive state in runes mode.

## Changes

- Improved `constant_assignment` error message to include guidance: "If the variable needs to be reassigned, declare it with `let` or use `$state()` for reactive state"
- Updated all corresponding test files to match the new message format