### PR TITLE
perf: O(n²)→O(n) Map lookups for legacy reactive statements

### DIFF
--- a/.changeset/legacy-reactive-map-lookups.md
+++ b/.changeset/legacy-reactive-map-lookups.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: O(n²)→O(n) Map lookups for legacy `$:` reactive statement ordering

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -1314,7 +1314,8 @@ function order_reactive_statements(unsorted_reactive_declarations) {
 	 * @returns
 	 */
 	const add_declaration = (node, declaration) => {
-		if ([...reactive_declarations.values()].includes(declaration)) return;
+		// Visited set: each ReactiveStatement is stored under exactly one LabeledStatement node
+		if (reactive_declarations.has(node)) return;
 
 		for (const binding of declaration.dependencies) {
 			if (declaration.assignments.has(binding)) continue;

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -247,11 +247,11 @@ export function client_component(analysis, options) {
 	}
 
 	for (const [node] of analysis.reactive_statements) {
-		const statement = [...state.legacy_reactive_statements].find(([n]) => n === node);
+		const statement = state.legacy_reactive_statements.get(node);
 		if (statement === undefined) {
 			throw new Error('Could not find reactive statement');
 		}
-		instance.body.push(statement[1]);
+		instance.body.push(statement);
 	}
 
 	if (analysis.reactive_statements.size > 0) {

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -148,7 +148,7 @@ export function server_component(analysis, options) {
 	const legacy_reactive_declarations = [];
 
 	for (const [node] of analysis.reactive_statements) {
-		const statement = [...state.legacy_reactive_statements].find(([n]) => n === node);
+		const statement = state.legacy_reactive_statements.get(node);
 		if (statement === undefined) {
 			throw new Error('Could not find reactive statement');
 		}
@@ -165,7 +165,7 @@ export function server_component(analysis, options) {
 			}
 		}
 
-		instance.body.push(statement[1]);
+		instance.body.push(statement);
 	}
 
 	if (legacy_reactive_declarations.length > 0) {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`. (Using `perf:` as a compile-time complexity win; happy to retitle if preferred.)
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it. (Behavior-preserving; covered by existing runtime-legacy reactive samples.)
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## Summary

While ordering and emitting legacy `$:` reactive statements, the compiler treated an already-keyed `Map<LabeledStatement, Statement>` as an array:

```js
const statement = [...state.legacy_reactive_statements].find(([n]) => n === node);
instance.body.push(statement[1]);
```

That is **O(n²)** in the number of `$:` statements per component (`n`), plus an O(n) temporary array per lookup. The map is already keyed by that node.

**Fix (same public behavior):**

1. Client + server transform: `state.legacy_reactive_statements.get(node)` then `push(statement)`.
2. Related path in `order_reactive_statements`: replace `[...values()].includes(declaration)` with `reactive_declarations.has(node)` (1:1 node↔declaration; DFS "visited" intent).

**Complexity:** O(n²) → O(n) for lookup/membership over `$:` count.

### Verification

- `pnpm test runtime-legacy` with reactive-focused filters — pass
- `pnpm test runtime-legacy` — 3304 passed
- `pnpm test validator -t reactive` — pass
- `pnpm test server-side-rendering` — pass
- `pnpm test runtime-browser` — 123 passed
- Full `pnpm test` — 7576+ passed

### Follow-ups

Related complexity cleanups filed separately (not in this PR):

- https://github.com/sveltejs/svelte/issues/18599 — `sort_const_tags` O(n²) membership
- https://github.com/sveltejs/svelte/issues/18600 — `spread_props` ownKeys quadratic key dedup
- https://github.com/sveltejs/svelte/issues/18601 — Set for rest-prop exclude lists (server / legacy / `exclude_from_object`)
