### PR TITLE
fix: skip unnecessary derived effect in earlier batch

### DIFF
--- a/.changeset/curly-wasps-hide.md
+++ b/.changeset/curly-wasps-hide.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip unnecessary derived effect in earlier batch

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -530,6 +530,10 @@ export class Batch {
 		const mark = (value) => {
 			var reactions = value.reactions;
 			if (reactions === null) return;
+			// skip if value is derived and is not dirty
+			if ((value.f & DERIVED) !== 0 && (value.f & DIRTY) == 0) {
+				return;
+			}
 
 			for (const reaction of reactions) {
 				var flags = reaction.f;

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -530,8 +530,10 @@ export class Batch {
 		const mark = (value) => {
 			var reactions = value.reactions;
 			if (reactions === null) return;
-			// skip if value is derived and is not dirty
-			if ((value.f & DERIVED) !== 0 && (value.f & DIRTY) == 0) {
+			// skip if value is derived and is neither dirty nor maybe dirty. transitive
+			// deriveds (a derived depending on another derived) are only MAYBE_DIRTY, so
+			// we must continue traversing them to reach the effects that depend on them
+			if ((value.f & DERIVED) !== 0 && (value.f & (DIRTY | MAYBE_DIRTY)) === 0) {
 				return;
 			}
 

--- a/packages/svelte/tests/runtime-runes/samples/async-batch-derived/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-batch-derived/_config.js
@@ -1,0 +1,28 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		const [increment, pop] = target.querySelectorAll('button');
+
+		increment.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>increment</button> <button>pop</button> <p>Loading...</p>`
+		);
+		increment.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			`<button>increment</button> <button>pop</button> <p>Loading...</p>`
+		);
+		pop.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<button>increment</button> <button>pop</button> 2 2 1`);
+
+		pop.click();
+		await tick();
+		assert.htmlEqual(target.innerHTML, `<button>increment</button> <button>pop</button> 2 2 1`);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-batch-derived/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-batch-derived/main.svelte
@@ -1,0 +1,29 @@
+<script>
+	let count = $state(0);
+	let other = $state(0);
+
+	const queue = [];
+  	let pending = $derived(defaultPending);
+	function push(v) {
+		return new Promise((resolve) => queue.push(() => resolve(v)));
+	}
+</script>
+
+<button onclick={() => {
+	if (count === 0) {
+		other++;
+		count++;
+	} else {
+		count++
+	}
+}}>increment</button>
+<button onclick={() => queue.pop()?.()}>pop</button>
+{#snippet defaultPending()}
+  <p>Loading...</p>
+{/snippet}
+
+{#if count > 0}
+	<svelte:boundary {pending}>
+		{await push(count)} {count} {other}
+	</svelte:boundary> 
+{/if}


### PR DESCRIPTION
fixes #18438 
Currently the `mark` method inside `#merge` for `earlier_batch` will schedule effect for undirty derived. Add the condition for derived to prevent unnecessary effect be scheduled.

```
if ((flags & DERIVED) !== 0) {
	mark(/** @type {Derived} */ (reaction));
}
```
I notice line 541 have condition for Derived reactions, perhaps we could refactor the recursion here, I'm not quite sure, but my code solves the original bug.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
