### PR TITLE
fix: add bigint to Primitive type for $state.snapshot

### DIFF
--- a/.changeset/some-parts-watch.md
+++ b/.changeset/some-parts-watch.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: type BigInts in `$state.snapshot(...)` return values

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -24,7 +24,7 @@ declare function $state<T>(initial: T): T;
 declare function $state<T>(): T | undefined;
 
 declare namespace $state {
-	type Primitive = string | number | boolean | null | undefined;
+	type Primitive = string | number | bigint | boolean | null | undefined;
 
 	type TypedArray =
 		| Int8Array

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -3229,7 +3229,7 @@ declare function $state<T>(initial: T): T;
 declare function $state<T>(): T | undefined;
 
 declare namespace $state {
-	type Primitive = string | number | boolean | null | undefined;
+	type Primitive = string | number | bigint | boolean | null | undefined;
 
 	type TypedArray =
 		| Int8Array


### PR DESCRIPTION
Fixes #18385

  ## Problem

  `$state.snapshot` infers BigInt properties as `never` because `bigint` is missing
  from the `Primitive` type definition. BigInt is a valid JavaScript primitive and is
  supported by `structuredClone`.

  ## Solution

  Added `bigint` to the `Primitive` type in both `packages/svelte/src/ambient.d.ts` and
  `packages/svelte/types/index.d.ts`.

  ## Before

  ```ts
  const object = $state({ number: 1n });
  const snapshot = $state.snapshot(object);
  // snapshot.number is inferred as never ❌

  After

  const object = $state({ number: 1n });
  const snapshot = $state.snapshot(object);
  // snapshot.number is correctly inferred as bigint ✅

  Tests and linting

  - [x] This is a type-only change, no runtime behavior affected