### PR TITLE
docs: clarify $bindable fallback binding requirement

### DIFF
--- a/documentation/docs/02-runes/06-$bindable.md
+++ b/documentation/docs/02-runes/06-$bindable.md
@@ -52,3 +52,5 @@ In this case, you can specify a fallback value for when no prop is passed at all
 /// file: FancyInput.svelte
 let { value = $bindable('fallback'), ...props } = $props();
 ```
+
+When a bindable prop has a fallback value, the parent must pass a value other than `undefined` if it uses `bind:`. This avoids ambiguity about which value should apply, since the parent and child should share the same value for a binding.


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`). N/A, docs-only.

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Summary

Closes #18417.

Adds the `$bindable` page note that the Svelte 5 migration guide already documents: when a bindable prop has a fallback value, a parent using `bind:` must pass a value other than `undefined`.

This keeps the docs local to where users first read about `$bindable('fallback')`.

### AI assistance

This PR was AI-assisted. I manually reviewed the final diff before submission.

### Test plan

- `corepack pnpm lint`
- `corepack pnpm test`

Note: I also tried `corepack pnpm check`, but it is blocked in this local environment by a nested install invoking a pnpm 11 lifecycle/build-approval path. The docs-only change is covered by lint and the full test suite above.
