### PR TITLE
docs: note that transitions bypass CSS prefers-reduced-motion

### DIFF
--- a/documentation/docs/03-template-syntax/14-transition.md
+++ b/documentation/docs/03-template-syntax/14-transition.md
@@ -41,6 +41,27 @@ Transitions are local by default. Local transitions only play when the block the
 
 A selection of built-in transitions can be imported from the [`svelte/transition`](svelte-transition) module.
 
+## Accessibility
+
+Transitions are driven by the [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API) rather than by CSS. A global `@media (prefers-reduced-motion: reduce)` rule that zeroes `transition-duration` and `animation-duration` therefore does not reach them, and someone who has asked their operating system for less motion will still see the full animation.
+
+Use [`prefersReducedMotion`](svelte-motion#prefersReducedMotion) to honour the preference:
+
+```svelte
+<script>
+	import { prefersReducedMotion } from 'svelte/motion';
+	import { fly } from 'svelte/transition';
+
+	let visible = $state(false);
+</script>
+
+{#if visible}
+	<p transition:fly={{ y: prefersReducedMotion.current ? 0 : 200 }}>
+		flies in, unless the user prefers reduced motion
+	</p>
+{/if}
+```
+
 ## Transition parameters
 
 Transitions can have parameters.

--- a/documentation/docs/03-template-syntax/14-transition.md
+++ b/documentation/docs/03-template-syntax/14-transition.md
@@ -41,27 +41,6 @@ Transitions are local by default. Local transitions only play when the block the
 
 A selection of built-in transitions can be imported from the [`svelte/transition`](svelte-transition) module.
 
-## Accessibility
-
-Transitions are driven by the [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API) rather than by CSS. A global `@media (prefers-reduced-motion: reduce)` rule that zeroes `transition-duration` and `animation-duration` therefore does not reach them, and someone who has asked their operating system for less motion will still see the full animation.
-
-Use [`prefersReducedMotion`](svelte-motion#prefersReducedMotion) to honour the preference:
-
-```svelte
-<script>
-	import { prefersReducedMotion } from 'svelte/motion';
-	import { fly } from 'svelte/transition';
-
-	let visible = $state(false);
-</script>
-
-{#if visible}
-	<p transition:fly={{ y: prefersReducedMotion.current ? 0 : 200 }}>
-		flies in, unless the user prefers reduced motion
-	</p>
-{/if}
-```
-
 ## Transition parameters
 
 Transitions can have parameters.
@@ -73,6 +52,12 @@ Transitions can have parameters.
 	<div transition:fade={{ duration: 2000 }}>fades in and out over two seconds</div>
 {/if}
 ```
+
+## Accessibility
+
+Transitions are driven by the [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API) rather than by CSS. A global `@media (prefers-reduced-motion: reduce)` rule that zeroes `transition-duration` and `animation-duration` therefore has no effect on them.
+
+Use [`prefersReducedMotion`](svelte-motion#prefersReducedMotion) to adjust (or completely disable) the transition accordingly for devices who request reduced motion.
 
 ## Custom transition functions
 


### PR DESCRIPTION
Svelte 5 transitions are driven by the Web Animations API, so a global `@media (prefers-reduced-motion: reduce)` rule that zeroes `transition-duration` and `animation-duration` has no effect on them. Someone reaching for the usual CSS reset gets no signal that it does nothing here — I hit this in a production app where the OS-level "reduce motion" setting was on and the transitions still played at full duration.

`prefersReducedMotion` already solves this and is documented on the [svelte/motion page](https://svelte.dev/docs/svelte/svelte-motion#prefersReducedMotion), but nothing on the `transition:` page points a reader to it — that page currently has no mention of reduced motion or accessibility at all.

This adds a short **Accessibility** section that links to it, reusing the example from the `svelte/motion` docs so the two pages stay consistent.

Deliberately docs-only. #5346 settled that transitions should not apply reduced motion automatically, and I'm not reopening that — this only makes the existing opt-in discoverable from the page where people actually look.

`in:`/`out:` and `animate:` share the same caveat. Happy to mirror the note there if you'd like it in this PR.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs — *references #5346*
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it. — *n/a, documentation only*
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`). — *n/a, no source changes; this touches only `documentation/`*

### Tests and linting

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` — *n/a, single markdown file under `documentation/`; happy to run the full suite if you'd prefer*