### PR TITLE
fix: don't duplicate comments in attributes

### DIFF
--- a/.changeset/modern-otters-pick.md
+++ b/.changeset/modern-otters-pick.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't duplicate comments in attributes

--- a/packages/svelte/src/compiler/print/index.js
+++ b/packages/svelte/src/compiler/print/index.js
@@ -82,6 +82,7 @@ function attributes(node, attributes, context, comments) {
 	}
 
 	const separator = context.new();
+	let previous_attribute_end = node.start;
 
 	const children = attributes.map((attribute) => {
 		const child_context = context.new();
@@ -90,12 +91,16 @@ function attributes(node, attributes, context, comments) {
 			const comment = comments[comment_index];
 
 			if (comment.start < attribute.start) {
-				if (comment.type === 'Line') {
-					child_context.write('//' + comment.value);
-					child_context.newline();
-				} else {
-					child_context.write('/*' + comment.value + '*/'); // TODO match indentation?
-					child_context.append(separator);
+				// Inside a previous attribute's value can be comments which don't
+				// advance comment_index, therefore this additional check
+				if (comment.start >= previous_attribute_end) {
+					if (comment.type === 'Line') {
+						child_context.write('//' + comment.value);
+						child_context.newline();
+					} else {
+						child_context.write('/*' + comment.value + '*/'); // TODO match indentation?
+						child_context.append(separator);
+					}
 				}
 
 				comment_index += 1;
@@ -105,6 +110,7 @@ function attributes(node, attributes, context, comments) {
 		}
 
 		child_context.visit(attribute);
+		previous_attribute_end = attribute.end;
 
 		length += child_context.measure() + 1;
 

--- a/packages/svelte/tests/print/samples/comment-inside-attribute/input.svelte
+++ b/packages/svelte/tests/print/samples/comment-inside-attribute/input.svelte
@@ -1,0 +1,7 @@
+<Button
+	onclick={() => {
+		// belongs to onclick
+		run();
+	}}
+	onkeydown={() => run()}
+/>

--- a/packages/svelte/tests/print/samples/comment-inside-attribute/output.svelte
+++ b/packages/svelte/tests/print/samples/comment-inside-attribute/output.svelte
@@ -1,0 +1,7 @@
+<Button
+	onclick={() => {
+		// belongs to onclick
+		run();
+	}}
+	onkeydown={() => run()}
+/>


### PR DESCRIPTION
An attribute with a comment would be printed again atop the following attribute because we didn't take that case into account.
