### PR TITLE
fix: force the first run innerText/innerHTML/textContent written for content_editable_bind

### DIFF
--- a/.changeset/eager-flowers-stay.md
+++ b/.changeset/eager-flowers-stay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: force the first run innerText/innerHTML/textContent written for content_editable_bind

--- a/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/universal.js
@@ -1,4 +1,5 @@
 import { render_effect, teardown } from '../../../reactivity/effects.js';
+import { hydrating } from '../../hydration.js';
 import { listen } from './shared.js';
 
 /**
@@ -14,10 +15,12 @@ export function bind_content_editable(property, element, get, set = get) {
 		set(element[property]);
 	});
 
+	var first_run = true;
 	render_effect(() => {
 		var value = get();
 
-		if (element[property] !== value) {
+		if (element[property] !== value || (first_run && !hydrating)) {
+			first_run = false;
 			if (value == null) {
 				// @ts-ignore
 				var non_null_value = element[property];

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-contenteditable-1/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-contenteditable-1/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from '../../../../src/index-client';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const h1 = /** @type {HTMLDivElement} */ (target.querySelector('h1'));
+
+		assert.equal(h1.textContent, 'h');
+		// don't use h1.textContent because h1.textContent will overwrite all childNodes
+		// The childNode created by {myTextBlock.current} is the reason for duplication
+		const textNode =
+			[...h1.childNodes].findLast((n) => n.nodeType === Node.TEXT_NODE) ??
+			h1.appendChild(document.createTextNode(''));
+		textNode.nodeValue = 'he';
+		h1.dispatchEvent(new window.Event('input'));
+		flushSync();
+
+		assert.equal(h1.textContent, 'he');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-contenteditable-1/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-contenteditable-1/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	const myTextBlock = $state({
+		current: 'h'
+	})
+
+	const renderTag = $state("h1")
+
+</script>
+
+<svelte:element this={renderTag} contenteditable="plaintext-only" class="test" bind:textContent={myTextBlock.current}>
+    {myTextBlock.current}
+</svelte:element>

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-contenteditable/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-contenteditable/_config.js
@@ -1,0 +1,19 @@
+import { flushSync } from '../../../../src/index-client';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const h1 = /** @type {HTMLDivElement} */ (target.querySelector('h1'));
+		assert.equal(h1.textContent, '');
+		// don't use h1.textContent because h1.textContent will overwrite all childNodes
+		// The childNode created by {myTextBlock.current} is the reason for duplication
+		const textNode =
+			[...h1.childNodes].findLast((n) => n.nodeType === Node.TEXT_NODE) ??
+			h1.appendChild(document.createTextNode(''));
+		textNode.nodeValue = 'h';
+		h1.dispatchEvent(new window.Event('input'));
+		flushSync();
+
+		assert.equal(h1.textContent, 'h');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-element-contenteditable/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-element-contenteditable/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	const myTextBlock = $state({
+		current: ''
+	})
+
+	const renderTag = $state("h1")
+
+</script>
+
+<svelte:element this={renderTag} contenteditable="plaintext-only" class="test" bind:textContent={myTextBlock.current}>
+    {myTextBlock.current}
+</svelte:element>


### PR DESCRIPTION
fix #17969 

https://github.com/sveltejs/svelte/blob/b4d1583ae20f3869a88a731d9a265c546c099f66/packages/svelte/src/internal/client/dom/elements/bindings/universal.js#L20-L29

Currently if the binding `value `is empty string, the `innerText/innerHTML/textContent` will not be overwritten during initialization, which keeps the ChildNodes created by other child elements. My solution is force the first time overwritten in client side code.

I notice Vue.js will throw compiler error when use `v-text` with child elements, I think that is a better and clean solution, but from previous PR https://github.com/sveltejs/svelte/pull/12210 , Svelte support child element in this case as a rendering fallback.

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
