### PR TITLE
docs: fix typo in read_version JSDoc

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -130,7 +130,7 @@ export function set_untracked_writes(value) {
  **/
 export let write_version = 1;
 
-/** @type {number} Used to version each read of a source of derived to avoid duplicating depedencies inside a reaction */
+/** @type {number} Used to version each read of a source of derived to avoid duplicating dependencies inside a reaction */
 let read_version = 0;
 
 export let update_version = read_version;


### PR DESCRIPTION
Fixes a typo in the JSDoc for `read_version` in `packages/svelte/src/internal/client/runtime.js`:

- `depedencies` -> `dependencies`

One-line prose fix; no code/behavior changes.

Detected with `typos`, narrowed to JSDoc only.
