### PR TITLE
feat: verified-links kernel for `$state` onchange (#15069)

### DIFF
--- a/.changeset/violet-signals-verify.md
+++ b/.changeset/violet-signals-verify.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: onchange kernel for deep proxied state via verified parent links

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -63,6 +63,7 @@ export const STATE_SYMBOL = Symbol('$state');
 export const LEGACY_PROPS = Symbol('legacy props');
 export const LOADING_ATTR_SYMBOL = Symbol('');
 export const PROXY_PATH_SYMBOL = Symbol('proxy path');
+export const PROXY_META_SYMBOL = Symbol('proxy meta');
 export const ATTRIBUTES_CACHE = Symbol('attributes');
 export const CLASS_CACHE = Symbol('class');
 export const STYLE_CACHE = Symbol('style');

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -6,8 +6,10 @@ import {
 	update_version,
 	active_reaction,
 	set_update_version,
-	set_active_reaction
+	set_active_reaction,
+	untrack
 } from './runtime.js';
+import { eager_effect } from './reactivity/effects.js';
 import {
 	array_prototype,
 	get_descriptor,
@@ -22,7 +24,7 @@ import {
 	flush_eager_effects,
 	set_eager_effects_deferred
 } from './reactivity/sources.js';
-import { PROXY_PATH_SYMBOL, STATE_SYMBOL } from '#client/constants';
+import { PROXY_META_SYMBOL, PROXY_PATH_SYMBOL, STATE_SYMBOL } from '#client/constants';
 import { UNINITIALIZED } from '../../constants.js';
 import * as e from './errors.js';
 import { tag } from './dev/tracing.js';
@@ -33,13 +35,153 @@ import { tracing_mode_flag } from '../flags/index.js';
 const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 
 /**
+ * @typedef {{
+ *   self: any;
+ *   sources: Map<any, Source<any>>;
+ *   links: Array<{ pm: ProxyMeta, k: any }>;
+ *   fires: Array<() => void>;
+ *   observed: boolean;
+ * }} ProxyMeta
+ */
+
+/**
+ * Creates the dispatch half of an `onchange` root: a notifier source paired with an
+ * eager effect, so callbacks run synchronously inside `set()` and inherit the existing
+ * fork gating and deferral behaviour
+ * @param {() => void} onchange
+ * @returns {() => void}
+ */
+function create_fire(onchange) {
+	var notifier = source(0);
+	var initial = true;
+	var running = false;
+
+	eager_effect(() => {
+		get(notifier);
+
+		if (initial) {
+			initial = false;
+			return;
+		}
+
+		// guard against the callback synchronously mutating its own tree
+		if (running) return;
+		running = true;
+
+		try {
+			untrack(onchange);
+		} finally {
+			running = false;
+		}
+	});
+
+	return () => increment(notifier);
+}
+
+/**
+ * Registers `parent_meta[key]` as a (possibly stale) way to reach a root from `child`.
+ * Links are never eagerly removed — they are verified and pruned during `collect_roots`
+ * @param {any} child
+ * @param {ProxyMeta} parent_meta
+ * @param {any} key
+ */
+function link_child(child, parent_meta, key) {
+	if (child === null || typeof child !== 'object' || !(STATE_SYMBOL in child)) return;
+
+	var get_meta = /** @type {(() => ProxyMeta) | undefined} */ (child[PROXY_META_SYMBOL]);
+	if (get_meta === undefined) return;
+
+	var meta = get_meta();
+	var links = meta.links;
+
+	for (var i = 0; i < links.length; i += 1) {
+		if (links[i].pm === parent_meta && links[i].k === key) return;
+	}
+
+	links.push({ pm: parent_meta, k: key });
+	meta.observed = true;
+}
+
+/**
+ * Walks rootward from `meta`, verifying each link against the parent's backing source
+ * (`parent.sources.get(key).v === child`). Dead links are pruned in place; live chains
+ * contribute their root callbacks to `fires`
+ * @param {ProxyMeta} meta
+ * @param {Set<ProxyMeta>} visited
+ * @param {Set<() => void>} fires
+ */
+function collect_roots(meta, visited, fires) {
+	if (visited.has(meta)) return;
+	visited.add(meta);
+
+	for (var i = 0; i < meta.fires.length; i += 1) {
+		fires.add(meta.fires[i]);
+	}
+
+	var links = meta.links;
+
+	for (var j = links.length - 1; j >= 0; j -= 1) {
+		var link = links[j];
+		var s = link.pm.sources.get(link.k);
+
+		if (s !== undefined && s.v === meta.self) {
+			collect_roots(link.pm, visited, fires);
+		} else {
+			links.splice(j, 1);
+		}
+	}
+
+	if (links.length === 0 && meta.fires.length === 0) {
+		meta.observed = false;
+	}
+}
+
+/** @param {ProxyMeta} meta */
+function notify_onchange(meta) {
+	/** @type {Set<() => void>} */
+	var fires = new Set();
+	collect_roots(meta, new Set(), fires);
+
+	for (var fire of fires) fire();
+}
+
+/**
+ * Wraps an array mutating method so onchange roots fire once per method call
+ * rather than once per internal `set` (e.g. `push` writes an element and `length`)
+ * @param {Function} fn
+ */
+function batch_eager_method(fn) {
+	return function (/** @type {any[]} */ ...args) {
+		set_eager_effects_deferred();
+
+		try {
+			// @ts-ignore
+			return fn.apply(this, args);
+		} finally {
+			flush_eager_effects();
+		}
+	};
+}
+
+/**
  * @template T
  * @param {T} value
+ * @param {() => void} [onchange] fires synchronously whenever anything in the tree changes
  * @returns {T}
  */
-export function proxy(value) {
+export function proxy(value, onchange) {
 	// if non-proxyable, or is already a proxy, return `value`
-	if (typeof value !== 'object' || value === null || STATE_SYMBOL in value) {
+	if (typeof value !== 'object' || value === null) {
+		return value;
+	}
+
+	if (STATE_SYMBOL in value) {
+		if (onchange !== undefined) {
+			// attach an additional root callback to an existing proxy
+			var m = /** @type {() => ProxyMeta} */ (/** @type {any} */ (value)[PROXY_META_SYMBOL])();
+			m.fires.push(create_fire(onchange));
+			m.observed = true;
+		}
 		return value;
 	}
 
@@ -53,6 +195,13 @@ export function proxy(value) {
 	var sources = new Map();
 	var is_proxied_array = is_array(value);
 	var version = source(0);
+
+	/**
+	 * Only allocated once this proxy participates in an observed tree —
+	 * proxies outside onchange trees never pay for this beyond a null check
+	 * @type {ProxyMeta | null}
+	 */
+	var meta = null;
 
 	var stack = DEV && tracing_mode_flag ? get_error('created at') : null;
 	var parent_version = update_version;
@@ -110,7 +259,7 @@ export function proxy(value) {
 		updating = false;
 	}
 
-	return new Proxy(/** @type {any} */ (value), {
+	var p = new Proxy(/** @type {any} */ (value), {
 		defineProperty(_, prop, descriptor) {
 			if (
 				!('value' in descriptor) ||
@@ -143,20 +292,27 @@ export function proxy(value) {
 
 		deleteProperty(target, prop) {
 			var s = sources.get(prop);
+			var changed = false;
 
 			if (s === undefined) {
 				if (prop in target) {
 					const s = with_parent(() => source(UNINITIALIZED, stack));
 					sources.set(prop, s);
 					increment(version);
+					changed = true;
 
 					if (DEV) {
 						tag(s, get_label(path, prop));
 					}
 				}
 			} else {
+				if (s.v !== UNINITIALIZED) changed = true;
 				set(s, UNINITIALIZED);
 				increment(version);
+			}
+
+			if (changed && meta !== null && meta.observed) {
+				notify_onchange(/** @type {ProxyMeta} */ (meta));
 			}
 
 			return true;
@@ -173,6 +329,11 @@ export function proxy(value) {
 
 			var s = sources.get(prop);
 			var exists = prop in target;
+
+			// symbols are never own properties, so this check can live off the hot path
+			if (s === undefined && prop === PROXY_META_SYMBOL) {
+				return () => (meta ??= { self: p, sources, links: [], fires: [], observed: false });
+			}
 
 			// create a source, but only if it's an own property and not a prototype property
 			if (s === undefined && (!exists || get_descriptor(target, prop)?.writable)) {
@@ -192,10 +353,32 @@ export function proxy(value) {
 
 			if (s !== undefined) {
 				var v = get(s);
+
+				// reads through an observed proxy establish (or refresh) the child's
+				// rootward link — mutation is only possible via a reference obtained
+				// through this trap or the set trap, so coverage matches reactivity's
+				if (meta !== null && meta.observed && v !== UNINITIALIZED) {
+					link_child(v, meta, prop);
+				}
+
 				return v === UNINITIALIZED ? undefined : v;
 			}
 
-			return Reflect.get(target, prop, receiver);
+			var reflected = Reflect.get(target, prop, receiver);
+
+			if (
+				is_proxied_array &&
+				typeof prop === 'string' &&
+				typeof reflected === 'function' &&
+				ARRAY_MUTATING_METHODS.has(prop) &&
+				meta !== null &&
+				meta.observed
+			) {
+				// batch array methods so e.g. `push` (element + length) fires roots once
+				return batch_eager_method(reflected);
+			}
+
+			return reflected;
 		},
 
 		getOwnPropertyDescriptor(target, prop) {
@@ -260,6 +443,7 @@ export function proxy(value) {
 		set(target, prop, value, receiver) {
 			var s = sources.get(prop);
 			var has = prop in target;
+			var changed = false;
 
 			// variable.length = value -> clear all signals with index >= value
 			if (is_proxied_array && prop === 'length') {
@@ -292,7 +476,14 @@ export function proxy(value) {
 					if (DEV) {
 						tag(s, get_label(path, prop));
 					}
-					set(s, proxy(value));
+
+					var np = proxy(value);
+					set(s, np);
+					changed = true;
+
+					if (meta !== null && meta.observed) {
+						link_child(np, /** @type {ProxyMeta} */ (meta), prop);
+					}
 
 					sources.set(prop, s);
 				}
@@ -300,7 +491,14 @@ export function proxy(value) {
 				has = s.v !== UNINITIALIZED;
 
 				var p = with_parent(() => proxy(value));
-				set(s, p);
+
+				if (meta !== null && meta.observed) {
+					if (s.v !== p) changed = true;
+					set(s, p);
+					link_child(p, meta, prop);
+				} else {
+					set(s, p);
+				}
 			}
 
 			var descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
@@ -325,6 +523,11 @@ export function proxy(value) {
 				}
 
 				increment(version);
+				changed = true;
+			}
+
+			if (changed && meta !== null && meta.observed) {
+				notify_onchange(/** @type {ProxyMeta} */ (meta));
 			}
 
 			return true;
@@ -351,6 +554,12 @@ export function proxy(value) {
 			e.state_prototype_fixed();
 		}
 	});
+
+	if (onchange !== undefined) {
+		meta = { self: p, sources, links: [], fires: [create_fire(onchange)], observed: true };
+	}
+
+	return p;
 }
 
 /**

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -1,4 +1,4 @@
-/** @import { Source } from '#client' */
+/** @import { Effect, Source } from '#client' */
 import { DEV } from 'esm-env';
 import {
 	get,
@@ -9,7 +9,7 @@ import {
 	set_active_reaction,
 	untrack
 } from './runtime.js';
-import { eager_effect } from './reactivity/effects.js';
+import { destroy_effect, eager_effect } from './reactivity/effects.js';
 import {
 	array_prototype,
 	get_descriptor,
@@ -39,7 +39,7 @@ const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
  *   self: any;
  *   sources: Map<any, Source<any>>;
  *   links: Array<{ pm: ProxyMeta, k: any }>;
- *   fires: Array<() => void>;
+ *   fires: Array<{ cb: () => void, fire: () => void, e: Effect }>;
  *   observed: boolean;
  * }} ProxyMeta
  */
@@ -47,16 +47,17 @@ const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 /**
  * Creates the dispatch half of an `onchange` root: a notifier source paired with an
  * eager effect, so callbacks run synchronously inside `set()` and inherit the existing
- * fork gating and deferral behaviour
+ * fork gating and deferral behaviour. The original callback is kept alongside so it
+ * can be detached again by identity
  * @param {() => void} onchange
- * @returns {() => void}
+ * @returns {{ cb: () => void, fire: () => void, e: Effect }}
  */
 function create_fire(onchange) {
 	var notifier = source(0);
 	var initial = true;
 	var running = false;
 
-	eager_effect(() => {
+	var effect = eager_effect(() => {
 		get(notifier);
 
 		if (initial) {
@@ -75,7 +76,7 @@ function create_fire(onchange) {
 		}
 	});
 
-	return () => increment(notifier);
+	return { cb: onchange, fire: () => increment(notifier), e: effect };
 }
 
 /**
@@ -88,10 +89,9 @@ function create_fire(onchange) {
 function link_child(child, parent_meta, key) {
 	if (child === null || typeof child !== 'object' || !(STATE_SYMBOL in child)) return;
 
-	var get_meta = /** @type {(() => ProxyMeta) | undefined} */ (child[PROXY_META_SYMBOL]);
-	if (get_meta === undefined) return;
+	var meta = /** @type {ProxyMeta | undefined} */ (child[PROXY_META_SYMBOL]);
+	if (meta === undefined) return;
 
-	var meta = get_meta();
 	var links = meta.links;
 
 	for (var i = 0; i < links.length; i += 1) {
@@ -99,7 +99,23 @@ function link_child(child, parent_meta, key) {
 	}
 
 	links.push({ pm: parent_meta, k: key });
+	observe(meta);
+}
+
+/**
+ * Marks a node observed and links its already-materialized children, so references
+ * captured before the node joined an observed tree still reach a root
+ * @param {ProxyMeta} meta
+ */
+function observe(meta) {
+	if (meta.observed) return;
 	meta.observed = true;
+
+	for (var [key, s] of meta.sources) {
+		if (s.v !== UNINITIALIZED) {
+			link_child(s.v, meta, key);
+		}
+	}
 }
 
 /**
@@ -115,7 +131,7 @@ function collect_roots(meta, visited, fires) {
 	visited.add(meta);
 
 	for (var i = 0; i < meta.fires.length; i += 1) {
-		fires.add(meta.fires[i]);
+		fires.add(meta.fires[i].fire);
 	}
 
 	var links = meta.links;
@@ -143,6 +159,33 @@ function notify_onchange(meta) {
 	collect_roots(meta, new Set(), fires);
 
 	for (var fire of fires) fire();
+}
+
+/**
+ * Detaches a callback previously attached with `proxy(value, onchange)`, used by the
+ * `$state` shell so a reassigned variable's old tree stops firing its callback
+ * @param {any} value
+ * @param {() => void} onchange
+ */
+export function remove_onchange(value, onchange) {
+	if (value === null || typeof value !== 'object' || !(STATE_SYMBOL in value)) return;
+
+	var meta = /** @type {ProxyMeta | undefined} */ (value[PROXY_META_SYMBOL]);
+	if (meta === undefined) return;
+
+	var fires = meta.fires;
+
+	for (var i = 0; i < fires.length; i += 1) {
+		if (fires[i].cb === onchange) {
+			destroy_effect(fires[i].e);
+			fires.splice(i, 1);
+			break;
+		}
+	}
+
+	if (fires.length === 0 && meta.links.length === 0) {
+		meta.observed = false;
+	}
 }
 
 /**
@@ -178,9 +221,9 @@ export function proxy(value, onchange) {
 	if (STATE_SYMBOL in value) {
 		if (onchange !== undefined) {
 			// attach an additional root callback to an existing proxy
-			var m = /** @type {() => ProxyMeta} */ (/** @type {any} */ (value)[PROXY_META_SYMBOL])();
+			var m = /** @type {ProxyMeta} */ (/** @type {any} */ (value)[PROXY_META_SYMBOL]);
 			m.fires.push(create_fire(onchange));
-			m.observed = true;
+			observe(m);
 		}
 		return value;
 	}
@@ -332,7 +375,7 @@ export function proxy(value, onchange) {
 
 			// symbols are never own properties, so this check can live off the hot path
 			if (s === undefined && prop === PROXY_META_SYMBOL) {
-				return () => (meta ??= { self: p, sources, links: [], fires: [], observed: false });
+				return (meta ??= { self: p, sources, links: [], fires: [], observed: false });
 			}
 
 			// create a source, but only if it's an own property and not a prototype property
@@ -367,12 +410,12 @@ export function proxy(value, onchange) {
 			var reflected = Reflect.get(target, prop, receiver);
 
 			if (
+				meta !== null &&
+				meta.observed &&
 				is_proxied_array &&
 				typeof prop === 'string' &&
 				typeof reflected === 'function' &&
-				ARRAY_MUTATING_METHODS.has(prop) &&
-				meta !== null &&
-				meta.observed
+				ARRAY_MUTATING_METHODS.has(prop)
 			) {
 				// batch array methods so e.g. `push` (element + length) fires roots once
 				return batch_eager_method(reflected);
@@ -479,7 +522,7 @@ export function proxy(value, onchange) {
 
 					var np = proxy(value);
 					set(s, np);
-					changed = true;
+					changed = !has || target[prop] !== value;
 
 					if (meta !== null && meta.observed) {
 						link_child(np, /** @type {ProxyMeta} */ (meta), prop);

--- a/packages/svelte/tests/signals/onchange.test.ts
+++ b/packages/svelte/tests/signals/onchange.test.ts
@@ -1,0 +1,187 @@
+import { assert, describe, it } from 'vitest';
+import { effect_root } from '../../src/internal/client/reactivity/effects';
+import { push, pop } from '../../src/internal/client/context';
+import { proxy } from '../../src/internal/client/proxy';
+
+function run(fn: () => void) {
+	push({}, true);
+	const destroy = effect_root(() => {
+		fn();
+	});
+	pop();
+	destroy();
+}
+
+describe('proxy onchange kernel', () => {
+	it('fires synchronously on deep mutation', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ a: { b: 1 } } as any, () => count++);
+
+			state.a.b = 2;
+			assert.equal(count, 1);
+
+			state.a.b = 3;
+			assert.equal(count, 2);
+		});
+	});
+
+	it('does not fire when a write does not change the value', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ x: 1 } as any, () => count++);
+
+			state.x = 2;
+			assert.equal(count, 1);
+
+			state.x = 2;
+			assert.equal(count, 1);
+		});
+	});
+
+	it('veto case 1 (shared-array flaw): detached children go silent', () => {
+		run(() => {
+			let count = 0;
+			const items = proxy([{ foo: 'a' }, { foo: 'b' }, { foo: 'c' }] as any[], () => count++);
+
+			const last = items[2];
+			assert.equal(count, 0);
+
+			items.pop();
+			assert.equal(count, 1);
+
+			// the popped item is no longer in the tree — mutating it must not fire
+			last.foo = 'blah';
+			assert.equal(count, 1);
+		});
+	});
+
+	it('veto case 2 (parent-chain dealbreaker): existing proxies can join observed trees', () => {
+		run(() => {
+			let foo = 0;
+			let bar = 0;
+			const inner = proxy({ x: 0 } as any, () => bar++);
+			const tree = proxy({} as any, () => foo++);
+
+			tree.slot = inner;
+			assert.equal(foo, 1);
+			assert.equal(bar, 0);
+
+			// mutating inner through its own reference notifies BOTH trees
+			inner.x = 1;
+			assert.equal(foo, 2);
+			assert.equal(bar, 1);
+
+			// and through the tree as well
+			tree.slot.x = 2;
+			assert.equal(foo, 3);
+			assert.equal(bar, 2);
+
+			delete tree.slot;
+			assert.equal(foo, 4);
+			assert.equal(bar, 2);
+
+			// detached again — only its own root fires
+			inner.x = 3;
+			assert.equal(foo, 4);
+			assert.equal(bar, 3);
+		});
+	});
+
+	it('veto case 3 (Set aliasing bug): same child under two keys survives one deletion', () => {
+		run(() => {
+			let count = 0;
+			const tree = proxy({} as any, () => count++);
+
+			tree.a = { z: 0 };
+			assert.equal(count, 1);
+
+			tree.b = tree.a;
+			assert.equal(count, 2);
+
+			delete tree.a;
+			assert.equal(count, 3);
+
+			// still reachable via `b` — must still fire
+			tree.b.z = 1;
+			assert.equal(count, 4);
+
+			const child = tree.b;
+			delete tree.b;
+			assert.equal(count, 5);
+
+			// now fully detached — silent
+			child.z = 2;
+			assert.equal(count, 5);
+		});
+	});
+
+	it('array methods fire once per call', () => {
+		run(() => {
+			let count = 0;
+			const arr = proxy([] as any[], () => count++);
+
+			arr.push(1);
+			assert.equal(count, 1);
+
+			arr.push(2, 3);
+			assert.equal(count, 2);
+
+			arr.splice(0, 1);
+			assert.equal(count, 3);
+		});
+	});
+
+	it('works without a parent effect (module-level state)', () => {
+		let count = 0;
+		const state = proxy({ n: 0 } as any, () => count++);
+
+		state.n = 1;
+		assert.equal(count, 1);
+	});
+
+	it('lazily-read nested objects are covered once traversed', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ nested: { deep: { v: 0 } } } as any, () => count++);
+
+			// mutation requires traversal, traversal establishes links
+			state.nested.deep.v = 1;
+			assert.equal(count, 1);
+
+			const deep = state.nested.deep;
+			deep.v = 2;
+			assert.equal(count, 2);
+		});
+	});
+
+	it('callback reads see the post-mutation tree', () => {
+		run(() => {
+			let seen = -1;
+			const state: any = proxy({ x: 0 } as any, () => (seen = state.x));
+
+			state.x = 42;
+			assert.equal(seen, 42);
+		});
+	});
+
+	it('replacing a subtree detaches the old one', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ child: { v: 0 } } as any, () => count++);
+
+			const old = state.child;
+			old.v = 1;
+			assert.equal(count, 1);
+
+			state.child = { v: 100 };
+			assert.equal(count, 2);
+
+			old.v = 2;
+			assert.equal(count, 2);
+
+			state.child.v = 101;
+			assert.equal(count, 3);
+		});
+	});
+});

--- a/packages/svelte/tests/signals/onchange.test.ts
+++ b/packages/svelte/tests/signals/onchange.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from 'vitest';
 import { effect_root } from '../../src/internal/client/reactivity/effects';
 import { push, pop } from '../../src/internal/client/context';
-import { proxy } from '../../src/internal/client/proxy';
+import { proxy, remove_onchange } from '../../src/internal/client/proxy';
 
 function run(fn: () => void) {
 	push({}, true);
@@ -162,6 +162,86 @@ describe('proxy onchange kernel', () => {
 
 			state.x = 42;
 			assert.equal(seen, 42);
+		});
+	});
+
+	it('does not fire when the first write of a property does not change it', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ x: 1 } as any, () => count++);
+
+			state.x = 1;
+			assert.equal(count, 0);
+
+			state.x = 2;
+			assert.equal(count, 1);
+		});
+	});
+
+	it('attached callbacks can be detached again (#15069 reassignment path)', () => {
+		run(() => {
+			const logs: string[] = [];
+			const b = proxy({ count: 0 } as any, () => logs.push('b'));
+			const c = () => logs.push('c');
+			proxy(b, c);
+
+			b.count = 1;
+			assert.deepEqual(logs, ['b', 'c']);
+
+			remove_onchange(b, c);
+
+			b.count = 2;
+			assert.deepEqual(logs, ['b', 'c', 'b']);
+		});
+	});
+
+	it('attaching to an existing proxy covers already-materialized children', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ a: { b: 0 } } as any);
+			const a = state.a;
+
+			proxy(state, () => count++);
+
+			a.b = 1;
+			assert.equal(count, 1);
+		});
+	});
+
+	it('references captured before a subtree joins an observed tree still notify', () => {
+		run(() => {
+			let count = 0;
+			const inner = proxy({ nested: { v: 0 } } as any);
+			const captured = inner.nested;
+
+			const tree = proxy({} as any, () => count++);
+			tree.slot = inner;
+			assert.equal(count, 1);
+
+			captured.v = 1;
+			assert.equal(count, 2);
+		});
+	});
+
+	it('children created while detached are covered after re-attachment', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ child: { v: 0 } } as any, () => count++);
+
+			const child = state.child;
+			state.child = null;
+			assert.equal(count, 1);
+
+			child.v = 1;
+			child.deep = { z: 0 };
+			const deep = child.deep;
+			assert.equal(count, 1);
+
+			state.child = child;
+			assert.equal(count, 2);
+
+			deep.z = 1;
+			assert.equal(count, 3);
 		});
 	});
 


