### PR TITLE
perf: use Set for visited tracking in sort_const_tags

### DIFF
--- a/.changeset/fix-const-tag-sort-set-membership.md
+++ b/.changeset/fix-const-tag-sort-set-membership.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: use Set for visited tracking in sort_const_tags to avoid O(n²) membership checks

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -84,12 +84,15 @@ function sort_const_tags(nodes, state) {
 		e.const_tag_cycle(tag.node, cycle.map((binding) => binding.node.name).join(' → '));
 	}
 
+	/** @type {Set<AST.ConstTag>} */
+	const visited = new Set();
+
 	/** @type {AST.ConstTag[]} */
 	const sorted = [];
 
 	/** @param {Tag} tag */
 	function add(tag) {
-		if (sorted.includes(tag.node)) {
+		if (visited.has(tag.node)) {
 			return;
 		}
 
@@ -98,6 +101,7 @@ function sort_const_tags(nodes, state) {
 			if (dep_tag) add(dep_tag);
 		}
 
+		visited.add(tag.node);
 		sorted.push(tag.node);
 	}
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrates what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Fixes #18599

## What changed

In `packages/svelte/src/compiler/phases/3-transform/utils.js`, the `sort_const_tags` topological sort used `Array.includes()` to check whether a `{@const}` tag had already been visited:

```js
if (sorted.includes(tag.node)) {
  return;
}
```

This is O(n) per check, making the DFS O(n²) overall for a fragment with `n` interdependent `{@const}` declarations.

The fix adds a dedicated `visited` Set for membership checks (O(1)), while keeping the ordered `sorted` array for the final output:

```js
if (visited.has(tag.node)) {
  return;
}
// ...
visited.add(tag.node);
sorted.push(tag.node);
```

Total complexity: O(n + edges).

## Test plan

- [x] Full test suite passes: `pnpm test` — 7595 tests pass, 0 new failures
- [x] Pre-existing browser suite skip (Playwright/Chromium not installed in CI environment) is unrelated to this change
- [x] `const-tag-ordering` and `const-tag-depends-on-const-tag` runtime-legacy samples produce identical output
- [x] `git diff HEAD` reviewed — only the two intended files changed (utils.js + changeset)