### PR TITLE
fix: avoid declaration tag warning in event handlers

### DIFF
--- a/.changeset/calm-keys-fix.md
+++ b/.changeset/calm-keys-fix.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid spurious `state_referenced_locally` warnings for declaration tags in event handlers

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/function.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/function.js
@@ -18,7 +18,9 @@ export function visit_function(node, context) {
 
 	context.next({
 		...context.state,
-		function_depth: context.state.function_depth + 1,
+		// Template scopes can move ahead of the analysis state's function depth
+		// without entering a JavaScript function.
+		function_depth: Math.max(context.state.function_depth, context.state.scope.function_depth) + 1,
 		expression: null
 	});
 }

--- a/packages/svelte/tests/validator/samples/declaration-tag-state-referenced-locally/input.svelte
+++ b/packages/svelte/tests/validator/samples/declaration-tag-state-referenced-locally/input.svelte
@@ -7,3 +7,10 @@
 {let e = $state(0), f = e}
 
 {a}{b}{c}{d}{e}{f}
+
+{const phrase = $derived('Hello, ' + a)}
+<button onclick={() => {
+	console.log(phrase);
+}}>
+	Print
+</button>


### PR DESCRIPTION
Fixes #18493

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Problem

Declaration tag bindings could incorrectly trigger `state_referenced_locally` when read inside an event-handler closure. Template scopes can advance `scope.function_depth` without the analysis state entering a JavaScript function, so the function visitor now accounts for the current scope depth before stepping into a function.

### Tests and linting

- [x] `pnpm playwright install chromium`
- [x] `pnpm --dir packages/svelte build`
- [x] `pnpm test`
- [x] `pnpm lint`