### PR TITLE
fix: don't notify `SvelteMap` key trackers when an existing key's value is set

### DIFF
--- a/.changeset/major-maps-agree.md
+++ b/.changeset/major-maps-agree.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't notify `SvelteMap` key trackers when an existing key's value is set

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -161,19 +161,23 @@ export class SvelteMap extends Map {
 		var sources = this.#sources;
 		var s = sources.get(key);
 		var prev_res = super.get(key);
+		var existed = super.has(key);
 		var res = super.set(key, value);
 		var version = this.#version;
 
 		if (s === undefined) {
-			s = this.#source(0);
+			// if the key existed but was never read individually, nothing tracks it and the key set is unchanged
+			if (!existed) {
+				s = this.#source(0);
 
-			if (DEV) {
-				tag(s, `SvelteMap get(${label(key)})`);
+				if (DEV) {
+					tag(s, `SvelteMap get(${label(key)})`);
+				}
+
+				sources.set(key, s);
+				set(this.#size, super.size);
+				increment(version);
 			}
-
-			sources.set(key, s);
-			set(this.#size, super.size);
-			increment(version);
 		} else if (prev_res !== value) {
 			increment(s);
 

--- a/packages/svelte/src/reactivity/map.test.ts
+++ b/packages/svelte/src/reactivity/map.test.ts
@@ -307,3 +307,33 @@ test('not invoking reactivity when value is not in the map after changes', () =>
 test('Map.instanceOf', () => {
 	assert.equal(new SvelteMap() instanceof Map, true);
 });
+
+test('map.keys() is not notified when an existing unread key is set to a new value', () => {
+	const map = new SvelteMap([
+		[1, 'a'],
+		[2, 'b']
+	]);
+
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(Array.from(map.keys()));
+		});
+	});
+
+	flushSync(() => {
+		map.set(1, 'c');
+	});
+
+	flushSync(() => {
+		map.set(3, 'd');
+	});
+
+	assert.deepEqual(log, [
+		[1, 2],
+		[1, 2, 3]
+	]);
+
+	cleanup();
+});


### PR DESCRIPTION
Fixes #18531

`SvelteMap.set()` can't tell a new key from a value update on an existing key that was never read individually, both take the `s === undefined` branch and bump `#version`, so `keys()` readers re-run on every value write. A key without a source can't have any value tracker (`get`/`has` create the source, and the iteration methods backfill one for every key via `#read_all`), so when the key already existed `set()` can return without notifying anything.

The added test in `map.test.ts` fails without the change.

---

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`)

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
