### PR TITLE
docs: fix await_waterfall workaround — eager const instead of lazy $derived

### DIFF
--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -93,18 +93,20 @@ let b = $derived(await two());
 
 (Note that if the values of `await one()` and `await two()` subsequently change, they can do so concurrently — the waterfall only occurs when the deriveds are first created.)
 
-You can solve this by creating the promises first and _then_ awaiting them:
+If the functions do not depend on reactive state, you can solve this by calling them eagerly (without `$derived`) so both promises start immediately:
 
 ```js
 async function one() { return 1 }
 async function two() { return 2 }
 // ---cut---
-let aPromise = $derived(one());
-let bPromise = $derived(two());
+const aPromise = one();
+const bPromise = two();
 
 let a = $derived(await aPromise);
 let b = $derived(await bPromise);
 ```
+
+Note that using `$derived(one())` for the promises does _not_ help — `$derived` is lazy, so `one()` and `two()` would still be called sequentially when `a` and `b` are first evaluated. Plain `const` assignments call the functions immediately, before either `$derived` is evaluated.
 
 ## binding_property_non_reactive
 


### PR DESCRIPTION
## Summary

Closes #16483

The `await_waterfall` warning documentation suggested using `$derived(one())` to start promises before awaiting them. This does **not** actually eliminate the waterfall because `$derived` is lazy — `one()` and `two()` are still called sequentially when the await-deriveds first read `aPromise` and `bPromise`.

The correct approach for functions that don't depend on reactive state is to use plain `const` assignments, which call the functions immediately (before either `$derived` is evaluated):

```js
// ✅ both promises start immediately
const aPromise = one();
const bPromise = two();

let a = $derived(await aPromise);
let b = $derived(await bPromise);
```

This PR updates the warning docs to use `const` instead of `$derived` for the promise variables, and adds an explanatory note about why `$derived` doesn't help here.

## Changes

- `packages/svelte/messages/client-warnings/warnings.md`: fix workaround example and add clarifying note

## Test plan
- [ ] Docs-only change; no runtime behaviour modified
- [ ] Example verified: plain `const` assignments start both promises before the `$derived` expressions evaluate