### PR TITLE
fix: preserve renderer type in copy() during SSR

### DIFF
--- a/.changeset/hydration-head-renderer-type.md
+++ b/.changeset/hydration-head-renderer-type.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: preserve renderer type when copying during SSR legacy bind: retry, preventing a hydration mismatch with `<svelte:head>`
+fix: don't corrupt renderer type during SSR's legacy `bind:` retry loop

--- a/.changeset/hydration-head-renderer-type.md
+++ b/.changeset/hydration-head-renderer-type.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: preserve renderer type when copying during SSR legacy bind: retry, preventing a hydration mismatch with `<svelte:head>`

--- a/packages/svelte/src/internal/server/renderer.js
+++ b/packages/svelte/src/internal/server/renderer.js
@@ -451,6 +451,7 @@ export class Renderer {
 	 */
 	copy() {
 		const copy = new Renderer(this.global, this.#parent);
+		copy.type = this.type;
 		copy.#out = this.#out.map((item) => (item instanceof Renderer ? item.copy() : item));
 		copy.promise = this.promise;
 		return copy;

--- a/packages/svelte/tests/server-side-rendering/samples/head-with-multiple-binding-components/Foo.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/head-with-multiple-binding-components/Foo.svelte
@@ -1,0 +1,3 @@
+<script>
+	let { bar = $bindable() } = $props();
+</script>

--- a/packages/svelte/tests/server-side-rendering/samples/head-with-multiple-binding-components/Wrapper.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/head-with-multiple-binding-components/Wrapper.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Foo from './Foo.svelte';
+	let bar = $state();
+</script>
+
+<Foo bind:bar />

--- a/packages/svelte/tests/server-side-rendering/samples/head-with-multiple-binding-components/_expected_head.html
+++ b/packages/svelte/tests/server-side-rendering/samples/head-with-multiple-binding-components/_expected_head.html
@@ -1,0 +1,4 @@
+<!--ssr:0-->
+<link rel="canonical" href="/test">
+<meta name="description" content="test">
+<!--ssr:0-->

--- a/packages/svelte/tests/server-side-rendering/samples/head-with-multiple-binding-components/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/head-with-multiple-binding-components/main.svelte
@@ -1,0 +1,12 @@
+<script>
+	import Wrapper from './Wrapper.svelte';
+</script>
+
+<svelte:head>
+	<link rel="canonical" href="/test" />
+	<meta name="description" content="test" />
+</svelte:head>
+
+<Wrapper />
+<Wrapper />
+<Wrapper />


### PR DESCRIPTION
fix: preserve renderer type in copy() during SSR

Full disclosure: I ran into this bug while building a project with Claude,
I used Claude to help me investigate, verify, and generate the contents of this PR.

Fixes #18404

## The bug
`<svelte:head>` combined with two or more components that each use `bind:`
on a child component's prop corrupts a renderer's `.type` during SSR,
misplacing the head hydration marker in `<body>` instead of `<head>`.
Only reproduces in a real `vite build` + `vite preview`, never dev.

## Root cause
`copy()` (`packages/svelte/src/internal/server/renderer.js`) rebuilds via
`new Renderer(this.global, this.#parent)`. That constructor defaults
`.type` from the *parent's* current type, not from `this.type`. That's
correct when constructing a genuine new child, but wrong here: `copy()`
is making a stand-in for `this` itself, used by the legacy
`bind:`-to-child-component retry loop (`uses_component_bindings`), so it
needs to preserve `this.type` verbatim.

The same fix already exists for the same reason elsewhere in this file:
the error-boundary `failed_renderer` path explicitly does
`failed_renderer.type = item.type` right after construction, for
identical reasoning.

## Test plan
- Added `tests/server-side-rendering/samples/head-with-multiple-binding-components`.
  It uses three `bind:`-using components rather than two: a real app (more
  component nesting between `<svelte:head>` and the offending components)
  needs only two to produce visibly wrong output, but this minimal internal
  test's shallower tree needs a third corruption pass to reach the specific
  renderer holding the hydration marker. Confirmed via debug logging that
  the same type corruption occurs at two already, it just doesn't reach the
  marker-holding renderer until the third pass in this particular test's
  structure.
- Confirmed the new test fails without this change and passes with it.
- Full suite (`pnpm test`): 7669 passed, 69 skipped, no regressions.
- `pnpm lint` and `pnpm check`: both clean.
- Added a `patch` changeset.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`