### PR TITLE
docs: added generic type parameter example for $state

### DIFF
--- a/documentation/docs/07-misc/03-typescript.md
+++ b/documentation/docs/07-misc/03-typescript.md
@@ -170,6 +170,12 @@ If you don't give `$state` an initial value, part of its types will be `undefine
 let count: number = $state();
 ```
 
+You can pass the type directly as a generic parameter to safely handle this. TypeScript will infer the variable as `number | undefined`.
+
+```ts
+let count = $state<number>();
+```
+
 If you know that the variable _will_ be defined before you first use it, use an `as` casting. This is especially useful in the context of classes:
 
 ```ts


### PR DESCRIPTION
# Overview

Added an example demonstrating how to pass a generic type parameter to `$state` when an initial value is omitted.

# Why

The current documentation outlines how a missing initial value results in an `undefined` type error. It then provides a solution using type assertion (`as`) for class constructors. 

While the assertion is perfect for guaranteed assignments, building DOM bindings or components with delayed mounting need a safe way to type reactive variables as `Type | undefined`. 

So adding a quick example of `$state<Type>()` bridges this gap and provides a complete picture of how to handle types without initial values.
