### PR TITLE
fix: don't treat whitespace around a snippet as default slot content

### DIFF
--- a/.changeset/olive-donuts-invent.md
+++ b/.changeset/olive-donuts-invent.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't treat whitespace around a snippet as default slot content under `preserveWhitespace`

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/component.js
@@ -325,6 +325,15 @@ export function build_component(node, component_name, loc, context) {
 	/** @type {import('estree').Property[]} */
 	const serialized_slots = [];
 
+	// Whitespace and comments surrounding a `{#snippet}` inside a component tag are
+	// formatting, not default-slot content. Under `preserveWhitespace: true` they survive
+	// and get serialized as an implicit default slot, which emits a spurious `children`
+	// prop -- and, when the component already has an explicit `{#snippet children}`, a
+	// *duplicate* `children` key that silently clobbers it. The analysis phase already
+	// treats such siblings as "not content" (`phases/2-analyze/visitors/SnippetBlock.js`
+	// raises `snippet_conflict` only for non-whitespace siblings); agree with it here.
+	const has_snippet = node.fragment.nodes.some((child) => child.type === 'SnippetBlock');
+
 	// Group children by slot
 	for (const child of node.fragment.nodes) {
 		if (child.type === 'SnippetBlock') {
@@ -343,6 +352,13 @@ export function build_component(node, component_name, loc, context) {
 				b.init(child.expression.name === 'children' ? 'default' : child.expression.name, b.true)
 			);
 
+			continue;
+		}
+
+		if (
+			has_snippet &&
+			(child.type === 'Comment' || (child.type === 'Text' && !child.data.trim()))
+		) {
 			continue;
 		}
 

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/component.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/component.js
@@ -165,6 +165,15 @@ export function build_inline_component(node, expression, context) {
 	/** @type {Property[]} */
 	const serialized_slots = [];
 
+	// Whitespace and comments surrounding a `{#snippet}` inside a component tag are
+	// formatting, not default-slot content. Under `preserveWhitespace: true` they survive
+	// and get serialized as an implicit default slot, which emits a spurious `children`
+	// prop -- and, when the component already has an explicit `{#snippet children}`, a
+	// *duplicate* `children` key that silently clobbers it. The analysis phase already
+	// treats such siblings as "not content" (`phases/2-analyze/visitors/SnippetBlock.js`
+	// raises `snippet_conflict` only for non-whitespace siblings); agree with it here.
+	const has_snippet = node.fragment.nodes.some((child) => child.type === 'SnippetBlock');
+
 	// Group children by slot
 	for (const child of node.fragment.nodes) {
 		if (child.type === 'SnippetBlock') {
@@ -183,6 +192,13 @@ export function build_inline_component(node, expression, context) {
 				b.init(child.expression.name === 'children' ? 'default' : child.expression.name, b.true)
 			);
 
+			continue;
+		}
+
+		if (
+			has_snippet &&
+			(child.type === 'Comment' || (child.type === 'Text' && !child.data.trim()))
+		) {
 			continue;
 		}
 

--- a/packages/svelte/tests/runtime-runes/samples/snippet-children-preserve-whitespace/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-children-preserve-whitespace/_config.js
@@ -1,0 +1,17 @@
+import { test } from '../../test';
+
+// Under `preserveWhitespace: true` the whitespace surrounding a `{#snippet}` inside a
+// component tag used to be serialized as implicit default-slot content. That emitted a
+// second `children` property into the component's props object, which — being the later
+// key in the same object literal — silently clobbered the explicit `{#snippet children}`,
+// so the first component below rendered whitespace instead of its paragraph.
+//
+// The second component checks the milder form of the same bug: with only a *named*
+// snippet, the surrounding whitespace produced a spurious `children` prop, making
+// `{#if children}`-style branches take the wrong path.
+export default test({
+	compileOptions: {
+		preserveWhitespace: true
+	},
+	html: `<p>explicit children snippet</p> <h1>titled</h1>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/snippet-children-preserve-whitespace/child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-children-preserve-whitespace/child.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { children, header } = $props();
+</script>
+
+{#if header}<h1>{@render header()}</h1>{/if}
+{@render children?.()}

--- a/packages/svelte/tests/runtime-runes/samples/snippet-children-preserve-whitespace/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/snippet-children-preserve-whitespace/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Child from './child.svelte';
+</script>
+
+<Child>
+	{#snippet children()}
+		<p>explicit children snippet</p>
+	{/snippet}
+</Child>
+
+<Child>
+	{#snippet header()}titled{/snippet}
+</Child>


### PR DESCRIPTION
Fixes #18659.

Under `preserveWhitespace: true`, the whitespace surrounding a `{#snippet}` inside a component tag is serialized as *implicit* default-slot content. That emits a spurious `children` property into the component's props object — and when the component also has an explicit `{#snippet children}`, a **duplicate `children` key**. Being the later key in the same object literal it wins, so the explicit snippet is silently discarded.

The failure is silent: no warning, no runtime error, no hydration mismatch — the subtree simply isn't there. `generate: 'client'` and `'server'` are affected identically.

## Quickest way to reproduce

No install and no preview build needed — the repo already contains a sample that demonstrates it. On `main`, add one line to `packages/svelte/tests/runtime-runes/samples/snippet-comment-sibling/_config.js`:

```js
export default test({
	compileOptions: { preserveWhitespace: true },   // <-- only change
	html: `The content`
});
```

```sh
pnpm vitest run packages/svelte/tests/runtime-runes/test.ts -t snippet-comment-sibling
```

```
AssertionError: expected '' to deeply equal 'The content'
Tests  4 failed
```

The component renders nothing at all, in all four client/SSR/hydration variants. That sample is #13936's own regression test (see below). With this PR applied, it passes.

<details>
<summary>The same thing as a standalone repro, if you'd rather</summary>

```svelte
<!-- Child.svelte -->
<script>
	let { children } = $props();
</script>
{@render children?.()}
```
```svelte
<!-- Mini.svelte -->
<Child>
	{#snippet children()}
		<p>rendered</p>
	{/snippet}
</Child>
```

`compile(source, { generate: 'client', preserveWhitespace: true })` currently emits:

```js
Child(node, {
	children,                                  // the explicit snippet
	children: ($$anchor, $$slotProps) => {     // duplicate key, whitespace only — wins
		$.next();
		var fragment_2 = root_1();             // root_1 = $.from_html(`\n\t\n`, 1)
		$.append($$anchor, fragment_2);
	},
	$$slots: { default: true, default: true }
});
```

so the component renders `"\n\t\n"` and the `<p>` never exists.

</details>

## Why the transform is out of step

The analysis phase already treats these siblings as "not content" — `phases/2-analyze/visitors/SnippetBlock.js` raises `snippet_conflict` only for siblings that are non-whitespace and non-`Comment`.

That `Comment` arm was added deliberately in #13936 (fixing #13865), which changed **only** the analysis phase and left both transforms as they were. So the rule that whitespace/comment siblings of a `children` snippet are legal is already the project's decision; only half the compiler follows it. This PR makes the transforms agree.

That is also why #13936's regression test doesn't catch it: it sets no `compileOptions`, so it runs at the default `preserveWhitespace: false`, where the siblings are trimmed before the default-slot group is built and the transform never gets the chance to mis-serialize them. Flipping that one option is the reproduction above.

## The fix

Skip whitespace-only `Text` and `Comment` children when grouping by slot, if the fragment contains any `SnippetBlock` — the same change in both transforms:

```js
const has_snippet = node.fragment.nodes.some((child) => child.type === 'SnippetBlock');

// ...in the grouping loop, before the child is added to `children[slot_name]`:
if (has_snippet && (child.type === 'Comment' || (child.type === 'Text' && !child.data.trim()))) {
	continue;
}
```

The skip is safe: `build_component` is reached only from `Component`, `SvelteComponent` and `SvelteSelf` — exactly the three parent types `SnippetBlock.js` validates — so whenever a `children` snippet is present, the default group provably holds nothing but whitespace `Text` and `Comment`.

Two things worth flagging for review:

- It keys on *any* snippet, not just `children`, which also fixes a milder variant of the same bug: a component given only **named** snippets currently gets a spurious whitespace `children` prop and `$$slots.default: true`, so any `{#if children}` branch takes the wrong path.
- It also drops sibling comments under `preserveComments: true`. Those comments have nowhere meaningful to go, and leaving them in reintroduces the duplicate key — a comment sibling alone triggers it even at zero whitespace.

## Testing

New sample `runtime-runes/samples/snippet-children-preserve-whitespace` covering both the explicit-`children` and named-snippet-only cases. Reverting either transform hunk fails it in all four variants.

Verified no over-reach — with the fix, output is identical between `preserveWhitespace: false` and `true` for the cases that should match, and still differs where the whitespace genuinely is content:

| case | `pw:false` == `pw:true`? |
|---|---|
| explicit `{#snippet children}` | yes (fixed) |
| named snippet only | yes (fixed) |
| named snippet + real text content | no — text preserved either way |
| plain text child, no snippet | yes |
| whitespace-only child, no snippet | no — whitespace preserved, untouched by this change |
| named slot + named snippet | yes (fixed) |

Full suite green (7599 passed, 0 failed).

## How this surfaced, and why only now

Snippets shipped in 5.0, so it's fair to ask why this is turning up at 5.56.9. It needs `preserveWhitespace: true`, which almost nobody sets deliberately — but there is a common way to get it by accident.

It was found in ordinary **`bun` CLI local development** (`bun --hot`, i.e. `Bun.serve`/Bake), where a `bits-ui` `Popover` never rendered. `bun-plugin-svelte` derives the Svelte *compiler* option `preserveWhitespace` from the *bundler's* `minify.whitespace` flag, and Bun's dev server hands plugins a stub bundler config that never sets `minify`. So `preserveWhitespace` is always `true` under the dev server, while production builds (`minify: true`) turn it off — dev silently broken, prod fine, which is a miserable signature to trace. `bits-ui`'s `popper-layer/popper-layer-inner.svelte` passes an entire popover subtree to `DismissibleLayer` as `{#snippet children({ props: dismissibleProps })}`, and that is what gets clobbered.

The one signal that would have exposed it immediately never appeared: Bun's bundler emits no duplicate-key warning, whereas esbuild on the same generated code says `▲ [WARNING] Duplicate key "children" in object literal`. Reproducing under esbuild is what showed this was a Svelte codegen bug and not a Bun or bits-ui problem.

Scale, for what it's worth: compiling all 226 `.svelte` files `bits-ui` ships, 2 files hit the fatal duplicate key, and `children` properties across the library drop from 80 to 35 with this fix — 45 spurious props across 27 files.

(The `bun-plugin-svelte` half — a cosmetic bundler flag setting a semantic compiler option, with no supported way to override it — is filed as oven-sh/bun#39378, PR oven-sh/bun#39376, and is not this PR's concern.)

