### PR TITLE
fix: coerce symbols to empty string in set_text

### DIFF
--- a/.changeset/set-text-symbol-guard.md
+++ b/.changeset/set-text-symbol-guard.md
@@ -1,0 +1,9 @@
+---
+'svelte': patch
+---
+
+fix: coerce symbols to empty string in `set_text`
+
+Under `experimental.async`, `$bindable` props can briefly surface `Symbol(UNINITIALIZED)`.
+`set_text` treated symbols as already-stringifiable values, then threw when assigning
+`text.nodeValue = \`${str}\``. Treat symbols like nullish values so text nodes stay stable.

--- a/packages/svelte/src/internal/client/render.js
+++ b/packages/svelte/src/internal/client/render.js
@@ -45,7 +45,7 @@ export function set_should_intro(value) {
  */
 export function set_text(text, value) {
 	// For objects, we apply string coercion (which might make things like $state array references in the template reactive) before diffing
-	var str = value == null ? '' : typeof value === 'object' ? `${value}` : value;
+	var str = value == null || typeof value === 'symbol' ? '' : typeof value === 'object' ? `${value}` : value;
 	// prettier-ignore
 	if (str !== (/** @type {any} */ (text)[TEXT_CACHE] ??= text.nodeValue)) {
 		/** @type {any} */ (text)[TEXT_CACHE] = str;


### PR DESCRIPTION
## Summary
Under `experimental.async`, `$bindable` props can surface `Symbol(UNINITIALIZED)` before a real value is ready. `set_text` currently treats symbols as already-string values (`typeof !== 'object'`), then throws when assigning `text.nodeValue = \`${str}\`` (`Cannot convert a Symbol value to a string`).

This mirrors nullish handling: coerce symbols to `''` so text updates stay stable during async/fork preloads.

## Test plan
- [ ] Existing client runtime tests pass
- [ ] Manual: render text from a prop that briefly holds `UNINITIALIZED` under `experimental.async` — should not throw