### PR TITLE
feat: add getOrInsert and getOrInsertComputed to SvelteMap

### DIFF
--- a/.changeset/fix-sveltemap-get-or-insert.md
+++ b/.changeset/fix-sveltemap-get-or-insert.md
@@ -1,0 +1,5 @@
+---
+'svelte': minor
+---
+
+feat: add `getOrInsert` and `getOrInsertComputed` to `SvelteMap`

--- a/packages/svelte/src/reactivity/map.js
+++ b/packages/svelte/src/reactivity/map.js
@@ -271,4 +271,27 @@ export class SvelteMap extends Map {
 		get(this.#size);
 		return super.size;
 	}
+
+	/**
+	 * @param {K} key
+	 * @param {V} value
+	 * @returns {V}
+	 */
+	getOrInsert(key, value) {
+		if (super.has(key)) return /** @type {V} */ (this.get(key));
+		this.set(key, value);
+		return value;
+	}
+
+	/**
+	 * @param {K} key
+	 * @param {(key: K) => V} callbackFn
+	 * @returns {V}
+	 */
+	getOrInsertComputed(key, callbackFn) {
+		if (super.has(key)) return /** @type {V} */ (this.get(key));
+		const value = callbackFn(key);
+		this.set(key, value);
+		return value;
+	}
 }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Prefixed with `feat:`.
- [x] Changeset added (minor).
- [x] References the issue.

### Tests and linting

- [x] `pnpm test` — 7595 pass, 0 new failures

---

Closes #18014

## What

Adds `SvelteMap.getOrInsert(key, value)` and `SvelteMap.getOrInsertComputed(key, callbackFn)` — the TC39 upsert proposal now at stage 4, shipping in TypeScript 6+ and all major browsers.

Without this override, calling `map.getOrInsert(k, v)` on a `SvelteMap` falls through to the native `Map` implementation, which calls `Map.prototype.set` directly and bypasses the reactive source tracking.

## Implementation

Both methods delegate to `this.get()` (tracks the key source on hit) and `this.set()` (increments the source on miss), so existing reactivity invariants are preserved in one line each.