### PR TITLE
fix: do not consider `style` literals inside `<script>` blocks

### DIFF
--- a/.changeset/modern-bats-work.md
+++ b/.changeset/modern-bats-work.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: do not consider `style` literals inside `<script>` blocks

--- a/packages/svelte/src/compiler/preprocess/index.js
+++ b/packages/svelte/src/compiler/preprocess/index.js
@@ -251,7 +251,7 @@ function stringify_tag_attributes(attributes) {
 }
 
 const regex_style_tags =
-	/<!--[^]*?-->|<style((?:\s+[^=>'"/\s]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/\s]+)*\s*)(?:\/>|>([\S\s]*?)<\/style>)/g;
+	/<!--[^]*?-->|<script[^]*?<\/script>|<style((?:\s+[^=>'"/\s]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/\s]+)*\s*)(?:\/>|>([\S\s]*?)<\/style>)/g;
 const regex_script_tags =
 	/<!--[^]*?-->|<script((?:\s+[^=>'"/\s]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"/\s]+)*\s*)(?:\/>|>([\S\s]*?)<\/script>)/g;
 

--- a/packages/svelte/tests/preprocess/samples/style-tag-in-script/_config.js
+++ b/packages/svelte/tests/preprocess/samples/style-tag-in-script/_config.js
@@ -1,0 +1,13 @@
+import * as assert from 'node:assert';
+import { test } from '../../test';
+
+export default test({
+	preprocess: {
+		style: ({ content }) => {
+			assert.equal(content, 'BEFORE');
+			return {
+				code: 'PROCESSED'
+			};
+		}
+	}
+});

--- a/packages/svelte/tests/preprocess/samples/style-tag-in-script/input.svelte
+++ b/packages/svelte/tests/preprocess/samples/style-tag-in-script/input.svelte
@@ -1,0 +1,5 @@
+<script>
+	const scope = (rules) => `<style>${rules.replaceAll('::highlight(a-', '::highlight(b-')}</style>`;
+</script>
+
+<style>BEFORE</style>

--- a/packages/svelte/tests/preprocess/samples/style-tag-in-script/output.svelte
+++ b/packages/svelte/tests/preprocess/samples/style-tag-in-script/output.svelte
@@ -1,0 +1,5 @@
+<script>
+	const scope = (rules) => `<style>${rules.replaceAll('::highlight(a-', '::highlight(b-')}</style>`;
+</script>
+
+<style>PROCESSED</style>


### PR DESCRIPTION
A bump in [highlight-svelte](https://github.com/metonym/svelte-highlight/blob/master/src/HighlightEditable.svelte#L116) starting causing a [build](https://github.com/immich-app/static-pages/actions/runs/30375509217/job/90330034579?pr=653) to fail with this error:

```
HighlightEditable.svelte.vite-preprocess.css:5:21: Unclosed bracket
```
`HighlightEditable.svelte` recently added a literal `<style>` string inside of the `<script>` blog, which conflicts with the `regex_style_tags` regex, leading to an incorrect replacement.

The PR addresses this by updating the regex to exclude `<style>` references  _inside_ of `<script>` tags.

---

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
