### PR TITLE
fix: avoid compiler crash on `<select value>` with a sibling block

### DIFF
--- a/.changeset/select-static-value-static-element.md
+++ b/.changeset/select-static-value-static-element.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: don't treat a `<select>` with a static `value` attribute as a static element

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/fragment.js
@@ -171,6 +171,10 @@ export function is_static_element(node) {
 			return false;
 		}
 
+		if (node.name === 'select' && attribute.name === 'value') {
+			return false;
+		}
+
 		// We need to apply src and loading after appending the img to the DOM for lazy loading to work
 		if (node.name === 'img' && attribute.name === 'loading') {
 			return false;

--- a/packages/svelte/tests/runtime-runes/samples/select-static-value-with-sibling-block/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/select-static-value-with-sibling-block/_config.js
@@ -1,0 +1,14 @@
+import { test } from '../../test';
+
+// A `<select>` with a static `value` attribute was wrongly treated as a static
+// element when it had a sibling block, so no element reference was created and
+// the compiler crashed while building the `__value` assignment. The select
+// should still pick the matching option.
+export default test({
+	mode: ['client'],
+	test({ assert, target }) {
+		const select = /** @type {HTMLSelectElement} */ (target.querySelector('select'));
+		assert.equal(select.value, 'b');
+		assert.equal(select.selectedIndex, 1);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/select-static-value-with-sibling-block/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/select-static-value-with-sibling-block/main.svelte
@@ -1,0 +1,5 @@
+{#if false}{/if}
+<select value="b">
+	<option>a</option>
+	<option>b</option>
+</select>


### PR DESCRIPTION
A `<select>` with a static `value` attribute crashes the compiler in client mode when it has a sibling block, e.g.:

```svelte
{#if false}{/if}
<select value="b">
	<option>a</option>
	<option>b</option>
</select>
```

This throws `TypeError: Cannot read properties of null (reading 'type')` from codegen rather than compiling. The sibling block is what routes the select through `is_static_element`, which classified it as fully static so no element reference was created for it. The regular-element visitor still needs that reference to emit the special `select.__value`/value assignment, so it ended up building `null.value = ...`.

`input`, `textarea` and `option` already opt out of the static fast path for their value attributes — `select` just needs the same. With the fix it compiles and the matching option is selected.

### Tests and linting

Added a `runtime-runes` sample that reproduces the crash and asserts the right option is selected; it fails without the fix and passes with it. Full `pnpm test`, `pnpm lint` and `pnpm check` are green. Added a changeset.