### PR TITLE
fix: preserve select selection when options change and no value was provided

### DIFF
--- a/.changeset/brave-selects-stay.md
+++ b/.changeset/brave-selects-stay.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep `<select>` selection when options change and no value was ever provided

--- a/packages/svelte/src/internal/client/dom/elements/bindings/select.js
+++ b/packages/svelte/src/internal/client/dom/elements/bindings/select.js
@@ -56,8 +56,12 @@ export function select_option(select, value, mounting = false) {
  */
 export function init_select(select) {
 	var observer = new MutationObserver(() => {
-		// @ts-ignore
-		select_option(select, select.__value);
+		// If no value was ever provided (e.g. a spread without `value`), leave the
+		// selection alone — re-asserting `undefined` would deselect everything
+		if ('__value' in select) {
+			// @ts-ignore
+			select_option(select, select.__value);
+		}
 		// Deliberately don't update the potential binding value,
 		// the model should be preserved unless explicitly changed
 	});

--- a/packages/svelte/tests/runtime-runes/samples/select-spread-options-change/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/select-spread-options-change/_config.js
@@ -1,0 +1,23 @@
+import { flushSync } from 'svelte';
+import { ok, test } from '../../test';
+
+// https://github.com/sveltejs/svelte/issues/18557
+export default test({
+	async test({ assert, target }) {
+		const select = target.querySelector('select');
+		const btn = target.querySelector('button');
+		ok(select);
+		ok(btn);
+
+		// no value was ever provided, so the browser selects the first option
+		assert.equal(select.selectedIndex, 0);
+
+		flushSync(() => btn.click());
+
+		// wait for the MutationObserver installed by the spread to run
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		assert.equal(select.options.length, 3);
+		assert.equal(select.selectedIndex, 0);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/select-spread-options-change/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/select-spread-options-change/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	let props = { 'data-testid': 'select' };
+	let options = $state(['a', 'b']);
+</script>
+
+<button onclick={() => (options = [...options, 'c'])}>add</button>
+
+<select {...props}>
+	{#each options as option}
+		<option value={option}>{option}</option>
+	{/each}
+</select>


### PR DESCRIPTION
fixes #18557

a \`<select>\` that gets spread attributes without a \`value\` (e.g. \`{...\$\$restProps}\`) loses its selection whenever an option is added or removed after mount — the trigger goes blank and \`selectedIndex\` becomes \`-1\`. this shows up when svelte 4 components are used in svelte 5 apps.

the mutation observer in \`init_select\` re-asserts \`select.__value\` on every option change to keep a programmatic value in sync, but it runs even when no value was ever provided. in that case \`__value\` is \`undefined\`, and re-asserting undefined ends up deselecting everything.

fixed by only re-asserting when \`__value\` was actually set — \`'__value' in select\`. the value paths (\`bind:value\` and \`<select value={...}>\`) both set \`__value\` before the observer can fire, so they're unaffected; an explicit \`value={undefined}\` still behaves as before.

added a runtime test with a spread select whose options grow after mount — it fails without the fix (\`selectedIndex\` -1) and passes with it. this is the post-mount counterpart to #12152.

- [x] tests pass with \`pnpm test\`
- [x] added a changeset