### PR TITLE
fix: avoid NaN keyframe values in slide transition

### DIFF
--- a/.changeset/tough-pandas-shout.md
+++ b/.changeset/tough-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid `NaN` keyframe values in `slide` transition for elements without a layout box

--- a/packages/svelte/src/transition/index.js
+++ b/packages/svelte/src/transition/index.js
@@ -29,6 +29,18 @@ function split_css_unit(value) {
 }
 
 /**
+ * Elements without a layout box (e.g. inside a `display: none` parent) have computed
+ * dimensions like `auto` that parse to `NaN`, producing keyframe values the browser
+ * rejects (https://github.com/sveltejs/svelte/issues/14205). Treat them as `0` instead
+ * @param {string} value
+ * @returns {number}
+ */
+function parse_dimension(value) {
+	const result = parseFloat(value);
+	return Number.isNaN(result) ? 0 : result;
+}
+
+/**
  * Animates a `blur` filter alongside an element's opacity.
  *
  * @param {Element} node
@@ -116,19 +128,21 @@ export function slide(node, { delay = 0, duration = 400, easing = cubic_out, axi
 
 	const opacity = +style.opacity;
 	const primary_property = axis === 'y' ? 'height' : 'width';
-	const primary_property_value = parseFloat(style[primary_property]);
+	const primary_property_value = parse_dimension(style[primary_property]);
 	const secondary_properties = axis === 'y' ? ['top', 'bottom'] : ['left', 'right'];
 	const capitalized_secondary_properties = secondary_properties.map(
 		(e) => /** @type {'Left' | 'Right' | 'Top' | 'Bottom'} */ (`${e[0].toUpperCase()}${e.slice(1)}`)
 	);
