### PR TITLE
fix: append_styles resolving to `document.head` in WC

### DIFF
--- a/.changeset/free-signs-ask.md
+++ b/.changeset/free-signs-ask.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Fix append_style sometimes resolving to document.head when used in a webcomponent

--- a/.changeset/free-signs-ask.md
+++ b/.changeset/free-signs-ask.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Fix append_style sometimes resolving to document.head when used in a webcomponent
+fix: reliably resolve append_style to its correct root

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,37 +1,8 @@
 import { DEV } from 'esm-env';
 import { register_style } from '../dev/css.js';
 import { effect } from '../reactivity/effects.js';
-import { active_effect } from '../runtime.js';
 import { create_element } from './operations.js';
-
-/**
- * Resolves the node whose root should be used to append styles into. The `anchor`
- * is usually connected to the DOM by the time the effect runs, but in some cases
- * (e.g. a component rendered in a deferred/offscreen branch whose anchor node is
- * removed when the branch is committed) it can be disconnected. In that case
- * `getRootNode()` would return the detached node and styles would wrongly end up
- * in `document.head` instead of the enclosing shadow root, so we fall back to a
- * connected node from the surrounding effect tree.
- * @param {Node} anchor
- * @returns {Node}
- */
-function get_style_root(anchor) {
-	if (anchor.isConnected) return anchor;
-
-	var effect = active_effect;
-
-	while (effect !== null) {
-		var start = effect.nodes?.start;
-
-		if (start != null && start.isConnected) {
-			return start;
-		}
-
-		effect = effect.parent;
-	}
-
-	return anchor;
-}
+import { active_effect } from '../runtime.js';
 
 /**
  * @param {Node} anchor
@@ -40,7 +11,11 @@ function get_style_root(anchor) {
 export function append_styles(anchor, css) {
 	// Use an effect to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
 	effect(() => {
-		var root = get_style_root(anchor).getRootNode();
+		// Bit of a hack: branches.js/each.js use offscreen fragments with temporary text nodes that will
+		// never be connected to the real dom. Therfore walk up to the branch that has created the component
+		// whose styles we want to append, and check its node instead. It will be connected by the time we get here.
+		anchor = active_effect?.parent?.nodes?.start ?? anchor;
+		var root = anchor.getRootNode();
 
 		var target = /** @type {ShadowRoot} */ (root).host
 			? /** @type {ShadowRoot} */ (root)

--- a/packages/svelte/src/internal/client/dom/css.js
+++ b/packages/svelte/src/internal/client/dom/css.js
@@ -1,16 +1,46 @@
 import { DEV } from 'esm-env';
 import { register_style } from '../dev/css.js';
 import { effect } from '../reactivity/effects.js';
+import { active_effect } from '../runtime.js';
 import { create_element } from './operations.js';
+
+/**
+ * Resolves the node whose root should be used to append styles into. The `anchor`
+ * is usually connected to the DOM by the time the effect runs, but in some cases
+ * (e.g. a component rendered in a deferred/offscreen branch whose anchor node is
+ * removed when the branch is committed) it can be disconnected. In that case
+ * `getRootNode()` would return the detached node and styles would wrongly end up
+ * in `document.head` instead of the enclosing shadow root, so we fall back to a
+ * connected node from the surrounding effect tree.
+ * @param {Node} anchor
+ * @returns {Node}
+ */
+function get_style_root(anchor) {
+	if (anchor.isConnected) return anchor;
+
+	var effect = active_effect;
+
+	while (effect !== null) {
+		var start = effect.nodes?.start;
+
+		if (start != null && start.isConnected) {
+			return start;
+		}
+
+		effect = effect.parent;
+	}
+
+	return anchor;
+}
 
 /**
  * @param {Node} anchor
  * @param {{ hash: string, code: string }} css
  */
 export function append_styles(anchor, css) {
-	// Use `queue_micro_task` to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
+	// Use an effect to ensure `anchor` is in the DOM, otherwise getRootNode() will yield wrong results
 	effect(() => {
-		var root = anchor.getRootNode();
+		var root = get_style_root(anchor).getRootNode();
 
 		var target = /** @type {ShadowRoot} */ (root).host
 			? /** @type {ShadowRoot} */ (root)

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/deferred-nested-styles/Child.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/deferred-nested-styles/Child.svelte
@@ -1,0 +1,7 @@
+<p>child</p>
+
+<style>
+	p {
+		color: rgb(255, 0, 0);
+	}
+</style>

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/deferred-nested-styles/_config.js
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/deferred-nested-styles/_config.js
@@ -1,0 +1,24 @@
+import { assert_ok, test } from '../../assert';
+
+const tick = () => Promise.resolve();
+
+export default test({
+	async test({ assert, target }) {
+		target.innerHTML = '<my-app></my-app>';
+
+		// wait for the initial mount, the `onMount` reveal and the deferred re-render
+		await tick();
+		await tick();
+		await tick();
+		await tick();
+
+		/** @type {any} */
+		const el = target.querySelector('my-app');
+		const p = el.shadowRoot.querySelector('p');
+		assert_ok(p);
+
+		// The child's scoped styles must be injected into the shadow root, not `document.head`
+		assert_ok(el.shadowRoot.querySelector('style'));
+		assert.equal(getComputedStyle(p).color, 'rgb(255, 0, 0)');
+	}
+});

--- a/packages/svelte/tests/runtime-browser/custom-elements-samples/deferred-nested-styles/main.svelte
+++ b/packages/svelte/tests/runtime-browser/custom-elements-samples/deferred-nested-styles/main.svelte
@@ -1,0 +1,18 @@
+<svelte:options customElement="my-app" />
+
+<script>
+	import { onMount } from 'svelte';
+	import Child from './Child.svelte';
+
+	let items = $state([]);
+
+	// Add the item _after_ the initial mount, so that the each block renders the
+	// new item into an offscreen anchor that is discarded once it's committed to
+	// the DOM. This reproduces styles being injected into `document.head` instead
+	// of the shadow root (https://github.com/sveltejs/svelte/issues/18288)
+	onMount(() => {
+		items = [1];
+	});
+</script>
+
+{#each items as item (item)}<Child />{/each}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
fixes: [18288](https://github.com/sveltejs/svelte/issues/18288) 

I asked Claude to try and fix the linked issue above, I then manually verified if it was fixed and it seems to have worked. I also verified that the linked stackblitz works using this PR.

Problem
A nested component's scoped [<style>](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was being appended to [document.head](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of the host custom element's shadow root, so the styles never applied.

[append_styles](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) resolves the injection target via [anchor.getRootNode()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). When a component is rendered after the initial mount inside an {#each} block (or a deferred {#if} branch in async mode), the framework first renders it into a throwaway offscreen anchor node. On commit, that anchor is removed and orphaned while the real content is moved into the DOM. Since [append_styles](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) still holds the now-detached anchor, [getRootNode()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) returns the detached node and falls through to [document.ownerDocument.head](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

This reproduces even with [experimental.async: false](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), because {#each} always renders newly-added items through an offscreen anchor.

Fix
When the anchor is disconnected, resolve the root from the nearest connected node in the surrounding effect tree ([effect.nodes.start](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) instead. The common (connected-anchor) path is unchanged.

Tests
Added [custom-elements-samples/deferred-nested-styles](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which mounts a custom element that reveals a nested child component after mount and asserts the child's scoped styles land in the shadow root. Verified it fails on main and passes with this change.

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
