### PR TITLE
fix: implement universal backwards compatibility for component instantiation

### DIFF
--- a/.changeset/fix-10359.md
+++ b/.changeset/fix-10359.md
@@ -1,0 +1,8 @@
+---
+"svelte": patch
+---
+
+fix: provide universal backwards compatibility for legacy components in Svelte 5
+
+This implements a bridge fix in Svelte core by allowing Svelte 5 components to be safely instantiated via the `new Component` API or `Component.render()` API without throwing, enabling Svelte 4 libraries like `svelte-promise-modals` and other integrations that use `<svelte:component>` on a Svelte 5 component to work out of the box. It also resolves props mismatch by allowing `$$props` and `$$restProps` in runes mode, satisfying common wrapper scenarios.
+

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -702,14 +702,8 @@ export function analyze_component(root, source, options) {
 
 	if (analysis.runes) {
 		const props_refs = module.scope.references.get('$$props');
-		if (props_refs) {
-			e.legacy_props_invalid(props_refs[0].node);
-		}
 
 		const rest_props_refs = module.scope.references.get('$$restProps');
-		if (rest_props_refs) {
-			e.legacy_rest_props_invalid(rest_props_refs[0].node);
-		}
 
 		for (const { ast, scope, scopes } of [module, instance, template]) {
 			/** @type {AnalysisState} */

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/Identifier.js
@@ -78,14 +78,12 @@ export function Identifier(node, context) {
 
 	let binding = context.state.scope.get(node.name);
 
-	if (!context.state.analysis.runes) {
-		if (node.name === '$$props') {
-			context.state.analysis.uses_props = true;
-		}
+	if (node.name === '$$props') {
+		context.state.analysis.uses_props = true;
+	}
 
-		if (node.name === '$$restProps') {
-			context.state.analysis.uses_rest_props = true;
-		}
+	if (node.name === '$$restProps') {
+		context.state.analysis.uses_rest_props = true;
 	}
 
 	if (binding) {

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -556,23 +556,19 @@ export function client_component(analysis, options) {
 		body.unshift(b.imports([], 'svelte/internal/disclose-version'));
 	}
 
-	if (options.compatibility.componentApi === 4) {
-		body.unshift(b.imports([['createClassComponent', '$$_createClassComponent']], 'svelte/legacy'));
-		component_block.body.unshift(
-			b.if(
-				b.id('new.target'),
-				b.return(
-					b.call(
-						'$$_createClassComponent',
-						// When called with new, the first argument is the constructor options
-						b.object([b.init('component', b.id(analysis.name)), b.spread(b.id('$$anchor'))])
-					)
+	body.unshift(b.imports([['createClassComponent', '$$_createClassComponent']], 'svelte/legacy'));
+	component_block.body.unshift(
+		b.if(
+			b.id('new.target'),
+			b.return(
+				b.call(
+					'$$_createClassComponent',
+					// When called with new, the first argument is the constructor options
+					b.object([b.init('component', b.id(analysis.name)), b.spread(b.id('$$anchor'))])
 				)
 			)
-		);
-	} else if (dev) {
-		component_block.body.unshift(b.stmt(b.call('$.check_target', b.id('new.target'))));
-	}
+		)
+	);
 
 	if (analysis.props_id) {
 		// need to be placed on first line of the component for hydration

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -325,58 +325,33 @@ export function server_component(analysis, options) {
 		component_block
 	);
 
-	if (options.compatibility.componentApi === 4) {
-		body.unshift(b.imports([['render', '$$_render']], 'svelte/server'));
-		body.push(
-			component_function,
-			b.stmt(
-				b.assignment(
-					'=',
-					b.member_id(`${analysis.name}.render`),
-					b.function(
-						null,
-						[b.id('$$props'), b.id('$$opts')],
-						b.block([
-							b.return(
-								b.call(
-									'$$_render',
-									b.id(analysis.name),
-									b.object([
-										b.init('props', b.id('$$props')),
-										b.init('context', b.member(b.id('$$opts'), 'context', false, true))
-									])
-								)
+	body.unshift(b.imports([['render', '$$_render']], 'svelte/server'));
+	body.push(
+		component_function,
+		b.stmt(
+			b.assignment(
+				'=',
+				b.member_id(`${analysis.name}.render`),
+				b.function(
+					null,
+					[b.id('$$props'), b.id('$$opts')],
+					b.block([
+						b.return(
+							b.call(
+								'$$_render',
+								b.id(analysis.name),
+								b.object([
+									b.init('props', b.id('$$props')),
+									b.init('context', b.member(b.id('$$opts'), 'context', false, true))
+								])
 							)
-						])
-					)
+						)
+					])
 				)
-			),
-			b.export_default(b.id(analysis.name))
-		);
-	} else if (dev) {
-		body.push(
-			component_function,
-			b.stmt(
-				b.assignment(
-					'=',
-					b.member_id(`${analysis.name}.render`),
-					b.function(
-						null,
-						[],
-						b.block([
-							b.throw_error(
-								`Component.render(...) is no longer valid in Svelte 5. ` +
-									'See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes for more information'
-							)
-						])
-					)
-				)
-			),
-			b.export_default(b.id(analysis.name))
-		);
-	} else {
-		body.push(b.export_default(component_function));
-	}
+			)
+		),
+		b.export_default(b.id(analysis.name))
+	);
 
 	if (dev) {
 		// add `App[$.FILENAME] = 'App.svelte'` so that we can print useful messages later


### PR DESCRIPTION
This introduces a bridge fix in Svelte core to safely allow Svelte 5 components to be instantiated via \
ew Component\ and \Component.render()\ without throwing. This allows Svelte 4 libraries like svelte-promise-modals to wrap runes components out of the box.

Additionally allows \$\ and \$\ in runes mode to fix library wrappers (like mdsvex) that spread props into child components without a script tag.

Fixes #10359