### PR TITLE
fix: release last_propagated_event after event propagation settles

### DIFF
--- a/.changeset/spotty-ducks-refuse.md
+++ b/.changeset/spotty-ducks-refuse.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: release `last_propagated_event` after event propagation settles so it no longer retains the last event's target subtree

--- a/packages/svelte/src/internal/client/dom/elements/events.js
+++ b/packages/svelte/src/internal/client/dom/elements/events.js
@@ -159,11 +159,14 @@ export function delegate(events) {
 }
 
 // used to store the reference to the currently propagated event
-// to prevent garbage collection between microtasks in Firefox
+// to prevent garbage collection between microtasks in Firefox (<= 141)
 // If the event object is GCed too early, the expando __root property
 // set on the event object is lost, causing the event delegation
 // to process the event twice
 let last_propagated_event = null;
+
+// whether a task is already queued to clear `last_propagated_event`
+let last_propagated_event_clear_scheduled = false;
 
 /**
  * @this {EventTarget}
@@ -178,6 +181,21 @@ export function handle_event_propagation(event) {
 	var current_target = /** @type {null | Element} */ (path[0] || event.target);
 
 	last_propagated_event = event;
+
+	// The reference is only needed while the event can still reach another
+	// delegated root, i.e. during the current (synchronous) dispatch and its
+	// microtask checkpoints. Clearing it in a later task preserves the
+	// Firefox workaround while making sure the slot doesn't retain the last
+	// event forever — through `event.target` it would otherwise keep the
+	// entire detached subtree of whatever the user last clicked in alive
+	// until the next delegated event happens to arrive.
+	if (!last_propagated_event_clear_scheduled) {
+		last_propagated_event_clear_scheduled = true;
+		setTimeout(() => {
+			last_propagated_event_clear_scheduled = false;
+			last_propagated_event = null;
+		});
+	}
 
 	// composedPath contains list of nodes the event has propagated through.
 	// We check `event_symbol` to skip all nodes below it in case this is a


### PR DESCRIPTION
Fixes #18568

`last_propagated_event` was added in #16527 to stop Firefox from garbage collecting the event wrapper mid-propagation, which loses the `__root` expando and makes delegated handlers run twice (#16522). The problem is that the reference is never released. Between user interactions the module keeps holding the last delegated event, and through `event.target` it also holds the detached subtree of whatever the user last clicked in. In long-lived apps (SPAs left idle, desktop webviews) that can be a whole closed view sitting in memory until the next delegated event happens to arrive. I found this while doing heap snapshot analysis on a desktop app, where a closed pane's ~10k node tree was still reachable and the retainer path ended at this slot.

This PR keeps the pin but clears it in a task scheduled during dispatch. Event dispatch is synchronous within a task, and the Firefox GC issue bites at the microtask checkpoints between listeners, so propagation can never cross a task boundary. That means the clear always runs after the event has finished reaching every delegated root, and the workaround keeps working exactly as before. Retention drops from "until the next delegated event" to milliseconds. The boolean guard just makes sure there's at most one pending timer no matter how many events come in.

### Verification

The Firefox bug still reproduces reliably on Firefox 141. It no longer reproduces on 142+ (looks like Mozilla fixed the underlying wrapper GC behavior), but ESR 140 is still supported, so the pin is still needed. I drove both the plain JS reduction from #16522 and a Vite-built app mirroring the #16522 REPL (delegated click toggling a 10k item `{#if}` list) with Playwright:

| variant | Firefox 141, default GC | Firefox 141, small nursery |
| --- | --- | --- |
| no pin (pre-#16527) | 26/60 events lose the expando; 68 toggles for 40 clicks | 53/60; 78 toggles for 40 clicks |
| pin, never cleared (current) | 0 lost; 200/200 clicks correct | 0 lost; 200/200 correct |
| **pin + deferred clear (this PR)** | **0 lost; 200/200 correct** | **0 lost; 200/200 correct** |
| pin + `queueMicrotask` clear | 26/60 lost | 50/60 lost |

The last row is why the clear has to be a task and not a microtask. Instrumentation shows a microtask clear fires between the mount root listener and the document fallback listener, right inside the danger window, while the task clear never does (the fallback listener saw the pin still in place on 60/60 dispatches). The app-level runs used the minified production bundle, so the mechanism also survives DCE/minification (the #16538 concern).

One side effect worth calling out: each delegated event now leaves at most one pending zero-delay timeout behind, which fake timer test setups can see. If that's a concern, a `MessageChannel` port would give the same task-boundary clear without being visible to fake timers. Happy to switch if preferred.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs (#18568)
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it. (The only observable here is GC behavior, since the slot is module-private and semantically invisible by design. A `WeakRef` + `--expose-gc` test that dispatches a delegated click, unmounts, and asserts the target becomes collectable does fail on `main` and pass with this PR. Happy to add it if a GC-dependent test is acceptable in CI. #16527 shipped without a test for the same reason.)
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

`pnpm test`: 7663 passed | 69 skipped (33 files). `pnpm lint`: clean. `pnpm check` (packages/svelte): clean. `pnpm build` (packages/svelte) incl. treeshakeability checks: clean.