### PR TITLE
fix: improve reactivity error message with context

### DIFF
--- a/documentation/docs/98-reference/.generated/client-errors.md
+++ b/documentation/docs/98-reference/.generated/client-errors.md
@@ -49,8 +49,21 @@ See the [migration guide](/docs/svelte/v5-migration-guide#Components-are-no-long
 ### derived_references_self
 
 ```
-A derived value cannot reference itself recursively
+A `$derived` or `$derived.by` expression read its own value during evaluation, creating a cycle
 ```
+
+This happens when a derived value references itself, directly or through a chain of other derived values that leads back to the original. The evaluation cannot proceed because it would loop forever.
+
+```js
+// direct self-reference
+let doubled = $derived(doubled * 2);
+
+// indirect cycle
+let a = $derived(b + 1);
+let b = $derived(a + 1);
+```
+
+To fix this, make sure the derived expression only reads state (`$state`) or other derived values that do not form a cycle with it.
 
 ### each_key_duplicate
 

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -34,7 +34,20 @@ See the [migration guide](/docs/svelte/v5-migration-guide#Components-are-no-long
 
 ## derived_references_self
 
-> A derived value cannot reference itself recursively
+> A `$derived` or `$derived.by` expression read its own value during evaluation, creating a cycle
+
+This happens when a derived value references itself, directly or through a chain of other derived values that leads back to the original. The evaluation cannot proceed because it would loop forever.
+
+```js
+// direct self-reference
+let doubled = $derived(doubled * 2);
+
+// indirect cycle
+let a = $derived(b + 1);
+let b = $derived(a + 1);
+```
+
+To fix this, make sure the derived expression only reads state (`$state`) or other derived values that do not form a cycle with it.
 
 ## each_key_duplicate
 

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -111,12 +111,12 @@ export function component_api_invalid_new(component, name) {
 }
 
 /**
- * A derived value cannot reference itself recursively
+ * A `$derived` or `$derived.by` expression read its own value during evaluation, creating a cycle
  * @returns {never}
  */
 export function derived_references_self() {
 	if (DEV) {
-		const error = new Error(`derived_references_self\nA derived value cannot reference itself recursively\nhttps://svelte.dev/e/derived_references_self`);
+		const error = new Error(`derived_references_self\nA \`$derived\` or \`$derived.by\` expression read its own value during evaluation, creating a cycle\nhttps://svelte.dev/e/derived_references_self`);
 
 		error.name = 'Svelte error';
 


### PR DESCRIPTION
## What
Improves a reactivity error message to include more debugging context.

## Why
Vague error messages slow down debugging. Adding context helps developers fix issues faster.

NO EM DASHES.