### PR TITLE
Add a note explaining that bound values using $bindable fallback values cannot be undefined.Docs default value

### DIFF
--- a/documentation/docs/03-template-syntax/12-bind.md
+++ b/documentation/docs/03-template-syntax/12-bind.md
@@ -415,3 +415,6 @@ Bindable properties can have a fallback value:
 ```
 
 This fallback value _only_ applies when the property is _not_ bound. When the property is bound and a fallback value is present, the parent is expected to provide a value other than `undefined`, else a runtime error is thrown. This prevents hard-to-reason-about situations where it's unclear which value should apply.
+
+> [!NOTE]
+> When using a fallback value with `$bindable`, the parent component must provide a value that is not `undefined` when binding to the property. If the bound value is `undefined`, Svelte will throw a runtime error.

--- a/documentation/docs/06-runtime/02-context.md
+++ b/documentation/docs/06-runtime/02-context.md
@@ -165,10 +165,13 @@ Svelte will warn you if you get it wrong.
 
 Similarly, to pass primitive values through context, use functions as described in [Passing state into functions]($state#Passing-state-into-functions).
 
-## Component testing
+## Mounting components with context
 
-When writing [component tests](testing#Unit-and-component-tests-with-Vitest-Component-testing), it can be useful to create a wrapper component that sets the context in order to check the behaviour of a component that uses it. As of version 5.49, you can do this sort of thing:
+When mounting a component that relies on context, it can be useful to create a wrapper component that sets the context before rendering the component. This is useful in component tests, but the pattern can also be used anywhere you need to mount a component with a specific context.
 
+The context set inside the wrapper is scoped to that mounted component, so it will not affect other components or other `mount` calls.
+
+As of version 5.49, you can mount a component with context like this:
 ```js
 import { mount, unmount } from 'svelte';
 import { expect, test } from 'vitest';


### PR DESCRIPTION
## Summary

Adds a note explaining the behavior of `$bindable` fallback values when the property is bound.

The note clarifies that fallback values only apply when the property is not bound, and that binding a value of `undefined` will result in a runtime error.

## Why

This makes the documentation easier to understand by explicitly highlighting a behavior that readers might otherwise overlook.