### PR TITLE
fix: ensure a batch exists when a boundary resolves synchronously

### DIFF
--- a/.changeset/hip-bats-flash.md
+++ b/.changeset/hip-bats-flash.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: ensure a batch exists when a boundary resolves synchronously

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -235,7 +235,7 @@ export class Boundary {
 					this.#pending_effect = null;
 				});
 
-				this.#resolve(/** @type {Batch} */ (current_batch));
+				this.#resolve(Batch.ensure());
 			}
 		});
 	}
@@ -257,7 +257,10 @@ export class Boundary {
 				const pending = /** @type {(anchor: Node) => void} */ (this.#props.pending);
 				this.#pending_effect = branch(() => pending(this.#anchor));
 			} else {
-				this.#resolve(/** @type {Batch} */ (current_batch));
+				// `current_batch` can be null here — e.g. a `flushSync()` at the top
+				// level of a component script flushes and clears the batch while
+				// we are still rendering (#18522) — so ensure one exists
+				this.#resolve(Batch.ensure());
 			}
 		} catch (error) {
 			this.error(error);

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-component-init/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-component-init/_config.js
@@ -1,0 +1,6 @@
+import { test } from '../../test';
+
+// https://github.com/sveltejs/svelte/issues/18522
+export default test({
+	html: `<h1>Hello!</h1>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-component-init/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-component-init/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { flushSync } from 'svelte';
+
+	flushSync();
+</script>
+
+<h1>Hello!</h1>


### PR DESCRIPTION
fixes #18522

calling `flushSync()` at the top level of a component script crashes since 5.53.12 with `Cannot read properties of null (reading 'transfer_effects')`. the flush consumes the current batch and leaves `current_batch = null` while the boundary is still rendering, and `#render()` then passes a null batch into `#resolve()` through the `/** @type {Batch} */ (current_batch)` cast. the same unsafe cast exists on the pending path in `#pending()`.

this replaces both casts with `Batch.ensure()`, which is what the surrounding code already uses when a batch may not exist. deferred effects (if any) land in the fresh batch and flush on the next microtask as usual.

added a test with a top-level `flushSync()` — it fails without the fix with exactly the reported error and passes with it. i also checked the `$effect.pre` variant from the issue crashes the same way before the fix and is fixed too. full suite passes locally including the browser tests.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`