### PR TITLE
perf: use Set for exclude checks in rest_props, exclude_from_object, legacy_rest_props

### DIFF
--- a/.changeset/fix-rest-props-set-membership.md
+++ b/.changeset/fix-rest-props-set-membership.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: use Set for exclude-list membership checks in rest_props, exclude_from_object, and legacy_rest_props

--- a/packages/svelte/src/internal/client/reactivity/props.js
+++ b/packages/svelte/src/internal/client/reactivity/props.js
@@ -96,11 +96,11 @@ export function rest_props(props, exclude, name) {
 
 /**
  * The proxy handler for legacy $$restProps and $$props
- * @type {ProxyHandler<{ props: Record<string | symbol, unknown>, exclude: Array<string | symbol>, special: Record<string | symbol, (v?: unknown) => unknown>, version: Source<number>, parent_effect: Effect }>}}
+ * @type {ProxyHandler<{ props: Record<string | symbol, unknown>, exclude: Set<string | symbol>, special: Record<string | symbol, (v?: unknown) => unknown>, version: Source<number>, parent_effect: Effect }>}}
  */
 const legacy_rest_props_handler = {
 	get(target, key) {
-		if (target.exclude.includes(key)) return;
+		if (target.exclude.has(key)) return;
 		get(target.version);
 		return key in target.special ? target.special[key]() : target.props[key];
 	},
@@ -132,7 +132,7 @@ const legacy_rest_props_handler = {
 		return true;
 	},
 	getOwnPropertyDescriptor(target, key) {
-		if (target.exclude.includes(key)) return;
+		if (target.exclude.has(key)) return;
 		if (key in target.props) {
 			return {
 				enumerable: true,
@@ -143,17 +143,17 @@ const legacy_rest_props_handler = {
 	},
 	deleteProperty(target, key) {
 		// Svelte 4 allowed for deletions on $$restProps
-		if (target.exclude.includes(key)) return true;
-		target.exclude.push(key);
+		if (target.exclude.has(key)) return true;
+		target.exclude.add(key);
 		update(target.version);
 		return true;
 	},
 	has(target, key) {
-		if (target.exclude.includes(key)) return false;
+		if (target.exclude.has(key)) return false;
 		return key in target.props;
 	},
 	ownKeys(target) {
-		return Reflect.ownKeys(target.props).filter((key) => !target.exclude.includes(key));
+		return Reflect.ownKeys(target.props).filter((key) => !target.exclude.has(key));
 	}
 };
 
@@ -166,7 +166,7 @@ export function legacy_rest_props(props, exclude) {
 	return new Proxy(
 		{
 			props,
-			exclude,
+			exclude: new Set(exclude),
 			special: {},
 			version: source(0),
 			// TODO this is only necessary because we need to track component

--- a/packages/svelte/src/internal/server/index.js
+++ b/packages/svelte/src/internal/server/index.js
@@ -347,11 +347,11 @@ export function slot(renderer, $$props, name, slot_props, fallback_fn) {
  * @returns {Record<string, unknown>}
  */
 export function rest_props(props, rest) {
+	const exclude = new Set(rest);
 	/** @type {Record<string, unknown>} */
 	const rest_props = {};
-	let key;
-	for (key of Object.keys(props)) {
-		if (!rest.includes(key)) {
+	for (const key of Object.keys(props)) {
+		if (!exclude.has(key)) {
 			rest_props[key] = props[key];
 		}
 	}

--- a/packages/svelte/src/internal/shared/utils.js
+++ b/packages/svelte/src/internal/shared/utils.js
@@ -125,17 +125,18 @@ export function to_array(value, n) {
  * @returns {Record<string | symbol, unknown>}
  */
 export function exclude_from_object(obj, keys) {
+	const exclude = new Set(keys);
 	/** @type {Record<string | symbol, unknown>} */
 	var result = {};
 
 	for (var key in obj) {
-		if (!keys.includes(key)) {
+		if (!exclude.has(key)) {
 			result[key] = obj[key];
 		}
 	}
 
 	for (var symbol of Object.getOwnPropertySymbols(obj)) {
-		if (Object.propertyIsEnumerable.call(obj, symbol) && !keys.includes(symbol)) {
+		if (Object.propertyIsEnumerable.call(obj, symbol) && !exclude.has(symbol)) {
 			result[symbol] = obj[symbol];
 		}
 	}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Fixes #18601

## What changed

Three sibling paths were using `Array.includes()` (O(n)) for exclude-list membership checks, while the modern client runes `rest_props` already used a `Set`. This PR brings the remaining paths in line.

| Path | File | Change |
|------|------|--------|
| Server SSR `rest_props` | `packages/svelte/src/internal/server/index.js` | `new Set(rest)` at entry, `.has()` |
| `exclude_from_object` | `packages/svelte/src/internal/shared/utils.js` | `new Set(keys)` at entry, `.has()` |
| `legacy_rest_props_handler` | `packages/svelte/src/internal/client/reactivity/props.js` | `new Set(exclude)` at construction, `.has()` / `.add()` |

No signature changes — callers (including the compiler) still pass arrays. Conversion to Set is done internally. The only behavioral difference: `deleteProperty` on `legacy_rest_props_handler` now calls `.add()` instead of `.push()`.

## Test plan

- [x] Full test suite: 7595 tests pass, 0 new failures
- [x] Pre-existing browser suite failure (Playwright not installed) is unrelated
- [x] `git diff HEAD` reviewed — only intended files changed