### PR TITLE
fix: improve DOM error message

### DIFF
--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -149,7 +149,28 @@ This can happen if you render a hydratable on the client that was not rendered o
 
 ## hydration_failed
 
-> Failed to hydrate the application
+> Hydration failed because the server-rendered HTML does not match what the client expected
+
+> Hydration failed because the server-rendered HTML does not match what the client expected. The original error was: %cause%
+
+Hydration fails when the DOM produced during server-side rendering cannot be reconciled with the client component tree. Common causes include:
+
+- Using browser-only APIs (e.g. `window`, `document`, `localStorage`) during server-side rendering
+- Rendering conditional content based on the environment (e.g. `{#if typeof window !== "undefined"}`)
+- Timestamps or random values that differ between server and client renders
+- Browser extensions (e.g. translation tools) that modify the server-rendered HTML before hydration
+
+To investigate, check the warnings in your browser console. To recover gracefully by falling back to client-side rendering, pass `recover: true` to `hydrate`:
+
+```js
+import { hydrate } from 'svelte';
+import App from './App.svelte';
+
+const app = hydrate(App, {
+	target: document.getElementById('app')!,
+	recover: true
+});
+```
 
 ## invalid_snippet
 

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -330,12 +330,15 @@ export function hydratable_missing_but_required(key) {
 }
 
 /**
- * Failed to hydrate the application
+ * Hydration failed because the server-rendered HTML does not match what the client expected. The original error was: %cause%
+ * @param {string | undefined | null} [cause]
  * @returns {never}
  */
-export function hydration_failed() {
+export function hydration_failed(cause) {
 	if (DEV) {
-		const error = new Error(`hydration_failed\nFailed to hydrate the application\nhttps://svelte.dev/e/hydration_failed`);
+		const error = new Error(`hydration_failed\n${cause
+			? `Hydration failed because the server-rendered HTML does not match what the client expected. The original error was: ${cause}`
+			: 'Hydration failed because the server-rendered HTML does not match what the client expected'}\nhttps://svelte.dev/e/hydration_failed`);
 
 		error.name = 'Svelte error';
 

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -135,7 +135,7 @@ export function hydrate(component, options) {
 		}
 
 		if (options.recover === false) {
-			e.hydration_failed();
+			e.hydration_failed(error !== HYDRATION_ERROR ? String(error) : undefined);
 		}
 
 		// If an error occurred above, the operations might not yet have been initialised.


### PR DESCRIPTION
## What
Improves the `hydration_failed` error message from the vague "Failed to hydrate the application" to a descriptive message that explains the server/client HTML mismatch, lists common causes, shows how to pass the original error as context, and documents the `recover: true` option for graceful fallback.

## Why
The previous message gave developers no information about what went wrong or how to investigate. The improved message includes the actual error when available, common causes (browser-only APIs, environment-conditional rendering, timestamps, browser extensions), and a code example showing how to fall back to client-side rendering.

NO EM DASHES.