### PR TITLE
fix: skip controlled each fast path while another batch is pending

### DIFF
--- a/.changeset/async-each-controlled-pending.md
+++ b/.changeset/async-each-controlled-pending.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: skip controlled each fast path while another batch is pending

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -103,8 +103,12 @@ function pause_effects(state, to_destroy, controlled_anchor) {
 	if (remaining === 0) {
 		// If we're in a controlled each block (i.e. the block is the only child of an
 		// element), and we are removing all items, _and_ there are no out transitions,
-		// we can use the fast path — emptying the element and replacing the anchor
-		var fast_path = transitions.length === 0 && controlled_anchor !== null;
+		// we can use the fast path — emptying the element and replacing the anchor.
+		// Skip the fast path when another batch is still pending on this each block:
+		// that batch's keys still reference EachItems in `state.items`, which
+		// `destroy_effects` needs to preserve offscreen (see #18610).
+		var fast_path =
+			transitions.length === 0 && controlled_anchor !== null && state.pending.size === 0;
 
 		if (fast_path) {
 			var anchor = /** @type {Element} */ (controlled_anchor);

--- a/packages/svelte/tests/runtime-runes/samples/async-each-controlled-empty-pending/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-each-controlled-empty-pending/_config.js
@@ -1,0 +1,50 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+// Regression for #18610: emptying a controlled keyed {#each} while another
+// batch is still pending must not take the fast path that clears state.items
+// before destroy_effects walks pending keys.
+export default test({
+	mode: ['client'],
+
+	async test({ assert, target }) {
+		await tick();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>startA</button>
+				<button>startB</button>
+				<button>settleB</button>
+				<p>A0/B0</p>
+				<div><span>1</span><span>2</span></div>
+			`
+		);
+
+		const [startA, startB, settleB] = target.querySelectorAll('button');
+
+		// Batch A: add key 9, then block forever on gate A.
+		startA.click();
+		await tick();
+
+		// Batch B: empty the collection, then block on gate B.
+		startB.click();
+		await tick();
+
+		// Settle B first so B commits while A is still pending.
+		// Without the fix this throws reading `.e` of undefined and leaves a/b stuck.
+		settleB.click();
+		await tick();
+
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+				<button>startA</button>
+				<button>startB</button>
+				<button>settleB</button>
+				<p>A0/B1</p>
+				<div></div>
+			`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-each-controlled-empty-pending/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-each-controlled-empty-pending/main.svelte
@@ -1,0 +1,54 @@
+<script>
+	let base = $state([1, 2]);
+	let extraKey = $state(/** @type {number | null} */ (null));
+	let tickA = $state(0);
+	let tickB = $state(0);
+
+	// Two independent sources so the batches touch disjoint source sets
+	// and are not merged.
+	const items = $derived(extraKey === null ? base : [...base, extraKey]);
+
+	/** @type {((value: string) => void) | undefined} */
+	let resolveB;
+
+	/**
+	 * @param {string} name
+	 * @param {number} n
+	 */
+	const gate = (name, n) =>
+		n === 0
+			? Promise.resolve(`${name}0`)
+			: new Promise((r) => {
+					if (name === 'B') resolveB = r;
+				});
+
+	const a = $derived(await gate('A', tickA));
+	const b = $derived(await gate('B', tickB));
+
+	function startA() {
+		extraKey = 9;
+		tickA = 1;
+	}
+
+	function startB() {
+		base = [];
+		tickB = 1;
+	}
+
+	function settleB() {
+		resolveB?.('B1');
+	}
+</script>
+
+<button onclick={startA}>startA</button>
+<button onclick={startB}>startB</button>
+<button onclick={settleB}>settleB</button>
+
+<p>{a}/{b}</p>
+
+<!-- Sole child so the each block is controlled and the fast path applies. -->
+<div>
+	{#each items as item (item)}
+		<span>{item}</span>
+	{/each}
+</div>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Fixes #18610

### Problem

In async mode, a controlled keyed `{#each}` throws `TypeError: Cannot read properties of undefined (reading 'e')` when its collection becomes empty while an earlier batch is still pending on the same block.

The fast path in `pause_effects` cleared `state.items` and then called `destroy_effects`, which walks pending batch keys and reads `state.items.get(key).e`. Those EachItems are still needed for the pending batch (preserved offscreen), so clearing the map makes the dereference throw and aborts the commit mid-flight.

### Fix

Only take the controlled-each fast path when `state.pending.size === 0`, so pending batches keep their items until they commit or discard.

```js
var fast_path =
  transitions.length === 0 && controlled_anchor !== null && state.pending.size === 0;
```

### Test

`async-each-controlled-empty-pending` reproduces the two-batch scenario from the issue (disjoint source sets so batches are not merged): empty the controlled each while another batch is pending, settle the emptying batch first, and assert the commit completes with `A0/B1` and an empty list.

Verified locally: the new test fails without the change (exact `undefined.e` throw) and passes with it. Related `async-each*` runtime-runes samples also pass.

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.