### PR TITLE
fix: render input default values in SSR

### DIFF
--- a/.changeset/fix-input-defaultvalue-ssr.md
+++ b/.changeset/fix-input-defaultvalue-ssr.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: render input defaultValue and defaultChecked during SSR

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
@@ -75,8 +75,11 @@ export function build_element_attributes(node, context, transform) {
 				) {
 					events_to_capture.add(attribute.name);
 				}
-				// the defaultValue/defaultChecked properties don't exist as attributes
-			} else if (attribute.name !== 'defaultValue' && attribute.name !== 'defaultChecked') {
+				// defaultValue/defaultChecked are serialized as value/checked for inputs
+			} else if (
+				node.name === 'input' ||
+				(attribute.name !== 'defaultValue' && attribute.name !== 'defaultChecked')
+			) {
 				if (attribute.name === 'class') {
 					if (attribute.metadata.needs_clsx) {
 						attributes.push({
@@ -218,7 +221,9 @@ export function build_element_attributes(node, context, transform) {
 		const css_hash = node.metadata.scoped ? context.state.analysis.css.hash : null;
 
 		for (const attribute of /** @type {AST.Attribute[]} */ (attributes)) {
-			const name = get_attribute_name(node, attribute);
+			if (should_skip_input_default_attribute(node, attribute)) continue;
+
+			const name = get_serialized_attribute_name(node, attribute);
 			const can_use_literal =
 				(name !== 'class' || class_directives.length === 0) &&
 				(name !== 'style' || style_directives.length === 0);
@@ -246,12 +251,26 @@ export function build_element_attributes(node, context, transform) {
 				continue;
 			}
 
-			const value = build_attribute_value(
+			let value = build_attribute_value(
 				attribute.value,
 				context,
 				transform,
 				WHITESPACE_INSENSITIVE_ATTRIBUTES.includes(name)
 			);
+
+			const fallback = get_input_default_attribute(node, attribute);
+			if (fallback) {
+				value = b.logical(
+					'??',
+					value,
+					build_attribute_value(
+						fallback.value,
+						context,
+						transform,
+						WHITESPACE_INSENSITIVE_ATTRIBUTES.includes(name)
+					)
+				);
+			}
 
 			// pre-escape and inline literal attributes :
 			if (can_use_literal && value.type === 'Literal' && typeof value.value === 'string') {
@@ -284,10 +303,70 @@ export function build_element_attributes(node, context, transform) {
 
 /**
  * @param {AST.RegularElement | AST.SvelteElement} element
+ * @param {AST.Attribute} attribute
+ */
+function get_serialized_attribute_name(element, attribute) {
+	return (
+		get_input_default_attribute_name(element, attribute) ?? get_attribute_name(element, attribute)
+	);
+}
+
+/**
+ * @param {AST.RegularElement | AST.SvelteElement} element
+ * @param {AST.Attribute | AST.BindDirective} attribute
+ */
+function get_input_default_attribute_name(element, attribute) {
+	if (element.name !== 'input') return null;
+	if (attribute.name === 'defaultValue') return 'value';
+	if (attribute.name === 'defaultChecked') return 'checked';
+	return null;
+}
+
+/**
+ * @param {AST.RegularElement | AST.SvelteElement} element
+ * @param {string} name
+ */
+function has_input_attribute(element, name) {
+	return element.attributes.some(
+		(attribute) =>
+			(attribute.type === 'Attribute' || attribute.type === 'BindDirective') &&
+			get_attribute_name(element, attribute) === name
+	);
+}
+
+/**
+ * @param {AST.RegularElement | AST.SvelteElement} element
+ * @param {AST.Attribute} attribute
+ */
+function get_input_default_attribute(element, attribute) {
+	if (element.name !== 'input') return null;
+	if (attribute.name !== 'value' && attribute.name !== 'checked') return null;
+
+	const default_name = attribute.name === 'value' ? 'defaultValue' : 'defaultChecked';
+
+	return /** @type {AST.Attribute | null} */ (
+		element.attributes.find(
+			(attribute) => attribute.type === 'Attribute' && attribute.name === default_name
+		) ?? null
+	);
+}
+
+/**
+ * @param {AST.RegularElement | AST.SvelteElement} element
+ * @param {AST.Attribute} attribute
+ */
+function should_skip_input_default_attribute(element, attribute) {
+	const name = get_input_default_attribute_name(element, attribute);
+	return name !== null && has_input_attribute(element, name);
+}
+
+/**
+ * @param {AST.RegularElement | AST.SvelteElement} element
  * @param {AST.Attribute | AST.BindDirective} attribute
  */
 function get_attribute_name(element, attribute) {
 	let name = attribute.name;
+
 	if (!element.metadata.svg && !element.metadata.mathml) {
 		name = name.toLowerCase();
 		// don't lookup boolean aliases here, the server runtime function does only

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -164,7 +164,7 @@ export function attributes(attrs, css_hash, classes, styles, flags = 0) {
 		if (is_input) {
 			if (name === 'defaultvalue' || name === 'defaultchecked') {
 				name = name === 'defaultvalue' ? 'value' : 'checked';
-				if (attrs[name]) continue;
+				if (attrs[name] != null) continue;
 			}
 		}
 

--- a/packages/svelte/tests/runtime-runes/samples/input-default-value-ssr/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/input-default-value-ssr/_config.js
@@ -1,0 +1,39 @@
+import { test } from '../../test';
+
+export default test({
+	ssrHtml: `<input value="foo"><input value="foo"><input value="foo"><input value="bar"><input value="foo"><input value="foo"><input value="spread"><input type="checkbox" checked=""><input type="checkbox" checked=""><input type="checkbox"><input type="checkbox" checked=""><input type="checkbox"><input value="bar"><input type="checkbox">`,
+
+	test({ assert, target }) {
+		const [
+			text,
+			text_with_undefined_value,
+			text_with_null_value,
+			text_with_explicit_value,
+			text_with_bound_value,
+			text_with_spread_undefined_value,
+			text_with_spread_explicit_value,
+			checkbox,
+			checkbox_with_undefined_checked,
+			checkbox_with_false_checked,
+			checkbox_with_bound_checked,
+			checkbox_with_spread_false_checked,
+			text_with_value,
+			checkbox_with_checked
+		] = target.querySelectorAll('input');
+
+		assert.equal(text.value, 'foo');
+		assert.equal(text_with_undefined_value.value, 'foo');
+		assert.equal(text_with_null_value.value, 'foo');
+		assert.equal(text_with_explicit_value.value, 'bar');
+		assert.equal(text_with_bound_value.value, 'foo');
+		assert.equal(text_with_spread_undefined_value.value, 'foo');
+		assert.equal(text_with_spread_explicit_value.value, 'spread');
+		assert.equal(checkbox.checked, true);
+		assert.equal(checkbox_with_undefined_checked.checked, true);
+		assert.equal(checkbox_with_false_checked.checked, false);
+		assert.equal(checkbox_with_bound_checked.checked, true);
+		assert.equal(checkbox_with_spread_false_checked.checked, false);
+		assert.equal(text_with_value.value, 'bar');
+		assert.equal(checkbox_with_checked.checked, false);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/input-default-value-ssr/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/input-default-value-ssr/main.svelte
@@ -1,0 +1,25 @@
+<script>
+	let value = $state();
+	let null_value = $state(null);
+	let explicit_value = $state('bar');
+	let checked = $state();
+	let false_checked = $state(false);
+	let spread_undefined_value = { value };
+	let spread_explicit_value = { value: 'spread' };
+	let spread_false_checked = { checked: false };
+</script>
+
+<input defaultValue="foo" />
+<input defaultValue="foo" value={value} />
+<input defaultValue="foo" value={null_value} />
+<input defaultValue="foo" value={explicit_value} />
+<input defaultValue="foo" bind:value />
+<input defaultValue="foo" {...spread_undefined_value} />
+<input defaultValue="foo" {...spread_explicit_value} />
+<input type="checkbox" defaultChecked />
+<input type="checkbox" defaultChecked checked={checked} />
+<input type="checkbox" defaultChecked checked={false_checked} />
+<input type="checkbox" defaultChecked bind:checked />
+<input type="checkbox" defaultChecked {...spread_false_checked} />
+<input value="bar" defaultValue="foo" />
+<input type="checkbox" checked={false} defaultChecked />


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Fixes #18446.

This makes SSR serialize `input` `defaultValue`/`defaultChecked` as `value`/`checked`, matching the initial DOM state users get after hydration. Explicit `value`/`checked` still wins when it is non-nullish, including `checked={false}`.

Test plan:

- `pnpm test runtime-runes -t input-default-value-ssr`
- `pnpm test runtime-runes -t "form-default-value"`
- `pnpm test`
- `pnpm lint`
- `pnpm check`

I also temporarily reverted the implementation while keeping the new regression sample; `pnpm test runtime-runes -t input-default-value-ssr` failed in both SSR variants, then passed again after restoring the fix.