### PR TITLE
perf: O(1) membership in sort_const_tags topological sort

### DIFF
--- a/.changeset/sort-const-tags-set.md
+++ b/.changeset/sort-const-tags-set.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: O(1) membership in `{@const}` topological sort (`sort_const_tags`)

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -87,9 +87,12 @@ function sort_const_tags(nodes, state) {
 	/** @type {AST.ConstTag[]} */
 	const sorted = [];
 
+	/** @type {Set<AST.ConstTag>} */
+	const seen = new Set();
+
 	/** @param {Tag} tag */
 	function add(tag) {
-		if (sorted.includes(tag.node)) {
+		if (seen.has(tag.node)) {
 			return;
 		}
 
@@ -98,6 +101,7 @@ function sort_const_tags(nodes, state) {
 			if (dep_tag) add(dep_tag);
 		}
 
+		seen.add(tag.node);
 		sorted.push(tag.node);
 	}
 

--- a/packages/svelte/tests/runtime-legacy/samples/const-tag-reverse-diamond/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/const-tag-reverse-diamond/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+// sum is declared before left/right; sort_const_tags must emit deps first.
+// Also exercises multi-parent membership (sum → left and sum → right).
+export default test({
+	html: '<p>23</p>',
+
+	async test({ component, target, assert }) {
+		component.n = 1;
+
+		assert.htmlEqual(target.innerHTML, '<p>5</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-legacy/samples/const-tag-reverse-diamond/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/const-tag-reverse-diamond/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	export let n = 10;
+</script>
+
+{#if true}
+	{@const sum = left + right}
+	{@const left = n + 1}
+	{@const right = n + 2}
+	<p>{sum}</p>
+{/if}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`. (Using `perf:` for a compile-time complexity win; happy to retitle if preferred.)
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it. (Behavior-preserving; new reverse-order diamond sample plus existing `{@const}` ordering suite.)
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## Summary

Closes #18599.

While topologically sorting `{@const}` tags in a fragment (legacy mode), DFS membership used an array scan:

```js
if (sorted.includes(tag.node)) {
  return;
}
// ...
sorted.push(tag.node);
```

That is **O(n²)** in the number of `{@const}` tags in the fragment. Cycle detection already builds a graph; the sort only needs a visited set.

**Fix (same public behavior):** track visited nodes with a `Set` — `seen.has(tag.node)` / `seen.add(tag.node)` next to the existing `sorted.push`. Order and cycle errors are unchanged.

**Complexity:** membership O(1); total sort O(n + edges) instead of O(n²) from includes.

## Verification

- `pnpm test runtime-legacy -t const-tag` — 114 passed
- `pnpm test runtime-legacy` — 3307 passed
- `pnpm test compiler-errors -t const-tag` — 5 passed (includes cycle detection)
- New sample `const-tag-reverse-diamond`: `sum` declared before `left`/`right`; updates when `n` changes

