### PR TITLE
fix: recompute tracked owned deriveds after owner teardown

### DIFF
--- a/.changeset/svelte18489.md
+++ b/.changeset/svelte18489.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: recompute dirty owned deriveds after owner teardown

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -347,9 +347,13 @@ export function execute_derived(derived) {
 		derived.v !== UNINITIALIZED && // if it was never evaluated before, it's guaranteed to fail downstream, so we try to execute instead
 		(parent.f & (DESTROYED | INERT)) !== 0
 	) {
-		w.derived_inert();
+		if (derived.rv === 0) {
+			w.derived_inert();
 
-		return derived.v;
+			return derived.v;
+		}
+
+		parent = null;
 	}
 
 	set_active_effect(parent);

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -1428,6 +1428,58 @@ describe('signals', () => {
 		};
 	});
 
+	test('class field derived updates after original parent effect is destroyed', () => {
+		return () => {
+			const warn = console.warn;
+			const warnings: string[] = [];
+			console.warn = (...args) => {
+				warnings.push(...args.map(String));
+			};
+
+			class Box {
+				value = state('A');
+				doubled = derived(() => $.get(this.value) + $.get(this.value));
+
+				get result() {
+					return $.get(this.doubled);
+				}
+			}
+
+			let box: Box | undefined;
+			const rendered: string[] = [];
+
+			try {
+				const destroy = effect_root(() => {
+					render_effect(() => {
+						let instance = box;
+						if (instance === undefined) {
+							instance = box = new Box();
+						}
+
+						rendered.push(instance.result);
+					});
+				});
+
+				flushSync();
+				assert.deepEqual(rendered, ['AA']);
+
+				flushSync(() => set(box!.value, 'B'));
+				assert.deepEqual(rendered, ['AA', 'BB']);
+
+				destroy();
+
+				flushSync(() => set(box!.value, 'C'));
+				assert.equal(box!.result, 'CC');
+				assert.deepEqual(
+					warnings.filter((warning) => warning.includes('derived_inert')),
+					[]
+				);
+			} finally {
+				console.warn = warn;
+			}
+		};
+	});
+
 	test('derived when connected should add new dependency to its reaction even when read outside effect', () => {
 		let count_a = state(0);
 		let count_b = state(0);


### PR DESCRIPTION
## Summary

This fixes a stale read from a class field `$derived` after the effect that originally owned it is destroyed.

In the failing case, a class instance is created inside a render effect. Its derived field is read while that effect is alive, then the effect is destroyed. After the source state changes from `B` to `C`, reading the derived should return `CC`, but it returned the cached `BB`.

## Root cause

`execute_derived` treated every initialized derived with a destroyed or inert parent as inert. That returned the cached value and emitted `derived_inert`, even when the derived had already been tracked by the reactive graph.

## Fix

The destroyed owner branch now checks the derived read version.

When `rv === 0`, the derived was never tracked by a reaction, so the existing inert warning and cached return behavior is preserved.

When `rv !== 0`, the derived was genuinely tracked before. It recomputes with no active parent, so the read is fresh without reconnecting to the destroyed effect.

## Tests

Focused signals regression test passed in legacy mode and runes mode.

Signals suite passed with 108 passed and 0 failed.

Store plus runtime production suite passed with 47 passed and 0 failed.

Server side rendering suite passed with 32 passed and 0 failed.

Runtime runes plus runtime legacy suite passed with 5935 passed and 0 failed.

Package typecheck passed. ESLint passed for the touched runtime source. A changeset is included.

Closes #18489
