### PR TITLE
fix: prevent crash on async custom element attributes

### DIFF
--- a/.changeset/spotty-files-trade.md
+++ b/.changeset/spotty-files-trade.md
@@ -2,4 +2,4 @@
 'svelte': patch
 ---
 
-Allow custom elements to receive async values as props
+fix: allow custom elements to receive async values as props

--- a/.changeset/spotty-files-trade.md
+++ b/.changeset/spotty-files-trade.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+Allow custom elements to receive async values as props

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -664,14 +664,25 @@ function build_element_attribute_update(element, node_id, name, value, attribute
  * @param {ComponentContext} context
  */
 function build_custom_element_attribute_update_assignment(node_id, attribute, context) {
-	const { value, has_state } = build_attribute_value(attribute.value, context);
+	const memoizer = new Memoizer();
+	const { value, has_state } = build_attribute_value(attribute.value, context, (value, metadata) =>
+		memoizer.add(value, metadata)
+	);
 
 	// don't lowercase name, as we set the element's property, which might be case sensitive
 	const call = b.call('$.set_custom_element_data', node_id, b.literal(attribute.name), value);
 
 	// this is different from other updates — it doesn't get grouped,
 	// because set_custom_element_data may not be idempotent
-	const update = has_state ? b.call('$.template_effect', b.thunk(call)) : call;
+	const update = has_state
+		? b.call(
+				'$.template_effect',
+				b.arrow(memoizer.apply(), call),
+				memoizer.sync_values(),
+				memoizer.async_values(),
+				memoizer.blockers()
+			)
+		: call;
 
 	context.state.init.push(b.stmt(update));
 }

--- a/packages/svelte/tests/runtime-runes/samples/async-custom-element-attribute/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-custom-element-attribute/_config.js
@@ -1,5 +1,11 @@
+import { tick } from 'svelte';
 import { test } from '../../test';
 
 export default test({
-	// The test is "should not crash at runtime", nothing else to assert
+	async test({ target, assert }) {
+		await tick();
+		const [element] = target.querySelectorAll('async-custom-element');
+
+		assert.htmlEqual(element.innerHTML, `Hello foobar!`);
+	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/async-custom-element-attribute/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-custom-element-attribute/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	// The test is "should not crash at runtime", nothing else to assert
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-custom-element-attribute/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-custom-element-attribute/main.svelte
@@ -1,0 +1,5 @@
+<script>
+  const foo = $derived(await "foo");
+</script>
+
+<custom-element {foo}>Hello World!</custom-element>

--- a/packages/svelte/tests/runtime-runes/samples/async-custom-element-attribute/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-custom-element-attribute/main.svelte
@@ -1,5 +1,41 @@
 <script>
-  const foo = $derived(await "foo");
+	class MyCustomElement extends HTMLElement {
+		constructor() {
+			super();
+			this._foo = null;
+			this._bar = null;
+		}
+
+		/**
+		 * @param {string} foo
+		 */
+		set foo(foo) {
+			this._foo = foo;
+			this.render();
+		}
+
+		/**
+		 * @param {string} foo
+		 */
+		set bar(bar) {
+			this._bar = bar;
+			this.render();
+		}
+
+		connectedCallback() {
+			this.render();
+		}
+
+		render() {
+			this.innerHTML = "Hello " + this._foo + this._bar + "!";
+		}
+	}
+
+	if (!customElements.get('async-custom-element')) {
+		customElements.define("async-custom-element", MyCustomElement);
+	}
+
+	const foo = $derived(await "foo");
 </script>
 
-<custom-element {foo}>Hello World!</custom-element>
+<async-custom-element {foo} bar={await 'bar'}></async-custom-element>

--- a/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/dynamic-attributes-casing/_expected/client/main.svelte.js
@@ -25,7 +25,7 @@ export default function Main($$anchor) {
 	var svg_1 = $.sibling(div_1, 2);
 	var custom_element_1 = $.sibling(svg_1, 2);
 
-	$.template_effect(() => $.set_custom_element_data(custom_element_1, 'fooBar', y()));
+	$.template_effect(($0) => $.set_custom_element_data(custom_element_1, 'fooBar', $0), [() => y()]);
 
 	$.template_effect(
 		($0, $1) => {


### PR DESCRIPTION
Hi!

This is what I believe is a fix for the following runtime error:

```
TypeError: can't access property "f", signal is undefined
```

This happens in very simple scenarios, e.g.:

```svelte
<script>
  const foo = $derived(await "foo");
</script>

<custom-element {foo}>Hello World!</custom-element>
```

Reproduction: https://svelte.dev/playground/274f0e1224f0440fba0d2a590cd402fb?version=latest

I noticed it happened because elements and custom elements do not produce the same code when async is at stake:

```js
// Custom element, broken
$.template_effect(() => $.set_custom_element_data(custom_element, 'foo', $.get(foo)));

// HTML element, ok
$.template_effect(() => $.set_attribute(p, 'foo', $.get(foo)), void 0, void 0, [$$promises[0]]);
```

I tried to have the same sync/async/blockers parameters produced for `$.set_custom_element_data`

(It's fun to realize I'm probably the first person to combine async and custom elements)

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
