### PR TITLE
perf: skip quadratic blocker analysis when no top-level await

### DIFF
--- a/.changeset/fast-cats-compile.md
+++ b/.changeset/fast-cats-compile.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: skip unnecessary blocker analysis when compiling components without top-level await

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1221,6 +1221,10 @@ function calculate_blockers(instance, analysis) {
 		}
 	}
 
+	// With no top-level await, no binding can have a blocker and function tracing
+	// cannot affect the output.
+	if (!awaited) return;
+
 	flush_sync_group();
 
 	for (const fn of functions) {


### PR DESCRIPTION
Skip function reference tracing in `calculate_blockers` when a component has no top-level `await`.

Blockers only represent dependencies on top-level async statements. Without a top-level `await`, no binding can have a blocker, so tracing every top-level function cannot affect the generated output. In large components with many functions and transitive assignments, that unnecessary work can become quadratic.

## Performance

Performance on Node 24 for a production app:

- 211 KB production component: 304 ms → 104 ms compile time (66% reduction)
- 74-component production build: 835 ms → 585 ms Svelte compile time (30% reduction)

Synthetic large component benchmark showing the quadratic slowdown:
<details>
  <summary>Code to generate a synthetic component at different sizes</summary>

```ts
function component(count) {
  const declarations = Array.from(
    { length: count },
    (_, i) => `let value${i};`,
  ).join('\n');

  const assignments = Array.from(
    { length: count },
    (_, i) => `value${i} = ${i === 0 ? '0' : `value${i - 1}`};`,
  ).join('\n');

  const calls = Array.from(
    { length: count },
    () => `consume(value${count - 1});`,
  ).join('\n');

  return `<script>
${declarations}
${assignments}
function run() {
${calls}
}
</script>`;
}
```

</details>

| Synthetic size | Before | After | Reduction |
| ---: | ---: | ---: | ---: |
| 100 | 4.78 ms | 2.83 ms | 41% |
| 200 | 10.99 ms | 4.03 ms | 63% |
| 400 | 34.06 ms | 7.42 ms | 78% |
| 800 | 123.03 ms | 14.88 ms | 88% |

The compiler output was byte-identical for 74 production components and a top-level await fixture.

I'll explore avoiding the quadratic behavior altogether, but that seems to be a more delicate task.

EDIT: fix for quadratic behavior in #18549.