### PR TITLE
fix: Support arguments for pseudo element selectors

### DIFF
--- a/.changeset/forty-baboons-do.md
+++ b/.changeset/forty-baboons-do.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: Support arguments for pseudo element selectors

--- a/packages/svelte/src/compiler/phases/1-parse/read/style.js
+++ b/packages/svelte/src/compiler/phases/1-parse/read/style.js
@@ -229,18 +229,23 @@ function read_selector(parser, inside_pseudo_class = false) {
 				end: parser.index
 			});
 		} else if (parser.eat('::')) {
+			const name = read_identifier(parser);
+
+			/** @type {null | AST.CSS.SelectorList} */
+			let args = null;
+
+			if (parser.eat('(')) {
+				args = read_selector_list(parser, true);
+				parser.eat(')', true);
+			}
+
 			relative_selector.selectors.push({
 				type: 'PseudoElementSelector',
-				name: read_identifier(parser),
+				name,
+				args,
 				start,
 				end: parser.index
 			});
-			// We read the inner selectors of a pseudo element to ensure it parses correctly,
-			// but we don't do anything with the result.
-			if (parser.eat('(')) {
-				read_selector_list(parser, true);
-				parser.eat(')', true);
-			}
 		} else if (parser.eat(':')) {
 			const name = read_identifier(parser);
 

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-analyze.js
@@ -284,6 +284,9 @@ const css_visitors = {
 		// visit block list, so parent rule metadata is populated
 		context.visit(node.block, state);
 	},
+	PseudoElementSelector() {
+		// Skip these. Arguments are global-like, so don't analyse.
+	},
 	NestingSelector(node, context) {
 		const rule = /** @type {AST.CSS.Rule} */ (context.state.rule);
 		const parent_rule = rule.metadata.parent_rule;

--- a/packages/svelte/src/compiler/phases/2-analyze/css/css-warn.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/css/css-warn.js
@@ -23,6 +23,9 @@ const visitors = {
 			context.next();
 		}
 	},
+	PseudoElementSelector() {
+		// Skip these. Arguments are global-like, so don't warn.
+	},
 	ComplexSelector(node, context) {
 		if (
 			!node.metadata.used &&

--- a/packages/svelte/src/compiler/phases/3-transform/css/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/css/index.js
@@ -374,6 +374,9 @@ const visitors = {
 		if (node.name === 'is' || node.name === 'where' || node.name === 'has' || node.name === 'not') {
 			context.next();
 		}
+	},
+	PseudoElementSelector() {
+		// Skip these. Arguments are global-like, don't want to prune them or anything.
 	}
 };
 

--- a/packages/svelte/src/compiler/print/index.js
+++ b/packages/svelte/src/compiler/print/index.js
@@ -277,6 +277,24 @@ const css_visitors = {
 
 	PseudoElementSelector(node, context) {
 		context.write(`::${node.name}`);
+
+		if (node.args) {
+			context.write('(');
+
+			let started = false;
+
+			for (const arg of node.args.children) {
+				if (started) {
+					context.write(', ');
+				}
+
+				context.visit(arg);
+
+				started = true;
+			}
+
+			context.write(')');
+		}
 	},
 
 	RelativeSelector(node, context) {

--- a/packages/svelte/src/compiler/types/css.d.ts
+++ b/packages/svelte/src/compiler/types/css.d.ts
@@ -135,6 +135,7 @@ export namespace _CSS {
 	export interface PseudoElementSelector extends BaseNode {
 		type: 'PseudoElementSelector';
 		name: string;
+		args: SelectorList | null;
 	}
 
 	export interface PseudoClassSelector extends BaseNode {

--- a/packages/svelte/tests/parser-modern/samples/css-pseudo-classes/output.json
+++ b/packages/svelte/tests/parser-modern/samples/css-pseudo-classes/output.json
@@ -24,8 +24,36 @@
 										{
 											"type": "PseudoElementSelector",
 											"name": "view-transition-old",
+											"args": {
+												"type": "SelectorList",
+												"start": 82,
+												"end": 85,
+												"children": [
+													{
+														"type": "ComplexSelector",
+														"start": 82,
+														"end": 85,
+														"children": [
+															{
+																"type": "RelativeSelector",
+																"combinator": null,
+																"selectors": [
+																	{
+																		"type": "TypeSelector",
+																		"name": "x-y",
+																		"start": 82,
+																		"end": 85
+																	}
+																],
+																"start": 82,
+																"end": 85
+															}
+														]
+													}
+												]
+											},
 											"start": 60,
-											"end": 81
+											"end": 86
 										}
 									],
 									"start": 60,
@@ -88,8 +116,36 @@
 																	{
 																		"type": "PseudoElementSelector",
 																		"name": "view-transition-old",
+																		"args": {
+																			"type": "SelectorList",
+																			"start": 141,
+																			"end": 144,
+																			"children": [
+																				{
+																					"type": "ComplexSelector",
+																					"start": 141,
+																					"end": 144,
+																					"children": [
+																						{
+																							"type": "RelativeSelector",
+																							"combinator": null,
+																							"selectors": [
+																								{
+																									"type": "TypeSelector",
+																									"name": "x-y",
+																									"start": 141,
+																									"end": 144
+																								}
+																							],
+																							"start": 141,
+																							"end": 144
+																						}
+																					]
+																				}
+																			]
+																		},
 																		"start": 119,
-																		"end": 140
+																		"end": 145
 																	}
 																],
 																"start": 119,
@@ -146,8 +202,36 @@
 										{
 											"type": "PseudoElementSelector",
 											"name": "highlight",
+											"args": {
+												"type": "SelectorList",
+												"start": 183,
+												"end": 198,
+												"children": [
+													{
+														"type": "ComplexSelector",
+														"start": 183,
+														"end": 198,
+														"children": [
+															{
+																"type": "RelativeSelector",
+																"combinator": null,
+																"selectors": [
+																	{
+																		"type": "TypeSelector",
+																		"name": "rainbow-color-1",
+																		"start": 183,
+																		"end": 198
+																	}
+																],
+																"start": 183,
+																"end": 198
+															}
+														]
+													}
+												]
+											},
 											"start": 171,
-											"end": 182
+											"end": 199
 										}
 									],
 									"start": 171,
@@ -199,8 +283,36 @@
 										{
 											"type": "PseudoElementSelector",
 											"name": "part",
+											"args": {
+												"type": "SelectorList",
+												"start": 241,
+												"end": 244,
+												"children": [
+													{
+														"type": "ComplexSelector",
+														"start": 241,
+														"end": 244,
+														"children": [
+															{
+																"type": "RelativeSelector",
+																"combinator": null,
+																"selectors": [
+																	{
+																		"type": "TypeSelector",
+																		"name": "foo",
+																		"start": 241,
+																		"end": 244
+																	}
+																],
+																"start": 241,
+																"end": 244
+															}
+														]
+													}
+												]
+											},
 											"start": 234,
-											"end": 240
+											"end": 245
 										}
 									],
 									"start": 220,
@@ -246,8 +358,36 @@
 										{
 											"type": "PseudoElementSelector",
 											"name": "slotted",
+											"args": {
+												"type": "SelectorList",
+												"start": 276,
+												"end": 284,
+												"children": [
+													{
+														"type": "ComplexSelector",
+														"start": 276,
+														"end": 284,
+														"children": [
+															{
+																"type": "RelativeSelector",
+																"combinator": null,
+																"selectors": [
+																	{
+																		"type": "ClassSelector",
+																		"name": "content",
+																		"start": 276,
+																		"end": 284
+																	}
+																],
+																"start": 276,
+																"end": 284
+															}
+														]
+													}
+												]
+											},
 											"start": 266,
-											"end": 275
+											"end": 285
 										}
 									],
 									"start": 266,
@@ -405,5 +545,6 @@
 		"type": "Fragment",
 		"nodes": []
 	},
