### PR TITLE
fix: give effect teardowns the value from before the first write in a flush

### DIFF
--- a/.changeset/lucky-pears-smoke.md
+++ b/.changeset/lucky-pears-smoke.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: give effect teardowns the value from before the first write in a flush

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -420,6 +420,7 @@ export class Batch {
 		}
 
 		if (next_batch !== null) {
+			old_values.clear();
 			next_batch.#process();
 		}
 	}

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -180,7 +180,13 @@ export function set(source, value, should_proxy = false) {
  */
 export function internal_set(source, value, updated_during_traversal = null) {
 	if (!source.equals(value)) {
-		old_values.set(source, is_destroying_effect ? value : source.v);
+		if (is_destroying_effect) {
+			old_values.set(source, value);
+		} else if (!old_values.has(source)) {
+			// only record the value from before the first write in this flush, otherwise a
+			// teardown would see the value from before whichever write happened to be last
+			old_values.set(source, source.v);
+		}
 
 		var batch = Batch.ensure();
 		batch.capture(source, value);

--- a/packages/svelte/tests/runtime-runes/samples/effect-teardown-multiple-writes/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/effect-teardown-multiple-writes/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+
+		assert.deepEqual(logs, [
+			'register: one',
+			'unregister: one',
+			'leftover: none',
+			'register: three'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/effect-teardown-multiple-writes/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/effect-teardown-multiple-writes/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let value = $state('one');
+
+	const registry = new Set();
+
+	$effect(() => {
+		registry.add(value);
+		console.log(`register: ${value}`);
+
+		return () => {
+			registry.delete(value);
+			console.log(`unregister: ${value}`);
+			console.log(`leftover: ${[...registry].join(', ') || 'none'}`);
+		};
+	});
+</script>
+
+<button onclick={() => {
+	value = 'two';
+	value = 'three';
+}}>go</button>


### PR DESCRIPTION

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Fixes #18619

### Problem

`old_values` lets an effect teardown read the value a source had *before* the change that destroyed it (#15469). But `internal_set` overwrites the entry on **every** write in a flush:

```js
old_values.set(source, is_destroying_effect ? value : source.v);
```

There is one slot per source, so when a source is written more than once in a flush, the value a teardown reads is "the value from just before the last write" — neither the value the effect ran with nor the current value. It changes with the number of writes.

This breaks any teardown that has to pair up with its effect body. Registering under a value and unregistering under the same value silently leaks:

```svelte
<script>
	let value = $state('one');

	const registry = new Set();

	$effect(() => {
		registry.add(value);

		return () => {
			registry.delete(value);
		};
	});
</script>

<button onclick={() => {
	value = 'two';
	value = 'three';
}}>go</button>
```

The effect registered `one`. The teardown is handed `two`, deletes `two` (a no-op), and `one` stays in the registry forever. With a single write in the handler it works correctly, which is why this has gone unnoticed.

### Fix

Only record the pre-write value the **first** time a source is written in a flush. `old_values` is cleared at the end of every flush, so the entry becomes a coherent "value at the start of this flush" snapshot instead of a moving target. Writes made *during* a teardown keep their current behaviour.

```js
if (is_destroying_effect) {
	old_values.set(source, value);
} else if (!old_values.has(source)) {
	old_values.set(source, source.v);
}
```

### Test plan

New test: `packages/svelte/tests/runtime-runes/samples/effect-teardown-multiple-writes`.

Red — the new test with `sources.js` reverted to `main`:

```
$ FILTER=effect-teardown-multiple-writes npx vitest run runtime-runes

 FAIL  runtime-runes/test.ts > effect-teardown-multiple-writes (dom)
 FAIL  runtime-runes/test.ts > effect-teardown-multiple-writes (hydrate)
AssertionError: expected [ 'register: one', …(3) ] to deeply equal [ 'register: one', …(3) ]

  [
    "register: one",
-   "unregister: one",
-   "leftover: none",
+   "unregister: two",
+   "leftover: one",
    "register: three",
  ]

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

Green — same test with this change:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Full suite and checks (all CI jobs reproduced locally):

```
$ npx vitest run                                    # Tests
 Test Files  33 passed (33)
      Tests  7669 passed | 69 skipped (7738)

$ SVELTE_NO_ASYNC=true npx vitest run runtime-runes # TestNoAsync
      Tests  1759 passed | 1021 skipped (2780)

$ pnpm lint                                         # Lint
✔ eslint clean, "All matched files use Prettier code style!"

$ cd packages/svelte && pnpm check
✔ clean

$ pnpm build && git status --porcelain              # generated types unchanged
✔ empty
```

No existing test changed behaviour.

### Known limitations

This narrows the defect rather than making `old_values` correct in general. Two things it deliberately does **not** fix:

**1. The snapshot is per-flush, not per-effect.** If an effect read a source through `untrack()` and that source changed in an *earlier* flush without re-running the effect, the teardown still gets the earlier-flush value:

```
step 1: x = 'b'   // effect does not re-run, x is not a dependency
step 2: show = false; x = 'c';

effect ran with : 'a'
teardown sees   : 'b'   // unchanged by this PR
```

Serving `'a'` would require a per-effect snapshot rather than a per-flush map. Happy to pursue that if you'd prefer that direction — it's a much larger change and I didn't want to bundle it here.

**2. `old_values.clear()` is still called mid-flush** from the `eager_block_effects` branch of `flush_queued_effects`, so "first write in a flush" is really "first write since the last clear". That's #18391's territory and #18402 proposes removing that clear; this change is compatible with either outcome and becomes strictly more meaningful once the early clear is gone.

### Notes

- This does not touch the "teardowns read old values" contract itself, which is under discussion in #16019 / #16140. It only makes the value that contract promises well-defined.
- The extra `old_values.has()` costs one additional `Map` lookup on the first write to a source per flush; subsequent writes to the same source now skip the `set()` entirely.

*Note: English is not my first language, so I used AI assistance to write this PR description and the patch. I reviewed the change and verified the red/green test runs and the full suite myself.*