### PR TITLE
fix: keep an own `__proto__` key in `$state.snapshot`

### DIFF
--- a/.changeset/snapshot-own-proto-key.md
+++ b/.changeset/snapshot-own-proto-key.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep an own `__proto__` key in `$state.snapshot`

--- a/packages/svelte/src/internal/shared/clone.js
+++ b/packages/svelte/src/internal/shared/clone.js
@@ -1,7 +1,7 @@
 /** @import { Snapshot } from './types' */
 import { DEV } from 'esm-env';
 import * as w from './warnings.js';
-import { get_prototype_of, is_array, object_prototype } from './utils.js';
+import { define_property, get_prototype_of, is_array, object_prototype } from './utils.js';
 
 /**
  * In dev, we keep track of which properties could not be cloned. In prod
@@ -90,7 +90,7 @@ function clone(value, cloned, path, paths, original = null, no_tojson = false) {
 			}
 
 			for (var key of Object.keys(value)) {
-				copy[key] = clone(
+				var cloned_value = clone(
 					// @ts-expect-error
 					value[key],
 					cloned,
@@ -99,6 +99,22 @@ function clone(value, cloned, path, paths, original = null, no_tojson = false) {
 					null,
 					no_tojson
 				);
+
+				if (key === '__proto__') {
+					// Assigning `__proto__` runs the setter inherited from `Object.prototype`
+					// rather than creating a property, so the key would be dropped and an
+					// object value would become the copy's prototype, leaving the snapshot
+					// inheriting fields that were data. `structuredClone`, which this
+					// function falls back to below, keeps it as an own property.
+					define_property(copy, key, {
+						value: cloned_value,
+						writable: true,
+						enumerable: true,
+						configurable: true
+					});
+				} else {
+					copy[key] = cloned_value;
+				}
 			}
 
 			return copy;

--- a/packages/svelte/tests/runtime-runes/samples/state-snapshot-proto-key/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-snapshot-proto-key/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<div>["__proto__","b"]</div><div>true</div><div></div>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-snapshot-proto-key/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-snapshot-proto-key/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	// An own `__proto__` key comes from JSON, which is where state hydrated
+	// from a response, from storage, or from a query string comes from.
+	let state = $state(JSON.parse('{"__proto__":{"admin":true},"b":2}'));
+
+	const snapshot = $state.snapshot(state);
+</script>
+
+<div>{JSON.stringify(Object.keys(snapshot))}</div>
+<div>{Object.getPrototypeOf(snapshot) === Object.prototype}</div>
+<div>{snapshot.admin}</div>


### PR DESCRIPTION
### The problem

`$state.snapshot` drops an own `__proto__` key, and hands back an object that answers for it anyway:

```js
const state = $state(JSON.parse('{"__proto__":{"admin":true},"b":2}'));
const snap = $state.snapshot(state);

Object.keys(snap);                                  // ['b']
Object.getPrototypeOf(snap) === Object.prototype;   // false
snap.admin;                                         // true
```

The key is gone from the copy, and the object it pointed at became the copy's prototype. So a field that was data is now something the snapshot inherits, and reading any property off it can return a value that was never a property of it.

An own `__proto__` key never comes from an object literal, which is why this is easy to miss. It comes from `JSON.parse`, which is where state hydrated from a response, from `localStorage`, or from a query string comes from.

### The cause

`clone` walks plain objects itself and copies the keys with assignment:

```js
for (var key of Object.keys(value)) {
	copy[key] = clone(value[key], ...);
}
```

`copy` is a `{}`, so `copy['__proto__'] = ...` runs the setter inherited from `Object.prototype` rather than creating a property. Nothing is stored, and an object value replaces the prototype.

Worth noting: `structuredClone`, which this same function falls back to for everything it does not walk itself, gets this right. The two halves of `clone` disagree with each other.

```js
structuredClone(JSON.parse('{"__proto__":{"admin":true},"b":2}'));
// { '__proto__': { admin: true }, b: 2 }   own key, prototype untouched
```

### The change

Define that one key instead of assigning it, which is what makes the walked path answer the same way `structuredClone` already does. Fourteen lines in `clone.js`, no change to any other path: `Map`, `Set`, arrays, `Date`, `toJSON` and the `structuredClone` fallback are untouched.

### Tests

`tests/runtime-runes/samples/state-snapshot-proto-key`, next to the existing `state-snapshot-*` samples. It asserts all three things the snippet above shows: the key survives, the prototype is left alone, and nothing is inherited.

Before the change it fails on the `dom` and `hydrate` variants:

```
- <div>["__proto__","b"]</div>       + <div>["b"]</div>
- <div>true</div>                    + <div>false</div>
- <div></div>                        + <div>true</div>
```

After it passes on all four.

I also ran `runtime-runes`, `server-side-rendering` and `signals` together: 2969 passed, 0 failed.

`prettier --check` is clean on all three files (it needs the built compiler through `prettier-plugin-svelte`, so `pnpm build` in `packages/svelte` has to run first).
