### PR TITLE
perf: O(1) key membership in spread_props ownKeys

### DIFF
--- a/.changeset/spread-props-ownkeys-set.md
+++ b/.changeset/spread-props-ownkeys-set.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: O(1) key membership in `spread_props` `ownKeys`

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -235,23 +235,23 @@ const spread_props_handler = {
 		return false;
 	},
 	ownKeys(target) {
-		/** @type {Array<string | symbol>} */
-		const keys = [];
+		/** @type {Set<string | symbol>} */
+		const keys = new Set();
 
 		for (let p of target.props) {
 			if (is_function(p)) p = p();
 			if (!p) continue;
 
 			for (const key in p) {
-				if (!keys.includes(key)) keys.push(key);
+				keys.add(key);
 			}
 
 			for (const key of Object.getOwnPropertySymbols(p)) {
-				if (!keys.includes(key)) keys.push(key);
+				keys.add(key);
 			}
 		}
 
-		return keys;
+		return Array.from(keys);
 	}
 };
 

--- a/packages/svelte/src/internal/client/reactivity/props.test.ts
+++ b/packages/svelte/src/internal/client/reactivity/props.test.ts
@@ -1,0 +1,68 @@
+import { assert, describe, test } from 'vitest';
+import { spread_props } from './props.js';
+
+/**
+ * Behavior lock for spread_props ownKeys (perf #18600).
+ * Constrains rewrites: first-seen order, for...in (incl. inherited enumerable strings),
+ * getOwnPropertySymbols (incl. non-enumerable), lazy fn props, falsy skip.
+ */
+describe('spread_props ownKeys', () => {
+	test('dedups string keys with first-seen order across objects', () => {
+		const props = spread_props({ z: 1, a: 2 }, { a: 3, b: 4 });
+
+		assert.deepEqual(Reflect.ownKeys(props), ['z', 'a', 'b']);
+		assert.deepEqual(Object.keys(props), ['z', 'a', 'b']);
+	});
+
+	test('integer-like key order is per-object, not global', () => {
+		// Object key order: integer indices ascending, then other strings in insertion order.
+		// Across spreads, later objects append only unseen keys — no global re-sort.
+		const props = spread_props({ b: 1, 2: 0, 1: 0 }, { a: 1 });
+
+		assert.deepEqual(Reflect.ownKeys(props), ['1', '2', 'b', 'a']);
+	});
+
+	test('includes inherited enumerable string keys from for...in', () => {
+		const child = Object.create(
+			{ inherited: 1 },
+			{ own: { value: 1, enumerable: true, configurable: true, writable: true } }
+		);
+		const props = spread_props(child);
+
+		// ownKeys uses for...in → inherited enumerable strings appear
+		assert.deepEqual(Reflect.ownKeys(props), ['own', 'inherited']);
+		// Object.keys also consults getOwnPropertyDescriptor; inherited has no own descriptor
+		assert.deepEqual(Object.keys(props), ['own']);
+	});
+
+	test('dedups symbols at first-seen index; non-enumerable own symbols included', () => {
+		const s1 = Symbol('s1');
+		const s2 = Symbol('s2');
+		const s_ne = Symbol('non-enumerable');
+
+		const first: Record<string | symbol, unknown> = { z: 1, a: 2, [s1]: 1 };
+		Object.defineProperty(first, s_ne, { value: 1, enumerable: false });
+
+		const second: Record<string | symbol, unknown> = { a: 3, b: 4, [s1]: 9, [s2]: 2 };
+
+		const props = spread_props(first, second);
+
+		// Per object: for...in strings, then getOwnPropertySymbols (all own symbols)
+		assert.deepEqual(Reflect.ownKeys(props), ['z', 'a', s1, s_ne, 'b', s2]);
+		assert.deepEqual(Object.keys(props), ['z', 'a', 'b']);
+	});
+
+	test('evaluates lazy function props and skips nullish returns', () => {
+		assert.deepEqual(
+			Reflect.ownKeys(spread_props(() => ({ x: 1 }), { y: 2 })),
+			['x', 'y']
+		);
+		assert.deepEqual(Reflect.ownKeys(spread_props(() => null, { a: 1 })), ['a']);
+	});
+
+	test('skips falsy non-object props (same as if (!p) continue)', () => {
+		// Note: has trap uses `p != null`; ownKeys uses truthiness. Harmonizing is out of scope.
+		// @ts-expect-error intentional falsy / nullish spreads to lock current skip semantics
+		assert.deepEqual(Reflect.ownKeys(spread_props(0, '', null, undefined, { a: 1 })), ['a']);
+	});
+});


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`. (Using `perf:` as a runtime complexity win; happy to retitle if preferred.)
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it. (Behavior-preserving complexity fix; unit tests constrain rewrite space — see below.)
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## Summary

Closes #18600.

`spread_props` `ownKeys` built a unique key list with `keys.includes(key)` while scanning every enumerable string key and own symbol across the spread list. That is **O(k²)** in the number of unique keys `k` (large design-system / multi-object prop bags; also invoked when `legacy_rest_props` does `Reflect.ownKeys` on a spread proxy).

**Fix (same public behavior):** collect keys in a `Set` (insertion-order) and return `Array.from(keys)`. `Array.prototype.includes` and `Set` both use SameValueZero; keys are always `string | symbol`, so dedup semantics are unchanged.

**Preserved:**
- `for...in` for enumerable string keys (including inherited)
- `Object.getOwnPropertySymbols` for own symbols (including non-enumerable)
- first-seen order across the props list
- lazy function props and falsy/`null`/`undefined` skip (`if (!p) continue`)
- no changes to `get` / `set` / `has` / `getOwnPropertyDescriptor`

Server `spread_props` is a different merge path and is out of scope.

## Test plan

- [x] Unit tests in `packages/svelte/src/internal/client/reactivity/props.test.ts`:
  - first-seen string dedup
  - per-object integer-like key order (no global re-sort)
  - inherited enumerable strings via `for...in` vs `Object.keys` filtering
  - symbol dedup + non-enumerable own symbols
  - lazy props and nullish returns
  - falsy non-object skip (`0`, empty string, `null`, `undefined`)
- [x] `pnpm test packages/svelte/src/internal/client/reactivity/props.test.ts` — 6 passed
- [x] `pnpm test runtime-runes -t spread-props` — 4 passed
- [x] `pnpm test runtime-legacy -t spread-component` — 32 passed
- [x] Full `pnpm test` — 7670 passed; 3 timeouts in `effect-loop-infinite` / `error-boundary-20` also reproduce on clean `main` (unrelated flake)
- No timing assertion on purpose (avoid flaky O(k²) smoke)
