### PR TITLE
fix: warn on undeclared shorthand event handlers on svelte:window/document/body

### DIFF
--- a/.changeset/cool-spoons-tap.md
+++ b/.changeset/cool-spoons-tap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: warn on undeclared shorthand event handlers on `<svelte:window>`, `<svelte:document>` and `<svelte:body>`

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
@@ -2,7 +2,7 @@
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
 import { is_event_attribute } from '../../../utils/ast.js';
-import { disallow_children } from './shared/special-element.js';
+import { check_global_event_reference, disallow_children } from './shared/special-element.js';
 
 /**
  * @param {AST.SvelteBody} node
@@ -11,10 +11,9 @@ import { disallow_children } from './shared/special-element.js';
 export function SvelteBody(node, context) {
 	disallow_children(node);
 	for (const attribute of node.attributes) {
-		if (
-			attribute.type === 'SpreadAttribute' ||
-			(attribute.type === 'Attribute' && !is_event_attribute(attribute))
-		) {
+		if (attribute.type === 'Attribute' && is_event_attribute(attribute)) {
+			check_global_event_reference(attribute, context);
+		} else if (attribute.type === 'SpreadAttribute' || attribute.type === 'Attribute') {
 			e.svelte_body_illegal_attribute(attribute);
 		}
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteBody.js
@@ -2,7 +2,8 @@
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
 import { is_event_attribute } from '../../../utils/ast.js';
-import { check_global_event_reference, disallow_children } from './shared/special-element.js';
+import { disallow_children } from './shared/special-element.js';
+import { check_global_event_reference } from './shared/utils.js';
 
 /**
  * @param {AST.SvelteBody} node

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteDocument.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteDocument.js
@@ -1,6 +1,6 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
-import { disallow_children } from './shared/special-element.js';
+import { check_global_event_reference, disallow_children } from './shared/special-element.js';
 import * as e from '../../../errors.js';
 import { is_event_attribute } from '../../../utils/ast.js';
 
@@ -12,10 +12,9 @@ export function SvelteDocument(node, context) {
 	disallow_children(node);
 
 	for (const attribute of node.attributes) {
-		if (
-			attribute.type === 'SpreadAttribute' ||
-			(attribute.type === 'Attribute' && !is_event_attribute(attribute))
-		) {
+		if (attribute.type === 'Attribute' && is_event_attribute(attribute)) {
+			check_global_event_reference(attribute, context);
+		} else if (attribute.type === 'SpreadAttribute' || attribute.type === 'Attribute') {
 			e.illegal_element_attribute(attribute, 'svelte:document');
 		}
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteDocument.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteDocument.js
@@ -1,8 +1,9 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
-import { check_global_event_reference, disallow_children } from './shared/special-element.js';
+import { disallow_children } from './shared/special-element.js';
 import * as e from '../../../errors.js';
 import { is_event_attribute } from '../../../utils/ast.js';
+import { check_global_event_reference } from './shared/utils.js';
 
 /**
  * @param {AST.SvelteDocument} node

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteWindow.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteWindow.js
@@ -1,6 +1,6 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
-import { disallow_children } from './shared/special-element.js';
+import { check_global_event_reference, disallow_children } from './shared/special-element.js';
 import * as e from '../../../errors.js';
 import { is_event_attribute } from '../../../utils/ast.js';
 
@@ -12,10 +12,9 @@ export function SvelteWindow(node, context) {
 	disallow_children(node);
 
 	for (const attribute of node.attributes) {
-		if (
-			attribute.type === 'SpreadAttribute' ||
-			(attribute.type === 'Attribute' && !is_event_attribute(attribute))
-		) {
+		if (attribute.type === 'Attribute' && is_event_attribute(attribute)) {
+			check_global_event_reference(attribute, context);
+		} else if (attribute.type === 'SpreadAttribute' || attribute.type === 'Attribute') {
 			e.illegal_element_attribute(attribute, 'svelte:window');
 		}
 	}

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteWindow.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/SvelteWindow.js
@@ -1,8 +1,9 @@
 /** @import { AST } from '#compiler' */
 /** @import { Context } from '../types' */
-import { check_global_event_reference, disallow_children } from './shared/special-element.js';
+import { disallow_children } from './shared/special-element.js';
 import * as e from '../../../errors.js';
 import { is_event_attribute } from '../../../utils/ast.js';
+import { check_global_event_reference } from './shared/utils.js';
 
 /**
  * @param {AST.SvelteWindow} node

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/element.js
@@ -9,6 +9,7 @@ import {
 	validate_attribute_name,
 	validate_slot_attribute
 } from './attribute.js';
+import { check_global_event_reference } from './utils.js';
 
 const EVENT_MODIFIERS = [
 	'preventDefault',
@@ -64,14 +65,7 @@ export function validate_element(node, context) {
 					e.attribute_invalid_event_handler(attribute);
 				}
 
-				const value = get_attribute_expression(attribute);
-				if (
-					value.type === 'Identifier' &&
-					value.name === attribute.name &&
-					!context.state.scope.get(value.name)
-				) {
-					w.attribute_global_event_reference(attribute, attribute.name);
-				}
+				check_global_event_reference(attribute, context);
 			}
 
 			if (attribute.name === 'slot') {

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/special-element.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/special-element.js
@@ -1,5 +1,28 @@
 /** @import { AST } from '#compiler' */
+/** @import { Context } from '../../types' */
+import { get_attribute_expression } from '../../../../utils/ast.js';
 import * as e from '../../../../errors.js';
