### PR TITLE
fix: skip position-less comment nodes in migration to prevent crash

### DIFF
--- a/.changeset/fix-migrate-comment-no-position.md
+++ b/.changeset/fix-migrate-comment-no-position.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-fix: migration no longer crashes when a `@component` HTML comment precedes a `export { x as y }` declaration
+fix: ignore comments of Program node during migration script

--- a/.changeset/fix-migrate-comment-no-position.md
+++ b/.changeset/fix-migrate-comment-no-position.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: migration no longer crashes when a `@component` HTML comment precedes a `export { x as y }` declaration

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1590,12 +1590,15 @@ function migrate_slot_usage(node, path, state) {
  */
 function extract_type_and_comment(declarator, state, path) {
 	const str = state.str;
-	const parent = path.at(-1);
+	let parent = path.at(-1);
+
+	if (parent?.type === 'Program') {
+		// We don't want comments from the program node
+		parent = undefined;
+	}
 
 	// Try to find jsdoc above the declaration
 	let comment_node = /** @type {Node} */ (parent)?.leadingComments?.at(-1);
-	// HTML comments (e.g. @component) are attached to the Program node without position info
-	if (comment_node?.start === undefined) comment_node = undefined;
 
 	const comment_start = /** @type {any} */ (comment_node)?.start;
 	const comment_end = /** @type {any} */ (comment_node)?.end;
@@ -1605,8 +1608,7 @@ function extract_type_and_comment(declarator, state, path) {
 	}
 
 	// Find trailing comments
-	let trailing_comment_node = /** @type {Node} */ (parent)?.trailingComments?.at(0);
-	if (trailing_comment_node?.start === undefined) trailing_comment_node = undefined;
+	const trailing_comment_node = /** @type {Node} */ (parent)?.trailingComments?.at(0);
 	const trailing_comment_start = /** @type {any} */ (trailing_comment_node)?.start;
 	const trailing_comment_end = /** @type {any} */ (trailing_comment_node)?.end;
 	let trailing_comment =

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -1594,6 +1594,8 @@ function extract_type_and_comment(declarator, state, path) {
 
 	// Try to find jsdoc above the declaration
 	let comment_node = /** @type {Node} */ (parent)?.leadingComments?.at(-1);
+	// HTML comments (e.g. @component) are attached to the Program node without position info
+	if (comment_node?.start === undefined) comment_node = undefined;
 
 	const comment_start = /** @type {any} */ (comment_node)?.start;
 	const comment_end = /** @type {any} */ (comment_node)?.end;
@@ -1603,7 +1605,8 @@ function extract_type_and_comment(declarator, state, path) {
 	}
 
 	// Find trailing comments
-	const trailing_comment_node = /** @type {Node} */ (parent)?.trailingComments?.at(0);
+	let trailing_comment_node = /** @type {Node} */ (parent)?.trailingComments?.at(0);
+	if (trailing_comment_node?.start === undefined) trailing_comment_node = undefined;
 	const trailing_comment_start = /** @type {any} */ (trailing_comment_node)?.start;
 	const trailing_comment_end = /** @type {any} */ (trailing_comment_node)?.end;
 	let trailing_comment =

--- a/packages/svelte/tests/migrate/samples/props-export-alias/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-export-alias/input.svelte
@@ -1,3 +1,4 @@
+<!-- @component x -->
 <script lang="ts">
 	let klass = '';
 	export { klass as class }

--- a/packages/svelte/tests/migrate/samples/props-export-alias/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-export-alias/output.svelte
@@ -1,3 +1,4 @@
+<!-- @component x -->
 <script lang="ts">
 	interface Props {
 		class?: string;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] PR references the issue discussed ahead of time.
- [x] Prefixed with \`fix:\`.
- [x] Body illustrates what problem it solves.
- [x] Changeset added.

### Tests and linting

- [x] \`pnpm test\` — 7595 pass, 0 new failures

---

Fixes #18304

## Root cause

\`extract_type_and_comment\` in the migration tool uses \`parent?.leadingComments?.at(-1)\` to find a JSDoc comment above a declaration. When a Svelte component starts with an HTML \`<!--...-->\` comment (e.g. \`@component\` docs), acorn attaches it to the \`Program\` node's \`leadingComments\` array **without \`start\`/\`end\` positions**.

For a component like:
\`\`\`svelte
<!--
    @component
    Lorem ipsum dolor sit.
-->
<script lang="ts">
    let forId: string | undefined = undefined;
    export { forId as for };
</script>
\`\`\`

The \`VariableDeclaration\` visitor finds \`Program\` as \`path.at(-1)\`. \`Program.leadingComments[0]\` is the HTML comment — present but with no positions. Then \`str.update(undefined, undefined, '')\` crashes with \`TypeError: Cannot set properties of undefined (setting 'next')\`.

## Fix

Two one-line guards in \`extract_type_and_comment\`: null out any \`comment_node\` or \`trailing_comment_node\` whose \`.start\` is \`undefined\` before using its position. No other callers affected.