### PR TITLE
docs: replace N-ary times `⨉` with multiplication sign `×`

### DIFF
--- a/documentation/docs/03-template-syntax/11-declaration-tags.md
+++ b/documentation/docs/03-template-syntax/11-declaration-tags.md
@@ -13,7 +13,7 @@ Declaration tags define local variables inside markup with `const` or `let`:
 
 {#each boxes as box}
 	{const area = box.width * box.height}
-	{const label = `${box.width} ⨉ ${box.height} = ${area}`}
+	{const label = `${box.width} × ${box.height} = ${area}`}
 
 	<p>{label}</p>
 {/each}


### PR DESCRIPTION
Replaces the incorrect N-Ary Times Operator `⨉` (U+2A09) with the correct Multiplication Sign `×` (U+00D7) in the box dimension label. Former is intended for mathematical set theory and type theory contexts. For physical dimensions (width × height), `×` is the correct symbol.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
