### PR TITLE
perf: use Set for rest-prop exclude lists (server, legacy)

### DIFF
--- a/.changeset/rest-props-exclude-set.md
+++ b/.changeset/rest-props-exclude-set.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: use Set for rest-prop exclude lists (server, legacy)

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -457,7 +457,8 @@ export function client_component(analysis, options) {
 				b.call(
 					'$.legacy_rest_props',
 					b.id('$$sanitized_props'),
-					b.array(named_props.map((name) => b.literal(name)))
+					// Per-instance Set: deleteProperty mutates exclude via .add
+					b.new('Set', b.array(named_props.map((name) => b.literal(name))))
 				)
 			)
 		);
@@ -477,7 +478,8 @@ export function client_component(analysis, options) {
 		component_block.body.unshift(
 			b.const(
 				'$$sanitized_props',
-				b.call('$.legacy_rest_props', b.id('$$props'), b.array(to_remove))
+				// Per-instance Set: deleteProperty mutates exclude via .add
+				b.call('$.legacy_rest_props', b.id('$$props'), b.new('Set', b.array(to_remove)))
 			)
 		);
 	}

--- a/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/transform-server.js
@@ -284,7 +284,7 @@ export function server_component(analysis, options) {
 				b.call(
 					'$.rest_props',
 					b.id('$$sanitized_props'),
-					b.array(named_props.map((name) => b.literal(name)))
+					b.new('Set', b.array(named_props.map((name) => b.literal(name))))
 				)
 			)
 		);

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -96,11 +96,11 @@ export function rest_props(props, exclude, name) {
 
 /**
  * The proxy handler for legacy $$restProps and $$props
- * @type {ProxyHandler<{ props: Record<string | symbol, unknown>, exclude: Array<string | symbol>, special: Record<string | symbol, (v?: unknown) => unknown>, version: Source<number>, parent_effect: Effect }>}}
+ * @type {ProxyHandler<{ props: Record<string | symbol, unknown>, exclude: Set<string | symbol>, special: Record<string | symbol, (v?: unknown) => unknown>, version: Source<number>, parent_effect: Effect }>}}
  */
 const legacy_rest_props_handler = {
 	get(target, key) {
-		if (target.exclude.includes(key)) return;
+		if (target.exclude.has(key)) return;
 		get(target.version);
 		return key in target.special ? target.special[key]() : target.props[key];
 	},
@@ -132,7 +132,7 @@ const legacy_rest_props_handler = {
 		return true;
 	},
 	getOwnPropertyDescriptor(target, key) {
-		if (target.exclude.includes(key)) return;
+		if (target.exclude.has(key)) return;
 		if (key in target.props) {
 			return {
 				enumerable: true,
@@ -143,23 +143,23 @@ const legacy_rest_props_handler = {
 	},
 	deleteProperty(target, key) {
 		// Svelte 4 allowed for deletions on $$restProps
-		if (target.exclude.includes(key)) return true;
-		target.exclude.push(key);
+		if (target.exclude.has(key)) return true;
+		target.exclude.add(key);
 		update(target.version);
 		return true;
 	},
 	has(target, key) {
-		if (target.exclude.includes(key)) return false;
+		if (target.exclude.has(key)) return false;
 		return key in target.props;
 	},
 	ownKeys(target) {
-		return Reflect.ownKeys(target.props).filter((key) => !target.exclude.includes(key));
+		return Reflect.ownKeys(target.props).filter((key) => !target.exclude.has(key));
 	}
 };
 
 /**
  * @param {Record<string, unknown>} props
- * @param {string[]} exclude
+ * @param {Set<string | symbol>} exclude
  * @returns {Record<string, unknown>}
  */
 export function legacy_rest_props(props, exclude) {

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -343,7 +343,7 @@ export function slot(renderer, $$props, name, slot_props, fallback_fn) {
 
 /**
  * @param {Record<string, unknown>} props
- * @param {string[]} rest
+ * @param {Set<string>} rest
  * @returns {Record<string, unknown>}
  */
 export function rest_props(props, rest) {
@@ -351,7 +351,7 @@ export function rest_props(props, rest) {
 	const rest_props = {};
 	let key;
 	for (key of Object.keys(props)) {
-		if (!rest.includes(key)) {
+		if (!rest.has(key)) {
 			rest_props[key] = props[key];
 		}
 	}

--- a/packages/svelte/tests/rest-props/test.ts
+++ b/packages/svelte/tests/rest-props/test.ts
@@ -1,0 +1,47 @@
+import { describe, assert, it } from 'vitest';
+import { rest_props as server_rest_props } from '../../src/internal/server/index.js';
+import { legacy_rest_props } from '../../src/internal/client/reactivity/props.js';
+
+/**
+ * #18601 — rest-prop exclude lists accept `Set` and use O(1) membership.
+ * These helpers are compiler-owned; the compiler emits `new Set([...])`.
+ */
+describe('server rest_props exclude Set', () => {
+	it('omits excluded keys', () => {
+		const result = server_rest_props({ a: 1, b: 2, c: 3 }, new Set(['a', 'b']));
+		assert.deepEqual(result, { c: 3 });
+	});
+
+	it('returns all keys when exclude is empty', () => {
+		const result = server_rest_props({ a: 1, b: 2 }, new Set());
+		assert.deepEqual(result, { a: 1, b: 2 });
+	});
+
+	it('returns empty object when all keys are excluded', () => {
+		const result = server_rest_props({ a: 1 }, new Set(['a']));
+		assert.deepEqual(result, {});
+	});
+});
+
+describe('legacy_rest_props exclude Set', () => {
+	it('omits excluded keys from get/has/ownKeys', () => {
+		const rest = legacy_rest_props({ a: 1, b: 2, c: 3 }, new Set(['a']));
+
+		assert.equal(rest.a, undefined);
+		assert.equal(rest.b, 2);
+		assert.equal(rest.c, 3);
+		assert.equal('a' in rest, false);
+		assert.equal('b' in rest, true);
+		assert.deepEqual(Object.keys(rest).sort(), ['b', 'c']);
+	});
+
+	it('deleteProperty adds the key to the exclude Set', () => {
+		const rest = legacy_rest_props({ a: 1, b: 2 }, new Set());
+
+		assert.equal(rest.a, 1);
+		delete rest.a;
+		assert.equal(rest.a, undefined);
+		assert.equal('a' in rest, false);
+		assert.deepEqual(Object.keys(rest), ['b']);
+	});
+});


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`. (Using `perf:`; happy to retitle if preferred.)
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## Summary

Fixes part of #18601.

Client runes `rest_props` already takes a `Set` of excluded keys (#18252). Two sibling paths still used arrays + `.includes`:

| Path | Before | After |
|------|--------|-------|
| Server `rest_props` | `string[]` + `.includes` | `Set` + `.has` |
| `legacy_rest_props` (`$$restProps` / `$$props`) | `Array` + `.includes` / `.push` | `Set` + `.has` / `.add` |

**Compiler** emits `new Set([...])` at:

- `transform-server.js` — `$.rest_props(..., new Set([...]))`
- `transform-client.js` — both `$.legacy_rest_props` sites (per instance; not hoisted, because `deleteProperty` mutates the exclude set)

**Not in this PR:** `exclude_from_object`. That helper rebuilds its exclude list on every update (each-block / await / derived destructuring). For typical 1–3 keys, `new Set` per update can lose to `Array.includes`. Left for a follow-up with numbers.

**Contract note:** These are compiler-owned `$.` helpers (same as client runes after #18252). Runtime now expects a `Set`; output from an older 5.x compiler against this runtime would throw. That matches the #18252 precedent.

### Complexity

Exclude membership goes from O(|exclude|) to O(1) on every get/has/ownKeys (legacy proxy) and on each prop key during SSR rest collection.

## Test plan

- [x] **RED → GREEN unit tests** (`packages/svelte/tests/rest-props/test.ts`): call both helpers with a `Set` — failed with `TypeError: …includes is not a function` before; 5/5 pass after
- [x] `pnpm test rest-props` — pass
- [x] `pnpm test runtime-legacy -t rest-props` — 15 pass
- [x] `pnpm test runtime-runes -t 'props-rest|rest-props'` — 10 pass
- [x] `pnpm test server-side-rendering` — 221 pass
- [x] `pnpm test snapshot` — 34 pass
- [x] `pnpm check` in `packages/svelte` — pass
- [x] Full `pnpm test` — 7672 pass / 69 skipped
