### PR TITLE
fix: ensure default slot is created for custom elements when no initial children exist

### DIFF
--- a/.changeset/fix-custom-element-default-slot.md
+++ b/.changeset/fix-custom-element-default-slot.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: always create default slot for custom elements even if no initial children are passed

--- a/packages/svelte/src/internal/client/dom/elements/custom-element.js
+++ b/packages/svelte/src/internal/client/dom/elements/custom-element.js
@@ -114,7 +114,7 @@ if (typeof HTMLElement === 'function') {
 				const $$slots = {};
 				const existing_slots = get_custom_elements_slots(this);
 				for (const name of this.$$s) {
-					if (name in existing_slots) {
+					if (name === 'default' || name in existing_slots) {
 						if (name === 'default' && !this.$$d.children) {
 							this.$$d.children = create_slot(name);
 							$$slots.default = true;


### PR DESCRIPTION
## Description
Fixes #13638

Currently in Svelte 5, if a custom element is created without passing any initial child elements, the default `<slot>` tag fails to be constructed internally. As a result, dynamically injecting children into the custom element later on fails to render them because the slot dictionary is missing the default target.

This patch modifies `custom-element.js`. Previously, the loop iterated over existing slots via `if (name in existing_slots)`. If no children were initially passed, the default slot was never created. This surgical fix changes the condition to `if (name === 'default' || name in existing_slots)`, ensuring that if the component explicitly declares a default slot via `this.___BEGIN___COMMAND_DONE_MARKER___$LASTEXITCODEs`, it will always be created regardless of the initial DOM state.

## Testing
Included a changeset tracking the patch.