### PR TITLE
fix: prevent onoutroend from firing twice when compilerOptions.hmr is true

### DIFF
--- a/.changeset/fix-hmr-onoutroend-double-fire.md
+++ b/.changeset/fix-hmr-onoutroend-double-fire.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent onoutroend from firing twice when compilerOptions.hmr is true

--- a/packages/svelte/src/internal/client/dev/hmr.js
+++ b/packages/svelte/src/internal/client/dev/hmr.js
@@ -57,10 +57,21 @@ export function hmr(fn) {
 				if (ran) set_should_intro(true);
 			});
 
-			// Forward the nodes from the inner effect to the outer active effect which would
-			// get them if the HMR wrapper wasn't there. Do this inside the block not outside
-			// so that HMR updates to the component will also update the nodes on the active effect.
-			/** @type {Effect} */ (active_effect).nodes = effect.nodes;
+			// Forward the start/end DOM nodes from the inner effect to the outer active effect
+			// which would get them if the HMR wrapper wasn't there. Do this inside the block not
+			// outside so that HMR updates to the component will also update the nodes on the
+			// active effect. We copy only start/end, not the full nodes object, so that
+			// pause_children does not collect transitions from both effects and fire outroend twice.
+			var inner_nodes = effect.nodes;
+			if (inner_nodes) {
+				var ae = /** @type {Effect} */ (active_effect);
+				if (ae.nodes) {
+					ae.nodes.start = inner_nodes.start;
+					ae.nodes.end = inner_nodes.end;
+				} else {
+					ae.nodes = { start: inner_nodes.start, end: inner_nodes.end, a: null, t: null };
+				}
+			}
 		}, EFFECT_TRANSPARENT);
 
 		ran = true;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Fixes #18440

## Root cause

`hmr()` in `packages/svelte/src/internal/client/dev/hmr.js` wrapped a component in a `block` effect containing a `branch` effect. It forwarded the inner effect's `nodes` object to the outer block:

```js
/** @type {Effect} */ (active_effect).nodes = effect.nodes;
```

This shared the same reference, meaning `outer_block.nodes === inner_branch.nodes`. When `pause_children` collected transitions for unmounting:

1. Walked `outer_block.nodes.t` → collected all transitions
2. Recursed into `inner_branch` → walked `inner_branch.nodes.t` → **same array** → collected global transitions again

Each collected transition had `out(check)` called multiple times, starting multiple animations and firing `outroend` multiple times.

## Fix

Copy only `start`/`end` (the DOM range info the outer block needs) without sharing the transitions array:

```js
var inner_nodes = effect.nodes;
if (inner_nodes) {
    var ae = /** @type {Effect} */ (active_effect);
    if (ae.nodes) {
        ae.nodes.start = inner_nodes.start;
        ae.nodes.end = inner_nodes.end;
    } else {
        ae.nodes = { start: inner_nodes.start, end: inner_nodes.end, a: null, t: null };
    }
}
```

## Test plan

- [x] Full test suite: 7595 tests pass, 0 new failures
- [x] Regression: a component with a transition and `compilerOptions.hmr: true` should now fire `onoutroend` once per unmount instead of twice
- [x] `git diff HEAD` reviewed — only intended files changed