### PR TITLE
fix: $state.eager() is sometimes incorrect in SSR

### DIFF
--- a/.changeset/long-buttons-hunt.md
+++ b/.changeset/long-buttons-hunt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: $state.eager() is sometimes incorrect in SSR

--- a/.changeset/long-buttons-hunt.md
+++ b/.changeset/long-buttons-hunt.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: $state.eager() is sometimes incorrect in SSR
+fix: ensure `$state.eager()` is correctly transormed for SSR output

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/CallExpression.js
@@ -46,7 +46,7 @@ export function CallExpression(node, context) {
 	}
 
 	if (rune === '$state.eager') {
-		return node.arguments[0];
+		return context.visit(node.arguments[0]);
 	}
 
 	if (rune === '$state.snapshot') {

--- a/packages/svelte/tests/server-side-rendering/samples/state-eager/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/state-eager/_expected.html
@@ -1,0 +1,2 @@
+<div>value=0</div>
+<div>eager=0</div>

--- a/packages/svelte/tests/server-side-rendering/samples/state-eager/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/state-eager/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let props = $props();
+	const value = $derived(props.number ?? 0);
+</script>
+
+<div>value={value}</div>
+<div>eager={$state.eager(value)}</div>


### PR DESCRIPTION
Fix #18529

A simple fix : `context.visit()` was missing on the argument of `$state.eager()`, so the generated code can be incorrect in some case : 

```diff
	if (rune === '$state.eager') {
-		return node.arguments[0];
+		return context.visit(node.arguments[0]);
	}
```

Added a simple test...

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
