### PR TITLE
WIP: fix: avoid repeated Acorn location scans

### DIFF
--- a/.changeset/tidy-apples-parse.md
+++ b/.changeset/tidy-apples-parse.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: improve compiler performance for components with many embedded expressions

--- a/packages/svelte/src/compiler/phases/1-parse/acorn.js
+++ b/packages/svelte/src/compiler/phases/1-parse/acorn.js
@@ -5,9 +5,48 @@ import * as acorn from 'acorn';
 import { walk } from 'zimmerframe';
 import { tsPlugin } from '@sveltejs/acorn-typescript';
 import * as e from '../../errors.js';
+import { locator } from '../../state.js';
 
 const JSParser = acorn.Parser;
 const TSParser = JSParser.extend(tsPlugin());
+
+/** @type {WeakMap<Parser, boolean>} */
+const standard_line_endings = new WeakMap();
+
+/**
+ * Avoid Acorn's O(index) line-number scan when starting a parser in the middle of a component.
+ * @param {Parser} parser
+ * @param {string} source
+ * @param {number} index
+ * @param {acorn.Options} options
+ */
+function create_parser_at(parser, source, index, options) {
+	const AcornParser = /** @type {any} */ (parser.ts ? TSParser : JSParser);
+	let standard = standard_line_endings.get(parser);
+
+	if (standard === undefined) {
+		standard = !/(?:\r(?!\n)|[\u2028\u2029])/.test(parser.template);
+		standard_line_endings.set(parser, standard);
+	}
+
+	// Destructured each contexts and TypeScript annotations are parsed from adjusted source text,
+	// whose positions intentionally differ from the component source.
+	// Acorn also treats bare CR and Unicode separators differently from Svelte's locator.
+	if (source !== parser.template || !standard) {
+		return new AcornParser(options, source, index);
+	}
+
+	const instance = new AcornParser(options, source);
+	const { line, column } = locator(index);
+
+	instance.pos = instance.start = instance.end = index;
+	instance.lastTokStart = instance.lastTokEnd = index;
+	instance.lineStart = index - column;
+	instance.curLine = line;
+	instance.startLoc = instance.endLoc = instance.curPosition();
+
+	return instance;
+}
 
 /**
  * @typedef {Comment & {
@@ -77,18 +116,18 @@ export function parse(source, comments, typescript, is_script) {
  * @returns {acorn.Expression & { leadingComments?: CommentWithLocation[]; trailingComments?: CommentWithLocation[]; }}
  */
 export function parse_expression_at(parser, source, index) {
-	const acorn = parser.ts ? TSParser : JSParser;
-
 	const { onComment, add_comments } = get_comment_handlers(source, parser.root.comments, index);
 
 	try {
-		const ast = acorn.parseExpressionAt(source, index, {
+		const p = create_parser_at(parser, source, index, {
 			onComment,
 			sourceType: 'module',
 			ecmaVersion: 16,
 			locations: true,
 			preserveParens: true
 		});
+		p.nextToken();
+		const ast = p.parseExpression();
 
 		add_comments(ast);
 
@@ -106,16 +145,16 @@ export function parse_expression_at(parser, source, index) {
  */
 export function parse_statement_at(parser, source, index) {
 	// cast to `any`: acorn's Parser constructor and parseStatement/nextToken aren't in its public types
-	const acorn = /** @type {any} */ (parser.ts ? TSParser : JSParser);
 	const { onComment, add_comments } = get_comment_handlers(source, parser.root.comments, index);
 
 	try {
 		// This is like parseExpressionAt but for statements
-		const p = new acorn(
-			{ onComment, sourceType: 'module', ecmaVersion: 16, locations: true },
-			source,
-			index
-		);
+		const p = create_parser_at(parser, source, index, {
+			onComment,
+			sourceType: 'module',
+			ecmaVersion: 16,
+			locations: true
+		});
 		p.nextToken();
 		const statement = /** @type {Statement} */ (p.parseStatement(null, true, Object.create(null)));
 		add_comments(/** @type {acorn.Node} */ (statement));

--- a/packages/svelte/tests/parser-modern/test.ts
+++ b/packages/svelte/tests/parser-modern/test.ts
@@ -158,3 +158,71 @@ it('Strips BOM from the input', () => {
 		]
 	});
 });
+
+it('preserves expression locations after newlines', () => {
+	const input = `<script>let value = 1;</script>
+<p>
+	{value +
+		1}
+</p>
+{#if value}
+	{@const doubled = value * 2}
+	{doubled}
+{/if}`;
+	const ast = parse(input, { modern: true });
+	const positions: Array<[string, number, number, number]> = [];
+
+	JSON.stringify(ast, (_key, value) => {
+		if (value?.type === 'Identifier' && value.start > 30) {
+			positions.push([value.name, value.start, value.loc.start.line, value.loc.start.column]);
+		}
+		return value;
+	});
+
+	assert.deepEqual(positions, [
+		['value', 38, 3, 2],
+		['value', 61, 6, 5],
+		['doubled', 77, 7, 9],
+		['value', 87, 7, 19],
+		['doubled', 100, 8, 2]
+	]);
+});
+
+it('preserves expression locations after CRLF line endings', () => {
+	const ast = parse('{foo}\r\n{bar}\r\n{baz}', { modern: true });
+	const positions: Array<[string, number, number]> = [];
+
+	JSON.stringify(ast, (_key, value) => {
+		if (value?.type === 'Identifier') {
+			positions.push([value.name, value.loc.start.line, value.loc.start.column]);
+		}
+		return value;
+	});
+
+	assert.deepEqual(positions, [
+		['foo', 1, 1],
+		['bar', 2, 1],
+		['baz', 3, 1]
+	]);
+});
+
+it('preserves expression locations across uncommon line endings', () => {
+	const ast = parse('{foo}\r\n{bar}\r{baz}\u2028{qux}\u2029{quux}\n{corge}', { modern: true });
+	const positions: Array<[string, number, number]> = [];
+
+	JSON.stringify(ast, (_key, value) => {
+		if (value?.type === 'Identifier') {
+			positions.push([value.name, value.loc.start.line, value.loc.start.column]);
+		}
+		return value;
+	});
+
+	assert.deepEqual(positions, [
+		['foo', 1, 1],
+		['bar', 2, 1],
+		['baz', 2, 7],
+		['qux', 2, 13],
+		['quux', 2, 19],
+		['corge', 6, 1]
+	]);
+});


### PR DESCRIPTION
NOTE: not ready for review yet. I'm using this to explore whether we should adjust Acorn's API in https://github.com/acornjs/acorn/issues/1448.

Svelte parses JavaScript embedded in component markup by repeatedly starting Acorn at different offsets in the same source string. Acorn initializes each parser by scanning the source prefix to recover the starting line, so components with many expression or declaration tags accumulate approximately quadratic parsing work.

This is the behavior described upstream in [acornjs/acorn#1448](https://github.com/acornjs/acorn/issues/1448).

- Reuse Svelte's existing source locator to initialize Acorn's line and token position when parsing directly from the component source.
- Keep Acorn's existing constructor path for adjusted source strings used by destructured contexts and TypeScript annotations.
- Fall back to Acorn's existing path for bare CR, U+2028, and U+2029 line separators, whose location semantics differ from Svelte's locator.
- Add regression coverage for multiline expressions, declaration tags, LF, CRLF, bare CR, and Unicode line separators.
- Add a patch changeset for `svelte`.

This preserves absolute offsets, AST locations, comments, diagnostics, and source-map behavior while avoiding the repeated prefix scan for normal LF/CRLF component sources.

## Performance

The patch shows 5-9% faster full compilation with no output differences for [Immich](https://github.com/immich-app/immich), [Open WebUI](https://github.com/open-webui/open-webui), and [Skeleton](https://github.com/skeletonlabs/skeleton).

| Project | Corpus | Mode | Before | After | Median improvement |
|---|---:|---|---:|---:|---:|
| Immich | 411 files / 1.40 MB | Parse | 263.5 ms | 243.5 ms | **7.7% faster** |
| Immich | 411 files / 1.40 MB | Client compile | 758.9 ms | 727.3 ms | **4.7% faster** |
| Immich | 411 files / 1.40 MB | Server compile | 691.4 ms | 644.2 ms | **7.3% faster** |
| Open WebUI | 593 files / 3.36 MB | Parse | 627.3 ms | 492.3 ms | **19.0% faster** |
| Open WebUI | 592 files / 3.36 MB | Client compile | 1,751.3 ms | 1,621.9 ms | **8.4% faster** |
| Open WebUI | 592 files / 3.36 MB | Server compile | 1,580.8 ms | 1,450.3 ms | **9.4% faster** |
| Skeleton | 686 files / 0.83 MB | Parse | 141.1 ms | 135.5 ms | **5.0% faster** |
| Skeleton | 686 files / 0.83 MB | Client compile | 429.8 ms | 424.3 ms | **2.3% faster** |
| Skeleton | 686 files / 0.83 MB | Server compile | 378.3 ms | 366.9 ms | **3.0% faster** |

Large individual components benefited substantially:
- Open WebUI MessageInput.svelte: 44% faster parsing
- Open WebUI Documents.svelte: 52% faster
- Immich album page: 25% faster
- Immich MemoryViewer.svelte: 27% faster
- Skeleton typography controls: 34% faster

Measured on macOS arm64 with Node 26.3.1 and pnpm 10.4.0. Each result is the median of 9 measurements after 3 warmups.

<details>
<summary>Synthetic benchmark to show quadratic behavior</summary>

| Expression tags | Parse before | Parse after | Doubling ratio before | Doubling ratio after |
|---:|---:|---:|---:|---:|
| 128 | 0.758 ms | 0.646 ms | — | — |
| 256 | 1.633 ms | 1.102 ms | 2.16× | 1.71× |
| 512 | 4.132 ms | 2.136 ms | 2.53× | 1.94× |
| 1,024 | 12.534 ms | 3.885 ms | 3.03× | 1.82× |
| 2,048 | 41.135 ms | 6.695 ms | 3.28× | 1.72× |
| 4,096 | 148.524 ms | 11.479 ms | 3.61× | 1.71× |

The fitted parse-time exponent drops from 1.53 to 0.84. At 4,096 expression tags, the parse phase is 12.9× faster.

</details>