-	const padding_start_value = parseFloat(style[`padding${capitalized_secondary_properties[0]}`]);
-	const padding_end_value = parseFloat(style[`padding${capitalized_secondary_properties[1]}`]);
-	const margin_start_value = parseFloat(style[`margin${capitalized_secondary_properties[0]}`]);
-	const margin_end_value = parseFloat(style[`margin${capitalized_secondary_properties[1]}`]);
-	const border_width_start_value = parseFloat(
+	const padding_start_value = parse_dimension(
+		style[`padding${capitalized_secondary_properties[0]}`]
+	);
+	const padding_end_value = parse_dimension(style[`padding${capitalized_secondary_properties[1]}`]);
+	const margin_start_value = parse_dimension(style[`margin${capitalized_secondary_properties[0]}`]);
+	const margin_end_value = parse_dimension(style[`margin${capitalized_secondary_properties[1]}`]);
+	const border_width_start_value = parse_dimension(
 		style[`border${capitalized_secondary_properties[0]}Width`]
 	);
-	const border_width_end_value = parseFloat(
+	const border_width_end_value = parse_dimension(
 		style[`border${capitalized_secondary_properties[1]}Width`]
 	);
 	return {

--- a/packages/svelte/src/transition/index.js
+++ b/packages/svelte/src/transition/index.js
@@ -29,15 +29,14 @@ function split_css_unit(value) {
 }
 
 /**
- * Elements without a layout box (e.g. inside a `display: none` parent) have computed
- * dimensions like `auto` that parse to `NaN`, producing keyframe values the browser
- * rejects (https://github.com/sveltejs/svelte/issues/14205). Treat them as `0` instead
- * @param {string} value
- * @returns {number}
+ * Omits unresolved dimensions rather than passing invalid values to Web Animations.
+ *
+ * @param {string} property
+ * @param {number} value
+ * @param {number} t
  */
-function parse_dimension(value) {
-	const result = parseFloat(value);
-	return Number.isNaN(result) ? 0 : result;
+function css_dimension(property, value, t) {
+	return Number.isNaN(value) ? '' : `${property}: ${t * value}px;`;
 }
 
 /**
@@ -128,21 +127,19 @@ export function slide(node, { delay = 0, duration = 400, easing = cubic_out, axi
 
 	const opacity = +style.opacity;
 	const primary_property = axis === 'y' ? 'height' : 'width';
-	const primary_property_value = parse_dimension(style[primary_property]);
+	const primary_property_value = parseFloat(style[primary_property]);
 	const secondary_properties = axis === 'y' ? ['top', 'bottom'] : ['left', 'right'];
 	const capitalized_secondary_properties = secondary_properties.map(
 		(e) => /** @type {'Left' | 'Right' | 'Top' | 'Bottom'} */ (`${e[0].toUpperCase()}${e.slice(1)}`)
 	);
-	const padding_start_value = parse_dimension(
-		style[`padding${capitalized_secondary_properties[0]}`]
-	);
-	const padding_end_value = parse_dimension(style[`padding${capitalized_secondary_properties[1]}`]);
-	const margin_start_value = parse_dimension(style[`margin${capitalized_secondary_properties[0]}`]);
-	const margin_end_value = parse_dimension(style[`margin${capitalized_secondary_properties[1]}`]);
-	const border_width_start_value = parse_dimension(
+	const padding_start_value = parseFloat(style[`padding${capitalized_secondary_properties[0]}`]);
+	const padding_end_value = parseFloat(style[`padding${capitalized_secondary_properties[1]}`]);
+	const margin_start_value = parseFloat(style[`margin${capitalized_secondary_properties[0]}`]);
+	const margin_end_value = parseFloat(style[`margin${capitalized_secondary_properties[1]}`]);
+	const border_width_start_value = parseFloat(
 		style[`border${capitalized_secondary_properties[0]}Width`]
 	);
-	const border_width_end_value = parse_dimension(
+	const border_width_end_value = parseFloat(
 		style[`border${capitalized_secondary_properties[1]}Width`]
 	);
 	return {
@@ -152,13 +149,13 @@ export function slide(node, { delay = 0, duration = 400, easing = cubic_out, axi
 		css: (t) =>
 			'overflow: hidden;' +
 			`opacity: ${Math.min(t * 20, 1) * opacity};` +
-			`${primary_property}: ${t * primary_property_value}px;` +
-			`padding-${secondary_properties[0]}: ${t * padding_start_value}px;` +
-			`padding-${secondary_properties[1]}: ${t * padding_end_value}px;` +
-			`margin-${secondary_properties[0]}: ${t * margin_start_value}px;` +
-			`margin-${secondary_properties[1]}: ${t * margin_end_value}px;` +
-			`border-${secondary_properties[0]}-width: ${t * border_width_start_value}px;` +
-			`border-${secondary_properties[1]}-width: ${t * border_width_end_value}px;` +
+			css_dimension(primary_property, primary_property_value, t) +
+			css_dimension(`padding-${secondary_properties[0]}`, padding_start_value, t) +
+			css_dimension(`padding-${secondary_properties[1]}`, padding_end_value, t) +
+			css_dimension(`margin-${secondary_properties[0]}`, margin_start_value, t) +
+			css_dimension(`margin-${secondary_properties[1]}`, margin_end_value, t) +
+			css_dimension(`border-${secondary_properties[0]}-width`, border_width_start_value, t) +
+			css_dimension(`border-${secondary_properties[1]}-width`, border_width_end_value, t) +
 			`min-${primary_property}: 0`
 	};
 }

--- a/packages/svelte/tests/runtime-browser/samples/transition-slide-hidden-parent/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/transition-slide-hidden-parent/_config.js
@@ -1,0 +1,25 @@
+import { test } from '../../assert';
+
+export default test({
+	async test({ assert, window }) {
+		window.document.querySelector('button')?.click();
+		await new Promise((r) => setTimeout(r, 100));
+
+		const p = window.document.querySelector('p');
+		const animations = /** @type {HTMLElement} */ (p).getAnimations();
+		assert.equal(animations.length, 1);
+
+		// when the element has no layout box, computed dimensions resolve to 'auto',
+		// which must not end up as NaN values that the browser rejects (#14205)
+		const keyframes = /** @type {KeyframeEffect} */ (animations[0].effect).getKeyframes();
+		assert.ok(keyframes.length > 0);
+
+		for (const keyframe of keyframes) {
+			assert.ok('height' in keyframe, 'height was rejected as an invalid keyframe value');
+
+			for (const value of Object.values(keyframe)) {
+				assert.ok(!String(value).includes('NaN'), `unexpected NaN in keyframe: ${value}`);
+			}
+		}
+	}
+});

--- a/packages/svelte/tests/runtime-browser/samples/transition-slide-hidden-parent/_config.js
+++ b/packages/svelte/tests/runtime-browser/samples/transition-slide-hidden-parent/_config.js
@@ -1,4 +1,4 @@
-import { test } from '../../assert';
+import { ok, test } from '../../assert';
 
 export default test({
 	async test({ assert, window }) {
@@ -11,14 +11,16 @@ export default test({
 
 		// when the element has no layout box, computed dimensions resolve to 'auto',
 		// which must not end up as NaN values that the browser rejects (#14205)
-		const keyframes = /** @type {KeyframeEffect} */ (animations[0].effect).getKeyframes();
-		assert.ok(keyframes.length > 0);
+		const effect = /** @type {KeyframeEffect} */ (animations[0].effect);
+		const keyframes = effect.getKeyframes();
+		ok(keyframes.length > 0);
+		assert.equal(effect.getTiming().duration, 400);
 
 		for (const keyframe of keyframes) {
-			assert.ok('height' in keyframe, 'height was rejected as an invalid keyframe value');
+			ok(!('height' in keyframe), 'unresolved height should be omitted');
 
 			for (const value of Object.values(keyframe)) {
-				assert.ok(!String(value).includes('NaN'), `unexpected NaN in keyframe: ${value}`);
+				ok(!String(value).includes('NaN'), `unexpected NaN in keyframe: ${value}`);
 			}
 		}
 	}

--- a/packages/svelte/tests/runtime-browser/samples/transition-slide-hidden-parent/main.svelte
+++ b/packages/svelte/tests/runtime-browser/samples/transition-slide-hidden-parent/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { slide } from 'svelte/transition';
+
+	let visible = $state(false);
+</script>
+
+<button onclick={() => (visible = !visible)}>toggle</button>
+
+<div style="display: none">
+	{#if visible}
+		<p transition:slide>hello</p>
+	{/if}
+</div>

--- a/packages/svelte/tests/runtime-legacy/samples/class-shortcut-with-transition/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/class-shortcut-with-transition/_config.js
@@ -18,7 +18,7 @@ export default test({
 		raf.tick(150);
 		assert.htmlEqual(
 			target.innerHTML,
-			'<p>foo</p><p class="red svelte-1yszte8 border" style="overflow: hidden; opacity: 0; border-top-width: 0.5px; border-bottom-width: 0.5px; min-height: 0;">bar</p>'
+			'<p>foo</p><p class="red svelte-1yszte8 border" style="overflow: hidden; opacity: 0; height: 0px; padding-top: 0px; padding-bottom: 0px; margin-top: 0px; margin-bottom: 0px; border-top-width: 0.5px; border-bottom-width: 0.5px; min-height: 0;">bar</p>'
 		);
 		component.open = true;
 		raf.tick(250);

--- a/packages/svelte/tests/runtime-legacy/samples/class-shortcut-with-transition/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/class-shortcut-with-transition/_config.js
@@ -18,7 +18,7 @@ export default test({
 		raf.tick(150);
 		assert.htmlEqual(
 			target.innerHTML,
-			'<p>foo</p><p class="red svelte-1yszte8 border" style="overflow: hidden; opacity: 0; height: 0px; padding-top: 0px; padding-bottom: 0px; margin-top: 0px; margin-bottom: 0px; border-top-width: 0.5px; border-bottom-width: 0.5px; min-height: 0;">bar</p>'
+			'<p>foo</p><p class="red svelte-1yszte8 border" style="overflow: hidden; opacity: 0; border-top-width: 0.5px; border-bottom-width: 0.5px; min-height: 0;">bar</p>'
 		);
 		component.open = true;
 		raf.tick(250);


### PR DESCRIPTION
Fixes #14205

When a `slide` transition runs on an element without a layout box, for example inside a `display: none` parent, `getComputedStyle` returns values like `auto` for the animated dimensions. These were passed through `parseFloat` unguarded, so the generated css contained `height: NaNpx` and the browser rejected the keyframe property with an "Invalid keyframe value" warning on every transition.

Svelte 4 had the same `NaN` but never surfaced it, because invalid declarations in injected stylesheet rules are silently dropped, while the Web Animations API validates keyframes and warns.

This treats unparseable computed dimensions as `0`. The keyframes now contain the coerced `0px` declarations instead of the browser dropping the invalid ones, as the updated `class-shortcut-with-transition` assertion shows. An element in this state has no layout box, so the applied values render nothing either way; the difference is the console warning disappearing, which was also the only signal that a slide had nothing to measure. The actual misuse cases (`display: inline` and friends) keep Svelte's own `transition_slide_display` warning.

---

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`)

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`