### PR TITLE
docs: correct readonly `<audio>` binding count (six → seven)

### DIFF
--- a/documentation/docs/03-template-syntax/12-bind.md
+++ b/documentation/docs/03-template-syntax/12-bind.md
@@ -261,7 +261,7 @@ You can give the `<select>` a default value by adding a `selected` attribute to 
 - [`volume`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/volume)
 - [`muted`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/muted)
 
-...and six readonly ones:
+...and seven readonly ones:
 
 - [`duration`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/duration)
 - [`buffered`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/buffered)


### PR DESCRIPTION
The `<audio>` bindings section says there are **six** readonly bindings, but then lists **seven**:

> ...and six readonly ones:
> `duration`, `buffered`, `seekable`, `seeking`, `ended`, `readyState`, `played`

All seven are genuine readonly `<audio>`/`<video>` bindings in `packages/svelte/src/compiler/phases/bindings.js` — only `currentTime`, `paused`, `volume`, `muted` and `playbackRate` carry `bidirectional: true` (the "five two-way ones", which is correct). The list is complete; only the number was stale. Updated "six" → "seven".