+import * as w from '../../../../warnings.js';
+
+/**
+ * Warns when an event attribute uses the shorthand form (`{onclick}`) but the
+ * referenced name isn't declared, so it silently resolves to the global handler.
+ * @param {AST.Attribute} attribute
+ * @param {Context} context
+ */
+export function check_global_event_reference(attribute, context) {
+	const value = get_attribute_expression(
+		/** @type {AST.Attribute & { value: [AST.ExpressionTag] | AST.ExpressionTag }} */ (attribute)
+	);
+
+	if (
+		value.type === 'Identifier' &&
+		value.name === attribute.name &&
+		!context.state.scope.get(value.name)
+	) {
+		w.attribute_global_event_reference(attribute, attribute.name);
+	}
+}
 
 /**
  * @param {AST.SvelteBody | AST.SvelteDocument | AST.SvelteOptionsRaw | AST.SvelteWindow} node

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/special-element.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/special-element.js
@@ -1,28 +1,5 @@
 /** @import { AST } from '#compiler' */
-/** @import { Context } from '../../types' */
-import { get_attribute_expression } from '../../../../utils/ast.js';
 import * as e from '../../../../errors.js';
-import * as w from '../../../../warnings.js';
-
-/**
- * Warns when an event attribute uses the shorthand form (`{onclick}`) but the
- * referenced name isn't declared, so it silently resolves to the global handler.
- * @param {AST.Attribute} attribute
- * @param {Context} context
- */
-export function check_global_event_reference(attribute, context) {
-	const value = get_attribute_expression(
-		/** @type {AST.Attribute & { value: [AST.ExpressionTag] | AST.ExpressionTag }} */ (attribute)
-	);
-
-	if (
-		value.type === 'Identifier' &&
-		value.name === attribute.name &&
-		!context.state.scope.get(value.name)
-	) {
-		w.attribute_global_event_reference(attribute, attribute.name);
-	}
-}
 
 /**
  * @param {AST.SvelteBody | AST.SvelteDocument | AST.SvelteOptionsRaw | AST.SvelteWindow} node

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
@@ -4,7 +4,11 @@
 /** @import { Scope } from '../../../scope' */
 /** @import { NodeLike } from '../../../../errors.js' */
 import * as e from '../../../../errors.js';
-import { extract_identifiers, get_parent } from '../../../../utils/ast.js';
+import {
+	extract_identifiers,
+	get_attribute_expression,
+	get_parent
+} from '../../../../utils/ast.js';
 import * as w from '../../../../warnings.js';
 import * as b from '#compiler/builders';
 import { get_rune } from '../../../scope.js';
@@ -296,5 +300,23 @@ export function validate_export(node, scope, name) {
 
 	if ((binding.kind === 'state' || binding.kind === 'raw_state') && binding.reassigned) {
 		e.state_invalid_export(node);
+	}
+}
+
+/**
+ * Warns when an event attribute uses the shorthand form (`{onclick}`) but the
+ * referenced name isn't declared, so it silently resolves to the global handler.
+ * @param {AST.Attribute & { value: [AST.ExpressionTag] | AST.ExpressionTag }} attribute
+ * @param {Context} context
+ */
+export function check_global_event_reference(attribute, context) {
+	const value = get_attribute_expression(attribute);
+
+	if (
+		value.type === 'Identifier' &&
+		value.name === attribute.name &&
+		!context.state.scope.get(value.name)
+	) {
+		w.attribute_global_event_reference(attribute, attribute.name);
 	}
 }

--- a/packages/svelte/tests/validator/samples/global-event-reference-special-elements/_config.js
+++ b/packages/svelte/tests/validator/samples/global-event-reference-special-elements/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/validator/samples/global-event-reference-special-elements/input.svelte
+++ b/packages/svelte/tests/validator/samples/global-event-reference-special-elements/input.svelte
@@ -1,0 +1,7 @@
+<script>
+	let onkeydown;
+</script>
+
+<svelte:window {onkeydown} {onresize} />
+<svelte:document {onvisibilitychange} />
+<svelte:body {onfocus} />

--- a/packages/svelte/tests/validator/samples/global-event-reference-special-elements/warnings.json
+++ b/packages/svelte/tests/validator/samples/global-event-reference-special-elements/warnings.json
@@ -1,0 +1,38 @@
+[
+	{
+		"code": "attribute_global_event_reference",
+		"message": "You are referencing `globalThis.onresize`. Did you forget to declare a variable with that name?",
+		"start": {
+			"column": 27,
+			"line": 5
+		},
+		"end": {
+			"column": 37,
+			"line": 5
+		}
+	},
+	{
+		"code": "attribute_global_event_reference",
+		"message": "You are referencing `globalThis.onvisibilitychange`. Did you forget to declare a variable with that name?",
+		"start": {
+			"column": 17,
+			"line": 6
+		},
+		"end": {
+			"column": 37,
+			"line": 6
+		}
+	},
+	{
+		"code": "attribute_global_event_reference",
+		"message": "You are referencing `globalThis.onfocus`. Did you forget to declare a variable with that name?",
+		"start": {
+			"column": 13,
+			"line": 7
+		},
+		"end": {
+			"column": 22,
+			"line": 7
+		}
+	}
+]


### PR DESCRIPTION
On a regular element, writing a shorthand event handler whose name isn't declared (e.g. `{onresize}`) gives you the `attribute_global_event_reference` warning, since it quietly falls back to the global handler. But `<svelte:window>`, `<svelte:document>` and `<svelte:body>` never ran that check, so the same typo there slipped by silently — closes #18275.

I pulled the shorthand-identifier check into a small helper in `special-element.js` and call it from the three special-element visitors for their event attributes. Spread/non-event attributes still error exactly as before. Added a validator sample covering all three (a declared handler stays quiet, undeclared ones warn).
