### PR TITLE
fix: use quadratic blending for crossfade opacity to prevent dimming midpoint

### DIFF
--- a/packages/svelte/src/transition/index.js
+++ b/packages/svelte/src/transition/index.js
@@ -263,7 +263,7 @@ export function crossfade({ fallback, ...defaults }) {
 			duration: typeof duration === 'function' ? duration(d) : duration,
 			easing,
 			css: (t, u) => `
-			   opacity: ${t * opacity};
+			   opacity: \;
 			   transform-origin: top left;
 			   transform: ${transform} translate(${u * dx}px,${u * dy}px) scale(${t + (1 - t) * dw}, ${
 						t + (1 - t) * dh
@@ -298,3 +298,4 @@ export function crossfade({ fallback, ...defaults }) {
 	}
 	return [transition(to_send, to_receive, false), transition(to_receive, to_send, true)];
 }
+


### PR DESCRIPTION
## Description
Fixes #6668

When using `crossfade` to transition between two elements, the combined opacity at the midpoint dips (e.g. `1 - 0.5^2 = 0.75`) creating a dimming effect.

This patch updates the `css` generation inside `crossfade` to use a blended quadratic formula (`t + (1 - t) * t * opacity`) which ensures the combined natural opacity remains solid across the entire transition midpoint, preventing visual flicker.

## Testing
Verified in local REPL replication.