### PR TITLE
fix: don't let a throwing $effect teardown strand the rest of a destroy pass

### DIFF
--- a/.changeset/slow-melons-cheer.md
+++ b/.changeset/slow-melons-cheer.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't let a throwing `$effect` teardown strand the rest of a destroy pass

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -13,6 +13,7 @@ import {
 	block,
 	branch,
 	destroy_effect,
+	flush_destroy_errors,
 	move_effect,
 	pause_effect
 } from '../../reactivity/effects.js';
@@ -408,19 +409,31 @@ export class Boundary {
 	 * @param {unknown} error
 	 */
 	#handle_error(error) {
-		if (this.#main_effect) {
-			destroy_effect(this.#main_effect);
-			this.#main_effect = null;
-		}
+		// defer teardown errors so one throwing teardown can't strand the boundary's
+		// other effects, still queued for destruction below (#18415)
+		/** @type {import('../../reactivity/effects.js').DestroyErrors} */
+		var errors = [];
+		var completed = false;
 
-		if (this.#pending_effect) {
-			destroy_effect(this.#pending_effect);
-			this.#pending_effect = null;
-		}
+		try {
+			if (this.#main_effect) {
+				destroy_effect(this.#main_effect, true, errors);
+				this.#main_effect = null;
+			}
 
-		if (this.#failed_effect) {
-			destroy_effect(this.#failed_effect);
-			this.#failed_effect = null;
+			if (this.#pending_effect) {
+				destroy_effect(this.#pending_effect, true, errors);
+				this.#pending_effect = null;
+			}
+
+			if (this.#failed_effect) {
+				destroy_effect(this.#failed_effect, true, errors);
+				this.#failed_effect = null;
+			}
+
+			completed = true;
+		} finally {
+			flush_destroy_errors(errors, completed);
 		}
 
 		if (hydrating) {

--- a/packages/svelte/src/internal/client/dom/blocks/branches.js
+++ b/packages/svelte/src/internal/client/dom/blocks/branches.js
@@ -3,6 +3,7 @@ import { Batch, current_batch } from '../../reactivity/batch.js';
 import {
 	branch,
 	destroy_effect,
+	flush_destroy_errors,
 	move_effect,
 	pause_effect,
 	resume_effect
@@ -110,55 +111,70 @@ export class BranchManager {
 			}
 		}
 
-		for (const [b, k] of this.#batches) {
-			this.#batches.delete(b);
+		// defer teardown errors so one throwing teardown can't strand the branches
+		// still queued for destruction below (#18415)
+		/** @type {import('../../reactivity/effects.js').DestroyErrors} */
+		var errors = [];
+		var completed = false;
 
-			if (b === batch) {
-				// keep values for newer batches
-				break;
-			}
+		try {
+			for (const [b, k] of this.#batches) {
+				this.#batches.delete(b);
 
-			const offscreen = this.#offscreen.get(k);
-
-			if (offscreen) {
-				// for older batches, destroy offscreen effects
-				// as they will never be committed
-				destroy_effect(offscreen.effect);
-				this.#offscreen.delete(k);
-			}
-		}
-
-		// outro/destroy all onscreen effects...
-		for (const [k, effect] of this.#onscreen) {
-			// ...except the one that was just committed
-			//    or those that are already outroing (else the transition is aborted and the effect destroyed right away)
-			if (k === key || this.#outroing.has(k)) continue;
-
-			const on_destroy = () => {
-				const keys = Array.from(this.#batches.values());
-
-				if (keys.includes(k)) {
-					// keep the effect offscreen, as another batch will need it
-					var fragment = document.createDocumentFragment();
-					move_effect(effect, fragment);
-
-					fragment.append(create_text()); // TODO can we avoid this?
-
-					this.#offscreen.set(k, { effect, fragment });
-				} else {
-					destroy_effect(effect);
+				if (b === batch) {
+					// keep values for newer batches
+					break;
 				}
 
-				this.#outroing.delete(k);
-				this.#onscreen.delete(k);
-			};
+				const offscreen = this.#offscreen.get(k);
 
-			if (this.#transition || !onscreen) {
-				this.#outroing.add(k);
-				pause_effect(effect, on_destroy, false);
-			} else {
-				on_destroy();
+				if (offscreen) {
+					// for older batches, destroy offscreen effects
+					// as they will never be committed
+					destroy_effect(offscreen.effect, true, errors);
+					this.#offscreen.delete(k);
+				}
 			}
+
+			// outro/destroy all onscreen effects...
+			for (const [k, effect] of this.#onscreen) {
+				// ...except the one that was just committed
+				//    or those that are already outroing (else the transition is aborted and the effect destroyed right away)
+				if (k === key || this.#outroing.has(k)) continue;
+
+				const on_destroy = () => {
+					const keys = Array.from(this.#batches.values());
+
+					if (keys.includes(k)) {
+						// keep the effect offscreen, as another batch will need it
+						var fragment = document.createDocumentFragment();
+						move_effect(effect, fragment);
+
+						fragment.append(create_text()); // TODO can we avoid this?
+
+						this.#offscreen.set(k, { effect, fragment });
+					} else {
+						// after an outro transition this callback runs once the pass has
+						// flushed — the destroy then owns its own errors and throws
+						// synchronously, same as any standalone destroy
+						destroy_effect(effect, true, errors.closed ? null : errors);
+					}
+
+					this.#outroing.delete(k);
+					this.#onscreen.delete(k);
+				};
+
+				if (this.#transition || !onscreen) {
+					this.#outroing.add(k);
+					pause_effect(effect, on_destroy, false);
+				} else {
+					on_destroy();
+				}
+			}
+
+			completed = true;
+		} finally {
+			flush_destroy_errors(errors, completed);
 		}
 	};
 
@@ -170,11 +186,23 @@ export class BranchManager {
 
 		const keys = Array.from(this.#batches.values());
 
-		for (const [k, branch] of this.#offscreen) {
-			if (!keys.includes(k)) {
-				destroy_effect(branch.effect);
-				this.#offscreen.delete(k);
+		// this loop initiates a destroy pass; collect teardown errors so one throwing
+		// teardown can't strand the branches still queued for destruction (#18415)
+		/** @type {import('../../reactivity/effects.js').DestroyErrors} */
+		var errors = [];
+		var completed = false;
+
+		try {
+			for (const [k, branch] of this.#offscreen) {
+				if (!keys.includes(k)) {
+					destroy_effect(branch.effect, true, errors);
+					this.#offscreen.delete(k);
+				}
 			}
+
+			completed = true;
+		} finally {
+			flush_destroy_errors(errors, completed);
 		}
 	};
 

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -29,6 +29,7 @@ import {
 	block,
 	branch,
 	destroy_effect,
+	flush_destroy_errors,
 	move_effect,
 	pause_effect,
 	resume_effect
@@ -147,17 +148,29 @@ function destroy_effects(state, to_destroy, remove_dom = true) {
 		}
 	}
 
-	for (var i = 0; i < to_destroy.length; i++) {
-		var e = to_destroy[i];
+	// this loop initiates a destroy pass; collect teardown errors so one throwing
+	// teardown can't strand the items still queued for destruction (#18415)
+	/** @type {import('../../reactivity/effects.js').DestroyErrors} */
+	var errors = [];
+	var completed = false;
 
-		if (preserved_effects?.has(e)) {
-			e.f |= EFFECT_OFFSCREEN;
+	try {
+		for (var i = 0; i < to_destroy.length; i++) {
+			var e = to_destroy[i];
 
-			const fragment = document.createDocumentFragment();
-			move_effect(e, fragment);
-		} else {
-			destroy_effect(to_destroy[i], remove_dom);
+			if (preserved_effects?.has(e)) {
+				e.f |= EFFECT_OFFSCREEN;
+
+				const fragment = document.createDocumentFragment();
+				move_effect(e, fragment);
+			} else {
+				destroy_effect(to_destroy[i], remove_dom, errors);
+			}
 		}
+
+		completed = true;
+	} finally {
+		flush_destroy_errors(errors, completed);
 	}
 }
 

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -25,7 +25,13 @@ import { clsx } from '../../../shared/attributes.js';
 import { set_class } from './class.js';
 import { set_style } from './style.js';
 import { ATTACHMENT_KEY, NAMESPACE_HTML, UNINITIALIZED } from '../../../../constants.js';
-import { branch, destroy_effect, effect, managed } from '../../reactivity/effects.js';
+import {
+	branch,
+	destroy_effect,
+	effect,
+	flush_destroy_errors,
+	managed
+} from '../../reactivity/effects.js';
 import { init_select, select_option } from './bindings/select.js';
 import { flatten } from '../../reactivity/async.js';
 
@@ -537,19 +543,31 @@ export function attribute_effect(
 				select_option(/** @type {HTMLSelectElement} */ (element), next.value);
 			}
 
-			for (let symbol of Object.getOwnPropertySymbols(effects)) {
-				if (!next[symbol]) destroy_effect(effects[symbol]);
-			}
+			// defer attachment-cleanup errors so one throwing cleanup can't strand the
+			// attachment effects still queued for destruction/replacement below (#18415)
+			/** @type {import('../../reactivity/effects.js').DestroyErrors} */
+			var errors = [];
+			var completed = false;
 
-			for (let symbol of Object.getOwnPropertySymbols(next)) {
-				var n = next[symbol];
-
-				if (symbol.description === ATTACHMENT_KEY && (!prev || n !== prev[symbol])) {
-					if (effects[symbol]) destroy_effect(effects[symbol]);
-					effects[symbol] = branch(() => attach(element, () => n));
+			try {
+				for (let symbol of Object.getOwnPropertySymbols(effects)) {
+					if (!next[symbol]) destroy_effect(effects[symbol], true, errors);
 				}
 
-				current[symbol] = n;
+				for (let symbol of Object.getOwnPropertySymbols(next)) {
+					var n = next[symbol];
+
+					if (symbol.description === ATTACHMENT_KEY && (!prev || n !== prev[symbol])) {
+						if (effects[symbol]) destroy_effect(effects[symbol], true, errors);
+						effects[symbol] = branch(() => attach(element, () => n));
+					}
+
+					current[symbol] = n;
+				}
+
+				completed = true;
+			} finally {
+				flush_destroy_errors(errors, completed);
 			}
 
 			prev = current;

--- a/packages/svelte/src/internal/client/reactivity/deriveds.js
+++ b/packages/svelte/src/internal/client/reactivity/deriveds.js
@@ -37,6 +37,7 @@ import {
 	destroy_effect,
 	destroy_effect_children,
 	effect_tracking,
+	flush_destroy_errors,
 	teardown
 } from './effects.js';
 import { eager_effects, internal_set, set_eager_effects, source } from './sources.js';
@@ -319,8 +320,20 @@ export function destroy_derived_effects(derived) {
 	if (effects !== null) {
 		derived.effects = null;
 
-		for (var i = 0; i < effects.length; i += 1) {
-			destroy_effect(/** @type {Effect} */ (effects[i]));
+		// this loop initiates a destroy pass; collect teardown errors so one throwing
+		// teardown can't strand the effects still queued for destruction (#18415)
+		/** @type {import('./effects.js').DestroyErrors} */
+		var errors = [];
+		var completed = false;
+
+		try {
+			for (var i = 0; i < effects.length; i += 1) {
+				destroy_effect(/** @type {Effect} */ (effects[i]), true, errors);
+			}
+
+			completed = true;
+		} finally {
+			flush_destroy_errors(errors, completed);
 		}
 	}
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -438,6 +438,45 @@ export function branch(fn) {
 }
 
 /**
+ * Teardown errors collected during a destroy pass, threaded explicitly through the
+ * destroy call chain. Deferring them lets the whole pass complete — every effect's
+ * structural cleanup (`remove_reactions`, DOM removal, unlinking) must run even if
+ * a sibling's teardown throws, otherwise the un-destroyed siblings stay subscribed
+ * to their dependencies and retain detached DOM for the lifetime of the parent
+ * block (#18415). The frame that CREATED the array (the owner — any destroy entry
+ * point that was not handed one) flushes it when its pass ends.
+ * `closed` is set on flush: destroy passes are synchronous, so a late push means
+ * the invariant was broken — surfaced loudly in DEV via {@link flush_destroy_errors}.
+ * @typedef {unknown[] & { closed?: boolean }} DestroyErrors
+ */
+
+/**
+ * Conclude a destroy pass: rethrow the first deferred teardown error, surface the
+ * rest in DEV. Pass `completed = false` when the pass is unwinding because of a
+ * structural (non-teardown) error — that error must keep propagating, so the
+ * deferred teardown errors are surfaced in DEV instead of being rethrown over it.
+ * @param {DestroyErrors} errors
+ * @param {boolean} completed
+ */
+export function flush_destroy_errors(errors, completed) {
+	errors.closed = true;
+
+	if (errors.length === 0) return;
+
+	if (DEV) {
+		// only the first deferred teardown error can be rethrown (none, if a structural
+		// error is already propagating); surface the rest in DEV so a cascade of
+		// throwing teardowns isn't silently swallowed (#18415)
+		for (var i = completed ? 1 : 0; i < errors.length; i++) {
+			// eslint-disable-next-line no-console
+			console.error(errors[i]);
+		}
+	}
+
+	if (completed) throw errors[0];
+}
+
+/**
  * @param {Effect} effect
  */
 export function execute_effect_teardown(effect) {
@@ -447,6 +486,9 @@ export function execute_effect_teardown(effect) {
 		const previous_reaction = active_reaction;
 		set_is_destroying_effect(true);
 		set_active_reaction(null);
+		// a destroy triggered from within a teardown (e.g. unmounting another root,
+		// guarded by the user's own try/catch) receives no errors array, so it is
+		// naturally its own pass and throws synchronously — no state to isolate
 		try {
 			teardown.call(null);
 		} finally {
@@ -459,9 +501,26 @@ export function execute_effect_teardown(effect) {
 /**
  * @param {Effect} signal
  * @param {boolean} remove_dom
+ * @param {DestroyErrors | null} [errors] enclosing destroy pass's accumulator; omitted = this call owns the pass
  * @returns {void}
  */
-export function destroy_effect_children(signal, remove_dom = false) {
+export function destroy_effect_children(signal, remove_dom = false, errors = null) {
+	if (errors === null) {
+		// this call initiates the destroy pass, so it owns the errors array
+		/** @type {DestroyErrors} */
+		var owned = [];
+		var completed = false;
+
+		try {
+			destroy_effect_children(signal, remove_dom, owned);
+			completed = true;
+		} finally {
+			flush_destroy_errors(owned, completed);
+		}
+
+		return;
+	}
+
 	var effect = signal.first;
 	signal.first = signal.last = null;
 
@@ -480,7 +539,7 @@ export function destroy_effect_children(signal, remove_dom = false) {
 			// this is now an independent root
 			effect.parent = null;
 		} else {
-			destroy_effect(effect, remove_dom);
+			destroy_effect(effect, remove_dom, errors);
 		}
 
 		effect = next;
@@ -489,15 +548,32 @@ export function destroy_effect_children(signal, remove_dom = false) {
 
 /**
  * @param {Effect} signal
+ * @param {DestroyErrors | null} [errors] enclosing destroy pass's accumulator; omitted = this call owns the pass
  * @returns {void}
  */
-export function destroy_block_effect_children(signal) {
+export function destroy_block_effect_children(signal, errors = null) {
+	if (errors === null) {
+		// this call initiates the destroy pass, so it owns the errors array
+		/** @type {DestroyErrors} */
+		var owned = [];
+		var completed = false;
+
+		try {
+			destroy_block_effect_children(signal, owned);
+			completed = true;
+		} finally {
+			flush_destroy_errors(owned, completed);
+		}
+
+		return;
+	}
+
 	var effect = signal.first;
 
 	while (effect !== null) {
 		var next = effect.next;
 		if ((effect.f & BRANCH_EFFECT) === 0) {
-			destroy_effect(effect);
+			destroy_effect(effect, true, errors);
 		}
 		effect = next;
 	}
@@ -506,9 +582,36 @@ export function destroy_block_effect_children(signal) {
 /**
  * @param {Effect} effect
  * @param {boolean} [remove_dom]
+ * @param {DestroyErrors | null} [errors] enclosing destroy pass's accumulator; omitted = this call owns the pass
  * @returns {void}
  */
-export function destroy_effect(effect, remove_dom = true) {
+export function destroy_effect(effect, remove_dom = true, errors = null) {
+	if (errors !== null) {
+		// part of an enclosing destroy pass — the owner of `errors` flushes it
+		destroy(effect, remove_dom, errors);
+		return;
+	}
+
+	// this call initiates the destroy pass, so it owns the errors array
+	/** @type {DestroyErrors} */
+	var owned = [];
+	var completed = false;
+
+	try {
+		destroy(effect, remove_dom, owned);
+		completed = true;
+	} finally {
+		flush_destroy_errors(owned, completed);
+	}
+}
+
+/**
+ * @param {Effect} effect
+ * @param {boolean} remove_dom
+ * @param {DestroyErrors} errors
+ * @returns {void}
+ */
+function destroy(effect, remove_dom, errors) {
 	var removed = false;
 
 	if (
@@ -521,7 +624,7 @@ export function destroy_effect(effect, remove_dom = true) {
 	}
 
 	effect.f |= DESTROYING;
-	destroy_effect_children(effect, remove_dom && !removed);
+	destroy_effect_children(effect, remove_dom && !removed, errors);
 	remove_reactions(effect, 0);
 
 	var transitions = effect.nodes && effect.nodes.t;
@@ -532,7 +635,24 @@ export function destroy_effect(effect, remove_dom = true) {
 		}
 	}
 
-	execute_effect_teardown(effect);
+	try {
+		execute_effect_teardown(effect);
+	} catch (error) {
+		if (DEV && errors.closed) {
+			// destroy passes are synchronous; a teardown error arriving after its pass
+			// flushed means that invariant was broken — surface the violation loudly and
+			// rethrow the error immediately rather than losing it in a closed array
+			// eslint-disable-next-line no-console
+			console.error(
+				'Svelte internal invariant violated: a teardown error was reported after its destroy pass finished'
+			);
+			throw error;
+		}
+
+		// defer the error so a throwing teardown can't abort the destroy pass and
+		// strand the effects still queued for destruction (#18415)
+		errors.push(error);
+	}
 
 	effect.f ^= DESTROYING;
 	effect.f |= DESTROYED;

--- a/packages/svelte/tests/runtime-runes/samples/each-throwing-teardown-does-not-strand/Item.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-throwing-teardown-does-not-strand/Item.svelte
@@ -1,0 +1,14 @@
+<script>
+	let { item, onteardown } = $props();
+
+	$effect(() => {
+		return () => {
+			// record that this item tore down, then throw. a throwing teardown must not
+			// prevent the sibling removed items from being torn down (#18415, each.js path)
+			onteardown(item);
+			throw new Error(`teardown boom ${item}`);
+		};
+	});
+</script>
+
+<span>{item}</span>

--- a/packages/svelte/tests/runtime-runes/samples/each-throwing-teardown-does-not-strand/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-throwing-teardown-does-not-strand/_config.js
@@ -1,0 +1,38 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+/** @type {number[]} */
+let torn = [];
+
+export default test({
+	props: {
+		items: [1, 2, 3, 4],
+		onteardown: (/** @type {number} */ item) => torn.push(item)
+	},
+
+	test({ assert, component }) {
+		torn.length = 0;
+
+		// remove every item at once. the each block destroys the removed items in a loop
+		// (`destroy_effects`); each item's `$effect` teardown throws. before #18415 the
+		// first throw aborted that loop, stranding the items queued after it — they stayed
+		// subscribed to their dependencies and retained their detached DOM. now the whole
+		// loop completes and the first teardown error is surfaced once.
+		component.items = [];
+
+		/** @type {unknown} */
+		let thrown;
+		try {
+			flushSync();
+		} catch (error) {
+			thrown = error;
+		}
+
+		assert.isDefined(thrown, 'the teardown error should still surface');
+		assert.deepEqual(
+			[...torn].sort((a, b) => a - b),
+			[1, 2, 3, 4],
+			'every removed item tore down despite a throwing teardown'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-throwing-teardown-does-not-strand/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-throwing-teardown-does-not-strand/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Item from './Item.svelte';
+
+	let { items, onteardown } = $props();
+</script>
+
+{#each items as item (item)}
+	<Item {item} {onteardown} />
+{/each}

--- a/packages/svelte/tests/runtime-runes/samples/spread-attachment-throwing-cleanup-does-not-strand/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/spread-attachment-throwing-cleanup-does-not-strand/_config.js
@@ -1,0 +1,37 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+/** @type {string[]} */
+let cleaned = [];
+
+export default test({
+	props: {
+		attached: true,
+		oncleanup: (/** @type {string} */ name) => cleaned.push(name)
+	},
+
+	test({ assert, component }) {
+		cleaned.length = 0;
+
+		// remove both spread attachments at once. `set_attributes` destroys the removed
+		// attachment effects in a loop; the first attachment's cleanup throws. before
+		// #18415's deferral that throw aborted the loop, stranding the second attachment —
+		// its cleanup never ran. now the whole loop completes and the error surfaces once.
+		component.attached = false;
+
+		/** @type {unknown} */
+		let thrown;
+		try {
+			flushSync();
+		} catch (error) {
+			thrown = error;
+		}
+
+		// (in DEV the message is suffixed with the component stack)
+		assert.ok(
+			/** @type {Error} */ (thrown)?.message.startsWith('first cleanup'),
+			'the first cleanup error should still surface'
+		);
+		assert.deepEqual(cleaned, ['first', 'second'], 'both attachment cleanups ran');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/spread-attachment-throwing-cleanup-does-not-strand/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/spread-attachment-throwing-cleanup-does-not-strand/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { createAttachmentKey } from 'svelte/attachments';
+
+	let { attached, oncleanup } = $props();
+
+	const attrs = {
+		[createAttachmentKey()]: (node) => () => {
+			oncleanup('first');
+			throw new Error('first cleanup');
+		},
+		[createAttachmentKey()]: (node) => () => {
+			oncleanup('second');
+		}
+	};
+</script>
+
+<div {...(attached ? attrs : {})}>x</div>

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -1521,4 +1521,95 @@ describe('signals', () => {
 			assert.equal(s.reactions, null);
 		};
 	});
+
+	// https://github.com/sveltejs/svelte/issues/18415
+	// Sibling effects are destroyed in a loop. A throwing `$effect` teardown used to abort the
+	// loop, so the effects still queued for destruction were never unsubscribed — they stayed
+	// subscribed to their dependencies (retaining detached DOM) for the lifetime of the parent.
+	// The whole pass must now complete, with the teardown error surfaced once at the end.
+	test('a throwing $effect teardown does not strand the rest of a destroy pass', () => {
+		const src = state(0);
+		const dep = derived(() => $.get(src));
+		let throw_on = -1;
+
+		const destroy = effect_root(() => {
+			render_effect(() => {
+				for (let i = 0; i < 3; i++) {
+					const idx = i;
+					effect(() => {
+						$.get(dep);
+						return () => {
+							if (idx === throw_on) throw new Error(`teardown boom ${idx}`);
+						};
+					});
+				}
+			});
+		});
+
+		return () => {
+			flushSync();
+			assert.equal(dep.reactions?.length, 3); // three subscribed siblings
+
+			throw_on = 0; // the first-destroyed sibling throws in its teardown
+
+			let thrown;
+			try {
+				destroy();
+			} catch (e) {
+				thrown = e;
+			}
+
+			// the error still surfaces, but the siblings after it were still destroyed
+			assert.isDefined(thrown, 'the teardown error should still surface');
+			assert.equal(dep.reactions, null);
+			assert.equal(src.reactions, null);
+		};
+	});
+
+	// https://github.com/sveltejs/svelte/issues/18415
+	// A destroy pass can only rethrow one teardown error. The rest must not vanish
+	// silently — in DEV they're surfaced via `console.error` so a cascade of throwing
+	// teardowns stays diagnosable.
+	test('surfaces the secondary throwing teardowns of a destroy pass in DEV', () => {
+		/** @type {unknown[]} */
+		const logged: unknown[] = [];
+		const original = console.error;
+		console.error = (...args: unknown[]) => {
+			logged.push(...args);
+		};
+
+		const destroy = effect_root(() => {
+			render_effect(() => {
+				for (let i = 0; i < 3; i++) {
+					const idx = i;
+					effect(() => {
+						return () => {
+							throw new Error(`teardown boom ${idx}`);
+						};
+					});
+				}
+			});
+		});
+
+		return () => {
+			flushSync();
+
+			let thrown;
+			try {
+				destroy();
+			} catch (e) {
+				thrown = e;
+			} finally {
+				console.error = original;
+			}
+
+			// one error is rethrown, the other two are surfaced rather than dropped
+			assert.ok(thrown instanceof Error, 'the first teardown error is still rethrown');
+			assert.equal(logged.length, 2, 'the other teardown errors are surfaced in DEV');
+			assert.ok(
+				logged.every((e) => e instanceof Error),
+				'each surfaced value is the dropped teardown error'
+			);
+		};
+	});
 });


### PR DESCRIPTION
Fixes #18415

### The problem

When a block is destroyed (keyed `{#each}` reconcile, branch teardown, component
unmount), its child effects are destroyed in a loop. If a user `$effect` teardown
throws, the exception aborts that loop, so the sibling effects still queued for
destruction are never passed to `destroy_effect`. They stay subscribed to their
dependencies and retain their now-detached DOM for the lifetime of the parent.
In a long-lived app with a virtualized list this is an unbounded leak: one row
with a throwing cleanup poisons every reconcile after it.

### The fix

Teardown errors are collected in an errors array threaded explicitly through the
destroy call chain, instead of propagating mid-pass. The single catch site in
`destroy_effect` pushes the error and completes the structural cleanup
(`remove_reactions`, DOM removal, unlinking) regardless. Ownership follows the
parameters: any destroy entry point that is not handed an array creates one, and
that owner rethrows the first collected error in a `try`/`finally` once its pass
completes. The observable contract is preserved: a throwing teardown still
surfaces as the same error object from the same outer call, just after the pass
completes instead of aborting it halfway.

Threading through parameters rather than module state keeps every failure mode
local and visible: a call site that omits the array becomes its own pass and
throws immediately, and there is no ambient counter or accumulator to corrupt. A
destroy initiated inside a user teardown receives no array, so it is naturally
its own pass and behaves identically wherever it is called from.

Structural (non-teardown) errors are deliberately not caught and keep their
priority: a pass unwinding because the destroy machinery itself threw flushes
with `completed = false`, which surfaces the collected teardown errors in DEV
without rethrowing them over the propagating error. Branch commit callbacks that
run after an outro transition (outside their originating pass) fall back to
owning their own errors via a closed flag the flush sets on the array. The same
flag backs a DEV-only invariant check: destroy passes are synchronous, and a
teardown error arriving after its pass flushed is surfaced loudly and rethrown
instead of being lost.

Only the first teardown error can be rethrown. In DEV the remaining ones are
surfaced via `console.error` instead of vanishing. Before this fix those
teardowns never executed at all, so no previously surfaced error is lost.

Design note: an alternative presentation is throwing an `AggregateError`
carrying all collected errors. We kept first-error-rethrow because existing
callers catch and inspect the raw error (`instanceof`, message routing, boundary
handlers), and changing the thrown type felt out of scope for a leak fix. The
collection machinery is presentation-agnostic, so if maintainers prefer
aggregation it is a one-line change in `flush_destroy_errors`.

### Tests

- Two signals tests: the strand regression (fails on main, passes here) and the
  DEV surfacing of secondary teardown errors.
- Two runtime-runes samples covering the `{#each}` reconcile loop and the spread
  attachment cleanup loop, both verified to fail without their respective wraps.
- Full suite: 7671 passing. `pnpm lint` clean. Changeset included.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`
- [x] This message body should clearly illustrate what problems it solves
- [x] Ideally, include a test that fails without this PR but passes with it
- [x] If this PR changes code within `packages/svelte/src`, add a changeset

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`