### PR TITLE
chore: deduplicate client/server context helpers

### DIFF
--- a/.changeset/shared-context-helpers.md
+++ b/.changeset/shared-context-helpers.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+chore: deduplicate client and server context helpers

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -6,7 +6,7 @@ import { create_user_effect } from './reactivity/effects.js';
 import { async_mode_flag, legacy_mode_flag } from '../flags/index.js';
 import { FILENAME } from '../../constants.js';
 import { BRANCH_EFFECT } from './constants.js';
-import { create_context, get_parent_context } from '../shared/context.js';
+import { create_context, get_or_init_context_map, get_parent_context } from '../shared/context.js';
 
 /** @type {ComponentContext | null} */
 export let component_context = null;
@@ -96,7 +96,7 @@ export function createContext() {
  * @returns {T}
  */
 export function getContext(key) {
-	const context_map = get_or_init_context_map('getContext');
+	const context_map = get_or_init_context_map(component_context, 'getContext');
 	const result = /** @type {T} */ (context_map.get(key));
 	return result;
 }
@@ -116,7 +116,7 @@ export function getContext(key) {
  * @returns {T}
  */
 export function setContext(key, context) {
-	const context_map = get_or_init_context_map('setContext');
+	const context_map = get_or_init_context_map(component_context, 'setContext');
 
 	if (async_mode_flag) {
 		var flags = /** @type {Effect} */ (active_effect).f;
@@ -143,7 +143,7 @@ export function setContext(key, context) {
  * @returns {boolean}
  */
 export function hasContext(key) {
-	const context_map = get_or_init_context_map('hasContext');
+	const context_map = get_or_init_context_map(component_context, 'hasContext');
 	return context_map.has(key);
 }
 
@@ -156,7 +156,7 @@ export function hasContext(key) {
  * @returns {T}
  */
 export function getAllContexts() {
-	const context_map = get_or_init_context_map('getAllContexts');
+	const context_map = get_or_init_context_map(component_context, 'getAllContexts');
 	return /** @type {T} */ (context_map);
 }
 
@@ -220,16 +220,4 @@ export function pop(component) {
 /** @returns {boolean} */
 export function is_runes() {
 	return !legacy_mode_flag || (component_context !== null && component_context.l === null);
-}
-
-/**
- * @param {string} name
- * @returns {Map<unknown, unknown>}
- */
-function get_or_init_context_map(name) {
-	if (component_context === null) {
-		e.lifecycle_outside_component(name);
-	}
-
-	return (component_context.c ??= new Map(get_parent_context(component_context) || undefined));
 }

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -6,6 +6,7 @@ import { create_user_effect } from './reactivity/effects.js';
 import { async_mode_flag, legacy_mode_flag } from '../flags/index.js';
 import { FILENAME } from '../../constants.js';
 import { BRANCH_EFFECT } from './constants.js';
+import { create_context, get_parent_context } from '../shared/context.js';
 
 /** @type {ComponentContext | null} */
 export let component_context = null;
@@ -79,18 +80,9 @@ export function set_dev_current_component_function(fn) {
  * @since 5.40.0
  */
 export function createContext() {
-	const key = {};
-
-	return [
-		() => {
-			if (!hasContext(key)) {
-				e.missing_context();
-			}
-
-			return getContext(key);
-		},
-		(context) => setContext(key, context)
-	];
+	return /** @type {[() => T, (context: T) => T]} */ (
+		create_context(getContext, setContext, hasContext)
+	);
 }
 
 /**
@@ -240,20 +232,4 @@ function get_or_init_context_map(name) {
 	}
 
 	return (component_context.c ??= new Map(get_parent_context(component_context) || undefined));
-}
-
-/**
- * @param {ComponentContext} component_context
- * @returns {Map<unknown, unknown> | null}
- */
-function get_parent_context(component_context) {
-	let parent = component_context.p;
-	while (parent !== null) {
-		const context_map = parent.c;
-		if (context_map !== null) {
-			return context_map;
-		}
-		parent = parent.p;
-	}
-	return null;
 }

--- a/packages/svelte/src/internal/client/context.js
+++ b/packages/svelte/src/internal/client/context.js
@@ -6,7 +6,7 @@ import { create_user_effect } from './reactivity/effects.js';
 import { async_mode_flag, legacy_mode_flag } from '../flags/index.js';
 import { FILENAME } from '../../constants.js';
 import { BRANCH_EFFECT } from './constants.js';
-import { create_context, get_or_init_context_map, get_parent_context } from '../shared/context.js';
+import { create_context, get_or_init_context_map } from '../shared/context.js';
 
 /** @type {ComponentContext | null} */
 export let component_context = null;

--- a/packages/svelte/src/internal/server/context.js
+++ b/packages/svelte/src/internal/server/context.js
@@ -1,6 +1,7 @@
 /** @import { SSRContext } from '#server' */
 import { DEV } from 'esm-env';
 import * as e from './errors.js';
+import { create_context, get_parent_context } from '../shared/context.js';
 
 /** @type {SSRContext | null} */
 export var ssr_context = null;
@@ -16,18 +17,9 @@ export function set_ssr_context(v) {
  * @since 5.40.0
  */
 export function createContext() {
-	const key = {};
-
-	return [
-		() => {
-			if (!hasContext(key)) {
-				e.missing_context();
-			}
-
-			return getContext(key);
-		},
-		(context) => setContext(key, context)
-	];
+	return /** @type {[() => T, (context: T) => T]} */ (
+		create_context(getContext, setContext, hasContext)
+	);
 }
 
 /**
@@ -92,24 +84,6 @@ export function push(fn) {
 
 export function pop() {
 	ssr_context = /** @type {SSRContext} */ (ssr_context).p;
-}
-
-/**
- * @param {SSRContext} ssr_context
- * @returns {Map<unknown, unknown> | null}
- */
-function get_parent_context(ssr_context) {
-	let parent = ssr_context.p;
-
-	while (parent !== null) {
-		const context_map = parent.c;
-		if (context_map !== null) {
-			return context_map;
-		}
-		parent = parent.p;
-	}
-
-	return null;
 }
 
 /**

--- a/packages/svelte/src/internal/server/context.js
+++ b/packages/svelte/src/internal/server/context.js
@@ -1,7 +1,6 @@
 /** @import { SSRContext } from '#server' */
 import { DEV } from 'esm-env';
-import * as e from './errors.js';
-import { create_context, get_parent_context } from '../shared/context.js';
+import { create_context, get_or_init_context_map, get_parent_context } from '../shared/context.js';
 
 /** @type {SSRContext | null} */
 export var ssr_context = null;
@@ -28,7 +27,7 @@ export function createContext() {
  * @returns {T}
  */
 export function getContext(key) {
-	const context_map = get_or_init_context_map('getContext');
+	const context_map = get_or_init_context_map(ssr_context, 'getContext');
 	const result = /** @type {T} */ (context_map.get(key));
 
 	return result;
@@ -41,7 +40,7 @@ export function getContext(key) {
  * @returns {T}
  */
 export function setContext(key, context) {
-	get_or_init_context_map('setContext').set(key, context);
+	get_or_init_context_map(ssr_context, 'setContext').set(key, context);
 	return context;
 }
 
@@ -50,24 +49,12 @@ export function setContext(key, context) {
  * @returns {boolean}
  */
 export function hasContext(key) {
-	return get_or_init_context_map('hasContext').has(key);
+	return get_or_init_context_map(ssr_context, 'hasContext').has(key);
 }
 
 /** @returns {Map<any, any>} */
 export function getAllContexts() {
-	return get_or_init_context_map('getAllContexts');
-}
-
-/**
- * @param {string} name
- * @returns {Map<unknown, unknown>}
- */
-function get_or_init_context_map(name) {
-	if (ssr_context === null) {
-		e.lifecycle_outside_component(name);
-	}
-
-	return (ssr_context.c ??= new Map(get_parent_context(ssr_context) || undefined));
+	return get_or_init_context_map(ssr_context, 'getAllContexts');
 }
 
 /**

--- a/packages/svelte/src/internal/server/context.js
+++ b/packages/svelte/src/internal/server/context.js
@@ -1,6 +1,6 @@
 /** @import { SSRContext } from '#server' */
 import { DEV } from 'esm-env';
-import { create_context, get_or_init_context_map, get_parent_context } from '../shared/context.js';
+import { create_context, get_or_init_context_map } from '../shared/context.js';
 
 /** @type {SSRContext | null} */
 export var ssr_context = null;

--- a/packages/svelte/src/internal/shared/context.js
+++ b/packages/svelte/src/internal/shared/context.js
@@ -32,14 +32,10 @@ export function create_context(get_context, set_context, has_context) {
  */
 export function get_parent_context(context) {
 	let parent = context.p;
-	while (parent !== null) {
-		const context_map = parent.c;
-		if (context_map !== null) {
-			return context_map;
-		}
+	while (parent !== null && parent.c === null) {
 		parent = parent.p;
 	}
-	return null;
+	return parent?.c ?? null;
 }
 
 /**

--- a/packages/svelte/src/internal/shared/context.js
+++ b/packages/svelte/src/internal/shared/context.js
@@ -1,4 +1,4 @@
-import { missing_context } from './errors.js';
+import { lifecycle_outside_component, missing_context } from './errors.js';
 
 /**
  * @template T
@@ -40,4 +40,17 @@ export function get_parent_context(context) {
 		parent = parent.p;
 	}
 	return null;
+}
+
+/**
+ * @param {Context | null} context
+ * @param {string} name
+ * @returns {Map<unknown, unknown>}
+ */
+export function get_or_init_context_map(context, name) {
+	if (context === null) {
+		lifecycle_outside_component(name);
+	}
+
+	return (context.c ??= new Map(get_parent_context(context) || undefined));
 }

--- a/packages/svelte/src/internal/shared/context.js
+++ b/packages/svelte/src/internal/shared/context.js
@@ -1,0 +1,43 @@
+import { missing_context } from './errors.js';
+
+/**
+ * @template T
+ * @param {(key: object) => T} get_context
+ * @param {(key: object, context: T) => T} set_context
+ * @param {(key: object) => boolean} has_context
+ * @returns {[() => T, (context: T) => T]}
+ */
+export function create_context(get_context, set_context, has_context) {
+	const key = {};
+
+	return [
+		() => {
+			if (!has_context(key)) {
+				missing_context();
+			}
+
+			return get_context(key);
+		},
+		(context) => set_context(key, context)
+	];
+}
+
+/**
+ * @typedef {{ p: Context | null, c: Map<unknown, unknown> | null }} Context
+ */
+
+/**
+ * @param {Context} context
+ * @returns {Map<unknown, unknown> | null}
+ */
+export function get_parent_context(context) {
+	let parent = context.p;
+	while (parent !== null) {
+		const context_map = parent.c;
+		if (context_map !== null) {
+			return context_map;
+		}
+		parent = parent.p;
+	}
+	return null;
+}

--- a/packages/svelte/src/internal/shared/context.js
+++ b/packages/svelte/src/internal/shared/context.js
@@ -30,7 +30,7 @@ export function create_context(get_context, set_context, has_context) {
  * @param {Context} context
  * @returns {Map<unknown, unknown> | null}
  */
-export function get_parent_context(context) {
+function get_parent_context(context) {
 	let parent = context.p;
 	while (parent !== null && parent.c === null) {
 		parent = parent.p;


### PR DESCRIPTION
The server copy of `createContext` shipped without the `missing_context` throw and #17580 had to hand-mirror the client body back in, so this duplication has already cost a bug. This moves the realm-independent parts, the `createContext` tuple, `get_parent_context`, and `get_or_init_context_map`, into `internal/shared/context.js`, and each realm keeps its public context functions as thin wrappers over its own state. No behavior change, generated types are byte-identical.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
