### PR TITLE
fix: parse declaration tags with a division operator in the initializer

### DIFF
--- a/.changeset/declaration-tag-division.md
+++ b/.changeset/declaration-tag-division.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: parse declaration tags whose initializer contains a division operator (e.g. `{const ratio = width / height}`)

--- a/.changeset/declaration-tag-division.md
+++ b/.changeset/declaration-tag-division.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: parse declaration tags whose initializer contains a division operator (e.g. `{const ratio = width / height}`)
+fix: parse declaration tag contents more robustly

--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -106,15 +106,12 @@ export function parse_expression_at(parser, source, index) {
  */
 export function parse_statement_at(parser, source, index) {
 	// cast to `any`: acorn's Parser constructor and parseStatement/nextToken aren't in its public types
-	const ParserClass = /** @type {any} */ (parser.ts ? TSParser : JSParser);
+	const acorn = /** @type {any} */ (parser.ts ? TSParser : JSParser);
 	const { onComment, add_comments } = get_comment_handlers(source, parser.root.comments, index);
 
 	try {
-		// Parse a single statement starting at `index` with acorn's own parser, so the statement
-		// boundary is decided by the JS grammar rather than by scanning for a matching bracket.
-		// acorn then handles `/` (division vs regex), comments, keywords, TS annotations,
-		// destructuring and multi-declarator declarations.
-		const p = new ParserClass(
+		// This is like parseExpressionAt but for statements
+		const p = new acorn(
 			{ onComment, sourceType: 'module', ecmaVersion: 16, locations: true },
 			source,
 			index

--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -121,10 +121,13 @@ export function parse_statement_at(parser, source, index) {
 		);
 		p.nextToken();
 		const statement = /** @type {Statement} */ (p.parseStatement(null, true, Object.create(null)));
-		add_comments(statement);
+		add_comments(/** @type {acorn.Node} */ (statement));
 		return statement;
-	} catch (e) {
-		handle_parse_error(e);
+	} catch (err) {
+		// A statement that runs to the end of the source (e.g. an unterminated declaration tag)
+		// is an EOF, not a stray token; preserve the friendlier `unexpected_eof` diagnostic.
+		if (/** @type {any} */ (err).pos === source.length) e.unexpected_eof(source.length);
+		handle_parse_error(err);
 	}
 }
 

--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -5,7 +5,6 @@ import * as acorn from 'acorn';
 import { walk } from 'zimmerframe';
 import { tsPlugin } from '@sveltejs/acorn-typescript';
 import * as e from '../../errors.js';
-import { find_matching_bracket } from './utils/bracket.js';
 
 const JSParser = acorn.Parser;
 const TSParser = JSParser.extend(tsPlugin());
@@ -106,35 +105,23 @@ export function parse_expression_at(parser, source, index) {
  * @returns {Statement}
  */
 export function parse_statement_at(parser, source, index) {
-	const acorn = parser.ts ? TSParser : JSParser;
-	let end = find_matching_bracket(source, index, '{');
-	if (end === undefined) e.unexpected_eof(source.length);
-
-	while (source[end - 1] === ';') {
-		end -= 1;
-	}
-
-	const padded_source = `${' '.repeat(index)}${source.slice(index, end)}`;
-	const { onComment, add_comments } = get_comment_handlers(
-		padded_source,
-		parser.root.comments,
-		index
-	);
+	// cast to `any`: acorn's Parser constructor and parseStatement/nextToken aren't in its public types
+	const ParserClass = /** @type {any} */ (parser.ts ? TSParser : JSParser);
+	const { onComment, add_comments } = get_comment_handlers(source, parser.root.comments, index);
 
 	try {
-		const ast = acorn.parse(padded_source, {
-			onComment,
-			sourceType: 'module',
-			ecmaVersion: 16,
-			locations: true
-		});
-
-		add_comments(ast);
-
-		const statement = /** @type {Statement} */ (
-			/** @type {unknown} */ (/** @type {Program} */ (ast).body[0])
+		// Parse a single statement starting at `index` with acorn's own parser, so the statement
+		// boundary is decided by the JS grammar rather than by scanning for a matching bracket.
+		// acorn then handles `/` (division vs regex), comments, keywords, TS annotations,
+		// destructuring and multi-declarator declarations.
+		const p = new ParserClass(
+			{ onComment, sourceType: 'module', ecmaVersion: 16, locations: true },
+			source,
+			index
 		);
-		statement.end = Math.min(/** @type {number} */ (statement.end), end);
+		p.nextToken();
+		const statement = /** @type {Statement} */ (p.parseStatement(null, true, Object.create(null)));
+		add_comments(statement);
 		return statement;
 	} catch (e) {
 		handle_parse_error(e);

--- a/packages/svelte/tests/print/samples/declaration-tag-division/input.svelte
+++ b/packages/svelte/tests/print/samples/declaration-tag-division/input.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	let visible = true;
+	let total = 10;
+	let width = 16;
+	let height = 9;
+	let divisor = 2;
+	let options: { fallback?: number } = {};
+</script>
+
+{#if visible}
+	{const half = total / 2}
+	{let derived = $derived(total / 4)}
+	{const member = width / height}
+	{const call = Math.max(total, 1) / 2}
+	{const string_then_division = 'ab' / divisor}
+	{const typed: number = total / 2}
+	{const { fallback = total / 2 } = options}
+	{const regex = /[}]/}
+	<p>{half} {derived} {member} {call} {string_then_division} {typed} {fallback} {regex}</p>
+{/if}

--- a/packages/svelte/tests/print/samples/declaration-tag-division/output.svelte
+++ b/packages/svelte/tests/print/samples/declaration-tag-division/output.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	let visible = true;
+	let total = 10;
+	let width = 16;
+	let height = 9;
+	let divisor = 2;
+	let options: { fallback?: number } = {};
+</script>
+
+{#if visible}
+	{const half = total / 2}
+	{let derived = $derived(total / 4)}
+	{const member = width / height}
+	{const call = Math.max(total, 1) / 2}
+	{const string_then_division = 'ab' / divisor}
+	{const typed: number = total / 2}
+	{const { fallback = total / 2 } = options}
+	{const regex = /[}]/}
+	<p>{half} {derived} {member} {call} {string_then_division} {typed} {fallback} {regex}</p>
+{/if}


### PR DESCRIPTION
`{const ratio = width / height}`, or any declaration tag with a top-level `/` in its initializer, currently fails to compile with `unexpected_eof`.

`parse_statement_at` figures out where the statement ends with `find_matching_bracket`, and that scanner treats every `/` as the start of a regex literal, so it skips past the real `}` and runs to the next unrelated `/` or EOF. `{@const}` isn't affected because it reads its initializer through acorn's `parseExpressionAt`, which knows a `/` after a value is division.

This parses the declaration with acorn directly instead, so acorn decides regex-vs-division (and handles comments, keywords, TS annotations, destructuring and multi-declarator declarations) and reports the real statement end. `find_matching_bracket` is unchanged and still used by the loose-parsing paths.

Added a `print` test sample (`declaration-tag-division`) covering top-level division, `$derived(a / b)`, member/call/string operands, a TS type annotation and a destructuring default, plus a regex containing `}` (`/[}]/`). On `main` the division cases throw `unexpected_eof`; with the fix the sample parses and round-trips. The regex case matters: a regex containing `}` is exactly what a weaker fix would misread as the tag close.
