### PR TITLE
chore: drop dead code that make TSGO fail

### DIFF
--- a/.changeset/big-months-shout.md
+++ b/.changeset/big-months-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: drop dead code that make TSGO fail

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -91,10 +91,7 @@ const rest_props_handler = {
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function rest_props(props, exclude, name) {
-	return new Proxy(
-		DEV ? { props, exclude, name, other: {}, to_proxy: [] } : { props, exclude },
-		rest_props_handler
-	);
+	return new Proxy(DEV ? { props, exclude, name } : { props, exclude }, rest_props_handler);
 }
 
 /**


### PR DESCRIPTION
I got annoyed by the TSGO fails...that's a bug in TSGO but while trying to understand the reason of the fail I realized the cause of the fail could be removed in the first place: `to_proxy` and `other` are never used anywhere, removing them doesn't make any test fail. They seem to have been introduced in this PR #11348, but even there they are not used 🤔

I guess we can just remove them and fix TSGO before they fix the bug?