### PR TITLE
perf: use Set for key dedup in spread_props ownKeys

### DIFF
--- a/.changeset/fix-spread-props-ownkeys-set.md
+++ b/.changeset/fix-spread-props-ownkeys-set.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: use Set for key deduplication in spread_props ownKeys to avoid O(k²) includes scan

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -235,23 +235,23 @@ const spread_props_handler = {
 		return false;
 	},
 	ownKeys(target) {
-		/** @type {Array<string | symbol>} */
-		const keys = [];
+		/** @type {Set<string | symbol>} */
+		const keys = new Set();
 
 		for (let p of target.props) {
 			if (is_function(p)) p = p();
 			if (!p) continue;
 
 			for (const key in p) {
-				if (!keys.includes(key)) keys.push(key);
+				keys.add(key);
 			}
 
 			for (const key of Object.getOwnPropertySymbols(p)) {
-				if (!keys.includes(key)) keys.push(key);
+				keys.add(key);
 			}
 		}
 
-		return keys;
+		return [...keys];
 	}
 };
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Fixes #18600

## What changed

`spread_props_handler.ownKeys` in `packages/svelte/src/internal/client/reactivity/props.js` used `Array.includes()` to deduplicate keys while building the `ownKeys` result:

```js
if (!keys.includes(key)) keys.push(key);
```

This is O(k) per key, making the full loop O(k²) for k unique keys across all spread objects.

The fix replaces the array with a `Set`. `Set.add` is O(1) and `Set` preserves insertion order, so first-seen key ordering is unchanged:

```js
const keys = new Set();
// ...
keys.add(key);
// ...
return [...keys];
```

Total complexity: O(k).

## Test plan

- [x] Full test suite passes: `pnpm test` — 7595 tests pass, 0 new failures
- [x] Pre-existing browser suite failure (Playwright/Chromium not installed) is unrelated
- [x] `git diff HEAD` reviewed — only the two intended files changed (props.js + changeset)