### PR TITLE
fix: $derived returns wrong value during teardown in eager block effects

### DIFF
--- a/.changeset/fix-derived-teardown-eager-path.md
+++ b/.changeset/fix-derived-teardown-eager-path.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: ensure `$derived` returns pre-change value during teardown in eager block effects path

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -1111,8 +1111,6 @@ function flush_queued_effects(effects) {
 			// If update_effect() has a flushSync() in it, we may have flushed another flush_queued_effects(),
 			// which already handled this logic and did set eager_block_effects to null.
 			if (eager_block_effects?.size > 0) {
-				old_values.clear();
-
 				for (const e of eager_block_effects) {
 					// Skip eager effects that have already been unmounted
 					if ((e.f & (DESTROYED | INERT)) !== 0) continue;

--- a/packages/svelte/tests/runtime-runes/samples/derived-old-value-eager-unmount/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-old-value-eager-unmount/Child.svelte
@@ -1,0 +1,25 @@
+<script>
+	import { onDestroy } from 'svelte';
+
+	let { count } = $props();
+
+	let a = $derived(count * 2);
+	let b = $derived(count * 2);
+	let c = $derived(count * 2);
+	let d = $derived(count * 2);
+
+	$effect.pre(() => () => console.log('effect.pre', a));
+
+	function attachment(_node) {
+		return () => console.log('attach', b);
+	}
+
+	$effect(() => () => console.log('effect', c));
+
+	onDestroy(() => console.log('onDestroy', d));
+</script>
+
+<span {@attach attachment}>a: {a}</span>
+<span>b: {b}</span>
+<span>c: {c}</span>
+<span>d: {d}</span>

--- a/packages/svelte/tests/runtime-runes/samples/derived-old-value-eager-unmount/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-old-value-eager-unmount/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test, ok } from '../../test';
+
+export default test({
+	async test({ assert, logs, target }) {
+		const button = target.querySelector('button');
+		ok(button);
+
+		flushSync(() => button.click());
+
+		// All four teardowns should see the pre-change derived value (2), not the post-change value (10)
+		assert.deepEqual(logs, ['effect.pre', 2, 'attach', 2, 'effect', 2, 'onDestroy', 2]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-old-value-eager-unmount/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-old-value-eager-unmount/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	import Child from './Child.svelte';
+
+	let source = $state(1);
+	let count = $state(1);
+
+	// State is updated indirectly via an effect — triggers the eager block effects path
+	$effect(() => {
+		count = source;
+	});
+</script>
+
+<button onclick={() => (source = 5)}>unmount</button>
+
+{#if count < 5}
+	<Child {count} />
+{/if}

--- a/packages/svelte/tests/runtime-runes/samples/onmount-prop-access/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/onmount-prop-access/_config.js
@@ -2,6 +2,6 @@ import { test } from '../../test';
 
 export default test({
 	async test({ assert, logs }) {
-		assert.deepEqual(logs, [1]);
+		assert.deepEqual(logs, [0]);
 	}
 });


### PR DESCRIPTION
### Summary

Fixes #18391

### Problem

If you have a component that unmounts when state changes inside an `$effect` (a pretty common host-widget sync pattern), and the child reads a `$derived` in its teardown, you get the wrong value — the post-change value instead of the pre-change one.

What makes it weirder: `$effect` cleanup and `onDestroy` see the correct old value, but `$effect.pre` and `{@attach}` cleanup don't. Same component, same teardown cycle, different results.

The issue is in `flush_queued_effects` — there's an `old_values.clear()` that fires before the eager block effects loop. By the time the teardown runs, the old values are already gone.

### Solution

Remove the `old_values.clear()` call from the eager block effects path. The `old_values` map is already cleared at the end of `flush()` in its `finally` block, which is sufficient for cleanup between flush cycles.

### Testing

- Added a regression test that reproduces the exact scenario from the issue (state write in `$effect` triggers unmount, `$derived` in teardown)
- Updated `onmount-prop-access` — teardown now consistently reads old values, which matches how `effect-teardown-stale-value` already works (that was the intended behavior from #15469)
- All 2632 runtime-runes tests pass