-	"options": null
+	"options": null,
+	"comments": []
 }

--- a/packages/svelte/tests/print/samples/style/input.svelte
+++ b/packages/svelte/tests/print/samples/style/input.svelte
@@ -35,6 +35,9 @@
     content: "";
     display: block;
   }
+	custom-element::part(header) {
+		color: green;
+	}
   .container > .item { color: red; }
   h1 + p { margin-top: 0; }
 

--- a/packages/svelte/tests/print/samples/style/output.svelte
+++ b/packages/svelte/tests/print/samples/style/output.svelte
@@ -57,6 +57,10 @@
 		display: block;
 	}
 
+	custom-element::part(header) {
+		color: green;
+	}
+
 	.container > .item {
 		color: red;
 	}

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -1788,6 +1788,7 @@ declare module 'svelte/compiler' {
 		export interface PseudoElementSelector extends BaseNode {
 			type: 'PseudoElementSelector';
 			name: string;
+			args: SelectorList | null;
 		}
 
 		export interface PseudoClassSelector extends BaseNode {


### PR DESCRIPTION
I was working on a Vite plugin in which I modify the AST (and return it via `svelte.print`) and I noticed my pseudo-selectors (specifically styling external custom elements, e.g. `::part(header)` and the likes) not coming through.

Did not create an issue beforehand because by the time I figured out what was going on, I pretty much had the fix in hand.

Without this fix, the following:

```
<style>
custom-element::part(header) {
	color: green;
}
</style>
```

Actually comes out as:

```
<style>
custom-element::part {
	color: green;
}
</style>
```

Verified by running the modified `packages/svelte/tests/print/samples/style` test on `main`:

```
❯❯ svelte git:(main) 19:06 pnpm test print

> svelte-monorepo@0.0.1 test /path/to/svelte
> vitest run print


 RUN  v4.1.7 /path/to/svelte

·····························x··············

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  packages/svelte/tests/print/test.ts > style
AssertionError: expected '<style>\n\t.foo {\n\t\tcolor: red;\n\…' to deeply equal '<style>\n\t.foo {\n\t\tcolor: red;\n\…'

- Expected
+ Received

@@ -53,11 +53,11 @@
  	.card::before {
  		content: "";
  		display: block;
  	}

- 	custom-element::part(header) {
+ 	custom-element::part {
  		color: green;
  	}

  	.container > .item {
  		color: red;

 ❯ packages/svelte/tests/print/test.ts:24:10
     22|
     23|   const expected = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
     24|   assert.deepEqual(outputCode.trim().replaceAll('\r', ''), expected.trim().replaceAll('\r', ''));
       |          ^
     25|  }
     26| });
 ❯ packages/svelte/tests/suite.ts:34:51

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 43 passed (44)
   Start at  19:06:18
   Duration  801ms (transform 411ms, setup 0ms, import 631ms, tests 69ms, environment 0ms)

 ELIFECYCLE  Test failed. See above for more details.
```

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
