### PR TITLE
docs: clarify when `$effect.pre` runs relative to DOM updates

### DIFF
--- a/.changeset/witty-donuts-explain.md
+++ b/.changeset/witty-donuts-explain.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: clarify when `$effect.pre` runs relative to DOM updates

--- a/documentation/docs/02-runes/04-$effect.md
+++ b/documentation/docs/02-runes/04-$effect.md
@@ -205,7 +205,27 @@ In rare cases, you may need to run code _before_ the DOM updates. For this we ca
 </div>
 ```
 
-Effects — including `$effect.pre` — run in tree order, interleaved with template updates. `$effect.pre` therefore runs before DOM updates that are scheduled after it in the same flush (its own component's template, and its children), but effects in ancestor components run earlier and may already have updated the DOM by the time it runs. It is not a phase that runs before every DOM mutation. When using [await expressions](await-expressions), block updates like `{#if ...}` and `{#each ...}` in the same component also run before `$effect.pre`.
+In this example the effect and the `{#each}` block live in the same component, so the measurement is guaranteed to happen before the list updates. Across components the ordering is less intuitive — effects, including `$effect.pre`, run in a single walk of the tree, interleaved with template updates:
+
+```
+state changes
+    │
+    ▼  update — tree order, parents before children
+Parent.svelte
+    $effect.pre
+    template updates       ← DOM changes begin
+    Child.svelte
+        $effect.pre        ← 'pre', yet the parent's DOM already updated
+        template updates
+    │
+    ▼  DOM fully updated
+$effect callbacks
+    │
+    ▼
+tick() resolves
+```
+
+`$effect.pre` therefore runs before DOM updates that are scheduled after it, but it is not a phase that runs before every DOM mutation — effects in ancestor components may already have updated the DOM by the time it runs. When using [await expressions](await-expressions), block updates like `{#if ...}` and `{#each ...}` in the same component also run before `$effect.pre`.
 
 Apart from the timing, `$effect.pre` works exactly like `$effect`.
 

--- a/documentation/docs/02-runes/04-$effect.md
+++ b/documentation/docs/02-runes/04-$effect.md
@@ -205,6 +205,8 @@ In rare cases, you may need to run code _before_ the DOM updates. For this we ca
 </div>
 ```
 
+Effects — including `$effect.pre` — run in tree order, interleaved with template updates. `$effect.pre` therefore runs before DOM updates that are scheduled after it in the same flush (its own component's template, and its children), but effects in ancestor components run earlier and may already have updated the DOM by the time it runs. It is not a phase that runs before every DOM mutation. When using [await expressions](await-expressions), block updates like `{#if ...}` and `{#each ...}` in the same component also run before `$effect.pre`.
+
 Apart from the timing, `$effect.pre` works exactly like `$effect`.
 
 ## `$effect.tracking`

--- a/documentation/docs/02-runes/04-$effect.md
+++ b/documentation/docs/02-runes/04-$effect.md
@@ -205,9 +205,7 @@ In rare cases, you may need to run code _before_ the DOM updates. For this we ca
 </div>
 ```
 
-In this example the effect and the `{#each}` block live in the same component, so the measurement runs before the list updates ([await expressions](await-expressions) change this, as described below). Across components there is no separate 'before the DOM updates' phase: effects, including `$effect.pre`, run in a single walk of the tree, interleaved with template updates, and a parent component's `$effect.pre` runs before its children's. By the time a component's `$effect.pre` runs, DOM belonging to other components may already have been updated.
-
-`$effect.pre` therefore runs before DOM updates that are scheduled after it, not before every DOM mutation in the flush. When using [await expressions](await-expressions), block updates like `{#if ...}` and `{#each ...}` in the same component also run before `$effect.pre`.
+`$effect.pre` runs before DOM updates that are scheduled after it, not before every DOM mutation in the flush - DOM of parent components may already be updated. When using [await expressions](await-expressions), block updates like `{#if ...}` and `{#each ...}` in the same component also run before `$effect.pre`.
 
 Apart from the timing, `$effect.pre` works exactly like `$effect`.
 

--- a/documentation/docs/02-runes/04-$effect.md
+++ b/documentation/docs/02-runes/04-$effect.md
@@ -205,27 +205,9 @@ In rare cases, you may need to run code _before_ the DOM updates. For this we ca
 </div>
 ```
 
-In this example the effect and the `{#each}` block live in the same component, so the measurement is guaranteed to happen before the list updates. Across components the ordering is less intuitive — effects, including `$effect.pre`, run in a single walk of the tree, interleaved with template updates:
+In this example the effect and the `{#each}` block live in the same component, so the measurement runs before the list updates ([await expressions](await-expressions) change this, as described below). Across components there is no separate 'before the DOM updates' phase: effects, including `$effect.pre`, run in a single walk of the tree, interleaved with template updates, and a parent component's `$effect.pre` runs before its children's. By the time a component's `$effect.pre` runs, DOM belonging to other components may already have been updated.
 
-```
-state changes
-    │
-    ▼  update — tree order, parents before children
-Parent.svelte
-    $effect.pre
-    template updates       ← DOM changes begin
-    Child.svelte
-        $effect.pre        ← 'pre', yet the parent's DOM already updated
-        template updates
-    │
-    ▼  DOM fully updated
-$effect callbacks
-    │
-    ▼
-tick() resolves
-```
-
-`$effect.pre` therefore runs before DOM updates that are scheduled after it, but it is not a phase that runs before every DOM mutation — effects in ancestor components may already have updated the DOM by the time it runs. When using [await expressions](await-expressions), block updates like `{#if ...}` and `{#each ...}` in the same component also run before `$effect.pre`.
+`$effect.pre` therefore runs before DOM updates that are scheduled after it, not before every DOM mutation in the flush. When using [await expressions](await-expressions), block updates like `{#if ...}` and `{#each ...}` in the same component also run before `$effect.pre`.
 
 Apart from the timing, `$effect.pre` works exactly like `$effect`.
 

--- a/documentation/docs/06-runtime/03-lifecycle-hooks.md
+++ b/documentation/docs/06-runtime/03-lifecycle-hooks.md
@@ -102,7 +102,7 @@ To implement a chat window that autoscrolls to the bottom when new messages appe
 
 In Svelte 4, we do this with `beforeUpdate`, but this is a flawed approach — it fires before _every_ update, whether it's relevant or not. In the example below, we need to introduce checks like `updatingMessages` to make sure we don't mess with the scroll position when someone toggles dark mode.
 
-With runes, we can use `$effect.pre`, which behaves the same as `$effect` but runs before the DOM is updated. As long as we explicitly reference `messages` inside the effect body, it will run whenever `messages` changes, but _not_ when `theme` changes.
+With runes, we can use `$effect.pre`, which behaves the same as `$effect` but runs before DOM updates scheduled after it (see [$effect.pre]($effect#$effect.pre) for the exact ordering). As long as we explicitly reference `messages` inside the effect body, it will run whenever `messages` changes, but _not_ when `theme` changes.
 
 `beforeUpdate`, and its equally troublesome counterpart `afterUpdate`, are therefore deprecated in Svelte 5.
 

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -261,7 +261,7 @@ declare function $effect(fn: () => void | (() => void)): void;
 declare namespace $effect {
 	/**
 	 * Runs code right before a component is mounted to the DOM, and then whenever its dependencies change, i.e. `$state` or `$derived` values.
-	 * The timing of the execution is right before the DOM is updated.
+	 * The timing of the execution is right before DOM updates scheduled after it in the same flush — effects in ancestor components run earlier and may already have updated the DOM.
 	 *
 	 * Example:
 	 * ```ts

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -261,7 +261,7 @@ declare function $effect(fn: () => void | (() => void)): void;
 declare namespace $effect {
 	/**
 	 * Runs code right before a component is mounted to the DOM, and then whenever its dependencies change, i.e. `$state` or `$derived` values.
-	 * The timing of the execution is right before DOM updates scheduled after it in the same flush — effects in ancestor components run earlier and may already have updated the DOM.
+	 * The timing of the execution is right before DOM updates that are scheduled after it in the same flush; parts of the DOM may already have been updated by the time it runs.
 	 *
 	 * Example:
 	 * ```ts

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -261,7 +261,7 @@ declare function $effect(fn: () => void | (() => void)): void;
 declare namespace $effect {
 	/**
 	 * Runs code right before a component is mounted to the DOM, and then whenever its dependencies change, i.e. `$state` or `$derived` values.
-	 * The timing of the execution is right before DOM updates that are scheduled after it in the same flush; parts of the DOM may already have been updated by the time it runs.
+	 * The timing of the execution is right before the DOM that comes after it is updated; parent DOM may already have been updated by the time it runs.
 	 *
 	 * Example:
 	 * ```ts

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -3466,7 +3466,7 @@ declare function $effect(fn: () => void | (() => void)): void;
 declare namespace $effect {
 	/**
 	 * Runs code right before a component is mounted to the DOM, and then whenever its dependencies change, i.e. `$state` or `$derived` values.
-	 * The timing of the execution is right before the DOM is updated.
+	 * The timing of the execution is right before DOM updates scheduled after it in the same flush — effects in ancestor components run earlier and may already have updated the DOM.
 	 *
 	 * Example:
 	 * ```ts

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -3466,7 +3466,7 @@ declare function $effect(fn: () => void | (() => void)): void;
 declare namespace $effect {
 	/**
 	 * Runs code right before a component is mounted to the DOM, and then whenever its dependencies change, i.e. `$state` or `$derived` values.
-	 * The timing of the execution is right before DOM updates scheduled after it in the same flush — effects in ancestor components run earlier and may already have updated the DOM.
+	 * The timing of the execution is right before DOM updates that are scheduled after it in the same flush; parts of the DOM may already have been updated by the time it runs.
 	 *
 	 * Example:
 	 * ```ts

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -3466,7 +3466,7 @@ declare function $effect(fn: () => void | (() => void)): void;
 declare namespace $effect {
 	/**
 	 * Runs code right before a component is mounted to the DOM, and then whenever its dependencies change, i.e. `$state` or `$derived` values.
-	 * The timing of the execution is right before DOM updates that are scheduled after it in the same flush; parts of the DOM may already have been updated by the time it runs.
+	 * The timing of the execution is right before the DOM that comes after it is updated; parent DOM may already have been updated by the time it runs.
 	 *
 	 * Example:
 	 * ```ts


### PR DESCRIPTION
Related to #16648.

The docs describe `$effect.pre` as running "before the DOM is updated", in the rune docs, the `beforeUpdate` migration guide, and the JSDoc. As explained in that issue, the actual guarantee is narrower, effects run in tree order interleaved with template updates, so an ancestor's effects may already have mutated the DOM by the time a child's `$effect.pre` runs, and in async mode same-component block updates run first too. The last part is already documented on the await expressions page but not where `$effect.pre` is defined, which is where people coming from `getSnapshotBeforeUpdate`/`onBeforeUpdate` land.

This tightens the three places that state the loose version, no behavior changes.

---

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it (docs only)
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`)

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
