### PR TITLE
breaking: remove Safari <18 overflow workaround in transitions

### DIFF
--- a/.changeset/shiny-donuts-applaud.md
+++ b/.changeset/shiny-donuts-applaud.md
@@ -1,0 +1,5 @@
+---
+'svelte': major
+---
+
+breaking: remove Safari <18 `overflow: hidden` transition workaround

--- a/documentation/docs/07-misc/.generated/browser-support-features.md
+++ b/documentation/docs/07-misc/.generated/browser-support-features.md
@@ -5,3 +5,4 @@
 | [`$state.snapshot`](/docs/svelte/$state#$state.snapshot) | 98 | 94 | 15.4 |
 | [`bind:devicePixelContentBoxSize`](/docs/svelte/bind#Dimensions) | <span style="color: var(--sk-fg-4)">—</span> | 93 | not supported |
 | [`flip` from `svelte/animate`](/docs/svelte/svelte-animate#flip) | <span style="color: var(--sk-fg-4)">—</span> | 126 | <span style="color: var(--sk-fg-4)">—</span> |
+| [`slide` from `svelte/transition`](/docs/svelte/svelte-transition#slide) | <span style="color: var(--sk-fg-4)">—</span> | <span style="color: var(--sk-fg-4)">—</span> | 18 |

--- a/packages/svelte/scripts/generate-browser-support.ts
+++ b/packages/svelte/scripts/generate-browser-support.ts
@@ -55,7 +55,8 @@ type ConditionalRow = {
 const doc_links: Record<string, string | null> = {
 	'`$state.snapshot`': '/docs/svelte/$state#$state.snapshot',
 	'`bind:devicePixelContentBoxSize`': '/docs/svelte/bind#Dimensions',
-	'`flip` from `svelte/animate`': '/docs/svelte/svelte-animate#flip'
+	'`flip` from `svelte/animate`': '/docs/svelte/svelte-animate#flip',
+	'`slide` from `svelte/transition`': '/docs/svelte/svelte-transition#slide'
 };
 
 // Supplemental detection rules for APIs `web-features` doesn't track
@@ -100,6 +101,19 @@ register_extra_rules([
 			safari: null,
 			safari_ios: null
 		}
+	},
+	{
+		// `overflow: hidden` emitted in `slide`'s keyframes (svelte/transition).
+		// Safari only started honouring `overflow` inside Web Animations
+		// keyframes in 18 (#4712); on 14–17 the runtime used to compensate by
+		// setting `element.style.overflow = 'hidden'` for the duration of the
+		// transition, a workaround removed in #18429. `web-features` has no
+		// compat key for per-property keyframe support.
+		string_literal: 'overflow: hidden;',
+		feature_id: 'extra:keyframe-overflow-hidden',
+		name: '`slide` from `svelte/transition`',
+		baseline_year: 2024,
+		versions: { safari: '18', safari_ios: '18' }
 	}
 ]);
 
@@ -138,7 +152,8 @@ const SAFE_TO_IGNORE = new Set(['devicepixelratio', 'trusted-types']);
 const BEHAVIORAL_IGNORE = new Set([
 	'structured-clone',
 	'extra:css-zoom-read',
-	'extra:device-pixel-content-box'
+	'extra:device-pixel-content-box',
+	'extra:keyframe-overflow-hidden'
 ]);
 
 /** Aggregate ignore set — used for the headline floor. */

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -204,13 +204,6 @@ export function transition(flags, element, get_fn, get_params) {
 
 	var inert = element.inert;
 
-	/**
-	 * The default overflow style, stashed so we can revert changes during the transition
-	 * that are necessary to work around a Safari <18 bug
-	 * TODO 6.0 remove this, if older versions of Safari have died out enough
-	 */
-	var overflow = element.style.overflow;
-
 	/** @type {Animation | undefined} */
 	var intro;
 
@@ -260,8 +253,6 @@ export function transition(flags, element, get_fn, get_params) {
 					// Ensure we cancel the animation to prevent leaking
 					intro?.abort();
 					intro = current_options = undefined;
-
-					element.style.overflow = overflow;
 				}
 			);
 		},
@@ -420,27 +411,13 @@ function animate(element, options, counterpart, t2, on_begin, on_finish) {
 		var keyframes = [];
 
 		if (duration > 0) {
-			/**
-			 * Whether or not the CSS includes `overflow: hidden`, in which case we need to
-			 * add it as an inline style to work around a Safari <18 bug
-			 * TODO 6.0 remove this, if possible
-			 */
-			var needs_overflow_hidden = false;
-
 			if (css) {
 				var n = Math.ceil(duration / (1000 / 60)); // `n` must be an integer, or we risk missing the `t2` value
 
 				for (var i = 0; i <= n; i += 1) {
 					var t = t1 + delta * easing(i / n);
-					var styles = css_to_keyframe(css(t, 1 - t));
-					keyframes.push(styles);
-
-					needs_overflow_hidden ||= styles.overflow === 'hidden';
+					keyframes.push(css_to_keyframe(css(t, 1 - t)));
 				}
-			}
-
-			if (needs_overflow_hidden) {
-				/** @type {HTMLElement} */ (element).style.overflow = 'hidden';
 			}
 
 			get_t = () => {


### PR DESCRIPTION
Resolves the two `TODO 6.0` comments in `transitions.js`.

#14930 added an inline `overflow: hidden` workaround because Safari before version 18 ignored `overflow` inside Web Animations keyframes, which broke `slide` (#4712). Safari 18 shipped in September 2024 with the bug fixed, and both code paths were marked `TODO 6.0 remove this, if older versions of Safari have died out enough`.

`npx browserslist --coverage "safari < 18, ios_saf < 18"` reports 2.11% of global users today, and that number only goes down.

The browser-support page still lists Safari 14 as the floor, so this adds `slide` to the exceptions table (Safari 18) via a `register_extra_rules` entry, following the `flip` zoom precedent.

---

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it (not applicable, this removes a browser workaround that the test environment cannot exercise)
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`)

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`