### PR TITLE
fix: apply CSS custom properties with falsy values on components

### DIFF
--- a/.changeset/css-props-falsy-values.md
+++ b/.changeset/css-props-falsy-values.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: apply CSS custom properties with falsy values on components

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -18,10 +18,10 @@ export function css_props(element, get_styles) {
 		for (var key in styles) {
 			var value = styles[key];
 
-			if (value) {
-				element.style.setProperty(key, value);
-			} else {
+			if (value == null || value === '') {
 				element.style.removeProperty(key);
+			} else {
+				element.style.setProperty(key, value);
 			}
 		}
 	});

--- a/packages/svelte/tests/runtime-runes/samples/component-css-props-falsy/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/component-css-props-falsy/Component.svelte
@@ -1,0 +1,1 @@
+<div>Hello</div>

--- a/packages/svelte/tests/runtime-runes/samples/component-css-props-falsy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/component-css-props-falsy/_config.js
@@ -1,0 +1,12 @@
+import { test } from '../../test';
+
+export default test({
+	ssrHtml: `<svelte-css-wrapper style="display: contents; --zero: 0; --one: 1;"><div>Hello</div></svelte-css-wrapper>`,
+
+	async test({ assert, target }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			`<svelte-css-wrapper style="display: contents; --zero: 0; --one: 1;"><div>Hello</div></svelte-css-wrapper>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/component-css-props-falsy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/component-css-props-falsy/main.svelte
@@ -1,0 +1,5 @@
+<script>
+	import Component from './Component.svelte';
+</script>
+
+<Component --zero={0} --one={1} --empty={''} --nullish={null} />


### PR DESCRIPTION
Fixes #18633

### Problem

`css_props` decides between setting and removing a custom property with a truthiness check, so valid CSS values that happen to be falsy in JS are dropped:

```svelte
<Component --foo={0} />
<!-- <svelte-css-wrapper style="display: contents;">  — --foo is gone -->
```

`0` is a perfectly valid CSS value. `<Component --foo="0" />` already works, because the string `"0"` is truthy — the behaviour depends on the JS type rather than on the CSS value.

It is also an SSR/CSR mismatch: `style_object_to_string` on the server filters on `!= null && !== ''`, so the server renders `--foo: 0;` and hydration then removes it.

`set_style` for element `style:` directives checks `== null`, and the docs describe the feature as desugaring straight into the wrapper's `style` attribute with no mention of filtering. `css_props` was the only one of the three using truthiness.

### Fix

Only remove on `null` / `undefined` / `''`, matching the server and `style:`:

```js
if (value == null || value === '') {
	element.style.removeProperty(key);
} else {
	element.style.setProperty(key, value);
}
```

### Test

`component-css-props-falsy` passes `--zero={0} --one={1} --empty={''} --nullish={null}` and asserts the wrapper keeps `--zero: 0;` while dropping the empty and nullish ones.

Without the change the `ssr` and `async-ssr` variants pass while `dom` and `hydrate` fail — which is the mismatch above, reproduced.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

`pnpm test` (33 files, 7672 passed), `pnpm lint` and `pnpm check` all pass locally. `runtime-browser` is not part of `pnpm test` and was not run locally.
