### PR TITLE
fix: don't treat declaration tags as parts inside each blocks

### DIFF
--- a/.changeset/young-doodles-beam.md
+++ b/.changeset/young-doodles-beam.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't treat declaration tags as parts inside each blocks

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -8,7 +8,7 @@ import { sanitize_template_string } from '../../../../../utils/sanitize_template
 import { regex_is_valid_identifier } from '../../../../patterns.js';
 import is_reference from 'is-reference';
 import { dev, is_ignored, locator, component_name } from '../../../../../state.js';
-import { build_getter } from '../../utils.js';
+import { build_getter, is_state_source } from '../../utils.js';
 import { ExpressionMetadata } from '../../../../nodes.js';
 
 /**
@@ -271,6 +271,10 @@ export function build_bind_this(expression, value, { state, visit }) {
 
 			const binding = state.scope.get(node.name);
 			if (!binding) return;
+
+			// if it is a state or a derived it means is a declaration tag...in that case we don't want to pass the
+			// value but the signal itself or assignment will break
+			if (is_state_source(binding, state.analysis) || binding.kind === 'derived') return;
 
 			for (const [owner, scope] of state.scopes) {
 				if (owner.type === 'EachBlock' && scope === binding.scope) {

--- a/packages/svelte/tests/runtime-runes/samples/declaration-tags-each/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/declaration-tags-each/_config.js
@@ -1,0 +1,10 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ target, assert }) {
+		const [btn1, btn2] = target.querySelectorAll('button');
+		flushSync(() => btn2.click());
+		assert.equal(btn1.textContent, '1');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/declaration-tags-each/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/declaration-tags-each/main.svelte
@@ -1,0 +1,6 @@
+{#each Array(1)}
+	{let ref = $state()}
+	{let count = $state(0)}
+	<button onclick={()=>count++} bind:this={ref}>{count}</button>
+	<button onclick={()=>ref.click()}></button>
+{/each}


### PR DESCRIPTION
Closes #18506

Declaration tags in the scope of an each block were considered "parts" and transformed to use their value instead of the signal itself. We can safely check on the `kind` of the binding since a `kind` of `state`, `state_raw` or `derived` in the each scope needs to be a declaration tag (and it's a stable reference so we can use them directly)