### PR TITLE
fix: include falsy values in CSS custom properties on client-side (Fixes #18633)

### DIFF
--- a/.changeset/lucky-pears-remain.md
+++ b/.changeset/lucky-pears-remain.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: include falsy values in CSS custom properties on client-side

--- a/packages/svelte/src/internal/client/dom/blocks/css-props.js
+++ b/packages/svelte/src/internal/client/dom/blocks/css-props.js
@@ -18,7 +18,7 @@ export function css_props(element, get_styles) {
 		for (var key in styles) {
 			var value = styles[key];
 
-			if (value) {
+			if (value != null) {
 				element.style.setProperty(key, value);
 			} else {
 				element.style.removeProperty(key);

--- a/packages/svelte/tests/runtime-runes/samples/css-props-falsy-values/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/css-props-falsy-values/Component.svelte
@@ -1,0 +1,8 @@
+<div class="falsy-test">Hello</div>
+
+<style>
+	div {
+		opacity: var(--opacity);
+		z-index: var(--zindex);
+	}
+</style>

--- a/packages/svelte/tests/runtime-runes/samples/css-props-falsy-values/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/css-props-falsy-values/_config.js
@@ -1,0 +1,10 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			`<svelte-css-wrapper style="display: contents; --opacity: 0; --zindex: false;"><div class="svelte-lsmn3l">Hello</div></svelte-css-wrapper>`
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/css-props-falsy-values/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/css-props-falsy-values/main.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Component from './Component.svelte';
+	let Comp = Component;
+</script>
+
+<svelte:component this={Comp} --opacity={0} --zindex={false} />


### PR DESCRIPTION
## Description

When a CSS custom property is defined on a component with a falsy value (e.g. `--foo={0}`), the client-side runtime incorrectly omits it because the truthiness check `if (value)` treats `0`, `false`, and `""` as falsy and calls `removeProperty` instead of `setProperty`.

The server-side `style_object_to_string()` already handles this correctly by using `!= null` checks. This PR aligns the client-side `css_props()` with the same behavior.

**Before:** `<Component --foo={0} />` renders `<svelte-css-wrapper style="display: contents;">` (missing `--foo: 0`)
**After:** `<Component --foo={0} />` renders `<svelte-css-wrapper style="display: contents; --foo: 0;">`

Fixes #18633

## Changes
- `packages/svelte/src/internal/client/dom/blocks/css-props.js`: Change `if (value)` to `if (value != null)`
- Added test case for falsy CSS custom property values