### PR TITLE
fix: strip comments from inline style values in linear time

### DIFF
--- a/.changeset/strip-style-comments.md
+++ b/.changeset/strip-style-comments.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: strip comments from inline `style` values in linear time

--- a/packages/svelte/src/internal/shared/attributes.js
+++ b/packages/svelte/src/internal/shared/attributes.js
@@ -142,8 +142,9 @@ export function to_style(value, styles) {
 		}
 
 		if (value) {
+			// strip comments; surrounding whitespace is handled by the trims below
 			value = String(value)
-				.replaceAll(/\s*\/\*.*?\*\/\s*/g, '')
+				.replaceAll(/\/\*.*?\*\//g, '')
 				.trim();
 
 			/** @type {boolean | '"' | "'"} */

--- a/packages/svelte/src/internal/shared/attributes.js
+++ b/packages/svelte/src/internal/shared/attributes.js
@@ -142,7 +142,7 @@ export function to_style(value, styles) {
 		}
 
 		if (value) {
-			// strip comments; surrounding whitespace is handled by the trims below
+			// strip comments; surrounding whitespace is handled by the trims below (which is much faster than doing it through regex)
 			value = String(value)
 				.replaceAll(/\/\*.*?\*\//g, '')
 				.trim();


### PR DESCRIPTION
### Problem

`to_style()` strips CSS comments from an inline `style` value with `/\s*\/\*.*?\*\/\s*/g`. The leading `\s*` makes the match retry from every position, so a long run of whitespace backtracks in O(n^2). When a dynamic `style={value}` sits on an element that also has a `style:` directive, that regex runs on `value`, so a large whitespace string can stall rendering (server) or the main thread (client).

### Fix

Drop the surrounding `\s*` and match only the comment: `/\/\*.*?\*\//g`. The surrounding whitespace was already removed by the `.trim()` that follows and the per-property trims in the loop, so output is unchanged. Matching runs in linear time.

Behavior:

- Happy path: `style="a: 1; /* note */ b: 2"` still strips the comment and renders `a: 1; b: 2`, same as before.
- Unhappy path (all whitespace): a multi-KB whitespace value returns immediately instead of blocking for seconds.
- Unhappy path (no `style:` directive): unaffected, the comment-strip branch never runs.

### Tests

Covered by the existing `style-directive-mutations` runtime sample, which renders a `style={...}` containing a CSS comment alongside `style:` directives in both SSR and hydrate modes.