### PR TITLE
fix: transform computed keys in keyed each block destructuring patterns

### DIFF
--- a/.changeset/shiny-keys-dance.md
+++ b/.changeset/shiny-keys-dance.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: transform computed keys in keyed `{#each}` destructuring patterns

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
@@ -294,8 +294,6 @@ export function EachBlock(node, context) {
 	let key_function = b.id('$.index');
 
 	if (node.metadata.keyed) {
-		// the pattern needs to be visited so that expressions inside it (e.g. computed
-		// keys or default values referencing component scope) are transformed correctly.
 		// can only be keyed when a context is provided
 		const pattern = /** @type {Pattern} */ (
 			context.visit(/** @type {Pattern} */ (node.context), key_state)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
@@ -294,7 +294,12 @@ export function EachBlock(node, context) {
 	let key_function = b.id('$.index');
 
 	if (node.metadata.keyed) {
-		const pattern = /** @type {Pattern} */ (node.context); // can only be keyed when a context is provided
+		// the pattern needs to be visited so that expressions inside it (e.g. computed
+		// keys or default values referencing component scope) are transformed correctly.
+		// can only be keyed when a context is provided
+		const pattern = /** @type {Pattern} */ (
+			context.visit(/** @type {Pattern} */ (node.context), key_state)
+		);
 		const expression = /** @type {Expression} */ (
 			context.visit(/** @type {Expression} */ (node.key), key_state)
 		);

--- a/packages/svelte/tests/runtime-runes/samples/each-keyed-computed-destructuring-key/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-keyed-computed-destructuring-key/Child.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { labelKey, valueKey, options } = $props();
+</script>
+
+{#each options as { [labelKey]: label, [valueKey]: value } (value)}
+	<p>{label}: {value}</p>
+{/each}

--- a/packages/svelte/tests/runtime-runes/samples/each-keyed-computed-destructuring-key/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-keyed-computed-destructuring-key/_config.js
@@ -1,0 +1,29 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+// https://github.com/sveltejs/svelte/issues/18519
+export default test({
+	html: `
+		<button>reverse</button>
+		<p>1: a1</p>
+		<p>2: a2</p>
+		<p>3: a3</p>
+	`,
+
+	test({ assert, target }) {
+		const btn = target.querySelector('button');
+		ok(btn);
+
+		flushSync(() => btn.click());
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>reverse</button>
+				<p>3: a3</p>
+				<p>2: a2</p>
+				<p>1: a1</p>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-keyed-computed-destructuring-key/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-keyed-computed-destructuring-key/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	import Child from './Child.svelte';
+
+	let options = $state([
+		{ a: 1, v: 'a1' },
+		{ a: 2, v: 'a2' },
+		{ a: 3, v: 'a3' }
+	]);
+</script>
+
+<button onclick={() => options.reverse()}>reverse</button>
+<Child {options} labelKey="a" valueKey="v" />


### PR DESCRIPTION
fixes #18519

when a keyed each block destructures with a computed key, e.g.

```svelte
{#each options as { [labelKey]: label, [valueKey]: value } (value)}
```

the generated key function reuses the raw pattern as its parameter, so expressions inside the pattern never go through the usual transforms. inside a child component where `labelKey` comes from `$props()` this compiles to `({ [labelKey]: label, [valueKey]: value }) => value` with bare identifiers that do not exist at runtime — a ReferenceError on mount. the each body itself was already fine because it goes through `extract_paths` and visits each path expression, which is why the same snippet works when it lives in the top-level component or when the key is removed.

the fix is to visit the pattern with the same `key_state` used for the key expression, so the compiled key function becomes `({ [$$props.labelKey]: label, [$$props.valueKey]: value }) => value`. the pattern's own bound names are unaffected since they're deleted from `key_state.transform` just above. this also covers default values in the pattern that reference component scope.

added a runtime-runes test that fails without the fix (dom and hydrate variants both throw) and passes with it.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`