### PR TITLE
docs: fix invalid `rows` CSS property in {#each} chess-board example

### DIFF
--- a/documentation/docs/03-template-syntax/03-each.md
+++ b/documentation/docs/03-template-syntax/03-each.md
@@ -106,7 +106,7 @@ In case you just want to render something `n` times, you can omit the `as` part:
 	.chess-board {
 		display: grid;
 		grid-template-columns: repeat(8, 1fr);
-		rows: repeat(8, 1fr);
+		grid-template-rows: repeat(8, 1fr);
 		border: 1px solid black;
 		aspect-ratio: 1;
 


### PR DESCRIPTION
## Problem

The `{#each}` docs page has a runnable "chess board" example whose `<style>` block uses an invalid CSS property:

```css
.chess-board {
	display: grid;
	grid-template-columns: repeat(8, 1fr);
	rows: repeat(8, 1fr);   /* ← not a real CSS property */
	...
}
```

There is no `rows` shorthand or longhand in CSS, so this line is silently dropped by every browser. The example clearly intends an 8×8 grid (note the matching `grid-template-columns` line directly above).

## Fix

`rows` → `grid-template-rows`. One line, in `documentation/docs/03-template-syntax/03-each.md`. No prose changes.
