### PR TITLE
fix: avoid declaration tag warning in event handlers

### DIFF
--- a/.changeset/dull-oranges-fry.md
+++ b/.changeset/dull-oranges-fry.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid declaration tag warning in event handlers

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/function.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/function.js
@@ -18,7 +18,9 @@ export function visit_function(node, context) {
 
 	context.next({
 		...context.state,
-		function_depth: context.state.function_depth + 1,
+		// we generally want to use scope.function_depth unless we specifically increased
+		// that in state.function_depth (e.g. a derived)
+		function_depth: Math.max(context.state.scope.function_depth, context.state.function_depth) + 1,
 		expression: null
 	});
 }

--- a/packages/svelte/tests/validator/samples/declaration-tag-state-referenced-locally/input.svelte
+++ b/packages/svelte/tests/validator/samples/declaration-tag-state-referenced-locally/input.svelte
@@ -7,3 +7,7 @@
 {let e = $state(0), f = e}
 
 {a}{b}{c}{d}{e}{f}
+
+<button onclick={() => {
+	console.log(a);
+}}>a</button>


### PR DESCRIPTION
Closes #18493