### PR TITLE
docs: document pattern for explicit dependency tracking across asynchronous boundaries

### DIFF
--- a/documentation/docs/02-runes/03-$derived.md
+++ b/documentation/docs/02-runes/03-$derived.md
@@ -91,8 +91,8 @@ let minAge = $state(18);
 let maxAge = $state(30);
 
 let query = $derived.by(() => {
-	// Read dependencies synchronously so they are tracked
-	void minAge, maxAge;
+	+++// Read dependencies synchronously so they are tracked+++
+	+++void minAge, maxAge;+++
 
 	return liveQuery(async () => {
 		// Values read inside this callback are not tracked automatically
@@ -102,6 +102,44 @@ let query = $derived.by(() => {
 			.toArray();
 	});
 });
+```
+
+Alternatively, you can extract the asynchronous callback into a separate function and pass the reactive values as arguments, which are evaluated synchronously:
+
+```js
+// @filename: ambient.d.ts
+declare module 'dexie' {
+	export class Dexie {
+		constructor(databaseName: string);
+		users: {
+			where(key: string): {
+				between(min: number, max: number): {
+					toArray(): Promise<any[]>;
+				};
+			};
+		};
+	}
+	export function liveQuery<T>(querier: () => T | Promise<T>): any;
+}
+
+// @filename: index.js
+import { Dexie, liveQuery } from 'dexie';
+
+const db = new Dexie('UserDatabase');
+let minAge = $state(18);
+let maxAge = $state(30);
+// ---cut---
++++function createUserQuery(minAge, maxAge) {+++
+	return liveQuery(async () => {
+		return await db.users
+			.where('age')
+			.between(minAge, maxAge)
+			.toArray();
+	});
+}
+
+// minAge and maxAge are read synchronously when the function is called
+let query = $derived(+++createUserQuery(minAge, maxAge)+++);
 ```
 
 To exempt a piece of state from being treated as a dependency, use [`untrack`](svelte#untrack).

--- a/documentation/docs/02-runes/03-$derived.md
+++ b/documentation/docs/02-runes/03-$derived.md
@@ -62,6 +62,31 @@ let total = $derived(await a + b);
 
 ...both `a` and `b` are tracked, even though `b` is only read once `a` has resolved, after the initial execution. (This does not apply to `await` in functions that are called by the expression, only the expression itself.)
 
+On the other hand, values that are read _asynchronously_ (such as inside asynchronous closures passed to third-party query or observable libraries) will not be tracked automatically. To track these values, read them synchronously outside the asynchronous boundary. A clear pattern for this is to evaluate the dependencies using the `void` operator:
+
+```js
+import { Dexie, liveQuery } from 'dexie';
+
+const db = new Dexie('UserDatabase');
+// ...database setup...
+
+let minAge = $state(18);
+let maxAge = $state(30);
+
+let query = $derived.by(() => {
+	// Read dependencies synchronously so they are tracked
+	void minAge, maxAge;
+
+	return liveQuery(async () => {
+		// Values read inside this callback are not tracked automatically
+		return await db.users
+			.where('age')
+			.between(minAge, maxAge)
+			.toArray();
+	});
+});
+```
+
 To exempt a piece of state from being treated as a dependency, use [`untrack`](svelte#untrack).
 
 ## Overriding derived values

--- a/documentation/docs/02-runes/03-$derived.md
+++ b/documentation/docs/02-runes/03-$derived.md
@@ -65,6 +65,23 @@ let total = $derived(await a + b);
 On the other hand, values that are read _asynchronously_ (such as inside asynchronous closures passed to third-party query or observable libraries) will not be tracked automatically. To track these values, read them synchronously outside the asynchronous boundary. A clear pattern for this is to evaluate the dependencies using the `void` operator:
 
 ```js
+// @filename: ambient.d.ts
+declare module 'dexie' {
+	export class Dexie {
+		constructor(databaseName: string);
+		users: {
+			where(key: string): {
+				between(min: number, max: number): {
+					toArray(): Promise<any[]>;
+				};
+			};
+		};
+	}
+	export function liveQuery<T>(querier: () => T | Promise<T>): any;
+}
+
+// @filename: index.js
+// ---cut---
 import { Dexie, liveQuery } from 'dexie';
 
 const db = new Dexie('UserDatabase');

--- a/documentation/docs/02-runes/04-$effect.md
+++ b/documentation/docs/02-runes/04-$effect.md
@@ -147,7 +147,7 @@ declare let size: number;
 $effect(() => {
 	const context = canvas.getContext('2d');
 	
-	+++const draw = (size) => {+++
+	+++const draw = (size: number) => {+++
 		setTimeout(() => {
 			context.fillRect(0, 0, size, size);
 		}, 0);

--- a/documentation/docs/02-runes/04-$effect.md
+++ b/documentation/docs/02-runes/04-$effect.md
@@ -107,6 +107,31 @@ $effect(() => {
 });
 ```
 
+To force the `$effect` to track the values read _asynchronously_, read them synchronously outside the asynchronous boundary. A clear pattern for this is to evaluate the dependencies using the `void` operator:
+
+```ts
+// @filename: index.ts
+declare let canvas: {
+	width: number;
+	height: number;
+	getContext(type: '2d', options?: CanvasRenderingContext2DSettings): CanvasRenderingContext2D;
+};
+declare let size: number;
+
+// ---cut---
+$effect(() => {
+	const context = canvas.getContext('2d');
+	
+	+++// read `size` synchronously so it is registered as a dependency+++
+	+++void size;+++
+
+	setTimeout(() => {
+		// ...and now this will also re-run when `size` changes
+		context.fillRect(0, 0, size, size);
+	}, 0);
+});
+```
+
 An effect only reruns when the object it reads changes, not when a property inside it changes. (If you want to observe changes _inside_ an object at dev time, you can use [`$inspect`]($inspect).)
 
 ```svelte

--- a/documentation/docs/02-runes/04-$effect.md
+++ b/documentation/docs/02-runes/04-$effect.md
@@ -132,6 +132,32 @@ $effect(() => {
 });
 ```
 
+Alternatively, you can extract the asynchronous logic into a separate function and pass the reactive values as arguments, which are evaluated synchronously:
+
+```ts
+// @filename: index.ts
+declare let canvas: {
+	width: number;
+	height: number;
+	getContext(type: '2d', options?: CanvasRenderingContext2DSettings): CanvasRenderingContext2D;
+};
+declare let size: number;
+
+// ---cut---
+$effect(() => {
+	const context = canvas.getContext('2d');
+	
+	+++const draw = (size) => {+++
+		setTimeout(() => {
+			context.fillRect(0, 0, size, size);
+		}, 0);
+	};
+
+	// size is read synchronously when the function is called
+	+++draw(size);+++
+});
+```
+
 An effect only reruns when the object it reads changes, not when a property inside it changes. (If you want to observe changes _inside_ an object at dev time, you can use [`$inspect`]($inspect).)
 
 ```svelte


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/18565

**Reason for PR**
Summing up https://github.com/sveltejs/svelte/issues/18565 and related discussions: While the current documentation explicitly notes that Svelte 5 does not automatically track dependencies read inside asynchronous boundaries, it doesn't demonstrate a way to work around it. Discussions show that explicitly listing the dependencies and using the `void` operator is the common solution. This PR explicitly documents this pattern to save developers from guessing or unnecessarily reaching for third-party solutions.

**Changes**
- `02-runes\03-$derived.md`: added short explanation and code snippets for 2 approaches to synchronously track dependencies before passing an asynchronous callback to a third-party library (using Dexie's `liveQuery` as a familiar, real-world example).
- `02-runes\04-$effect.md`: extended the existing `setTimeout` code snippet to demonstrate tracking the `size` dependency across the async boundary with 2 approaches. Edited demo for both of them [here](https://svelte.dev/playground/d22cae1e25334b0da7611ed850589662?version=5.56.7#H4sIAAAAAAAACo1TXYvbMBD8K4vu4HLgWE7LvfjsQOk_6MdTXTjFWjsCRTbSxrk0-L8XSXHiHHelLwkazY5ndlcnZsQOWc5-GlKkUcICpSKUjyxhjdLoWP7rxOjYe5IHWDKVfOn71A2oyWMb4fA9vO4MoSHHcla42qqe1pWpSCOBU38QSrh3JAgXT9nj83RTd7qz16uHu6b5jFn2EBkXljCDcB4yFd1j02BNi8UjlGs4BR7VnXFezRC-EpTnirRF-hqxxcMnOanSmZfWGoX95sWyBLJkqjooSdvLaYuq3dLVUEWcA22Vg4PSGiwu7d7AYYsGB7TwEiK9QL0VpkWXpuntNxul9Xc6at-QQJ0JxxTSigOUsPBdm2esyCH9UDvs9m_Sn02labrZE5juAEK7LniCFy9zsXPlz_3MWuDZ8XdqVkVjAqvpNMYhVORdRosTwjl0Fpza9fp4QYZOySD3PKN9lINzuA1CH2cI3P8OwTmMCZwXb_R_Bb8uqSnirGGjjMz9bMtTREYIy1BWbJVlFYO4DNNxXfBIiyJSDVBr4VxZhddgO-0qFl5BocUG9TqaKZTp9wT-qZUVsz5UxeK3B6H3WJ689RH4OmQI9Xwm8G-9sFRv9AIWBOPtjWLBpRpiAucXM6imU4BpNpvOSrRL6vocVv0ruE4rCXd1XZ9b3AsplWlzWOEOsjO4E7ZV5haTyvVaHHNoNL6esVb0gRTnc3n73uFk4L0yoVVrlopw53Ko0RDauWCWPl0lC35JZ1jC_N6wnOwex98JI6H0QRnJ8kZoh-NfzTfLny4FAAA).

Let me know if the wording or examples need changing. Conversely, if the maintainers feel this pattern shouldn't be officially documented right now, please feel completely free to close this PR.