### PR TITLE
fix: clear previous_task reference after abort in Tween

### DIFF
--- a/.changeset/tween-previous-task-leak.md
+++ b/.changeset/tween-previous-task-leak.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+fix: clear previous_task reference after abort in Tween to prevent memory leak on interrupted tweens

--- a/packages/svelte/src/motion/tweened.js
+++ b/packages/svelte/src/motion/tweened.js
@@ -275,6 +275,7 @@ export class Tween {
 				}
 
 				previous_task?.abort();
+				previous_task = null;
 			}
 
 			const elapsed = now - start;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

## Problem

`Tween.set()` (in `packages/svelte/src/motion/tweened.js`) aborts the previous task when interrupted by a new `set()` call, but never clears the `previous_task` closure variable afterward. Each new `set()` call's rAF loop closure retains a reference to the previous (already-aborted) task — and transitively, the entire chain of prior tasks — so on any long-lived or frequently-interrupted `Tween`, memory grows unbounded across interruptions and is never released.

No linked issue — new issue creation is currently restricted on this repo for my account, so filing the details directly here instead.

## Repro

```js
import { Tween } from 'svelte/motion';
const t = new Tween(new Array(10_000).fill(0));
setInterval(() => t.set(new Array(10_000).fill(Math.random())), 20);
```

Chrome DevTools heap snapshots taken across repeated intervals show a steadily growing retainer chain rooted at `{promise, abort}` → `previous_task`, never released between GC passes.

## Fix

One-line fix: null the `previous_task` reference immediately after aborting it, inside the `!started` branch of the rAF loop:

```diff
 previous_task?.abort();
+previous_task = null;
```

This mirrors the identical pattern already present in the deprecated `tweened()` store further up in the same file:
```js
if (previous_task) {
  previous_task.abort();
  previous_task = null;
}
```
It appears this line was dropped when the newer `Tween` class was written. `previous_task` is not read anywhere else after this point in the closure, so this change has no effect on control flow — it only releases a reference that was never used again.

## Verification

- Confirmed via Chrome DevTools heap snapshot diffing across many rounds of interrupted tweens in a real-world app: the `previous_task` retainer chain is fully eliminated post-fix, with allocation/collection back in balance.
- No change to existing `abort()`/resolve/reject semantics — the fix only clears a variable, it doesn't alter when or how tasks are aborted.
- `pnpm test`: 7558 passed, 154 skipped. One unrelated failure in `runtime-browser/test.ts` due to a missing local Playwright browser binary (environment-only, not present in CI).
- `pnpm lint`: clean.

Happy to add a regression test if maintainers can point me to the right pattern under `packages/svelte/tests/motion` — didn't want to guess at the existing test conventions for this file.