### PR TITLE
 fix: remove stale capture listeners from spread attributes

### DIFF
--- a/.changeset/happy-spoons-talk.md
+++ b/.changeset/happy-spoons-talk.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: clean up removed capture event handlers from spread attributes

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -315,7 +315,7 @@ function set_attributes(
 	var is_option_element = element.nodeName === OPTION_TAG;
 
 	for (var key in prev) {
-		if (!(key in next)) {
+		if (!(key in next) && key[0] + key[1] !== '$$') {
 			next[key] = null;
 		}
 	}

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -315,6 +315,7 @@ function set_attributes(
 	var is_option_element = element.nodeName === OPTION_TAG;
 
 	for (var key in prev) {
+		// don't null our internal $$onX listeners
 		if (!(key in next) && key[0] + key[1] !== '$$') {
 			next[key] = null;
 		}

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-spread-update/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-spread-update/_config.js
@@ -3,16 +3,31 @@ import { test } from '../../test';
 
 export default test({
 	test({ assert, target }) {
-		const [change, increment] = target.querySelectorAll('button');
+		const [change, remove, increment] = target.querySelectorAll('button');
 
 		increment.click();
 		flushSync();
-		assert.htmlEqual(target.innerHTML, '<button>change handlers</button><button>1 / 1</button>');
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>change handlers</button><button>remove capture handler</button><button>1 / 1</button>'
+		);
 
 		change.click();
 		flushSync();
 		increment.click();
 		flushSync();
-		assert.htmlEqual(target.innerHTML, '<button>change handlers</button><button>3 / 3</button>');
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>change handlers</button><button>remove capture handler</button><button>3 / 3</button>'
+		);
+
+		remove.click();
+		flushSync();
+		increment.click();
+		flushSync();
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>change handlers</button><button>remove capture handler</button><button>5 / 3</button>'
+		);
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/event-attribute-spread-update/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/event-attribute-spread-update/main.svelte
@@ -24,4 +24,7 @@
 >
 	change handlers
 </button>
+<button onclick={() => (attrs = { onclick: attrs.onclick, onclickcapture: undefined })}>
+	remove capture handler
+</button>
 <button {...attrs}>{delegated} / {non_delegated}</button>


### PR DESCRIPTION
Fixes #18608.

  When `set_attributes` normalized removed spread attributes, it also copied its internal `$$` listener bookkeeping keys into `next` with a `null` value. This cleared the stored callback before event cleanup, so
  removing a capture handler passed `null` to `removeEventListener` and left the listener attached.

  Skip internal `$$` keys during missing-attribute normalization. The updated runtime-runes sample verifies replacing and then removing a spread capture handler in both client and hydration modes.

  ### Before submitting the PR, please make sure you do the following

  - [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  - [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
  - [x] This message body should clearly illustrate what problems it solves.
  - [x] Ideally, include a test that fails without this PR but passes with it.
  - [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

  ### Tests and linting

  - [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

  Test plan:

  - `corepack pnpm test runtime-runes -t event-attribute-spread-update` — 2 passed
  - `corepack pnpm check` from `packages/svelte` — passed
  - Prettier and ESLint on the changed files — passed
  - `git diff --check` — passed
  - Four full-suite runs reached 7,664–7,666 passed and 69 skipped. The remaining failures varied between unchanged 30-second runtime/signals timeouts and one unchanged Windows/Chromium layout test. The timeout cases
  pass in isolation; the layout failure reproduces independently with the local headless browser returning a zero layout width.
  - `corepack pnpm lint` completed ESLint successfully, then repo-wide Prettier reported line-ending differences in 3,747 unchanged files from the Windows checkout. All changed files pass the scoped Prettier check.