### PR DESCRIPTION
This implements the deep-notification kernel for #15069, the part its design discussion stalled on. The rest of what it needs landed since with #17934, and #15069's API, compiler surface and tests sit on top of this unchanged.

## What changed since the design discussion stalled

| open question in April 2025 | on main today |
|---|---|
| how do callbacks run synchronously inside `set()` | `eager_effects`, flushed in `set()` (`sources.js`, #17934) |
| what happens during forks | eager effects skip them (`!batch.is_fork`) |
| `push` fires twice (element + `length`) | `set_eager_effects_deferred()` / `flush_eager_effects()` (`proxy.js`) |
| per-proxy listener storage too expensive, detach vs composition trade-off | the one remaining problem, addressed here |

## The kernel

The earlier designs all kept listener bookkeeping correct at write time, which forces a choice between memory (callbacks stored on every proxy), detach correctness (shared arrays can't be un-shared), and composition (single parent pointers ban inserting existing proxies).

This inverts the invariant. Children keep possibly-stale `(parent, key)` back-links, created lazily in the `get`/`set` traps, and correctness is enforced at fire time: the walk verifies `parent.sources.get(key).v === child` at each hop and prunes dead links as it goes. Detaching costs zero writes. Composition is unrestricted because links are a list, not a single parent.

```mermaid
graph TD
    M([a mutation lands in a proxy trap]) --> V[visit node: collect its onchange, mark visited]
    V --> L{"any links left to check on this walk?"}
    L -->|"link verifies: parent.sources.get(key).v === child"| U[visit that parent]
    U --> V
    L -->|"link is stale: popped / replaced / deleted"| X[prune it]
    X --> L
    L -->|"no more links, walk complete"| F([fire each collected onchange once])
```

Dispatch is an `eager_effect` reading a per-root notifier source, so fork gating and array-method batching are inherited from existing machinery rather than reimplemented.

The scenarios that killed the previous designs are tests now (`tests/signals/onchange.test.ts`):

```js
const last = items[2];
items.pop();
last.foo = 'blah'; // does not fire, the link fails verification
```

```js
tree.slot = existingStateProxy; // allowed, a second link rather than a re-parent
existingStateProxy.x = 1; // notifies both trees
```

```js
tree.a = obj;
tree.b = tree.a;
delete tree.a;
tree.b.z = 1; // still fires, links are per-key so nothing collapses
```

## Cost

State outside observed trees pays one always-null field and one null check per trap operation. Observed trees pay an O(depth) verified walk per mutation, and roughly 1µs per callback fire.

| dormant (no onchange anywhere) | base | kernel |
|---|---|---|
| create 30k proxies | ~3.4ms | ~3.6ms |
| 300k deep reads | ~12.0ms | ~12.1ms |
| 300k deep writes | ~27.9ms | ~26.3ms |

Same-process A/B, both implementations loaded side by side with alternating rounds. `bench:compare` against the base commit shows median delta −1.1% across the suite, worst case +3.8%, within run noise. These are my machine's numbers, treat CI as the final word.

## Out of scope / known gaps

- the `$state(value, { onchange })` compiler surface and top-level primitive reassignment (intact in #15069, composes with this kernel)
- `defineProperty` doesn't notify yet
- a mutation inside a discarded fork can leave one spurious post-commit fire (the callback observes no actual change)
- the re-entrancy guard is per-root (a callback mutating its own tree won't loop, sibling cycles can)

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
