### PR TITLE
docs: document rune_missing_parentheses compiler error

### DIFF
--- a/documentation/docs/98-reference/.generated/compile-errors.md
+++ b/documentation/docs/98-reference/.generated/compile-errors.md
@@ -821,6 +821,18 @@ Cannot use `%rune%` rune in non-runes mode
 Cannot use rune without parentheses
 ```
 
+Runes are keywords rather than values — they can't be assigned to a variable or passed to a function, only called. Referencing one without parentheses is therefore an error...
+
+```js
+let count = $state;
+```
+
+...whether it's a rune like `$state` or one reached through a property, like `$derived.by`. Add the parentheses, along with any arguments the rune expects:
+
+```js
+let count = $state(0);
+```
+
 ### rune_removed
 
 ```

--- a/packages/svelte/messages/compile-errors/script.md
+++ b/packages/svelte/messages/compile-errors/script.md
@@ -186,6 +186,18 @@ This turned out to be buggy and unpredictable, particularly when working with de
 
 > Cannot use rune without parentheses
 
+Runes are keywords rather than values — they can't be assigned to a variable or passed to a function, only called. Referencing one without parentheses is therefore an error...
+
+```js
+let count = $state;
+```
+
+...whether it's a rune like `$state` or one reached through a property, like `$derived.by`. Add the parentheses, along with any arguments the rune expects:
+
+```js
+let count = $state(0);
+```
+
 ## rune_removed
 
 > The `%name%` rune has been removed


### PR DESCRIPTION
`rune_missing_parentheses` currently renders on the docs site with only the raw
message string and no explanation, so there is nothing telling the reader what
they did wrong or how to fix it. This fills in a description and examples.

The wording follows `documentation/docs/02-runes/01-what-are-runes.md`, which
describes runes as keywords that "are not values — you can't assign them to a
variable or pass them as arguments to a function", since that is exactly the
mistake this error catches.

The generated reference page was updated by running
`node scripts/process-messages`. Nothing under `packages/svelte/src` changed, so
no changeset is needed.

### Test plan

Confirmed the documented behaviour against the compiler directly, so the
examples reflect what the compiler actually does:

| source | result |
| --- | --- |
| `let count = $state;` | `rune_missing_parentheses` |
| `let count = $state(0);` | compiles |
| `let b = $derived.by;` | `rune_missing_parentheses` |
| `let b = $derived.by(() => a);` | compiles |
| `let p = $props;` | `rune_missing_parentheses` |

- `pnpm lint` — passes (eslint clean, `prettier --check .` reports
  "All matched files use Prettier code style!")
- `pnpm test` — **7576 passed, 160 skipped, 0 failed**; 32 of 33 suites pass.

  The one suite that does not run locally is `tests/runtime-browser`, which
  fails at `chromium.launch()` because Playwright 1.60.0 cannot install a
  browser on this machine's OS (`Playwright does not support chromium on
  ubuntu26.04-x64`). That is an environment limitation unrelated to this
  change — this PR touches no runtime code.

- Existing coverage for this error is unchanged and still passing
  (`tests/compiler-errors/samples/runes-props-not-called` and
  `runes-bindable-not-called`).
