### PR TITLE
fix: prevent derived connection leak in untracked contexts

### DIFF
--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -665,7 +665,7 @@ export function get(signal) {
 			(derived.f & CONNECTED) === 0 &&
 			!untracking &&
 			active_reaction !== null &&
-			(is_updating_effect || (active_reaction.f & CONNECTED) !== 0);
+			(active_reaction.f & CONNECTED) !== 0;
 
 		var is_new = (derived.f & REACTION_RAN) === 0;
 

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -61,6 +61,9 @@ import { without_reactive_context } from './dom/elements/bindings/shared.js';
 import { set_signal_status, update_derived_status } from './reactivity/status.js';
 import * as w from './warnings.js';
 
+/**
+ * True if updating in an effect context that is reactive (i.e. not branch/root effects)
+ */
 let is_updating_effect = false;
 
 export let is_destroying_effect = false;
@@ -444,7 +447,7 @@ export function update_effect(effect) {
 	var was_updating_effect = is_updating_effect;
 
 	active_effect = effect;
-	is_updating_effect = true;
+	is_updating_effect = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) === 0; // Branch/root effects are not reactive contexts
 
 	if (DEV) {
 		var previous_component_fn = dev_current_component_function;
@@ -665,7 +668,7 @@ export function get(signal) {
 			(derived.f & CONNECTED) === 0 &&
 			!untracking &&
 			active_reaction !== null &&
-			(active_reaction.f & CONNECTED) !== 0;
+			(is_updating_effect || (active_reaction.f & CONNECTED) !== 0);
 
 		var is_new = (derived.f & REACTION_RAN) === 0;
 

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -1503,4 +1503,22 @@ describe('signals', () => {
 			assert.deepEqual(log, ['inner destroyed', 'inner destroyed']);
 		};
 	});
+
+	test('derived read in an untracked context should not leak in deps reactions', () => {
+		return () => {
+			let s = state('hello');
+			let a = derived(() => $.get(s));
+			let b = derived(() => $.get(a));
+
+			let destroy = effect_root(() => {
+				$.get(b);
+			});
+
+			destroy();
+
+			// a was spuriously added to s.reactions via is_updating_effect
+			// even though the entire derived chain was read in an untracked context
+			assert.equal(s.reactions, null);
+		};
+	});
 });


### PR DESCRIPTION
Fixes #18501.

## Summary

When a `$derived` is only read from an untracked context such as `$state($derived(...))`, `is_updating_effect` allows `should_connect` to return `true` even though the active derived is not connected.

This causes the inner derived to be marked CONNECTED and retained in its dependencies' reactions list after teardown. When the component is destroyed, this stale reaction is never removed, leaving the derived and its closure reachable.

This change removes the `is_updating_effect` shortcut so a derived is only connected when its reader is already connected.

## Test plan

- Added a regression test reproducing the reported leak.
- Verified the new test fails before the fix and passes after it.
- Ran `pnpm test signals`
- Ran `pnpm test runtime-runes`
- Ran the full test suite:
  - 2,733 tests passed
  - 0 failures
- Browser-only Playwright tests require a local Chromium installation.