### PR TITLE
fix: strip `?` from optional parameters in svelte lang ts

### DIFF
--- a/.changeset/strip-optional-param-marker.md
+++ b/.changeset/strip-optional-param-marker.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: strip `?` from optional parameters in `<script lang="ts">` so generated JavaScript is valid

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -181,7 +181,7 @@
     "clsx": "^2.1.1",
     "devalue": "^5.8.1",
     "esm-env": "^1.2.1",
-    "esrap": "^2.2.11",
+    "esrap": "^2.2.12",
     "is-reference": "^3.0.3",
     "locate-character": "^3.0.0",
     "magic-string": "^0.30.11",

--- a/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
+++ b/packages/svelte/src/compiler/phases/1-parse/remove_typescript_nodes.js
@@ -30,6 +30,12 @@ const visitors = {
 		delete n.readonly;
 		delete n.definite;
 		delete n.override;
+
+		// `optional` is reused by JS optional chaining (`a?.b`, `a?.()`), so only
+		// strip the TypeScript optional marker (`x?: T`, `m?(): T`, `x?: T` fields)
+		if (n.type !== 'MemberExpression' && n.type !== 'CallExpression') {
+			delete n.optional;
+		}
 	},
 	Decorator(node) {
 		e.typescript_invalid_feature(node, 'decorators (related TSC proposal is not stage 4 yet)');

--- a/packages/svelte/tests/snapshot/samples/typescript-optional-parameter/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/typescript-optional-parameter/_expected/client/index.svelte.js
@@ -1,0 +1,22 @@
+import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/legacy';
+import * as $ from 'svelte/internal/client';
+
+export default function Typescript_optional_parameter($$anchor) {
+	// the `?` on the optional parameter must be stripped, but optional chaining
+	// (`x?.length`, `o?.b`) must be preserved
+	function a(x) {
+		return x?.length;
+	}
+
+	const o = {};
+	const v = o?.b?.c;
+
+	a();
+	$.next();
+
+	var text = $.text();
+
+	$.template_effect(() => $.set_text(text, v));
+	$.append($$anchor, text);
+}

--- a/packages/svelte/tests/snapshot/samples/typescript-optional-parameter/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/typescript-optional-parameter/_expected/server/index.svelte.js
@@ -1,0 +1,15 @@
+import * as $ from 'svelte/internal/server';
+
+export default function Typescript_optional_parameter($$renderer) {
+	// the `?` on the optional parameter must be stripped, but optional chaining
+	// (`x?.length`, `o?.b`) must be preserved
+	function a(x) {
+		return x?.length;
+	}
+
+	const o = {};
+	const v = o?.b?.c;
+
+	a();
+	$$renderer.push(`<!---->${$.escape(v)}`);
+}

--- a/packages/svelte/tests/snapshot/samples/typescript-optional-parameter/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/typescript-optional-parameter/index.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	// the `?` on the optional parameter must be stripped, but optional chaining
+	// (`x?.length`, `o?.b`) must be preserved
+	function a(x?: string) {
+		return x?.length;
+	}
+
+	const o: { b?: { c: number } } = {};
+	const v = o?.b?.c;
+
+	a();
+</script>
+
+{v}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       esrap:
-        specifier: ^2.2.11
-        version: 2.2.11(@typescript-eslint/types@8.59.4)
+        specifier: ^2.2.12
+        version: 2.2.12(@typescript-eslint/types@8.59.4)
       is-reference:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1418,8 +1418,8 @@ packages:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
-  esrap@2.2.11:
-    resolution: {integrity: sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==}
+  esrap@2.2.12:
+    resolution: {integrity: sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -2886,7 +2886,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.4':
@@ -3695,7 +3695,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.2.11(@typescript-eslint/types@8.59.4):
+  esrap@2.2.12(@typescript-eslint/types@8.59.4):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:


### PR DESCRIPTION
In `esrap@2.2.12` we fixed the missing `?` in ts files https://github.com/sveltejs/esrap/pull/139
It's good for `ts`, but bad for svelte compiler that was not removing it as it was a esrap issue not printing it :/

This issue came: https://github.com/sveltejs/esrap/issues/141

This PR is fixing the issue in the compiler stripping the `?`

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
