### PR TITLE
chore: add benchmarks

### DIFF
--- a/benchmarking/benchmarks/reactivity/tests/kairo_broad_block.bench.js
+++ b/benchmarking/benchmarks/reactivity/tests/kairo_broad_block.bench.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert';
+import * as $ from 'svelte/internal/client';
+import { block } from '../../../../packages/svelte/src/internal/client/reactivity/effects.js';
+
+// Like `kairo_broad`, but each derived is also read by a block effect, as
+// happens with e.g. `{#if derived}` in a component. Measures our #traverse perf better.
+export default () => {
+	let head = $.state(0);
+	let last = head;
+	let counter = 0;
+
+	const destroy = $.effect_root(() => {
+		for (let i = 0; i < 50; i++) {
+			let current = $.derived(() => {
+				return $.get(head) + i;
+			});
+			let current2 = $.derived(() => {
+				return $.get(current) + 1;
+			});
+			block(() => {
+				$.get(current2);
+			});
+			$.render_effect(() => {
+				$.get(current2);
+				counter++;
+			});
+			last = current2;
+		}
+	});
+
+	return {
+		destroy,
+		run() {
+			$.flush(() => {
+				$.set(head, 1);
+			});
+			counter = 0;
+			for (let i = 0; i < 50; i++) {
+				$.flush(() => {
+					$.set(head, i);
+				});
+				assert.equal($.get(last), i + 50);
+			}
+			assert.equal(counter, 50 * 50);
+		}
+	};
+};

--- a/benchmarking/benchmarks/reactivity/tests/kairo_deep_block.bench.js
+++ b/benchmarking/benchmarks/reactivity/tests/kairo_deep_block.bench.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import * as $ from 'svelte/internal/client';
+import { block } from '../../../../packages/svelte/src/internal/client/reactivity/effects.js';
+
+let len = 50;
+const iter = 50;
+
+// Like `kairo_deep`, but the derived chain is also read by a block effect, as
+// happens with e.g. `{#if derived}` in a component. Measures our #traverse perf better.
+export default () => {
+	let head = $.state(0);
+	let current = head;
+	for (let i = 0; i < len; i++) {
+		let c = current;
+		current = $.derived(() => {
+			return $.get(c) + 1;
+		});
+	}
+	let counter = 0;
+
+	const destroy = $.effect_root(() => {
+		block(() => {
+			$.get(current);
+		});
+
+		$.render_effect(() => {
+			$.get(current);
+			counter++;
+		});
+	});
+
+	return {
+		destroy,
+		run() {
+			$.flush(() => {
+				$.set(head, 1);
+			});
+			counter = 0;
+			for (let i = 0; i < iter; i++) {
+				$.flush(() => {
+					$.set(head, i);
+				});
+				assert.equal($.get(current), len + i);
+			}
+			assert.equal(counter, iter);
+		}
+	};
+};


### PR DESCRIPTION
Add two kairo variants to better measure of `#traverse` / block effects perf
