### PR TITLE
feat: export RenderOutput, SyncRenderOutput, Csp and Sha256Source from svelte/server

### DIFF
--- a/.changeset/olive-jars-repeat.md
+++ b/.changeset/olive-jars-repeat.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: export `RenderOutput`, `SyncRenderOutput`, `Csp` and `Sha256Source` from `svelte/server`

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -1,5 +1,5 @@
 /** @import { ComponentType, SvelteComponent, Component } from 'svelte' */
-/** @import { Csp, RenderOutput } from '#server' */
+/** @import { Csp, RenderOutput } from '../../server/public.js' */
 /** @import { Store } from '#shared' */
 export { FILENAME, HMR } from '../../constants.js';
 import { attr, clsx, to_class, to_style } from '../shared/attributes.js';

--- a/packages/svelte/src/internal/server/renderer.js
+++ b/packages/svelte/src/internal/server/renderer.js
@@ -1,5 +1,6 @@
 /** @import { Component } from 'svelte' */
-/** @import { Csp, HydratableContext, RenderOutput, SSRContext, SyncRenderOutput, Sha256Source } from './types.js' */
+/** @import { HydratableContext, SSRContext } from './types.js' */
+/** @import { Csp, RenderOutput, SyncRenderOutput, Sha256Source } from '../../server/public.js' */
 /** @import { MaybePromise } from '#shared' */
 import { async_mode_flag } from '../flags/index.js';
 import { abort } from './abort-signal.js';

--- a/packages/svelte/src/internal/server/types.d.ts
+++ b/packages/svelte/src/internal/server/types.d.ts
@@ -15,8 +15,6 @@ export interface SSRContext {
 	element?: Element;
 }
 
-export type Csp = { nonce?: string; hash?: boolean };
-
 export interface HydratableLookupEntry {
 	value: unknown;
 	serialized: string;
@@ -34,19 +32,3 @@ export interface HydratableContext {
 export interface RenderContext {
 	hydratable: HydratableContext;
 }
-
-export type Sha256Source = `sha256-${string}`;
-
-export interface SyncRenderOutput {
-	/** HTML that goes into the `<head>` */
-	head: string;
-	/** @deprecated use `body` instead */
-	html: string;
-	/** HTML that goes somewhere into the `<body>` */
-	body: string;
-	hashes: {
-		script: Sha256Source[];
-	};
-}
-
-export type RenderOutput = SyncRenderOutput & PromiseLike<SyncRenderOutput>;

--- a/packages/svelte/src/legacy/legacy-server.js
+++ b/packages/svelte/src/legacy/legacy-server.js
@@ -1,5 +1,5 @@
 /** @import { SvelteComponent } from '../index.js' */
-/** @import { Csp } from '#server' */
+/** @import { Csp } from '../server/public.js' */
 import { asClassComponent as as_class_component, createClassComponent } from './legacy-client.js';
 import { render } from '../internal/server/index.js';
 import { async_mode_flag } from '../internal/flags/index.js';

--- a/packages/svelte/src/server/index.d.ts
+++ b/packages/svelte/src/server/index.d.ts
@@ -1,5 +1,7 @@
-import type { Csp, RenderOutput } from '#server';
+import type { Csp, RenderOutput } from './public.js';
 import type { ComponentProps, Component, SvelteComponent, ComponentType } from 'svelte';
+
+export type { Csp, RenderOutput, SyncRenderOutput, Sha256Source } from './public.js';
 
 /**
  * Only available on the server and when compiling with the `server` option.

--- a/packages/svelte/src/server/public.d.ts
+++ b/packages/svelte/src/server/public.d.ts
@@ -1,0 +1,17 @@
+export type Csp = { nonce?: string; hash?: boolean };
+
+export type Sha256Source = `sha256-${string}`;
+
+export interface SyncRenderOutput {
+	/** HTML that goes into the `<head>` */
+	head: string;
+	/** @deprecated use `body` instead */
+	html: string;
+	/** HTML that goes somewhere into the `<body>` */
+	body: string;
+	hashes: {
+		script: Sha256Source[];
+	};
+}
+
+export type RenderOutput = SyncRenderOutput & PromiseLike<SyncRenderOutput>;

--- a/packages/svelte/tests/server-side-rendering/test.ts
+++ b/packages/svelte/tests/server-side-rendering/test.ts
@@ -6,13 +6,12 @@
 
 import * as fs from 'node:fs';
 import { assert } from 'vitest';
-import { render } from 'svelte/server';
+import { render, type SyncRenderOutput } from 'svelte/server';
 import { compile_directory, should_update_expected, try_read_file } from '../helpers.js';
 import { assert_html_equal_with_options } from '../html_equal.js';
 import { suite_with_variants, type BaseTest } from '../suite.js';
 import type { CompileOptions } from '#compiler';
 import { seen } from '../../src/internal/server/dev.js';
-import type { SyncRenderOutput } from '#server';
 
 interface SSRTest extends BaseTest {
 	mode?: ('sync' | 'async')[];

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -2612,11 +2612,11 @@ declare module 'svelte/server' {
 					}
 				]
 	): RenderOutput;
-	type Csp = { nonce?: string; hash?: boolean };
+	export type Csp = { nonce?: string; hash?: boolean };
 
-	type Sha256Source = `sha256-${string}`;
+	export type Sha256Source = `sha256-${string}`;
 
-	interface SyncRenderOutput {
+	export interface SyncRenderOutput {
 		/** HTML that goes into the `<head>` */
 		head: string;
 		/** @deprecated use `body` instead */
@@ -2628,7 +2628,7 @@ declare module 'svelte/server' {
 		};
 	}
 
-	type RenderOutput = SyncRenderOutput & PromiseLike<SyncRenderOutput>;
+	export type RenderOutput = SyncRenderOutput & PromiseLike<SyncRenderOutput>;
 
 	export {};
 }


### PR DESCRIPTION
`render` returns `RenderOutput` and takes `csp: Csp`, but both are declared in `src/internal/server/types.d.ts` and never exported. The generated `svelte/server` block has them without `export`, so nothing outside the repo can import them and the docs page names `RenderOutput` as the return type with nothing on the page defining it.

Moves them into `src/server/public.d.ts` the way `svelte/motion` went in #17967, rather than re-exporting internals.
