### PR TITLE
fix: keep leading comments off server derived getters

### DIFF
--- a/.changeset/derived-forward-ref-comments.md
+++ b/.changeset/derived-forward-ref-comments.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep leading comments off server derived getters (avoid ASI `return undefined`)

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/utils.js
@@ -286,7 +286,12 @@ export function build_getter(node, state) {
 	}
 
 	if (binding.kind === 'derived') {
-		return (binding.declaration_kind === 'var' ? b.maybe_call : b.call)(binding.node);
+		// Use the reference `node`, not `binding.node` (the declaration identifier).
+		// Reusing the declaration node would carry its source `loc`, and esrap would
+		// then emit any leading comments from the declaration site next to this call —
+		// e.g. `return // comment\nlater()` which ASI turns into `return undefined`.
+		// See https://github.com/sveltejs/svelte/issues/18607
+		return (binding.declaration_kind === 'var' ? b.maybe_call : b.call)(node);
 	}
 
 	return node;

--- a/packages/svelte/tests/runtime-runes/samples/derived-forward-ref-leading-comments/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/derived-forward-ref-leading-comments/_config.js
@@ -1,0 +1,8 @@
+import { test } from '../../test';
+
+// Repro for #18607: leading comments on a later $derived must not break
+// server compilation of an earlier getter that returns that derived
+// (comments between `return` and the value → ASI → return undefined).
+export default test({
+	html: '<p>LATER</p>'
+});

--- a/packages/svelte/tests/runtime-runes/samples/derived-forward-ref-leading-comments/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/derived-forward-ref-leading-comments/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	const ctx = {
+		get later() {
+			return later;
+		}
+	};
+
+	// a leading comment on the declaration
+	// that spans more than one line
+	const later = $derived.by(() => 'LATER');
+</script>
+
+<p>{ctx.later}</p>

--- a/packages/svelte/tests/snapshot/samples/derived-forward-ref-leading-comments/_config.js
+++ b/packages/svelte/tests/snapshot/samples/derived-forward-ref-leading-comments/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/snapshot/samples/derived-forward-ref-leading-comments/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/derived-forward-ref-leading-comments/_expected/client/index.svelte.js
@@ -1,0 +1,23 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<p> </p>`);
+
+export default function Derived_forward_ref_leading_comments($$anchor) {
+	const ctx = {
+		get later() {
+			return $.get(later);
+		}
+	};
+
+	// a leading comment on the declaration
+	// that spans more than one line
+	const later = $.derived(() => 'LATER');
+
+	var p = root();
+	var text = $.child(p, true);
+
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, ctx.later));
+	$.append($$anchor, p);
+}

--- a/packages/svelte/tests/snapshot/samples/derived-forward-ref-leading-comments/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/derived-forward-ref-leading-comments/_expected/server/index.svelte.js
@@ -1,0 +1,15 @@
+import * as $ from 'svelte/internal/server';
+
+export default function Derived_forward_ref_leading_comments($$renderer) {
+	const ctx = {
+		get later() {
+			return later();
+		}
+	};
+
+	// a leading comment on the declaration
+	// that spans more than one line
+	const later = $.derived(() => 'LATER');
+
+	$$renderer.push(`<p>${$.escape(ctx.later)}</p>`);
+}

--- a/packages/svelte/tests/snapshot/samples/derived-forward-ref-leading-comments/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/derived-forward-ref-leading-comments/index.svelte
@@ -1,0 +1,13 @@
+<script>
+	const ctx = {
+		get later() {
+			return later;
+		}
+	};
+
+	// a leading comment on the declaration
+	// that spans more than one line
+	const later = $derived.by(() => 'LATER');
+</script>
+
+<p>{ctx.later}</p>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Fixes #18607

### Problem

When server-generating a component, a getter that returns a `$derived` declared later in the same scope would emit incorrectly if that declaration had leading line comments. Esrap placed those comments between `return` and the value:

```js
get later() {
  return // a leading comment on the declaration
  // that spans more than one line
  later();
}
```

ASI turns that into `return;` → the getter yields `undefined`. Client generation was fine.

### Root cause

Server `build_getter` transformed derived reads as `later()` using **`binding.node`** (the declaration identifier and its source `loc`). Esrap associates comments by location, so leading comments from the declaration site were printed next to that node wherever it was reused — including inside an earlier getter's `return`.

Client avoids this by reading through `state.transform[name].read(node)` with the **reference** node.

### Fix

Use the reference `node` as the callee instead of `binding.node`:

```js
return (binding.declaration_kind === 'var' ? b.maybe_call : b.call)(node);
```

Comments stay on the declaration; the getter becomes `return later();`.

### Tests

- **runtime-runes** `derived-forward-ref-leading-comments` — SSR + client HTML assert `<p>LATER</p>`
- **snapshot** same sample — server output must keep comments on the `const later` line, not inside the getter

Verified: without the change, server compile shows `return // comment\nlater()`; with the change, both modes place comments on the declaration and the runtime sample passes (4 variants).

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.